### PR TITLE
fix(arm): gale-wasm linkability — internal-call relocations + Thumb BL encoding (#167) + graceful skip (#168)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -221,11 +221,13 @@ fn compile_wasm_to_arm(
     let mut relocations = Vec::new();
 
     for instr in &arm_instrs {
-        // Record relocation for BL instructions targeting external symbols.
-        // The BL is encoded with offset 0; the linker patches it.
-        if let ArmOp::Bl { label } = &instr.op
-            && label.starts_with("__meld_")
-        {
+        // Record a relocation for every BL: the encoder emits `bl #0` and
+        // relies on a relocation to patch the target. This covers BOTH import
+        // dispatch stubs (`__meld_*`, undefined externals) AND internal calls
+        // (`func_N`, defined in this object). Previously only `__meld_*` was
+        // recorded, so internal `BL func_N` calls were left as unpatched
+        // `bl #0` placeholders branching to a garbage address (#167).
+        if let ArmOp::Bl { label } = &instr.op {
             relocations.push(CodeRelocation {
                 offset: code.len() as u32,
                 symbol: label.clone(),

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -2492,10 +2492,17 @@ impl ArmEncoder {
             }
 
             ArmOp::Bl { label: _ } => {
-                // BL is always 32-bit in Thumb-2
-                // Simplified: BL with offset 0
+                // BL is always 32-bit in Thumb-2, encoded here with offset 0
+                // (a relocation patches the target — see arm_backend.rs).
+                // Second halfword must be 0xF800, NOT 0xD000: the Thumb-2 BL
+                // offset uses I1 = NOT(J1 XOR S), I2 = NOT(J2 XOR S). For a true
+                // zero offset (S=0, imm=0) we need I1=I2=0, i.e. J1=J2=1, giving
+                //   hw2 = 11 J1(=1) 1 J2(=1) imm11(=0) = 0b1111_1000_0000_0000 = 0xF800.
+                // The old 0xD000 (J1=J2=0) decodes to I1=I2=1 → a bogus built-in
+                // addend of ~+0x600000, which produced the garbage `bl c0000c`
+                // target and "relocation truncated to fit" at link time (#167).
                 let hw1: u16 = 0xF000;
-                let hw2: u16 = 0xD000;
+                let hw2: u16 = 0xF800;
                 let mut bytes = hw1.to_le_bytes().to_vec();
                 bytes.extend_from_slice(&hw2.to_le_bytes());
                 Ok(bytes)

--- a/crates/synth-backend/src/elf_builder.rs
+++ b/crates/synth-backend/src/elf_builder.rs
@@ -322,6 +322,10 @@ impl ProgramHeader {
 /// ARM relocation type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArmRelocationType {
+    /// R_ARM_THM_CALL (10) — Thumb BL/BLX instruction (Cortex-M). This is the
+    /// correct relocation for a Thumb-2 `bl` call site; `Call`/R_ARM_CALL below
+    /// is the ARM-mode form and is mis-resolved by `ld` for Thumb calls.
+    ThmCall = 10,
     /// R_ARM_CALL (28) — BL/BLX instruction
     Call = 28,
     /// R_ARM_JUMP24 (29) — B/BL<cond> instruction

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1816,6 +1816,7 @@ fn compile_all_exports(
 
     // Compile each function via the selected backend
     let mut compiled_funcs = Vec::new();
+    let mut skipped_funcs: Vec<(String, String)> = Vec::new();
     for func in &all_exports {
         let name = func.export_name.clone().ok_or_else(|| {
             anyhow::anyhow!("function at index {} has no export name", func.index)
@@ -1826,11 +1827,26 @@ fn compile_all_exports(
             backend.name()
         );
 
-        let compiled = backend
-            .compile_function(&name, &func.ops, &config)
-            .map_err(|e| {
-                anyhow::anyhow!("Backend '{}' failed on '{}': {}", backend.name(), name, e)
-            })?;
+        // In the all-exports path, a single un-compilable function (e.g. an
+        // i64-heavy compiler_builtins helper that exhausts the register
+        // allocator, #168) must not abort the whole module. Emit a diagnostic,
+        // record it, and continue — the function is simply absent from the
+        // output object. Callers that need it get a link error naming the
+        // missing symbol, which is far more actionable than a whole-module
+        // failure on dead-weight pulled in by `--whole-archive`.
+        let compiled = match backend.compile_function(&name, &func.ops, &config) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "warning: skipping function '{}': backend '{}' failed: {}",
+                    name,
+                    backend.name(),
+                    e
+                );
+                skipped_funcs.push((name.clone(), e.to_string()));
+                continue;
+            }
+        };
         info!("  {} bytes of machine code", compiled.code.len());
 
         if !compiled.relocations.is_empty() {
@@ -1857,6 +1873,27 @@ fn compile_all_exports(
                 eprintln!("  Rebuild with: cargo build --features verify");
             }
         }
+    }
+
+    // Surface skipped functions (no silent omissions): a skipped function is
+    // absent from the output object, so report the count + names explicitly.
+    if !skipped_funcs.is_empty() {
+        eprintln!(
+            "warning: {} of {} functions were skipped (not in output): {}",
+            skipped_funcs.len(),
+            all_exports.len(),
+            skipped_funcs
+                .iter()
+                .map(|(n, _)| n.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    if compiled_funcs.is_empty() {
+        anyhow::bail!(
+            "no functions compiled successfully ({} skipped) — nothing to emit",
+            skipped_funcs.len()
+        );
     }
 
     // Check if any function has relocations (import calls)

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -668,6 +668,10 @@ fn print_hardware_info(caps: &HardwareCapabilities) {
 /// Compiled function for ELF building (name + code bytes + relocations)
 struct ElfFunction {
     name: String,
+    /// WASM function index — used to define a `func_{index}` symbol so that
+    /// internal calls (`BL func_N`, emitted by the selector against the WASM
+    /// index) resolve to this function's address (#167).
+    wasm_index: u32,
     code: Vec<u8>,
     /// Relocations targeting external symbols (from import dispatch stubs)
     relocations: Vec<synth_core::backend::CodeRelocation>,
@@ -1838,6 +1842,7 @@ fn compile_all_exports(
 
         compiled_funcs.push(ElfFunction {
             name: name.clone(),
+            wasm_index: func.index,
             code: compiled.code,
             relocations: compiled.relocations,
         });
@@ -2027,41 +2032,74 @@ fn build_relocatable_elf(funcs: &[ElfFunction], imports: &[ImportEntry]) -> Resu
 
     elf_builder.add_section(text_section);
 
-    // Add defined symbols for each compiled function
+    // Symbol-name -> symbol index map. Symbol indices are 1-based (index 0 is
+    // the reserved null symbol); each `add_symbol` appends one, so we track the
+    // running count to know the index of each symbol we define.
+    let mut sym_indices: HashMap<String, u32> = HashMap::new();
+    let mut sym_count: u32 = 0; // number of real symbols added so far
+
+    // Add defined symbols for each compiled function. We define TWO names per
+    // function: the export name (global, for the host linker) and a stable
+    // `func_{wasm_index}` name (the label the instruction selector emits for
+    // internal `call`s). Internal `BL func_N` relocations resolve against the
+    // latter; without it, internal calls were left as unpatched `bl #0` (#167).
     for (i, func) in funcs.iter().enumerate() {
-        let func_sym = Symbol::new(&func.name)
+        let export_sym = Symbol::new(&func.name)
             .with_value(func_offsets[i])
             .with_size(func.code.len() as u32)
             .with_binding(SymbolBinding::Global)
             .with_type(SymbolType::Func)
             .with_section(4); // .text is section 4 (null=0, shstrtab=1, strtab=2, symtab=3, .text=4)
+        elf_builder.add_symbol(export_sym);
+        sym_count += 1;
+        sym_indices.insert(func.name.clone(), sym_count);
 
-        elf_builder.add_symbol(func_sym);
+        // `func_{wasm_index}` alias (skip if the export name already is that).
+        let internal_label = format!("func_{}", func.wasm_index);
+        if internal_label != func.name {
+            let internal_sym = Symbol::new(&internal_label)
+                .with_value(func_offsets[i])
+                .with_size(func.code.len() as u32)
+                .with_binding(SymbolBinding::Global)
+                .with_type(SymbolType::Func)
+                .with_section(4);
+            elf_builder.add_symbol(internal_sym);
+            sym_count += 1;
+            sym_indices.insert(internal_label, sym_count);
+        }
     }
 
-    // Collect unique external symbol names from all relocations and add as undefined
-    let mut extern_sym_indices: HashMap<String, u32> = HashMap::new();
+    // Any relocation symbol not already defined (i.e. import dispatch stubs like
+    // `__meld_dispatch_import`, and any internal call whose callee was not among
+    // the compiled functions) becomes an undefined external symbol.
+    let mut external_count = 0usize;
     for func in funcs {
         for reloc in &func.relocations {
-            if !extern_sym_indices.contains_key(&reloc.symbol) {
+            if !sym_indices.contains_key(&reloc.symbol) {
                 let idx = elf_builder.add_undefined_symbol(&reloc.symbol);
-                extern_sym_indices.insert(reloc.symbol.clone(), idx);
+                sym_indices.insert(reloc.symbol.clone(), idx);
+                external_count += 1;
             }
         }
     }
 
-    // Add R_ARM_CALL relocations for each BL to an external symbol
+    // Emit an R_ARM_THM_CALL relocation for every BL (internal `func_N` resolves
+    // against the defined symbol; imports against the undefined external). Thumb
+    // BL on Cortex-M requires R_ARM_THM_CALL (10), not the ARM-mode R_ARM_CALL.
+    let mut reloc_count = 0usize;
     for (i, func) in funcs.iter().enumerate() {
         let func_base = func_offsets[i];
         for reloc in &func.relocations {
-            let sym_idx = extern_sym_indices[&reloc.symbol];
+            let sym_idx = sym_indices[&reloc.symbol];
             elf_builder.add_relocation(Relocation {
                 offset: func_base + reloc.offset,
                 symbol_index: sym_idx,
-                reloc_type: ArmRelocationType::Call, // R_ARM_CALL (28)
+                reloc_type: ArmRelocationType::ThmCall, // R_ARM_THM_CALL (10)
             });
+            reloc_count += 1;
         }
     }
+    let extern_sym_indices = (external_count, reloc_count); // for the info! below
 
     // Add a .meld_import_table section with import metadata
     // This is a custom section that the Kiln bridge can read to understand
@@ -2097,11 +2135,12 @@ fn build_relocatable_elf(funcs: &[ElfFunction], imports: &[ImportEntry]) -> Resu
         }
     }
 
+    let (external_count, reloc_count) = extern_sym_indices;
     info!(
         "Relocatable ELF: {} functions, {} external symbols, {} relocations",
         funcs.len(),
-        extern_sym_indices.len(),
-        funcs.iter().map(|f| f.relocations.len()).sum::<usize>()
+        external_count,
+        reloc_count
     );
 
     elf_builder


### PR DESCRIPTION
Fixes the two **serious gale-wasm compilation blockers** filed against v0.11.0.

## #167 — non-linkable ELF (regression from v0.3.0)

Every synth ARM object containing a function call was non-linkable. Three chained defects:

1. **Dropped relocations.** `arm_backend.rs` recorded a relocation only for `BL` labels starting with `__meld_` (import dispatch). Internal `BL func_N` got none → emitted as bare `bl #0` with nothing to patch. → record a relocation for *every* `BL`.
2. **No target symbol + wrong reloc type.** `build_relocatable_elf` defined only export-name symbols, but the selector emits `BL func_{wasm_index}`. → define a `func_{index}` symbol per function and emit **`R_ARM_THM_CALL`** (Thumb) instead of `R_ARM_CALL` (ARM-mode).
3. **Garbage BL encoding.** The Thumb BL placeholder used second halfword `0xD000` — with `J1=J2=0, S=0` that decodes to `I1=I2=1`, baking in a bogus **~+0x600000** addend. That is the original garbage `bl c0000c` target *and* the linker `relocation truncated to fit`. A true zero-offset Thumb BL is **`0xF800`** (`J1=J2=1`). Fixed.

**Verified** on the issue's minimal 2-function repro: the `.o` now carries `R_ARM_THM_CALL → func_0`, **links with `arm-none-eabi-ld` with zero errors** (was "truncated to fit"), and the call resolves to the callee.

## #168 — register exhaustion aborts whole module

`compiler_builtins::float::div` exhausts the i64 consecutive-pair allocator; under `--all-exports` (gale's `--whole-archive`) this killed the entire module. Now `compile_all_exports` skips the un-compilable function with a diagnostic, continues, and reports the skipped set; a caller that references it gets a clean `undefined symbol func_N` link error (via the #167 relocation path). Erroring only if *every* function fails. (The allocator limitation itself — spill / pair-coalescing — remains a follow-up.)

## Tests
- All synth-backend (180+), synth-cli, synth-synthesis (241) tests pass.
- Manual: #167 mini repro links cleanly end-to-end.

## Falsification
This is wrong if: a module with internal calls still produces a `.o` that fails to link (no `R_ARM_THM_CALL` for the call, or a bogus addend), or `--all-exports` still aborts on a single un-compilable function.

## Follow-ups (filed-worthy, not blocking)
- Standalone `--cortex-m` (non-relocatable) direct call resolution.
- `$t`/`$a` mapping symbols (Thumb disassembly/debug display; not required for linking).
- i64 register-pair spill / coalescing (the root #168 allocator limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)