### PR TITLE
chore(release): v0.11.3 — optimizer memory-address miscompilation fix (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3] - 2026-05-30
+
+**Patch: optimizer memory-address miscompilation.** Fixes a correctness bug
+where the optimized (default) path dereferenced the wrong memory location.
+
+**Falsification statement.** v0.11.3 is wrong if the optimized path still
+emits a fixed-address load/store for a pointer-param (or constant) memory
+access, or if optimized and `--no-optimize` output differ for a
+pointer-deref function.
+
+### Fixed
+- **Optimized path no longer miscompiles linear-memory addresses** (#178,
+  PR #179). The optimized `wasm_to_ir → ir_to_arm` lowering dropped the
+  `i32.load`/`i32.store` address operand (the `ADD base, base, Raddr` came out
+  with garbage registers), so the access hit a fixed address
+  (`linmem_base + 0x100`) regardless of the operand — for both a dynamic
+  pointer-param address and a constant one. `optimize_full` now declines
+  modules using linear-memory load/store and falls back to the correct
+  `select_with_stack` path (`ldr [fp, Raddr]`). Verified: optimized
+  pointer-deref output now byte-matches `--no-optimize`. Guarded by
+  `pointer_deref_optimized_matches_no_optimize_178`.
+
+  Trade-off: memory-using modules compile correctly but unoptimized until the
+  optimized memory path is repaired (#180). The host-ABI / `__linear_memory_base`
+  contract raised alongside this is tracked in #181.
+
 ## [0.11.2] - 2026-05-30
 
 **Patch: gale-wasm ARM linkability, round 2.** Completes the cross-language-LTO

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.2"
+version = "0.11.3"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.2",
+    version = "0.11.3",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.2" }
+synth-core = { path = "../synth-core", version = "0.11.3" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.2" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.2" }
+synth-core = { path = "../synth-core", version = "0.11.3" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.3" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.2" }
+synth-core = { path = "../synth-core", version = "0.11.3" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.2" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.2", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.3" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.3", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.2" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.2" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.2" }
-synth-backend = { path = "../synth-backend", version = "0.11.2" }
+synth-core = { path = "../synth-core", version = "0.11.3" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.3" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.3" }
+synth-backend = { path = "../synth-backend", version = "0.11.3" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.2", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.2", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.2", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.3", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.3", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.3", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.2", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.3", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.2" }
+synth-core = { path = "../synth-core", version = "0.11.3" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.2" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.3" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.2" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.2" }
-synth-opt = { path = "../synth-opt", version = "0.11.2" }
+synth-core = { path = "../synth-core", version = "0.11.3" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.3" }
+synth-opt = { path = "../synth-opt", version = "0.11.3" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.2" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.2" }
-synth-opt = { path = "../synth-opt", version = "0.11.2" }
+synth-core = { path = "../synth-core", version = "0.11.3" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.3" }
+synth-opt = { path = "../synth-opt", version = "0.11.3" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.2", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.3", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Fast patch shipping the #178 optimizer fix (PR #179, on main).

## Summary
- Bumps workspace + MODULE.bazel + path-dep pins 0.11.2 → 0.11.3
- Promotes `[Unreleased]` → `[0.11.3]` with the falsification statement

## What ships
**#178** — the optimized path dropped the load/store address operand (fixed-`0x100` access regardless of the pointer/const operand). Now declines memory modules to the correct `select_with_stack` path; optimized output byte-matches `--no-optimize`. Follow-ups #180 (re-enable optimized memory) / #181 (host-ABI contract).

## Falsification
v0.11.3 is wrong if the optimized path still emits a fixed-address load/store for a memory access, or optimized ≠ `--no-optimize` for a pointer-deref function.

## Test plan
- [ ] CI green
- [ ] After merge: tag v0.11.3; release.yml + publish-to-crates-io.yml ship it