### PR TITLE
fix(release): drop chicken-and-egg verify step from publish-to-crates-io.yml

### DIFF
--- a/.github/workflows/publish-to-crates-io.yml
+++ b/.github/workflows/publish-to-crates-io.yml
@@ -82,11 +82,17 @@ jobs:
       - name: Build publish helper
         run: rustc --edition 2024 scripts/publish.rs -o publish
 
-      - name: Verify all crates can publish
-        run: ./publish verify
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-
+      # NOTE: the historical `./publish verify` step was removed in v0.7.0
+      # because `cargo publish --dry-run -p <name>` resolves dependencies
+      # through the public crates.io index — so dependent workspace crates
+      # always fail until their synth-* deps are already on the registry
+      # at the new version (chicken-and-egg for any first publish of a new
+      # version). The actual `cargo publish` performs the same metadata
+      # validation before upload, and `./publish publish` has a 10-attempt
+      # retry loop with a 40s sleep that rides out registry index
+      # propagation. The verify step is recoverable as `cargo package`
+      # (which uses path deps) if a fail-fast metadata check is needed —
+      # tracked as a follow-up.
       - name: Publish workspace to crates.io
         run: ./publish publish
         env:


### PR DESCRIPTION
## Summary
- Removes the `./publish verify` step from `.github/workflows/publish-to-crates-io.yml`
- Unblocks crates.io publishing on `v0.7.0` (and every future version's first publish)
- No replacement step needed: `./publish publish`'s 10-attempt retry loop + `cargo publish`'s own metadata validation cover the same ground correctly

## Root cause
`cargo publish --dry-run -p <name>` resolves dependencies through the **public crates.io index**, not the local workspace. For a first publish of v0.7.0 of an internally-coupled workspace, the dependents (synth-opt, synth-frontend, synth-synthesis, …) fail dry-run because synth-cfg / synth-core / etc. aren't on the registry at 0.7.0 yet. This is inherent to cargo's dry-run semantics, not a script bug per se — but it makes a pre-flight `verify` step structurally impossible for new-version publishes.

## Evidence
The first run of publish-to-crates-io.yml on the (re-tagged) v0.7.0 commit `70f5fd2` failed in the verify step with:
```
error: failed to select a version for the requirement `synth-cfg = "^0.7.0"`
FAIL: synth-opt dry-run failed: exit status: 101
```
([run 26384884309](https://github.com/pulseengine/synth/actions/runs/26384884309))

## What the publish step does that verify doesn't
- `cargo publish` (without `--dry-run`) runs the same metadata + packaging checks before upload, so we don't lose validation.
- `./publish publish` has a curated dependency order + per-attempt retry, sleeping 40s between attempts to ride out crates.io index propagation as each leaf publishes.

## Recovery
After merge: re-run publish-to-crates-io.yml via `gh workflow run publish-to-crates-io.yml -f tag=v0.7.0` to actually publish the workspace.

## Follow-up
If a fail-fast metadata pre-flight is wanted later, `./publish verify` could be changed to use `cargo package -p <name>` (path deps, no registry hit). Tracked as a separate issue.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: workflow_dispatch publish-to-crates-io.yml on v0.7.0 tag, watch all 11 crates publish in order