### PR TITLE
feat(cli): resolve standalone --cortex-m internal calls in place (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.7] - 2026-05-30
+
+**Standalone `--cortex-m` internal call resolution (#170).** A standalone
+(non-`--relocatable`) `--cortex-m` build of a module with an internal `call` was
+silently routed to the relocatable-object builder (every internal BL records a
+relocation since #167), producing an `ET_REL` object with an unresolved
+`R_ARM_THM_CALL` and a `bl #0` placeholder — which, with no linker, stayed
+garbage. Now internal-only modules build a standalone `ET_EXEC` and each internal
+`BL func_N` is patched in place to the callee entry after layout. The Thumb BL
+encoding (`target − (P+4)`, J1/J2 from the sign bit) is verified byte-for-byte
+against `arm-none-eabi-as`. The `$t`/`$a`/`$d` mapping-symbol half of #170 is
+deferred (needs an ElfBuilder symtab-ordering rework).
+
+**Falsification statement.** v0.11.7 is wrong if a standalone `--cortex-m`
+internal `BL func_N` resolves to anything other than the callee's entry address
+(e.g. callee+4, or an unpatched `f7ff fffe` placeholder).
+
 ## [0.11.6] - 2026-05-30
 
 **Patch: encoder is now total under fuzzing (#186).** The `encoder_no_panic`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.6"
+version = "0.11.7"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.6"
+version = "0.11.7"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.6"
+version = "0.11.7"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.6",
+    version = "0.11.7",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.6" }
+synth-core = { path = "../synth-core", version = "0.11.7" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.6" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.6" }
+synth-core = { path = "../synth-core", version = "0.11.7" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.7" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.6" }
+synth-core = { path = "../synth-core", version = "0.11.7" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.6" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.6", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.7" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.7", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.6" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.6" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.6" }
-synth-backend = { path = "../synth-backend", version = "0.11.6" }
+synth-core = { path = "../synth-core", version = "0.11.7" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.7" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.7" }
+synth-backend = { path = "../synth-backend", version = "0.11.7" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.6", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.6", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.6", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.7", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.7", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.7", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.6", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.7", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1899,17 +1899,50 @@ fn compile_all_exports(
     // Check if any function has relocations (import calls)
     let has_relocations = compiled_funcs.iter().any(|f| !f.relocations.is_empty());
 
+    // Every defined function exposes two relocation labels the selector may
+    // emit for an internal `call`: its export name and `func_{wasm_index}`.
+    // A relocation whose symbol is one of these is an INTERNAL call to a
+    // function laid out in this same image (so it can be patched directly,
+    // no linker needed). Any other relocation symbol (an import field name,
+    // `func_{import_index}`, or a `__meld_*` dispatch stub) is EXTERNAL and
+    // requires the relocatable-object path so a host linker can resolve it.
+    let mut internal_labels: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for f in &compiled_funcs {
+        internal_labels.insert(f.name.as_str());
+    }
+    let func_index_labels: Vec<String> = compiled_funcs
+        .iter()
+        .map(|f| format!("func_{}", f.wasm_index))
+        .collect();
+    for label in &func_index_labels {
+        internal_labels.insert(label.as_str());
+    }
+    let has_external_relocations = compiled_funcs
+        .iter()
+        .flat_map(|f| &f.relocations)
+        .any(|r| !internal_labels.contains(r.symbol.as_str()));
+
     // Build multi-function ELF
-    // When there are relocations, produce a relocatable object (.o) instead of
-    // an executable. This lets the output be linked with the Kiln bridge crate
-    // (which provides __meld_dispatch_import and __meld_get_memory_base).
-    // The --relocatable flag forces ET_REL output even when the wasm has no
-    // imports, for linking into a host build system (e.g. Zephyr).
+    // When there are EXTERNAL relocations, produce a relocatable object (.o)
+    // instead of an executable. This lets the output be linked with the Kiln
+    // bridge crate (which provides __meld_dispatch_import and
+    // __meld_get_memory_base). The --relocatable flag forces ET_REL output
+    // even when the wasm has no imports, for linking into a host build system
+    // (e.g. Zephyr).
+    //
+    // A standalone `--cortex-m` executable, however, has NO linker: its
+    // INTERNAL `BL func_N` calls cannot be left as unresolved relocations.
+    // When every relocation is internal (no imports) and we are building a
+    // standalone Cortex-M executable, route to the cortex-m builder, which
+    // patches each internal BL displacement in place after layout (#170).
     let is_riscv = matches!(target_spec.family, synth_core::target::ArchFamily::RiscV);
+    // Tracks whether we emitted an ET_REL object (needs linking) vs a standalone
+    // executable, so the summary below reports the right type and link hint.
+    let produced_relocatable = is_riscv || has_external_relocations || relocatable;
     let elf_data = if is_riscv {
         info!("Building RISC-V multi-function relocatable object (EM_RISCV)");
         build_multi_func_riscv_elf(&compiled_funcs)?
-    } else if has_relocations || relocatable {
+    } else if has_external_relocations || relocatable {
         let total_relocs: usize = compiled_funcs.iter().map(|f| f.relocations.len()).sum();
         if has_relocations {
             info!(
@@ -1972,7 +2005,7 @@ fn compile_all_exports(
     );
     println!("  Total code size: {} bytes", total_code);
     println!("  ELF size: {} bytes", elf_data.len());
-    if has_relocations {
+    if produced_relocatable {
         println!(
             "  Relocations: {} (requires linking with Kiln bridge)",
             total_relocs
@@ -1981,6 +2014,13 @@ fn compile_all_exports(
         println!(
             "\n  Link with: arm-none-eabi-ld -o firmware.elf {} kiln_bridge.o",
             output.display()
+        );
+    } else if has_relocations {
+        // Standalone executable whose internal `BL func_N` calls were resolved
+        // directly (no linker). Report them as patched, not pending (#170).
+        println!(
+            "  Internal calls: {} resolved in place (standalone executable)",
+            total_relocs
         );
     }
     println!("\nFunction addresses:");
@@ -2214,6 +2254,44 @@ fn build_relocatable_elf(funcs: &[ElfFunction], imports: &[ImportEntry]) -> Resu
         .context("Relocatable ELF generation failed")
 }
 
+/// Encode a Thumb-2 `BL` instruction (4 bytes, two little-endian halfwords)
+/// that branches from the instruction at address `bl_addr` to `target_addr`.
+///
+/// Thumb BL computes `target = (P + 4) + signed_offset`, where P is the address
+/// of the BL. So `signed_offset = target_addr - (bl_addr + 4)`, in bytes; the
+/// encoded immediate is that value in halfword units. The J1/J2 bits are
+/// derived from the sign bit S as `I1 = NOT(J1 XOR S)` (rearranged:
+/// `J1 = NOT(I1 XOR S)`), and likewise for J2/I2.
+///
+/// This is the DIRECT encoding used by the standalone Cortex-M path, which has
+/// no linker to apply an R_ARM_THM_CALL relocation. Verified byte-for-byte
+/// against `arm-none-eabi-as` (both forward and backward, near and far) so we
+/// do not repeat the hand-decode error of #174.
+///
+/// `target_addr` must be the even function entry address; the Thumb state bit
+/// is implicit in BL and must NOT be encoded into the displacement. Returning
+/// the wrong even/odd target would land the call one instruction off (the
+/// symbol+4 class of bug in #174).
+fn encode_thumb_bl(bl_addr: u32, target_addr: u32) -> [u8; 4] {
+    let offset = (target_addr as i64) - (bl_addr as i64 + 4); // bytes
+    let off = (offset >> 1) as i32; // halfword units, sign-extended
+    let s_bit = ((off >> 24) & 1) as u32;
+    let i1 = ((off >> 23) & 1) as u32;
+    let i2 = ((off >> 22) & 1) as u32;
+    let imm10 = ((off >> 11) & 0x3FF) as u32;
+    let imm11 = (off & 0x7FF) as u32;
+    let j1 = (!(i1 ^ s_bit)) & 1;
+    let j2 = (!(i2 ^ s_bit)) & 1;
+    // hw1: 1111 0 S imm10            -> 0xF000 | (S<<10) | imm10
+    // hw2: 11 J1 1 J2 imm11          -> 0xD000 | (J1<<13) | (J2<<11) | imm11
+    let hw1: u16 = (0xF000 | (s_bit << 10) | imm10) as u16;
+    let hw2: u16 = (0xD000 | (j1 << 13) | (j2 << 11) | imm11) as u16;
+    let mut bytes = [0u8; 4];
+    bytes[0..2].copy_from_slice(&hw1.to_le_bytes());
+    bytes[2..4].copy_from_slice(&hw2.to_le_bytes());
+    bytes
+}
+
 /// Build a complete Cortex-M multi-function ELF with vector table
 fn build_multi_func_cortex_m_elf(
     funcs: &[ElfFunction],
@@ -2283,6 +2361,61 @@ fn build_multi_func_cortex_m_elf(
         }
         func_offsets.push(all_func_code.len() as u32);
         all_func_code.extend_from_slice(&func.code);
+    }
+
+    // Resolve internal `BL func_N` calls directly. A standalone Cortex-M
+    // executable has no linker, so the `bl #0` placeholder + R_ARM_THM_CALL
+    // relocation strategy used by the relocatable path cannot apply here:
+    // nothing patches the displacement. Instead, now that every function's
+    // address is known, encode the real Thumb BL displacement in place (#170).
+    //
+    // The caller routes here only when all relocations are internal (no
+    // imports); we map each relocation symbol (export name or `func_{index}`)
+    // to the callee's laid-out address and patch the 4 BL bytes.
+    {
+        use std::collections::HashMap;
+        let mut label_to_addr: HashMap<&str, u32> = HashMap::new();
+        for (i, func) in funcs.iter().enumerate() {
+            let addr = funcs_base + func_offsets[i];
+            label_to_addr.insert(func.name.as_str(), addr);
+        }
+        // `func_{wasm_index}` labels need owned storage to key the map.
+        let index_labels: Vec<(String, u32)> = funcs
+            .iter()
+            .enumerate()
+            .map(|(i, func)| {
+                (
+                    format!("func_{}", func.wasm_index),
+                    funcs_base + func_offsets[i],
+                )
+            })
+            .collect();
+        for (label, addr) in &index_labels {
+            label_to_addr.insert(label.as_str(), *addr);
+        }
+
+        for (i, func) in funcs.iter().enumerate() {
+            for reloc in &func.relocations {
+                let Some(&callee_addr) = label_to_addr.get(reloc.symbol.as_str()) else {
+                    // Should not happen: the dispatcher only routes here when
+                    // every relocation is internal. Be loud rather than emit a
+                    // silently-broken BL.
+                    anyhow::bail!(
+                        "internal call to unknown symbol '{}' in standalone Cortex-M ELF (#170)",
+                        reloc.symbol
+                    );
+                };
+                // Absolute address of the BL instruction's first halfword.
+                let bl_addr = funcs_base + func_offsets[i] + reloc.offset;
+                let bytes = encode_thumb_bl(bl_addr, callee_addr);
+                let pos = (func_offsets[i] + reloc.offset) as usize;
+                all_func_code[pos..pos + 4].copy_from_slice(&bytes);
+                info!(
+                    "  patched internal BL at 0x{:08x} -> '{}' 0x{:08x}",
+                    bl_addr, reloc.symbol, callee_addr
+                );
+            }
+        }
     }
 
     info!("Cortex-M multi-function layout:");
@@ -2459,6 +2592,18 @@ fn build_multi_func_cortex_m_elf(
             .with_section(4);
         elf_builder.add_symbol(func_sym);
     }
+
+    // TODO(#170, mapping-symbols): emit ARM `$t`/`$a`/`$d` mapping symbols so
+    // tools (objdump, gdb, debuggers) know each .text region is Thumb code vs
+    // data without relying on the Func-typed symbols above. This is the
+    // secondary half of #170 and is intentionally deferred: mapping symbols are
+    // STB_LOCAL and ELF requires all local symbols to precede globals in the
+    // symtab, with `.symtab`'s sh_info pointing at the first global. ElfBuilder
+    // currently appends symbols in call order and does not maintain
+    // local-before-global ordering or set sh_info, so adding locals here would
+    // produce a malformed symtab. Direct call resolution (the primary fix)
+    // works without these; objdump already disassembles correctly via the
+    // Func-typed function symbols.
 
     elf_builder.build().context("ELF generation failed")
 }
@@ -3162,6 +3307,22 @@ fn link_firmware(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `encode_thumb_bl` must match `arm-none-eabi-as` byte-for-byte. These
+    /// vectors were taken directly from gas disassembly (#170), covering
+    /// backward/forward and near/far branches — the cases that exercise the
+    /// S/J1/J2 sign-bit logic that bit #174.
+    #[test]
+    fn test_encode_thumb_bl_matches_gas() {
+        // gas: P=0x6  S=0x4    -> f7ff fffd  (bytes ff f7 fd ff), near backward
+        assert_eq!(encode_thumb_bl(0x6, 0x4), [0xff, 0xf7, 0xfd, 0xff]);
+        // gas: P=0xa  S=0x12   -> f000 f802  (bytes 00 f0 02 f8), near forward
+        assert_eq!(encode_thumb_bl(0xa, 0x12), [0x00, 0xf0, 0x02, 0xf8]);
+        // gas: P=0x138a S=0x0  -> f7fe fe39  (bytes fe f7 39 fe), far backward
+        assert_eq!(encode_thumb_bl(0x138a, 0x0), [0xfe, 0xf7, 0x39, 0xfe]);
+        // gas: P=0x138e S=0x2b02 -> f001 fbb8 (bytes 01 f0 b8 fb), far forward
+        assert_eq!(encode_thumb_bl(0x138e, 0x2b02), [0x01, 0xf0, 0xb8, 0xfb]);
+    }
 
     #[test]
     fn test_cortex_m_binary_structure() {

--- a/crates/synth-cli/tests/wast_compile.rs
+++ b/crates/synth-cli/tests/wast_compile.rs
@@ -607,3 +607,145 @@ fn pointer_deref_optimized_uses_address_operand_178_180() {
         "optimized .text must contain `add.w ip, ip, rN` (base + address operand) — #180"
     );
 }
+
+/// Decode a Thumb-2 `BL` (two little-endian halfwords at `text[off..off+4]`)
+/// and return its branch target address, given the BL's own address `bl_addr`.
+/// Thumb BL: `target = (bl_addr + 4) + signed_offset`, the inverse of the
+/// encoder in main.rs. Used to assert the patched displacement (#170).
+fn decode_thumb_bl_target(text: &[u8], off: usize, bl_addr: u32) -> u32 {
+    let hw1 = u16::from_le_bytes([text[off], text[off + 1]]) as u32;
+    let hw2 = u16::from_le_bytes([text[off + 2], text[off + 3]]) as u32;
+    let s = (hw1 >> 10) & 1;
+    let imm10 = hw1 & 0x3FF;
+    let j1 = (hw2 >> 13) & 1;
+    let j2 = (hw2 >> 11) & 1;
+    let imm11 = hw2 & 0x7FF;
+    let i1 = 1 - (j1 ^ s);
+    let i2 = 1 - (j2 ^ s);
+    // Reassemble the 25-bit signed offset (in bytes): S:I1:I2:imm10:imm11:0.
+    let mut off_bytes: i32 =
+        ((s << 24) | (i1 << 23) | (i2 << 22) | (imm10 << 12) | (imm11 << 1)) as i32;
+    // Sign-extend from bit 24.
+    if s == 1 {
+        off_bytes |= !0i32 << 25;
+    }
+    ((bl_addr as i64) + 4 + (off_bytes as i64)) as u32
+}
+
+/// Regression test for #170: a STANDALONE `--cortex-m` executable has no
+/// linker, so its internal `BL func_N` calls must be patched in place rather
+/// than left as `bl #0` placeholders with a dangling R_ARM_THM_CALL relocation
+/// (which would otherwise stay a `bl <self>` branching to garbage). This module
+/// has only an internal call (no imports), so `--cortex-m` must yield an
+/// ET_EXEC whose patched BL targets the callee's ENTRY address — not entry+4
+/// (the symbol+4 off-by-one-instruction class of bug from #174).
+#[test]
+fn compile_standalone_internal_call_resolves_bl_170() {
+    use object::{Object, ObjectSection, ObjectSymbol};
+
+    let wat = workspace_root()
+        .join("tests")
+        .join("integration")
+        .join("internal_call.wat");
+    assert!(
+        wat.exists(),
+        "internal_call.wat not found: {}",
+        wat.display()
+    );
+
+    let output = std::env::temp_dir().join("synth_test_standalone_internal_call.elf");
+    let result = Command::new(synth_binary())
+        .args([
+            "compile",
+            wat.to_str().unwrap(),
+            "--target",
+            "cortex-m4f",
+            "--all-exports",
+            "--cortex-m",
+            "-o",
+            output.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to run synth binary");
+    assert!(
+        result.status.success(),
+        "synth compile failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr),
+    );
+
+    let data = std::fs::read(&output).unwrap();
+
+    // No linker is involved: this must be a standalone executable (ET_EXEC = 2),
+    // NOT a relocatable object (ET_REL = 1).
+    let e_type = u16::from_le_bytes([data[16], data[17]]);
+    assert_eq!(
+        e_type, 2,
+        "standalone --cortex-m internal-call module must be ET_EXEC (2), got {} (#170)",
+        e_type
+    );
+
+    let elf = object::File::parse(&*data).expect("parse ARM ELF executable");
+
+    // The standalone executable must NOT carry leftover relocations — they would
+    // be unresolvable with no linker. The call is patched directly instead.
+    const R_ARM_THM_CALL: u32 = 10;
+    let mut thm_call_relocs = 0usize;
+    for section in elf.sections() {
+        for (_off, reloc) in section.relocations() {
+            if let object::RelocationFlags::Elf { r_type } = reloc.flags()
+                && r_type == R_ARM_THM_CALL
+            {
+                thm_call_relocs += 1;
+            }
+        }
+    }
+    assert_eq!(
+        thm_call_relocs, 0,
+        "standalone executable must not retain R_ARM_THM_CALL relocations (#170)"
+    );
+
+    // Resolve callee/caller addresses from the symbol table. Cortex-M function
+    // symbols carry the Thumb state bit (value = addr | 1); strip it to get the
+    // even instruction address.
+    let callee_addr = elf
+        .symbols()
+        .find(|s| s.name() == Ok("callee"))
+        .map(|s| s.address() as u32 & !1)
+        .expect("callee symbol");
+    let caller_addr = elf
+        .symbols()
+        .find(|s| s.name() == Ok("caller"))
+        .map(|s| s.address() as u32 & !1)
+        .expect("caller symbol");
+
+    // The .text section is loaded at its sh_addr; compute the byte offset of the
+    // BL within .text. `caller` begins with `local.get 0; call $callee`, so the
+    // BL is the first instruction at the caller's entry.
+    let text_sec = elf.section_by_name(".text").expect(".text section");
+    let text_addr = text_sec.address() as u32;
+    let text = text_sec.data().expect(".text data");
+
+    let bl_addr = caller_addr;
+    let bl_off = (bl_addr - text_addr) as usize;
+    // Sanity: the patched BL must not be the relocatable self-branch placeholder
+    // `f7ff fffe` (bytes ff f7 fe ff), which would mean it was never resolved.
+    let placeholder = [0xFF, 0xF7, 0xFE, 0xFF];
+    assert_ne!(
+        &text[bl_off..bl_off + 4],
+        &placeholder,
+        "internal BL left as unresolved self-branch placeholder (#170)"
+    );
+
+    let target = decode_thumb_bl_target(text, bl_off, bl_addr);
+
+    // The decoded BL target must equal the callee's ENTRY address (symbol value
+    // has the Thumb bit stripped by `object`), NOT callee+4 (#174).
+    assert_eq!(
+        target, callee_addr,
+        "patched BL target 0x{:08x} must equal callee entry 0x{:08x}, not callee+4 (#170/#174)",
+        target, callee_addr
+    );
+
+    let _ = std::fs::remove_file(&output);
+}

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.6" }
+synth-core = { path = "../synth-core", version = "0.11.7" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.6" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.7" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.6" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.6" }
-synth-opt = { path = "../synth-opt", version = "0.11.6" }
+synth-core = { path = "../synth-core", version = "0.11.7" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.7" }
+synth-opt = { path = "../synth-opt", version = "0.11.7" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.6" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.6" }
-synth-opt = { path = "../synth-opt", version = "0.11.6" }
+synth-core = { path = "../synth-core", version = "0.11.7" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.7" }
+synth-opt = { path = "../synth-opt", version = "0.11.7" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.6", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.7", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Summary

Closes #170 (primary half). A standalone `--cortex-m` build of a module with an internal `call` was silently routed to the **relocatable-object** builder (dispatch keyed on `has_relocations`, and every internal BL records a relocation since #167). Output was an `ET_REL` object with an unresolved `R_ARM_THM_CALL` against `func_N` and a `bl #0` (`f7ff fffe`) placeholder — garbage in a standalone image with no linker.

## Fix
- `has_external_relocations`: a relocation is *internal* iff its symbol is a defined function's export name or `func_{index}`. Only external relocations (imports, `__meld_*`) or explicit `--relocatable` force the `ET_REL` path; internal-only `--cortex-m` modules now build a standalone `ET_EXEC`.
- `encode_thumb_bl(bl_addr, target_addr)` → `target − (P+4)`, `imm10/imm11` with `J1=NOT(I1^S)`, `J2=NOT(I2^S)`. **Verified byte-for-byte against `arm-none-eabi-as`** on 4 near/far vectors (pinned in `test_encode_thumb_bl_matches_gas`) — no hand-decode (the #174 lesson).
- `build_multi_func_cortex_m_elf` patches each internal `BL func_N` in place after layout; unknown symbols `bail!` loudly.

## Verification
- New integration test `compile_standalone_internal_call_resolves_bl_170`: asserts `ET_EXEC`, zero retained `R_ARM_THM_CALL`, BL decodes to the callee **entry** (not callee+4). Independently re-verified: a 2-func standalone module's `bl` resolves to the callee entry (`bl 0xa0` for callee@0xa0).
- fmt + clippy clean; `cargo test -p synth-cli -p synth-backend` passes.

## Deferred
The `$t`/`$a`/`$d` mapping-symbol half of #170 needs an `ElfBuilder` `sh_info` / local-before-global rework — left with a clear TODO. Call resolution works without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)