### PR TITLE
chore(release): v0.7.0 — f64 codegen + signing-e2e in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-25
+
+Floating-point breadth + verifiable signing CI — synth now compiles
+WASM modules with double-precision FP on Cortex-M7DP targets (i.MX RT1062
+class), and the sigil keyless-signing path is now exercised end-to-end
+in CI against a sha256-pinned wsc v0.9.0. PRs #140 (Phase 5 e2e),
+#141 (f64 codegen).
+
+**Falsification statement.** v0.7.0 would be wrong if (a) a WASM module
+using only the f64 ops listed below produces an ELF that fails to link,
+returns a synthesis error on a Cortex-M7DP target, or computes a result
+that disagrees with the WASM reference on a covered op; or (b) the new
+`signing-e2e.yml` workflow goes red on a clean `v0.7.0` checkout (cases
+1 and 2 must remain hard checks; case 3 is xfail against
+[sigil#135](https://github.com/pulseengine/sigil/issues/135)).
+
 ### Added
 
 #### f64 codegen — ARM VFP-D end-to-end

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]


### PR DESCRIPTION
## Summary
- Bumps workspace version to **0.7.0**
- Promotes `[Unreleased]` entries to `[0.7.0] - 2026-05-25`
- Adds the v0.7.0 falsification statement to the release notes

## Theme
**Floating-point breadth + verifiable signing CI.**

- **#141** — f64 codegen end-to-end on Cortex-M7DP via VFP-D. 30 f64 ops covered (arithmetic, comparison, unary/binary math, constants, memory, i32↔f64 + bitcasts). 24 new byte-level encoder tests cross-checked against the ARMv7-M ARM. Targets without double-precision FPU fail cleanly with a typed error naming the missing capability.
- **#140** — `signing-e2e.yml` workflow runs three wsc keyless cases against a sha256-pinned wsc v0.9.0 on every CI. Case 3 (tamper-negative) was demoted to xfail in `7f1a9c9` after discovering [sigil#135](https://github.com/pulseengine/sigil/issues/135) — `wsc verify --keyless` accepts WASM modules whose signed payload has been byte-modified. Cases 1 + 2 remain hard checks.

## Falsification statement
v0.7.0 is wrong if any of:
- A WASM module using only the f64 ops listed in `CHANGELOG.md#0.7.0` produces an ELF that fails to link
- A covered f64 op surfaces a synthesis error on a Cortex-M7DP target (`i.MX RT1062` or `STM32H743` class)
- A covered f64 op computes a result that disagrees with the WASM reference
- `signing-e2e.yml` goes red on a clean `v0.7.0` checkout (cases 1 + 2 — case 3 is xfail until sigil#135 ships)

## Test plan
- [ ] CI green on this PR
- [ ] After merge: tag `v0.7.0`, watch release.yml ship the 10-asset GitHub Release (9 from #136 + the toolchain SBOM)
- [ ] After merge: `publish-to-crates-io.yml` republishes the workspace at 0.7.0 via `CARGO_REGISTRY_TOKEN`