### PR TITLE
fix(backend): byte-accurate local branch resolution (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.12] - 2026-05-31
+
+**Byte-accurate local branch resolution — fixes mid-instruction branch targets
+(#202).** gale's `z_impl` faulted on real Cortex-M4 hardware (NUCLEO-G474RE): a
+`bne.n` conditional branch landed in the *middle* of the following 32-bit
+Thumb-2 instruction, so taking the branch executed from mid-instruction →
+UsageFault (stacked fault PC == the bad target). Root cause: `select_with_stack`
+emits `if`/`else`/`block`/`loop` branches as label placeholders (`Bcc`/`B`/`Bhs`/
+`Blo` + `Label`) but nothing ever resolved them — the encoder emitted `bne.n #0`
+placeholders. The only resolver (`control_flow::resolve_branches`) was dead *and*
+counted instruction indices rather than bytes. Before #197 this path only ran for
+`--no-optimize`/declined functions, so the bug stayed latent; routing relocatable
+code through `select_with_stack` surfaced branches that skip a 32-bit instruction
+(an `ldr.w` spill-reload, a `movw`/`movt` constant, …). New `resolve_label_branches`
+pass in the backend encodes each instruction to learn its real byte length (16-
+vs 32-bit and multi-instruction expansions are exact), maps each `Label` to its
+byte position, and rewrites every local label branch to the displacement the
+encoder consumes — `(target − branch − 4) / 2` halfwords — with a bounded
+fixed-point for the case where an offset grows a branch 16→32-bit. External
+labels (`Trap_Handler`, resolved by relocation) and the optimized path's inline
+`BCondOffset` are left untouched. An `if` over a 32-bit `movw`/`movt` now emits
+`beq 0x12` (else boundary) instead of `beq 0x0a` (mid-`movw`).
+
+_Falsification:_ this release is wrong if any conditional or unconditional Thumb
+branch in synth `.text` targets an address that is not an instruction boundary —
+i.e. if hand-decoding the halfword stream shows a `B<cond>`/`B.N` whose
+`(addr + 4 + 2·imm)` lands on the second halfword of a 32-bit instruction.
+
 ## [0.11.11] - 2026-05-30
 
 **Relocatable host-link correctness — fp-relative memory + caller-saved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.11"
+version = "0.11.12"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.11"
+version = "0.11.12"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.11"
+version = "0.11.12"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.11"
+version = "0.11.12"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.11",
+    version = "0.11.12",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.11" }
+synth-core = { path = "../synth-core", version = "0.11.12" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.11" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.11" }
+synth-core = { path = "../synth-core", version = "0.11.12" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.12" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.11" }
+synth-core = { path = "../synth-core", version = "0.11.12" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.11" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.11", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.12" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.12", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -238,6 +238,18 @@ fn compile_wasm_to_arm(
         ArmEncoder::new_arm32()
     };
 
+    // #202: resolve local label branches (Bcc/B/Bhs/Blo) to byte-accurate
+    // offsets before encoding. `select_with_stack` emits them as label
+    // placeholders and never resolves them — without this they encode as
+    // `bne.n #0` and land mid-instruction whenever a 32-bit Thumb-2 instruction
+    // sits between the branch and its target (UsageFault on real hardware).
+    // Only meaningful for Thumb-2 (the offset units are halfword/PC+4).
+    let arm_instrs = if use_thumb2 {
+        resolve_label_branches(arm_instrs, &encoder)?
+    } else {
+        arm_instrs
+    };
+
     let mut code = Vec::new();
     let mut relocations = Vec::new();
 
@@ -262,6 +274,103 @@ fn compile_wasm_to_arm(
     }
 
     Ok((code, relocations))
+}
+
+/// Resolve local label branches to byte-accurate offsets (#202).
+///
+/// `select_with_stack` emits conditional/unconditional branches as label
+/// placeholders (`Bcc`/`B`/`Bhs`/`Blo` + `Label`) and never resolves them; the
+/// encoder then emits a `0xD000`/`0xE000` placeholder with offset 0. Before #197
+/// this path only ran for `--no-optimize`/declined functions, so the latent bug
+/// stayed hidden — routing relocatable code through it surfaced branches that
+/// land mid-instruction (a Cortex-M UsageFault) whenever a 32-bit Thumb-2
+/// instruction sits between the branch and its target.
+///
+/// This pass encodes each instruction to learn its real byte length (so 16- vs
+/// 32-bit forms and multi-instruction expansions are exact), maps each `Label`
+/// to its byte position, and rewrites every label branch to the displacement
+/// the encoder consumes: `(target - branch - 4) / 2` halfwords. A bounded
+/// fixed-point handles an offset growing a branch from 16- to 32-bit (which
+/// shifts later positions). `BCondOffset`/`BOffset` already produced inline by
+/// the optimized path carry no label and are left untouched.
+fn resolve_label_branches(
+    arm_instrs: Vec<ArmInstruction>,
+    encoder: &ArmEncoder,
+) -> Result<Vec<ArmInstruction>, String> {
+    use std::collections::HashMap;
+    use synth_synthesis::Condition;
+
+    enum BKind {
+        Cond(Condition),
+        Uncond,
+    }
+    // Record each label branch ONCE — indices are stable across iterations.
+    let mut branches: Vec<(usize, BKind, String)> = Vec::new();
+    for (i, instr) in arm_instrs.iter().enumerate() {
+        match &instr.op {
+            ArmOp::Bcc { cond, label } => branches.push((i, BKind::Cond(*cond), label.clone())),
+            ArmOp::Bhs { label } => branches.push((i, BKind::Cond(Condition::HS), label.clone())),
+            ArmOp::Blo { label } => branches.push((i, BKind::Cond(Condition::LO), label.clone())),
+            ArmOp::B { label } => branches.push((i, BKind::Uncond, label.clone())),
+            _ => {}
+        }
+    }
+    if branches.is_empty() {
+        return Ok(arm_instrs);
+    }
+
+    let mut resolved = arm_instrs;
+    // Sizes only grow (16→32-bit), so this converges quickly; cap for safety.
+    for _ in 0..16 {
+        // 1. Byte position of each instruction (Label encodes to 0 bytes).
+        let mut positions = Vec::with_capacity(resolved.len());
+        let mut pos: i64 = 0;
+        for instr in &resolved {
+            positions.push(pos);
+            pos += encoder
+                .encode(&instr.op)
+                .map_err(|e| format!("branch-resolve size probe failed: {}", e))?
+                .len() as i64;
+        }
+        // 2. Label name -> byte position (owned keys so the borrow ends here).
+        let mut labels: HashMap<String, i64> = HashMap::new();
+        for (i, instr) in resolved.iter().enumerate() {
+            if let ArmOp::Label { name } = &instr.op {
+                labels.insert(name.clone(), positions[i]);
+            }
+        }
+        // 3. Rewrite each branch to its byte-accurate offset.
+        let mut changed = false;
+        for (idx, kind, label) in &branches {
+            // A label not defined locally is an EXTERNAL target (e.g.
+            // `Trap_Handler` resolved by a relocation / the vector table). Leave
+            // such branches as their placeholder for the existing relocation
+            // path — only local control-flow labels are byte-resolved here.
+            let Some(&target) = labels.get(label) else {
+                continue;
+            };
+            // Encoder consumes the field as (target - branch - 4) / 2 halfwords.
+            // Positions are always even, so this division is exact.
+            let halfword_offset = ((target - positions[*idx] - 4) / 2) as i32;
+            let new_op = match kind {
+                BKind::Cond(c) => ArmOp::BCondOffset {
+                    cond: *c,
+                    offset: halfword_offset,
+                },
+                BKind::Uncond => ArmOp::BOffset {
+                    offset: halfword_offset,
+                },
+            };
+            if resolved[*idx].op != new_op {
+                resolved[*idx].op = new_op;
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    Ok(resolved)
 }
 
 #[cfg(test)]

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.11" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.11" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.11" }
-synth-backend = { path = "../synth-backend", version = "0.11.11" }
+synth-core = { path = "../synth-core", version = "0.11.12" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.12" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.12" }
+synth-backend = { path = "../synth-backend", version = "0.11.12" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.11", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.11", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.11", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.12", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.12", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.12", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.11", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.12", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-cli/tests/wast_compile.rs
+++ b/crates/synth-cli/tests/wast_compile.rs
@@ -673,6 +673,100 @@ fn relocatable_pointer_deref_uses_fp_base_197() {
     );
 }
 
+/// Regression test for #202: a conditional branch that skips a 32-bit Thumb-2
+/// instruction must target an instruction boundary, not the middle of it.
+///
+/// `select_with_stack` emits `if`/`else` branches as label placeholders; before
+/// the byte-accurate resolution pass they encoded as `beq #0` and, when a 32-bit
+/// `movw`/`movt` sat in the skipped block, landed mid-instruction → UsageFault
+/// on the NUCLEO-G474RE (gale's on-target failure). This decodes every Thumb
+/// 16-bit `B<cond>`/`B.N` in `.text` and asserts its target is a valid
+/// instruction boundary.
+#[test]
+fn relocatable_conditional_branch_targets_instruction_boundary_202() {
+    use object::{Object, ObjectSection};
+
+    let wat = workspace_root()
+        .join("tests")
+        .join("integration")
+        .join("branch_over_32bit.wat");
+    assert!(wat.exists(), "fixture not found: {}", wat.display());
+
+    let out = std::env::temp_dir().join("synth_br32_202.o");
+    let result = Command::new(synth_binary())
+        .args([
+            "compile",
+            wat.to_str().unwrap(),
+            "--target",
+            "cortex-m4f",
+            "--all-exports",
+            "--relocatable",
+            "-o",
+            out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        result.status.success(),
+        "compile failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let data = std::fs::read(&out).unwrap();
+    let elf = object::File::parse(&*data).expect("parse ELF");
+    let text = elf
+        .section_by_name(".text")
+        .and_then(|s| s.data().ok())
+        .expect(".text")
+        .to_vec();
+    let _ = std::fs::remove_file(&out);
+
+    // First pass: walk the halfword stream and record every instruction-start
+    // byte offset, distinguishing 16- from 32-bit Thumb-2 (top 5 bits of the
+    // first halfword are 0b11101/0b11110/0b11111 for 32-bit).
+    let hw: Vec<u16> = text
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    let mut boundaries: std::collections::HashSet<i32> = std::collections::HashSet::new();
+    let mut branches: Vec<(i32, i32)> = Vec::new(); // (byte_addr, halfword imm)
+    let (mut i, mut addr) = (0usize, 0i32);
+    while i < hw.len() {
+        boundaries.insert(addr);
+        let h = hw[i];
+        let is32 = matches!(h >> 11, 0b11101..=0b11111);
+        if !is32 && (h & 0xF000) == 0xD000 && (h & 0x0F00) != 0x0F00 {
+            // 16-bit B<cond> (excludes 0xDF = SVC / 0xDE = UDF via the !=0xF00 guard)
+            let imm8 = (h & 0xFF) as i8 as i32; // sign-extend
+            branches.push((addr, imm8));
+        } else if !is32 && (h & 0xF800) == 0xE000 {
+            // 16-bit unconditional B.N
+            let imm11 = (((h & 0x7FF) as i32) << 21) >> 21; // sign-extend 11-bit
+            branches.push((addr, imm11));
+        }
+        if is32 && i + 1 < hw.len() {
+            i += 2;
+            addr += 4;
+        } else {
+            i += 1;
+            addr += 2;
+        }
+    }
+    boundaries.insert(addr);
+
+    assert!(
+        !branches.is_empty(),
+        "#202: fixture should emit at least one conditional/unconditional branch"
+    );
+    for (baddr, imm) in branches {
+        let target = baddr + 4 + 2 * imm;
+        assert!(
+            boundaries.contains(&target),
+            "#202: branch at 0x{baddr:x} targets 0x{target:x}, which is NOT an instruction \
+             boundary (lands mid-instruction → UsageFault)"
+        );
+    }
+}
+
 /// Decode a Thumb-2 `BL` (two little-endian halfwords at `text[off..off+4]`)
 /// and return its branch target address, given the BL's own address `bl_addr`.
 /// Thumb BL: `target = (bl_addr + 4) + signed_offset`, the inverse of the

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.11" }
+synth-core = { path = "../synth-core", version = "0.11.12" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.11" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.12" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.11" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.11" }
-synth-opt = { path = "../synth-opt", version = "0.11.11" }
+synth-core = { path = "../synth-core", version = "0.11.12" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.12" }
+synth-opt = { path = "../synth-opt", version = "0.11.12" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.11" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.11" }
-synth-opt = { path = "../synth-opt", version = "0.11.11" }
+synth-core = { path = "../synth-core", version = "0.11.12" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.12" }
+synth-opt = { path = "../synth-opt", version = "0.11.12" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.11", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.12", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }

--- a/tests/integration/branch_over_32bit.wat
+++ b/tests/integration/branch_over_32bit.wat
@@ -1,0 +1,14 @@
+;; Regression fixture for #202: an `if` whose then-block contains a 32-bit
+;; Thumb-2 instruction (movw+movt to materialize a >16-bit constant). The
+;; BEQ that skips the then-block must target an instruction boundary, not the
+;; middle of the 32-bit movw. Pre-#202 the branch encoded as `beq #0` and
+;; landed mid-instruction → UsageFault on hardware.
+(module
+  (memory 1)
+  (func (export "f") (param i32) (result i32)
+    local.get 0
+    if (result i32)
+      i32.const 70000   ;; > 0xFFFF -> movw + movt (two 32-bit instructions)
+    else
+      i32.const 1
+    end))


### PR DESCRIPTION
## Summary

Fixes #202 — gale's on-target UsageFault. A `bne.n` conditional branch landed in the **middle of the following 32-bit Thumb-2 instruction** on real Cortex-M4 hardware (NUCLEO-G474RE); taking the branch executed from mid-instruction (stacked fault PC == the bad target).

## Root cause

`select_with_stack` emits `if`/`else`/`block`/`loop` branches as label placeholders (`Bcc`/`B`/`Bhs`/`Blo` + `Label`) — but **nothing ever resolved them**. The encoder emitted `bne.n #0` placeholders. The only resolver, `control_flow::resolve_branches`, is dead *and* counts instruction indices rather than bytes. Before #197 this path only ran for `--no-optimize`/declined functions, so the bug stayed latent; routing relocatable code through `select_with_stack` surfaced branches that skip a 32-bit instruction (an `ldr.w` spill-reload, a `movw`/`movt` constant), where index-distance ≠ halfword-distance.

## Fix

New `resolve_label_branches` pass in the backend: encode each instruction to learn its **real byte length** (16- vs 32-bit and multi-instruction expansions are exact), map each `Label` to its byte position, and rewrite every local label branch to the displacement the encoder consumes — `(target − branch − 4) / 2` halfwords. A bounded fixed-point handles an offset growing a branch 16→32-bit (which shifts later positions). External labels (`Trap_Handler`, resolved by relocation) and the optimized path's inline `BCondOffset`/`BOffset` are left untouched.

## Verified

An `if` whose then-block is a 32-bit `movw`/`movt`:
- **before:** `beq #0` → target `0x0a` (mid-`movw`)
- **after:** `beq 0x12` (else-block boundary); the `B.N` also resolves to `0x16`

All branch targets land on instruction boundaries — confirmed for the gale-like shape (import call + spill + `if` over a 32-bit const) too.

## Regression test

`relocatable_conditional_branch_targets_instruction_boundary_202` decodes `.text`, walks the halfword stream to find instruction boundaries, and asserts every 16-bit `B<cond>`/`B.N` target is a valid boundary (the on-silicon failure mode). Plus fixture `tests/integration/branch_over_32bit.wat`.

Pin-sweep to v0.11.12 (verified by the #145 gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)