### PR TITLE
fix(opt): i64 lowering miscompiles memset-style loop counter on Cortex-M (#93)

### DIFF
--- a/crates/synth-opt/src/lib.rs
+++ b/crates/synth-opt/src/lib.rs
@@ -456,6 +456,36 @@ pub enum Opcode {
         src_lo: Reg,
     },
 
+    /// i32 -> i64 zero-extension. `dest_lo` aliases `src` (same vreg by IR
+    /// convention — see `wasm_to_ir`); `dest_hi` is freshly allocated and
+    /// holds the constant 0. Lowering MUST move `src`'s ARM reg into a
+    /// non-AAPCS-param register before treating it as the i64 lo half — the
+    /// downstream `I64Shl/ShrU/ShrS` emitters use `rm_lo`/`rm_hi` as scratch
+    /// and clobber them, so we must not place a live param register there.
+    /// This was the proximate cause of issue #93 (memset infinite loop on
+    /// silicon) before this opcode existed and the bridge silently fell
+    /// through to `Opcode::Nop` + `R0`-fallback in `get_arm_reg`.
+    I64ExtendI32U {
+        dest_lo: Reg,
+        dest_hi: Reg,
+        src: Reg,
+    },
+
+    /// i32 -> i64 sign-extension. Same constraints as I64ExtendI32U; the
+    /// `dest_hi` is filled by an arithmetic shift right by 31 of the src.
+    I64ExtendI32S {
+        dest_lo: Reg,
+        dest_hi: Reg,
+        src: Reg,
+    },
+
+    /// i64 -> i32 wrap (truncate to low 32 bits). `dest` aliases the i64's
+    /// `src_lo` vreg (same value); the high half is simply discarded.
+    I32WrapI64 {
+        dest: Reg,
+        src_lo: Reg,
+    },
+
     // i64 shifts and multiply (result is i64 pair)
     I64Mul {
         dest_lo: Reg,

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -397,6 +397,23 @@ impl OptimizerBridge {
                 while j > 0 && found < count {
                     j -= 1;
                     match &wasm_ops[j] {
+                        // I64ExtendI32U/S consume an i32 LocalGet and produce an
+                        // i64 — so they account for one i64 operand and we must
+                        // skip the i32 LocalGet that immediately precedes them
+                        // (otherwise we'd mistakenly mark that i32 LocalGet as
+                        // i64, double-loading the local). See issue #93.
+                        WasmOp::I64ExtendI32U | WasmOp::I64ExtendI32S => {
+                            found += 1;
+                            // Skip the i32 producer that fed this extend.
+                            if j > 0
+                                && matches!(
+                                    &wasm_ops[j - 1],
+                                    WasmOp::LocalGet(_) | WasmOp::I32Const(_)
+                                )
+                            {
+                                j -= 1;
+                            }
+                        }
                         WasmOp::LocalGet(_) => {
                             i64_local_gets.insert(j);
                             found += 1;
@@ -993,6 +1010,87 @@ impl OptimizerBridge {
                         is_dead: false,
                     });
                     inst_id += 1;
+                    builder.add_instruction();
+                    continue;
+                }
+
+                // i32 -> i64 zero-extend.
+                //
+                // Net stack effect: pop 1 i32 slot, push i64 (= 2 slots).
+                // We REUSE the consumed i32 slot for `dest_lo` (same vreg,
+                // same value semantically) and add 1 fresh slot for
+                // `dest_hi`. This keeps the `inst_id.saturating_sub(K)`
+                // arithmetic in subsequent i64 ops correct without any
+                // off-by-one shift in slot numbering.
+                //
+                // Pre-fix this op fell through to the catch-all `_ =>
+                // Opcode::Nop` arm; subsequent `Opcode::I64ShrU` /
+                // `Opcode::I64Shl` source-vreg lookups missed `vreg_to_arm`
+                // and `get_arm_reg` returned `Reg::R0` as a silent fallback,
+                // causing the i64-shift emitter to clobber AAPCS param R0
+                // (the memset destination pointer). See issue #93.
+                WasmOp::I64ExtendI32U => {
+                    let src_slot = inst_id.saturating_sub(1) as u32;
+                    let opcode = Opcode::I64ExtendI32U {
+                        dest_lo: OptReg(src_slot),
+                        dest_hi: OptReg(inst_id as u32),
+                        src: OptReg(src_slot),
+                    };
+                    instructions.push(Instruction {
+                        id: inst_id,
+                        opcode,
+                        block_id: 0,
+                        is_dead: false,
+                    });
+                    inst_id += 1; // +1 slot net (dest_hi only; dest_lo reuses src)
+                    builder.add_instruction();
+                    continue;
+                }
+
+                // i32 -> i64 sign-extend. Same slot accounting as
+                // `I64ExtendI32U` — see comment there.
+                WasmOp::I64ExtendI32S => {
+                    let src_slot = inst_id.saturating_sub(1) as u32;
+                    let opcode = Opcode::I64ExtendI32S {
+                        dest_lo: OptReg(src_slot),
+                        dest_hi: OptReg(inst_id as u32),
+                        src: OptReg(src_slot),
+                    };
+                    instructions.push(Instruction {
+                        id: inst_id,
+                        opcode,
+                        block_id: 0,
+                        is_dead: false,
+                    });
+                    inst_id += 1;
+                    builder.add_instruction();
+                    continue;
+                }
+
+                // i64 -> i32 wrap (truncate). Net stack effect: pop i64
+                // (2 slots), push i32 (1 slot) = -1 slot. The result IS
+                // the low 32 bits of the input i64, so `dest` aliases
+                // `src_lo` by IR convention. We don't increment `inst_id`
+                // (the natural +1 from the wildcard fallthrough cancels
+                // with the -1 i64-pop, net 0 fresh slot).
+                WasmOp::I32WrapI64 => {
+                    // src_lo is at inst_id-2 (lo of the popped i64),
+                    // src_hi is at inst_id-1 (hi, discarded).
+                    let src_lo_slot = inst_id.saturating_sub(2) as u32;
+                    let opcode = Opcode::I32WrapI64 {
+                        dest: OptReg(src_lo_slot),
+                        src_lo: OptReg(src_lo_slot),
+                    };
+                    instructions.push(Instruction {
+                        id: inst_id,
+                        opcode,
+                        block_id: 0,
+                        is_dead: false,
+                    });
+                    // No inst_id increment: the wildcard `inst_id += 1`
+                    // is balanced by the -1 net slot delta of the wrap.
+                    // We `continue` to skip the wildcard's +1 and emit nothing extra.
+                    inst_id = inst_id.saturating_sub(1);
                     builder.add_instruction();
                     continue;
                 }
@@ -2918,6 +3016,85 @@ impl OptimizerBridge {
                     last_result_vreg = Some(dest_lo.0);
                     last_result_vreg_hi = Some(dest_hi.0);
                     is_i64_result = true;
+                }
+
+                // i32 -> i64 zero-extension (issue #93 fix).
+                //
+                // Critical: we MUST move `src` into a callee-saved register
+                // pair, even if `src` was already in a non-param register.
+                // The downstream `I64Shl/ShrU/ShrS` ARM emitter writes to
+                // both `rm_lo` and `rm_hi` (see `arm_encoder.rs:2872`,
+                // `:2954`, `:3036` — `AND.W rm_lo, rm_lo, #63;
+                // SUBS.W rm_hi, rm_lo, #32; ...`). Pre-fix, `src` could be
+                // an AAPCS param register (R0..R3) and the shift would
+                // clobber the caller's argument. By Mov'ing into a fresh
+                // pair from `alloc_i64_pair` (which excludes params and
+                // live vregs), we guarantee `rm_lo`/`rm_hi` are scratch.
+                Opcode::I64ExtendI32U {
+                    dest_lo,
+                    dest_hi,
+                    src,
+                } => {
+                    let src_arm = get_arm_reg(src, &vreg_to_arm, &spilled_vregs);
+                    let (new_lo, new_hi) =
+                        alloc_i64_pair(&vreg_to_arm, &local_to_reg, &param_reserved_regs);
+                    if src_arm != new_lo {
+                        arm_instrs.push(ArmOp::Mov {
+                            rd: new_lo,
+                            op2: crate::rules::Operand2::Reg(src_arm),
+                        });
+                    }
+                    arm_instrs.push(ArmOp::Movw {
+                        rd: new_hi,
+                        imm16: 0,
+                    });
+                    // Re-map dest_lo (which IS the src vreg by IR convention)
+                    // to the new lo arm reg, AND map dest_hi to the new hi.
+                    vreg_to_arm.insert(dest_lo.0, new_lo);
+                    vreg_to_arm.insert(dest_hi.0, new_hi);
+                    last_result_vreg = Some(dest_lo.0);
+                    last_result_vreg_hi = Some(dest_hi.0);
+                    is_i64_result = true;
+                }
+
+                // i32 -> i64 sign-extension. Same scratch-pair discipline as
+                // I64ExtendI32U; the high half is `src ASR #31`.
+                Opcode::I64ExtendI32S {
+                    dest_lo,
+                    dest_hi,
+                    src,
+                } => {
+                    let src_arm = get_arm_reg(src, &vreg_to_arm, &spilled_vregs);
+                    let (new_lo, new_hi) =
+                        alloc_i64_pair(&vreg_to_arm, &local_to_reg, &param_reserved_regs);
+                    if src_arm != new_lo {
+                        arm_instrs.push(ArmOp::Mov {
+                            rd: new_lo,
+                            op2: crate::rules::Operand2::Reg(src_arm),
+                        });
+                    }
+                    // hi = src ASR #31 — sign bit replicated across all 32 bits.
+                    arm_instrs.push(ArmOp::Asr {
+                        rd: new_hi,
+                        rn: new_lo,
+                        shift: 31,
+                    });
+                    vreg_to_arm.insert(dest_lo.0, new_lo);
+                    vreg_to_arm.insert(dest_hi.0, new_hi);
+                    last_result_vreg = Some(dest_lo.0);
+                    last_result_vreg_hi = Some(dest_hi.0);
+                    is_i64_result = true;
+                }
+
+                // i64 -> i32 wrap. The result IS the low 32 bits of the
+                // input — by IR convention `dest == src_lo` (same vreg),
+                // so the lookup of `dest` is already correctly mapped to
+                // the i64 lo half's ARM register. Emit no ARM code.
+                Opcode::I32WrapI64 { dest, src_lo } => {
+                    let src_arm = get_arm_reg(src_lo, &vreg_to_arm, &spilled_vregs);
+                    vreg_to_arm.insert(dest.0, src_arm);
+                    last_result_vreg = Some(dest.0);
+                    is_i64_result = false;
                 }
 
                 // i64 multiply: UMULL + MLA cross products

--- a/crates/synth-synthesis/tests/issue_93_memset_i64_codegen.rs
+++ b/crates/synth-synthesis/tests/issue_93_memset_i64_codegen.rs
@@ -1,0 +1,260 @@
+//! Regression test for issue #93: memset/memcpy/memmove i64-codegen produces
+//! non-terminating loop on Cortex-M.
+//!
+//! Symptom:
+//! When `compiler_builtins::memset` is compiled through `synth compile
+//! --target cortex-m4f` (the default optimized path), the body of the emitted
+//! memset contains a 64-bit shift sequence (`rsb r3,r2,#32; lsl.w r3,r1,r3;
+//! lsr.w r0,r0,r2; orr.w r0,r0,r3; lsr.w r1,r1,r2`) where a byte-counter loop
+//! should be. On real STM32G474RE silicon the chip enters this loop at
+//! `memset+0x4c` and never exits.
+//!
+//! Root cause:
+//! `optimizer_bridge::wasm_to_ir` does NOT handle `WasmOp::I64ExtendI32U` /
+//! `WasmOp::I64ExtendI32S`. They fall through the catch-all `_ => Opcode::Nop`,
+//! consuming an inst_id slot but never registering the produced i64-pair vregs
+//! in `vreg_to_arm`. Subsequent `Opcode::I64ShrU` / `I64Shl` lookups for the
+//! shift-count operand miss the map and `get_arm_reg` returns `Reg::R0` as a
+//! silent fallback (`optimizer_bridge.rs:1333`). The `I64ShrU` ARM emitter
+//! then issues `AND.W R0, R0, #63; SUBS.W R0, R0, #32; ...` — clobbering the
+//! first AAPCS parameter (R0, the memset destination pointer / loop pointer).
+//! The loop counter / pointer is corrupted on every iteration → non-termination.
+//!
+//! This test asserts the emission for an `i64.shr_u` whose shift amount comes
+//! from `i64.extend_i32_u(local.get $n)` does NOT use R0 as the shift's
+//! `rm_lo`/`rm_hi` when the function has 4 AAPCS params (so R0 is reserved).
+//!
+//! Pre-fix: this assertion fails because the unhandled extend leaves the
+//! `Opcode::I64ShrU`'s `src2_lo` / `src2_hi` vregs unmapped, and `ir_to_arm`'s
+//! fallback returns R0.
+//!
+//! Post-fix: `I64ExtendI32U` / `I64ExtendI32S` are handled in `wasm_to_ir`
+//! and `ir_to_arm`, so the shift's `rm_lo`/`rm_hi` resolve to the actual
+//! register pair the extend wrote into — distinct from any param register.
+
+use synth_synthesis::{ArmOp, InstructionSelector, OptimizerBridge, Reg, WasmOp};
+
+/// Compile the WASM op sequence through the optimized pipeline (the default,
+/// matching `synth compile --target cortex-m4f` without `--no-optimize`) and
+/// return the emitted ARM ops.
+fn compile_optimized(wasm_ops: &[WasmOp], num_params: usize) -> Vec<ArmOp> {
+    let bridge = OptimizerBridge::new();
+    let (ir, _cfg, _stats) = bridge
+        .optimize_full(wasm_ops)
+        .expect("optimize_full should succeed for valid input");
+    bridge.ir_to_arm(&ir, num_params)
+}
+
+/// Returns true if the ARM op is one of the 64-bit shift pseudo-ops (the
+/// expansion of which is what corrupts R0 in the bug).
+fn is_i64_shift(op: &ArmOp) -> bool {
+    matches!(
+        op,
+        ArmOp::I64Shl { .. } | ArmOp::I64ShrU { .. } | ArmOp::I64ShrS { .. }
+    )
+}
+
+/// Returns the (rm_lo, rm_hi) of an i64 shift op, or None if not a shift.
+fn shift_count_regs(op: &ArmOp) -> Option<(Reg, Reg)> {
+    match op {
+        ArmOp::I64Shl { rm_lo, rm_hi, .. }
+        | ArmOp::I64ShrU { rm_lo, rm_hi, .. }
+        | ArmOp::I64ShrS { rm_lo, rm_hi, .. } => Some((*rm_lo, *rm_hi)),
+        _ => None,
+    }
+}
+
+/// Returns the (rn_lo, rn_hi) of an i64 shift op (the value being shifted).
+fn shift_value_regs(op: &ArmOp) -> Option<(Reg, Reg)> {
+    match op {
+        ArmOp::I64Shl { rn_lo, rn_hi, .. }
+        | ArmOp::I64ShrU { rn_lo, rn_hi, .. }
+        | ArmOp::I64ShrS { rn_lo, rn_hi, .. } => Some((*rn_lo, *rn_hi)),
+        _ => None,
+    }
+}
+
+/// Minimal repro of the broken codegen pattern.
+///
+/// WASM (4 params; R0..R3 hold them, R0 is memset's destination pointer):
+///   ;; build i64 fill word
+///   i64.const 0x0101010101010101
+///   ;; shift count from a loop-local i32, zero-extended to i64
+///   local.get 1                ;; -> R1
+///   i64.extend_i32_u           ;; produces an i64 pair on the WASM stack
+///   i64.shr_u                  ;; (i64 const) >> (zero-extended i32)
+///
+/// In the buggy code the I64ShrU's `rm_lo`/`rm_hi` resolve to R0 because the
+/// extend was Nopped and the i64 shift count's vregs are unmapped.  The ARM
+/// emitter then writes to R0 inside `AND.W R0, R0, #63; SUBS.W R0, R0, #32;
+/// ...`, clobbering the AAPCS first-param register.
+fn repro_wasm_ops() -> Vec<WasmOp> {
+    vec![
+        // 4 params (synth's count_params heuristic walks LocalGet indices)
+        WasmOp::LocalGet(0),
+        WasmOp::LocalGet(1),
+        WasmOp::LocalGet(2),
+        WasmOp::LocalGet(3),
+        WasmOp::Drop,
+        WasmOp::Drop,
+        WasmOp::Drop,
+        WasmOp::Drop,
+        // i64 fill pattern (the value being shifted)
+        WasmOp::I64Const(0x0101_0101_0101_0101),
+        // shift amount: take an i32 local and zero-extend to i64
+        WasmOp::LocalGet(1),
+        WasmOp::I64ExtendI32U,
+        // the actual 64-bit logical shift
+        WasmOp::I64ShrU,
+        WasmOp::Drop,
+    ]
+}
+
+/// Returns true if any AAPCS parameter register (R0..R3) is the i64 shift's
+/// `rm_lo` or `rm_hi` — both of which the ARM emitter clobbers as scratch.
+fn shift_clobbers_param_reg(arm_ops: &[ArmOp]) -> bool {
+    for op in arm_ops {
+        if let Some((rm_lo, rm_hi)) = shift_count_regs(op) {
+            for reg in [rm_lo, rm_hi] {
+                if matches!(reg, Reg::R0 | Reg::R1 | Reg::R2 | Reg::R3) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Sanity check: the no-optimize path (select_with_stack) handles the same
+/// repro correctly — its output's i64 shift `rm_lo`/`rm_hi` do not alias an
+/// AAPCS param register. This shows the bug is specific to the optimizer
+/// path.
+#[test]
+fn issue_93_no_optimize_path_handles_repro() {
+    let wasm = repro_wasm_ops();
+    let mut sel = InstructionSelector::new(vec![]);
+    let arm: Vec<_> = sel
+        .select_with_stack(&wasm, 4)
+        .expect("no-optimize path should compile the repro")
+        .into_iter()
+        .map(|i| i.op)
+        .collect();
+    assert!(arm.iter().any(|o| matches!(o, ArmOp::I64ShrU { .. })));
+    assert!(
+        !shift_clobbers_param_reg(&arm),
+        "no-optimize path also clobbers AAPCS params (unexpected): {:#?}",
+        arm.iter().filter(|o| is_i64_shift(o)).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn issue_93_optimized_i64_shr_u_does_not_use_r0_as_shift_count() {
+    // 4-param function — R0..R3 are all live AAPCS params on entry.
+    // The i64.shr_u's shift count must NOT map to any of R0..R3.
+    let wasm = repro_wasm_ops();
+    let arm = compile_optimized(&wasm, 4);
+
+    // Make sure the op we care about was actually emitted.
+    let n_shifts = arm.iter().filter(|o| is_i64_shift(o)).count();
+    assert!(
+        n_shifts >= 1,
+        "expected at least one I64ShrU in optimized output; got: {:#?}",
+        arm
+    );
+
+    // The shift count regs (rm_lo, rm_hi) are clobbered by the emitter.
+    // They must not alias an AAPCS param register, otherwise the param is
+    // destroyed on every shift (e.g. the memset loop pointer in R0).
+    assert!(
+        !shift_clobbers_param_reg(&arm),
+        "I64 shift's rm_lo/rm_hi (clobbered by the emitter) aliases an AAPCS \
+         param register R0..R3 — would corrupt the parameter on every shift. \
+         Shift ops: {:#?}",
+        arm.iter().filter(|o| is_i64_shift(o)).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn issue_93_optimized_i64_shr_u_value_and_count_are_distinct() {
+    // The i64-being-shifted (rn_lo:rn_hi) and the i64 shift count
+    // (rm_lo:rm_hi) must occupy disjoint registers — otherwise the AND/SUBS
+    // on rm_lo would corrupt the value, and the LSR on rn_lo would no longer
+    // see the original. This also pre-empts the `R0 fallback` regression
+    // from being silently masked by happening to alias the value's regs.
+    let wasm = repro_wasm_ops();
+    let arm = compile_optimized(&wasm, 4);
+
+    for op in &arm {
+        if let (Some((rn_lo, rn_hi)), Some((rm_lo, rm_hi))) =
+            (shift_value_regs(op), shift_count_regs(op))
+        {
+            assert_ne!(rn_lo, rm_lo, "rn_lo aliases rm_lo (clobbers value)");
+            assert_ne!(rn_lo, rm_hi, "rn_lo aliases rm_hi (clobbers value)");
+            assert_ne!(rn_hi, rm_lo, "rn_hi aliases rm_lo (clobbers value)");
+            assert_ne!(rn_hi, rm_hi, "rn_hi aliases rm_hi (clobbers value)");
+        }
+    }
+}
+
+#[test]
+fn issue_93_optimized_i64_shl_does_not_use_r0_as_shift_count() {
+    // Same scenario, but using i64.shl instead of i64.shr_u — the shl
+    // emitter has the same clobber pattern on rm_lo/rm_hi.
+    let wasm = vec![
+        WasmOp::LocalGet(0),
+        WasmOp::LocalGet(1),
+        WasmOp::LocalGet(2),
+        WasmOp::LocalGet(3),
+        WasmOp::Drop,
+        WasmOp::Drop,
+        WasmOp::Drop,
+        WasmOp::Drop,
+        WasmOp::I64Const(0x0101_0101_0101_0101),
+        WasmOp::LocalGet(2),
+        WasmOp::I64ExtendI32U,
+        WasmOp::I64Shl,
+        WasmOp::Drop,
+    ];
+    let arm = compile_optimized(&wasm, 4);
+    assert!(
+        arm.iter().any(|o| matches!(o, ArmOp::I64Shl { .. })),
+        "expected an I64Shl in the output: {:#?}",
+        arm
+    );
+    assert!(
+        !shift_clobbers_param_reg(&arm),
+        "I64Shl's rm_lo/rm_hi aliases an AAPCS param register: {:#?}",
+        arm
+    );
+}
+
+#[test]
+fn issue_93_optimized_i64_shr_s_does_not_use_r0_as_shift_count() {
+    // Same scenario for the arithmetic right shift.
+    let wasm = vec![
+        WasmOp::LocalGet(0),
+        WasmOp::LocalGet(1),
+        WasmOp::LocalGet(2),
+        WasmOp::LocalGet(3),
+        WasmOp::Drop,
+        WasmOp::Drop,
+        WasmOp::Drop,
+        WasmOp::Drop,
+        WasmOp::I64Const(-1),
+        WasmOp::LocalGet(3),
+        WasmOp::I64ExtendI32S,
+        WasmOp::I64ShrS,
+        WasmOp::Drop,
+    ];
+    let arm = compile_optimized(&wasm, 4);
+    assert!(
+        arm.iter().any(|o| matches!(o, ArmOp::I64ShrS { .. })),
+        "expected an I64ShrS in the output: {:#?}",
+        arm
+    );
+    assert!(
+        !shift_clobbers_param_reg(&arm),
+        "I64ShrS's rm_lo/rm_hi aliases an AAPCS param register: {:#?}",
+        arm
+    );
+}


### PR DESCRIPTION
Closes #93.

## Diagnosis

The default `synth compile --target cortex-m4f` (optimized) path in
`crates/synth-synthesis/src/optimizer_bridge.rs` had no handler for
`WasmOp::I64ExtendI32U` / `WasmOp::I64ExtendI32S` / `WasmOp::I32WrapI64`.
They fell through the catch-all `_ => Opcode::Nop` arm in `wasm_to_ir`,
advancing `inst_id` by 1 but never registering the produced i64-pair
vregs in `vreg_to_arm`.

When a downstream `Opcode::I64ShrU` / `I64Shl` / `I64ShrS` looked up its
shift-count vreg via `get_arm_reg`, the lookup missed the map and silently
fell back to `Reg::R0` (`optimizer_bridge.rs:1333`):

```rust
let get_arm_reg = |vreg, map, spills| -> Reg {
    if let Some(&r) = map.get(&vreg.0) { r }
    else if spills.contains_key(&vreg.0) { Reg::R12 }
    else { Reg::R0 }   // <-- silent R0 fallback
};
```

The ARM emitter for the variable 64-bit shift (`crates/synth-backend/src/arm_encoder.rs:2856` for `I64Shl`, `:2938` for `I64ShrU`, `:3019` for `I64ShrS`) writes to both `rm_lo` and `rm_hi` as scratch:

```
AND.W   rm_lo, rm_lo, #63
SUBS.W  rm_hi, rm_lo, #32   ;; bug surface: rm_hi clobbered
BPL     .large
RSB.W   rm_hi, rm_lo, #32
LSL.W   rm_hi, rn_hi, rm_hi
...
```

So any wasm function doing `i64.shr_u` of an `i64.extend_i32_u`-ed shift
count clobbered AAPCS first-param register R0 inside the shift
expansion. For `compiler_builtins::memset`, R0 is the destination
pointer, so the byte loop's pointer was destroyed every iteration →
non-terminating loop on STM32G474RE silicon at `memset+0x4c` (PC
bouncing between `0x...c668` and `0x...c67e`).

## Repro WAT (minimal)

```wasm
(module
  (func (param i32) (param i32) (param i32) (param i32) (result i64)
    i64.const 0x0101010101010101         ;; the i64 fill word
    local.get 1                          ;; 32-bit count, lives in R1 (param 1)
    i64.extend_i32_u                     ;; -> i64 shift amount
    i64.shr_u                            ;; emits I64ShrU{rm_lo=Rx, rm_hi=R0!}
  )
)
```

The `WasmOp` sequence used by the regression test is the same shape; see `crates/synth-synthesis/tests/issue_93_memset_i64_codegen.rs::repro_wasm_ops`. Pre-fix, the optimized path emits:

```
I64ShrU { rd_lo: R6, rd_hi: R7, rn_lo: R5, rn_hi: R2, rm_lo: R3, rm_hi: R0 }
```

`rm_hi: R0` is the smoking gun — that's the first AAPCS param, and the encoder writes to it inside the shift expansion. Post-fix, the same sequence allocates a callee-saved pair (R4..R11) for the shift count, leaving R0..R3 untouched.

## Fix scope

Three additions, all narrow:

1. **`crates/synth-opt/src/lib.rs`** — adds three `Opcode` variants:
   `I64ExtendI32U`, `I64ExtendI32S`, `I32WrapI64`. All optimization
   passes have `_ => {}` wildcards, so existing passes are unaffected.

2. **`crates/synth-synthesis/src/optimizer_bridge.rs`**:
   - `wasm_to_ir`: handlers for the three new ops, with slot accounting
     that keeps `inst_id.saturating_sub(K)` arithmetic correct for
     downstream i64 ops (extend reuses the consumed i32 slot for
     `dest_lo`; wrap reuses the i64-lo slot and decrements `inst_id`
     so the natural +1 cancels with the -1 net slot delta).
   - `ir_to_arm`: lowerings that allocate a callee-saved consecutive
     pair via `alloc_i64_pair` and `Mov` the i32 source into the new
     `dest_lo` — even when the source is already in a non-param
     register — so the downstream shift's clobbered `rm_lo`/`rm_hi`
     can never be a live AAPCS param.
   - `analyze_i64_local_gets`: skips the i32 producer that feeds an
     `I64ExtendI32U` / `I64ExtendI32S`, otherwise the analyzer would
     mistakenly mark that `LocalGet` as i64 and double-load the local.

3. **`crates/synth-synthesis/tests/issue_93_memset_i64_codegen.rs`** —
   5 new regression tests:
   - `issue_93_no_optimize_path_handles_repro` — sanity check that
     `select_with_stack` is and was always correct for this input.
   - `issue_93_optimized_i64_shr_u_does_not_use_r0_as_shift_count` —
     the headline regression. Asserts the optimized path's `I64ShrU`
     emission has `rm_lo`/`rm_hi` outside R0..R3.
   - `issue_93_optimized_i64_shr_u_value_and_count_are_distinct` — no
     value/count register aliasing.
   - `issue_93_optimized_i64_shl_does_not_use_r0_as_shift_count` —
     same for `I64Shl` (uses `local.get 2` to also exercise R2 path).
   - `issue_93_optimized_i64_shr_s_does_not_use_r0_as_shift_count` —
     same for `I64ShrS` (sign-extend variant).

   Pre-fix: 3/5 fail (one per shift variant). Post-fix: 5/5 pass.

## Verification

- `cargo test --workspace` — all green (1095 tests, +5 from this PR)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## v0.2.1 patch candidate

This is silicon-blocking for any merged-wasm bench integration that
links `compiler_builtins`. The patch is intentionally narrow (no
refactor, no broader regalloc rework) and targeted at the v0.2.1 patch
release line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)