### PR TITLE
fix(release): publish verify uses cargo package, restore CI step (#146)

### DIFF
--- a/.github/workflows/publish-to-crates-io.yml
+++ b/.github/workflows/publish-to-crates-io.yml
@@ -82,17 +82,20 @@ jobs:
       - name: Build publish helper
         run: rustc --edition 2024 scripts/publish.rs -o publish
 
-      # NOTE: the historical `./publish verify` step was removed in v0.7.0
-      # because `cargo publish --dry-run -p <name>` resolves dependencies
-      # through the public crates.io index — so dependent workspace crates
-      # always fail until their synth-* deps are already on the registry
-      # at the new version (chicken-and-egg for any first publish of a new
-      # version). The actual `cargo publish` performs the same metadata
-      # validation before upload, and `./publish publish` has a 10-attempt
-      # retry loop with a 40s sleep that rides out registry index
-      # propagation. The verify step is recoverable as `cargo package`
-      # (which uses path deps) if a fail-fast metadata check is needed —
-      # tracked as a follow-up.
+      # Pre-flight fail-fast (#146): `./publish verify` now runs `cargo package`
+      # per crate, NOT `cargo publish --dry-run`. `--dry-run` resolved deps
+      # through the public crates.io index, so dependent workspace crates always
+      # failed until their synth-* deps were already on the registry at the new
+      # version (the chicken-and-egg that sank the v0.7.0 step, dropped in #144).
+      # `cargo package` resolves through path deps and builds each `.crate`
+      # end-to-end, catching broken metadata / missing files / compile errors
+      # before any upload. (`publish = false` crates like synth-abi are not in
+      # CRATES_TO_PUBLISH, so the synth-wit-version quirk in #146 is not hit.)
+      - name: Verify packaging (cargo package, no chicken-and-egg)
+        run: ./publish verify
+
+      # `./publish publish` has a 10-attempt retry loop with a 40s sleep that
+      # rides out registry index propagation between dependent crates.
       - name: Publish workspace to crates.io
         run: ./publish publish
         env:

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -1,7 +1,7 @@
 //! Helper script for publishing the synth workspace to crates.io.
 //!
 //! Modes:
-//!   ./publish verify   — `cargo publish --dry-run` every publishable crate
+//!   ./publish verify   — `cargo package` every publishable crate (#146)
 //!                        in dependency order, fail on first error.
 //!   ./publish publish  — `cargo publish` every publishable crate in
 //!                        dependency order; retries up to 10 times to
@@ -102,15 +102,23 @@ fn read_workspace_version() -> String {
 }
 
 fn verify(crates: &[Krate]) {
+    // #146: use `cargo package` rather than `cargo publish --dry-run`.
+    // `--dry-run` resolves every workspace dep against crates.io, so for a
+    // first publish of any new version the dependents always fail with the
+    // chicken-and-egg "dep not yet published" error (this sank the v0.7.0
+    // verify step, dropped in PR #144). `cargo package` resolves through the
+    // local path deps, builds the `.crate` end-to-end, and still catches the
+    // surface a pre-flight check should: missing README/license, bad
+    // include/exclude, broken metadata, and code that doesn't compile.
     let mut failed = Vec::new();
     for k in crates {
-        println!("--- cargo publish --dry-run -p {} ---", k.name);
+        println!("--- cargo package -p {} ---", k.name);
         let status = Command::new("cargo")
-            .args(["publish", "--dry-run", "-p", &k.name])
+            .args(["package", "-p", &k.name])
             .status()
             .expect("invoke cargo");
         if !status.success() {
-            println!("FAIL: {} dry-run failed: {status}", k.name);
+            println!("FAIL: {} package failed: {status}", k.name);
             failed.push(k.name.clone());
         }
     }
@@ -118,7 +126,7 @@ fn verify(crates: &[Krate]) {
         eprintln!("\nverify failed for: {}", failed.join(", "));
         std::process::exit(1);
     }
-    println!("\nAll {} crates passed cargo publish --dry-run.", crates.len());
+    println!("\nAll {} crates passed cargo package.", crates.len());
 }
 
 fn publish_all(mut crates: Vec<Krate>) {
@@ -136,7 +144,11 @@ fn publish_all(mut crates: Vec<Krate>) {
     }
     eprintln!(
         "\nstill failing after 10 attempts: {}",
-        crates.iter().map(|k| k.name.as_str()).collect::<Vec<_>>().join(", ")
+        crates
+            .iter()
+            .map(|k| k.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
     );
     std::process::exit(1);
 }
@@ -180,4 +192,3 @@ fn already_published(name: &str, version: &str) -> bool {
         _ => false,
     }
 }
-


### PR DESCRIPTION
## Summary

Closes #146. `./publish verify` ran `cargo publish --dry-run -p <name>`, which resolves every workspace dep through the public crates.io index — so on a first publish of a new version the dependents always fail with the chicken-and-egg "dep not yet published" error. That sank the v0.7.0 verify step; PR #144 dropped it entirely, losing the fail-fast metadata/compile check.

`cargo package -p <name>` resolves through the local **path** deps (no chicken-and-egg), builds each `.crate` end-to-end, and catches the real pre-flight surface: missing README/license, bad include/exclude, broken metadata, code that doesn't compile.

## Changes
- `scripts/publish.rs::verify` → `cargo package -p <name>` (+ header doc)
- restore the `./publish verify` step in `publish-to-crates-io.yml`, ahead of publish

## Validation
- **`cargo package` resolves for all 11 `CRATES_TO_PUBLISH` on a clean workspace** with no prior version on crates.io (the #146 falsification check — confirmed via `--no-verify` metadata pass on all 11, + full package+build of the leaf layer locally).
- Full package+build of all 11 is bounded locally by `synth-verify`'s z3-sys dependency (the known local-build quirk) + build time, so the **full verify run is first exercised in CI on the next release tag**. Risk is low: `cargo package` is build + metadata, both of which the publish workflow already does for `cargo publish`, and the step runs *before* upload so a failure blocks cleanly with nothing partially published.

## Notes
- `publish = false` crates (synth-abi, synth-wit) are not in `CRATES_TO_PUBLISH`, so the synth-wit-version quirk noted in #146 is never hit by the verify pass.
- Tooling only — `scripts/publish.rs` is not a published crate, so this merges to main **without a crates.io version bump**.

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)