### PR TITLE
fix(encoder): ARM32 indexed loads/stores keep the register index (#206, v0.11.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.15] - 2026-06-01
+
+**ARM32 (A32) encoder dropped the register index on indexed loads/stores
+(#206).** On the default `--target arm`, `Ldr`/`Str`/`Ldrb`/`Strb`/`Ldrh`/`Strh`/
+`Ldrsb`/`Ldrsh` fed their address through `encode_mem_addr`, which returns only
+the 12-bit immediate — so a register offset (`[rn, rm, #off]`, e.g. a WASM
+`iN.load`/`store` with a runtime address) silently collapsed to `[rn, #off]`,
+sending the access to the wrong address. A register offset now materializes
+`ip = rn + rm` (clobbering the scratch IP/R12) and loads from `[ip, #off]`,
+uniform across word/byte/halfword/signed forms. This only affected the default
+ARM/A32 target; Cortex-M (Thumb-2) was already correct (its encoder handles the
+register-offset addressing mode), which is why gale's `--target cortex-m4` build
+was unaffected. Found while diagnosing #204.
+
+Regression test: `test_encode_arm32_indexed_load_keeps_index_206` (verify-bytes —
+`ldr r0,[r11,r1,#8]` must encode as `ADD ip,r11,r1` + `LDR r0,[ip,#8]`, never a
+bare `LDR r0,[r11,#8]`).
+
+_Falsification:_ this release is wrong if any ARM32 `Ldr*`/`Str*` whose `MemAddr`
+carries an `offset_reg` encodes to a single instruction (the register index would
+again be dropped).
+
 ## [0.11.14] - 2026-05-31
 
 **Three control-flow miscompiles in the direct selector — fixes the binary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.14"
+version = "0.11.15"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.14",
+    version = "0.11.15",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.14" }
+synth-core = { path = "../synth-core", version = "0.11.15" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.14" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.14" }
+synth-core = { path = "../synth-core", version = "0.11.15" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.15" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.14" }
+synth-core = { path = "../synth-core", version = "0.11.15" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.14" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.14", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.15" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.15", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -51,7 +51,87 @@ impl ArmEncoder {
     }
 
     /// Encode an ARM instruction in ARM32 mode (32-bit instructions)
+    /// #206: encode an ARM32 (A32) load/store whose address uses a register
+    /// offset (`[rn, rm{, #off}]`). Returns `None` for ops with no register
+    /// offset (the caller falls through to the immediate-form arms). Computes
+    /// `ip = base + rm` then re-encodes the op against `[ip, #off]`, which works
+    /// uniformly for word/byte/halfword/signed forms. IP (R12) is the scratch
+    /// register the selector already treats as clobberable across memory ops.
+    fn encode_arm_reg_offset_mem(&self, op: &ArmOp) -> Result<Option<Vec<u8>>> {
+        use synth_synthesis::Reg;
+        let addr = match op {
+            ArmOp::Ldr { addr, .. }
+            | ArmOp::Str { addr, .. }
+            | ArmOp::Ldrb { addr, .. }
+            | ArmOp::Strb { addr, .. }
+            | ArmOp::Ldrh { addr, .. }
+            | ArmOp::Strh { addr, .. }
+            | ArmOp::Ldrsb { addr, .. }
+            | ArmOp::Ldrsh { addr, .. } => addr,
+            _ => return Ok(None),
+        };
+        let Some(rm) = addr.offset_reg else {
+            return Ok(None);
+        };
+        let ip = Reg::R12;
+        // ADD ip, base, rm  (cond=AL, opcode=ADD, S=0, register operand2)
+        let add: u32 = 0xE0800000
+            | (reg_to_bits(&addr.base) << 16)
+            | (reg_to_bits(&ip) << 12)
+            | reg_to_bits(&rm);
+        let mut bytes = add.to_le_bytes().to_vec();
+        // Re-encode the op against [ip, #off] (immediate form → no offset_reg,
+        // so this recursion hits the immediate arms, not this helper again).
+        let imm_addr = MemAddr::imm(ip, addr.offset);
+        let imm_op = match op {
+            ArmOp::Ldr { rd, .. } => ArmOp::Ldr {
+                rd: *rd,
+                addr: imm_addr,
+            },
+            ArmOp::Str { rd, .. } => ArmOp::Str {
+                rd: *rd,
+                addr: imm_addr,
+            },
+            ArmOp::Ldrb { rd, .. } => ArmOp::Ldrb {
+                rd: *rd,
+                addr: imm_addr,
+            },
+            ArmOp::Strb { rd, .. } => ArmOp::Strb {
+                rd: *rd,
+                addr: imm_addr,
+            },
+            ArmOp::Ldrh { rd, .. } => ArmOp::Ldrh {
+                rd: *rd,
+                addr: imm_addr,
+            },
+            ArmOp::Strh { rd, .. } => ArmOp::Strh {
+                rd: *rd,
+                addr: imm_addr,
+            },
+            ArmOp::Ldrsb { rd, .. } => ArmOp::Ldrsb {
+                rd: *rd,
+                addr: imm_addr,
+            },
+            ArmOp::Ldrsh { rd, .. } => ArmOp::Ldrsh {
+                rd: *rd,
+                addr: imm_addr,
+            },
+            _ => unreachable!(),
+        };
+        bytes.extend(self.encode_arm(&imm_op)?);
+        Ok(Some(bytes))
+    }
+
     fn encode_arm(&self, op: &ArmOp) -> Result<Vec<u8>> {
+        // #206: ARM32 register-offset loads/stores. `encode_mem_addr` only
+        // returns the 12-bit immediate, so the immediate-form arms below
+        // silently DROP `addr.offset_reg` — a runtime address index vanished,
+        // turning `ldr rd,[rn,rm,#off]` into `ldr rd,[rn,#off]` (the access went
+        // to the wrong address). Compute the effective base into IP and re-encode
+        // against `[ip, #off]`, which is uniform for word/byte/halfword/signed.
+        if let Some(bytes) = self.encode_arm_reg_offset_mem(op)? {
+            return Ok(bytes);
+        }
         let instr: u32 = match op {
             // Data processing instructions
             ArmOp::Add { rd, rn, op2 } => {
@@ -6965,6 +7045,38 @@ mod tests {
         assert_eq!(lo.len(), 6, "ITE(2) + MOVS(2) + MOVS(2): {lo:02x?}");
         assert_eq!(lo[2..4], [0x01, 0x20], "then = MOVS R0,#1");
         assert_eq!(lo[4..6], [0x00, 0x20], "else = MOVS R0,#0");
+    }
+
+    /// #206 regression: the ARM32 (A32) `Ldr`/`Str` encoders fed `addr` through
+    /// `encode_mem_addr`, which returns only the 12-bit immediate — so a register
+    /// offset (`[rn, rm, #off]`) was silently dropped to `[rn, #off]`, sending
+    /// the access to the wrong runtime address (silent miscompile on the default
+    /// `--target arm`). A register offset must materialize `ip = rn + rm` and
+    /// load from `[ip, #off]`. Verify the bytes.
+    #[test]
+    fn test_encode_arm32_indexed_load_keeps_index_206() {
+        use synth_synthesis::{ArmOp, MemAddr, Reg};
+        let enc = ArmEncoder::new_arm32();
+        // ldr r0, [r11, r1, #8]  must NOT collapse to a single immediate ldr.
+        let bytes = enc
+            .encode(&ArmOp::Ldr {
+                rd: Reg::R0,
+                addr: MemAddr::reg_imm(Reg::R11, Reg::R1, 8),
+            })
+            .unwrap();
+        assert_eq!(
+            bytes.len(),
+            8,
+            "expected ADD ip + LDR (2 words): {bytes:02x?}"
+        );
+        let add = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let ldr = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        // ADD ip, r11, r1  = 0xE08BC001
+        assert_eq!(add, 0xE08B_C001, "ADD ip,r11,r1: {add:#010x}");
+        // LDR r0, [ip, #8] = 0xE59C0008
+        assert_eq!(ldr, 0xE59C_0008, "LDR r0,[ip,#8]: {ldr:#010x}");
+        // A bare immediate ldr (the bug) would be 0xE59B0008 (base=r11) — reject.
+        assert_ne!(ldr, 0xE59B_0008, "index must not be dropped");
     }
 
     /// #178/#180 regression: the Thumb `Add`/`Adds`/`Subs` reg-forms used the

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.14" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.14" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.14" }
-synth-backend = { path = "../synth-backend", version = "0.11.14" }
+synth-core = { path = "../synth-core", version = "0.11.15" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.15" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.15" }
+synth-backend = { path = "../synth-backend", version = "0.11.15" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.14", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.14", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.14", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.15", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.15", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.15", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.14", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.15", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.14" }
+synth-core = { path = "../synth-core", version = "0.11.15" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.14" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.15" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.14" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.14" }
-synth-opt = { path = "../synth-opt", version = "0.11.14" }
+synth-core = { path = "../synth-core", version = "0.11.15" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.15" }
+synth-opt = { path = "../synth-opt", version = "0.11.15" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.14" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.14" }
-synth-opt = { path = "../synth-opt", version = "0.11.14" }
+synth-core = { path = "../synth-core", version = "0.11.15" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.15" }
+synth-opt = { path = "../synth-opt", version = "0.11.15" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.14", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.15", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Fixes #206

On the default `--target arm` (A32), `Ldr`/`Str`/`Ldrb`/`Strb`/`Ldrh`/`Strh`/`Ldrsb`/`Ldrsh` ran their address through `encode_mem_addr`, which returns **only the 12-bit immediate** — so a register offset (`[rn, rm, #off]`, e.g. a WASM `iN.load`/`store` with a runtime-computed address) silently collapsed to `[rn, #off]`. The access went to the wrong address — a silent miscompile.

Found while diagnosing #204 (the local repro accidentally used the default `--target arm` instead of gale's `--target cortex-m4`).

### Fix
A register offset now materializes `ip = rn + rm` (IP/R12, the scratch the selector already treats as clobberable across memory ops) and re-encodes against `[ip, #off]` — uniform for word/byte/halfword/signed forms. Example (`i32.load offset=8` with a register address):

```
- ldr r0, [fp, #8]          ; bug: index r0 dropped
+ add ip, fp, r0            ; ip = base + index
+ ldr r0, [ip, #8]          ; correct
```

**Cortex-M (Thumb-2) was already correct** (its encoder handles the register-offset addressing mode), so gale's `--target cortex-m4` builds were unaffected.

### Verification
- `test_encode_arm32_indexed_load_keeps_index_206` (verify-bytes): `ldr r0,[r11,r1,#8]` must encode as `ADD ip,r11,r1` + `LDR r0,[ip,#8]`, never a bare `LDR r0,[r11,#8]`.
- Full suite + clippy + fmt green; version pins swept to 0.11.15.

_Falsification:_ wrong if any ARM32 `Ldr*`/`Str*` whose `MemAddr` carries an `offset_reg` encodes to a single instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)