### PR TITLE
chore: backfill CHANGELOG sections for v0.1.1, v0.2.0, v0.2.1, v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,35 +7,107 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+(In flight: PR #113 validator-pattern prototype for issues #73/#76;
+PR for Phase 1 binary-safety implementation per docs/binary-safety-design.md;
+RISC-V cross-function calls + i64 lowering for parity with ARM.)
+
+## [0.3.0] - 2026-05-15
+
 ### Added
 
-#### RISC-V backend (new — Track B in the multi-target plan)
-- New `synth-backend-riscv` crate with RV32IMAC encoder, ELF builder
-  (EM_RISCV=0xF3), PMP allocator, instruction selector, bare-metal startup
-  generator, and linker script generator.
-- CLI integration: `--backend riscv`, `--target riscv32imac/rv32imac/rv32i/rv32gc/rv64imac/rv64gc`.
-- New `synth riscv-runtime` command emits `startup.c` + `linker.ld` for
-  cross-compilation with `riscv64-unknown-elf-gcc`.
-- Selector covers the i32 surface (arithmetic, logic, shifts, comparisons,
-  division with trap-on-zero), i32.load/store + sub-word load8/16 + store8/16,
-  and control flow (block, loop, if/else, br, br_if). Locals for params 0..7.
-- ~30 wasm ops; encoder cross-validated against canonical RV32 hex encodings.
-  98 RISC-V backend tests passing.
-- Renode RV32IMAC platform (`tests/renode/synth_riscv.repl`).
-- Offline smoke tests + calculator end-to-end demo.
+#### Optimizations
+- **`(i32.const C)(i32.load offset=O)`** folds to a single 4-byte
+  `LDR rd, [base, #(C+O)]` when `C+O ≤ 4095`. Drops from ≥10 bytes
+  (MOVW+MOVT+LDR triplet). Applies to load/store + sub-word variants. (#96)
+- **u64-packed FFI return extraction**: `(i64.shr_u 32; i32.wrap_i64)`
+  and friends lower to a direct hi/lo register rename. **83% size
+  reduction** on the canonical pattern (48 bytes → 8 bytes). (#98)
 
-#### Cortex-M7 hardening
-- `HardwareCapabilities::imxrt1062()` — Cortex-M7 single-precision FPU,
-  16 MPU regions, 8 MB QSPI flash, 1 MB OCRAM.
-- `HardwareCapabilities::stm32h743()` — Cortex-M7 double-precision FPU,
-  16 MPU regions, 2 MB Flash, 1 MB RAM.
-- CLI `--hardware {imxrt1062,stm32h743}` and target-info wired up.
-- Renode `synth_cortex_m7.repl` profile + `cortex_m7_test.robot`.
-- MPU allocator tests proving 16-region operation on M7-class parts.
+#### Test + verification infrastructure
+- 59 new semantic-correctness tests covering every i64 wasm op. Closes
+  the gap that allowed #93 to ship. (#99)
+- 37 tests of coverage uplift for the v0.1.1 diff. (#92)
+- 4 cargo-fuzz harnesses + CI smoke gate (#100):
+  - `wasm_ops_lower_or_error` (gating) — arbitrary `Vec<WasmOp>` through
+    both lowering paths, asserts no panic / no unencodable instruction
+  - `wasm_to_ir_roundtrip_op_coverage` (gating) — value-producing ops
+    must emit live IR (catches the #93-class silent-drop bug)
+  - `i64_lowering_doesnt_clobber_params` (exploration) — random
+    i64/i32-param mixes, asserts AAPCS preservation
+  - `encoder_no_panic` (exploration) — random ArmOp values, encoder
+    panic-freedom
+- Spectre/csdb policy doc + aarch64 CVE audit (CVE-2026-34971 /
+  CVE-2026-34944) + arXiv 2604.17391 citation. (#105)
+- 842-line binary-safety design covering MPU/PMP/CFI/PAC/BTI/MSPLIM with
+  per-target applicability matrix and 5-phase roadmap. (#110)
 
 ### Fixed
 
-#### AAPCS regalloc bugs (real-hardware-found)
+#### AAPCS bug class — systematic closure
+- 24 i64 ops (Eq/Ne/Lt/Le/Gt/Ge × Signed/Unsigned, Mul/Div/Rem,
+  Rotl/Rotr, Clz/Ctz/Popcnt, Extend8/16/32 Signed, I32WrapI64)
+  re-routed through `alloc_consecutive_pair`. (#106, #103)
+- CSE missing arms for `MemLoad`/`MemStore`/`Extend` consumers added —
+  fixes silent miscompile when CSE killed a duplicate load. (#107, #104)
+- **Systematic audit**: 47 hardcoded R0..R3 sites swept, 6 new `Opcode`
+  variants, 27 regression tests. (#108)
+- `WasmOp::Call` had no `wasm_to_ir` handler — fell through to `Nop`,
+  causing recursive `fib` to silently miscompile. (#109)
+- **Defensive panic** on unmapped vreg replaces the silent `R0` fallback.
+  Future wasm_to_ir gaps now crash the compiler with a diagnostic instead
+  of producing miscompiled firmware. (#101)
+- `I32WrapI64` no longer preassigns R0 — defers to function-return
+  epilogue. (#111)
+
+### CI / infrastructure
+- Test + Clippy moved back to ubuntu-latest (smithy runners couldn't
+  hold the z3-sys C++ build's intermediate files). (#102)
+- Fuzz workflow split into gating (2 harnesses) + exploration (2 harnesses,
+  `continue-on-error: true`). Promotion criterion documented.
+
+## [0.2.1] - 2026-05-10
+
+### Fixed
+- **Silicon-blocking memset i64-codegen non-terminating loop** on
+  Cortex-M. `optimizer_bridge::wasm_to_ir` had no handler for
+  `I64ExtendI32U` / `I64ExtendI32S` / `I32WrapI64` — their result vregs
+  were never mapped to ARM registers, and `get_arm_reg`'s silent R0
+  fallback caused subsequent i64 shifts to read R0 as `rm_lo`/`rm_hi`,
+  destroying memset's destination pointer. Discovered on real
+  STM32G474RE silicon at `memset+0x4c` during Zephyr's `z_bss_zero`.
+  Synth-emitted memset was 454 bytes vs picolibc's ~80 and looped
+  forever. (#93 / #97)
+
+## [0.2.0] - 2026-05-10
+
+### Added — RISC-V RV32IMAC GA
+
+- New `synth-backend-riscv` crate: RV32IMAC encoder, ELF builder
+  (EM_RISCV=0xF3), PMP allocator, instruction selector, bare-metal
+  startup + linker script generators.
+- CLI: `--backend riscv`, `--target riscv32imac/rv32imac/rv32i/rv32gc/rv64imac/rv64gc`.
+- New `synth riscv-runtime` command emits `startup.c` + `linker.ld` for
+  cross-compilation with `riscv64-unknown-elf-gcc`.
+- Selector covers the i32 surface (arithmetic, logic, shifts,
+  comparisons, division with trap-on-zero), `i32.load/store` +
+  sub-word load8/16 + store8/16, and control flow (block, loop,
+  if/else, br, br_if). Locals for params 0..7.
+- 98 RISC-V backend tests passing; encoder cross-validated against
+  canonical RV32 hex encodings.
+- Renode RV32IMAC platform (`tests/renode/synth_riscv.repl`) wired into
+  Bazel CI.
+- Offline integration smoke + end-to-end calculator demo.
+
+### Known gaps (deferred to v0.3.x)
+- i64 lowering for RV32 (register pairs)
+- RV32F/D floating point
+- br_table jump-table emission
+- Cross-function calls + relocations
+- RISC-V Rocq proofs
+
+## [0.1.1] - 2026-05-10
+
+### Fixed — AAPCS regalloc bugs (real-hardware-found via gale silicon tests)
 - **Optimized path** — `optimizer_bridge::ir_to_arm` no longer hardcodes
   i64 ops to R0:R1 / R2:R3. New `alloc_i64_pair` picks free callee-saved
   pairs (R4..R11) skipping live param registers. Fixes silent corruption
@@ -45,11 +117,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upper half doesn't get dropped. Fixes corruption of the callee-saved
   spill area when a function has any non-param local.
 
-#### CLI
-- `--relocatable` flag — forces ET_REL output even when the wasm has no
-  imports, for linking into a host build system (e.g. Zephyr).
+### Added
+- `HardwareCapabilities::imxrt1062()` — Cortex-M7 single-precision FPU,
+  16 MPU regions, 8 MB QSPI flash, 1 MB OCRAM.
+- `HardwareCapabilities::stm32h743()` — Cortex-M7 double-precision FPU,
+  16 MPU regions, 2 MB Flash, 1 MB RAM.
+- CLI `--hardware {imxrt1062,stm32h743}` and target-info wired up.
+- Renode `synth_cortex_m7.repl` profile + `cortex_m7_test.robot`.
+- MPU allocator tests proving 16-region operation on M7-class parts.
+- CLI `--relocatable` flag — forces ET_REL output even when the wasm
+  has no imports, for linking into a host build system (e.g. Zephyr).
 
-#### Toolchain hygiene
+### Toolchain hygiene
 - 8 clippy errors fixed (Rust 1.95 lint refresh): `unnecessary_sort_by`,
   `collapsible_match`, `collapsible_if`, `manual_checked_division`.
 


### PR DESCRIPTION
Hygiene fix only. The CHANGELOG had a single sprawling `[Unreleased]` block that mixed content shipped across **four** releases (v0.1.1 / v0.2.0 / v0.2.1 / v0.3.0). Split into per-version sections matching the actual `git tag` history.

`[Unreleased]` is now empty and ready for v0.3.1 entries (mentions in-flight PRs #113 + Phase 1 safety as context).

No semantic changes; existing `[0.1.0]` block preserved as-is. +107 -28 lines.