### PR TITLE
fix(arm): import-call relocations use wasm field names (#173) + regression tests for #167/#168

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,14 +1946,15 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.7.0"
+version = "0.11.1"
 
 [[package]]
 name = "synth-cli"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",
+ "object",
  "serde_json",
  "synth-backend",
  "synth-backend-awsm",
@@ -1971,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -1984,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1998,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2013,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.7.0"
+version = "0.11.1"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2032,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2048,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.7.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2066,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.7.0"
+version = "0.11.1"
 
 [[package]]
 name = "tempfile"

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -328,6 +328,38 @@ mod tests {
         assert!(func.relocations.is_empty());
     }
 
+    /// Regression test for #167: a call to an INTERNAL function (index
+    /// >= num_imports) must record a relocation against `func_{index}`.
+    /// Before the fix, only `__meld_*` (import) BLs were relocated, so
+    /// internal `BL func_N` was emitted as an unpatched `bl #0` branching
+    /// to a garbage address — making the object non-linkable. This test
+    /// would have caught that regression.
+    #[test]
+    fn test_compile_internal_call_produces_relocation_167() {
+        let backend = ArmBackend::new();
+        // num_imports = 1, so Call(2) is an INTERNAL call → `BL func_2`.
+        let ops = vec![WasmOp::Call(2)];
+        let config = CompileConfig {
+            num_imports: 1,
+            no_optimize: true,
+            ..CompileConfig::default()
+        };
+
+        let func = backend
+            .compile_function("caller", &ops, &config)
+            .expect("internal call compiles");
+
+        assert_eq!(
+            func.relocations.len(),
+            1,
+            "an internal call must emit exactly one relocation (#167)"
+        );
+        assert_eq!(
+            func.relocations[0].symbol, "func_2",
+            "internal call must relocate against the callee's func_{{index}} symbol (#167)"
+        );
+    }
+
     // ─── Phase 1 safety-bounds plumbing for ARM ──────────────────────────
 
     #[test]

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -6911,6 +6911,32 @@ mod tests {
         assert_eq!(instr & 0x0F000000, 0x0B000000);
     }
 
+    /// Regression test for #167: the Thumb-2 BL placeholder must encode a
+    /// TRUE zero offset so a relocation can patch it cleanly. The second
+    /// halfword must be 0xF800 (J1=J2=1 ⟹ I1=I2=0), NOT 0xD000 (J1=J2=0 ⟹
+    /// I1=I2=1), which bakes in a bogus ~+0x600000 addend — the source of
+    /// the garbage `bl c0000c` target and the linker "relocation truncated
+    /// to fit". hw1=0xF000, hw2=0xF800 → little-endian bytes 00 F0 00 F8.
+    #[test]
+    fn test_encode_thumb_bl_zero_offset_167() {
+        let encoder = ArmEncoder::new_thumb2();
+        let op = ArmOp::Bl {
+            label: "callee".to_string(),
+        };
+
+        let code = encoder.encode(&op).unwrap();
+        assert_eq!(code.len(), 4, "Thumb-2 BL is 32-bit");
+
+        let hw1 = u16::from_le_bytes([code[0], code[1]]);
+        let hw2 = u16::from_le_bytes([code[2], code[3]]);
+        assert_eq!(hw1, 0xF000, "BL first halfword");
+        assert_eq!(
+            hw2, 0xF800,
+            "BL second halfword must be 0xF800 (true zero offset), not 0xD000 (#167)"
+        );
+        assert_ne!(hw2, 0xD000, "0xD000 bakes in a ~+0x600000 addend (#167)");
+    }
+
     #[test]
     fn test_encode_sequence() {
         let encoder = ArmEncoder::new_arm32();

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -51,3 +51,6 @@ tracing-subscriber.workspace = true
 serde_json.workspace = true
 wat.workspace = true
 wast.workspace = true
+
+[dev-dependencies]
+object.workspace = true

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2106,17 +2106,46 @@ fn build_relocatable_elf(funcs: &[ElfFunction], imports: &[ImportEntry]) -> Resu
         }
     }
 
-    // Any relocation symbol not already defined (i.e. import dispatch stubs like
-    // `__meld_dispatch_import`, and any internal call whose callee was not among
-    // the compiled functions) becomes an undefined external symbol.
+    // Map the BL label of a call to a wasm import (`func_{import_index}`) to
+    // the import's field name. The selector emits `BL func_N` for imported
+    // calls too (N is the wasm function index, which for imports is the import
+    // index); naming the undefined symbol `func_N` means a real host (e.g. the
+    // Zephyr kernel) cannot resolve it — it defines `k_spin_lock`, not `func_0`.
+    // synth knows the field names (it logs them + emits .meld_import_table), so
+    // use them for the undefined symbol (#173). Internal defined calls keep
+    // their `func_N`/export-name symbol (already in sym_indices).
+    let mut import_label_to_field: HashMap<String, String> = HashMap::new();
+    for imp in imports {
+        if matches!(imp.kind, synth_core::ImportKind::Function(_)) {
+            import_label_to_field.insert(format!("func_{}", imp.index), imp.name.clone());
+        }
+    }
+
+    // Any relocation symbol not already defined becomes an undefined external:
+    // import calls under their wasm field name, dispatch stubs (`__meld_*`) and
+    // skipped-internal callees under their original label.
     let mut external_count = 0usize;
     for func in funcs {
         for reloc in &func.relocations {
-            if !sym_indices.contains_key(&reloc.symbol) {
-                let idx = elf_builder.add_undefined_symbol(&reloc.symbol);
-                sym_indices.insert(reloc.symbol.clone(), idx);
-                external_count += 1;
+            if sym_indices.contains_key(&reloc.symbol) {
+                continue; // internal call to a compiled function — already defined
             }
+            let effective = import_label_to_field
+                .get(&reloc.symbol)
+                .cloned()
+                .unwrap_or_else(|| reloc.symbol.clone());
+            let idx = match sym_indices.get(&effective) {
+                Some(&i) => i,
+                None => {
+                    let i = elf_builder.add_undefined_symbol(&effective);
+                    sym_indices.insert(effective.clone(), i);
+                    external_count += 1;
+                    i
+                }
+            };
+            // Resolve the original label (func_N) to the effective symbol index
+            // so the relocation-emission loop below finds it.
+            sym_indices.insert(reloc.symbol.clone(), idx);
         }
     }
 

--- a/crates/synth-cli/tests/wast_compile.rs
+++ b/crates/synth-cli/tests/wast_compile.rs
@@ -387,3 +387,131 @@ fn all_wast_files_present() {
         files.len()
     );
 }
+
+/// Regression test for #167: a module with an INTERNAL call (no imports)
+/// must compile to a relocatable object whose internal call carries an
+/// `R_ARM_THM_CALL` relocation against the callee's `func_{index}` symbol —
+/// i.e. it is actually linkable. Before the fix, internal calls produced
+/// neither a relocation nor a `func_N` symbol (the object was non-linkable:
+/// the call was a `bl #0` placeholder branching to a garbage address).
+#[test]
+fn compile_internal_call_is_linkable_167() {
+    use object::{Object, ObjectSection, ObjectSymbol};
+
+    let wat = workspace_root()
+        .join("tests")
+        .join("integration")
+        .join("internal_call.wat");
+    assert!(wat.exists(), "internal_call.wat not found: {}", wat.display());
+
+    let output = std::env::temp_dir().join("synth_test_internal_call.o");
+    let result = Command::new(synth_binary())
+        .args([
+            "compile",
+            wat.to_str().unwrap(),
+            "--target",
+            "cortex-m4f",
+            "--all-exports",
+            "--relocatable",
+            "-o",
+            output.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to run synth binary");
+    assert!(
+        result.status.success(),
+        "synth compile failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr),
+    );
+
+    let data = std::fs::read(&output).unwrap();
+    let elf = object::File::parse(&*data).expect("parse ARM ELF object");
+
+    // A `func_0` symbol must be defined so internal `BL func_0` resolves.
+    let has_func_sym = elf.symbols().any(|s| s.name() == Ok("func_0"));
+    assert!(
+        has_func_sym,
+        "internal call target symbol `func_0` not defined in the object (#167)"
+    );
+
+    // The internal call must carry an R_ARM_THM_CALL (10) relocation — NOT
+    // R_ARM_CALL (28, ARM mode), and not be absent entirely.
+    const R_ARM_THM_CALL: u32 = 10;
+    let mut thm_call_relocs = 0usize;
+    for section in elf.sections() {
+        for (_off, reloc) in section.relocations() {
+            if let object::RelocationFlags::Elf { r_type } = reloc.flags() {
+                if r_type == R_ARM_THM_CALL {
+                    thm_call_relocs += 1;
+                }
+            }
+        }
+    }
+    assert!(
+        thm_call_relocs >= 1,
+        "expected at least one R_ARM_THM_CALL relocation for the internal call (#167), found {}",
+        thm_call_relocs
+    );
+
+    let _ = std::fs::remove_file(&output);
+}
+
+/// Regression test for #173: a call to a wasm IMPORT must relocate against the
+/// import's field name (e.g. `host_fn`), so the object resolves against a real
+/// host that defines that symbol — NOT a generic `func_N` the host never
+/// defines. synth knows the name (it logs it); it must reach the symbol table.
+#[test]
+fn compile_import_call_uses_field_name_173() {
+    use object::{Object, ObjectSymbol};
+
+    let wat = workspace_root()
+        .join("tests")
+        .join("integration")
+        .join("import_field_name.wat");
+    assert!(wat.exists(), "import_field_name.wat not found: {}", wat.display());
+
+    let output = std::env::temp_dir().join("synth_test_import_field_name.o");
+    let result = Command::new(synth_binary())
+        .args([
+            "compile",
+            wat.to_str().unwrap(),
+            "--target",
+            "cortex-m4f",
+            "--all-exports",
+            "--relocatable",
+            "-o",
+            output.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to run synth binary");
+    assert!(
+        result.status.success(),
+        "synth compile failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr),
+    );
+
+    let data = std::fs::read(&output).unwrap();
+    let elf = object::File::parse(&*data).expect("parse ARM ELF object");
+
+    // The import's field name must be an UNDEFINED symbol the host resolves.
+    let has_field_name = elf
+        .symbols()
+        .any(|s| s.name() == Ok("host_fn") && s.is_undefined());
+    assert!(
+        has_field_name,
+        "import call must produce an undefined symbol named after the wasm field (`host_fn`) (#173)"
+    );
+
+    // And it must NOT name the import as a generic `func_0`.
+    let has_generic_import_label = elf
+        .symbols()
+        .any(|s| s.name() == Ok("func_0") && s.is_undefined());
+    assert!(
+        !has_generic_import_label,
+        "import call must not be left as a generic `func_0` symbol (#173)"
+    );
+
+    let _ = std::fs::remove_file(&output);
+}

--- a/tests/integration/import_field_name.wat
+++ b/tests/integration/import_field_name.wat
@@ -1,0 +1,4 @@
+(module
+  (import "env" "host_fn" (func $host (param i32) (result i32)))
+  (func $caller (export "caller") (param i32) (result i32)
+    local.get 0  call $host))

--- a/tests/integration/internal_call.wat
+++ b/tests/integration/internal_call.wat
@@ -1,0 +1,6 @@
+(module
+  (func $callee (param i32) (result i32)
+    local.get 0  i32.const 7  i32.add)
+  (func $caller (export "caller") (param i32) (result i32)
+    local.get 0  call $callee  i32.const 2  i32.mul)
+  (export "callee" (func $callee)))


### PR DESCRIPTION
Solves the new gale-team issue **#173** (the final blocker for the cross-language-LTO-via-wasm route) and adds the **regression tests** that were missing when the #167/#168 fixes shipped in v0.11.1.

## #173 — import-call relocations now use the wasm field name
Follow-up to #167. The selector emits `BL func_{wasm_index}` for imported calls too (an import's wasm index < num_imports), so `build_relocatable_elf` named the undefined symbol `func_0`/`func_1`/… A real host defines `k_spin_lock`, not `func_0`, so the object couldn't resolve against the Zephyr kernel.

synth already knows the names (logs them + emits `.meld_import_table`). `build_relocatable_elf` now maps `func_{import_index}` relocation labels → the import's **field name** (from the `imports` table it already receives). Internal defined calls keep their `func_N`/export-name symbol; `__meld_*` dispatch stubs unchanged.

**Verified:** a module importing `env::host_fn` now emits `R_ARM_THM_CALL host_fn` and `U host_fn` (was `U func_0`).

## Regression tests (the guard that was missing)
The v0.3.0→v0.11.0 regression slipped through because nothing tested internal-call linkability. Added:
- `test_encode_thumb_bl_zero_offset_167` — BL placeholder must be `0xF800`, never `0xD000` (the garbage-addend bug).
- `test_compile_internal_call_produces_relocation_167` — internal call records a `func_N` relocation.
- `compile_internal_call_is_linkable_167` (integration) — relocatable object carries `R_ARM_THM_CALL` against a defined `func_0`, end-to-end.
- `compile_import_call_uses_field_name_173` (integration) — import → `U host_fn`, not `U func_0`.

(Adds `object` as a synth-cli dev-dependency for ELF inspection.)

## Tests
All synth-backend (182, +2) and synth-cli suites pass. The 4 new tests each fail on the pre-fix code (genuine regression guards).

## Falsification
Wrong if: an imported call still produces a `func_N` undefined symbol instead of the field name, or any of the 4 regression tests pass against the un-fixed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)