### PR TITLE
fix(release): sweep intra-workspace path-dep pins 0.6.0 → 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1998,14 +1998,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2013,11 +2013,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "tempfile"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.6.0",
+    version = "0.7.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.6.0" }
+synth-core = { path = "../synth-core", version = "0.7.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.6.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.6.0" }
+synth-core = { path = "../synth-core", version = "0.7.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.7.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.6.0" }
+synth-core = { path = "../synth-core", version = "0.7.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.6.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.6.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.7.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.7.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.6.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.6.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.6.0" }
-synth-backend = { path = "../synth-backend", version = "0.6.0" }
+synth-core = { path = "../synth-core", version = "0.7.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.7.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.7.0" }
+synth-backend = { path = "../synth-backend", version = "0.7.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.6.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.6.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.6.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.7.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.7.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.7.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.6.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.7.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.6.0" }
+synth-core = { path = "../synth-core", version = "0.7.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.6.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.7.0" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.6.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.6.0" }
-synth-opt = { path = "../synth-opt", version = "0.6.0" }
+synth-core = { path = "../synth-core", version = "0.7.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.7.0" }
+synth-opt = { path = "../synth-opt", version = "0.7.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.6.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.6.0" }
-synth-opt = { path = "../synth-opt", version = "0.6.0" }
+synth-core = { path = "../synth-core", version = "0.7.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.7.0" }
+synth-opt = { path = "../synth-opt", version = "0.7.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.6.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.7.0", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Summary
- Sweeps 23 intra-workspace `version = "0.6.0"` pins → `"0.7.0"` across 8 crate manifests
- Bumps MODULE.bazel `module(version = ...)` to 0.7.0
- Unblocks release.yml + publish-to-crates-io.yml on the (next) v0.7.0 tag

## Root cause
PR #142 bumped the `[workspace.package] version` to 0.7.0 but did not sweep the per-crate path-dep pins introduced in #136 (e.g. `synth-cli/Cargo.toml`: `synth-backend = { path = "../synth-backend", version = "0.6.0" }`). With workspace at 0.7.0 and pins requesting `^0.6.0`, cargo refuses to resolve — every release-y workflow on the v0.7.0 tag died at the very first `cargo build` / `cargo publish --dry-run`. The original v0.7.0 tag was deleted from origin (no GitHub Release was created; `Create GitHub Release` was skipped after the build matrix failed) and will be re-pushed against this commit's merge once green.

## Local validation
- `cargo metadata --no-deps --format-version 1` resolves cleanly at 0.7.0
- `cargo build --release -p synth-cli` green in 53s

## Follow-up
Tracked as a docs/CI gap: `docs/release-process.md` (or `scripts/publish.rs`) should gain an explicit "sweep intra-workspace pins" step — ideally a CI gate that fails when workspace version diverges from any path-dep `version =` pin. Will file an issue separately so v0.8.0 doesn't repeat the trap.

## Test plan
- [ ] Workspace CI green on this PR
- [ ] After merge: re-tag v0.7.0 against the merge commit
- [ ] release.yml + publish-to-crates-io.yml both green on the re-tagged push