### PR TITLE
fix(fuzz): carve out return-value-placement dead stores — closes #112

### DIFF
--- a/fuzz/fuzz_targets/i64_lowering_doesnt_clobber_params.rs
+++ b/fuzz/fuzz_targets/i64_lowering_doesnt_clobber_params.rs
@@ -109,7 +109,7 @@ fuzz_target!(|input: FuzzInput| {
             3 => Reg::R3,
             _ => continue,
         };
-        for instr in &arm_instrs {
+        for (instr_idx, instr) in arm_instrs.iter().enumerate() {
             // The function prologue (Push, Sub from SP) has source_line None.
             // We only care about instructions that flow from user-level wasm ops.
             let line = match instr.source_line {
@@ -128,6 +128,34 @@ fuzz_target!(|input: FuzzInput| {
             if let Some(WasmOp::LocalSet(p_op)) | Some(WasmOp::LocalTee(p_op)) =
                 wasm_ops.get(line)
                 && *p_op as usize == p
+            {
+                continue;
+            }
+            // Skip return-value-placement dead stores: when the very next ARM
+            // op also writes R{p}, the current write's value is dead and
+            // overwritten before any observer can read it. This pattern
+            // appears in the function-final return-value sequence where the
+            // selector emits e.g. `Movw R0, 0` followed by `Mov R0, R8` to
+            // place an i32 return value (the Movw is a redundant zero-init
+            // that the second Mov immediately overwrites). The lowering is
+            // suboptimal — see issue #112 option (a) for a peephole fix —
+            // but the param IS already preserved at this point (the LocalGet
+            // we're protecting reads from R{p} earlier in the function), so
+            // this is not a real AAPCS clobber.
+            //
+            // Soundness note: this carve-out is safe because:
+            //  1. The next-op-overwrites-same-reg condition is *local* — we
+            //     don't carve out arbitrary writes, only ones whose result is
+            //     provably dead at the next instruction.
+            //  2. If a real bug were to emit `Movw R0, _; Mov R0, R8` in the
+            //     middle of computation (not return-value placement), the
+            //     param's value is already gone anyway — both writes overwrite
+            //     it. The carve-out doesn't *hide* a clobber, it just suppresses
+            //     a duplicate report. The single Mov R0, R8 still gets flagged
+            //     if it precedes any LocalGet(0) — except its own next op is
+            //     usually Pop, which doesn't write R0.
+            if let Some(next) = arm_instrs.get(instr_idx + 1)
+                && writes(&next.op).contains(&param_reg)
             {
                 continue;
             }


### PR DESCRIPTION
## Summary

Closes #112 — the exploration fuzz harness \`i64_lowering_doesnt_clobber_params\` was false-positiving on the \`Movw R0, 0; Mov R0, R8\` return-value-placement pair. The Movw zeros R0 and is then immediately overwritten by the Mov — a redundant dead store, not a real AAPCS clobber. The param IS already preserved at that point in the function.

This is the **option (b) harness-side fix** per the issue's investigation comment, deliberately cheaper than the underlying codegen peephole (option a, deferred to a future codegen-quality PR).

## Carve-out

For each ARM instruction in the param-protection window, check the *immediately-following* instruction: if it also writes the same param reg, the current write is provably dead and gets skipped. Indexed iteration via \`arm_instrs.get(instr_idx + 1)\` keeps the lookup O(1) and side-steps the prior \`std::ptr::eq\` hack-shape.

## Soundness

The carve-out is local — it only suppresses writes whose result is provably dead at the next instruction. A real mid-computation clobber would either:
- have a non-overwriting next-op → still flagged.
- be part of a chain where the *final* write overwrites R{p} → still flagged on the final write (its next op is typically Pop, which doesn't write the param reg).

So the carve-out does not hide real AAPCS clobbers; it only suppresses the duplicate report on the first write of a write-then-overwrite pair.

## What this enables

Once green for a couple of fuzz-smoke cycles, this harness can be promoted from \`gating: false\` to \`gating: true\` in \`.github/workflows/fuzz-smoke.yml\` — tracked as a follow-up.

## Test plan

- [ ] CI green
- [ ] Fuzz-smoke \`i64_lowering_doesnt_clobber_params\` no longer reports on the \`Movw R0, 0; Mov R0, _\` pattern
- [ ] No regression in the LocalSet/LocalTee carve-out path (existing logic preserved verbatim)

Refs: #112 (will be auto-closed by this PR's merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)