### PR TITLE
fix(ci): move Test + Clippy back to ubuntu-latest (unblocks all open PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,13 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: [self-hosted, linux, x64, rust-cpu]
+    # NOTE: moved back to ubuntu-latest from [self-hosted, linux, x64, rust-cpu]
+    # because z3-sys's C++ build was exhausting the smithy runners' temp disk
+    # ("No space left on device" while compiling z3 AST sources). The Test job
+    # builds the entire workspace including synth-verify (which depends on z3),
+    # so the disk pressure is real. Once the smithy runners get a bigger /tmp
+    # we can move this back.
+    runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -Dwarnings
     steps:
@@ -33,7 +39,8 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: [self-hosted, linux, x64, rust-cpu]
+    # Same reasoning as Test — z3-sys build exhausts the smithy runner's /tmp.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Every open PR opened after #91 landed has been failing Test + Clippy with `fatal error: No space left on device` during z3-sys's C++ build. Both jobs build the entire workspace including synth-verify (which depends on z3), and the smithy rust-cpu runners' /tmp can't hold the z3 AST source's intermediate .s files.

This reverts just those two jobs back to ubuntu-latest. The other smithy migrations (Z3 Verification, Code Coverage, Rivet Validation, Format) don't build z3 in the same way and stay on smithy.

This unblocks #97 (silicon-blocking memset fix), #96, #99, #100, #101 — all currently failing on the same disk-full error.

Once the smithy runner image gets a bigger /tmp or libz3-dev preinstalled, we can move these back.