### PR TITLE
ci(release): gate intra-workspace version-pin desync at PR time (#145)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,17 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  pin-sweep:
+    name: Version Pin Sweep
+    runs-on: [self-hosted, linux, x64, light]
+    steps:
+      - uses: actions/checkout@v4
+      # Issue #145: fail at PR time if [workspace.package].version drifts from
+      # any intra-workspace path-dep `version =` pin or MODULE.bazel — the
+      # v0.7.0-class desync that breaks release.yml + publish at tag-push time.
+      - name: Check intra-workspace version pins
+        run: python3 scripts/check_version_pins.py
+
   verify:
     name: Z3 Verification
     # Stays on ubuntu-latest: needs `sudo apt-get install -y libz3-dev`

--- a/scripts/check_version_pins.py
+++ b/scripts/check_version_pins.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Verify intra-workspace version pins are in lockstep (issue #145).
+
+A release bumps `[workspace.package].version` in the root `Cargo.toml`. Every
+intra-workspace path dependency also carries an explicit `version = "X.Y.Z"`
+pin (added in #136 so `cargo publish` has real crates.io coordinates), and
+`MODULE.bazel` carries a matching `module(version = ...)`. If any of these drift
+from the workspace version, `cargo` refuses to resolve and BOTH `release.yml`
+and `publish-to-crates-io.yml` break at tag-push time — exactly what sank the
+v0.7.0 tag (recovered by the 23-pin sweep in #143).
+
+This gate fails at PR-merge time instead, making the desync structurally
+uncatchable-too-late. Run with no args from the repo root; exits non-zero and
+prints every offending pin on mismatch.
+"""
+
+from __future__ import annotations
+
+import glob
+import re
+import sys
+from pathlib import Path
+
+VERSION_RE = re.compile(r'version\s*=\s*"([^"]+)"')
+
+
+def workspace_version(root: Path) -> str:
+    """Extract `version` from the root Cargo.toml `[workspace.package]` table."""
+    in_section = False
+    for line in (root / "Cargo.toml").read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_section = stripped == "[workspace.package]"
+            continue
+        if in_section:
+            m = VERSION_RE.match(stripped)
+            if m:
+                return m.group(1)
+    sys.exit("ERROR: no [workspace.package] version found in Cargo.toml")
+
+
+def check_path_dep_pins(root: Path, expected: str) -> list[str]:
+    """Every `{ path = "../sibling", version = "X" }` pin must equal `expected`."""
+    errors: list[str] = []
+    for path in sorted(glob.glob(str(root / "crates" / "*" / "Cargo.toml"))):
+        rel = Path(path).relative_to(root)
+        for n, line in enumerate(Path(path).read_text().splitlines(), 1):
+            # An intra-workspace pin is a single inline table carrying BOTH a
+            # relative `path =` and a `version =`. (Plain `version = "..."` for
+            # the crate's own [package] or for external deps is ignored.)
+            if 'path = "../' in line and "version" in line:
+                m = VERSION_RE.search(line)
+                if m and m.group(1) != expected:
+                    name = line.split("=", 1)[0].strip()
+                    errors.append(
+                        f"{rel}:{n}: path-dep `{name}` pinned at "
+                        f'"{m.group(1)}" but workspace is "{expected}"'
+                    )
+    return errors
+
+
+def check_module_bazel(root: Path, expected: str) -> list[str]:
+    """`module(version = ...)` in MODULE.bazel must equal `expected`."""
+    mod = root / "MODULE.bazel"
+    if not mod.exists():
+        return []
+    in_module = False
+    for n, line in enumerate(mod.read_text().splitlines(), 1):
+        if line.startswith("module("):
+            in_module = True
+        if in_module:
+            m = VERSION_RE.search(line)
+            if m:
+                if m.group(1) != expected:
+                    return [
+                        f"MODULE.bazel:{n}: module version "
+                        f'"{m.group(1)}" but workspace is "{expected}"'
+                    ]
+                return []
+        if in_module and line.startswith(")"):
+            break
+    return []
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    expected = workspace_version(root)
+    errors = check_path_dep_pins(root, expected) + check_module_bazel(root, expected)
+    if errors:
+        print(f"Version-pin desync (workspace = {expected}) — issue #145:\n")
+        for e in errors:
+            print(f"  {e}")
+        print(
+            "\nBump every intra-workspace path-dep `version =` pin + MODULE.bazel "
+            "in lockstep with [workspace.package].version before tagging.\n"
+            "Helper: scripts/check_version_pins.py is the gate; the sweep itself "
+            "is a one-liner perl over Cargo.toml + MODULE.bazel."
+        )
+        return 1
+    print(f"OK: all intra-workspace pins + MODULE.bazel at {expected}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #145. Adds a CI gate that makes the v0.7.0-class pin desync **uncatchable-too-late**.

v0.7.0's tag broke `release.yml` + `publish-to-crates-io.yml` because `[workspace.package].version` was bumped while every `crates/*/Cargo.toml` path-dep pin + `MODULE.bazel` still carried the old version — cargo refused to resolve (recovered by the 23-pin sweep in #143). The sweep was a manual, forgettable step (this bit me twice this week, caught only by ritual discipline).

## What this does (Option C from the issue)

- **`scripts/check_version_pins.py`** — parses `[workspace.package].version` and checks it against every intra-workspace `{ path = "../x", version = "Y" }` pin and `MODULE.bazel`'s `module(version=...)`. Exits non-zero listing every offending `file:line` on mismatch.
- **`Version Pin Sweep` CI job** — runs the script on every PR/push. A divergent pin now fails at merge time, not at tag-push.

The script doubles as a local pre-tag check (run from repo root).

## Verified

```
$ python3 scripts/check_version_pins.py
OK: all intra-workspace pins + MODULE.bazel at 0.11.11      # exit 0

# inject synth-core pin 0.11.11 -> 0.11.10:
Version-pin desync (workspace = 0.11.11) — issue #145:
  crates/synth-backend/Cargo.toml:18: path-dep `synth-core` pinned at "0.11.10" but workspace is "0.11.11"   # exit 1
```

## Falsification

Closed wrong if a `[workspace.package].version` bump can still merge with a stale path-dep pin or MODULE.bazel version. Follow-up (issue's Option B, deferred): an ergonomic `bump_workspace_version` helper that performs the sweep in one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)