### PR TITLE
fix(arm): BL placeholder -4 addend — calls land on callee, not symbol+4 (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,19 @@ Backend bugfix + regression tests; no proof-suite changes.
 
 **Falsification statement.** v0.11.2 is wrong if an imported wasm call still
 produces a generic `func_N` undefined symbol instead of the import's field
-name, or if any of the four new regression tests pass against the pre-fix code.
+name, if a linked call lands at `symbol+4` instead of `symbol`, or if any of
+the new regression tests pass against the pre-fix code.
 
 ### Fixed
+- **Calls land on the callee entry, not `symbol+4`** (#174, PR #177). After
+  the #167 fix the Thumb BL placeholder was `0xF800` (addend 0), which under
+  `R_ARM_THM_CALL` nets to `S+4` — every call branched one instruction-pair
+  *past* the callee entry (links cleanly, runs wrong). The correct relocatable
+  placeholder is what `gas` emits for `bl <extern>`: `f7ff fffe`
+  (`hw1=0xF7FF, hw2=0xFFFE`), carrying a `-4` addend that nets to exactly `S`.
+  Verified: `mini.o` links and `caller`'s `bl` lands on `callee` (0x8000), not
+  0x8004. Guarded by `test_encode_thumb_bl_placeholder_addend_167_174` and an
+  end-to-end `.text` placeholder check.
 - **Import-call relocations now use the wasm field name** (#173, PR #175).
   The selector emits `BL func_{wasm_index}` for imported calls too (an import's
   wasm index < num_imports), so `build_relocatable_elf` named the undefined

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -2492,17 +2492,22 @@ impl ArmEncoder {
             }
 
             ArmOp::Bl { label: _ } => {
-                // BL is always 32-bit in Thumb-2, encoded here with offset 0
-                // (a relocation patches the target — see arm_backend.rs).
-                // Second halfword must be 0xF800, NOT 0xD000: the Thumb-2 BL
-                // offset uses I1 = NOT(J1 XOR S), I2 = NOT(J2 XOR S). For a true
-                // zero offset (S=0, imm=0) we need I1=I2=0, i.e. J1=J2=1, giving
-                //   hw2 = 11 J1(=1) 1 J2(=1) imm11(=0) = 0b1111_1000_0000_0000 = 0xF800.
-                // The old 0xD000 (J1=J2=0) decodes to I1=I2=1 → a bogus built-in
-                // addend of ~+0x600000, which produced the garbage `bl c0000c`
-                // target and "relocation truncated to fit" at link time (#167).
-                let hw1: u16 = 0xF000;
-                let hw2: u16 = 0xF800;
+                // BL is always 32-bit in Thumb-2, encoded here as a relocatable
+                // placeholder; an R_ARM_THM_CALL relocation patches the target
+                // (see arm_backend.rs). The placeholder must carry an embedded
+                // addend of -4 so the relocation nets to exactly the symbol S.
+                //
+                // Thumb BL computes `target = (P + 4) + signed_offset`. Under
+                // R_ARM_THM_CALL the linker resolves using the in-place addend;
+                // a 0xF800 placeholder (addend 0) lands at S+4 — every call one
+                // instruction past the callee entry (#174). The correct
+                // placeholder is what `gas` emits for `bl <extern>`:
+                //   f7ff fffe  ->  `bl <self>`  (S=1, J1=J2=1, imm = -4 addend),
+                // i.e. hw1=0xF7FF, hw2=0xFFFE. This nets to S, not S+4.
+                // (The earlier 0xD000 was worse still — a ~+0x600000 addend,
+                // the garbage `bl c0000c` and "truncated to fit" of #167.)
+                let hw1: u16 = 0xF7FF;
+                let hw2: u16 = 0xFFFE;
                 let mut bytes = hw1.to_le_bytes().to_vec();
                 bytes.extend_from_slice(&hw2.to_le_bytes());
                 Ok(bytes)
@@ -6911,14 +6916,17 @@ mod tests {
         assert_eq!(instr & 0x0F000000, 0x0B000000);
     }
 
-    /// Regression test for #167: the Thumb-2 BL placeholder must encode a
-    /// TRUE zero offset so a relocation can patch it cleanly. The second
-    /// halfword must be 0xF800 (J1=J2=1 ⟹ I1=I2=0), NOT 0xD000 (J1=J2=0 ⟹
-    /// I1=I2=1), which bakes in a bogus ~+0x600000 addend — the source of
-    /// the garbage `bl c0000c` target and the linker "relocation truncated
-    /// to fit". hw1=0xF000, hw2=0xF800 → little-endian bytes 00 F0 00 F8.
+    /// Regression test for #167 + #174: the Thumb-2 BL relocatable placeholder
+    /// must carry a -4 addend so an R_ARM_THM_CALL nets to exactly the symbol S.
+    /// The correct encoding is what `gas` emits for `bl <extern>`: f7ff fffe
+    /// (hw1=0xF7FF, hw2=0xFFFE), little-endian bytes FF F7 FE FF.
+    ///   - 0xD000 (J1=J2=0) → ~+0x600000 garbage addend: `bl c0000c` / truncated
+    ///     to fit (#167).
+    ///   - 0xF800 (addend 0) → lands at S+4, one instruction past the callee
+    ///     entry (#174).
+    ///   - 0xFFFE (addend -4) → lands at S. Correct.
     #[test]
-    fn test_encode_thumb_bl_zero_offset_167() {
+    fn test_encode_thumb_bl_placeholder_addend_167_174() {
         let encoder = ArmEncoder::new_thumb2();
         let op = ArmOp::Bl {
             label: "callee".to_string(),
@@ -6929,11 +6937,12 @@ mod tests {
 
         let hw1 = u16::from_le_bytes([code[0], code[1]]);
         let hw2 = u16::from_le_bytes([code[2], code[3]]);
-        assert_eq!(hw1, 0xF000, "BL first halfword");
+        assert_eq!(hw1, 0xF7FF, "BL first halfword (matches gas `bl <extern>`)");
         assert_eq!(
-            hw2, 0xF800,
-            "BL second halfword must be 0xF800 (true zero offset), not 0xD000 (#167)"
+            hw2, 0xFFFE,
+            "BL second halfword must be 0xFFFE (-4 addend → nets to S), not 0xF800 (→ S+4, #174) or 0xD000 (#167)"
         );
+        assert_ne!(hw2, 0xF800, "0xF800 (addend 0) lands at S+4 (#174)");
         assert_ne!(hw2, 0xD000, "0xD000 bakes in a ~+0x600000 addend (#167)");
     }
 

--- a/crates/synth-cli/tests/wast_compile.rs
+++ b/crates/synth-cli/tests/wast_compile.rs
@@ -454,6 +454,24 @@ fn compile_internal_call_is_linkable_167() {
         thm_call_relocs
     );
 
+    // #174: the BL placeholder must carry a -4 addend (`ff f7 fe ff`, the bytes
+    // gas emits for a relocatable `bl`) so the relocation nets to S, not S+4.
+    // A 0xF800 placeholder (`00 f0 00 f8`) would land one instruction late.
+    let text = elf
+        .section_by_name(".text")
+        .and_then(|s| s.data().ok())
+        .expect(".text section");
+    let correct_placeholder = [0xFF, 0xF7, 0xFE, 0xFF];
+    let bad_placeholder = [0x00, 0xF0, 0x00, 0xF8];
+    assert!(
+        text.windows(4).any(|w| w == correct_placeholder),
+        "compiled .text must contain the -4 BL placeholder ff f7 fe ff (#174)"
+    );
+    assert!(
+        !text.windows(4).any(|w| w == bad_placeholder),
+        "compiled .text must not contain the S+4 BL placeholder 00 f0 00 f8 (#174)"
+    );
+
     let _ = std::fs::remove_file(&output);
 }
 


### PR DESCRIPTION
Fixes the gale-team correctness bug **#174**, folded into the (untagged) v0.11.2 so gale gets a release that both *links* (#173) and *calls correctly* (#174).

## Root cause
After the #167 fix the Thumb BL relocatable placeholder was `0xF800` (addend 0). Thumb BL computes `target = (P+4) + offset`; under `R_ARM_THM_CALL` a 0-addend placeholder nets to **`S+4`** — every call branches one instruction-pair *past* the callee entry. The object links cleanly (no `ld` error) but runs wrong: `z_impl_k_sem_give` would call `gale_k_sem_give_decide+4`, skipping its first two instructions.

## Fix
The correct relocatable placeholder is exactly what `gas` emits for `bl <extern>`:
```
f7ff fffe   bl <self>     # hw1=0xF7FF, hw2=0xFFFE — a -4 addend that nets to S
```
**Verified:** `mini.o` links and `caller`'s `bl` lands on `callee` (0x8000), **not 0x8004**:
```
8008:  f7ff fffa  bl  0x8000
```

## Regression tests
- `test_encode_thumb_bl_placeholder_addend_167_174` — placeholder must be `0xF7FF/0xFFFE`, not `0xF800` (→S+4, #174) or `0xD000` (#167).
- end-to-end `.text` check in `compile_internal_call_is_linkable_167` — compiled output must contain `ff f7 fe ff`, never `00 f0 00 f8`.

All synth-backend + synth-cli suites pass.

## Falsification
Wrong if a linked call still lands at `symbol+4`, or the placeholder regression tests pass against the `0xF800` code.

Closes #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)