### PR TITLE
fix(selector): preserve caller-saved registers across calls (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.8] - 2026-05-30
+
+**Caller-saved register preservation across calls (#188).** gale-confirmed
+miscompile: a value (param or temp) live across a `call` was corrupted. The
+selector maps params to r0–r3 and allocates r0–r3/r12 (AAPCS caller-saved) as
+temps, but the `Call` lowering modeled nothing about the `BL` clobbering them —
+so `g`: `drop(call $clob); i32.load(local.get 0)` read param0 from r0 *after*
+`clob` overwrote it (blocking gale's `z_impl_k_sem_give`, whose `sem` pointer is
+live across `k_spin_lock`). Now the direct selector spills live caller-saved
+registers to a reserved frame scratch area before each `BL` and reloads them
+after; the optimized path declines functions containing a local call so the
+backend re-lowers them with the corrected direct selector (import calls stay on
+the optimized path to preserve the #173 field-name relocations). Verified: `g`
+now emits `str r0,[sp]; bl; ldr r0,[sp]; ldr r0,[fp,r0]` — the load derives from
+the original param0.
+
+Scoped out (tracked in #193): the broader no-call subset of the param-register
+clobber class (i64 results / constants / return values landing in r0–r3 before a
+live param read), and general argument marshalling for calls with register args.
+
+**Falsification statement.** v0.11.8 is wrong if a value live across a `call`
+(e.g. a pointer param dereferenced after a call) is read from a caller-saved
+register the call clobbered rather than from its preserved home.
+
 ## [0.11.7] - 2026-05-30
 
 **Standalone `--cortex-m` internal call resolution (#170).** A standalone

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.7"
+version = "0.11.8"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.7"
+version = "0.11.8"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.7"
+version = "0.11.8"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.7"
+version = "0.11.8"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.7",
+    version = "0.11.8",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.7" }
+synth-core = { path = "../synth-core", version = "0.11.8" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.7" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.7" }
+synth-core = { path = "../synth-core", version = "0.11.8" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.8" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.7" }
+synth-core = { path = "../synth-core", version = "0.11.8" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.7" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.7", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.8" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.8", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -177,7 +177,11 @@ fn compile_wasm_to_arm(
             OptimizationConfig::all()
         };
 
-        let bridge = OptimizerBridge::with_config(opt_config);
+        let mut bridge = OptimizerBridge::with_config(opt_config);
+        // #188: tell the bridge how many imports there are so it declines only
+        // LOCAL calls (and leaves import calls on the optimized path, keeping
+        // the #173 field-name relocation rewrite intact).
+        bridge.set_num_imports(config.num_imports);
         // `ir_to_arm` now returns `Result` — an `Err` means the optimized path
         // hit an unmapped vreg (issue-#93-class). Treat it identically to an
         // `optimize_full` failure: fall back to the direct selector rather

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.7" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.7" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.7" }
-synth-backend = { path = "../synth-backend", version = "0.11.7" }
+synth-core = { path = "../synth-core", version = "0.11.8" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.8" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.8" }
+synth-backend = { path = "../synth-backend", version = "0.11.8" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.7", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.7", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.7", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.8", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.8", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.8", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.7", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.8", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-cli/tests/wast_compile.rs
+++ b/crates/synth-cli/tests/wast_compile.rs
@@ -719,15 +719,31 @@ fn compile_standalone_internal_call_resolves_bl_170() {
         .map(|s| s.address() as u32 & !1)
         .expect("caller symbol");
 
-    // The .text section is loaded at its sh_addr; compute the byte offset of the
-    // BL within .text. `caller` begins with `local.get 0; call $callee`, so the
-    // BL is the first instruction at the caller's entry.
+    // The .text section is loaded at its sh_addr; locate the BL within the
+    // caller. The BL is no longer the caller's first instruction: since #188 a
+    // call-containing function gets a prologue + caller-saved-preservation
+    // scratch frame ahead of the `bl`. So scan the caller's bytes for the
+    // 32-bit Thumb BL (hw1 in 0xF000..=0xF7FF, hw2 & 0xF800 == 0xF800); the
+    // caller does only i32 arithmetic around the call, so no MOVW/STR.W 32-bit
+    // op in 0xF0xx range collides with it.
     let text_sec = elf.section_by_name(".text").expect(".text section");
     let text_addr = text_sec.address() as u32;
     let text = text_sec.data().expect(".text data");
 
-    let bl_addr = caller_addr;
-    let bl_off = (bl_addr - text_addr) as usize;
+    let caller_off = (caller_addr - text_addr) as usize;
+    let mut bl_off = None;
+    let mut o = caller_off;
+    while o + 4 <= text.len() {
+        let hw1 = u16::from_le_bytes([text[o], text[o + 1]]);
+        let hw2 = u16::from_le_bytes([text[o + 2], text[o + 3]]);
+        if (0xF000..=0xF7FF).contains(&hw1) && (hw2 & 0xF800) == 0xF800 {
+            bl_off = Some(o);
+            break;
+        }
+        o += 2;
+    }
+    let bl_off = bl_off.expect("no Thumb BL found in caller (#170)");
+    let bl_addr = text_addr + bl_off as u32;
     // Sanity: the patched BL must not be the relocatable self-branch placeholder
     // `f7ff fffe` (bytes ff f7 fe ff), which would mean it was never resolved.
     let placeholder = [0xFF, 0xF7, 0xFE, 0xFF];

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.7" }
+synth-core = { path = "../synth-core", version = "0.11.8" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.7" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.8" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.7" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.7" }
-synth-opt = { path = "../synth-opt", version = "0.11.7" }
+synth-core = { path = "../synth-core", version = "0.11.8" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.8" }
+synth-opt = { path = "../synth-opt", version = "0.11.8" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -205,6 +205,16 @@ fn alloc_consecutive_pair(
     ))
 }
 
+/// AAPCS caller-saved registers that this allocator may hand out as operand
+/// temps or use to hold incoming params. A `BL`/`BLX` clobbers all of these,
+/// so any live value residing here must be preserved across a call.
+///
+/// R4–R8 are callee-saved (pushed in the prologue) and survive calls untouched;
+/// they are deliberately excluded.
+fn is_caller_saved(reg: Reg) -> bool {
+    matches!(reg, Reg::R0 | Reg::R1 | Reg::R2 | Reg::R3 | Reg::R12)
+}
+
 /// Given the low register of an i64 register pair, return the high register.
 ///
 /// Convention: i64 values on 32-bit ARM use two consecutive registers.
@@ -242,6 +252,12 @@ struct LocalLayout {
     /// idx -> (offset_from_sp, is_i64)
     locals: std::collections::HashMap<u32, (i32, bool)>,
     frame_size: i32,
+    /// Byte offset (from SP, after frame allocation) of the call-spill scratch
+    /// area. This area holds caller-saved registers (R0–R3, R12, and live
+    /// operand-stack temps) across `Call`/`CallIndirect` so they survive the
+    /// AAPCS-clobbering branch-and-link. `None` when the function contains no
+    /// calls (no scratch reserved). See the `Call` lowering for usage.
+    spill_base: Option<i32>,
 }
 
 /// Compute the stack-frame layout for non-parameter locals in a function.
@@ -287,10 +303,31 @@ fn compute_local_layout(wasm_ops: &[WasmOp], num_params: u32) -> LocalLayout {
         locals.insert(idx, (offset, is_i64));
         offset += if is_i64 { 8 } else { 4 };
     }
+    // If the function contains any call, reserve a fixed scratch area to spill
+    // caller-saved registers (R0–R3, R12 — at most 5 distinct registers) across
+    // each call. Slots are reused across calls (spill/reload is bracketed within
+    // a single call), so 5 slots suffice regardless of call count.
+    let has_call = wasm_ops
+        .iter()
+        .any(|op| matches!(op, WasmOp::Call(_) | WasmOp::CallIndirect { .. }));
+    let spill_base = if has_call {
+        // i64 locals are 8-byte aligned; scratch slots are 4-byte i32 stores so
+        // place them after the locals at the current `offset`.
+        let base = offset;
+        offset += 5 * 4;
+        Some(base)
+    } else {
+        None
+    };
+
     // Round frame to 8-byte multiple for AAPCS SP alignment.
     let frame_size = (offset + 7) & !7;
 
-    LocalLayout { locals, frame_size }
+    LocalLayout {
+        locals,
+        frame_size,
+        spill_base,
+    }
 }
 
 /// Infer which non-parameter wasm locals are i64 (8-byte) values.
@@ -3806,6 +3843,141 @@ impl InstructionSelector {
 
     /// Select ARM instructions using a stack-based approach with AAPCS calling convention
     ///
+    /// #188: Spill every live caller-saved register to the call-spill scratch
+    /// area before a `Call`/`CallIndirect`, so it survives the AAPCS-clobbering
+    /// branch-and-link. Returns the list of `(register, slot_offset)` pairs that
+    /// were spilled, to be reloaded by [`restore_caller_saved`].
+    ///
+    /// "Live caller-saved" = the union of (a) operand-`stack` entries and
+    /// (b) param registers tracked in `local_to_reg`, restricted to R0–R3/R12
+    /// (see [`is_caller_saved`]), deduplicated by physical register.
+    fn preserve_caller_saved(
+        &self,
+        instructions: &mut Vec<ArmInstruction>,
+        stack: &[Reg],
+        local_to_reg: &std::collections::HashMap<u32, Reg>,
+        layout: &LocalLayout,
+        idx: usize,
+    ) -> Result<Vec<(Reg, i32)>> {
+        // Collect distinct live caller-saved registers in a deterministic order:
+        // operand-stack entries first, then param registers.
+        let mut live: Vec<Reg> = Vec::new();
+        let push_unique = |reg: Reg, live: &mut Vec<Reg>| {
+            if is_caller_saved(reg) && !live.contains(&reg) {
+                live.push(reg);
+            }
+        };
+        for &reg in stack {
+            push_unique(reg, &mut live);
+        }
+        // Deterministic param iteration order.
+        let mut params: Vec<(u32, Reg)> = local_to_reg.iter().map(|(&i, &r)| (i, r)).collect();
+        params.sort_by_key(|&(i, _)| i);
+        for (_, reg) in params {
+            push_unique(reg, &mut live);
+        }
+
+        if live.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let base = layout.spill_base.ok_or_else(|| {
+            synth_core::Error::synthesis(
+                "call-spill scratch area not reserved despite a call being present \
+                 (compiler bug: compute_local_layout/spill_base mismatch)"
+                    .to_string(),
+            )
+        })?;
+        // The scratch area has 5 slots (R0–R3, R12). `live` can never exceed
+        // that because it only contains distinct caller-saved registers.
+        debug_assert!(live.len() <= 5, "more than 5 distinct caller-saved regs");
+
+        let mut preserved: Vec<(Reg, i32)> = Vec::with_capacity(live.len());
+        for (slot, &reg) in live.iter().enumerate() {
+            let off = base + (slot as i32) * 4;
+            instructions.push(ArmInstruction {
+                op: ArmOp::Str {
+                    rd: reg,
+                    addr: MemAddr::imm(Reg::SP, off),
+                },
+                source_line: Some(idx),
+            });
+            preserved.push((reg, off));
+        }
+        Ok(preserved)
+    }
+
+    /// #188: Reload caller-saved registers spilled by [`preserve_caller_saved`]
+    /// after a call returns, and return the register that holds the call's
+    /// AAPCS return value (R0, unless R0 itself had to be preserved — in which
+    /// case the result is first moved to a free callee-saved register before R0
+    /// is reloaded).
+    fn restore_caller_saved(
+        &self,
+        instructions: &mut Vec<ArmInstruction>,
+        preserved: &[(Reg, i32)],
+        stack: &[Reg],
+        local_to_reg: &std::collections::HashMap<u32, Reg>,
+        layout: &LocalLayout,
+        idx: usize,
+    ) -> Result<Reg> {
+        // If R0 (the return value) is among the preserved registers, its slot
+        // holds the *old* value; reloading it would destroy the call result.
+        // Move the result to a free callee-saved register first.
+        let r0_preserved = preserved.iter().any(|&(r, _)| r == Reg::R0);
+        let result_reg = if r0_preserved {
+            let free = self.free_callee_saved(stack, local_to_reg, layout)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::Mov {
+                    rd: free,
+                    op2: Operand2::Reg(Reg::R0),
+                },
+                source_line: Some(idx),
+            });
+            free
+        } else {
+            Reg::R0
+        };
+
+        for &(reg, off) in preserved {
+            instructions.push(ArmInstruction {
+                op: ArmOp::Ldr {
+                    rd: reg,
+                    addr: MemAddr::imm(Reg::SP, off),
+                },
+                source_line: Some(idx),
+            });
+        }
+        Ok(result_reg)
+    }
+
+    /// Find a callee-saved register (R4–R8) not currently holding a live value
+    /// (neither on the operand stack, nor a param/local home). Used to park a
+    /// call's return value when R0 must be reloaded with a preserved param.
+    fn free_callee_saved(
+        &self,
+        stack: &[Reg],
+        local_to_reg: &std::collections::HashMap<u32, Reg>,
+        _layout: &LocalLayout,
+    ) -> Result<Reg> {
+        const CALLEE_SAVED: [Reg; 5] = [Reg::R4, Reg::R5, Reg::R6, Reg::R7, Reg::R8];
+        for &reg in &CALLEE_SAVED {
+            let on_stack = stack.contains(&reg)
+                || stack
+                    .iter()
+                    .any(|&s| i64_pair_hi(s).map(|hi| hi == reg).unwrap_or(false));
+            let is_local = local_to_reg.values().any(|&r| r == reg);
+            if !on_stack && !is_local {
+                return Ok(reg);
+            }
+        }
+        Err(synth_core::Error::synthesis(
+            "register exhaustion: no free callee-saved register to hold a call \
+             result while reloading a preserved param"
+                .to_string(),
+        ))
+    }
+
     /// This method properly tracks the WASM virtual stack and generates code that
     /// uses r0-r3 for the first 4 parameters per AAPCS. Handles WASM structured
     /// control flow (block, loop, if/else, br, br_if, br_table, return, call).
@@ -5089,6 +5261,25 @@ impl InstructionSelector {
                 }
 
                 Call(func_idx) => {
+                    // ── #188: caller-saved preservation across the call ──
+                    // A BL clobbers R0–R3 and R12. Any live value (operand-stack
+                    // temp or param) residing in one of those registers and needed
+                    // after the call must be spilled before the BL and reloaded
+                    // after it. R4–R8 are callee-saved and survive untouched.
+                    //
+                    // NOTE (scoped out): general AAPCS argument marshalling (moving
+                    // the top-N operand-stack values into R0..R(N-1)) is NOT done
+                    // here — the selector has no access to the callee's signature
+                    // (arg count). The 0-arg reproducers compile correctly; calls
+                    // with register args are a separate, signature-plumbing fix.
+                    let preserved = self.preserve_caller_saved(
+                        &mut instructions,
+                        &stack,
+                        &local_to_reg,
+                        &layout,
+                        idx,
+                    )?;
+
                     if *func_idx < self.num_imports {
                         // Import call — dispatch through Meld runtime
                         instructions.push(ArmInstruction {
@@ -5115,8 +5306,17 @@ impl InstructionSelector {
                         });
                     }
                     cf.add_instruction();
-                    // Push R0 as return value
-                    stack.push(Reg::R0);
+
+                    let result_reg = self.restore_caller_saved(
+                        &mut instructions,
+                        &preserved,
+                        &stack,
+                        &local_to_reg,
+                        &layout,
+                        idx,
+                    )?;
+                    // Push the call's return value as a live operand.
+                    stack.push(result_reg);
                 }
 
                 CallIndirect { type_index, .. } => {
@@ -5125,6 +5325,16 @@ impl InstructionSelector {
                             "stack underflow: malformed WASM or compiler bug".to_string(),
                         )
                     })?;
+                    // #188: preserve caller-saved registers across the indirect
+                    // call (the table-index reg is already popped and consumed by
+                    // the call dispatch, so it is excluded from preservation).
+                    let preserved = self.preserve_caller_saved(
+                        &mut instructions,
+                        &stack,
+                        &local_to_reg,
+                        &layout,
+                        idx,
+                    )?;
                     instructions.push(ArmInstruction {
                         op: ArmOp::CallIndirect {
                             rd: Reg::R0,
@@ -5134,7 +5344,15 @@ impl InstructionSelector {
                         source_line: Some(idx),
                     });
                     cf.add_instruction();
-                    stack.push(Reg::R0);
+                    let result_reg = self.restore_caller_saved(
+                        &mut instructions,
+                        &preserved,
+                        &stack,
+                        &local_to_reg,
+                        &layout,
+                        idx,
+                    )?;
+                    stack.push(result_reg);
                 }
 
                 Unreachable => {
@@ -7009,6 +7227,122 @@ mod tests {
         // Should contain a B (branch) instruction targeting the loop label
         let has_branch = arm_instrs.iter().any(|i| matches!(&i.op, ArmOp::B { .. }));
         assert!(has_branch, "Loop with br should emit a B instruction");
+    }
+
+    /// #188 regression: a param that is live across a call must be preserved.
+    ///
+    /// Reproducer body (`g` in /tmp/liveacross.wat):
+    ///   `(drop (call $clob)) (i32.load (local.get 0))`
+    /// Pre-fix, `g` did `bl clob` (clobbering R0=param0) and then computed the
+    /// load address from the clobbered R0 — reading the call's return instead
+    /// of param0. The fix spills R0 before the BL and reloads it after, so the
+    /// load's address register still holds the ORIGINAL param0.
+    #[test]
+    fn test_188_param_preserved_across_call() {
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        // Default bounds config (None) → I32Load lowers to a single LDR whose
+        // offset_reg is the address register.
+        let wasm_ops = vec![
+            WasmOp::Call(7),     // call $clob (local func, idx >= num_imports)
+            WasmOp::Drop,        // discard clob's result
+            WasmOp::LocalGet(0), // push param0 (R0)
+            WasmOp::I32Load {
+                offset: 0,
+                align: 2,
+            },
+        ];
+        let arm = selector.select_with_stack(&wasm_ops, 1).unwrap();
+
+        let bl_pos = arm
+            .iter()
+            .position(|i| matches!(&i.op, ArmOp::Bl { .. }))
+            .expect("a BL must be emitted for the call");
+
+        // R0 (param0) spilled before the BL, reloaded after it.
+        assert!(
+            arm[..bl_pos]
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Str { rd: Reg::R0, .. })),
+            "param0 (R0) must be spilled before the BL: {:#?}",
+            arm
+        );
+        assert!(
+            arm[bl_pos..]
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Ldr { rd: Reg::R0, .. })),
+            "param0 (R0) must be reloaded after the BL: {:#?}",
+            arm
+        );
+
+        // The load's address register must be R0 (the reloaded param0), i.e.
+        // the load derives from param0, not from the call's return value. Take
+        // the LAST Ldr (the actual memory load; the param reload is an earlier
+        // Ldr R0).
+        let mem_load = arm
+            .iter()
+            .rev()
+            .find_map(|i| match &i.op {
+                ArmOp::Ldr { addr, .. } if addr.offset_reg.is_some() => Some(addr.clone()),
+                _ => None,
+            })
+            .expect("a memory LDR with a register offset must be emitted");
+        assert_eq!(
+            mem_load.offset_reg,
+            Some(Reg::R0),
+            "i32.load base must be param0 (R0), got {:?}",
+            mem_load.offset_reg
+        );
+    }
+
+    /// #171: i64-heavy functions that keep more i64 values live than fit in the
+    /// 5 consecutive register pairs hit register exhaustion. This must surface
+    /// as a clean typed `Err` (NOT a panic), so the backend's function-level
+    /// skip-and-continue net (#168) can drop just that function rather than
+    /// crash the whole compile. A moderate i64 expression (well within the
+    /// register budget) must still compile.
+    ///
+    /// Scope note: a full spill-to-stack fallback for `alloc_consecutive_pair`
+    /// (so deeply-i64-live functions compile rather than being skipped) requires
+    /// changing the operand-stack representation from `Vec<Reg>` to a spillable
+    /// slot type across ~170 push/pop sites — out of scope for this change. The
+    /// clean-error + skip-net behaviour below is the mitigation.
+    #[test]
+    fn test_171_i64_exhaustion_is_clean_error_not_panic() {
+        let db = RuleDatabase::new();
+
+        // Moderate i64 expression: compiles fine (operands consumed before the
+        // result pair is allocated, so live pressure stays low).
+        let mut sel_ok = InstructionSelector::new(db.rules().to_vec());
+        let ok_ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I64Add,
+            WasmOp::LocalGet(0),
+            WasmOp::I64Mul,
+        ];
+        assert!(
+            sel_ok.select_with_stack(&ok_ops, 2).is_ok(),
+            "a moderate i64 function must compile"
+        );
+
+        // Pathological: keep 6 i64 values live simultaneously (12 regs needed,
+        // only 10 allocatable) → exhaustion. Must be Err, must not panic.
+        let mut sel_bad = InstructionSelector::new(db.rules().to_vec());
+        let mut bad_ops = Vec::new();
+        // Six independent i64 constants — each allocates a FRESH register pair,
+        // so all six are live simultaneously before any consumer.
+        for _ in 0..6 {
+            bad_ops.push(WasmOp::I64Const(1));
+        }
+        // Now fold them: five adds consume the six live values.
+        for _ in 0..5 {
+            bad_ops.push(WasmOp::I64Add);
+        }
+        // The key property under test: this returns a Result (clean error or
+        // success) and does NOT panic. Either outcome is acceptable; the #168
+        // backend skip-net drops the function on Err.
+        let _res = sel_bad.select_with_stack(&bad_ops, 0);
     }
 
     #[test]

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -126,6 +126,12 @@ pub struct OptimizationStats {
 /// Optimizer bridge that integrates with synthesis pipeline
 pub struct OptimizerBridge {
     config: OptimizationConfig,
+    /// Number of imported functions (wasm function indices `< num_imports` are
+    /// imports). Used to distinguish import calls (handled in the optimized
+    /// path, dispatched via `func_N` → field-name rewrite, #173) from local
+    /// calls (declined so the direct selector can preserve caller-saved regs
+    /// across them, #188). Defaults to 0.
+    num_imports: u32,
 }
 
 impl OptimizerBridge {
@@ -133,12 +139,21 @@ impl OptimizerBridge {
     pub fn new() -> Self {
         Self {
             config: OptimizationConfig::default(),
+            num_imports: 0,
         }
     }
 
     /// Create with custom configuration
     pub fn with_config(config: OptimizationConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            num_imports: 0,
+        }
+    }
+
+    /// Set the number of imported functions (see [`OptimizerBridge::num_imports`]).
+    pub fn set_num_imports(&mut self, num_imports: u32) {
+        self.num_imports = num_imports;
     }
 
     /// Preprocess WASM ops to transform patterns before IR conversion
@@ -2191,6 +2206,30 @@ impl OptimizerBridge {
     pub fn ir_to_arm(&self, instructions: &[Instruction], num_params: usize) -> Result<Vec<ArmOp>> {
         use crate::rules::{ArmOp, Operand2, Reg};
         use std::collections::HashMap;
+
+        // #188: the optimized path's register allocator does NOT model the
+        // AAPCS caller-saved clobber of a `BL` (R0–R3, R12). A function
+        // containing a LOCAL call can therefore read a param (or temp) from a
+        // register the callee overwrote — the confirmed miscompile in issue
+        // #188. Decline such functions so the backend falls back to the direct
+        // `select_with_stack` selector, which spills/reloads caller-saved
+        // registers across calls. This is honest degradation: the function
+        // still compiles correctly, just without IR-level optimization.
+        //
+        // Import calls (`func_idx < num_imports`) are NOT declined: they keep
+        // going through the optimized path so the CLI's import-field-name
+        // relocation rewrite (`func_N` → wasm field name, #173) still applies.
+        // (Caller-saved preservation across import calls is a separate, pre-
+        // existing gap tracked outside #188.)
+        if instructions.iter().any(|inst| {
+            matches!(inst.opcode, Opcode::Call { func_idx, .. } if func_idx >= self.num_imports)
+        }) {
+            return Err(synth_core::Error::synthesis(
+                "optimized path declines functions with local calls (no caller-saved \
+                 clobber model — see #188); falling back to direct selector"
+                    .to_string(),
+            ));
+        }
 
         let mut arm_instrs = Vec::new();
         let mut vreg_to_arm: HashMap<u32, Reg> = HashMap::new();

--- a/crates/synth-synthesis/tests/regression_call_result_vreg.rs
+++ b/crates/synth-synthesis/tests/regression_call_result_vreg.rs
@@ -1,52 +1,34 @@
-//! Regression test: `WasmOp::Call` left its result vreg unmapped in the
-//! optimized path, triggering the PR #101 defensive panic on lawful WASM
-//! that consumes a call's return value (e.g., the recursive `fib` example
-//! in `examples/wat/simple_add.wat`).
+//! Regression test: `WasmOp::Call` in the optimized path.
 //!
-//! Symptom (pre-fix, with the defensive panic):
+//! History:
+//!  * Originally `wasm_to_ir` had no arm for `WasmOp::Call`, so it fell through
+//!    to `Opcode::Nop`, the call's result vreg was unmapped, and any downstream
+//!    consumer tripped the PR #101 defensive panic (or silently miscompiled by
+//!    consuming a stale R0). That was fixed by adding `Opcode::Call` and
+//!    lowering it to `BL func_<idx>` in `ir_to_arm`.
 //!
-//! ```text
-//! thread 'main' panicked at crates/synth-synthesis/src/optimizer_bridge.rs:1583:21:
-//! synth internal compiler error: vreg v13 has no assigned ARM register and no spill slot.
-//! This is a wasm_to_ir bug — likely a wasm op whose result is unmapped (see issue #93).
-//! ```
+//!  * Issue #188: the optimized path's register allocator does NOT model the
+//!    AAPCS caller-saved clobber of a `BL` (R0–R3, R12). A function that holds a
+//!    param or temp in a caller-saved register across a call therefore reads a
+//!    value the callee overwrote — a *confirmed* miscompile (the `g`/`clob`
+//!    reproducer). Because correctly modelling call-boundary regalloc in the
+//!    optimized path is a deep rework, `ir_to_arm` now **declines** any function
+//!    containing a LOCAL call (`func_idx >= num_imports`, returns `Err`). The
+//!    backend's existing fallback (`arm_backend::compile_wasm_to_arm`) then
+//!    re-lowers the function with the direct `select_with_stack` selector, which
+//!    spills/reloads caller-saved registers across calls (see
+//!    `instruction_selector::preserve_caller_saved`). Import calls stay on the
+//!    optimized path so the #173 field-name relocation rewrite is preserved.
 //!
-//! Root cause: `wasm_to_ir`'s `match wasm_op` had no arm for `WasmOp::Call`,
-//! so it fell through to `_ => Opcode::Nop`. The IR therefore had no record
-//! that `inst_id N` defined a vreg, and any downstream consumer (here, the
-//! outer `i32.add` of the two recursive call results in `fib`) resolved its
-//! `src` operand via `get_arm_reg` -> unmapped -> defensive panic (PR #101)
-//! or, with the silent R0 fallback, silently consumed a stale R0 value.
-//!
-//! Fix: added `Opcode::Call { dest, func_idx }` to `synth-opt`, mapped
-//! `WasmOp::Call` -> `Opcode::Call` in `wasm_to_ir`, and lowered it in
-//! `ir_to_arm` to `BL func_<idx>` with `dest -> R0` registered in
-//! `vreg_to_arm` (AAPCS: R0 holds the return value).
-//!
-//! Scope note: this test verifies the compiler does NOT crash and that the
-//! call's result vreg is bound to a real ARM register. It does *not* verify
-//! correctness of call-boundary regalloc (e.g., that locals held in R0..R3
-//! across a call are properly preserved/reloaded) — that's a separate,
-//! deeper rework tracked in the optimizer-call-lowering follow-up.
+//! These tests pin that contract: the optimized path declines local calls, and
+//! the direct selector lowers them to a `BL` while preserving live caller-saved
+//! registers.
 
-use synth_synthesis::{ArmOp, OptimizerBridge, WasmOp};
-
-/// Compile through the optimized pipeline (matches `synth compile` without
-/// `--no-optimize`) and return the emitted ARM ops.
-fn compile_optimized(wasm_ops: &[WasmOp], num_params: usize) -> Vec<ArmOp> {
-    let bridge = OptimizerBridge::new();
-    let (ir, _cfg, _stats) = bridge
-        .optimize_full(wasm_ops)
-        .expect("optimize_full should succeed for valid input");
-    bridge
-        .ir_to_arm(&ir, num_params)
-        .expect("ir_to_arm should succeed for valid input")
-}
+use synth_synthesis::{ArmOp, InstructionSelector, OptimizerBridge, RuleDatabase, WasmOp};
 
 /// The exact wasm-op sequence emitted by `wat2wasm` for the `fib` function
-/// in `examples/wat/simple_add.wat`. This is the reproducer the task
-/// originated from — its outer `i32.add` consumes two `call` results, the
-/// second of which is `v13` (the vreg the defensive panic flagged).
+/// in `examples/wat/simple_add.wat`. Its outer `i32.add` consumes two `call`
+/// results.
 fn fib_wasm_ops() -> Vec<WasmOp> {
     vec![
         // Condition: local.get $n <=u 1
@@ -61,81 +43,84 @@ fn fib_wasm_ops() -> Vec<WasmOp> {
         WasmOp::LocalGet(0),
         WasmOp::I32Const(1),
         WasmOp::I32Sub,
-        WasmOp::Call(1), // first recursive call -> v9
+        WasmOp::Call(1), // first recursive call
         WasmOp::LocalGet(0),
         WasmOp::I32Const(2),
         WasmOp::I32Sub,
-        WasmOp::Call(1), // second recursive call -> v13 (was the panic site)
-        WasmOp::I32Add,  // consumes v12 and v13
+        WasmOp::Call(1), // second recursive call
+        WasmOp::I32Add,  // consumes both call results
         WasmOp::End,
         WasmOp::End,
     ]
 }
 
-/// Pre-fix: this panicked with "vreg v13 has no assigned ARM register and
-/// no spill slot" when the defensive panic was active, or silently
-/// miscompiled (the second add operand resolved to whatever R0 happened to
-/// hold) when the silent fallback was active.
-///
-/// Post-fix: returns ARM ops including the two `Bl { label: "func_1" }`
-/// instructions; the i32.add reads R0 (where the second call's return value
-/// landed) as one of its operands — no unmapped vregs are encountered.
+/// #188: the optimized path must DECLINE a function containing calls so the
+/// backend falls back to the direct selector. (Previously it lowered the calls
+/// itself without modelling the caller-saved clobber — the miscompile.)
 #[test]
-fn fib_compiles_through_optimized_path() {
-    let ops = fib_wasm_ops();
-    let arm = compile_optimized(&ops, /* num_params = */ 1);
-
-    // Both recursive calls must lower to `BL func_1`.
-    let bl_count = arm
-        .iter()
-        .filter(|op| matches!(op, ArmOp::Bl { label } if label == "func_1"))
-        .count();
-    assert_eq!(
-        bl_count, 2,
-        "expected two `BL func_1` (one per recursive call) — got {} BL ops total in: {:#?}",
-        bl_count, arm
-    );
-
-    // And the outer `i32.add` must be present.
-    let add_count = arm
-        .iter()
-        .filter(|op| matches!(op, ArmOp::Add { .. }))
-        .count();
+fn optimized_path_declines_functions_with_calls() {
+    let bridge = OptimizerBridge::new();
+    let (ir, _cfg, _stats) = bridge
+        .optimize_full(&fib_wasm_ops())
+        .expect("optimize_full should succeed for valid input");
+    let res = bridge.ir_to_arm(&ir, /* num_params = */ 1);
     assert!(
-        add_count >= 1,
-        "expected at least one ADD lowering the outer `i32.add` — got: {:#?}",
-        arm
+        res.is_err(),
+        "ir_to_arm must decline call-containing functions (#188) so the backend \
+         falls back to the direct selector — got Ok"
     );
 }
 
-// Note: a third test that exercised the full backend pipeline
-// (`ArmBackend::compile_function("fib", ...)`) was removed because the
-// synth-synthesis crate sits below synth-backend in the dep graph — using
-// `ArmBackend` from this test file would close a cycle. The existing
-// `crates/synth-cli/tests/wast_compile.rs::compile_fib_recursive`-style
-// tests cover that end-to-end path; the two tests in this file cover the
-// optimizer-bridge layer where the bug lived.
-
-/// Direct check that `Opcode::Call` -> `BL` is emitted and registers `dest`
-/// to an ARM register (any of R0..R12 is acceptable; AAPCS puts it in R0).
-/// The pre-fix bug was that no ARM op was emitted for `Call` *at all* — the
-/// IR contained an `Opcode::Nop`, the BL was missing, and the result vreg
-/// was unmapped.
+/// The direct selector lowers `Call` to `BL func_<idx>` and (for a function
+/// with a param) preserves the param across the call: a `STR`/`LDR` of the
+/// caller-saved param register must bracket the `BL`.
 #[test]
-fn call_emits_bl_in_optimized_path() {
-    // Simplest possible: one call, then store the result.
-    let ops = vec![
-        WasmOp::Call(5),
-        WasmOp::LocalSet(0), // consume the call result -> would trip unmapped-vreg pre-fix
-    ];
-    let arm = compile_optimized(&ops, /* num_params = */ 1);
+fn direct_selector_lowers_and_preserves_across_call() {
+    let db = RuleDatabase::new();
+    let mut selector = InstructionSelector::new(db.rules().to_vec());
+
+    // param0 is live across a call: `drop(call 5); local.get 0` returns param0.
+    let ops = vec![WasmOp::Call(5), WasmOp::Drop, WasmOp::LocalGet(0)];
+    let arm = selector
+        .select_with_stack(&ops, /* num_params = */ 1)
+        .expect("direct selector should lower a call-containing function");
 
     let has_bl_func_5 = arm
         .iter()
-        .any(|op| matches!(op, ArmOp::Bl { label } if label == "func_5"));
+        .any(|i| matches!(&i.op, ArmOp::Bl { label } if label == "func_5"));
+    assert!(has_bl_func_5, "Call(5) must lower to `BL func_5`");
+
+    // R0 (param0, caller-saved) must be spilled before the BL and reloaded after.
+    let bl_pos = arm
+        .iter()
+        .position(|i| matches!(&i.op, ArmOp::Bl { .. }))
+        .expect("a BL must be emitted");
+    let str_r0_before = arm[..bl_pos].iter().any(|i| {
+        matches!(
+            &i.op,
+            ArmOp::Str {
+                rd: synth_synthesis::Reg::R0,
+                ..
+            }
+        )
+    });
+    let ldr_r0_after = arm[bl_pos..].iter().any(|i| {
+        matches!(
+            &i.op,
+            ArmOp::Ldr {
+                rd: synth_synthesis::Reg::R0,
+                ..
+            }
+        )
+    });
     assert!(
-        has_bl_func_5,
-        "WasmOp::Call(5) must lower to `BL func_5` — got: {:#?}",
+        str_r0_before,
+        "param0 (R0) must be spilled (STR R0, [SP,#..]) before the BL — got: {:#?}",
+        arm
+    );
+    assert!(
+        ldr_r0_after,
+        "param0 (R0) must be reloaded (LDR R0, [SP,#..]) after the BL — got: {:#?}",
         arm
     );
 }

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.7" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.7" }
-synth-opt = { path = "../synth-opt", version = "0.11.7" }
+synth-core = { path = "../synth-core", version = "0.11.8" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.8" }
+synth-opt = { path = "../synth-opt", version = "0.11.8" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.7", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.8", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Summary

Closes #188 (the gale-confirmed across-call miscompile). A value (param or temp) **live across a `call`** was corrupted: the selector maps params to r0–r3 and allocates r0–r3/r12 (AAPCS caller-saved) as temps, but `Call` lowering modeled nothing about the `BL` clobbering them. gale's `liveacross.wat` — `drop(call $clob); i32.load(local.get 0)` — read param0 from r0 *after* `clob` overwrote it (blocking `z_impl_k_sem_give`, whose `sem` pointer is live across `k_spin_lock`).

## Fix
- **Direct selector:** `preserve_caller_saved`/`restore_caller_saved` around `Call`/`CallIndirect` — live caller-saved regs (operand-stack temps + params in `local_to_reg`, restricted to r0–r3/r12) are STR'd to a reserved 5-slot frame scratch area before the `BL` and LDR'd back after. If r0 itself was preserved, the call result is moved to a free callee-saved reg before r0 is reloaded.
- **Optimized path:** `ir_to_arm` declines functions with a **local** call (the backend re-lowers via the corrected direct selector); import calls stay on the optimized path to keep the #173 field-name relocation rewrite (`num_imports` plumbed in).

## Verification (independently re-checked off current main)
`g` now emits:
```
str.w r0, [sp]      ; preserve param0 before the call
bl    clob
mov   r4, r0        ; park clob's return
ldr.w r0, [sp]      ; reload original param0
ldr.w r0, [fp, r0]  ; load derives from param0 — CORRECT
```
863 synthesis/backend tests + new regression tests pass; fmt + clippy clean.

## Scoped out → #193
The broader **no-call** subset of the param-register clobber class (i64 results / constants / return values landing in r0–r3 before a *live* param read — the #85/#86 class) and general argument marshalling for calls with register args. The `i64_lowering` fuzz gate (non-required) stays red on that class until #193 lands.

Closes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)