### PR TITLE
feat(coq): i64 comparison T1 lifts (v0.9.0 PR 4)

### DIFF
--- a/coq/Synth/Synth/CorrectnessI64Comparisons.v
+++ b/coq/Synth/Synth/CorrectnessI64Comparisons.v
@@ -1,13 +1,54 @@
 (** * Correctness Proofs for I64 Comparison Operations
 
-    This file contains correctness proofs for all i64 comparison operations.
-    I64 comparisons compile to CMP+MOV+conditional-MOV sequences
-    (same as i32 but operating on simplified 32-bit representation).
+    v0.8.0 (#149/#150) baseline: each i64 comparison op compiles to a single
+    high-level pseudo-op (`I64SetCond R0 R0 R1 R2 R3 <cond>` for binary cmps,
+    `I64SetCondZ R0 R0 R1` for `i64.eqz`). The pseudo-ops are introduced as
+    axiomatic result functions in `ArmSemantics.v` (`i64_setcond_bits`,
+    `i64_setcondz_bits`).
 
-    All proofs are closeable because:
-    1. CMP always returns Some (set_flags ...)
-    2. MOV always returns Some (set_reg ...)
-    3. Conditional MOV (MOVEQ/MOVNE/etc) always returns Some
+    v0.9.0 PR 1 (#153) precursor: the `i64_setcond_bits_spec` and
+    `i64_setcondz_bits_spec` axioms pin those result functions to the
+    WASM-spec form `if I64.<cmp> (combine_i32 lo hi) ... then I32.one else I32.zero`.
+
+    v0.9.0 PR 4 (this file): the 11 i64 comparison theorems are lifted from
+    T2 (existence-only) to T1 (result-correspondence) using:
+
+    - **I64-typed hypotheses**: operands are pinned via lo/hi halves living
+      in (R0:R1) and (R2:R3) for binops, and (R0:R1) for `i64.eqz`. The
+      combined 64-bit operand is `combine_i32 lo hi`.
+
+    - **Single-register post-condition**: WASM i64 comparisons return an
+      *i32 boolean* (0 or 1), so the postcondition pins only R0:
+        get_reg astate' R0 = if I64.<cmp> v1 v2 then I32.one else I32.zero
+      where `v1 := combine_i32 lo1 hi1`, `v2 := combine_i32 lo2 hi2`.
+
+    - **No `exec_wasm_instr` hypothesis**: per the precursor PR's pattern,
+      the vacuous `exec_wasm_instr I64Eq wstate = Some ...` hypothesis is
+      dropped (WasmSemantics.v does not model i64 comparisons, so that
+      hypothesis is False and the prior T2 theorems were vacuously true).
+
+    The proof of each theorem is mechanical:
+      1. `unfold compile_wasm_to_arm, exec_program, exec_instr; simpl`
+         exposes the `I64SetCond ...` pseudo-op step,
+      2. `rewrite HR0, HR1, HR2, HR3` substitutes register reads,
+      3. `rewrite i64_setcond_bits_spec; simpl` reduces the axiomatic result
+         function to the WASM-spec `if I64.<cmp> ... then I32.one else I32.zero`
+         form (the `simpl` reduces the inner `match cond` to the specific
+         comparison),
+      4. `eexists; split; [reflexivity | apply get_set_reg_eq]` closes both
+         halves of the existential.
+
+    Architectural finding: the i64 flag-correspondence lemmas added in #149
+    (`z_flag_sub_eq_i64`, `flags_ne_i64`, ..., `z_flag_sub_eqz_i64`) and the
+    `synth_cmp_binop_proof_i64` / `synth_cmp_unop_proof_i64` tactics are
+    **not used** by this PR. Those lemmas/tactics presupposed that i64 cmps
+    would lower to a CMP+MOV+conditional-MOV sequence (mirroring the i32 path),
+    in which case the proof would need to reflect ARM N/Z/C/V flags back into
+    WASM cmp semantics. Under the actual v0.8.0 codegen, i64 cmps lower to a
+    single `I64SetCond` pseudo-op whose semantic axiom already returns the
+    WASM-spec result directly, so no flag bridging is required. The lemmas
+    remain in `ArmFlagLemmas.v` for the i32 path (which still uses them) and
+    are available for any future direct dual-precision CMP/SBC modelling.
 *)
 
 From Stdlib Require Import ZArith.
@@ -16,6 +57,7 @@ From Stdlib Require Import QArith.
 Require Import Synth.Common.Base.
 Require Import Synth.Common.Integers.
 Require Import Synth.ARM.ArmState.
+Require Import Synth.ARM.ArmInstructions.
 Require Import Synth.ARM.ArmSemantics.
 Require Import Synth.WASM.WasmValues.
 Require Import Synth.WASM.WasmInstructions.
@@ -25,14 +67,8 @@ Require Import Synth.Synth.Compilation.
 Import ListNotations.
 Open Scope Z_scope.
 
-(** Helper tactic for CMP+MOV+conditional-MOV sequences *)
-Ltac solve_cmp_mov :=
-  intros; unfold compile_wasm_to_arm, exec_program, exec_instr; simpl;
-  repeat match goal with
-  | |- context [if ?b then _ else _] => destruct b
-  end;
-  eexists; reflexivity.
-
+(** Helper tactics retained from the v0.8.0 baseline for the bit-manipulation
+    and shift/rotate T2 proofs further down this file. *)
 Ltac solve_single_arm :=
   intros; unfold compile_wasm_to_arm;
   unfold exec_program; simpl;
@@ -42,140 +78,206 @@ Ltac solve_empty_arm :=
   intros; unfold compile_wasm_to_arm; simpl;
   eexists; reflexivity.
 
-(** ** I64 Comparison Operations *)
-(** All comparisons compile to 3-instruction CMP+MOV+conditional-MOV sequences *)
+(** ** I64 Comparison Operations — T1 lifts (v0.9.0 PR 4)
 
-Theorem i64_eqz_correct : forall wstate astate v stack',
-  wstate.(stack) = VI64 v :: stack' ->
-  exec_wasm_instr I64Eqz wstate =
-    Some (mkWasmState
-            (VI32 (if I64.eq v I64.zero then I32.one else I32.zero) :: stack')
-            wstate.(locals)
-            wstate.(globals)
-            wstate.(memory)) ->
-  exists astate',
-    exec_program (compile_wasm_to_arm I64Eqz) astate = Some astate'.
-Proof. solve_cmp_mov. Qed.
+    Each theorem below corresponds to a row of the per-op table in the PR body.
+    The dispatch is uniform: the spec axiom `i64_setcond_bits_spec` (binary)
+    or `i64_setcondz_bits_spec` (unary) is the sole non-mechanical step. *)
 
-Theorem i64_eq_correct : forall wstate astate v1 v2 stack',
-  wstate.(stack) = VI64 v2 :: VI64 v1 :: stack' ->
-  exec_wasm_instr I64Eq wstate =
-    Some (mkWasmState
-            (VI32 (if I64.eq v1 v2 then I32.one else I32.zero) :: stack')
-            wstate.(locals)
-            wstate.(globals)
-            wstate.(memory)) ->
+Theorem i64_eqz_correct : forall astate lo hi,
+  get_reg astate R0 = lo ->
+  get_reg astate R1 = hi ->
   exists astate',
-    exec_program (compile_wasm_to_arm I64Eq) astate = Some astate'.
-Proof. solve_cmp_mov. Qed.
+    exec_program (compile_wasm_to_arm I64Eqz) astate = Some astate' /\
+    get_reg astate' R0 =
+      (if I64.eq (combine_i32 lo hi) I64.zero then I32.one else I32.zero).
+Proof.
+  intros astate lo hi HR0 HR1.
+  unfold compile_wasm_to_arm; simpl.
+  rewrite HR0, HR1.
+  rewrite i64_setcondz_bits_spec.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
 
-Theorem i64_ne_correct : forall wstate astate v1 v2 stack',
-  wstate.(stack) = VI64 v2 :: VI64 v1 :: stack' ->
-  exec_wasm_instr I64Ne wstate =
-    Some (mkWasmState
-            (VI32 (if I64.ne v1 v2 then I32.one else I32.zero) :: stack')
-            wstate.(locals)
-            wstate.(globals)
-            wstate.(memory)) ->
+Theorem i64_eq_correct : forall astate lo1 hi1 lo2 hi2,
+  get_reg astate R0 = lo1 ->
+  get_reg astate R1 = hi1 ->
+  get_reg astate R2 = lo2 ->
+  get_reg astate R3 = hi2 ->
   exists astate',
-    exec_program (compile_wasm_to_arm I64Ne) astate = Some astate'.
-Proof. solve_cmp_mov. Qed.
+    exec_program (compile_wasm_to_arm I64Eq) astate = Some astate' /\
+    get_reg astate' R0 =
+      (if I64.eq (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm; simpl.
+  rewrite HR0, HR1, HR2, HR3.
+  rewrite i64_setcond_bits_spec; simpl.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
 
-Theorem i64_lts_correct : forall wstate astate v1 v2 stack',
-  wstate.(stack) = VI64 v2 :: VI64 v1 :: stack' ->
-  exec_wasm_instr I64LtS wstate =
-    Some (mkWasmState
-            (VI32 (if I64.lts v1 v2 then I32.one else I32.zero) :: stack')
-            wstate.(locals)
-            wstate.(globals)
-            wstate.(memory)) ->
+Theorem i64_ne_correct : forall astate lo1 hi1 lo2 hi2,
+  get_reg astate R0 = lo1 ->
+  get_reg astate R1 = hi1 ->
+  get_reg astate R2 = lo2 ->
+  get_reg astate R3 = hi2 ->
   exists astate',
-    exec_program (compile_wasm_to_arm I64LtS) astate = Some astate'.
-Proof. solve_cmp_mov. Qed.
+    exec_program (compile_wasm_to_arm I64Ne) astate = Some astate' /\
+    get_reg astate' R0 =
+      (if I64.ne (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm; simpl.
+  rewrite HR0, HR1, HR2, HR3.
+  rewrite i64_setcond_bits_spec; simpl.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
 
-Theorem i64_ltu_correct : forall wstate astate v1 v2 stack',
-  wstate.(stack) = VI64 v2 :: VI64 v1 :: stack' ->
-  exec_wasm_instr I64LtU wstate =
-    Some (mkWasmState
-            (VI32 (if I64.ltu v1 v2 then I32.one else I32.zero) :: stack')
-            wstate.(locals)
-            wstate.(globals)
-            wstate.(memory)) ->
+Theorem i64_lts_correct : forall astate lo1 hi1 lo2 hi2,
+  get_reg astate R0 = lo1 ->
+  get_reg astate R1 = hi1 ->
+  get_reg astate R2 = lo2 ->
+  get_reg astate R3 = hi2 ->
   exists astate',
-    exec_program (compile_wasm_to_arm I64LtU) astate = Some astate'.
-Proof. solve_cmp_mov. Qed.
+    exec_program (compile_wasm_to_arm I64LtS) astate = Some astate' /\
+    get_reg astate' R0 =
+      (if I64.lts (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm; simpl.
+  rewrite HR0, HR1, HR2, HR3.
+  rewrite i64_setcond_bits_spec; simpl.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
 
-Theorem i64_gts_correct : forall wstate astate v1 v2 stack',
-  wstate.(stack) = VI64 v2 :: VI64 v1 :: stack' ->
-  exec_wasm_instr I64GtS wstate =
-    Some (mkWasmState
-            (VI32 (if I64.gts v1 v2 then I32.one else I32.zero) :: stack')
-            wstate.(locals)
-            wstate.(globals)
-            wstate.(memory)) ->
+Theorem i64_ltu_correct : forall astate lo1 hi1 lo2 hi2,
+  get_reg astate R0 = lo1 ->
+  get_reg astate R1 = hi1 ->
+  get_reg astate R2 = lo2 ->
+  get_reg astate R3 = hi2 ->
   exists astate',
-    exec_program (compile_wasm_to_arm I64GtS) astate = Some astate'.
-Proof. solve_cmp_mov. Qed.
+    exec_program (compile_wasm_to_arm I64LtU) astate = Some astate' /\
+    get_reg astate' R0 =
+      (if I64.ltu (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm; simpl.
+  rewrite HR0, HR1, HR2, HR3.
+  rewrite i64_setcond_bits_spec; simpl.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
 
-Theorem i64_gtu_correct : forall wstate astate v1 v2 stack',
-  wstate.(stack) = VI64 v2 :: VI64 v1 :: stack' ->
-  exec_wasm_instr I64GtU wstate =
-    Some (mkWasmState
-            (VI32 (if I64.gtu v1 v2 then I32.one else I32.zero) :: stack')
-            wstate.(locals)
-            wstate.(globals)
-            wstate.(memory)) ->
+Theorem i64_gts_correct : forall astate lo1 hi1 lo2 hi2,
+  get_reg astate R0 = lo1 ->
+  get_reg astate R1 = hi1 ->
+  get_reg astate R2 = lo2 ->
+  get_reg astate R3 = hi2 ->
   exists astate',
-    exec_program (compile_wasm_to_arm I64GtU) astate = Some astate'.
-Proof. solve_cmp_mov. Qed.
+    exec_program (compile_wasm_to_arm I64GtS) astate = Some astate' /\
+    get_reg astate' R0 =
+      (if I64.gts (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm; simpl.
+  rewrite HR0, HR1, HR2, HR3.
+  rewrite i64_setcond_bits_spec; simpl.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
 
-Theorem i64_les_correct : forall wstate astate v1 v2 stack',
-  wstate.(stack) = VI64 v2 :: VI64 v1 :: stack' ->
-  exec_wasm_instr I64LeS wstate =
-    Some (mkWasmState
-            (VI32 (if I64.les v1 v2 then I32.one else I32.zero) :: stack')
-            wstate.(locals)
-            wstate.(globals)
-            wstate.(memory)) ->
+Theorem i64_gtu_correct : forall astate lo1 hi1 lo2 hi2,
+  get_reg astate R0 = lo1 ->
+  get_reg astate R1 = hi1 ->
+  get_reg astate R2 = lo2 ->
+  get_reg astate R3 = hi2 ->
   exists astate',
-    exec_program (compile_wasm_to_arm I64LeS) astate = Some astate'.
-Proof. solve_cmp_mov. Qed.
+    exec_program (compile_wasm_to_arm I64GtU) astate = Some astate' /\
+    get_reg astate' R0 =
+      (if I64.gtu (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm; simpl.
+  rewrite HR0, HR1, HR2, HR3.
+  rewrite i64_setcond_bits_spec; simpl.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
 
-Theorem i64_leu_correct : forall wstate astate v1 v2 stack',
-  wstate.(stack) = VI64 v2 :: VI64 v1 :: stack' ->
-  exec_wasm_instr I64LeU wstate =
-    Some (mkWasmState
-            (VI32 (if I64.leu v1 v2 then I32.one else I32.zero) :: stack')
-            wstate.(locals)
-            wstate.(globals)
-            wstate.(memory)) ->
+Theorem i64_les_correct : forall astate lo1 hi1 lo2 hi2,
+  get_reg astate R0 = lo1 ->
+  get_reg astate R1 = hi1 ->
+  get_reg astate R2 = lo2 ->
+  get_reg astate R3 = hi2 ->
   exists astate',
-    exec_program (compile_wasm_to_arm I64LeU) astate = Some astate'.
-Proof. solve_cmp_mov. Qed.
+    exec_program (compile_wasm_to_arm I64LeS) astate = Some astate' /\
+    get_reg astate' R0 =
+      (if I64.les (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm; simpl.
+  rewrite HR0, HR1, HR2, HR3.
+  rewrite i64_setcond_bits_spec; simpl.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
 
-Theorem i64_ges_correct : forall wstate astate v1 v2 stack',
-  wstate.(stack) = VI64 v2 :: VI64 v1 :: stack' ->
-  exec_wasm_instr I64GeS wstate =
-    Some (mkWasmState
-            (VI32 (if I64.ges v1 v2 then I32.one else I32.zero) :: stack')
-            wstate.(locals)
-            wstate.(globals)
-            wstate.(memory)) ->
+Theorem i64_leu_correct : forall astate lo1 hi1 lo2 hi2,
+  get_reg astate R0 = lo1 ->
+  get_reg astate R1 = hi1 ->
+  get_reg astate R2 = lo2 ->
+  get_reg astate R3 = hi2 ->
   exists astate',
-    exec_program (compile_wasm_to_arm I64GeS) astate = Some astate'.
-Proof. solve_cmp_mov. Qed.
+    exec_program (compile_wasm_to_arm I64LeU) astate = Some astate' /\
+    get_reg astate' R0 =
+      (if I64.leu (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm; simpl.
+  rewrite HR0, HR1, HR2, HR3.
+  rewrite i64_setcond_bits_spec; simpl.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
 
-Theorem i64_geu_correct : forall wstate astate v1 v2 stack',
-  wstate.(stack) = VI64 v2 :: VI64 v1 :: stack' ->
-  exec_wasm_instr I64GeU wstate =
-    Some (mkWasmState
-            (VI32 (if I64.geu v1 v2 then I32.one else I32.zero) :: stack')
-            wstate.(locals)
-            wstate.(globals)
-            wstate.(memory)) ->
+Theorem i64_ges_correct : forall astate lo1 hi1 lo2 hi2,
+  get_reg astate R0 = lo1 ->
+  get_reg astate R1 = hi1 ->
+  get_reg astate R2 = lo2 ->
+  get_reg astate R3 = hi2 ->
   exists astate',
-    exec_program (compile_wasm_to_arm I64GeU) astate = Some astate'.
-Proof. solve_cmp_mov. Qed.
+    exec_program (compile_wasm_to_arm I64GeS) astate = Some astate' /\
+    get_reg astate' R0 =
+      (if I64.ges (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm; simpl.
+  rewrite HR0, HR1, HR2, HR3.
+  rewrite i64_setcond_bits_spec; simpl.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
+
+Theorem i64_geu_correct : forall astate lo1 hi1 lo2 hi2,
+  get_reg astate R0 = lo1 ->
+  get_reg astate R1 = hi1 ->
+  get_reg astate R2 = lo2 ->
+  get_reg astate R3 = hi2 ->
+  exists astate',
+    exec_program (compile_wasm_to_arm I64GeU) astate = Some astate' /\
+    get_reg astate' R0 =
+      (if I64.geu (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm; simpl.
+  rewrite HR0, HR1, HR2, HR3.
+  rewrite i64_setcond_bits_spec; simpl.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
 
 (** ** I64 Bit Manipulation Operations *)
 


### PR DESCRIPTION
## Summary

Lifts the 11 i64 comparison theorems in `coq/Synth/Synth/CorrectnessI64Comparisons.v` from **T2** (existence-only) to **T1** (result-correspondence) using the `i64_setcond_bits_spec` and `i64_setcondz_bits_spec` axioms shipped in v0.9.0 PR 1 (#153).

Part of umbrella #152 (v0.9.0 i64 T2 → T1 fan-out). This PR is disjoint from PR 2 (CorrectnessI64.v arith/bitwise), PR 3 (CorrectnessI64.v shifts/rotates), and PR 5 (CorrectnessI64.v bit-manip) — the parallelism is only sound because everyone stays in their lane.

## Theorem shape

Each theorem is restated with:

- **I64-typed hypotheses**: operands pinned via lo/hi halves living in `(R0:R1)` and `(R2:R3)` for binops, just `(R0:R1)` for `i64.eqz`. The combined 64-bit operand is `combine_i32 lo hi`.
- **Single-register post-condition**: `get_reg astate' R0 = if I64.<cmp> v1 v2 then I32.one else I32.zero` (WASM i64 comparison returns an i32 boolean — only R0 is pinned).
- **No `exec_wasm_instr` hypothesis**: per #153's pattern, the vacuous `exec_wasm_instr I64Eq wstate = Some ...` hypothesis is dropped (`WasmSemantics.v` does not model i64 comparisons, so the prior T2 theorems were vacuously true on a `False` premise).

## Per-theorem dispatch table

All 11 theorems close as `Qed` with the same 5-line proof, dispatching through `i64_setcond_bits_spec` (binary) or `i64_setcondz_bits_spec` (unary):

| Theorem            | Spec axiom                       | ARM cond  | Outcome |
|--------------------|----------------------------------|-----------|---------|
| `i64_eqz_correct`  | `i64_setcondz_bits_spec`         | (n/a)     | **Qed** |
| `i64_eq_correct`   | `i64_setcond_bits_spec`          | `Cond_EQ` | **Qed** |
| `i64_ne_correct`   | `i64_setcond_bits_spec`          | `Cond_NE` | **Qed** |
| `i64_lts_correct`  | `i64_setcond_bits_spec`          | `Cond_LT` | **Qed** |
| `i64_ltu_correct`  | `i64_setcond_bits_spec`          | `Cond_CC` | **Qed** |
| `i64_gts_correct`  | `i64_setcond_bits_spec`          | `Cond_GT` | **Qed** |
| `i64_gtu_correct`  | `i64_setcond_bits_spec`          | `Cond_HI` | **Qed** |
| `i64_les_correct`  | `i64_setcond_bits_spec`          | `Cond_LE` | **Qed** |
| `i64_leu_correct`  | `i64_setcond_bits_spec`          | `Cond_LS` | **Qed** |
| `i64_ges_correct`  | `i64_setcond_bits_spec`          | `Cond_GE` | **Qed** |
| `i64_geu_correct`  | `i64_setcond_bits_spec`          | `Cond_CS` | **Qed** |

**Lifted: 11/11.** No `Admitted` carryover.

Uniform proof body:

```coq
intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
unfold compile_wasm_to_arm; simpl.
rewrite HR0, HR1, HR2, HR3.
rewrite i64_setcond_bits_spec; simpl.
eexists. split; [reflexivity | apply get_set_reg_eq].
```

## Architectural finding

The i64 flag-correspondence lemmas added in #149 (`z_flag_sub_eq_i64`, `flags_ne_i64`, `nv_flag_sub_lts_i64`, `flags_ltu_i64`, `flags_ges_i64`, `flags_geu_i64`, `flags_gts_i64`, `flags_gtu_i64`, `flags_les_i64`, `flags_leu_i64`, `z_flag_sub_eqz_i64`) and the `synth_cmp_binop_proof_i64` / `synth_cmp_unop_proof_i64` tactics in `Tactics.v` are **not used** by this PR.

Those lemmas/tactics presupposed that i64 comparisons would lower to a CMP + MOV + conditional-MOV sequence (mirroring the i32 path), in which case the proof would need to reflect ARM N/Z/C/V flags back into WASM cmp semantics. Under the actual v0.8.0 codegen (`Compilation.v` line 270 ff.), i64 cmps lower to a single `I64SetCond` pseudo-op whose semantic axiom (`i64_setcond_bits_spec`) already returns the WASM-spec result directly — no flag bridging is required.

The flag lemmas remain in `ArmFlagLemmas.v` for the **i32 path** (which still uses them via the i32 CMP+MOV+CMOV pattern in `CorrectnessI32.v`) and are available for any future direct dual-precision CMP/SBC modeling (e.g., if the encoder is later refactored to inline the comparison sequence). No code is removed.

## Constraints satisfied

- [x] No new spec axioms
- [x] No new flag lemmas
- [x] No new `Admitted.` proofs
- [x] No weakened theorem statements (all 11 strengthened from T2 to T1)
- [x] Single file only (`CorrectnessI64Comparisons.v`) — disjoint from PRs 2/3/5

## Test plan

- [ ] `bazel test //coq:verify_proofs` passes (CI gates the Rocq proof toolchain via Nix)
- [ ] `bazel build //coq:correctness_complete` succeeds (master index loads new T1 statements)
- [ ] `cargo test --workspace --exclude synth-verify` passes (no Rust impact expected — file is in `correctness_core` Rocq group only)

Refs: #152 (umbrella), #149 (i64 flag lemmas — unused under pseudo-op compilation), #153 (precursor spec axioms — used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)