### PR TITLE
fix(cli): synth verify exits non-zero when built without verify feature

### DIFF
--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -187,7 +187,8 @@ enum Commands {
     /// List available compilation backends and their status
     Backends,
 
-    /// Verify compilation correctness via Z3 (e.g., synth verify input.wat output.elf)
+    /// Verify compilation correctness via Z3 — requires a build with
+    /// `--features verify` (e.g., synth verify input.wat output.elf)
     Verify {
         /// Input WASM or WAT file (source)
         #[arg(value_name = "WASM")]
@@ -2236,8 +2237,19 @@ fn verify_command(wasm_input: PathBuf, elf_input: PathBuf, backend_name: &str) -
 
         #[cfg(not(feature = "verify"))]
         {
-            println!("\n  Rebuild with verification support:");
-            println!("    cargo build --features verify");
+            // This binary was built without the `verify` feature, so no Z3
+            // translation validation can run. Returning Ok here would make
+            // `synth verify` exit success-shaped while doing nothing — a
+            // script or CI step gating on `synth verify` would silently
+            // believe the binary was validated (issue #124). Fail loudly
+            // with a non-zero exit instead.
+            anyhow::bail!(
+                "this `synth` binary was built without the `verify` feature — \
+                 Z3 translation validation is unavailable.\n  \
+                 Rebuild with verification support:\n    \
+                 cargo build --features verify\n  \
+                 (or `cargo install --path crates/synth-cli --features verify`)"
+            );
         }
     } else if caps.supports_binary_verification {
         println!("  Strategy: Binary-level translation validation (ASIL B path)");


### PR DESCRIPTION
## Summary

Closes #124. `synth verify` is advertised in `synth --help` and the usage examples, but on a binary built without the `verify` feature it printed a "rebuild" hint and returned `Ok(())` — **exit code 0**. A script or CI step gating on `synth verify` would silently believe the binary was validated when nothing ran.

`synth verify` is the Z3 translation-validation oracle — the "did the ARM lowering preserve WASM semantics" check, load-bearing on the ASIL-D path. A success-shaped no-op defeats it.

## Fix

The `#[cfg(not(feature = "verify"))]` branch now `anyhow::bail!`s with a clear message and a **non-zero exit**:

```
Error: this `synth` binary was built without the `verify` feature — Z3 translation
validation is unavailable.
  Rebuild with verification support:
    cargo build --features verify
  (or `cargo install --path crates/synth-cli --features verify`)
```

Also marks the `Verify` subcommand's help text as requiring `--features verify`.

## What's deliberately NOT changed

`verify` stays a **non-default** feature. Making it default would pull `z3-sys` into every `cargo install` — z3-sys needs network at build time, which is exactly why it's opt-in. The fix is to fail honestly, not to force the dependency on everyone.

## Test plan

- [ ] `cargo install --path crates/synth-cli` (no verify) → `synth verify a.wasm b.elf` exits non-zero with the clear message.
- [ ] `cargo install --path crates/synth-cli --features verify` → `synth verify` runs Z3 validation as before.
- [ ] `synth --help` shows the `--features verify` requirement on the Verify subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)