### PR TITLE
perf(selector): drop dead divisor constant on reciprocal-multiply path (#221, v0.11.22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.22] - 2026-06-03
+
+**Drop the dead divisor constant on the reciprocal-multiply path (#209 cleanup).**
+The constant-divisor reciprocal-multiply (Opt 1b) reads the magic constant via
+`UMULL`, never the divisor itself -- but the divisor was still eagerly
+materialized (`MOVW #d`) because the `#209` cost-gate UDIV fallback *might* need
+it in a register. On the common (UMULL) path that `MOVW` is dead. It is now
+dropped via the same `drop_prev_const_materialization` technique already used for
+const-address folding (#95): when the reciprocal-multiply is taken, the divisor
+const (`i32.const` at `idx-1`, the only op tagged there) is removed; the UDIV
+fallback branch is unaffected.
+
+Measured on gale's `control_step` (4 non-pow2 const `div_u`): `.text` 410 -> 394
+bytes (-16 B, four dead `MOVW` removed, ~-4 cycles). `divu_500` drops `movw
+#500`. Behavior frozen: control_step `0x00210a55` (13/13), inlined + flat
+`flight_algo` `0x07FDF307`, and the div_const signed/unsigned matrix (338/338)
+all stay bit-identical. Regression: `test_209_const_divisor_uses_reciprocal_multiply`
+now asserts the dead `MOVW #500` is absent.
+
+Architectural note: the principled end-state is lazy/value-numbered constant
+materialization (LLVM/gcc-style -- never emit a const until a consumer needs it
+in a register, fold into the instruction otherwise). This is one consistent step
+toward that, reusing the existing drop-eager-const mechanism rather than adding a
+new shortcut.
+
+Falsification: wrong if any const `div_u`/`rem_u` result changes, or if a
+reciprocal-multiply still emits its divisor constant.
+
 ## [0.11.21] - 2026-06-03
 
 **Expose RV32 target profiles so `-b riscv` is reachable from `compile` (#218).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.21"
+version = "0.11.22"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.21"
+version = "0.11.22"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.21"
+version = "0.11.22"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.21"
+version = "0.11.22"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.21",
+    version = "0.11.22",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.21" }
+synth-core = { path = "../synth-core", version = "0.11.22" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.21" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.21" }
+synth-core = { path = "../synth-core", version = "0.11.22" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.22" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.21" }
+synth-core = { path = "../synth-core", version = "0.11.22" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.21" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.21", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.22" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.22", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.21" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.21" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.21" }
-synth-backend = { path = "../synth-backend", version = "0.11.21" }
+synth-core = { path = "../synth-core", version = "0.11.22" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.22" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.22" }
+synth-backend = { path = "../synth-backend", version = "0.11.22" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.21", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.21", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.21", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.22", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.22", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.22", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.21", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.22", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.21" }
+synth-core = { path = "../synth-core", version = "0.11.22" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.21" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.22" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.21" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.21" }
-synth-opt = { path = "../synth-opt", version = "0.11.21" }
+synth-core = { path = "../synth-core", version = "0.11.22" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.22" }
+synth-opt = { path = "../synth-opt", version = "0.11.22" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -5216,6 +5216,15 @@ impl InstructionSelector {
                             };
 
                         if let Some((rmag, rlo, rhi)) = recip {
+                            // #209 cleanup: the reciprocal-multiply reads the magic
+                            // constant, never the divisor — so the divisor's eager
+                            // materialization (the `i32.const` at idx-1, the only op
+                            // tagged there) is dead on this path. Drop it. The
+                            // cost-gate UDIV fallback below still materializes its
+                            // own divisor, so behavior is unchanged.
+                            if idx >= 1 {
+                                instructions.retain(|i| i.source_line != Some(idx - 1));
+                            }
                             // Materialize the magic constant m into rmag.
                             instructions.push(ArmInstruction {
                                 op: ArmOp::Movw {
@@ -13387,6 +13396,16 @@ mod tests {
         assert!(
             instrs.iter().any(|i| matches!(&i.op, ArmOp::Umull { .. })),
             "non-pow2 const divisor divides via UMULL high-word"
+        );
+        // #209 cleanup: the reciprocal-multiply reads the magic, never the
+        // divisor — so the divisor's eager materialization (MOVW #500) is dead and
+        // must NOT be emitted. (Magic for /500 is 0x10624DD3 → MOVW #0x4dd3, so
+        // 500 = 0x1f4 only ever appeared as the dead divisor const.)
+        assert!(
+            !instrs
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Movw { imm16: 500, .. })),
+            "dead divisor const MOVW #500 must not be emitted on the UMULL path"
         );
     }
 

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.21" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.21" }
-synth-opt = { path = "../synth-opt", version = "0.11.21" }
+synth-core = { path = "../synth-core", version = "0.11.22" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.22" }
+synth-opt = { path = "../synth-opt", version = "0.11.22" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.21", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.22", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Closes #221 — oracle-gated cleanup cycle (one tagged shortcut, one reversible change).

## What

The Opt 1b reciprocal-multiply divides via `UMULL` against a magic constant and never reads the divisor, yet the divisor was eagerly materialized (`MOVW #d`) in case the `#209` cost-gate `UDIV` fallback needs it. On the common UMULL path that `MOVW` is dead. Drop it via the existing `drop_prev_const_materialization` mechanism (#95) when the reciprocal-multiply is taken; the UDIV fallback branch is unaffected.

## Measured (control_step, 4 non-pow2 const `div_u`)

- `.text` **410 → 394 B** (−16 B, 4 dead `MOVW` removed, ~−4 cycles)
- `divu_500` drops `movw #500`; `umull`+`lsrs` kept.

## Behavior frozen — bit-identical (verified before opening)

- control_step `0x00210a55` — 13/13
- inlined + flat `flight_algo` `0x07FDF307` — MATCH
- div_const signed/unsigned matrix — 338/338
- 260 lib tests + fuzz green; new regression asserts `MOVW #500` absent.

## Direction

Reuses the existing drop-eager-const technique rather than adding a shortcut. The architectural end-state (lazy/value-numbered constant materialization, LLVM/GCC-style) would subsume this globally — noted in #221, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)