### PR TITLE
perf(selector): constant-divisor strength reduction + dead trap-guard elision (#209 Opt 1, v0.11.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.17] - 2026-06-02
+
+**Constant-divisor strength reduction + dead trap-guard elision (#209 Opt 1).**
+When the divisor of `i32.div_u/div_s/rem_u/rem_s` is a known constant (the
+immediately-preceding op is `i32.const C` — sound because `i32.const` is a
+(0,1) stack op, so it *is* the value the division pops as its divisor),
+`select_with_stack` now lowers it without the dead runtime traps:
+
+- A nonzero constant divisor makes the div-by-zero `CMP/BNE/UDF` guard dead —
+  it is elided. For `div_s`, a non-`-1` constant also makes the INT_MIN/-1
+  overflow guard (`MOVW/MOVT` INT_MIN + `CMP` + `CMN #1` + `BNE` + `UDF #1`)
+  dead — also elided. gale's `control_step` (binning `/500 /5 /80 /1000`) loses
+  3 instructions per unsigned divide and ~9 per signed divide.
+- `div_u` by a power of two `2^k` lowers to `LSR rd, rn, #k` — no `UDIV`, no
+  guard (`0x8000_0000` counts as `2^31` since the divisor is unsigned).
+- Division by 1 becomes an identity `MOV`; `rem` by 1 becomes `MOV #0`.
+
+A constant *zero* divisor keeps the guard (it must still trap at runtime). The
+signed `div_s` by `-1` keeps the overflow guard (INT_MIN/-1 traps). Only the
+unsigned path strength-reduces beyond guard elision; signed power-of-two (which
+needs a rounding-bias sequence) and the non-power-of-two reciprocal-multiply
+(needs a new `UMULL` op) are deferred to a follow-up.
+
+Validated against the wasmtime differential oracle: 260/260 across all 10
+lowered forms × 26 edge-case inputs (INT_MIN, `0x8000_0000`, `0xFFFF_FFFF`,
+power-of-two boundaries, signed negatives) on the actual `--relocatable`
+`select_with_stack` path. Regression fixtures:
+`scripts/repro/div_const.wat` + `scripts/repro/div_const_differential.py`, and
+seven `test_209_*` selector unit tests asserting the lowered instruction
+sequences (and that zero/`-1` divisors keep their guards).
+
+Falsification: this release is wrong if any `i32.div_*`/`i32.rem_*` by a
+constant produces a result differing from the WebAssembly spec semantics
+(wasmtime) — including the trap behaviour for a constant-zero divisor.
+
 ## [0.11.16] - 2026-06-02
 
 **Param-register reservation — fixes the call-free param clobber (#193), gale's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.15"
+version = "0.11.17"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.15"
+version = "0.11.17"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.15"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.15"
+version = "0.11.17"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.16"
+version = "0.11.17"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.16",
+    version = "0.11.17",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.16" }
+synth-core = { path = "../synth-core", version = "0.11.17" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.16" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.16" }
+synth-core = { path = "../synth-core", version = "0.11.17" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.17" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.16" }
+synth-core = { path = "../synth-core", version = "0.11.17" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.16" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.16", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.17" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.17", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.16" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.16" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.16" }
-synth-backend = { path = "../synth-backend", version = "0.11.16" }
+synth-core = { path = "../synth-core", version = "0.11.17" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.17" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.17" }
+synth-backend = { path = "../synth-backend", version = "0.11.17" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.16", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.16", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.16", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.17", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.17", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.17", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.16", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.17", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.16" }
+synth-core = { path = "../synth-core", version = "0.11.17" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.16" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.17" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.16" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.16" }
-synth-opt = { path = "../synth-opt", version = "0.11.16" }
+synth-core = { path = "../synth-core", version = "0.11.17" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.17" }
+synth-opt = { path = "../synth-opt", version = "0.11.17" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -200,6 +200,46 @@ impl SpillState {
 /// [`StackVal::Reg`]'s `r` and its conventional [`i64_pair_hi`]. Spilled entries
 /// reserve nothing. (Over-reserving the pair_hi for i32 entries is the
 /// pre-existing conservative behaviour — safe.)
+/// Detect `…; i32.const C; i32.{div,rem}_{u,s}` — a statically-known divisor.
+///
+/// Sound because `i32.const` is a (0,1) stack op (pushes one value, pops none):
+/// when it is the op immediately preceding the division, the value it pushes is
+/// exactly the divisor the division pops off the top of the stack. Any op that
+/// consumed the const before the division (e.g. `i32.const; i32.add; i32.div_u`)
+/// would sit at `idx-1` instead, so the `I32Const` match fails and we bail.
+///
+/// The constant lets the division handlers (#209 Opt 1):
+///   * elide the div-by-zero trap guard when `C != 0` (the trap is dead code);
+///   * elide the signed INT_MIN/-1 overflow guard when `C != -1`;
+///   * strength-reduce a power-of-two unsigned divisor to a shift, and a
+///     divisor of 1 to an identity move.
+fn const_divisor(wasm_ops: &[WasmOp], idx: usize) -> Option<i32> {
+    if idx == 0 {
+        return None;
+    }
+    match wasm_ops[idx - 1] {
+        WasmOp::I32Const(c) => Some(c),
+        _ => None,
+    }
+}
+
+/// If `c` (read as an unsigned 32-bit divisor) is a power of two `2^k` with
+/// `k >= 1`, return `k` so `i32.div_u` can lower to `LSR rd, rn, #k`.
+///
+/// `k == 0` (divisor 1) is excluded on purpose: Thumb-2 `LSR #0` does not encode
+/// a zero-shift — the immediate-shift form reads `imm5 == 0` as `LSR #32`, which
+/// would yield 0 instead of the identity. Divisor-by-1 is handled separately as
+/// a `MOV`. `0x8000_0000` (i32 `-2147483648`) is a valid `2^31` here because the
+/// divisor is interpreted unsigned.
+fn pow2_shift_u(c: i32) -> Option<u32> {
+    let u = c as u32;
+    if u > 1 && u.is_power_of_two() {
+        Some(u.trailing_zeros())
+    } else {
+        None
+    }
+}
+
 fn stack_live_regs(stack: &[StackVal]) -> Vec<Reg> {
     let mut live: Vec<Reg> = Vec::with_capacity(stack.len() * 2);
     for v in stack {
@@ -5029,6 +5069,10 @@ impl InstructionSelector {
 
                 // Division operations with trap checks for divide-by-zero
                 I32DivU => {
+                    // #209 Opt 1: a statically-known nonzero divisor lets us
+                    // strength-reduce the UDIV and drop the dead div-by-zero
+                    // trap guard. Snapshot before popping (pop_operand mutates).
+                    let cdiv = const_divisor(wasm_ops, idx);
                     let divisor = pop_operand(
                         &mut stack,
                         &mut next_temp,
@@ -5051,42 +5095,71 @@ impl InstructionSelector {
                         alloc_temp_safe(&mut next_temp, &stack, &live_params)?
                     };
 
-                    // Trap check: if divisor == 0, trigger UDF (UsageFault -> Trap_Handler)
-                    // CMP divisor, #0
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Cmp {
-                            rn: divisor,
-                            op2: Operand2::Imm(0),
-                        },
-                        source_line: Some(idx),
-                    });
-                    // BNE.N +0 (skip UDF if divisor != 0)
-                    // offset=0 means skip to PC+4, which skips the 2-byte UDF
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::BCondOffset {
-                            cond: Condition::NE,
-                            offset: 0,
-                        },
-                        source_line: Some(idx),
-                    });
-                    // UDF #0 (triggers trap on divide by zero)
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Udf { imm: 0 },
-                        source_line: Some(idx),
-                    });
-                    // UDIV dst, dividend, divisor
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Udiv {
-                            rd: dst,
-                            rn: dividend,
-                            rm: divisor,
-                        },
-                        source_line: Some(idx),
-                    });
+                    if cdiv == Some(1) {
+                        // x / 1 == x (no trap possible). Identity move.
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Mov {
+                                rd: dst,
+                                op2: Operand2::Reg(dividend),
+                            },
+                            source_line: Some(idx),
+                        });
+                    } else if let Some(k) = cdiv.and_then(pow2_shift_u) {
+                        // x / 2^k == x >> k (unsigned). No guard, no UDIV.
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Lsr {
+                                rd: dst,
+                                rn: dividend,
+                                shift: k,
+                            },
+                            source_line: Some(idx),
+                        });
+                    } else {
+                        // A nonzero constant divisor can never trap; only emit
+                        // the div-by-zero guard when the divisor is unknown or 0.
+                        let needs_guard = cdiv.is_none_or(|c| c == 0);
+                        if needs_guard {
+                            // CMP divisor, #0
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Cmp {
+                                    rn: divisor,
+                                    op2: Operand2::Imm(0),
+                                },
+                                source_line: Some(idx),
+                            });
+                            // BNE.N +0 (skip UDF if divisor != 0): offset=0 means
+                            // skip to PC+4, which skips the 2-byte UDF.
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::BCondOffset {
+                                    cond: Condition::NE,
+                                    offset: 0,
+                                },
+                                source_line: Some(idx),
+                            });
+                            // UDF #0 (triggers trap on divide by zero)
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Udf { imm: 0 },
+                                source_line: Some(idx),
+                            });
+                        }
+                        // UDIV dst, dividend, divisor
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Udiv {
+                                rd: dst,
+                                rn: dividend,
+                                rm: divisor,
+                            },
+                            source_line: Some(idx),
+                        });
+                    }
                     stack.push(StackVal::i32(dst));
                 }
 
                 I32DivS => {
+                    // #209 Opt 1: a known divisor lets us drop the dead trap
+                    // guards — div-by-zero when C != 0, and the INT_MIN/-1
+                    // overflow guard when C != -1 (overflow only at divisor -1).
+                    let cdiv = const_divisor(wasm_ops, idx);
                     let divisor = pop_operand(
                         &mut stack,
                         &mut next_temp,
@@ -5109,96 +5182,118 @@ impl InstructionSelector {
                         alloc_temp_safe(&mut next_temp, &stack, &live_params)?
                     };
 
-                    // Trap check 1: divide by zero
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Cmp {
-                            rn: divisor,
-                            op2: Operand2::Imm(0),
-                        },
-                        source_line: Some(idx),
-                    });
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::BCondOffset {
-                            cond: Condition::NE,
-                            offset: 0,
-                        },
-                        source_line: Some(idx),
-                    });
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Udf { imm: 0 },
-                        source_line: Some(idx),
-                    });
+                    if cdiv == Some(1) {
+                        // x / 1 == x (INT_MIN/1 = INT_MIN, no overflow). Identity.
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Mov {
+                                rd: dst,
+                                op2: Operand2::Reg(dividend),
+                            },
+                            source_line: Some(idx),
+                        });
+                        stack.push(StackVal::i32(dst));
+                    } else {
+                        // Trap check 1: divide by zero (dead for a nonzero const).
+                        let needs_dz_guard = cdiv.is_none_or(|c| c == 0);
+                        if needs_dz_guard {
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Cmp {
+                                    rn: divisor,
+                                    op2: Operand2::Imm(0),
+                                },
+                                source_line: Some(idx),
+                            });
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::BCondOffset {
+                                    cond: Condition::NE,
+                                    offset: 0,
+                                },
+                                source_line: Some(idx),
+                            });
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Udf { imm: 0 },
+                                source_line: Some(idx),
+                            });
+                        }
 
-                    // Trap check 2: signed overflow (INT_MIN / -1)
-                    // We need a temp register for INT_MIN (0x80000000)
-                    let tmp = alloc_temp_safe(&mut next_temp, &stack, &live_params)?;
+                        // Trap check 2: signed overflow (INT_MIN / -1). Dead
+                        // unless the divisor could be -1.
+                        let needs_ovf_guard = cdiv.is_none_or(|c| c == -1);
+                        if needs_ovf_guard {
+                            // We need a temp register for INT_MIN (0x80000000)
+                            let tmp = alloc_temp_safe(&mut next_temp, &stack, &live_params)?;
 
-                    // Load INT_MIN into tmp: MOVW tmp, #0; MOVT tmp, #0x8000
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Movw { rd: tmp, imm16: 0 },
-                        source_line: Some(idx),
-                    });
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Movt {
-                            rd: tmp,
-                            imm16: 0x8000,
-                        },
-                        source_line: Some(idx),
-                    });
-                    // CMP dividend, tmp (check if dividend == INT_MIN)
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Cmp {
-                            rn: dividend,
-                            op2: Operand2::Reg(tmp),
-                        },
-                        source_line: Some(idx),
-                    });
-                    // BNE.N +3 (skip overflow check if dividend != INT_MIN)
-                    // Skip 8 bytes: CMN.W(4) + BNE(2) + UDF(2)
-                    // Branch target = PC + (imm8 << 1) = B+4 + 6 = B+10 (SDIV)
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::BCondOffset {
-                            cond: Condition::NE,
-                            offset: 3,
-                        },
-                        source_line: Some(idx),
-                    });
-                    // CMN divisor, #1 (check if divisor == -1: -1 + 1 = 0 sets Z flag)
-                    // CMN.W is 4 bytes
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Cmn {
-                            rn: divisor,
-                            op2: Operand2::Imm(1),
-                        },
-                        source_line: Some(idx),
-                    });
-                    // BNE.N +0 (skip UDF if divisor != -1)
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::BCondOffset {
-                            cond: Condition::NE,
-                            offset: 0,
-                        },
-                        source_line: Some(idx),
-                    });
-                    // UDF #1 (triggers trap on overflow)
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Udf { imm: 1 },
-                        source_line: Some(idx),
-                    });
+                            // Load INT_MIN into tmp: MOVW tmp, #0; MOVT tmp, #0x8000
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Movw { rd: tmp, imm16: 0 },
+                                source_line: Some(idx),
+                            });
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Movt {
+                                    rd: tmp,
+                                    imm16: 0x8000,
+                                },
+                                source_line: Some(idx),
+                            });
+                            // CMP dividend, tmp (check if dividend == INT_MIN)
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Cmp {
+                                    rn: dividend,
+                                    op2: Operand2::Reg(tmp),
+                                },
+                                source_line: Some(idx),
+                            });
+                            // BNE.N +3 (skip overflow check if dividend != INT_MIN)
+                            // Skip 8 bytes: CMN.W(4) + BNE(2) + UDF(2)
+                            // Branch target = PC + (imm8 << 1) = B+4 + 6 = B+10 (SDIV)
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::BCondOffset {
+                                    cond: Condition::NE,
+                                    offset: 3,
+                                },
+                                source_line: Some(idx),
+                            });
+                            // CMN divisor, #1 (divisor == -1: -1 + 1 = 0 sets Z)
+                            // CMN.W is 4 bytes
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Cmn {
+                                    rn: divisor,
+                                    op2: Operand2::Imm(1),
+                                },
+                                source_line: Some(idx),
+                            });
+                            // BNE.N +0 (skip UDF if divisor != -1)
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::BCondOffset {
+                                    cond: Condition::NE,
+                                    offset: 0,
+                                },
+                                source_line: Some(idx),
+                            });
+                            // UDF #1 (triggers trap on overflow)
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Udf { imm: 1 },
+                                source_line: Some(idx),
+                            });
+                        }
 
-                    // SDIV dst, dividend, divisor (safe to divide now)
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Sdiv {
-                            rd: dst,
-                            rn: dividend,
-                            rm: divisor,
-                        },
-                        source_line: Some(idx),
-                    });
-                    stack.push(StackVal::i32(dst));
+                        // SDIV dst, dividend, divisor (safe to divide now)
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Sdiv {
+                                rd: dst,
+                                rn: dividend,
+                                rm: divisor,
+                            },
+                            source_line: Some(idx),
+                        });
+                        stack.push(StackVal::i32(dst));
+                    }
                 }
 
                 I32RemU => {
+                    // #209 Opt 1: drop the dead div-by-zero guard for a nonzero
+                    // constant divisor; fold `x % 1` to 0.
+                    let cdiv = const_divisor(wasm_ops, idx);
                     let divisor = pop_operand(
                         &mut stack,
                         &mut next_temp,
@@ -5221,51 +5316,70 @@ impl InstructionSelector {
                         alloc_temp_safe(&mut next_temp, &stack, &live_params)?
                     };
 
-                    // Trap check: divide by zero
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Cmp {
-                            rn: divisor,
-                            op2: Operand2::Imm(0),
-                        },
-                        source_line: Some(idx),
-                    });
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::BCondOffset {
-                            cond: Condition::NE,
-                            offset: 0,
-                        },
-                        source_line: Some(idx),
-                    });
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Udf { imm: 0 },
-                        source_line: Some(idx),
-                    });
+                    if cdiv == Some(1) {
+                        // x % 1 == 0
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Mov {
+                                rd: dst,
+                                op2: Operand2::Imm(0),
+                            },
+                            source_line: Some(idx),
+                        });
+                        stack.push(StackVal::i32(dst));
+                    } else {
+                        // Trap check: divide by zero (dead for a nonzero const).
+                        let needs_guard = cdiv.is_none_or(|c| c == 0);
+                        if needs_guard {
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Cmp {
+                                    rn: divisor,
+                                    op2: Operand2::Imm(0),
+                                },
+                                source_line: Some(idx),
+                            });
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::BCondOffset {
+                                    cond: Condition::NE,
+                                    offset: 0,
+                                },
+                                source_line: Some(idx),
+                            });
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Udf { imm: 0 },
+                                source_line: Some(idx),
+                            });
+                        }
 
-                    // Remainder: dst = dividend - (dividend / divisor) * divisor
-                    // quotient = UDIV tmp, dividend, divisor
-                    let tmp = alloc_temp_safe(&mut next_temp, &stack, &live_params)?;
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Udiv {
-                            rd: tmp,
-                            rn: dividend,
-                            rm: divisor,
-                        },
-                        source_line: Some(idx),
-                    });
-                    // MLS dst, tmp, divisor, dividend  (dst = dividend - tmp * divisor)
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Mls {
-                            rd: dst,
-                            rn: tmp,
-                            rm: divisor,
-                            ra: dividend,
-                        },
-                        source_line: Some(idx),
-                    });
-                    stack.push(StackVal::i32(dst));
+                        // Remainder: dst = dividend - (dividend / divisor) * divisor
+                        // quotient = UDIV tmp, dividend, divisor
+                        let tmp = alloc_temp_safe(&mut next_temp, &stack, &live_params)?;
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Udiv {
+                                rd: tmp,
+                                rn: dividend,
+                                rm: divisor,
+                            },
+                            source_line: Some(idx),
+                        });
+                        // MLS dst, tmp, divisor, dividend (dst = dividend - tmp*divisor)
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Mls {
+                                rd: dst,
+                                rn: tmp,
+                                rm: divisor,
+                                ra: dividend,
+                            },
+                            source_line: Some(idx),
+                        });
+                        stack.push(StackVal::i32(dst));
+                    }
                 }
 
                 I32RemS => {
+                    // #209 Opt 1: drop the dead div-by-zero guard for a nonzero
+                    // constant divisor; fold `x % 1` to 0. (`x % -1 == 0` is left
+                    // to SDIV+MLS, which already yields 0 for all dividends.)
+                    let cdiv = const_divisor(wasm_ops, idx);
                     let divisor = pop_operand(
                         &mut stack,
                         &mut next_temp,
@@ -5288,46 +5402,62 @@ impl InstructionSelector {
                         alloc_temp_safe(&mut next_temp, &stack, &live_params)?
                     };
 
-                    // Trap check: divide by zero (rem_s doesn't trap on INT_MIN % -1)
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Cmp {
-                            rn: divisor,
-                            op2: Operand2::Imm(0),
-                        },
-                        source_line: Some(idx),
-                    });
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::BCondOffset {
-                            cond: Condition::NE,
-                            offset: 0,
-                        },
-                        source_line: Some(idx),
-                    });
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Udf { imm: 0 },
-                        source_line: Some(idx),
-                    });
+                    if cdiv == Some(1) {
+                        // x % 1 == 0
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Mov {
+                                rd: dst,
+                                op2: Operand2::Imm(0),
+                            },
+                            source_line: Some(idx),
+                        });
+                        stack.push(StackVal::i32(dst));
+                    } else {
+                        // Trap check: divide by zero (rem_s doesn't trap on
+                        // INT_MIN % -1). Dead for a nonzero constant divisor.
+                        let needs_guard = cdiv.is_none_or(|c| c == 0);
+                        if needs_guard {
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Cmp {
+                                    rn: divisor,
+                                    op2: Operand2::Imm(0),
+                                },
+                                source_line: Some(idx),
+                            });
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::BCondOffset {
+                                    cond: Condition::NE,
+                                    offset: 0,
+                                },
+                                source_line: Some(idx),
+                            });
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Udf { imm: 0 },
+                                source_line: Some(idx),
+                            });
+                        }
 
-                    // Signed remainder: dst = dividend - (dividend / divisor) * divisor
-                    let tmp = alloc_temp_safe(&mut next_temp, &stack, &live_params)?;
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Sdiv {
-                            rd: tmp,
-                            rn: dividend,
-                            rm: divisor,
-                        },
-                        source_line: Some(idx),
-                    });
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Mls {
-                            rd: dst,
-                            rn: tmp,
-                            rm: divisor,
-                            ra: dividend,
-                        },
-                        source_line: Some(idx),
-                    });
-                    stack.push(StackVal::i32(dst));
+                        // Signed remainder: dst = dividend - (dividend/divisor)*divisor
+                        let tmp = alloc_temp_safe(&mut next_temp, &stack, &live_params)?;
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Sdiv {
+                                rd: tmp,
+                                rn: dividend,
+                                rm: divisor,
+                            },
+                            source_line: Some(idx),
+                        });
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Mls {
+                                rd: dst,
+                                rn: tmp,
+                                rm: divisor,
+                                ra: dividend,
+                            },
+                            source_line: Some(idx),
+                        });
+                        stack.push(StackVal::i32(dst));
+                    }
                 }
 
                 // Memory operations need stack-aware handling
@@ -12953,6 +13083,187 @@ mod tests {
         assert!(
             has_overflow_trap,
             "I32DivS must have UDF #1 for overflow trap"
+        );
+    }
+
+    // =========================================================================
+    // #209 Opt 1: constant-divisor guard elision + strength reduction.
+    // The div-by-zero / overflow traps are dead when the divisor is a known
+    // nonzero constant; power-of-two and by-1 divisors lower without UDIV.
+    // =========================================================================
+
+    /// A nonzero constant divisor makes the div-by-zero trap dead: no CMP/UDF,
+    /// but still a real UDIV (non-power-of-two, so no shift fold).
+    #[test]
+    fn test_209_const_divisor_elides_dz_guard() {
+        let mut selector = fresh_selector();
+        let instrs = selector
+            .select_with_stack(
+                &[
+                    WasmOp::I32Const(1000),
+                    WasmOp::I32Const(500),
+                    WasmOp::I32DivU,
+                ],
+                0,
+            )
+            .unwrap();
+        assert!(
+            !instrs.iter().any(|i| matches!(&i.op, ArmOp::Udf { .. })),
+            "nonzero const divisor must drop the div-by-zero UDF guard"
+        );
+        assert!(
+            !instrs.iter().any(|i| matches!(&i.op, ArmOp::Cmp { .. })),
+            "nonzero const divisor must drop the CMP #0 guard"
+        );
+        assert!(
+            instrs.iter().any(|i| matches!(&i.op, ArmOp::Udiv { .. })),
+            "non-pow2 divisor still divides via UDIV"
+        );
+    }
+
+    /// A power-of-two unsigned divisor lowers to LSR — no UDIV, no guard.
+    #[test]
+    fn test_209_pow2_divu_uses_lsr() {
+        let mut selector = fresh_selector();
+        let instrs = selector
+            .select_with_stack(
+                &[WasmOp::I32Const(1000), WasmOp::I32Const(8), WasmOp::I32DivU],
+                0,
+            )
+            .unwrap();
+        assert!(
+            instrs
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Lsr { shift: 3, .. })),
+            "x / 8 must lower to LSR #3"
+        );
+        assert!(
+            !instrs.iter().any(|i| matches!(&i.op, ArmOp::Udiv { .. })),
+            "pow2 divisor must not emit UDIV"
+        );
+        assert!(
+            !instrs.iter().any(|i| matches!(&i.op, ArmOp::Udf { .. })),
+            "pow2 divisor must not emit a trap guard"
+        );
+    }
+
+    /// `0x8000_0000` is 2^31 when the divisor is read unsigned: LSR #31.
+    #[test]
+    fn test_209_pow2_divu_high_bit_divisor() {
+        let mut selector = fresh_selector();
+        let instrs = selector
+            .select_with_stack(
+                &[
+                    WasmOp::I32Const(7),
+                    WasmOp::I32Const(i32::MIN),
+                    WasmOp::I32DivU,
+                ],
+                0,
+            )
+            .unwrap();
+        assert!(
+            instrs
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Lsr { shift: 31, .. })),
+            "x / 2^31 must lower to LSR #31"
+        );
+    }
+
+    /// Division by 1 is the identity — a MOV, no shift, no UDIV.
+    #[test]
+    fn test_209_divu_by_one_is_identity() {
+        let mut selector = fresh_selector();
+        let instrs = selector
+            .select_with_stack(
+                &[WasmOp::I32Const(1000), WasmOp::I32Const(1), WasmOp::I32DivU],
+                0,
+            )
+            .unwrap();
+        assert!(
+            instrs.iter().any(|i| matches!(&i.op, ArmOp::Mov { .. })),
+            "x / 1 must be a MOV identity"
+        );
+        assert!(
+            !instrs
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Udiv { .. } | ArmOp::Lsr { .. })),
+            "x / 1 must not emit UDIV or LSR"
+        );
+    }
+
+    /// Remainder by 1 is always 0 — MOV #0, no UDIV/MLS.
+    #[test]
+    fn test_209_remu_by_one_is_zero() {
+        let mut selector = fresh_selector();
+        let instrs = selector
+            .select_with_stack(
+                &[WasmOp::I32Const(1000), WasmOp::I32Const(1), WasmOp::I32RemU],
+                0,
+            )
+            .unwrap();
+        assert!(
+            instrs.iter().any(|i| matches!(
+                &i.op,
+                ArmOp::Mov {
+                    op2: Operand2::Imm(0),
+                    ..
+                }
+            )),
+            "x % 1 must be MOV #0"
+        );
+        assert!(
+            !instrs.iter().any(|i| matches!(&i.op, ArmOp::Udiv { .. })),
+            "x % 1 must not emit UDIV"
+        );
+    }
+
+    /// A nonzero, non-`-1` constant divisor makes BOTH signed guards dead: no
+    /// div-by-zero UDF, no INT_MIN/-1 overflow check — just SDIV.
+    #[test]
+    fn test_209_divs_const_drops_both_guards() {
+        let mut selector = fresh_selector();
+        let instrs = selector
+            .select_with_stack(
+                &[WasmOp::I32Const(1000), WasmOp::I32Const(5), WasmOp::I32DivS],
+                0,
+            )
+            .unwrap();
+        assert!(
+            !instrs.iter().any(|i| matches!(&i.op, ArmOp::Udf { .. })),
+            "const divisor != 0,-1 must drop both div-by-zero and overflow UDFs"
+        );
+        assert!(
+            !instrs
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Movt { imm16: 0x8000, .. })),
+            "no INT_MIN materialization when overflow is statically impossible"
+        );
+        assert!(
+            !instrs.iter().any(|i| matches!(&i.op, ArmOp::Cmn { .. })),
+            "no CMN #1 (-1 check) when divisor is a known non-(-1) constant"
+        );
+        assert!(
+            instrs.iter().any(|i| matches!(&i.op, ArmOp::Sdiv { .. })),
+            "still divides via SDIV"
+        );
+    }
+
+    /// Guard elision must NOT fire for a constant-zero divisor: the div-by-zero
+    /// trap stays live (the program must trap at runtime).
+    #[test]
+    fn test_209_zero_const_divisor_keeps_guard() {
+        let mut selector = fresh_selector();
+        let instrs = selector
+            .select_with_stack(
+                &[WasmOp::I32Const(42), WasmOp::I32Const(0), WasmOp::I32DivU],
+                0,
+            )
+            .unwrap();
+        assert!(
+            instrs
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Udf { imm: 0 })),
+            "const-zero divisor must keep the div-by-zero trap"
         );
     }
 

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.16" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.16" }
-synth-opt = { path = "../synth-opt", version = "0.11.16" }
+synth-core = { path = "../synth-core", version = "0.11.17" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.17" }
+synth-opt = { path = "../synth-opt", version = "0.11.17" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.16", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.17", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }

--- a/scripts/repro/div_const.wat
+++ b/scripts/repro/div_const.wat
@@ -1,0 +1,18 @@
+(module
+  ;; #209 Opt 1 regression fixture: constant-divisor strength reduction +
+  ;; dead trap-guard elision. Each export divides/remainders its single i32
+  ;; param by a compile-time constant, exercising every lowered form:
+  ;;   pow2 div_u -> LSR, non-pow2 -> guard-elided UDIV, /1 -> MOV identity,
+  ;;   2^31 -> LSR #31, rem_u -> guard-elided UDIV+MLS, %1 -> MOV #0,
+  ;;   signed -> both guards elided when divisor != 0,-1.
+  (func (export "divu_pow2")   (param i32) (result i32) local.get 0 i32.const 8          i32.div_u)
+  (func (export "divu_500")    (param i32) (result i32) local.get 0 i32.const 500        i32.div_u)
+  (func (export "divu_one")    (param i32) (result i32) local.get 0 i32.const 1          i32.div_u)
+  (func (export "divu_2e31")   (param i32) (result i32) local.get 0 i32.const 0x80000000 i32.div_u)
+  (func (export "remu_500")    (param i32) (result i32) local.get 0 i32.const 500        i32.rem_u)
+  (func (export "remu_one")    (param i32) (result i32) local.get 0 i32.const 1          i32.rem_u)
+  (func (export "divs_5")      (param i32) (result i32) local.get 0 i32.const 5          i32.div_s)
+  (func (export "divs_neg7")   (param i32) (result i32) local.get 0 i32.const -7         i32.div_s)
+  (func (export "rems_5")      (param i32) (result i32) local.get 0 i32.const 5          i32.rem_s)
+  (func (export "divs_one")    (param i32) (result i32) local.get 0 i32.const 1          i32.div_s)
+)

--- a/scripts/repro/div_const_differential.py
+++ b/scripts/repro/div_const_differential.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""#209 Opt 1 — constant-divisor strength-reduction differential oracle.
+
+wasmtime runs div_const.wat as ground truth; unicorn runs synth's ARM (the
+`--relocatable` / select_with_stack path, which is where the optimization lives)
+for the same inputs. Every export divides/remainders its i32 param by a
+compile-time constant, so this validates that guard elision + LSR/MOV strength
+reduction is numerically identical to a trapping UDIV/SDIV across the edge cases
+(INT_MIN, 0x80000000, 0xFFFFFFFF, pow2 boundaries, signed negatives).
+
+Run:
+  synth compile scripts/repro/div_const.wat -o /tmp/dc.elf --target cortex-m4 --relocatable
+  /tmp/armv/bin/python scripts/repro/div_const_differential.py /tmp/dc.elf
+
+Exits nonzero on any mismatch so it can gate a release.
+"""
+import re
+import subprocess
+import sys
+
+import wasmtime
+from capstone import CS_ARCH_ARM, CS_MODE_THUMB, Cs  # noqa: F401 (handy when debugging)
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = "scripts/repro/div_const.wat"
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/dc.elf"
+SYNTH = "./target/debug/synth"
+
+# (wasm export, ELF symbol) — the relocatable build renames most exports func_N.
+PAIRS = [
+    ("divu_pow2", "func_0"),
+    ("divu_500", "func_1"),
+    ("divu_one", "func_2"),
+    ("divu_2e31", "func_3"),
+    ("remu_500", "remu_500"),
+    ("remu_one", "remu_one"),
+    ("divs_5", "func_6"),
+    ("divs_neg7", "func_7"),
+    ("rems_5", "rems_5"),
+    ("divs_one", "func_9"),
+]
+
+INPUTS = [
+    0, 1, 2, 7, 8, 9, 15, 16, 17, 100, 499, 500, 501, 999, 1000, 1001,
+    0x7FFFFFFF, 0x80000000, 0x80000001, 0xFFFFFFFF, 0xFFFFFFFE,
+    0x12345678, 0xABCDEF01, 3500, 28, 0x40000000,
+]
+
+CODE, RET = 0x10000, 0x90000
+
+
+def as_i32(v):
+    return v - 0x100000000 if v >= 0x80000000 else v
+
+
+def main():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, open(WAT).read())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    wt = {w: inst.exports(store)[w] for w, _ in PAIRS}
+
+    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
+    addr = {m.group(2): int(m.group(1), 16)
+            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
+    text = ELFFile(open(ELF, "rb")).get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+
+    def run(a, x):
+        mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+        mu.mem_map(CODE, 0x20000)
+        mu.mem_map(0x80000, 0x20000)
+        mu.mem_write(CODE, code)
+        mu.reg_write(UC_ARM_REG_SP, 0x9F000)
+        mu.reg_write(UC_ARM_REG_R11, 0x88000)
+        mu.reg_write(UC_ARM_REG_R0, x & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        try:
+            mu.emu_start((CODE + a - base) | 1, RET, count=200)
+        except UcError as e:
+            return ("ERR", str(e))
+        return ("OK", mu.reg_read(UC_ARM_REG_R0))
+
+    fails = total = 0
+    for w, sym in PAIRS:
+        a = addr[sym]
+        for x in INPUTS:
+            total += 1
+            gt = wt[w](store, as_i32(x)) & 0xFFFFFFFF
+            st, got = run(a, x)
+            if st != "OK" or got != gt:
+                fails += 1
+                shown = hex(got) if st == "OK" else got
+                print(f"MISMATCH {w}(0x{x:08X}): wasmtime=0x{gt:08X} synth={st}:{shown}")
+    print(f"\n{total - fails}/{total} match  [--relocatable / select_with_stack path]")
+    print("ORACLE: PASS" if fails == 0 else f"ORACLE: FAIL ({fails} mismatches)")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## #209 Opt 1 — data-driven from gale's hardware stats

gale's `control_step` measured **188 cyc synth / 80 native (2.35×)**, "dominated by the 4× udiv (binning `/500 /5 /80 /1000`, each with the dead `udf` guard) + table-index regalloc" (#210). This lands the guard-elision + the no-`UMULL` strength reductions; the reciprocal-multiply (needs a new `UMULL` op) is the planned follow-up.

## What changed

When the divisor of `i32.div_u/div_s/rem_u/rem_s` is a known constant (the preceding op is `i32.const C` — **sound** because `i32.const` is a (0,1) stack op, so it *is* the value the division pops as its divisor), `select_with_stack` lowers it without the dead runtime traps:

- **Guard elision:** a nonzero constant divisor makes the div-by-zero `CMP/BNE/UDF` dead. For `div_s`, a non-`-1` constant also makes the INT_MIN/-1 overflow guard dead. gale's binning divides drop 3 instrs each (unsigned) / ~9 (signed).
- **`div_u` by 2^k → `LSR #k`** (no UDIV, no guard; `0x8000_0000` = `2^31` unsigned).
- **`x / 1 → MOV`**, **`x % 1 → MOV #0`**.

Const-zero divisor keeps its guard (must trap); `div_s` by `-1` keeps the overflow guard (INT_MIN/-1 traps).

Before/after on the `--relocatable` path:
```
divu_500:  movw r1,#500; cmp r1,#0; bne; udf #0; udiv r2,r0,r1   ->   movw r1,#500; udiv r2,r0,r1
divu_pow2: ...; udiv r2,r0,r1                                    ->   lsrs r2,r0,#3
divs_5:    ...; cmp; bne; udf; movw/movt INT_MIN; cmp; cmn; bne; udf; sdiv -> movw r1,#5; sdiv r2,r0,r1
```

## Oracle (the correctness gate)

wasmtime differential **260/260** across 10 lowered forms × 26 edge-case inputs (INT_MIN, `0x8000_0000`, `0xFFFF_FFFF`, pow2 boundaries, signed negatives) on the actual `--relocatable` `select_with_stack` path. Fixtures committed: `scripts/repro/div_const.wat` + `scripts/repro/div_const_differential.py`.

Plus seven `test_209_*` selector unit tests asserting the lowered sequences; existing `test_i32_div_zero_trap_sequence` / `test_i32_divs_overflow_trap_sequence` still green (zero and `-1` divisors keep their guards).

## Falsification

This release is wrong if any `i32.div_*`/`i32.rem_*` by a constant produces a result differing from the WebAssembly spec semantics (wasmtime), including the trap behaviour for a constant-zero divisor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)