### PR TITLE
feat(coq): close i64_to_i32_to_i64_wrap + bitwise lift infrastructure (v0.10.0 PR 2)

### DIFF
--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -1,6 +1,26 @@
 # Rocq Proof Suite — Honest Status
 
-**Last Updated:** May 2026 (v0.10.0 PR 1: i64_add/i64_sub closed as T1 Qed via ADDS/ADC + SUBS/SBC carry/borrow-propagation lemmas — no new axioms)
+**Last Updated:** May 2026 (v0.10.0 PR 2: i64_to_i32_to_i64_wrap closed; bitwise halves-distribute infrastructure landed; i64 and/or/xor T1 deferred to v0.11.0)
+
+## v0.10.0 PR 2 outcome: Z.mod_mod wrap closed + bitwise lift infrastructure
+
+`i64_to_i32_to_i64_wrap` (Common/Integers.v) — the long-standing Rocq 9
+`Z.mod_mod` Admit — is now Qed (canonical symbolic-atom modular proof; no
+axioms). Landed the bitwise halves-distribute infrastructure for the i64
+and/or/xor T1 lifts: six pure-Z distribution lemmas (`{land,lor,lxor}_{low,high}32`),
+`combine_i32_raw`, `mod64_mod32`, `combine_lo32`/`combine_hi32`, and
+`and_lo_combine` — all Qed, no axioms.
+
+**Deferred to v0.11.0:** `i64_and_correct` / `i64_or_correct` /
+`i64_xor_correct` remain Admitted (3 admits). The remaining work is the
+high-half combine helper (`(Z.land X Y mod 2^64)/2^32 mod 2^32`, via
+`ZDivEucl.mod_mul_r`), the or/xor analogues, and the three theorem
+exec-proofs (template: `i64_add_correct` minus flag handling). The
+infrastructure to close them is in place.
+
+**Total admits: 12** — 4 i32 division (separate exec_program-model gap),
+2 Compilation.v, 1 CorrectnessSimple.v, 3 i64 and/or/xor (above),
+2 ArmRefinement.v.
 
 ## v0.10.0 PR 1 outcome: i64 add/sub carry/borrow propagation
 

--- a/coq/Synth/Common/Integers.v
+++ b/coq/Synth/Common/Integers.v
@@ -392,10 +392,15 @@ Proof.
   unfold i32_to_i64_unsigned, i64_to_i32.
   unfold I64.unsigned, I32.unsigned, I64.repr, I32.repr.
   unfold I32.modulus, I64.modulus.
-  (* Goal: (x mod 2^64 mod 2^32 mod 2^32) mod 2^64 = x mod 2^64 mod 2^32 *)
-  (* Let y = x mod 2^64 mod 2^32. Then goal is (y mod 2^32) mod 2^64 = y. *)
-  (* ADMITTED: Rocq 9 Z.mod_mod signature changed — rewrite matching fails.
-     Goal: (x mod 2^64 mod 2^32 mod 2^32) mod 2^64 = x mod 2^64 mod 2^32
-     The proof is mathematically trivial but Rocq 9's rewrite tactic
-     cannot disambiguate nested mod subterms. Tracked in VG-002. *)
-Admitted.
+  (* Goal: (x mod 2^64 mod 2^32 mod 2^32) mod 2^64 = x mod 2^64 mod 2^32.
+     Keep the moduli as small symbolic atoms so lia reasons over atoms
+     rather than choking on 2^64-scale literal certificates. *)
+  set (m32 := 2 ^ 32). set (m64 := 2 ^ 64).
+  assert (Hm0 : 0 < m32) by (subst m32; reflexivity).
+  assert (Hlt : m32 < m64) by (subst m32 m64; reflexivity).
+  set (y := x mod m64 mod m32).
+  assert (Hy : 0 <= y < m32) by (subst y; apply Z.mod_pos_bound; exact Hm0).
+  rewrite (Z.mod_small y m32 Hy).
+  rewrite !(Z.mod_small y m64) by lia.
+  reflexivity.
+Qed.

--- a/coq/Synth/Synth/CorrectnessI64.v
+++ b/coq/Synth/Synth/CorrectnessI64.v
@@ -417,6 +417,53 @@ Proof.
   intros a b. rewrite <- !Z.shiftr_div_pow2 by lia. apply Z.shiftr_lxor.
 Qed.
 
+(** combine_i32 as a raw Z: the sum fits in 64 bits, so the I64.repr mod
+    is the identity. *)
+Lemma combine_i32_raw : forall lo hi : I32.int,
+  combine_i32 lo hi = I32.unsigned lo + 2 ^ 32 * I32.unsigned hi.
+Proof.
+  intros lo hi. unfold combine_i32, I64.repr, I32.modulus, I64.modulus.
+  assert (Hl : 0 <= I32.unsigned lo < 2 ^ 32)
+    by (unfold I32.unsigned, I32.modulus; apply Z_mod_lt; lia).
+  assert (Hh : 0 <= I32.unsigned hi < 2 ^ 32)
+    by (unfold I32.unsigned, I32.modulus; apply Z_mod_lt; lia).
+  assert (H64 : 2 ^ 64 = 2 ^ 32 * 2 ^ 32) by reflexivity.
+  apply Z.mod_small. nia.
+Qed.
+
+(** (w mod 2^64) mod 2^32 = w mod 2^32 (2^32 divides 2^64). *)
+Lemma mod64_mod32 : forall w, (w mod 2 ^ 64) mod 2 ^ 32 = w mod 2 ^ 32.
+Proof.
+  intros w. rewrite <- !Z.land_ones by lia.
+  rewrite <- Z.land_assoc. f_equal.
+Qed.
+
+(** The low 32 bits of combine_i32 lo hi are I32.unsigned lo. *)
+Lemma combine_lo32 : forall lo hi : I32.int,
+  combine_i32 lo hi mod 2 ^ 32 = I32.unsigned lo.
+Proof.
+  intros lo hi. rewrite combine_i32_raw.
+  assert (Hl : 0 <= I32.unsigned lo < 2 ^ 32)
+    by (unfold I32.unsigned, I32.modulus; apply Z_mod_lt; lia).
+  rewrite (Z.mul_comm (2 ^ 32) (I32.unsigned hi)).
+  rewrite Z_mod_plus_full. rewrite Z.mod_small by lia. reflexivity.
+Qed.
+
+(** The high 32 bits of combine_i32 lo hi are I32.unsigned hi. *)
+Lemma combine_hi32 : forall lo hi : I32.int,
+  combine_i32 lo hi / 2 ^ 32 mod 2 ^ 32 = I32.unsigned hi.
+Proof.
+  intros lo hi. rewrite combine_i32_raw.
+  assert (Hl : 0 <= I32.unsigned lo < 2 ^ 32)
+    by (unfold I32.unsigned, I32.modulus; apply Z_mod_lt; lia).
+  assert (Hh : 0 <= I32.unsigned hi < 2 ^ 32)
+    by (unfold I32.unsigned, I32.modulus; apply Z_mod_lt; lia).
+  rewrite (Z.mul_comm (2 ^ 32) (I32.unsigned hi)).
+  rewrite Z.div_add by lia.
+  rewrite (Z.div_small (I32.unsigned lo) (2 ^ 32)) by lia.
+  rewrite Z.add_0_l. rewrite Z.mod_small by lia. reflexivity.
+Qed.
+
 Theorem i64_and_correct : forall astate lo1 hi1 lo2 hi2,
   get_reg astate R0 = lo1 ->
   get_reg astate R1 = hi1 ->

--- a/coq/Synth/Synth/CorrectnessI64.v
+++ b/coq/Synth/Synth/CorrectnessI64.v
@@ -464,6 +464,19 @@ Proof.
   rewrite Z.add_0_l. rewrite Z.mod_small by lia. reflexivity.
 Qed.
 
+(** The low half of I64.and on combined operands equals I32.and of the lows. *)
+Lemma and_lo_combine : forall lo1 hi1 lo2 hi2,
+  I32.and lo1 lo2 = lo_of_i64 (I64.and (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)).
+Proof.
+  intros lo1 hi1 lo2 hi2. rewrite lo_of_i64_repr.
+  unfold I64.and, I64.unsigned, I64.repr, I64.modulus, I32.repr, I32.and, I32.modulus.
+  rewrite Zmod_mod, mod64_mod32.
+  rewrite (land_low32 (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)).
+  rewrite !combine_lo32.
+  unfold I32.repr, I32.unsigned, I32.modulus.
+  apply land_low32.
+Qed.
+
 Theorem i64_and_correct : forall astate lo1 hi1 lo2 hi2,
   get_reg astate R0 = lo1 ->
   get_reg astate R1 = hi1 ->

--- a/coq/Synth/Synth/CorrectnessI64.v
+++ b/coq/Synth/Synth/CorrectnessI64.v
@@ -76,6 +76,7 @@
 *)
 
 From Stdlib Require Import ZArith.
+From Stdlib Require Import Lia.
 Require Import Synth.Common.Base.
 Require Import Synth.Common.Integers.
 Require Import Synth.ARM.ArmState.
@@ -364,6 +365,57 @@ Qed.
     Per the v0.9.0 PR 2 task brief, no new spec axiom is introduced. The
     decomposition lemma is purely arithmetic (no codegen claim), and is
     tracked as a follow-up alongside the Rocq 9 `Z.mod_mod` rework. *)
+
+(** ** v0.10.0 PR 2: bitwise halves-distribute helpers (pure Z, no axioms)
+
+    A bitwise op commutes with taking the low 32 bits (mod 2^32) and with
+    taking the high 32 bits (/ 2^32). Proven by bit extensionality for the
+    low half and by the shiftr-distributes lemmas for the high half. *)
+
+Lemma land_low32 : forall a b : Z,
+  Z.land a b mod 2 ^ 32 = Z.land (a mod 2 ^ 32) (b mod 2 ^ 32).
+Proof.
+  intros a b. rewrite <- !Z.land_ones by lia.
+  apply Z.bits_inj'; intros n Hn.
+  rewrite ?Z.land_spec, ?Z.lor_spec, ?Z.lxor_spec, ?Z.land_spec.
+  destruct (Z.testbit a n), (Z.testbit b n), (Z.testbit (Z.ones 32) n); reflexivity.
+Qed.
+
+Lemma lor_low32 : forall a b : Z,
+  Z.lor a b mod 2 ^ 32 = Z.lor (a mod 2 ^ 32) (b mod 2 ^ 32).
+Proof.
+  intros a b. rewrite <- !Z.land_ones by lia.
+  apply Z.bits_inj'; intros n Hn.
+  rewrite ?Z.land_spec, ?Z.lor_spec, ?Z.lxor_spec, ?Z.land_spec.
+  destruct (Z.testbit a n), (Z.testbit b n), (Z.testbit (Z.ones 32) n); reflexivity.
+Qed.
+
+Lemma lxor_low32 : forall a b : Z,
+  Z.lxor a b mod 2 ^ 32 = Z.lxor (a mod 2 ^ 32) (b mod 2 ^ 32).
+Proof.
+  intros a b. rewrite <- !Z.land_ones by lia.
+  apply Z.bits_inj'; intros n Hn.
+  rewrite ?Z.land_spec, ?Z.lor_spec, ?Z.lxor_spec, ?Z.land_spec.
+  destruct (Z.testbit a n), (Z.testbit b n), (Z.testbit (Z.ones 32) n); reflexivity.
+Qed.
+
+Lemma land_high32 : forall a b : Z,
+  Z.land a b / 2 ^ 32 = Z.land (a / 2 ^ 32) (b / 2 ^ 32).
+Proof.
+  intros a b. rewrite <- !Z.shiftr_div_pow2 by lia. apply Z.shiftr_land.
+Qed.
+
+Lemma lor_high32 : forall a b : Z,
+  Z.lor a b / 2 ^ 32 = Z.lor (a / 2 ^ 32) (b / 2 ^ 32).
+Proof.
+  intros a b. rewrite <- !Z.shiftr_div_pow2 by lia. apply Z.shiftr_lor.
+Qed.
+
+Lemma lxor_high32 : forall a b : Z,
+  Z.lxor a b / 2 ^ 32 = Z.lxor (a / 2 ^ 32) (b / 2 ^ 32).
+Proof.
+  intros a b. rewrite <- !Z.shiftr_div_pow2 by lia. apply Z.shiftr_lxor.
+Qed.
 
 Theorem i64_and_correct : forall astate lo1 hi1 lo2 hi2,
   get_reg astate R0 = lo1 ->


### PR DESCRIPTION
## Summary
- Closes `i64_to_i32_to_i64_wrap` (Common/Integers.v) — the long-standing Rocq 9 `Z.mod_mod` Admit
- Lands the bitwise halves-distribute infrastructure for the i64 and/or/xor T1 lifts
- No new axioms; all new lemmas Qed; verified locally (`bazel build //coq:verify_proofs` green)

## What's closed (Qed)
- `i64_to_i32_to_i64_wrap` — canonical symbolic-atom modular proof (keeps moduli as atoms so `lia` avoids 2^64-scale literal certificates; `rewrite !` clears the double `mod 2^64` from `I64.repr`+`I64.unsigned`)
- 6 pure-Z distribution lemmas: `{land,lor,lxor}_low32` (via `Z.land_ones` + bit extensionality) and `{land,lor,lxor}_high32` (via `Z.shiftr_{land,lor,lxor}`)
- `combine_i32_raw`, `mod64_mod32`, `combine_lo32`, `combine_hi32`, `and_lo_combine`

## Deferred to v0.11.0
`i64_and_correct` / `i64_or_correct` / `i64_xor_correct` remain Admitted (3 admits). Remaining work: high-half combine helper (`(Z.land X Y mod 2^64)/2^32 mod 2^32`, via `ZDivEucl.mod_mul_r`), or/xor analogues of `and_lo_combine`, and the 3 exec-proofs (template: `i64_add_correct` minus flags). The infrastructure to close them is in this PR.

## Note on process
Subagents in this environment cannot run Bash, so these proofs were authored + verified directly against the local Nix/Bazel Rocq checker (`. nix-daemon.sh && bazel build //coq:verify_proofs`). All commits were verified green locally before push.

## Falsification
v0.10.0 (PR 1 + PR 2) is wrong if: any newly-Qed lemma is actually Admitted/Abort; `bazel test //coq:verify_proofs` goes red on a clean checkout; or a new axiom was introduced (grep confirms zero). Total admits: 12 (4 i32-div, 2 Compilation, 1 CorrectnessSimple, 3 i64 and/or/xor, 2 ArmRefinement).

## Test plan
- [ ] CI `Bazel Build & Proofs` green
- [ ] After merge: cut v0.10.0 (version bump + CHANGELOG + pin sweep + tag)