### PR TITLE
fix(opt): defensive panic on unmapped vreg instead of silent R0 fallback

### DIFF
--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -1600,12 +1600,12 @@ impl OptimizerBridge {
         // as their `rm_lo`/`rm_hi`, destroying the loop counter on real silicon.
         // A loud panic here is strictly better than a quiet miscompilation —
         // crash the compiler, not the firmware.
-        // Note: the silent R0 fallback is intentionally preserved here. PR #101
-        // holds the defensive panic version of this helper; it will land once
-        // every wasm_to_ir gap is closed. The previously-known `v13` case
-        // during `fib` compilation was fixed in this PR by adding a `Call`
-        // opcode and handler — see `Opcode::Call` below and `WasmOp::Call` in
-        // `wasm_to_ir`.
+        // History: PR #108 (47-site AAPCS audit) deferred this panic, leaving a
+        // silent R0 fallback while one last v13 case in fib compilation was
+        // tracked down. PR #109 fixed that case (WasmOp::Call had no wasm_to_ir
+        // handler, falling through to Opcode::Nop). With #109 stacked under
+        // this PR, every known wasm_to_ir gap is closed and this panic is safe
+        // to ship as a permanent guard against the class.
         let get_arm_reg =
             |vreg: &OptReg, map: &HashMap<u32, Reg>, spills: &HashMap<u32, i32>| -> Reg {
                 if let Some(&r) = map.get(&vreg.0) {
@@ -1614,7 +1614,12 @@ impl OptimizerBridge {
                     // Will be reloaded into R12 by reload_spill
                     Reg::R12
                 } else {
-                    Reg::R0
+                    panic!(
+                        "synth internal compiler error: vreg v{} has no assigned \
+                         ARM register and no spill slot. This is a wasm_to_ir bug — \
+                         likely a wasm op whose result is unmapped (see issue #93).",
+                        vreg.0
+                    );
                 }
             };
 


### PR DESCRIPTION
Follow-up to PR #97 (which fixed the silicon-blocking #93 memset bug).

The root cause of #93 was that `optimizer_bridge::wasm_to_ir` silently dropped three wasm ops (I64ExtendI32U/S, I32WrapI64). The downstream lookup helper `get_arm_reg` returned `Reg::R0` as a silent fallback when a vreg had no assignment — so subsequent i64 shifts read R0 as their `rm_lo`/`rm_hi`, destroying memset's destination pointer.

This PR replaces the silent fallback with a diagnostic panic naming the offending vreg. Any future "wasm op silently dropped" bugs of this class will surface as a compiler crash with a useful error message, instead of producing miscompiled firmware that boots-and-loops on real silicon.

A compiler crash is strictly better than a hung MCU.

## Test plan

- [x] `cargo test --workspace` — all pass (the post-#97 codebase produces mappings for every wasm op it emits IR for, so no test legitimately hits the fallback path)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)