### PR TITLE
fix(cli): expose RV32 target profiles so -b riscv is reachable (#218, v0.11.21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.21] - 2026-06-03
+
+**Expose RV32 target profiles so `-b riscv` is reachable from `compile` (#218).**
+The RISC-V backend existed and worked, but there was no way to target it: `-t`
+only accepted Cortex-M triples, so `-b riscv` always inherited the default
+`ArmCortexM` profile and bailed (`RISC-V backend cannot compile for ArmCortexM`),
+and the short ISA names the toolchains use (`rv32imac`, …) were "unknown target
+triple". This was purely a CLI/target-profile wiring gap.
+
+- `TargetSpec::from_triple` now accepts the short RV32 names — `rv32imac`,
+  `rv32imc`, `rv32im`, `rv32i`, `rv32gc`, the generic `riscv32`/`rv32`, and the
+  `esp32c3` board alias (RV32IMC) — alongside the existing long LLVM triples,
+  via a new parameterized `TargetSpec::riscv32(extensions)`.
+- `synth compile -b riscv` with no `--target` now defaults to `rv32imac` instead
+  of inheriting the ARM profile, so the backend is reachable out of the box.
+- The "unknown target triple" error now lists the RV32 options, and `-t`'s help
+  text documents them.
+
+`synth compile fn.wasm -b riscv -t rv32imac --relocatable` (and `-t rv32imc`,
+`-t esp32c3`, or bare `-b riscv`) now emit a RISC-V (`EM_RISCV`, ELFCLASS32)
+relocatable object. This unblocks the wasm→loom→`synth -b riscv`→RV32 path for
+ESP32-C3 / qemu_riscv32. Tests: `test_rv32_short_target_names_218` (parsing) +
+`test_resolve_target_spec_riscv_default_218` (the `-b riscv` default).
+
+Not in scope (follow-ups): `target-info` still only knows the ARM board profiles
+(it uses board `HardwareCapabilities`, not target triples); RISC-V codegen
+quality/correctness is validated separately on-target.
+
+Falsification: this release is wrong if `synth compile -b riscv -t rv32imac`
+fails to produce a valid RISC-V object, or if an RV32 target name resolves to a
+non-RISC-V spec.
+
 ## [0.11.20] - 2026-06-02
 
 **Cost-gate the reciprocal-multiply — fixes the Opt 1b register-pressure

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.20"
+version = "0.11.21"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.20"
+version = "0.11.21"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.20"
+version = "0.11.21"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.20"
+version = "0.11.21"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.20",
+    version = "0.11.21",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.20" }
+synth-core = { path = "../synth-core", version = "0.11.21" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.20" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.20" }
+synth-core = { path = "../synth-core", version = "0.11.21" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.21" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.20" }
+synth-core = { path = "../synth-core", version = "0.11.21" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.20" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.20", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.21" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.21", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.20" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.20" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.20" }
-synth-backend = { path = "../synth-backend", version = "0.11.20" }
+synth-core = { path = "../synth-core", version = "0.11.21" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.21" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.21" }
+synth-backend = { path = "../synth-backend", version = "0.11.21" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.20", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.20", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.20", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.21", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.21", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.21", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.20", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.21", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -139,7 +139,9 @@ enum Commands {
         #[arg(long)]
         cortex_m: bool,
 
-        /// Target profile (cortex-m3, cortex-m4, cortex-m4f, cortex-m7, cortex-m7dp)
+        /// Target profile. ARM: cortex-m3, cortex-m4, cortex-m4f, cortex-m7,
+        /// cortex-m7dp. RISC-V (-b riscv): rv32imac, rv32imc, rv32im, rv32i,
+        /// rv32gc, esp32c3 (RV32IMC). `-b riscv` defaults to rv32imac.
         /// Implies --cortex-m for Cortex-M targets
         #[arg(short, long, value_name = "TARGET")]
         target: Option<String>,
@@ -332,7 +334,7 @@ fn main() -> Result<()> {
             sign_output,
         } => {
             // Resolve target spec: --target overrides, --cortex-m is backwards compat
-            let target_spec = resolve_target_spec(target.as_deref(), cortex_m)?;
+            let target_spec = resolve_target_spec(target.as_deref(), cortex_m, &backend)?;
             let is_cortex_m =
                 cortex_m || target_spec.family == synth_core::target::ArchFamily::ArmCortexM;
 
@@ -678,13 +680,13 @@ struct ElfFunction {
 }
 
 /// Resolve --target / --cortex-m into a TargetSpec
-fn resolve_target_spec(target: Option<&str>, cortex_m: bool) -> Result<TargetSpec> {
+fn resolve_target_spec(target: Option<&str>, cortex_m: bool, backend: &str) -> Result<TargetSpec> {
     match target {
-        Some(name) => TargetSpec::from_triple(name).map_err(|e| {
-            anyhow::anyhow!(
-                "{e}. Supported: cortex-m3, cortex-m4, cortex-m4f, cortex-m7, cortex-m7dp"
-            )
-        }),
+        // from_triple already lists the supported ARM + RV32 names in its error.
+        Some(name) => TargetSpec::from_triple(name).map_err(|e| anyhow::anyhow!("{e}")),
+        // No --target given: pick a backend-appropriate default so `-b riscv`
+        // doesn't inherit the ARM profile and bail (#218).
+        None if backend == "riscv" => Ok(TargetSpec::riscv32("imac")),
         None if cortex_m => Ok(TargetSpec::cortex_m3()),
         None => {
             // Default: Arm32 ISA (non-Cortex-M, no vector table)
@@ -3596,29 +3598,43 @@ mod tests {
     fn test_resolve_target_spec_default_no_cortex_m() {
         // When neither --target nor --cortex-m is given, the default is an
         // Arm32-ISA cortex_m4 spec (used by the non-Cortex-M flow).
-        let spec = resolve_target_spec(None, false).unwrap();
+        let spec = resolve_target_spec(None, false, "arm").unwrap();
         assert_eq!(spec.isa, synth_core::target::IsaVariant::Arm32);
     }
 
     #[test]
     fn test_resolve_target_spec_cortex_m_flag() {
         // --cortex-m without --target maps to cortex-m3.
-        let spec = resolve_target_spec(None, true).unwrap();
+        let spec = resolve_target_spec(None, true, "arm").unwrap();
         assert_eq!(spec.triple, "thumbv7m-none-eabi");
     }
 
     #[test]
     fn test_resolve_target_spec_explicit_target_wins_over_cortex_m() {
         // --target overrides --cortex-m.
-        let spec = resolve_target_spec(Some("cortex-m7"), true).unwrap();
+        let spec = resolve_target_spec(Some("cortex-m7"), true, "arm").unwrap();
         assert_eq!(spec.triple, "thumbv7em-none-eabihf");
     }
 
     #[test]
     fn test_resolve_target_spec_unknown_triple_errors() {
-        let err = resolve_target_spec(Some("totally-bogus-triple"), false).unwrap_err();
+        let err = resolve_target_spec(Some("totally-bogus-triple"), false, "arm").unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("totally-bogus-triple"));
         assert!(msg.contains("Supported"));
+    }
+
+    /// #218: `-b riscv` with no `--target` must default to an RV32 profile, not
+    /// inherit the ARM default (which makes the RISC-V backend bail).
+    #[test]
+    fn test_resolve_target_spec_riscv_default_218() {
+        let spec = resolve_target_spec(None, false, "riscv").unwrap();
+        assert_eq!(spec.family, synth_core::target::ArchFamily::RiscV);
+        assert_eq!(
+            spec.isa,
+            synth_core::target::IsaVariant::RiscV32 {
+                extensions: "imac".to_string()
+            }
+        );
     }
 }

--- a/crates/synth-core/src/target.rs
+++ b/crates/synth-core/src/target.rs
@@ -463,16 +463,23 @@ impl TargetSpec {
     }
 
     /// RISC-V RV32IMAC with 16 PMP entries
-    pub fn riscv32imac() -> Self {
+    /// A bare-metal RV32 profile with the given ISA `extensions` string (e.g.
+    /// `"imac"`, `"imc"`, `"im"`, `"i"`, `"gc"`). All RV32 variants share the
+    /// PMP memory-protection model and have no hardware FPU in the base profile.
+    pub fn riscv32(extensions: &str) -> Self {
         Self {
             family: ArchFamily::RiscV,
-            triple: "riscv32imac-unknown-none-elf".to_string(),
+            triple: format!("riscv32{extensions}-unknown-none-elf"),
             isa: IsaVariant::RiscV32 {
-                extensions: "imac".to_string(),
+                extensions: extensions.to_string(),
             },
             mem_protection: MemProtection::Pmp { entries: 16 },
             fpu: None,
         }
+    }
+
+    pub fn riscv32imac() -> Self {
+        Self::riscv32("imac")
     }
 
     /// Cortex-M55 with Helium MVE, single-precision FPU, TrustZone
@@ -497,8 +504,23 @@ impl TargetSpec {
             "thumbv8.1m.main-none-eabi" | "cortex-m55" => Ok(Self::cortex_m55()),
             "armv7r-none-eabihf" | "cortex-r5" => Ok(Self::cortex_r5()),
             "aarch64-none-elf" | "cortex-a53" => Ok(Self::cortex_a53()),
-            "riscv32imac-unknown-none-elf" | "riscv32imac" => Ok(Self::riscv32imac()),
-            _ => Err(format!("unknown target triple: {}", triple)),
+            // RV32 — accept the short ISA names that `riscv-runtime` and the
+            // toolchains use (`rv32imac`, …) as well as the long LLVM triples.
+            // The ESP32-C3 is RV32IMC (#218).
+            "riscv32imac-unknown-none-elf" | "riscv32imac" | "rv32imac" => {
+                Ok(Self::riscv32("imac"))
+            }
+            "riscv32imc" | "rv32imc" | "esp32c3" => Ok(Self::riscv32("imc")),
+            "riscv32im" | "rv32im" => Ok(Self::riscv32("im")),
+            "riscv32i" | "rv32i" => Ok(Self::riscv32("i")),
+            "riscv32gc" | "rv32gc" => Ok(Self::riscv32("gc")),
+            // Generic RV32 default → the broadly-supported imac profile.
+            "riscv32" | "rv32" => Ok(Self::riscv32("imac")),
+            _ => Err(format!(
+                "unknown target triple: {triple}. Supported: \
+                 cortex-m3, cortex-m4, cortex-m4f, cortex-m7, cortex-m7dp; \
+                 rv32imac, rv32imc, rv32im, rv32i, rv32gc, esp32c3"
+            )),
         }
     }
 
@@ -516,6 +538,41 @@ impl TargetSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #218: the short RV32 ISA names (and the ESP32-C3 board alias) that
+    /// `riscv-runtime` / the toolchains use must resolve to RISC-V target specs,
+    /// not "unknown target triple", so `synth compile -b riscv -t rv32imac` is
+    /// reachable.
+    #[test]
+    fn test_rv32_short_target_names_218() {
+        for (name, ext) in [
+            ("rv32imac", "imac"),
+            ("rv32imc", "imc"),
+            ("rv32im", "im"),
+            ("rv32i", "i"),
+            ("rv32gc", "gc"),
+            ("esp32c3", "imc"),  // ESP32-C3 is RV32IMC
+            ("riscv32", "imac"), // generic default
+            ("riscv32imac", "imac"),
+        ] {
+            let spec = TargetSpec::from_triple(name)
+                .unwrap_or_else(|e| panic!("RV32 target '{name}' must resolve: {e}"));
+            assert_eq!(spec.family, ArchFamily::RiscV, "{name}");
+            assert_eq!(
+                spec.isa,
+                IsaVariant::RiscV32 {
+                    extensions: ext.to_string()
+                },
+                "{name}"
+            );
+        }
+        // An unknown triple still errors, and now lists the RV32 options.
+        let err = TargetSpec::from_triple("rv99zzz").unwrap_err();
+        assert!(
+            err.contains("rv32imac"),
+            "error should list RV32 targets: {err}"
+        );
+    }
 
     #[test]
     fn test_target_spec_from_triple() {

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.20" }
+synth-core = { path = "../synth-core", version = "0.11.21" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.20" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.21" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.20" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.20" }
-synth-opt = { path = "../synth-opt", version = "0.11.20" }
+synth-core = { path = "../synth-core", version = "0.11.21" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.21" }
+synth-opt = { path = "../synth-opt", version = "0.11.21" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.20" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.20" }
-synth-opt = { path = "../synth-opt", version = "0.11.20" }
+synth-core = { path = "../synth-core", version = "0.11.21" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.21" }
+synth-opt = { path = "../synth-opt", version = "0.11.21" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.20", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.21", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## #218 — RISC-V backend `available` but unreachable from the CLI

gale: the `riscv` backend exists and reports available, but there's no way to target it — `-t` only accepts Cortex-M triples, so `-b riscv` always inherits the default `ArmCortexM` profile and bails, and the short ISA names (`rv32imac`, …) the toolchains/`riscv-runtime` use are "unknown target triple". Purely a CLI/target-profile wiring gap (the backend itself works — `riscv32imac` long-name already compiled).

## Fix

- **`TargetSpec::from_triple` accepts the short RV32 names** — `rv32imac`, `rv32imc`, `rv32im`, `rv32i`, `rv32gc`, generic `riscv32`/`rv32`, and the **`esp32c3`** board alias (RV32IMC) — via a new parameterized `TargetSpec::riscv32(extensions)`.
- **`synth compile -b riscv` with no `--target` defaults to `rv32imac`** instead of inheriting the ARM profile, so the backend is reachable out of the box.
- The "unknown target triple" error + `-t` help now list the RV32 options.

## Verified

```
$ synth compile fn.wasm -b riscv -t rv32imac --relocatable -o fn.o   # OK
$ synth compile fn.wasm -b riscv -t rv32imc  ...                     # OK (ESP32-C3)
$ synth compile fn.wasm -b riscv -t esp32c3  ...                     # OK
$ synth compile fn.wasm -b riscv --relocatable ...                   # OK (defaults rv32imac)
→ EM_RISCV, ELFCLASS32 relocatable object
```

Tests: `test_rv32_short_target_names_218` (parsing incl. esp32c3 + the listed error) + `test_resolve_target_spec_riscv_default_218` (the `-b riscv` default). Full workspace green, fmt/clippy clean.

## Out of scope (follow-ups)

`target-info` still only knows the ARM board profiles (it uses board `HardwareCapabilities`, not target triples) — a RISC-V board-profile addition is separate. RISC-V codegen quality/correctness is for on-target validation.

## Falsification

Wrong if `synth compile -b riscv -t rv32imac` fails to produce a valid RISC-V object, or if an RV32 target name resolves to a non-RISC-V spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)