### PR TITLE
feat(coq): close i64 and/or/xor T1 — true i64 T1 parity (v0.11.0)

### DIFF
--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -1,6 +1,23 @@
 # Rocq Proof Suite — Honest Status
 
-**Last Updated:** May 2026 (v0.10.0 PR 2: i64_to_i32_to_i64_wrap closed; bitwise halves-distribute infrastructure landed; i64 and/or/xor T1 deferred to v0.11.0)
+**Last Updated:** May 2026 (v0.11.0: i64 and/or/xor T1 closed — TRUE i64 T1 PARITY, 0 i64 admits)
+
+## v0.11.0 outcome: true i64 T1 parity
+
+`i64_and_correct` / `i64_or_correct` / `i64_xor_correct` are now **Qed** —
+the final i64 bitwise T1 lifts. This completes i64 T1 result-correspondence
+parity with i32 (40 i64 T1 Qed, **0 i64 admits**).
+
+New helpers (all Qed, no axioms): `div32_mod64`
+(`(a mod 2^64)/2^32 = (a/2^32) mod 2^32`, bit-extensionality), `and_hi_combine`
++ the or/xor lo/hi combine analogues. The three theorem exec-proofs step
+`exec_program` over the flag-free pairs `[AND R0 R0 R2; AND R1 R1 R3]`
+(ORR/EOR identical) and apply the combine lemmas — the `i64_add_correct`
+template minus flag-peeling.
+
+**Total admits: 9** (was 12) — 4 i32 division (separate exec_program-model
+gap #73), 2 Compilation.v, 1 CorrectnessSimple.v, 2 ArmRefinement.v. No
+remaining i64 admits.
 
 ## v0.10.0 PR 2 outcome: Z.mod_mod wrap closed + bitwise lift infrastructure
 

--- a/coq/Synth/Synth/CorrectnessI64.v
+++ b/coq/Synth/Synth/CorrectnessI64.v
@@ -477,6 +477,43 @@ Proof.
   apply land_low32.
 Qed.
 
+(** Bits [32,64) survive the mod 2^64: extracting the high 32-bit slice of
+    (a mod 2^64) equals the high slice of a. Proven via the mixed-radix
+    decomposition a mod (2^32 * 2^32) = a mod 2^32 + 2^32 * ((a/2^32) mod 2^32). *)
+Lemma div32_mod64 : forall a, (a mod 2 ^ 64) / 2 ^ 32 = (a / 2 ^ 32) mod 2 ^ 32.
+Proof.
+  intros a. apply Z.bits_inj'; intros n Hn.
+  pose proof (Z.div_pow2_bits (a mod 2 ^ 64) 32 n ltac:(lia) ltac:(lia)) as HD0.
+  rewrite HD0.
+  destruct (n <? 32) eqn:E.
+  - rewrite Z.ltb_lt in E.
+    pose proof (Z.mod_pow2_bits_low a 64 (n + 32) ltac:(lia)) as HL.
+    pose proof (Z.mod_pow2_bits_low (a / 2 ^ 32) 32 n ltac:(lia)) as HR.
+    pose proof (Z.div_pow2_bits a 32 n ltac:(lia) ltac:(lia)) as HD.
+    rewrite HL. transitivity (Z.testbit (a / 2 ^ 32) n).
+    + symmetry. exact HD.
+    + symmetry. exact HR.
+  - rewrite Z.ltb_ge in E.
+    pose proof (Z.mod_pow2_bits_high a 64 (n + 32) ltac:(lia)) as HL.
+    pose proof (Z.mod_pow2_bits_high (a / 2 ^ 32) 32 n ltac:(lia)) as HR.
+    rewrite HL. symmetry. exact HR.
+Qed.
+
+(** The high half of I64.and on combined operands equals I32.and of the highs. *)
+Lemma and_hi_combine : forall lo1 hi1 lo2 hi2,
+  I32.and hi1 hi2 = hi_of_i64 (I64.and (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)).
+Proof.
+  intros lo1 hi1 lo2 hi2. unfold hi_of_i64.
+  unfold I64.and, I64.unsigned, I64.repr, I64.modulus, I32.repr, I32.and, I32.modulus.
+  rewrite Zmod_mod, div32_mod64, Zmod_mod.
+  pose proof (land_high32 (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)) as HH.
+  rewrite HH.
+  rewrite (land_low32 (combine_i32 lo1 hi1 / 2 ^ 32) (combine_i32 lo2 hi2 / 2 ^ 32)).
+  rewrite !combine_hi32.
+  unfold I32.unsigned, I32.modulus.
+  apply land_low32.
+Qed.
+
 Theorem i64_and_correct : forall astate lo1 hi1 lo2 hi2,
   get_reg astate R0 = lo1 ->
   get_reg astate R1 = hi1 ->

--- a/coq/Synth/Synth/CorrectnessI64.v
+++ b/coq/Synth/Synth/CorrectnessI64.v
@@ -580,13 +580,17 @@ Theorem i64_and_correct : forall astate lo1 hi1 lo2 hi2,
     get_reg astate' R1 = hi_of_i64 (I64.and (combine_i32 lo1 hi1)
                                             (combine_i32 lo2 hi2)).
 Proof.
-  (* ADMITTED: needs `lo_of_i64_and` / `hi_of_i64_and` helper lemmas in
-     Common/Integers.v. The ARM execution yields R0 = I32.and lo1 lo2 and
-     R1 = I32.and hi1 hi2; correspondence with the dual-register post-
-     condition reduces to the halves-distribute-over-Z.land property,
-     blocked by the same Rocq 9 Z.mod_mod issue as
-     `i64_to_i32_to_i64_wrap`. No new spec axiom introduced. *)
-Admitted.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm.
+  cbn [exec_program exec_instr eval_operand2].
+  eexists. split; [reflexivity | split].
+  - rewrite (get_set_reg_neq _ R1 R0) by discriminate.
+    rewrite get_set_reg_eq. rewrite HR0, HR2. apply and_lo_combine.
+  - rewrite get_set_reg_eq.
+    rewrite (get_set_reg_neq astate R0 R1) by discriminate.
+    rewrite (get_set_reg_neq astate R0 R3) by discriminate.
+    rewrite HR1, HR3. apply and_hi_combine.
+Qed.
 
 Theorem i64_or_correct : forall astate lo1 hi1 lo2 hi2,
   get_reg astate R0 = lo1 ->
@@ -600,10 +604,17 @@ Theorem i64_or_correct : forall astate lo1 hi1 lo2 hi2,
     get_reg astate' R1 = hi_of_i64 (I64.or (combine_i32 lo1 hi1)
                                            (combine_i32 lo2 hi2)).
 Proof.
-  (* ADMITTED: same shape as i64_and_correct — needs `lo_of_i64_or` /
-     `hi_of_i64_or` decomposition lemmas. Tracked as v0.9.0 PR 2
-     follow-up; no new spec axiom introduced. *)
-Admitted.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm.
+  cbn [exec_program exec_instr eval_operand2].
+  eexists. split; [reflexivity | split].
+  - rewrite (get_set_reg_neq _ R1 R0) by discriminate.
+    rewrite get_set_reg_eq. rewrite HR0, HR2. apply or_lo_combine.
+  - rewrite get_set_reg_eq.
+    rewrite (get_set_reg_neq astate R0 R1) by discriminate.
+    rewrite (get_set_reg_neq astate R0 R3) by discriminate.
+    rewrite HR1, HR3. apply or_hi_combine.
+Qed.
 
 Theorem i64_xor_correct : forall astate lo1 hi1 lo2 hi2,
   get_reg astate R0 = lo1 ->
@@ -617,10 +628,17 @@ Theorem i64_xor_correct : forall astate lo1 hi1 lo2 hi2,
     get_reg astate' R1 = hi_of_i64 (I64.xor (combine_i32 lo1 hi1)
                                             (combine_i32 lo2 hi2)).
 Proof.
-  (* ADMITTED: same shape as i64_and_correct — needs `lo_of_i64_xor` /
-     `hi_of_i64_xor` decomposition lemmas. Tracked as v0.9.0 PR 2
-     follow-up; no new spec axiom introduced. *)
-Admitted.
+  intros astate lo1 hi1 lo2 hi2 HR0 HR1 HR2 HR3.
+  unfold compile_wasm_to_arm.
+  cbn [exec_program exec_instr eval_operand2].
+  eexists. split; [reflexivity | split].
+  - rewrite (get_set_reg_neq _ R1 R0) by discriminate.
+    rewrite get_set_reg_eq. rewrite HR0, HR2. apply xor_lo_combine.
+  - rewrite get_set_reg_eq.
+    rewrite (get_set_reg_neq astate R0 R1) by discriminate.
+    rewrite (get_set_reg_neq astate R0 R3) by discriminate.
+    rewrite HR1, HR3. apply xor_hi_combine.
+Qed.
 
 (** v0.9.0 PR 3 lift: Shl/ShrU/ShrS/Rotl/Rotr restated with I64-typed
     hypotheses (operand lo/hi in R0:R1, 32-bit shift/rotate count in R2)

--- a/coq/Synth/Synth/CorrectnessI64.v
+++ b/coq/Synth/Synth/CorrectnessI64.v
@@ -514,6 +514,60 @@ Proof.
   apply land_low32.
 Qed.
 
+(** or/xor combine helpers — direct analogues of and_lo/and_hi_combine,
+    substituting lor/lxor (distribution lemmas {lor,lxor}_{low,high}32). *)
+Lemma or_lo_combine : forall lo1 hi1 lo2 hi2,
+  I32.or lo1 lo2 = lo_of_i64 (I64.or (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)).
+Proof.
+  intros lo1 hi1 lo2 hi2. rewrite lo_of_i64_repr.
+  unfold I64.or, I64.unsigned, I64.repr, I64.modulus, I32.repr, I32.or, I32.modulus.
+  rewrite Zmod_mod, mod64_mod32.
+  rewrite (lor_low32 (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)).
+  rewrite !combine_lo32.
+  unfold I32.repr, I32.unsigned, I32.modulus.
+  apply lor_low32.
+Qed.
+
+Lemma or_hi_combine : forall lo1 hi1 lo2 hi2,
+  I32.or hi1 hi2 = hi_of_i64 (I64.or (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)).
+Proof.
+  intros lo1 hi1 lo2 hi2. unfold hi_of_i64.
+  unfold I64.or, I64.unsigned, I64.repr, I64.modulus, I32.repr, I32.or, I32.modulus.
+  rewrite Zmod_mod, div32_mod64, Zmod_mod.
+  pose proof (lor_high32 (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)) as HH.
+  rewrite HH.
+  rewrite (lor_low32 (combine_i32 lo1 hi1 / 2 ^ 32) (combine_i32 lo2 hi2 / 2 ^ 32)).
+  rewrite !combine_hi32.
+  unfold I32.unsigned, I32.modulus.
+  apply lor_low32.
+Qed.
+
+Lemma xor_lo_combine : forall lo1 hi1 lo2 hi2,
+  I32.xor lo1 lo2 = lo_of_i64 (I64.xor (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)).
+Proof.
+  intros lo1 hi1 lo2 hi2. rewrite lo_of_i64_repr.
+  unfold I64.xor, I64.unsigned, I64.repr, I64.modulus, I32.repr, I32.xor, I32.modulus.
+  rewrite Zmod_mod, mod64_mod32.
+  rewrite (lxor_low32 (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)).
+  rewrite !combine_lo32.
+  unfold I32.repr, I32.unsigned, I32.modulus.
+  apply lxor_low32.
+Qed.
+
+Lemma xor_hi_combine : forall lo1 hi1 lo2 hi2,
+  I32.xor hi1 hi2 = hi_of_i64 (I64.xor (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)).
+Proof.
+  intros lo1 hi1 lo2 hi2. unfold hi_of_i64.
+  unfold I64.xor, I64.unsigned, I64.repr, I64.modulus, I32.repr, I32.xor, I32.modulus.
+  rewrite Zmod_mod, div32_mod64, Zmod_mod.
+  pose proof (lxor_high32 (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)) as HH.
+  rewrite HH.
+  rewrite (lxor_low32 (combine_i32 lo1 hi1 / 2 ^ 32) (combine_i32 lo2 hi2 / 2 ^ 32)).
+  rewrite !combine_hi32.
+  unfold I32.unsigned, I32.modulus.
+  apply lxor_low32.
+Qed.
+
 Theorem i64_and_correct : forall astate lo1 hi1 lo2 hi2,
   get_reg astate R0 = lo1 ->
   get_reg astate R1 = hi1 ->


### PR DESCRIPTION
## Summary
Closes the final 3 i64 bitwise admits → **true i64 T1 result-correspondence parity** (40 i64 T1 Qed, **0 i64 admits**). Closes #163.

## What landed (all Qed, no axioms — verified locally `bazel build //coq:verify_proofs` green)
- `div32_mod64` — `(a mod 2^64)/2^32 = (a/2^32) mod 2^32` (bits [32,64) survive the mod 2^64), bit-extensionality via `Z.div_pow2_bits` + `Z.mod_pow2_bits_{low,high}`.
- `and_hi_combine` + `or_lo/or_hi/xor_lo/xor_hi_combine` — high/low halves of `I64.{and,or,xor}` on combined operands = `I32.{and,or,xor}` of the respective halves.
- `i64_and_correct` / `i64_or_correct` / `i64_xor_correct` — discharged. AND/ORR/EOR compile to two flag-free register ops (`[_ R0 R0 R2; _ R1 R1 R3]`); proof is the `i64_add_correct` template minus flag-peeling.

## Verification delta
- i64 admits: **3 → 0**. Tree-wide admits: **12 → 9** (remaining: 4 i32-division behind the separate exec_program-model gap #73, 2 Compilation.v, 1 CorrectnessSimple.v, 2 ArmRefinement.v).
- Zero new axioms (grep-confirmed). Clean-room verified: 3 theorems genuinely Qed, no statement weakening (dual-register post-conditions intact), Qed-backed helpers.

## Falsification
v0.11.0 is wrong if: any of `i64_and/or/xor_correct` is not `Qed`; any statement was weakened; a new `Axiom` was introduced; or `bazel test //coq:verify_proofs` goes red on a clean checkout.

## Test plan
- [ ] CI `Bazel Build & Proofs` green
- [ ] After merge: cut v0.11.0 (version bump + pin sweep + CHANGELOG falsification statement + tag + verify release)