### PR TITLE
docs(rivet): mark static-linking reqs implemented + SYS.4 verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,17 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  pin-sweep:
+    name: Version Pin Sweep
+    runs-on: [self-hosted, linux, x64, light]
+    steps:
+      - uses: actions/checkout@v4
+      # Issue #145: fail at PR time if [workspace.package].version drifts from
+      # any intra-workspace path-dep `version =` pin or MODULE.bazel — the
+      # v0.7.0-class desync that breaks release.yml + publish at tag-push time.
+      - name: Check intra-workspace version pins
+        run: python3 scripts/check_version_pins.py
+
   verify:
     name: Z3 Verification
     # Stays on ubuntu-latest: needs `sudo apt-get install -y libz3-dev`

--- a/artifacts/static-linking.yaml
+++ b/artifacts/static-linking.yaml
@@ -28,7 +28,7 @@ artifacts:
       (3) the Zephyr SDK's arm-zephyr-eabi-gcc. The toolchain shall be
       detectable at synth build time or configurable via --linker flag.
       This addresses issue #27 (ARM cross-compilation toolchain).
-    status: draft
+    status: implemented
     tags: [static-linking, toolchain, arm, cross-compilation, issue-27]
     links:
       - type: derives-from
@@ -64,7 +64,7 @@ artifacts:
       EXTERN declarations for __meld_dispatch_import and
       __meld_get_memory_base shall be emitted when Meld integration
       is enabled.
-    status: draft
+    status: implemented
     tags: [static-linking, linker-script, meld-sections, memory-layout]
     links:
       - type: derives-from
@@ -116,7 +116,7 @@ artifacts:
       missing symbol and suggesting that kiln-builtins.a is required.
       Weak symbols (__meld_get_memory_base_default) provide fallback
       for bare-metal operation without kiln-builtins.
-    status: draft
+    status: implemented
     tags: [static-linking, symbols, resolution, kiln-builtins]
     links:
       - type: derives-from
@@ -155,7 +155,7 @@ artifacts:
       that Zephyr C code or other firmware components can call them via
       extern declarations. Non-exported WASM functions shall be local
       symbols (STB_LOCAL) to avoid namespace pollution.
-    status: draft
+    status: implemented
     tags: [static-linking, symbols, exports, visibility]
     links:
       - type: derives-from
@@ -192,7 +192,7 @@ artifacts:
       shall be 4 bytes (Thumb-2 instruction alignment). The linker shall
       merge .text from module.o and kiln-builtins.a into a single .text
       output section.
-    status: draft
+    status: implemented
     tags: [static-linking, memory-layout, flash, text-section]
     links:
       - type: derives-from
@@ -231,7 +231,7 @@ artifacts:
       kiln-builtins). For multi-memory modules, each memory gets a
       separate section (.wasm_linear_memory_0, .wasm_linear_memory_1, etc.)
       with individual MPU region allocation.
-    status: draft
+    status: implemented
     tags: [static-linking, memory-layout, ram, linear-memory, mpu]
     links:
       - type: derives-from
@@ -270,7 +270,7 @@ artifacts:
       Both sections have ALLOC flag but not WRITE or EXEC. Placing import
       metadata in FLASH saves RAM on constrained targets and ensures the
       import table cannot be corrupted by software bugs.
-    status: draft
+    status: implemented
     tags: [static-linking, memory-layout, flash, import-table, read-only]
     links:
       - type: derives-from
@@ -307,7 +307,7 @@ artifacts:
       import metadata. The method is composable with existing
       with_meld_integration() and board-specific constructors
       (new_stm32, new_nrf52840, new_generic).
-    status: planned
+    status: implemented
     tags: [static-linking, linker-script, synth-backend]
     links:
       - type: derives-from
@@ -336,7 +336,7 @@ artifacts:
       flag, SYNTH_LINKER environment variable, or PATH detection of
       arm-none-eabi-ld. Linker errors are captured and reported with
       context (which symbol is unresolved, which object needs it).
-    status: planned
+    status: implemented
     tags: [static-linking, cli, linker-invocation, synth-cli]
     links:
       - type: derives-from
@@ -366,7 +366,7 @@ artifacts:
       BL instruction's offset field to point to the resolved symbol address.
       The BL encoding shall leave the offset field as zero (or a placeholder)
       in the relocatable object, to be filled by the linker.
-    status: planned
+    status: implemented
     tags: [static-linking, relocations, elf, arm-thumb]
     links:
       - type: refines
@@ -383,3 +383,59 @@ artifacts:
         readelf -r module.o shows R_ARM_THM_CALL entries for each import
         call; symbol indices reference correct UND symbols; after linking,
         objdump -d shows BL instructions with correct target addresses.
+
+  # ---------------------------------------------------------------------------
+  # Integration verification (SYS.4) — added after the gale cross-LTO arc
+  # shipped (synth v0.11.1–v0.11.11). sys-integration-verification can target
+  # a system-req directly, so these close the SL-00x lifecycle coverage.
+  # ---------------------------------------------------------------------------
+
+  - id: SL-IV-001
+    type: sys-integration-verification
+    title: Relocatable host-link integration verification (v0.11.11)
+    description: >
+      Verifies that synth-compiled relocatable objects (--relocatable) link
+      against a host kernel and dereference linear memory correctly, closing
+      the static-linking system requirements. Evidence from the gale
+      cross-language-LTO bring-up (synth v0.11.1–v0.11.11):
+      (1) synth emits ET_REL objects with R_ARM_THM_CALL relocations against
+          the wasm import field names (e.g. k_spin_lock) and func_N internal
+          symbols — gale's z_impl_k_sem_give object links with 5 real kernel
+          relocations resolved;
+      (2) the generated linker script carries .meld_import_table, .text in
+          FLASH, and .wasm_linear_memory in RAM;
+      (3) a pointer param live across an import call is preserved and
+          dereferenced fp-relative ([fp, sem]), not from an absolute base.
+    status: implemented
+    tags: [static-linking, integration-test, gale, relocatable, v0.11.11]
+    links:
+      - type: verifies
+        target: SL-001
+      - type: verifies
+        target: SL-002
+      - type: verifies
+        target: SL-003
+      - type: verifies
+        target: SL-004
+      - type: verifies
+        target: SL-005
+      - type: verifies
+        target: SL-006
+      - type: verifies
+        target: SL-007
+    fields:
+      method: automated-test
+      preconditions:
+        - synth v0.11.11 (relocatable direct selector, #197)
+        - arm-zephyr-eabi toolchain (Zephyr SDK)
+      steps:
+        - "synth compile merged.both.loom.wasm --target cortex-m4f --all-exports --relocatable -o out.o"
+        - "arm-zephyr-eabi-objdump -dr out.o  # BL k_spin_lock + R_ARM_THM_CALL; ldr [fp, rN]"
+        - "link out.o against the Zephyr kernel; readelf -r confirms the kernel relocations resolve"
+      pass-criteria: >
+        Object links with no unresolved symbols beyond the declared kernel
+        imports; z_impl dereferences sem via [fp, sem] with the param spilled
+        across the call. Regression-tested by
+        test_compile_internal_call_produces_relocation_167,
+        test_compile_relocatable_import_uses_direct_func_symbol_197, and
+        relocatable_pointer_deref_uses_fp_base_197.

--- a/scripts/check_version_pins.py
+++ b/scripts/check_version_pins.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Verify intra-workspace version pins are in lockstep (issue #145).
+
+A release bumps `[workspace.package].version` in the root `Cargo.toml`. Every
+intra-workspace path dependency also carries an explicit `version = "X.Y.Z"`
+pin (added in #136 so `cargo publish` has real crates.io coordinates), and
+`MODULE.bazel` carries a matching `module(version = ...)`. If any of these drift
+from the workspace version, `cargo` refuses to resolve and BOTH `release.yml`
+and `publish-to-crates-io.yml` break at tag-push time — exactly what sank the
+v0.7.0 tag (recovered by the 23-pin sweep in #143).
+
+This gate fails at PR-merge time instead, making the desync structurally
+uncatchable-too-late. Run with no args from the repo root; exits non-zero and
+prints every offending pin on mismatch.
+"""
+
+from __future__ import annotations
+
+import glob
+import re
+import sys
+from pathlib import Path
+
+VERSION_RE = re.compile(r'version\s*=\s*"([^"]+)"')
+
+
+def workspace_version(root: Path) -> str:
+    """Extract `version` from the root Cargo.toml `[workspace.package]` table."""
+    in_section = False
+    for line in (root / "Cargo.toml").read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_section = stripped == "[workspace.package]"
+            continue
+        if in_section:
+            m = VERSION_RE.match(stripped)
+            if m:
+                return m.group(1)
+    sys.exit("ERROR: no [workspace.package] version found in Cargo.toml")
+
+
+def check_path_dep_pins(root: Path, expected: str) -> list[str]:
+    """Every `{ path = "../sibling", version = "X" }` pin must equal `expected`."""
+    errors: list[str] = []
+    for path in sorted(glob.glob(str(root / "crates" / "*" / "Cargo.toml"))):
+        rel = Path(path).relative_to(root)
+        for n, line in enumerate(Path(path).read_text().splitlines(), 1):
+            # An intra-workspace pin is a single inline table carrying BOTH a
+            # relative `path =` and a `version =`. (Plain `version = "..."` for
+            # the crate's own [package] or for external deps is ignored.)
+            if 'path = "../' in line and "version" in line:
+                m = VERSION_RE.search(line)
+                if m and m.group(1) != expected:
+                    name = line.split("=", 1)[0].strip()
+                    errors.append(
+                        f"{rel}:{n}: path-dep `{name}` pinned at "
+                        f'"{m.group(1)}" but workspace is "{expected}"'
+                    )
+    return errors
+
+
+def check_module_bazel(root: Path, expected: str) -> list[str]:
+    """`module(version = ...)` in MODULE.bazel must equal `expected`."""
+    mod = root / "MODULE.bazel"
+    if not mod.exists():
+        return []
+    in_module = False
+    for n, line in enumerate(mod.read_text().splitlines(), 1):
+        if line.startswith("module("):
+            in_module = True
+        if in_module:
+            m = VERSION_RE.search(line)
+            if m:
+                if m.group(1) != expected:
+                    return [
+                        f"MODULE.bazel:{n}: module version "
+                        f'"{m.group(1)}" but workspace is "{expected}"'
+                    ]
+                return []
+        if in_module and line.startswith(")"):
+            break
+    return []
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    expected = workspace_version(root)
+    errors = check_path_dep_pins(root, expected) + check_module_bazel(root, expected)
+    if errors:
+        print(f"Version-pin desync (workspace = {expected}) — issue #145:\n")
+        for e in errors:
+            print(f"  {e}")
+        print(
+            "\nBump every intra-workspace path-dep `version =` pin + MODULE.bazel "
+            "in lockstep with [workspace.package].version before tagging.\n"
+            "Helper: scripts/check_version_pins.py is the gate; the sweep itself "
+            "is a one-liner perl over Cargo.toml + MODULE.bazel."
+        )
+        return 1
+    print(f"OK: all intra-workspace pins + MODULE.bazel at {expected}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The gale cross-LTO arc (v0.11.1–v0.11.11) shipped the static-linking capability, so its rivet requirements can move off `draft`/`planned`.

- **SL-001..007** (system-reqs) + **SL-TR-001..003** (sw-reqs) → `implemented`
- **SL-IV-001** (`sys-integration-verification`) added, verifying SL-001..007 with the on-target evidence (gale's z_impl links with 5 kernel relocations; fp-relative `[fp, sem]`) + the regression tests.

**`rivet validate`: error count unchanged at 35** — all 35 are pre-existing broken cross-repo links to `gale:`/`kiln:`/`sigil:` externals that have no `rivet.yaml` to sync against, orthogonal to status. Info-level SL coverage gaps drop as SL-IV-001 closes the backlinks. Verified via `rivet check gaps-json` severity histogram before/after.

Note: SL-TR-* sw-reqs keep info-level coverage gaps — neither verification type targets a sw-req directly (rivet#350). Non-blocking (info, not error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)