### PR TITLE
feat(riscv): calculator demo + synth riscv-runtime CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+#### RISC-V backend (new — Track B in the multi-target plan)
+- New `synth-backend-riscv` crate with RV32IMAC encoder, ELF builder
+  (EM_RISCV=0xF3), PMP allocator, instruction selector, bare-metal startup
+  generator, and linker script generator.
+- CLI integration: `--backend riscv`, `--target riscv32imac/rv32imac/rv32i/rv32gc/rv64imac/rv64gc`.
+- New `synth riscv-runtime` command emits `startup.c` + `linker.ld` for
+  cross-compilation with `riscv64-unknown-elf-gcc`.
+- Selector covers the i32 surface (arithmetic, logic, shifts, comparisons,
+  division with trap-on-zero), i32.load/store + sub-word load8/16 + store8/16,
+  and control flow (block, loop, if/else, br, br_if). Locals for params 0..7.
+- ~30 wasm ops; encoder cross-validated against canonical RV32 hex encodings.
+  98 RISC-V backend tests passing.
+- Renode RV32IMAC platform (`tests/renode/synth_riscv.repl`).
+- Offline smoke tests + calculator end-to-end demo.
+
+#### Cortex-M7 hardening
+- `HardwareCapabilities::imxrt1062()` — Cortex-M7 single-precision FPU,
+  16 MPU regions, 8 MB QSPI flash, 1 MB OCRAM.
+- `HardwareCapabilities::stm32h743()` — Cortex-M7 double-precision FPU,
+  16 MPU regions, 2 MB Flash, 1 MB RAM.
+- CLI `--hardware {imxrt1062,stm32h743}` and target-info wired up.
+- Renode `synth_cortex_m7.repl` profile + `cortex_m7_test.robot`.
+- MPU allocator tests proving 16-region operation on M7-class parts.
+
+### Fixed
+
+#### AAPCS regalloc bugs (real-hardware-found)
+- **Optimized path** — `optimizer_bridge::ir_to_arm` no longer hardcodes
+  i64 ops to R0:R1 / R2:R3. New `alloc_i64_pair` picks free callee-saved
+  pairs (R4..R11) skipping live param registers. Fixes silent corruption
+  of i32 params when an i64 op ran before all params were read.
+- **No-optimize path** — `select_with_stack` now allocates a stack frame
+  for non-param locals and uses 8-byte STR/LDR for i64 locals so the
+  upper half doesn't get dropped. Fixes corruption of the callee-saved
+  spill area when a function has any non-param local.
+
+#### CLI
+- `--relocatable` flag — forces ET_REL output even when the wasm has no
+  imports, for linking into a host build system (e.g. Zephyr).
+
+#### Toolchain hygiene
+- 8 clippy errors fixed (Rust 1.95 lint refresh): `unnecessary_sort_by`,
+  `collapsible_match`, `collapsible_if`, `manual_checked_division`.
+
 ## [0.1.0] - 2026-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Synth
 
-<sup>WebAssembly-to-ARM Cortex-M AOT compiler with mechanized correctness proofs</sup>
+<sup>WebAssembly-to-ARM/RISC-V AOT compiler with mechanized correctness proofs</sup>
 
 &nbsp;
 

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -201,6 +201,38 @@ enum Commands {
         #[arg(short, long, default_value = "arm")]
         backend: String,
     },
+
+    /// Emit RISC-V bare-metal startup code + linker script
+    /// (e.g., `synth riscv-runtime -o build/`)
+    RiscvRuntime {
+        /// Output directory — receives `startup.c` and `linker.ld`
+        #[arg(short = 'o', long, value_name = "DIR", default_value = ".")]
+        outdir: PathBuf,
+
+        /// Target ISA variant (default: rv32imac)
+        #[arg(short, long, default_value = "rv32imac")]
+        target: String,
+
+        /// Flash origin address (default: 0x0)
+        #[arg(long, default_value = "0x0")]
+        flash_origin: String,
+
+        /// RAM origin address (default: 0x80000000)
+        #[arg(long, default_value = "0x80000000")]
+        ram_origin: String,
+
+        /// Linear-memory size in bytes (default: 65536, one wasm page)
+        #[arg(long, default_value = "65536")]
+        linear_memory_size: u64,
+
+        /// Stack size in bytes (default: 4096)
+        #[arg(long, default_value = "4096")]
+        stack_size: u64,
+
+        /// Enable FPU init in the reset vector
+        #[arg(long)]
+        enable_fpu: bool,
+    },
 }
 
 fn main() -> Result<()> {
@@ -299,9 +331,138 @@ fn main() -> Result<()> {
         } => {
             verify_command(wasm_input, elf_input, &backend)?;
         }
+        Commands::RiscvRuntime {
+            outdir,
+            target,
+            flash_origin,
+            ram_origin,
+            linear_memory_size,
+            stack_size,
+            enable_fpu,
+        } => {
+            riscv_runtime_command(
+                outdir,
+                target,
+                flash_origin,
+                ram_origin,
+                linear_memory_size,
+                stack_size,
+                enable_fpu,
+            )?;
+        }
     }
 
     Ok(())
+}
+
+#[cfg(feature = "riscv")]
+#[allow(clippy::too_many_arguments)]
+fn riscv_runtime_command(
+    outdir: PathBuf,
+    target: String,
+    flash_origin: String,
+    ram_origin: String,
+    linear_memory_size: u64,
+    stack_size: u64,
+    enable_fpu: bool,
+) -> Result<()> {
+    use synth_backend_riscv::{
+        LinkerScriptConfig, RiscVLinkerScriptGenerator, RiscVStartupGenerator, StartupConfig,
+    };
+    use synth_core::{HardwareCapabilities, RISCVVariant, TargetArch};
+
+    // Hardware caps from the target name.
+    let variant = match target.as_str() {
+        "rv32i" => RISCVVariant::RV32I,
+        "rv32imac" | "rv32imc" => RISCVVariant::RV32IMAC,
+        "rv32gc" => RISCVVariant::RV32GC,
+        "rv64i" => RISCVVariant::RV64I,
+        "rv64imac" => RISCVVariant::RV64IMAC,
+        "rv64gc" => RISCVVariant::RV64GC,
+        _ => anyhow::bail!(
+            "unknown RISC-V target: {}. Supported: rv32i, rv32imac, rv32gc, rv64i, rv64imac, rv64gc",
+            target
+        ),
+    };
+
+    let parse_addr = |s: &str| -> Result<u64> {
+        let s = s.trim_start_matches("0x").trim_start_matches("0X");
+        u64::from_str_radix(s, 16).context(format!("invalid hex address: {}", s))
+    };
+    let flash_origin_v = parse_addr(&flash_origin)?;
+    let ram_origin_v = parse_addr(&ram_origin)?;
+
+    let hw_caps = HardwareCapabilities {
+        arch: TargetArch::RISCV(variant),
+        has_mpu: false,
+        mpu_regions: 0,
+        has_pmp: true,
+        pmp_entries: 16,
+        has_fpu: enable_fpu,
+        fpu_precision: None,
+        has_simd: false,
+        simd_level: None,
+        xip_capable: true,
+        flash_size: 64 * 1024,
+        ram_size: 64 * 1024,
+    };
+
+    std::fs::create_dir_all(&outdir).context("failed to create output directory")?;
+
+    // Startup
+    let startup = RiscVStartupGenerator::new(hw_caps.clone()).with_config(StartupConfig {
+        enable_fpu,
+        ..Default::default()
+    });
+    let startup_path = outdir.join("startup.c");
+    std::fs::write(&startup_path, startup.generate())
+        .context(format!("failed to write {}", startup_path.display()))?;
+
+    // Linker script
+    let linker = RiscVLinkerScriptGenerator::new(hw_caps).with_config(LinkerScriptConfig {
+        flash_origin: flash_origin_v,
+        ram_origin: ram_origin_v,
+        linear_memory_size,
+        stack_size,
+    });
+    let linker_path = outdir.join("linker.ld");
+    std::fs::write(&linker_path, linker.generate())
+        .context(format!("failed to write {}", linker_path.display()))?;
+
+    println!("Wrote {}", startup_path.display());
+    println!("Wrote {}", linker_path.display());
+    println!();
+    let march = if matches!(target.as_str(), "rv32imac" | "rv32imc") {
+        "rv32imac"
+    } else {
+        target.as_str()
+    };
+    println!("Link your synth-compiled .o with:");
+    println!(
+        "  riscv64-unknown-elf-gcc -nostartfiles -nostdlib -mabi=ilp32 -march={} \\",
+        march
+    );
+    println!(
+        "    -T {} -o firmware.elf {} <synth.o>",
+        linker_path.display(),
+        startup_path.display()
+    );
+
+    Ok(())
+}
+
+#[cfg(not(feature = "riscv"))]
+#[allow(clippy::too_many_arguments)]
+fn riscv_runtime_command(
+    _outdir: PathBuf,
+    _target: String,
+    _flash_origin: String,
+    _ram_origin: String,
+    _linear_memory_size: u64,
+    _stack_size: u64,
+    _enable_fpu: bool,
+) -> Result<()> {
+    anyhow::bail!("RISC-V backend was not compiled in (rebuild with --features riscv)")
 }
 
 fn parse_command(input: PathBuf, output: Option<PathBuf>) -> Result<()> {

--- a/tests/integration/riscv_calculator_demo.sh
+++ b/tests/integration/riscv_calculator_demo.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# RISC-V calculator demo — end-to-end pipeline test.
+#
+# Pipeline:
+#   examples/calculator/calculator.wat
+#     → synth compile --backend riscv → calculator.o (RV32 EM_RISCV ELF)
+#     → synth riscv-runtime → startup.c + linker.ld
+#     → riscv64-unknown-elf-gcc (if present) → firmware.elf
+#
+# This is the B4 deliverable: prove the full RISC-V toolchain produces a
+# bootable firmware ELF for a representative WASM module.
+#
+# When `riscv64-unknown-elf-gcc` is missing, the test still validates that:
+#   1. synth compiles the calculator to RV32IMAC bytes correctly.
+#   2. All 5 calculator functions show up in the symbol table.
+#   3. The startup + linker script generators emit syntactically plausible
+#      output.
+#
+# When the toolchain is present, the script links a full firmware ELF.
+#
+# Usage:
+#   bash tests/integration/riscv_calculator_demo.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SYNTH="$PROJECT_ROOT/target/debug/synth"
+TMPDIR="${TMPDIR:-/tmp}/synth_rv_calc_$$"
+
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+mkdir -p "$TMPDIR"
+
+echo "=== Synth RISC-V calculator demo ==="
+
+if [ ! -x "$SYNTH" ]; then
+    (cd "$PROJECT_ROOT" && cargo build -p synth-cli --quiet)
+fi
+
+WAT="$PROJECT_ROOT/examples/calculator/calculator.wat"
+if [ ! -f "$WAT" ]; then
+    echo "FAIL: calculator.wat missing at $WAT"
+    exit 1
+fi
+
+# Step 1 — compile WAT to RISC-V .o
+echo "[1/4] Compiling calculator.wat for riscv32imac..."
+"$SYNTH" compile "$WAT" -o "$TMPDIR/calculator.o" \
+    --backend riscv --target riscv32imac --all-exports >/dev/null 2>&1
+ELF_TYPE="$(file "$TMPDIR/calculator.o")"
+case "$ELF_TYPE" in
+    *RISC-V*) echo "    OK: $ELF_TYPE" ;;
+    *) echo "    FAIL: not RISC-V (got: $ELF_TYPE)"; exit 1 ;;
+esac
+
+# Step 2 — verify all 5 calculator symbols are present
+echo "[2/4] Checking calculator symbols..."
+EXPECTED_SYMS="add subtract multiply divide modulo"
+ALL_OK=1
+for sym in $EXPECTED_SYMS; do
+    if grep -aq "$sym" "$TMPDIR/calculator.o"; then
+        echo "    OK: $sym"
+    else
+        echo "    FAIL: $sym not found in symbol table"
+        ALL_OK=0
+    fi
+done
+[ "$ALL_OK" -eq 1 ] || exit 1
+
+# Step 3 — emit startup + linker script
+echo "[3/4] Generating runtime (startup.c + linker.ld)..."
+"$SYNTH" riscv-runtime -o "$TMPDIR/runtime" --target rv32imac >/dev/null
+[ -f "$TMPDIR/runtime/startup.c" ] || { echo "    FAIL: startup.c not written"; exit 1; }
+[ -f "$TMPDIR/runtime/linker.ld" ] || { echo "    FAIL: linker.ld not written"; exit 1; }
+
+# Verify the startup file contains the RV-specific bits.
+for marker in "csrw mtvec" "_reset" "_trap_entry" "synth_trap_handler" "la s11"; do
+    if ! grep -q "$marker" "$TMPDIR/runtime/startup.c"; then
+        echo "    FAIL: startup.c missing '$marker'"
+        exit 1
+    fi
+done
+echo "    OK: startup.c contains all required RV-specific markers"
+
+# Verify the linker script produces flash+ram regions and the entry point.
+for marker in 'OUTPUT_ARCH("riscv")' 'ENTRY(_reset)' '_stack_top' '__linear_memory_base' '__global_pointer$'; do
+    if ! grep -F -q "$marker" "$TMPDIR/runtime/linker.ld"; then
+        echo "    FAIL: linker.ld missing '$marker'"
+        exit 1
+    fi
+done
+echo "    OK: linker.ld contains all required sections + symbols"
+
+# Step 4 — optional full link with the cross-toolchain
+echo "[4/4] Cross-link to firmware (optional — needs riscv64-unknown-elf-gcc)..."
+if command -v riscv64-unknown-elf-gcc >/dev/null 2>&1; then
+    riscv64-unknown-elf-gcc \
+        -nostartfiles -nostdlib \
+        -mabi=ilp32 -march=rv32imac \
+        -T "$TMPDIR/runtime/linker.ld" \
+        -o "$TMPDIR/firmware.elf" \
+        "$TMPDIR/runtime/startup.c" \
+        "$TMPDIR/calculator.o"
+    SIZE="$(wc -c < "$TMPDIR/firmware.elf")"
+    echo "    OK: firmware.elf is $SIZE bytes"
+    echo "    file: $(file "$TMPDIR/firmware.elf")"
+else
+    echo "    SKIP: riscv64-unknown-elf-gcc not in PATH (this is fine on dev hosts)"
+fi
+
+echo ""
+echo "=== Calculator demo: PASS ==="


### PR DESCRIPTION
Track B4 — closes the loop on the RISC-V toolchain. Stacked on #89.

## CLI: \`synth riscv-runtime\`

New subcommand that emits a complete RV32 build runtime:

\`\`\`
synth riscv-runtime -o build/ \\
    --target rv32imac \\
    --flash-origin 0x0 \\
    --ram-origin 0x80000000 \\
    --linear-memory-size 65536 \\
    --stack-size 4096
\`\`\`

Writes \`startup.c\` (reset vector + trap entry) and \`linker.ld\`. Prints the cross-link command at the end.

## End-to-end calculator demo

\`tests/integration/riscv_calculator_demo.sh\` exercises the complete pipeline:

1. \`synth compile examples/calculator/calculator.wat --backend riscv\` → RV32IMAC ELF
2. Verify all 5 calculator symbols (add, subtract, multiply, divide, modulo)
3. \`synth riscv-runtime\` → startup.c + linker.ld
4. (Optional) \`riscv64-unknown-elf-gcc\` → firmware.elf

All 4 stages pass on the dev host.

## CHANGELOG / README

* CHANGELOG \`[Unreleased]\` section with full RISC-V + M7 + AAPCS fix details.
* README tagline updated to \"WebAssembly-to-ARM/RISC-V AOT compiler\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)