### PR TITLE
chore(release): v0.11.0 — true i64 T1 parity (0 i64 admits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-29
+
+**Theme: true i64 T1 result-correspondence parity.**
+
+v0.11.0 closes the final three i64 bitwise admits (`i64_and_correct`,
+`i64_or_correct`, `i64_xor_correct`), completing i64 T1 parity with i32:
+**40 i64 T1 Qed, 0 i64 admits.** Tree-wide admits drop 12 → 9. All proofs
+authored and verified against the local Nix/Bazel Rocq checker before
+push (`bazel build //coq:verify_proofs` green); clean-room verified
+(5/5 claims: genuinely Qed, no statement weakening, zero new axioms,
+Qed-backed helpers, admit accounting matches).
+
+**Falsification statement.** v0.11.0 is wrong if (a) any of
+`i64_and/or/xor_correct` is not `Qed` (Admitted/Abort/admit), (b) any of
+the three theorem statements was weakened from its v0.10.0 `Admitted`
+form (each must still assert `exec_program … = Some astate'` plus BOTH
+`get_reg astate' R0 = lo_of_i64 (…)` and `get_reg astate' R1 = hi_of_i64 (…)`),
+(c) a new `Axiom` was introduced anywhere under `coq/` (grep: zero), or
+(d) `bazel test //coq:verify_proofs` goes red on a clean v0.11.0 checkout.
+
+### Added
+- **i64 bitwise T1 result-correspondence** (PR #164, closes #163).
+  `i64_and_correct` / `i64_or_correct` / `i64_xor_correct` discharged.
+  AND/ORR/EOR compile to two flag-free register ops
+  (`[_ R0 R0 R2; _ R1 R1 R3]`); the proof is the `i64_add_correct`
+  template minus flag-peeling — step `exec_program` over the pair, route
+  R0/R1 via `get_set_reg_{eq,neq}`, apply the combine lemmas.
+- **Bitwise combine + slice helpers** (PR #164, all Qed, no axioms):
+  `div32_mod64` (`(a mod 2^64)/2^32 = (a/2^32) mod 2^32`, bit
+  extensionality via `Z.div_pow2_bits` + `Z.mod_pow2_bits_{low,high}`),
+  `and_hi_combine`, and the `or_lo/or_hi/xor_lo/xor_hi_combine`
+  analogues. Complete the infrastructure begun in v0.10.0
+  (`{land,lor,lxor}_{low,high}32`, `combine_lo32/hi32`, `and_lo_combine`).
+
 ## [0.10.0] - 2026-05-29
 
 **Theme: i64 add/sub T1 + Rocq 9 Z.mod_mod wrap closed + bitwise lift infrastructure.**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.10.0",
+    version = "0.11.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.10.0" }
+synth-core = { path = "../synth-core", version = "0.11.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.10.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.10.0" }
+synth-core = { path = "../synth-core", version = "0.11.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.10.0" }
+synth-core = { path = "../synth-core", version = "0.11.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.10.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.10.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.10.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.10.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.10.0" }
-synth-backend = { path = "../synth-backend", version = "0.10.0" }
+synth-core = { path = "../synth-core", version = "0.11.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.0" }
+synth-backend = { path = "../synth-backend", version = "0.11.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.10.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.10.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.10.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.10.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.10.0" }
+synth-core = { path = "../synth-core", version = "0.11.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.10.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.0" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.10.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.10.0" }
-synth-opt = { path = "../synth-opt", version = "0.10.0" }
+synth-core = { path = "../synth-core", version = "0.11.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.0" }
+synth-opt = { path = "../synth-opt", version = "0.11.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.10.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.10.0" }
-synth-opt = { path = "../synth-opt", version = "0.10.0" }
+synth-core = { path = "../synth-core", version = "0.11.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.0" }
+synth-opt = { path = "../synth-opt", version = "0.11.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.10.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.0", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Summary
- Bumps workspace + MODULE.bazel + path-dep pins 0.10.0 → 0.11.0
- Promotes `[Unreleased]` → `[0.11.0] - 2026-05-29` with the falsification statement

## Theme
**True i64 T1 result-correspondence parity.** PR #164 (closes #163) discharged the final 3 i64 bitwise admits (`i64_and/or/xor_correct`). i64 now has **40 T1 Qed, 0 admits** — full parity with i32. Tree-wide admits 12 → 9 (remaining: 4 i32-division behind the separate exec_program-model gap #73, 2 Compilation.v, 1 CorrectnessSimple.v, 2 ArmRefinement.v).

## Process
Every proof in the v0.11.0 work was authored and verified against the local Nix/Bazel Rocq checker before push (no blind CI round-trips). Clean-room verified: 5/5 claims (genuinely Qed, no statement weakening, zero new axioms, Qed-backed helpers, admit accounting matches).

## Falsification
v0.11.0 is wrong if: any of `i64_and/or/xor_correct` is not `Qed`; any statement was weakened from its v0.10.0 Admitted form (dual-register post-conditions must remain); a new `Axiom` appears under `coq/`; or `bazel test //coq:verify_proofs` goes red on a clean checkout.

## Test plan
- [ ] CI green (incl. Bazel Build & Proofs)
- [ ] After merge: tag v0.11.0; release.yml ships the 10-asset GitHub Release; publish-to-crates-io.yml republishes at 0.11.0