### PR TITLE
fix(encoder): high-register Thumb CMN uses 32-bit CMN.W (#184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.5] - 2026-05-30
+
+**Patch: high-register Thumb CMN (#184).** Closes the last sibling of the #180
+16-bit-truncation class. The 16-bit `CMN` (T1) reg-form encodes only R0–R7;
+high-register operands overflowed the 3-bit fields. CMN has no high-register
+16-bit form, so high registers now use 32-bit `CMN.W` (`EB10 Rn | 0F00 Rm`),
+byte-verified against `gas`. Latent (the optimized divide-guard uses the CMN
+*immediate* form; the reg-form is only emitted by the non-optimized selector
+with low registers) — closed as defense-in-depth.
+
+**Falsification statement.** v0.11.5 is wrong if `encode(Cmn { rn, op2: Reg(rm) })`
+emits a 16-bit instruction when `rn` or `rm` is ≥ R8 (truncating the operand).
+
 ## [0.11.4] - 2026-05-30
 
 **Patch: root-cause + re-enable the optimized memory path (#180).** The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.4"
+version = "0.11.5"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.4"
+version = "0.11.5"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.4"
+version = "0.11.5"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.4",
+    version = "0.11.5",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.4" }
+synth-core = { path = "../synth-core", version = "0.11.5" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.4" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.4" }
+synth-core = { path = "../synth-core", version = "0.11.5" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.5" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.4" }
+synth-core = { path = "../synth-core", version = "0.11.5" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.4" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.4", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.5" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.5", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -7016,7 +7016,11 @@ mod tests {
                 op2: Operand2::Reg(Reg::R2),
             })
             .unwrap();
-        assert_eq!(lo.len(), 2, "low-reg CMN should remain 16-bit, got {lo:02X?}");
+        assert_eq!(
+            lo.len(),
+            2,
+            "low-reg CMN should remain 16-bit, got {lo:02X?}"
+        );
         assert_eq!(lo, vec![0xD1, 0x42], "low-reg CMN bytes wrong: {lo:02X?}");
     }
 

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -2024,9 +2024,22 @@ impl ArmEncoder {
                     }
                 } else if let Operand2::Reg(rm) = op2 {
                     let rm_bits = reg_to_bits(rm) as u16;
-                    // CMN Rn, Rm (16-bit): 0100 0010 11 Rm Rn
-                    let instr: u16 = 0x42C0 | (rm_bits << 3) | rn_bits;
-                    Ok(instr.to_le_bytes().to_vec())
+                    // 16-bit CMN (T1) only encodes R0-R7; high registers overflow
+                    // the 3-bit fields and corrupt the operands (#184, the #180
+                    // class). CMN has no high-register 16-bit form, so fall back
+                    // to 32-bit CMN.W (T2): EB10 Rn | 0F00 Rm (ADD.W with S=1 and
+                    // Rd discarded as PC/1111).
+                    if rn_bits < 8 && rm_bits < 8 {
+                        // CMN Rn, Rm (16-bit): 0100 0010 11 Rm Rn
+                        let instr: u16 = 0x42C0 | (rm_bits << 3) | rn_bits;
+                        Ok(instr.to_le_bytes().to_vec())
+                    } else {
+                        let hw1: u16 = 0xEB10 | rn_bits;
+                        let hw2: u16 = 0x0F00 | rm_bits;
+                        let mut bytes = hw1.to_le_bytes().to_vec();
+                        bytes.extend_from_slice(&hw2.to_le_bytes());
+                        Ok(bytes)
+                    }
                 } else {
                     Ok(vec![0xBF, 0x00])
                 }
@@ -6975,6 +6988,36 @@ mod tests {
             vec![0xBA, 0xEB, 0x08, 0x0A],
             "high-reg SUBS must be 32-bit SUBS.W (EBBA 0A08); got {subs:02X?}"
         );
+    }
+
+    /// #184 (sibling of #180): 16-bit CMN (T1) only encodes R0-R7. High registers
+    /// must use 32-bit CMN.W, not the corrupt truncated 16-bit form.
+    #[test]
+    fn test_encode_thumb_cmn_high_reg_uses_cmn_w_184() {
+        let encoder = ArmEncoder::new_thumb2();
+
+        // cmn r10, r8  → CMN.W = EB1A 0F08 (ADD.W S=1, Rd=PC discarded).
+        let cmn = encoder
+            .encode(&ArmOp::Cmn {
+                rn: Reg::R10,
+                op2: Operand2::Reg(Reg::R8),
+            })
+            .unwrap();
+        assert_eq!(
+            cmn,
+            vec![0x1A, 0xEB, 0x08, 0x0F],
+            "high-reg CMN must be 32-bit CMN.W (EB1A 0F08); got {cmn:02X?}"
+        );
+
+        // Low registers stay 16-bit: cmn r1, r2 = 0x42D1.
+        let lo = encoder
+            .encode(&ArmOp::Cmn {
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            })
+            .unwrap();
+        assert_eq!(lo.len(), 2, "low-reg CMN should remain 16-bit, got {lo:02X?}");
+        assert_eq!(lo, vec![0xD1, 0x42], "low-reg CMN bytes wrong: {lo:02X?}");
     }
 
     /// #185 regression: feeding PC (R15) as a data operand to a Thumb-2 op that

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.4" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.4" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.4" }
-synth-backend = { path = "../synth-backend", version = "0.11.4" }
+synth-core = { path = "../synth-core", version = "0.11.5" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.5" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.5" }
+synth-backend = { path = "../synth-backend", version = "0.11.5" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.4", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.4", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.4", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.5", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.5", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.5", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.4", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.5", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.4" }
+synth-core = { path = "../synth-core", version = "0.11.5" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.4" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.5" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.4" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.4" }
-synth-opt = { path = "../synth-opt", version = "0.11.4" }
+synth-core = { path = "../synth-core", version = "0.11.5" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.5" }
+synth-opt = { path = "../synth-opt", version = "0.11.5" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.4" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.4" }
-synth-opt = { path = "../synth-opt", version = "0.11.4" }
+synth-core = { path = "../synth-core", version = "0.11.5" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.5" }
+synth-opt = { path = "../synth-opt", version = "0.11.5" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.4", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.5", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Summary

Closes #184 — the last sibling of the #180 16-bit-truncation class found by the encoder audit.

The 16-bit `CMN` (T1) reg-form (`0x42C0 | rm<<3 | rn`) only encodes R0–R7; high-register operands (R8–R11/R12) overflow the 3-bit fields and corrupt the operands. CMN has no high-register 16-bit form, so high registers now fall back to 32-bit `CMN.W` (`EB10 Rn | 0F00 Rm` — ADD.W with S=1, Rd discarded as PC).

## Verification
- Byte-level encoder regression test (`cmn r10, r8` → `EB1A 0F08`; low-reg `cmn r1,r2` stays 16-bit `0x42D1`)
- **Ground-truth checked against `gas`**: `arm-none-eabi-as` assembles `cmn r10, r8` to exactly `eb1a 0f08`
- Full suite: 1284 passed, 0 failed

## Reachability
Latent — the optimized divide-by-zero/INT_MIN guard uses the CMN *immediate* form (already 32-bit CMN.W), and the reg-form is only emitted by the non-optimized selector with low registers. Closed as defense-in-depth: the last 16-bit reg-form encoder lacking a high-register guard (Add/Adds/Subs fixed in #180; MVNS sites use hardcoded R0).

Closes #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)