### PR TITLE
feat(cli): add --relocatable flag to force ET_REL output

### DIFF
--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -170,6 +170,11 @@ enum Commands {
         /// Path to kiln-builtins object file (.o) for linking (used with --link)
         #[arg(long, value_name = "BUILTINS")]
         builtins: Option<PathBuf>,
+
+        /// Force relocatable object (.o, ET_REL) output even when wasm has no imports
+        /// — for linking into a host build system.
+        #[arg(long)]
+        relocatable: bool,
     },
 
     /// Disassemble an ARM ELF file (e.g., synth disasm output.elf)
@@ -248,6 +253,7 @@ fn main() -> Result<()> {
             verify,
             link,
             builtins,
+            relocatable,
         } => {
             // Resolve target spec: --target overrides, --cortex-m is backwards compat
             let target_spec = resolve_target_spec(target.as_deref(), cortex_m)?;
@@ -272,6 +278,7 @@ fn main() -> Result<()> {
                 &backend,
                 verify,
                 &target_spec,
+                relocatable,
             )?;
 
             // If --link requested, invoke the cross-linker
@@ -553,6 +560,7 @@ fn compile_command(
     backend_name: &str,
     verify: bool,
     target_spec: &TargetSpec,
+    relocatable: bool,
 ) -> Result<()> {
     // Validate backend exists
     let registry = build_backend_registry();
@@ -595,6 +603,7 @@ fn compile_command(
             backend,
             verify,
             target_spec,
+            relocatable,
         );
     }
 
@@ -1222,6 +1231,7 @@ fn compile_all_exports(
     backend: &dyn Backend,
     verify: bool,
     target_spec: &TargetSpec,
+    relocatable: bool,
 ) -> Result<()> {
     let path = input.context("--all-exports requires an input file")?;
 
@@ -1428,8 +1438,18 @@ fn compile_all_exports(
     // When there are relocations, produce a relocatable object (.o) instead of
     // an executable. This lets the output be linked with the Kiln bridge crate
     // (which provides __meld_dispatch_import and __meld_get_memory_base).
-    let elf_data = if has_relocations {
-        info!("Module has import calls — producing relocatable object (ET_REL)");
+    // The --relocatable flag forces ET_REL output even when the wasm has no
+    // imports, for linking into a host build system (e.g. Zephyr).
+    let elf_data = if has_relocations || relocatable {
+        let total_relocs: usize = compiled_funcs.iter().map(|f| f.relocations.len()).sum();
+        if has_relocations {
+            info!(
+                "Producing relocatable object (ET_REL): {} import call relocations",
+                total_relocs
+            );
+        } else {
+            info!("Producing relocatable object (ET_REL): forced by --relocatable");
+        }
         build_relocatable_elf(&compiled_funcs, &all_imports)?
     } else if cortex_m {
         build_multi_func_cortex_m_elf(&compiled_funcs, &all_memories, target_spec)?


### PR DESCRIPTION
## Summary

- Currently synth produces ET_REL (relocatable .o) only when the input wasm has imports — the relocations they generate trigger that path. Self-contained wasm modules with no imports produce a complete ET_EXEC firmware (vector table, Reset_Handler, linear_memory section, etc.).
- Adds a `--relocatable` flag that forces ET_REL output regardless of whether the wasm has imports — for linking into a host build system that has its own startup code (e.g., integrating verified Rust kernel primitives compiled to wasm into a Zephyr build).
- Flag is additive; default behaviour is unchanged.

## Context

This unblocks a follow-up experiment on the gale engine bench: compiling gale-ffi (formally-verified Rust replacement for Zephyr kernel primitives) to wasm32, then using synth to lower the wasm to a Cortex-M4F relocatable .o that links into the existing Zephyr build alongside the C kernel. The rest of the build expects `libgale_ffi.a` (which we'll wrap from synth's .o), so synth's output needs to be a relocatable, not a full firmware.

Tested with gale-ffi.wasm (200 functions, 0 imports):
- Without `--relocatable`: 27052-byte ET_EXEC firmware with Reset_Handler, vector table, linear_memory section.
- With `--relocatable`: 26645-byte ET_REL ARM EABI5 object with all gale_* symbols defined and no firmware machinery.

## Test plan

- [x] `cargo check` passes
- [x] `cargo install --path crates/synth-cli --force` succeeds
- [x] Default path (no `--relocatable`) still produces ET_EXEC — verified with `file output.elf`
- [x] `--relocatable` produces ET_REL — verified with `file output.o` reporting "ELF 32-bit LSB relocatable, ARM, EABI5"
- [x] All 193 gale_* symbols present in the relocatable; Reset_Handler / Default_Handler / Trap_Handler / __linear_memory_base absent — verified with `nm`
- [ ] CI passes