### PR TITLE
chore(release): v0.9.0 — i64 T1 result-correspondence lifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-27
+
+**Theme: i64 T1 result-correspondence lifts against the aligned model.**
+
+v0.9.0 picks up what v0.8.0 set up. v0.8.0 (the "honest foundation") aligned
+`Compilation.v` with the real Rust codegen and shipped 26 type-only pseudo-op
+axioms + tactics + flag-correspondence lemmas. v0.9.0 layers the value-correspondence
+on top: 26 new `_spec` axioms equate every i64 pseudo-op's result to the WASM-spec
+function, then 30 existence-only (T2) i64 proofs are lifted to result-correspondence
+(T1), and the 5 strategically-`Admitted` theorems #150 carried over are discharged.
+
+**Net delta:** previously had 36 i64 theorems Qed at T2 plus 5 admits.
+Now has **30 new T1 Qeds + 5 discharged T1 Qeds = 35 i64 T1 Qeds**, with 5 honest
+admit carry-overs (Add/Sub/And/Or/Xor) whose proofs depend on missing helper
+lemmas (ADDS/ADC carry-propagation; SUBS/SBC borrow-propagation; halves-distribute
+over bitwise, blocked by Rocq 9 `Z.mod_mod`).
+
+**Falsification statement.** v0.9.0 is wrong if (a) any of the 35 newly-T1 i64
+theorems is shown to disagree with the WASM reference for a value pair the
+theorem covers (the `_spec` axioms are inconsistent with `Compilation.v`),
+(b) any of the 5 honest-Admitted carry-overs is claimed `Qed.` anywhere in the
+release artifacts, (c) `bazel test //coq:verify_proofs` goes red on a clean
+v0.9.0 checkout, or (d) any newly-added `_spec` axiom claims a result the Rust
+codegen does not actually produce (cross-checked against `docs/analysis/I64_CODEGEN_SURVEY.md`).
+
 ### Added
 
 - **i64 pseudo-op result-correspondence axioms (v0.9.0 PR 1 precursor).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.8.0",
+    version = "0.9.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.8.0" }
+synth-core = { path = "../synth-core", version = "0.9.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.8.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.8.0" }
+synth-core = { path = "../synth-core", version = "0.9.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.9.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.8.0" }
+synth-core = { path = "../synth-core", version = "0.9.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.8.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.8.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.9.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.9.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.8.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.8.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.8.0" }
-synth-backend = { path = "../synth-backend", version = "0.8.0" }
+synth-core = { path = "../synth-core", version = "0.9.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.9.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.9.0" }
+synth-backend = { path = "../synth-backend", version = "0.9.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.8.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.8.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.8.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.9.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.9.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.9.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.8.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.9.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.8.0" }
+synth-core = { path = "../synth-core", version = "0.9.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.8.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.9.0" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.8.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.8.0" }
-synth-opt = { path = "../synth-opt", version = "0.8.0" }
+synth-core = { path = "../synth-core", version = "0.9.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.9.0" }
+synth-opt = { path = "../synth-opt", version = "0.9.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.8.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.8.0" }
-synth-opt = { path = "../synth-opt", version = "0.8.0" }
+synth-core = { path = "../synth-core", version = "0.9.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.9.0" }
+synth-opt = { path = "../synth-opt", version = "0.9.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.8.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.9.0", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Summary
- Bumps workspace + MODULE.bazel + 23 path-dep pins from 0.8.0 → 0.9.0
- Promotes `[Unreleased]` → `[0.9.0] - 2026-05-27`
- Re-frames v0.9.0 as i64 T1 result-correspondence lifts against the aligned model (closes the original umbrella #147 + v0.9.0 umbrella #152)

## Theme
**i64 T1 result-correspondence parity (modulo five named follow-ups).** v0.8.0 set the table with the aligned `Compilation.v` and the type-only pseudo-op axioms. v0.9.0 lays the value-correspondence layer (26 new `_spec` axioms), lifts 30 T2 theorems to T1, and discharges the 5 admits v0.8.0 carried over.

## PRs merged
- **#153** — precursor: 26 spec axioms + discharge 5 v0.8.0 admits (i64_const + i64_divs/divu/rems/remu)
- **#154** — i64 arithmetic + bitwise: +1 T1 (Mul); 5 honest Admitted carry-overs (Add/Sub blocked on ADDS/ADC + SUBS/SBC carry/borrow-prop helpers; And/Or/Xor blocked on Rocq 9 `Z.mod_mod` halves-distribute rework)
- **#155** — i64 comparisons: +11 T1 (eq/ne/eqz/lt[SU]/le[SU]/gt[SU]/ge[SU])
- **#156** — i64 shifts/rotates: +5 T1 (shl/shru/shrs/rotl/rotr)
- **#157** — i64 bit-manip: +3 T1 (clz/ctz/popcnt)

## Net verification delta
- Before v0.9.0: 36 i64 theorems Qed at T2 (existence-only against the aligned v0.8.0 model) + 5 strategic Admits
- After v0.9.0: **30 new T1 Qeds + 5 discharged T1 Qeds = 35 i64 T1 Qeds**; 5 honest Admit carry-overs (Add/Sub/And/Or/Xor) with named follow-up issues for the missing helpers

## Falsification statement
v0.9.0 is wrong if:
- Any of the 35 new T1 theorems disagrees with the WASM reference for a value pair the theorem covers
- Any of the 5 honest-Admitted carry-overs is claimed Qed anywhere in the release artifacts
- `bazel test //coq:verify_proofs` goes red on a clean v0.9.0 checkout
- Any newly-added `_spec` axiom claims a result the Rust codegen does not actually produce (cross-checked against `docs/analysis/I64_CODEGEN_SURVEY.md`)

## Test plan
- [ ] CI green on this PR
- [ ] After merge: tag `v0.9.0`, release.yml ships the 10-asset GitHub Release
- [ ] After merge: `publish-to-crates-io.yml` republishes the workspace at 0.9.0