### PR TITLE
chore(release): v0.10.0 — i64 add/sub T1 + Z.mod_mod wrap + bitwise infra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-29
+
+**Theme: i64 add/sub T1 + Rocq 9 Z.mod_mod wrap closed + bitwise lift infrastructure.**
+
+v0.10.0 closes the two carry/borrow i64 admits and the long-standing
+`Z.mod_mod` blocker, and lands the infrastructure for the remaining
+bitwise T1 lifts. All proofs verified against the local Nix/Bazel Rocq
+toolchain (`bazel build //coq:verify_proofs` green) before each push —
+this session established that synth's Rocq proofs can be checked locally,
+ending the blind-CI-round-trip pattern.
+
+**Falsification statement.** v0.10.0 is wrong if (a) any newly-Qed lemma
+is actually `Admitted`/`Abort` (grep confirms the claimed Qeds compile),
+(b) `bazel test //coq:verify_proofs` goes red on a clean v0.10.0 checkout,
+(c) a new `Axiom` was introduced (grep confirms zero), or (d) the stated
+admit count (12) does not match the tree.
+
+### Added
+- **i64 add/sub T1 result-correspondence** (PR #160). `i64_add_correct`
+  and `i64_sub_correct` (Admitted in v0.9.0) are now Qed, via new
+  ADDS/ADC carry-propagation and SUBS/SBC borrow-propagation lemmas in
+  `coq/Synth/ARM/ArmFlagLemmas.v` (`i64_add_via_adds_adc`,
+  `i64_sub_via_subs_sbc`, `carry_split_add`, `borrow_split_sub`). The
+  discharge steps `exec_program` over the real `[ADDS; ADC]` / `[SUBS; SBC]`
+  pairs, reading the C flag set by the low-half instruction. No new axioms.
+- **Bitwise halves-distribute infrastructure** (PR #161). Six pure-Z
+  distribution lemmas (`{land,lor,lxor}_low32` via `Z.land_ones` + bit
+  extensionality; `{land,lor,lxor}_high32` via `Z.shiftr_{land,lor,lxor}`),
+  plus `combine_i32_raw`, `mod64_mod32`, `combine_lo32`, `combine_hi32`,
+  and `and_lo_combine` — all in `coq/Synth/Synth/CorrectnessI64.v`, all
+  Qed, no axioms.
+
+### Fixed
+- **`i64_to_i32_to_i64_wrap` closed** (PR #161). The long-standing Rocq 9
+  `Z.mod_mod` Admit in `coq/Synth/Common/Integers.v` is now Qed via a
+  canonical symbolic-atom modular proof (keeps moduli as atoms so `lia`
+  avoids 2^64-scale literal certificates; `rewrite !Z.mod_small` clears the
+  double `mod 2^64` introduced by `I64.repr` + `I64.unsigned`).
+
+### Deferred to v0.11.0
+- `i64_and_correct` / `i64_or_correct` / `i64_xor_correct` remain Admitted
+  (3 of the 12 total admits). The remaining work is the high-half combine
+  helper (`(Z.land X Y mod 2^64) / 2^32 mod 2^32`, via `ZDivEucl.mod_mul_r`),
+  the or/xor analogues of `and_lo_combine`, and the three theorem
+  exec-proofs (template: `i64_add_correct` minus flag handling). The
+  infrastructure to close them shipped in this release.
+
 ## [0.9.0] - 2026-05-27
 
 **Theme: i64 T1 result-correspondence lifts against the aligned model.**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.9.0",
+    version = "0.10.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.9.0" }
+synth-core = { path = "../synth-core", version = "0.10.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.9.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.9.0" }
+synth-core = { path = "../synth-core", version = "0.10.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.10.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.9.0" }
+synth-core = { path = "../synth-core", version = "0.10.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.9.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.9.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.10.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.10.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.9.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.9.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.9.0" }
-synth-backend = { path = "../synth-backend", version = "0.9.0" }
+synth-core = { path = "../synth-core", version = "0.10.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.10.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.10.0" }
+synth-backend = { path = "../synth-backend", version = "0.10.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.9.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.9.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.9.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.10.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.10.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.10.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.9.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.10.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.9.0" }
+synth-core = { path = "../synth-core", version = "0.10.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.9.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.10.0" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.9.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.9.0" }
-synth-opt = { path = "../synth-opt", version = "0.9.0" }
+synth-core = { path = "../synth-core", version = "0.10.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.10.0" }
+synth-opt = { path = "../synth-opt", version = "0.10.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.9.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.9.0" }
-synth-opt = { path = "../synth-opt", version = "0.9.0" }
+synth-core = { path = "../synth-core", version = "0.10.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.10.0" }
+synth-opt = { path = "../synth-opt", version = "0.10.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.9.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.10.0", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Summary
- Bumps workspace + MODULE.bazel + 23 path-dep pins 0.9.0 → 0.10.0
- Promotes `[Unreleased]` → `[0.10.0] - 2026-05-29` with the falsification statement

## Theme
**i64 add/sub T1 + Rocq 9 Z.mod_mod wrap closed + bitwise lift infrastructure.**

PRs in this release:
- **#160** — i64 `add`/`sub` → T1 Qed (ADDS/ADC + SUBS/SBC carry/borrow lemmas; no axioms)
- **#161** — `i64_to_i32_to_i64_wrap` closed (Rocq 9 `Z.mod_mod` blocker) + 6 bitwise distribution lemmas + combine/mod helpers + `and_lo_combine` (all Qed, no axioms)

## Process milestone
This session established that synth's Rocq proofs can be **checked locally** via the Nix/Bazel toolchain (`. nix-daemon.sh && bazel build //coq:verify_proofs`), ending the blind-CI-round-trip pattern that dogged the earlier proof work. Every commit was verified green locally before push.

## Deferred to v0.11.0
`i64_and/or/xor_correct` remain Admitted (3 of 12 total admits). The closing infrastructure (distribution lemmas, combine projections, `and_lo_combine`) shipped here; remaining is the high-half combine helper + or/xor analogues + 3 exec-proofs.

## Falsification
v0.10.0 is wrong if: any claimed-Qed lemma is actually Admitted/Abort; `bazel test //coq:verify_proofs` red on clean checkout; a new Axiom was introduced (grep: zero); or admit count ≠ 12.

## Test plan
- [ ] CI green
- [ ] After merge: tag v0.10.0; release.yml ships the 10-asset GitHub Release; publish-to-crates-io.yml republishes at 0.10.0