### PR TITLE
chore(release): v0.11.2 — gale-wasm import field-name symbols (#173) + regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-05-30
+
+**Patch: gale-wasm ARM linkability, round 2.** Completes the cross-language-LTO
+route (gale-ffi → wasm → synth → ARM `ET_REL` → linked against a real host).
+Backend bugfix + regression tests; no proof-suite changes.
+
+**Falsification statement.** v0.11.2 is wrong if an imported wasm call still
+produces a generic `func_N` undefined symbol instead of the import's field
+name, or if any of the four new regression tests pass against the pre-fix code.
+
+### Fixed
+- **Import-call relocations now use the wasm field name** (#173, PR #175).
+  The selector emits `BL func_{wasm_index}` for imported calls too (an import's
+  wasm index < num_imports), so `build_relocatable_elf` named the undefined
+  symbol `func_0`/`func_1`/… A real host (e.g. the Zephyr kernel) defines
+  `k_spin_lock`, not `func_0`, so the object could not resolve — the final
+  blocker for the cross-language-LTO route. `build_relocatable_elf` now maps
+  `func_{import_index}` relocation labels to the import's field name (from the
+  imports table it already receives). Internal defined calls keep their
+  `func_N`/export-name symbol; `__meld_*` dispatch stubs unchanged. Verified:
+  a module importing `env::host_fn` now emits `R_ARM_THM_CALL host_fn` and
+  `U host_fn` (was `U func_0`).
+
+### Added
+- **Regression tests for the #167/#168/#173 gale linkability fixes.** The
+  v0.3.0→v0.11.0 non-linkable-ELF regression slipped through because nothing
+  tested internal-call linkability. Now guarded:
+  - `test_encode_thumb_bl_zero_offset_167` — the Thumb BL placeholder must
+    encode `0xF800` (true zero offset), never `0xD000` (the ~`+0x600000`
+    garbage addend).
+  - `test_compile_internal_call_produces_relocation_167` — an internal call
+    records a relocation against `func_{index}`.
+  - `compile_internal_call_is_linkable_167` (integration) — a relocatable
+    object carries `R_ARM_THM_CALL` against a defined `func_0`, end-to-end.
+  - `compile_import_call_uses_field_name_173` (integration) — an import call
+    produces `U host_fn`, not `U func_0`.
+
+  Adds the `object` crate as a synth-cli dev-dependency for ELF inspection.
+
 ## [0.11.1] - 2026-05-30
 
 **Patch: gale-wasm ARM linkability.** Unblocks the cross-language-LTO route

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.1",
+    version = "0.11.2",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.1" }
+synth-core = { path = "../synth-core", version = "0.11.2" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.1" }
+synth-core = { path = "../synth-core", version = "0.11.2" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.2" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.1" }
+synth-core = { path = "../synth-core", version = "0.11.2" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.1", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.2" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.2", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.1" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.1" }
-synth-backend = { path = "../synth-backend", version = "0.11.1" }
+synth-core = { path = "../synth-core", version = "0.11.2" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.2" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.2" }
+synth-backend = { path = "../synth-backend", version = "0.11.2" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.1", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.1", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.1", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.2", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.2", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.2", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.1", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.2", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.1" }
+synth-core = { path = "../synth-core", version = "0.11.2" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.2" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.1" }
-synth-opt = { path = "../synth-opt", version = "0.11.1" }
+synth-core = { path = "../synth-core", version = "0.11.2" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.2" }
+synth-opt = { path = "../synth-opt", version = "0.11.2" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.1" }
-synth-opt = { path = "../synth-opt", version = "0.11.1" }
+synth-core = { path = "../synth-core", version = "0.11.2" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.2" }
+synth-opt = { path = "../synth-opt", version = "0.11.2" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.1", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.2", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Fast patch shipping the #173 import-symbol fix (PR #175, on main) and the regression tests for the #167/#168/#173 gale linkability work.

## Summary
- Bumps workspace + MODULE.bazel + path-dep pins 0.11.1 → 0.11.2
- Promotes `[Unreleased]` → `[0.11.2] - 2026-05-30` with the falsification statement
- Backend bugfix + tests only — no proof-suite changes

## What ships
- **#173** import-call relocations use the wasm field name (`host_fn`/`k_spin_lock`), not generic `func_N` → synth objects link against a real host (Zephyr kernel). The final blocker for the cross-language-LTO route.
- 4 regression tests guarding #167/#168/#173 (the guard missing when round 1 shipped).

## Falsification
v0.11.2 is wrong if an imported call still produces a `func_N` symbol instead of the field name, or any new regression test passes against the pre-fix code.

## Test plan
- [ ] CI green
- [ ] After merge: tag v0.11.2; release.yml ships the 10-asset GitHub Release; publish-to-crates-io.yml republishes at 0.11.2