### PR TITLE
chore(release): v0.11.1 — gale-wasm ARM linkability patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-05-30
+
+**Patch: gale-wasm ARM linkability.** Unblocks the cross-language-LTO route
+(gale-ffi → wasm → synth → ARM `ET_REL` → linked into a Zephyr build). No
+proof-suite changes; the v0.12 control-flow-model verification work is
+separate and unaffected.
+
+**Falsification statement.** v0.11.1 is wrong if a WASM module containing an
+internal function call still compiles to an ARM object that fails to link
+(no `R_ARM_THM_CALL` for the call, or a non-zero built-in BL addend), or if
+`--all-exports` still aborts the whole module on a single un-compilable
+function.
+
+### Fixed
+- **Internal calls are now linkable** (#167, PR #169). Every synth ARM object
+  containing a function call was non-linkable (a regression from v0.3.0).
+  Three chained defects:
+  1. `arm_backend.rs` recorded a relocation only for `BL __meld_*` (import
+     dispatch); internal `BL func_N` got none, so they were emitted as bare
+     `bl #0` with nothing to patch. Now records a relocation for every `BL`.
+  2. `build_relocatable_elf` defined only export-name symbols and used
+     `R_ARM_CALL` (ARM mode). Now defines a `func_{index}` symbol per function
+     and emits `R_ARM_THM_CALL` (Thumb).
+  3. The Thumb BL placeholder encoded second halfword `0xD000`, which
+     (`J1=J2=0, S=0` ⟹ `I1=I2=1`) bakes in a bogus ~`+0x600000` addend — the
+     source of the garbage `bl c0000c` target *and* the linker
+     "relocation truncated to fit". A true zero-offset Thumb BL is `0xF800`.
+
+     Verified on a minimal 2-internal-call module: the `.o` now carries
+     `R_ARM_THM_CALL → func_0`, links with `arm-none-eabi-ld` with zero
+     errors, and the call resolves to the callee.
+- **`--all-exports` no longer aborts on one un-compilable function** (#168,
+  PR #169). A function the backend cannot compile (e.g.
+  `compiler_builtins::float::div`, which exhausts the i64 register-pair
+  allocator) is now skipped with a diagnostic and an end-of-run report; a
+  caller that references it gets a clean `undefined symbol func_N` link error.
+  Erroring only if every function fails.
+
+### Known follow-ups (not blocking the gale `--relocatable` route)
+- Standalone `--cortex-m` (no linker) internal-call direct resolution + `$t`
+  mapping symbols (#170).
+- i64 consecutive-pair allocator spill / coalescing — the root of #168 (#171).
+
 ## [0.11.0] - 2026-05-29
 
 **Theme: true i64 T1 result-correspondence parity.**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.0",
+    version = "0.11.1",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.0" }
+synth-core = { path = "../synth-core", version = "0.11.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.0" }
+synth-core = { path = "../synth-core", version = "0.11.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.0" }
+synth-core = { path = "../synth-core", version = "0.11.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.1", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.0" }
-synth-backend = { path = "../synth-backend", version = "0.11.0" }
+synth-core = { path = "../synth-core", version = "0.11.1" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.1" }
+synth-backend = { path = "../synth-backend", version = "0.11.1" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.1", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.1", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.1", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.1", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.0" }
+synth-core = { path = "../synth-core", version = "0.11.1" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.1" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.0" }
-synth-opt = { path = "../synth-opt", version = "0.11.0" }
+synth-core = { path = "../synth-core", version = "0.11.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.1" }
+synth-opt = { path = "../synth-opt", version = "0.11.1" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.0" }
-synth-opt = { path = "../synth-opt", version = "0.11.0" }
+synth-core = { path = "../synth-core", version = "0.11.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.1" }
+synth-opt = { path = "../synth-opt", version = "0.11.1" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.1", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Fast patch shipping the gale-wasm linkability fix (PR #169, already on main).

## Summary
- Bumps workspace + MODULE.bazel + path-dep pins 0.11.0 → 0.11.1
- Promotes `[Unreleased]` → `[0.11.1] - 2026-05-30` with the falsification statement
- Backend bugfix only — no proof-suite changes (the v0.12 control-flow verification work is separate)

## What ships
- **#167** internal-call relocations + correct Thumb BL encoding (`0xF800`, not the garbage-addend `0xD000`) → synth ARM objects with function calls link again (v0.3.0 regression). Verified: minimal repro links with `arm-none-eabi-ld`, zero errors.
- **#168** `--all-exports` skips an un-compilable function (diagnostic + report) instead of aborting the module.

## Falsification
v0.11.1 is wrong if a module with an internal call still produces a non-linkable `.o`, or `--all-exports` still aborts on one un-compilable function.

## Test plan
- [ ] CI green
- [ ] After merge: tag v0.11.1; release.yml ships the 10-asset GitHub Release; publish-to-crates-io.yml republishes at 0.11.1