### PR TITLE
fix(release): cargo-cyclonedx uses --manifest-path, not cargo's -p

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,14 @@ jobs:
           set -euo pipefail
           VERSION="${INPUT_TAG:-${GITHUB_REF#refs/tags/}}"
           BARE="${VERSION#v}"
-          cargo cyclonedx --format json --spec-version 1.5 -p synth-cli
+          # cargo-cyclonedx doesn't proxy cargo's `-p` package-selection flag
+          # (caught the hard way on the first v0.6.0 release attempt). Use
+          # `--manifest-path` to target synth-cli's Cargo.toml directly; the
+          # generated SBOM lands next to that Cargo.toml.
+          cargo cyclonedx \
+            --manifest-path crates/synth-cli/Cargo.toml \
+            --format json \
+            --spec-version 1.5
           SBOM_SRC="crates/synth-cli/synth-cli.cdx.json"
           if [ ! -f "$SBOM_SRC" ]; then
             SBOM_SRC=$(find crates/synth-cli -maxdepth 2 -name '*.cdx.json' | head -1)


### PR DESCRIPTION
## Summary

v0.6.0's release pipeline failed at the toolchain-SBOM step:

```
error: unexpected argument '-p' found
```

`cargo-cyclonedx` is a cargo subcommand but does **not** proxy cargo's package-selection flag. The correct way to target a single workspace crate is `--manifest-path crates/synth-cli/Cargo.toml`. Patch swaps `-p synth-cli` for that.

All 4 binary builds (v0.6.0 run 26366062176) succeeded; only `Create GitHub Release` failed at this step, so no v0.6.0 GitHub Release was created (only the git tag exists). Plan: merge this → delete + re-push the v0.6.0 tag against the fixed commit → release pipeline runs cleanly.

The PR #136 agent's command was a reasonable assumption (cargo subcommands often proxy `-p`); the clean-room verification confirmed the workflow file matched the agent's claim but didn't run the command. Real validation only happened at release time — which is the gating-fuzz-class pattern, just at release granularity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)