### PR TITLE
ci: migrate 5 of 8 jobs to smithy self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     env:
       RUSTFLAGS: -Dwarnings
     steps:
@@ -33,7 +33,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -54,7 +54,7 @@ jobs:
 
   fmt:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -75,6 +75,9 @@ jobs:
 
   verify:
     name: Z3 Verification
+    # Stays on ubuntu-latest: needs `sudo apt-get install -y libz3-dev`
+    # (smithy runners have no sudo). Move once libz3-dev is added to
+    # the smithy toolchains role.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +102,7 @@ jobs:
   coverage:
     name: Code Coverage
     needs: [test]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -132,6 +135,9 @@ jobs:
 
   kani:
     name: Kani Verification
+    # Stays on ubuntu-latest: Kani-CBMC bundle is not yet provisioned
+    # in the smithy toolchains role (tracked in playbook out-of-scope
+    # table). Move once smithy ships kani-verifier + CBMC.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -143,7 +149,7 @@ jobs:
 
   rivet:
     name: Rivet Validation
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -180,6 +186,9 @@ jobs:
 
   bazel:
     name: Bazel Build & Proofs
+    # Stays on ubuntu-latest: needs Nix + Bazel + Rocq via Bazel
+    # (none provisioned on smithy; tracked in playbook out-of-scope
+    # table for both Bazel and Rocq).
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
## Summary

Migrates the bulk of synth's gating CI from GitHub-hosted runners to
the pulseengine self-hosted fleet (smithy). Five of the eight jobs in
`ci.yml` move to smithy; the remaining three stay on `ubuntu-latest`
for documented infra reasons (sudo apt, Kani-CBMC, Bazel + Nix +
Rocq) and are tagged in-place with the reason.

## Coverage

| Job | New runner | Class |
|---|---|---|
| `test` | smithy | `rust-cpu` |
| `clippy` | smithy | `rust-cpu` |
| `coverage` | smithy | `rust-cpu` |
| `rivet` | smithy | `rust-cpu` |
| `fmt` | smithy | `light` |

## Stays on ubuntu-latest

| Job | Reason |
|---|---|
| `verify` | Needs `sudo apt-get install libz3-dev`; smithy has no sudo and libz3-dev is not yet in the toolchains role. |
| `kani` | Kani-CBMC bundle is not yet provisioned on smithy (tracked in playbook out-of-scope table). |
| `bazel` | Needs Nix + Bazel + Rocq, none of which are on smithy (tracked in playbook out-of-scope table). |

## Workarounds applied

None — every migrated job is a clean `runs-on:` swap. No installer
scripts, no sudo, no `cargo-deny-action` / `cargo-semver-checks-action` /
`free-disk-space` patterns in this workflow.

## Test plan

- [ ] CI run completes; the five migrated jobs land on the matching
      smithy runner class within seconds (no GitHub queue).
- [ ] `test`, `clippy`, `coverage`, `rivet` succeed end-to-end on
      `rust-cpu`.
- [ ] `fmt` succeeds on `light`.
- [ ] `verify`, `kani`, `bazel` still run on `ubuntu-latest` exactly
      as before.

## Rollback

Revert this commit. Every migrated job returns to `ubuntu-latest` and
the next run uses GitHub-hosted compute.