### PR TITLE
fix(backend): route --relocatable to fp-relative direct selector (#197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.11] - 2026-05-30
+
+**Relocatable host-link correctness — fp-relative memory + caller-saved
+preservation across imports (#197).** gale's `z_impl_k_sem_give` miscompiled on
+the optimized path: a pointer param live across an import call (`k_spin_lock`)
+was read from a fixed absolute base (`0x20000100 + clobbered-r0`) instead of
+`[fp, sem]`. Two root causes, both specific to the optimized path and both only
+wrong for relocatable output: (1) the optimized `Call` lowering does not
+preserve caller-saved registers across a `BL`, and (2) `MemLoad`/`MemStore`
+materialize an absolute SRAM base (`0x20000100`) — valid for a bare-metal
+`ET_EXEC` at a known address, but wrong for a host-linked `ET_REL` where the host
+supplies the linear-memory base in `fp` (R11) at runtime. Fix: `--relocatable`
+now routes to the direct selector (`select_with_stack`), which preserves
+caller-saved registers (#188), marshals AAPCS args (#195), spills i64 pairs under
+pressure (#171), and addresses memory fp-relative. Imports in relocatable mode
+emit a direct `BL func_N` (rewritten to the wasm field name, e.g. `k_spin_lock`,
+by `build_relocatable_elf`) instead of `__meld_dispatch_import`. The optimized
+path and its Meld-dispatch import ABI are unchanged for non-relocatable output.
+gale's shape now lowers to `str.w r0,[sp]; bl k_spin_lock; ldr.w r0,[sp]; ldr.w
+r0,[fp,r0]` with an `R_ARM_THM_CALL k_spin_lock` relocation. Follow-up tracked
+separately: an fp-aware optimized path so relocatable builds can be optimized too.
+
+_Falsification:_ this release is wrong if a `--relocatable` object with a pointer
+param live across an import call still reads that param from an absolute base or a
+call-clobbered register — i.e. if `arm-*-objdump -dr` on the `.text` shows a
+`MOVT ip,#0x2000` feeding the dereference, or the param's home register is neither
+spilled across the `BL` nor callee-saved.
+
 ## [0.11.10] - 2026-05-30
 
 **i64 register-pair spill (#171).** i64-heavy functions that kept more i64 values

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.10"
+version = "0.11.11"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.10"
+version = "0.11.11"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.10"
+version = "0.11.11"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.10"
+version = "0.11.11"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.10",
+    version = "0.11.11",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.10" }
+synth-core = { path = "../synth-core", version = "0.11.11" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.10" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.10" }
+synth-core = { path = "../synth-core", version = "0.11.11" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.11" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.10" }
+synth-core = { path = "../synth-core", version = "0.11.11" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.10" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.10", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.11" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.11", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -168,13 +168,24 @@ fn compile_wasm_to_arm(
             config.func_arg_counts.clone(),
             config.type_arg_counts.clone(),
         );
+        // #197: in relocatable host-link mode, emit direct `func_N` BLs for
+        // imports (rewritten to the wasm field name by build_relocatable_elf)
+        // instead of `__meld_dispatch_import`.
+        selector.set_relocatable(config.relocatable);
         selector
             .select_with_stack(wasm_ops, num_params)
             .map_err(|e| format!("instruction selection failed: {}", e))
     };
 
-    // Instruction selection: optimized or direct
-    let arm_instrs = if config.no_optimize {
+    // Instruction selection: optimized or direct.
+    //
+    // #197: `--relocatable` (host-link ET_REL) forces the direct selector. The
+    // optimized path materializes an absolute linmem base (0x20000100) and does
+    // not preserve caller-saved registers across calls — both wrong for a
+    // host-linked object, where the linmem base arrives via `fp` at runtime and
+    // callees follow AAPCS. `select_with_stack` (now i64-spill capable after
+    // #171) handles fp-relative memory + caller-saved preservation correctly.
+    let arm_instrs = if config.no_optimize || config.relocatable {
         select_direct()?
     } else {
         let opt_config = if config.loom_compat {
@@ -326,6 +337,32 @@ mod tests {
         assert_eq!(func.relocations[0].symbol, "__meld_dispatch_import");
         // The BL is the second instruction (after MOV R0, #0), so offset should be > 0
         assert!(func.relocations[0].offset > 0);
+    }
+
+    /// Regression test for #197: in `relocatable` mode, an import call must
+    /// relocate against the direct `func_N` symbol (rewritten to the wasm field
+    /// name by `build_relocatable_elf`), NOT `__meld_dispatch_import`. This is
+    /// the ABI half of the #197 fix — without it, a host linker cannot resolve
+    /// the call to the real kernel symbol (e.g. `k_spin_lock`).
+    #[test]
+    fn test_compile_relocatable_import_uses_direct_func_symbol_197() {
+        let backend = ArmBackend::new();
+        let ops = vec![WasmOp::Call(0)]; // func 0 is an import
+        let config = CompileConfig {
+            num_imports: 1,
+            relocatable: true,
+            ..CompileConfig::default()
+        };
+
+        let func = backend
+            .compile_function("caller", &ops, &config)
+            .expect("relocatable import call compiles");
+
+        assert_eq!(func.relocations.len(), 1);
+        assert_eq!(
+            func.relocations[0].symbol, "func_0",
+            "#197: relocatable import must relocate against func_0 (→ field name), not Meld dispatch"
+        );
     }
 
     #[test]

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.10" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.10" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.10" }
-synth-backend = { path = "../synth-backend", version = "0.11.10" }
+synth-core = { path = "../synth-core", version = "0.11.11" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.11" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.11" }
+synth-backend = { path = "../synth-backend", version = "0.11.11" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.10", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.10", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.10", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.11", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.11", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.11", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.10", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.11", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1846,6 +1846,10 @@ fn compile_all_exports(
         func_arg_counts,
         type_arg_counts,
         target: target_spec.clone(),
+        // #197: --relocatable forces the direct selector + direct func_N import
+        // ABI so host-linked objects get fp-relative memory access and
+        // caller-saved preservation (the optimized path is wrong for ET_REL).
+        relocatable,
         ..CompileConfig::default()
     };
 

--- a/crates/synth-cli/tests/wast_compile.rs
+++ b/crates/synth-cli/tests/wast_compile.rs
@@ -551,6 +551,13 @@ fn compile_import_call_uses_field_name_173() {
 /// optimized output is now correct AND keeps optimizing (it is no longer
 /// declined to `select_with_stack`), so it legitimately differs from
 /// `--no-optimize` in instruction selection while computing the same address.
+///
+/// NOTE (#197): this exercises the optimized path, which is now used only for
+/// NON-relocatable (ET_EXEC) output. `--relocatable` deliberately routes to the
+/// direct fp-relative selector instead (see
+/// `relocatable_pointer_deref_uses_fp_base_197` below), because the optimized
+/// path materializes an absolute SRAM base (`0x20000100`) that is valid for a
+/// bare-metal binary at a known address but wrong for a host-linked object.
 #[test]
 fn pointer_deref_optimized_uses_address_operand_178_180() {
     use object::{Object, ObjectSection};
@@ -569,7 +576,7 @@ fn pointer_deref_optimized_uses_address_operand_178_180() {
             "--target",
             "cortex-m4f",
             "--all-exports",
-            "--relocatable",
+            // No --relocatable: the optimized path is the default for ET_EXEC.
             "-o",
             out.to_str().unwrap(),
         ])
@@ -605,6 +612,64 @@ fn pointer_deref_optimized_uses_address_operand_178_180() {
     assert!(
         has_add_w_ip,
         "optimized .text must contain `add.w ip, ip, rN` (base + address operand) — #180"
+    );
+}
+
+/// Regression test for #197: a `--relocatable` (host-link ET_REL) pointer-param
+/// `i32.load` must compute its address fp-relative — the host supplies the
+/// linear-memory base in `fp` (R11) at runtime — NOT via the optimized path's
+/// absolute `0x20000100` base. gale's `z_impl` read `sem->count` from
+/// `0x20000100 + clobbered-r0`; the absolute base is the root of that miscompile
+/// for relocatable output. After #197, `--relocatable` uses the direct selector,
+/// which addresses memory through `fp`.
+#[test]
+fn relocatable_pointer_deref_uses_fp_base_197() {
+    use object::{Object, ObjectSection};
+
+    let wat = workspace_root()
+        .join("tests")
+        .join("integration")
+        .join("ptr_deref.wat");
+    assert!(wat.exists(), "ptr_deref.wat not found: {}", wat.display());
+
+    let out = std::env::temp_dir().join("synth_ptr_rel_197.o");
+    let result = Command::new(synth_binary())
+        .args([
+            "compile",
+            wat.to_str().unwrap(),
+            "--target",
+            "cortex-m4f",
+            "--all-exports",
+            "--relocatable",
+            "-o",
+            out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        result.status.success(),
+        "relocatable compile failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let data = std::fs::read(&out).unwrap();
+    let elf = object::File::parse(&*data).expect("parse ELF");
+    let text = elf
+        .section_by_name(".text")
+        .and_then(|s| s.data().ok())
+        .expect(".text")
+        .to_vec();
+    let _ = std::fs::remove_file(&out);
+
+    // The optimized path's absolute base is `movt ip, #0x2000` (high half of
+    // 0x20000100): Thumb `MOVT R12,#0x2000` = F2C2 0C00 = bytes C2 F2 00 0C.
+    // It must be ABSENT — relocatable output addresses memory via fp, not an
+    // absolute SRAM constant.
+    let has_movt_ip_2000 = text
+        .windows(4)
+        .any(|w| w[0] == 0xc2 && w[1] == 0xf2 && w[2] == 0x00 && w[3] == 0x0c);
+    assert!(
+        !has_movt_ip_2000,
+        "#197: relocatable .text must NOT materialize the absolute 0x20000100 base (MOVT ip,#0x2000)"
     );
 }
 

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -104,6 +104,15 @@ pub struct CompileConfig {
     /// AAPCS integer-argument count per function type, indexed by type index.
     /// Used by `call_indirect` (issue #195).
     pub type_arg_counts: Vec<u32>,
+    /// Produce relocatable (ET_REL) host-link output. When set, the backend
+    /// uses the direct instruction selector (`select_with_stack`) rather than
+    /// the optimized path: the optimizer materializes an *absolute* linear-
+    /// memory base (0x20000100) and does not preserve caller-saved registers
+    /// across calls, both wrong for a host-linked object where the linmem base
+    /// is supplied via `fp` at runtime and callees follow AAPCS. Imports are
+    /// also emitted as direct `func_N` BLs (resolved to the wasm field name)
+    /// instead of `__meld_dispatch_import`. (#197 — follow-up to #188/#171.)
+    pub relocatable: bool,
 }
 
 impl CompileConfig {
@@ -131,6 +140,7 @@ impl Default for CompileConfig {
             num_imports: 0,
             func_arg_counts: Vec::new(),
             type_arg_counts: Vec::new(),
+            relocatable: false,
         }
     }
 }

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.10" }
+synth-core = { path = "../synth-core", version = "0.11.11" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.10" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.11" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.10" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.10" }
-synth-opt = { path = "../synth-opt", version = "0.11.10" }
+synth-core = { path = "../synth-core", version = "0.11.11" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.11" }
+synth-opt = { path = "../synth-opt", version = "0.11.11" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -974,6 +974,10 @@ pub struct InstructionSelector {
     bounds_check: BoundsCheckConfig,
     /// Number of imported functions (calls to func_idx < this go through Meld dispatch)
     num_imports: u32,
+    /// Relocatable host-link mode (#197). When set, an import call emits a
+    /// direct `BL func_N` (the relocatable-ELF builder rewrites `func_N` to the
+    /// wasm field name, e.g. `k_spin_lock`) instead of `__meld_dispatch_import`.
+    relocatable: bool,
     /// AAPCS argument count per function, indexed by the *full* WASM function
     /// index (imports first, then locals). Plumbed from the frontend's type +
     /// function sections (issue #195). `func_arg_counts[i]` = number of integer
@@ -1010,6 +1014,7 @@ impl InstructionSelector {
             regs: RegisterState::new(),
             bounds_check: BoundsCheckConfig::None,
             num_imports: 0,
+            relocatable: false,
             func_arg_counts: Vec::new(),
             type_arg_counts: Vec::new(),
             fpu: None,
@@ -1029,6 +1034,7 @@ impl InstructionSelector {
             regs: RegisterState::new(),
             bounds_check,
             num_imports: 0,
+            relocatable: false,
             func_arg_counts: Vec::new(),
             type_arg_counts: Vec::new(),
             fpu: None,
@@ -1044,6 +1050,13 @@ impl InstructionSelector {
     /// Set the number of imported functions for Meld dispatch
     pub fn set_num_imports(&mut self, num_imports: u32) {
         self.num_imports = num_imports;
+    }
+
+    /// Enable relocatable host-link mode (#197): import calls emit a direct
+    /// `BL func_N` (rewritten to the wasm field name by the relocatable-ELF
+    /// builder) instead of dispatching through `__meld_dispatch_import`.
+    pub fn set_relocatable(&mut self, relocatable: bool) {
+        self.relocatable = relocatable;
     }
 
     /// Set the per-function AAPCS argument-count table (issue #195).
@@ -5797,15 +5810,22 @@ impl InstructionSelector {
 
                 Call(func_idx) => {
                     let is_import = *func_idx < self.num_imports;
+                    // #197: a relocatable host-link import is a *direct* AAPCS
+                    // call (`BL func_N` → wasm field name), so it marshals args
+                    // into R0–R3 exactly like a local call. Only the legacy Meld
+                    // dispatch ABI (non-relocatable imports) puts the import
+                    // index in R0 and takes no AAPCS args.
+                    let meld_dispatch = is_import && !self.relocatable;
 
                     // ── #195: AAPCS argument count for this callee ──
                     // Look up how many integer args the callee expects so we can
-                    // move the top-N operand-stack values into R0–R3. Import
-                    // calls are excluded: the Meld dispatch ABI puts the import
-                    // index in R0 (see below), which would collide with arg0, so
-                    // arg marshalling for imports stays out of scope (matches the
-                    // #188 note on import-call register handling).
-                    let arg_count = if is_import {
+                    // move the top-N operand-stack values into R0–R3. Meld
+                    // dispatch imports are excluded: that ABI puts the import
+                    // index in R0 (see below), which would collide with arg0.
+                    // Direct imports (#197) and local calls marshal normally —
+                    // `func_arg_counts` is indexed by the full wasm function
+                    // index (imports first), so an import's entry is valid.
+                    let arg_count = if meld_dispatch {
                         0
                     } else {
                         self.func_arg_counts
@@ -5858,8 +5878,9 @@ impl InstructionSelector {
                         cf.add_instruction();
                     }
 
-                    if is_import {
-                        // Import call — dispatch through Meld runtime
+                    if meld_dispatch {
+                        // Legacy import call — dispatch through the Meld runtime
+                        // (import index in R0, then BL __meld_dispatch_import).
                         instructions.push(ArmInstruction {
                             op: ArmOp::Mov {
                                 rd: Reg::R0,
@@ -5875,7 +5896,10 @@ impl InstructionSelector {
                             source_line: Some(idx),
                         });
                     } else {
-                        // Local function call
+                        // Direct `BL func_N`: a local call, or (#197) a
+                        // relocatable import whose `func_N` symbol the ELF
+                        // builder rewrites to the wasm field name (e.g.
+                        // `k_spin_lock`) for the host linker to resolve.
                         instructions.push(ArmInstruction {
                             op: ArmOp::Bl {
                                 label: format!("func_{}", func_idx),
@@ -8370,6 +8394,85 @@ mod tests {
             .iter()
             .any(|i| matches!(i.op, ArmOp::Str { .. }) || matches!(i.op, ArmOp::Ldr { .. }));
         assert!(has_mem, "spill must emit STR/LDR frame traffic");
+    }
+
+    /// Regression test for #197: in relocatable host-link mode, a pointer param
+    /// live across an import call must be preserved, the import must be a DIRECT
+    /// `BL func_N` (rewritten to the field name by the ELF builder), and the
+    /// dereference must be fp-relative — NOT the optimized path's absolute
+    /// 0x20000100 linmem base.
+    ///
+    /// This is gale's `z_impl_k_sem_give` shape: a `sem` pointer param is passed
+    /// to an import (`k_spin_lock`) and then dereferenced afterward. Pre-#197
+    /// the register-heavy function went through the optimized path, which loaded
+    /// `sem->count` from `0x20000100 + clobbered-r0` instead of `[fp, sem]`.
+    /// Forcing `--relocatable` onto `select_with_stack` (now i64-spill capable
+    /// after #171) gives correct preservation + fp-relative memory + direct ABI.
+    #[test]
+    fn test_197_relocatable_import_preserves_pointer_param() {
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        selector.set_num_imports(1); // func 0 is the import (e.g. k_spin_lock)
+        selector.set_relocatable(true); // host-link ET_REL
+        // The import takes one integer arg (the pointer) per AAPCS.
+        selector.set_func_arg_counts(vec![1], vec![]);
+
+        // local.get $sem ; call $import(0) ; local.get $sem ; i32.load ; drop ; end
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::Call(0),
+            WasmOp::LocalGet(0),
+            WasmOp::I32Load {
+                offset: 0,
+                align: 2,
+            },
+            WasmOp::Drop,
+            WasmOp::End,
+        ];
+        let instrs = selector
+            .select_with_stack(&ops, 1)
+            .expect("#197: relocatable import + deref must compile via select_with_stack");
+
+        let bl_labels: Vec<&str> = instrs
+            .iter()
+            .filter_map(|i| match &i.op {
+                ArmOp::Bl { label } => Some(label.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        // (A) Direct import ABI: `BL func_0`, NOT `__meld_dispatch_import`.
+        assert!(
+            bl_labels.contains(&"func_0"),
+            "#197: relocatable import must emit direct `BL func_0`, got {bl_labels:?}"
+        );
+        assert!(
+            !bl_labels.contains(&"__meld_dispatch_import"),
+            "#197: relocatable import must NOT route through Meld dispatch, got {bl_labels:?}"
+        );
+
+        // (B) Defect-2 absent: no absolute 0x20000100 base materialized. The
+        // optimized path emits `Movt R12, #0x2000` (high half of 0x20000100);
+        // select_with_stack uses fp (R11) instead.
+        let has_abs_base = instrs
+            .iter()
+            .any(|i| matches!(&i.op, ArmOp::Movt { rd: Reg::R12, imm16 } if *imm16 == 0x2000));
+        assert!(
+            !has_abs_base,
+            "#197: must NOT materialize the absolute 0x20000100 linmem base (defect 2)"
+        );
+
+        // (C) The dereference is fp-relative (R11 = linmem base), via either a
+        // register-offset load `[R11, rN]` or an `ADD rT, R11, rN; LDR [rT]`.
+        let uses_fp_for_mem = instrs.iter().any(|i| match &i.op {
+            ArmOp::Ldr { addr, .. } => addr.base == Reg::R11,
+            ArmOp::Add { rn, .. } => *rn == Reg::R11,
+            _ => false,
+        });
+        assert!(
+            uses_fp_for_mem,
+            "#197: the i32.load must be fp-relative (R11 linmem base), not absolute"
+        );
     }
 
     #[test]

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.10" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.10" }
-synth-opt = { path = "../synth-opt", version = "0.11.10" }
+synth-core = { path = "../synth-core", version = "0.11.11" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.11" }
+synth-opt = { path = "../synth-opt", version = "0.11.11" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.10", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.11", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Summary

Fixes #197 — gale's `z_impl_k_sem_give` miscompiled on the **optimized path**: a pointer param live across an import call was read from `0x20000100 + clobbered-r0` instead of `[fp, sem]`.

Two root causes, both specific to the optimized path and both **only wrong for relocatable (host-link) output**:

1. **Caller-saved not preserved** — the optimized `Opcode::Call` lowering does not spill/reload vregs a `BL` clobbers (the in-code comment already flagged this as needing a "broader rework").
2. **Absolute linmem base** — `MemLoad`/`MemStore` materialize `0x20000100` as the base. Valid for a bare-metal `ET_EXEC` at a known SRAM address, but wrong for a host-linked `ET_REL` where the host supplies the base in `fp` (R11) at runtime.

## Fix

`--relocatable` now routes to the **direct selector** (`select_with_stack`), which already:
- preserves caller-saved registers across calls (#188),
- marshals AAPCS args into R0–R3 (#195),
- spills i64 register pairs under pressure (#171 — shipped in v0.11.10, which is what lets this complex function compile on the direct path at all),
- and addresses linear memory **fp-relative**.

The selector also emits a direct `BL func_N` for imports in relocatable mode (rewritten to the wasm field name, e.g. `k_spin_lock`, by `build_relocatable_elf`) instead of `__meld_dispatch_import`. The optimized path and its Meld-dispatch import ABI are **unchanged for non-relocatable output**.

## Verified — gale's exact shape now lowers correctly

```
8:  str.w r0, [sp]            ; sem preserved before the call
c:  bl    k_spin_lock         ; R_ARM_THM_CALL k_spin_lock  (direct kernel reloc)
12: ldr.w r0, [sp]            ; sem reloaded after the call
16: ldr.w r0, [fp, r0]        ; sem->count via [fp, sem]
```

Symbol table: `k_spin_lock` is `*UND*` for the host linker — no `func_0`, no `__meld_dispatch_import`.

## Trade-off (tracked follow-up)

Relocatable builds now use the correct-but-unoptimized direct selector. A future change can teach the optimized path fp-relative memory + caller-saved preservation so relocatable builds can be optimized too; until then correctness wins.

## Regression tests
- `instruction_selector::test_197_relocatable_import_preserves_pointer_param` — direct `func_N` BL, no absolute `0x2000` base, fp-relative load
- `arm_backend::test_compile_relocatable_import_uses_direct_func_symbol_197` — import relocates against `func_0` (→ field name), not `__meld_dispatch_import`
- `wast_compile::relocatable_pointer_deref_uses_fp_base_197` — no `MOVT ip,#0x2000`
- `pointer_deref_optimized_uses_address_operand_178_180` repinned onto NON-relocatable output (where the optimized path is still used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)