### PR TITLE
fix(selector): br_table decode + select flags + SetCond high-reg — binary-sem WAKE path (#204, v0.11.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.14] - 2026-05-31
+
+**Three control-flow miscompiles in the direct selector — fixes the binary
+semaphore's WAKE path (#204 follow-up).** After v0.11.13 fixed the no-waiter
+*increment* path on hardware (gale confirmed `sem->count` now oscillates
+0→1→0), the *waiter* (WAKE) path still couldn't be exercised on silicon — the
+debugger perturbs the give/take race (a true heisenbug). A wasmtime-oracle vs
+unicorn differential harness (`scripts/repro/wake_path_differential.py`) drove
+`z_impl_k_sem_give` with a non-empty wait_q and pinned three independent bugs,
+all in the `--relocatable` direct-selector path, that combined to make the give
+always increment and never wake:
+
+1. **The decoder silently dropped `br_table`.** `convert_operator` had no arm
+   for it, so the multi-way dispatch vanished and control fell straight into
+   table arm 0 — `has_waiter` never selected the WAKE branch. Now decoded with
+   its target list + default preserved.
+2. **`select` clobbered its own condition flags.** The lowering emitted
+   `CMP cond,#0; MOV dst,val1; cond-move` — the middle `MOV` is a 16-bit Thumb
+   `MOVS` (flag-setting) for low registers, destroying the `CMP` result before
+   the conditional move read it (so the select returned the wrong arm under
+   register pressure). Reordered to `CMP` immediately followed by two
+   flag-preserving `IT;MOV` conditional moves; correct under any register
+   aliasing.
+3. **`SetCond` corrupted a high-register result.** It materialized 0/1 with the
+   16-bit `MOVS Rd,#imm` (T1), whose Rd field is 3 bits (R0–R7); for a high Rd
+   (R8–R12) the register bits overflowed the opcode, turning `MOVS` into `CMP`,
+   so the comparison result was never written. `has_waiter` (allocated to R12)
+   stayed stale. High Rd now uses the 32-bit `MOV.W` (T2).
+
+End-to-end: synth's `z_impl_k_sem_give` now matches the WASM semantics on **both**
+paths (no-waiter → `count=1`, no wake; waiter → `count=0`, `z_ready_thread`
+called with the unpended thread) under unicorn emulation of gale's gist on the
+cortex-m4 (Thumb-2) build. Regression tests: `test_decode_br_table` (synth-core),
+`test_encode_setcond_high_reg_uses_mov_w_204` (synth-backend, verify-bytes).
+
+_Falsification:_ this release is wrong if, for a Cortex-M (Thumb-2) target, a
+`br_table` fails to dispatch on its index, or a `select`/comparison whose result
+lands in R8–R12 reads back a value other than the materialized 0/1.
+
 ## [0.11.13] - 2026-05-31
 
 **i64 width-conversion decode + i32/i64-aware spilling + param frame-backing —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.12"
+version = "0.11.14"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.12"
+version = "0.11.14"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.12"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.12"
+version = "0.11.14"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.13"
+version = "0.11.14"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.13",
+    version = "0.11.14",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.13" }
+synth-core = { path = "../synth-core", version = "0.11.14" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.13" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.13" }
+synth-core = { path = "../synth-core", version = "0.11.14" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.14" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.13" }
+synth-core = { path = "../synth-core", version = "0.11.14" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.13" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.13", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.14" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.14", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -2633,16 +2633,31 @@ impl ArmEncoder {
                 let mask = if (cond_bits & 1) == 0 { 0xC } else { 0x4 };
                 let ite_instr: u16 = 0xBF00 | (cond_bits << 4) | mask;
 
-                // MOV Rd, #1 (Then branch - condition true)
-                let mov_one: u16 = 0x2001 | (rd_bits << 8);
-
-                // MOV Rd, #0 (Else branch - condition false)
-                let mov_zero: u16 = 0x2000 | (rd_bits << 8);
-
-                // Emit: ITE, MOV #1 (Then), MOV #0 (Else)
+                // Materialize 0/1 into Rd. The 16-bit MOVS (T1) encodes Rd in a
+                // 3-bit field (bits[10:8]) — only R0–R7. For a high register
+                // (R8–R12) `rd_bits << 8` overflows into bit 11 and silently
+                // turns MOVS into CMP (00100 → 00101), corrupting the result
+                // (this mis-materialized gale's `has_waiter`, so its `local.set`
+                // stored a stale register → the binary-sem WAKE dispatch read
+                // garbage). Use the 32-bit MOV.W (T2) for high registers, which
+                // has a 4-bit Rd field. MOV.W with S=0 doesn't set flags, which
+                // is fine inside the ITE (the materialized value is the result;
+                // the flags are not consumed afterwards).
                 let mut bytes = ite_instr.to_le_bytes().to_vec();
-                bytes.extend_from_slice(&mov_one.to_le_bytes());
-                bytes.extend_from_slice(&mov_zero.to_le_bytes());
+                let push_mov = |bytes: &mut Vec<u8>, imm: u16| {
+                    if rd_bits <= 7 {
+                        let m: u16 = 0x2000 | (rd_bits << 8) | imm; // 16-bit MOVS Rd,#imm
+                        bytes.extend_from_slice(&m.to_le_bytes());
+                    } else {
+                        // 32-bit MOV.W Rd, #imm (T2): F04F | (Rd<<8) | imm8
+                        let hw1: u16 = 0xF04F;
+                        let hw2: u16 = (rd_bits << 8) | imm;
+                        bytes.extend_from_slice(&hw1.to_le_bytes());
+                        bytes.extend_from_slice(&hw2.to_le_bytes());
+                    }
+                };
+                push_mov(&mut bytes, 1); // Then branch (condition true)  → 1
+                push_mov(&mut bytes, 0); // Else branch (condition false) → 0
                 Ok(bytes)
             }
 
@@ -6915,6 +6930,41 @@ mod tests {
 
         let encoder_thumb = ArmEncoder::new_thumb2();
         assert!(encoder_thumb.thumb_mode);
+    }
+
+    /// #204 WAKE-path regression: `SetCond` materialized 0/1 with the 16-bit
+    /// `MOVS Rd,#imm` (T1), whose Rd field is 3 bits (R0–R7). For a high Rd
+    /// (R8–R12) `rd_bits << 8` overflows bit 11, flipping the opcode MOVS→CMP
+    /// (`0x2c00`), so the boolean was never written — gale's `has_waiter` kept a
+    /// stale value and the binary-sem WAKE dispatch read garbage. High Rd must
+    /// use the 32-bit `MOV.W` (T2). Verify the bytes, not the IR.
+    #[test]
+    fn test_encode_setcond_high_reg_uses_mov_w_204() {
+        use synth_synthesis::{ArmOp, Condition, Reg};
+        let enc = ArmEncoder::new_thumb2();
+        // R12 (high): must be ITE + MOV.W #1 + MOV.W #0, never a 16-bit MOVS/CMP.
+        let hi = enc
+            .encode(&ArmOp::SetCond {
+                rd: Reg::R12,
+                cond: Condition::NE,
+            })
+            .unwrap();
+        assert_eq!(hi.len(), 10, "ITE(2) + MOV.W(4) + MOV.W(4): {hi:02x?}");
+        // both value halfwords are MOV.W (0xF04F) — NOT the corrupt CMP (0x2c..).
+        assert_eq!(&hi[2..4], &[0x4F, 0xF0], "then = MOV.W: {hi:02x?}");
+        assert_eq!(&hi[6..8], &[0x4F, 0xF0], "else = MOV.W: {hi:02x?}");
+        assert_eq!(hi[4] & 0x0F, 0x01, "then imm = #1");
+        assert_eq!(hi[8] & 0x0F, 0x00, "else imm = #0");
+        // Low Rd keeps the compact 16-bit MOVS form.
+        let lo = enc
+            .encode(&ArmOp::SetCond {
+                rd: Reg::R0,
+                cond: Condition::NE,
+            })
+            .unwrap();
+        assert_eq!(lo.len(), 6, "ITE(2) + MOVS(2) + MOVS(2): {lo:02x?}");
+        assert_eq!(lo[2..4], [0x01, 0x20], "then = MOVS R0,#1");
+        assert_eq!(lo[4..6], [0x00, 0x20], "else = MOVS R0,#0");
     }
 
     /// #178/#180 regression: the Thumb `Add`/`Adds`/`Subs` reg-forms used the

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.13" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.13" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.13" }
-synth-backend = { path = "../synth-backend", version = "0.11.13" }
+synth-core = { path = "../synth-core", version = "0.11.14" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.14" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.14" }
+synth-backend = { path = "../synth-backend", version = "0.11.14" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.13", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.13", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.13", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.14", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.14", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.14", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.13", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.14", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -433,6 +433,19 @@ fn convert_operator(op: &wasmparser::Operator) -> Option<WasmOp> {
         Loop { .. } => Some(WasmOp::Loop),
         Br { relative_depth } => Some(WasmOp::Br(*relative_depth)),
         BrIf { relative_depth } => Some(WasmOp::BrIf(*relative_depth)),
+        // br_table: indexed multi-way branch. Previously UNMAPPED → silently
+        // dropped, so the selector never emitted the index dispatch and control
+        // fell straight into the first table arm — every br_table behaved as if
+        // it always took target 0 (gale's binary-sem WAKE path never fired). The
+        // jump-table relative depths + default depth are preserved in order.
+        BrTable { targets } => {
+            let default = targets.default();
+            let tgts: Vec<u32> = targets.targets().filter_map(Result::ok).collect();
+            Some(WasmOp::BrTable {
+                targets: tgts,
+                default,
+            })
+        }
         Return => Some(WasmOp::Return),
         Call { function_index } => Some(WasmOp::Call(*function_index)),
         CallIndirect {
@@ -695,6 +708,36 @@ mod tests {
             ops.contains(&WasmOp::I32WrapI64),
             "i32.wrap_i64 must decode (not be dropped): {ops:?}"
         );
+    }
+
+    /// #204 WAKE-path regression: `br_table` must DECODE (it was unmapped in
+    /// `convert_operator` → silently dropped, so the selector emitted no index
+    /// dispatch and every `br_table` fell through to target 0 — gale's binary
+    /// semaphore never took its WAKE branch). Targets + default are preserved.
+    #[test]
+    fn test_decode_br_table() {
+        let wat = r#"
+            (module
+                (func (export "bt") (param i32) (result i32)
+                    (block (block (block
+                        local.get 0
+                        br_table 2 0 1 2)
+                      i32.const 30 return)
+                      i32.const 20 return)
+                    i32.const 10))
+        "#;
+        let wasm = wat::parse_str(wat).expect("parse");
+        let functions = decode_wasm_functions(&wasm).expect("decode");
+        let bt = functions[0]
+            .ops
+            .iter()
+            .find_map(|o| match o {
+                WasmOp::BrTable { targets, default } => Some((targets.clone(), *default)),
+                _ => None,
+            })
+            .expect("br_table must decode (not be dropped)");
+        assert_eq!(bt.0, vec![2, 0, 1], "br_table targets preserved in order");
+        assert_eq!(bt.1, 2, "br_table default preserved");
     }
 
     #[test]

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.13" }
+synth-core = { path = "../synth-core", version = "0.11.14" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.13" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.14" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.13" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.13" }
-synth-opt = { path = "../synth-opt", version = "0.11.13" }
+synth-core = { path = "../synth-core", version = "0.11.14" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.14" }
+synth-opt = { path = "../synth-opt", version = "0.11.14" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -6235,7 +6235,16 @@ impl InstructionSelector {
                     )?;
                     let dst = alloc_temp_safe(&mut next_temp, &stack)?;
 
-                    // CMP cond, #0
+                    // CMP cond, #0 — sets the flags FIRST, before anything writes
+                    // `dst`. The previous lowering put a `MOV dst, val1` between
+                    // the CMP and the conditional move; that MOV is a 16-bit Thumb
+                    // `MOVS` for low registers and SETS the flags, clobbering the
+                    // comparison whenever the allocator picked a low `dst` — which
+                    // mis-computed gale's br_table index so the binary-semaphore
+                    // WAKE path never ran. Both `SelectMove`s below are `IT;MOV`
+                    // (the flag-preserving 0x46xx MOV), so neither disturbs the
+                    // flags and exactly one fires — correct under any aliasing of
+                    // dst with cond/val1/val2 (cond is already consumed by CMP).
                     instructions.push(ArmInstruction {
                         op: ArmOp::Cmp {
                             rn: cond_reg,
@@ -6245,17 +6254,18 @@ impl InstructionSelector {
                     });
                     cf.add_instruction();
 
-                    // MOV dst, val1 (default: pick val1)
+                    // cond != 0 → dst = val1
                     instructions.push(ArmInstruction {
-                        op: ArmOp::Mov {
+                        op: ArmOp::SelectMove {
                             rd: dst,
-                            op2: Operand2::Reg(val1),
+                            rm: val1,
+                            cond: Condition::NE,
                         },
                         source_line: Some(idx),
                     });
                     cf.add_instruction();
 
-                    // If cond == 0, overwrite with val2 using IT EQ + MOV
+                    // cond == 0 → dst = val2
                     instructions.push(ArmInstruction {
                         op: ArmOp::SelectMove {
                             rd: dst,

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.13" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.13" }
-synth-opt = { path = "../synth-opt", version = "0.11.13" }
+synth-core = { path = "../synth-core", version = "0.11.14" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.14" }
+synth-opt = { path = "../synth-opt", version = "0.11.14" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.13", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.14", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }

--- a/scripts/repro/wake_path_differential.py
+++ b/scripts/repro/wake_path_differential.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+#204 WAKE-path differential harness (gale's binary semaphore).
+
+Compares synth's compiled `z_impl_k_sem_give` against the WASM semantics
+(wasmtime as the oracle) for both the no-waiter (increment) and waiter (WAKE)
+paths — the WAKE path can't be exercised on hardware because the debugger
+perturbs the give/take race (gale's heisenbug).
+
+Setup:
+    python3 -m venv /tmp/armv
+    /tmp/armv/bin/pip install unicorn capstone wasmtime
+    # fetch gale's gist to /tmp/merged.wat:
+    curl -sL https://api.github.com/gists/d30f965ac96b8ca4cac7d4fea2832a6a \
+      | python3 -c "import sys,json;print(json.load(sys.stdin)['files']['merged.both.loom.wat']['content'])" \
+      > /tmp/merged.wat
+    # compile for gale's target (Thumb-2 — NOT the default --target arm!):
+    synth compile /tmp/merged.wat --target cortex-m4 --relocatable -o /tmp/gz_m4.elf
+
+Run:
+    /tmp/armv/bin/python3 scripts/repro/wake_path_differential.py
+
+Key gotcha: synth's default `--target arm` emits ARM/A32 and its encoder drops
+the register index on indexed loads/stores (#206). gale builds Thumb-2
+(cortex-m4); the harness runs UC_MODE_THUMB to match. Disassemble with capstone
+THUMB mode, not `synth disasm` (which decodes as ARM).
+"""
+import struct
+from unicorn import *
+from unicorn.arm_const import *
+from capstone import *
+import wasmtime
+
+WAT = "/tmp/merged.wat"
+ELF = "/tmp/gz_m4.elf"
+THREAD = 0x5000  # fake pended-waiter pointer for the WAKE scenario
+
+
+def oracle(thread):
+    eng = wasmtime.Engine(); store = wasmtime.Store(eng)
+    mod = wasmtime.Module.from_file(eng, WAT); calls = []
+    i32 = wasmtime.ValType.i32()
+    ft0 = wasmtime.FuncType([i32], [i32]); ft1 = wasmtime.FuncType([i32, i32], [])
+    ft2 = wasmtime.FuncType([i32], []); ft3 = wasmtime.FuncType([i32, i32], [i32])
+    imp = [wasmtime.Func(store, ft0, lambda x: (calls.append("k_spin_lock") or 0x400)),
+           wasmtime.Func(store, ft0, lambda x: (calls.append("z_unpend") or thread)),
+           wasmtime.Func(store, ft1, lambda t, v: calls.append("arch_ret")),
+           wasmtime.Func(store, ft2, lambda t: calls.append("z_ready_thread")),
+           wasmtime.Func(store, ft3, lambda k, a: (calls.append("z_reschedule") or 0))]
+    inst = wasmtime.Instance(store, mod, imp); mem = inst.exports(store)["memory"]
+    mem.write(store, (0).to_bytes(4, "little"), 0x100)
+    mem.write(store, (1).to_bytes(4, "little"), 0x104)
+    inst.exports(store)["z_impl_k_sem_give"](store, 0x100)
+    return calls, int.from_bytes(mem.read(store, 0x100, 0x104), "little")
+
+
+def synth(thread):
+    d = open(ELF, "rb").read()
+    so = struct.unpack_from("<I", d, 0x20)[0]; n = struct.unpack_from("<H", d, 0x30)[0]
+    sx = struct.unpack_from("<H", d, 0x32)[0]
+    secs = [struct.unpack_from("<IIIIIIIIII", d, so + i * 0x28) for i in range(n)]
+    shstr = secs[sx][4]
+
+    def nm(x):
+        e = d.index(b"\0", shstr + x); return d[shstr + x:e].decode()
+    S = {nm(s[0]): s for s in secs}
+    code = d[S[".text"][4]:S[".text"][4] + S[".text"][5]]
+    rel = S[".rel.text"]
+    relofs = sorted(struct.unpack_from("<II", d, rel[4] + i * 8)[0] for i in range(rel[5] // 8))
+    NM = dict(zip(relofs, ["k_spin_lock", "z_unpend", "arch_ret", "z_ready_thread", "z_reschedule"]))
+    md = Cs(CS_ARCH_ARM, CS_MODE_THUMB); md.skipdata = True
+    pushes = [i.address for i in md.disasm(code, 0) if i.mnemonic.startswith("push")]
+    zimpl = max(p for p in pushes if p < relofs[0])
+    CODE = 0x10000; LIN = 0x40000; SEM = 0x100
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    for b in (CODE, 0x20000, LIN):
+        mu.mem_map(b, 0x10000)
+    mu.mem_write(CODE, code)
+    mu.mem_write(LIN + SEM, (0).to_bytes(4, "little"))
+    mu.mem_write(LIN + SEM + 4, (1).to_bytes(4, "little"))
+    mu.reg_write(UC_ARM_REG_SP, 0x28000); mu.reg_write(UC_ARM_REG_R11, LIN)
+    mu.reg_write(UC_ARM_REG_R0, SEM); mu.reg_write(UC_ARM_REG_LR, 0x15000 | 1)
+    calls = []
+
+    def ch(mu, a, s, u):
+        o = a - CODE
+        if o in NM:
+            calls.append(NM[o])
+            mu.reg_write(UC_ARM_REG_R0, thread if NM[o] == "z_unpend" else 0)
+            mu.reg_write(UC_ARM_REG_PC, (a + 4) | 1)
+    mu.hook_add(UC_HOOK_CODE, ch)
+    try:
+        mu.emu_start((CODE + zimpl) | 1, 0x15000, count=8000)
+    except UcError as e:
+        calls.append(f"ERR:{e}")
+    return calls, int.from_bytes(mu.mem_read(LIN + SEM, 4), "little")
+
+
+for label, thread in [("NO-WAITER", 0), ("WAITER", THREAD)]:
+    oc, ocnt = oracle(thread); sc, scnt = synth(thread)
+    print(f"{label}:")
+    print(f"  wasm oracle: count={ocnt} calls={oc}")
+    print(f"  synth ARM  : count={scnt} calls={sc}")
+    print(f"  {'MATCH' if (oc == sc and ocnt == scnt) else 'MISMATCH <<< synth miscompiles this path'}")


### PR DESCRIPTION
## #204 follow-up — the binary-semaphore WAKE path

v0.11.13 fixed the no-waiter *increment* path (gale confirmed on NUCLEO-G474RE: `sem->count` now oscillates 0→1→0). But the *waiter* (WAKE) path couldn't be exercised on silicon — the debugger perturbs the give/take race (a true heisenbug; in free-run the bench stalls, under gdb the WAKE branch never fires).

I built a **wasmtime-oracle vs unicorn differential harness** (`scripts/repro/wake_path_differential.py`), drove `z_impl_k_sem_give` with a non-empty wait_q, and found **three independent direct-selector bugs** that combined to make the give *always increment and never wake*:

1. **Decoder dropped `br_table`.** `convert_operator` had no arm → the multi-way dispatch vanished and control fell into table arm 0. `has_waiter` never selected the WAKE branch. Now decoded (targets + default preserved).
2. **`select` clobbered its own flags.** `CMP cond,#0; MOV dst,val1; cond-move` — the middle `MOV` is a 16-bit `MOVS` (flag-setting) for low regs, destroying the CMP result before the conditional move. Reordered to `CMP` + two flag-preserving `IT;MOV` moves (correct under any aliasing).
3. **`SetCond` corrupted a high-register result.** 16-bit `MOVS Rd,#imm` has a 3-bit Rd field (R0–R7); a high Rd (R8–R12) overflowed the opcode `MOVS`→`CMP`, so the boolean was never written. `has_waiter` (allocated to R12) stayed stale. High Rd now uses 32-bit `MOV.W`. *(Same class as #180's high-reg encoder bug.)*

### Verification
synth's `z_impl` now matches the WASM semantics (wasmtime) on **both** paths under unicorn (cortex-m4 / Thumb-2):
- no-waiter → `count=1`, no wake
- waiter → `count=0`, `z_ready_thread(thread)` called

Regression tests: `test_decode_br_table` (synth-core), `test_encode_setcond_high_reg_uses_mov_w_204` (synth-backend, verify-bytes). Full suite + clippy + fmt green; version pins swept to 0.11.14.

_Falsification:_ wrong if a Cortex-M `br_table` fails to dispatch on its index, or a `select`/comparison whose result lands in R8–R12 reads back a value other than the materialized 0/1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)