### PR TITLE
fix(riscv): implement Select, non-param locals, i32 sign-extend (#223, v0.11.23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.23] - 2026-06-03
+
+**RISC-V backend: implement `Select`, non-parameter locals, and i32 sign-extend (#223).**
+The RV32 selector rejected ops the ARM backend handles, blocking every realistic
+function (the straight-line `filter_axis` slipped through; `control_step` /
+`controller_step` / `flat_flight` did not). Added:
+- **`select`** (ternary) — lowers to a short branch + two moves (RV32 has no
+  conditional-move), for both i32 and i64 operands. Pervasive: every saturating
+  clamp / min/max lowers to it.
+- **Non-parameter locals** (`local.get/set/tee` for `idx >= num_params`) — now
+  frame-backed: each i32 local gets a 4-byte stack slot (`sw`/`lw`). The slots
+  sit at the bottom of the frame; the #220 callee-saved spills go above, in one
+  unified prologue -- so locals + saved registers share a single `addi sp,-N`.
+- **`i32.extend8_s` / `i32.extend16_s`** — `slli`+`srai` (RV32 has no sign-extend).
+
+With these + #220, gale's dissolved `control_step` compiles to RV32 and runs
+correctly: a unicorn RV32 differential matches wasmtime -- and the ARM backend --
+on `(3000,50,40,0) = 0x00210a55` across vectors, reading its `.rodata` table via
+`s11` and preserving the caller's callee-saved registers. Fixtures:
+`scripts/repro/control_step_riscv_differential.py`; unit tests
+`select_lowers_to_branch_223`, `sign_extend_uses_slli_srai_223`,
+`non_param_local_uses_frame_223`; 163 riscv tests green.
+
+Note: i32 locals only (i64 locals would need two slots) -- not yet hit by the
+dissolved modules; leaf functions per #220.
+
+Falsification: wrong if any RV32 function with `select`/non-param-locals/sign-
+extend returns a value differing from wasmtime, or if the unified frame
+misaligns a local or saved-register slot.
+
 ## [0.11.22] - 2026-06-03
 
 **RISC-V backend: preserve callee-saved registers per the RV psABI (#220).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.21"
+version = "0.11.22"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.21"
+version = "0.11.22"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.21"
+version = "0.11.22"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.22"
+version = "0.11.23"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.22",
+    version = "0.11.23",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.22" }
+synth-core = { path = "../synth-core", version = "0.11.23" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.22" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.22" }
+synth-core = { path = "../synth-core", version = "0.11.23" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.23" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -175,15 +175,17 @@ pub fn select_with_options(
     options: SelectorOptions,
 ) -> Result<RiscVSelection, SelectorError> {
     let mut ctx = Selector::new_with_options(num_params, options);
+    ctx.compute_local_layout(wasm_ops, num_params); // #223
     ctx.lower_seq(wasm_ops)?;
     ctx.emit_return_epilogue();
+    let local_frame_bytes = ctx.local_frame_bytes;
     // #220: the temp pool includes callee-saved s-registers (s1..s6), but the
     // RV psABI requires a function to preserve s0..s11. Wrap the body in a
     // prologue/epilogue that spills+restores exactly the callee-saved registers
     // it writes — otherwise calling the function corrupts the caller's s-regs
     // (including s11 = __linear_memory_base). These functions are leaves, so no
     // `ra`/caller-saved preservation is needed (non-leaf is a follow-up).
-    preserve_callee_saved(&mut ctx.out);
+    preserve_callee_saved(&mut ctx.out, local_frame_bytes);
     Ok(RiscVSelection { ops: ctx.out })
 }
 
@@ -246,9 +248,11 @@ fn is_callee_saved_temp(r: Reg) -> bool {
     n == 9 || (18..=26).contains(&n)
 }
 
-/// #220: spill+restore the callee-saved registers `out` writes, per the RV
-/// psABI. No-op when the body uses only caller-saved (`t`/`a`) registers.
-fn preserve_callee_saved(out: &mut Vec<RiscVOp>) {
+/// #220 + #223: open a stack frame for the non-parameter locals (`local_bytes`,
+/// laid out at the bottom `0..local_bytes`) and spill+restore the callee-saved
+/// registers `out` writes (above the locals, per the RV psABI). No-op only when
+/// the body uses no callee-saved register AND has no frame-backed locals.
+fn preserve_callee_saved(out: &mut Vec<RiscVOp>, local_bytes: i32) {
     let mut saved: Vec<Reg> = Vec::new();
     for op in out.iter() {
         if let Some(rd) = op_dest(op)
@@ -258,12 +262,14 @@ fn preserve_callee_saved(out: &mut Vec<RiscVOp>) {
             saved.push(rd);
         }
     }
-    if saved.is_empty() {
+    if saved.is_empty() && local_bytes == 0 {
         return;
     }
     saved.sort_by_key(|r| *r as u8); // deterministic slot order
-    // 16-byte-aligned frame (RV psABI) holding one word per saved register.
-    let frame = ((saved.len() as i32) * 4 + 15) & !15;
+    // 16-byte-aligned frame (RV psABI): [ locals 0..local_bytes | saved regs ].
+    let frame = (local_bytes + (saved.len() as i32) * 4 + 15) & !15;
+    // Saved registers sit just above the locals region.
+    let sreg_off = |k: usize| local_bytes + (k as i32) * 4;
 
     let mut prologue = vec![RiscVOp::Addi {
         rd: Reg::SP,
@@ -274,7 +280,7 @@ fn preserve_callee_saved(out: &mut Vec<RiscVOp>) {
         prologue.push(RiscVOp::Sw {
             rs1: Reg::SP,
             rs2: r,
-            imm: (k as i32) * 4,
+            imm: sreg_off(k),
         });
     }
 
@@ -284,7 +290,7 @@ fn preserve_callee_saved(out: &mut Vec<RiscVOp>) {
         .map(|(k, &r)| RiscVOp::Lw {
             rd: r,
             rs1: Reg::SP,
-            imm: (k as i32) * 4,
+            imm: sreg_off(k),
         })
         .collect();
     epilogue.push(RiscVOp::Addi {
@@ -359,6 +365,12 @@ struct Selector {
     emitted_return: bool,
     /// Phase-1 safety options (bounds-check policy, signed-div overflow trap).
     options: SelectorOptions,
+    /// #223: non-parameter local `idx` → byte offset within the stack frame
+    /// (the locals region, laid out first at `0..local_frame_bytes`). The #220
+    /// callee-saved spills go after it; the unified prologue opens both.
+    local_offsets: std::collections::HashMap<u32, i32>,
+    /// Bytes reserved for non-parameter locals (4 per i32 local, 16-aligned).
+    local_frame_bytes: i32,
 }
 
 impl Selector {
@@ -391,7 +403,31 @@ impl Selector {
             next_label: 0,
             emitted_return: false,
             options,
+            local_offsets: std::collections::HashMap::new(),
+            local_frame_bytes: 0,
         }
+    }
+
+    /// #223: lay out the non-parameter locals referenced by `wasm_ops` into the
+    /// stack frame, one 4-byte i32 slot each, at offsets `0,4,8,…`. The slots
+    /// sit at the bottom of the frame; the #220 callee-saved spills go above.
+    fn compute_local_layout(&mut self, wasm_ops: &[WasmOp], num_params: u32) {
+        use std::collections::BTreeSet;
+        let mut used: BTreeSet<u32> = BTreeSet::new();
+        for op in wasm_ops {
+            match op {
+                WasmOp::LocalGet(i) | WasmOp::LocalSet(i) | WasmOp::LocalTee(i)
+                    if *i >= num_params =>
+                {
+                    used.insert(*i);
+                }
+                _ => {}
+            }
+        }
+        for (slot, idx) in used.into_iter().enumerate() {
+            self.local_offsets.insert(idx, (slot as i32) * 4);
+        }
+        self.local_frame_bytes = self.local_offsets.len() as i32 * 4;
     }
 
     fn fresh_label(&mut self, prefix: &str) -> String {
@@ -490,6 +526,9 @@ impl Selector {
             LocalSet(idx) => self.lower_local_set(*idx, op)?,
             LocalTee(idx) => self.lower_local_tee(*idx, op)?,
 
+            // ─── Select (ternary) — #223 ────────────────────────────────
+            Select => self.lower_select(op)?,
+
             // ─── Constants ──────────────────────────────────────────────
             I32Const(v) => {
                 let dst = self.alloc_temp();
@@ -530,6 +569,10 @@ impl Selector {
             I32Shl => self.bin(op, |rd, rs1, rs2| RiscVOp::Sll { rd, rs1, rs2 })?,
             I32ShrS => self.bin(op, |rd, rs1, rs2| RiscVOp::Sra { rd, rs1, rs2 })?,
             I32ShrU => self.bin(op, |rd, rs1, rs2| RiscVOp::Srl { rd, rs1, rs2 })?,
+
+            // ─── Sign extension — #223 (slli/srai) ─────────────────────
+            I32Extend8S => self.lower_sign_extend(op, 24)?,
+            I32Extend16S => self.lower_sign_extend(op, 16)?,
 
             // ─── Comparisons (return 0 or 1 in a register) ─────────────
             I32Eqz => self.lower_eqz(op)?,
@@ -700,6 +743,86 @@ impl Selector {
         Ok(())
     }
 
+    /// #223: `select` — wasm pops `cond` (top), then `b`, then `a`; the result
+    /// is `cond != 0 ? a : b`. RV32 has no conditional-move, so this lowers to a
+    /// short branch (the same shape the ARM backend builds with IT/SelectMove):
+    /// ```text
+    ///   bne cond, zero, .Lsel_a   ; cond != 0 → take a
+    ///   mv  dst, b                ; cond == 0 → b
+    ///   j   .Lsel_end
+    /// .Lsel_a:
+    ///   mv  dst, a
+    /// .Lsel_end:
+    /// ```
+    /// Handles both i32 and i64 operands (the i64 case selects both halves under
+    /// one branch). `dst` may alias `a`/`b` — safe, because the two arms are
+    /// mutually exclusive.
+    fn lower_select(&mut self, op: &WasmOp) -> Result<(), SelectorError> {
+        let cond = self.pop_i32(op)?;
+        let b = self.pop_any(op)?;
+        let a = self.pop_any(op)?;
+        let take_a = self.fresh_label("Lsel_a");
+        let end = self.fresh_label("Lsel_end");
+        let mv = |dst: Reg, src: Reg| RiscVOp::Addi {
+            rd: dst,
+            rs1: src,
+            imm: 0,
+        };
+        match (a, b) {
+            (VstackVal::I32(ra), VstackVal::I32(rb)) => {
+                let dst = self.alloc_temp();
+                self.out.push(RiscVOp::Branch {
+                    cond: Branch::Ne,
+                    rs1: cond,
+                    rs2: Reg::ZERO,
+                    label: take_a.clone(),
+                });
+                self.out.push(mv(dst, rb)); // cond == 0 → b
+                self.out.push(RiscVOp::Jal {
+                    rd: Reg::ZERO,
+                    label: end.clone(),
+                });
+                self.out.push(RiscVOp::Label { name: take_a });
+                self.out.push(mv(dst, ra)); // cond != 0 → a
+                self.out.push(RiscVOp::Label { name: end });
+                self.push_i32(dst);
+            }
+            (VstackVal::I64 { lo: alo, hi: ahi }, VstackVal::I64 { lo: blo, hi: bhi }) => {
+                let dlo = self.alloc_temp();
+                let dhi = self.alloc_temp();
+                self.out.push(RiscVOp::Branch {
+                    cond: Branch::Ne,
+                    rs1: cond,
+                    rs2: Reg::ZERO,
+                    label: take_a.clone(),
+                });
+                self.out.push(mv(dlo, blo)); // cond == 0 → b
+                self.out.push(mv(dhi, bhi));
+                self.out.push(RiscVOp::Jal {
+                    rd: Reg::ZERO,
+                    label: end.clone(),
+                });
+                self.out.push(RiscVOp::Label { name: take_a });
+                self.out.push(mv(dlo, alo)); // cond != 0 → a
+                self.out.push(mv(dhi, ahi));
+                self.out.push(RiscVOp::Label { name: end });
+                self.push_i64(dlo, dhi);
+            }
+            (x, y) => {
+                return Err(SelectorError::StackTypeMismatch {
+                    op: op.clone(),
+                    expected: "matching i32/i64 select operands",
+                    found: if x.type_name() != y.type_name() {
+                        "mismatched"
+                    } else {
+                        x.type_name()
+                    },
+                });
+            }
+        }
+        Ok(())
+    }
+
     // ────────── Locals ──────────
 
     fn lower_local_get(&mut self, idx: u32, op: &WasmOp) -> Result<(), SelectorError> {
@@ -712,14 +835,26 @@ impl Selector {
                 imm: 0,
             });
         } else {
-            // Locals beyond params are stack-allocated. For the skeleton
-            // we don't materialize the frame — emit a clear error instead.
-            return Err(SelectorError::Unsupported(op.clone()));
+            // #223: non-param local — load from its frame slot (lw dst, off(sp)).
+            let off = self.local_slot(idx, op)?;
+            self.out.push(RiscVOp::Lw {
+                rd: dst,
+                rs1: Reg::SP,
+                imm: off,
+            });
         }
         // Phase 1: locals are always treated as i32. i64 locals would need
-        // two arg-register slots and live outside the scope of this PR.
+        // two slots and live outside the scope of this PR.
         self.push_i32(dst);
         Ok(())
+    }
+
+    /// #223: byte offset of a non-parameter local within the stack frame.
+    fn local_slot(&self, idx: u32, op: &WasmOp) -> Result<i32, SelectorError> {
+        self.local_offsets
+            .get(&idx)
+            .copied()
+            .ok_or_else(|| SelectorError::Unsupported(op.clone()))
     }
 
     fn lower_local_set(&mut self, idx: u32, op: &WasmOp) -> Result<(), SelectorError> {
@@ -733,7 +868,14 @@ impl Selector {
             });
             Ok(())
         } else {
-            Err(SelectorError::Unsupported(op.clone()))
+            // #223: non-param local — store to its frame slot (sw src, off(sp)).
+            let off = self.local_slot(idx, op)?;
+            self.out.push(RiscVOp::Sw {
+                rs1: Reg::SP,
+                rs2: src,
+                imm: off,
+            });
+            Ok(())
         }
     }
 
@@ -763,8 +905,35 @@ impl Selector {
             });
             Ok(())
         } else {
-            Err(SelectorError::Unsupported(op.clone()))
+            // #223: tee = store to the frame slot, value stays on the vstack.
+            let off = self.local_slot(idx, op)?;
+            self.out.push(RiscVOp::Sw {
+                rs1: Reg::SP,
+                rs2: src,
+                imm: off,
+            });
+            Ok(())
         }
+    }
+
+    /// #223: `i32.extend8_s` / `i32.extend16_s` — sign-extend the low byte or
+    /// halfword of an i32. RV32 has no sign-extend op, so shift the bits up to
+    /// the top and arithmetic-shift back (`shift` = 24 for 8-bit, 16 for 16-bit).
+    fn lower_sign_extend(&mut self, op: &WasmOp, shift: u8) -> Result<(), SelectorError> {
+        let src = self.pop_i32(op)?;
+        let dst = self.alloc_temp();
+        self.out.push(RiscVOp::Slli {
+            rd: dst,
+            rs1: src,
+            shamt: shift,
+        });
+        self.out.push(RiscVOp::Srai {
+            rd: dst,
+            rs1: dst,
+            shamt: shift,
+        });
+        self.push_i32(dst);
+        Ok(())
     }
 
     // ────────── Binary helpers ──────────
@@ -5196,6 +5365,90 @@ mod tests {
                 .iter()
                 .any(|op| matches!(op, RiscVOp::Addi { rd: Reg::SP, imm, .. } if *imm != 0)),
             "no stack-frame adjustment when no callee-saved register is used"
+        );
+    }
+
+    /// #223: `select` lowers to a branch + two moves (RV32 has no cmov).
+    #[test]
+    fn select_lowers_to_branch_223() {
+        let sel = select(
+            &[
+                WasmOp::I32Const(10),
+                WasmOp::I32Const(20),
+                WasmOp::I32Const(1),
+                WasmOp::Select,
+            ],
+            0,
+        )
+        .unwrap();
+        assert!(
+            sel.ops.iter().any(|op| matches!(
+                op,
+                RiscVOp::Branch {
+                    cond: Branch::Ne,
+                    rs2: Reg::ZERO,
+                    ..
+                }
+            )),
+            "select branches on `cond != 0`"
+        );
+        // Two arms, each a `mv` (Addi rd, rs, 0).
+        assert!(
+            count(&sel.ops, |op| matches!(op, RiscVOp::Addi { imm: 0, .. })) >= 2,
+            "select moves both candidate values"
+        );
+    }
+
+    /// #223: `i32.extend16_s` / `extend8_s` lower to `slli`+`srai`.
+    #[test]
+    fn sign_extend_uses_slli_srai_223() {
+        for (op, sh) in [(WasmOp::I32Extend16S, 16u8), (WasmOp::I32Extend8S, 24u8)] {
+            let sel = select(&[WasmOp::LocalGet(0), op], 1).unwrap();
+            assert!(
+                sel.ops
+                    .iter()
+                    .any(|o| matches!(o, RiscVOp::Slli { shamt, .. } if *shamt == sh)),
+                "sign-extend uses slli #{sh}"
+            );
+            assert!(
+                sel.ops
+                    .iter()
+                    .any(|o| matches!(o, RiscVOp::Srai { shamt, .. } if *shamt == sh)),
+                "sign-extend uses srai #{sh}"
+            );
+        }
+    }
+
+    /// #223: a non-parameter local (idx >= num_params) is frame-backed — set
+    /// stores to the stack (`sw`), get loads from it (`lw`), and the unified
+    /// prologue opens a frame to hold it.
+    #[test]
+    fn non_param_local_uses_frame_223() {
+        // num_params = 0, so local 0 is a non-param local.
+        let sel = select(
+            &[
+                WasmOp::I32Const(42),
+                WasmOp::LocalSet(0),
+                WasmOp::LocalGet(0),
+            ],
+            0,
+        )
+        .unwrap();
+        assert!(
+            sel.ops
+                .iter()
+                .any(|op| matches!(op, RiscVOp::Sw { rs1: Reg::SP, .. })),
+            "local.set on a non-param local stores to the frame"
+        );
+        assert!(
+            sel.ops
+                .iter()
+                .any(|op| matches!(op, RiscVOp::Lw { rs1: Reg::SP, .. })),
+            "local.get on a non-param local loads from the frame"
+        );
+        assert!(
+            matches!(sel.ops.first(), Some(RiscVOp::Addi { rd: Reg::SP, imm, .. }) if *imm < 0),
+            "a frame is opened for the local"
         );
     }
 

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.22" }
+synth-core = { path = "../synth-core", version = "0.11.23" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.22" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.22", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.23" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.23", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.22" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.22" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.22" }
-synth-backend = { path = "../synth-backend", version = "0.11.22" }
+synth-core = { path = "../synth-core", version = "0.11.23" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.23" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.23" }
+synth-backend = { path = "../synth-backend", version = "0.11.23" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.22", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.22", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.22", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.23", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.23", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.23", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.22", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.23", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.22" }
+synth-core = { path = "../synth-core", version = "0.11.23" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.22" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.23" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.22" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.22" }
-synth-opt = { path = "../synth-opt", version = "0.11.22" }
+synth-core = { path = "../synth-core", version = "0.11.23" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.23" }
+synth-opt = { path = "../synth-opt", version = "0.11.23" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.22" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.22" }
-synth-opt = { path = "../synth-opt", version = "0.11.22" }
+synth-core = { path = "../synth-core", version = "0.11.23" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.23" }
+synth-opt = { path = "../synth-opt", version = "0.11.23" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.22", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.23", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }

--- a/scripts/repro/control_step_riscv_differential.py
+++ b/scripts/repro/control_step_riscv_differential.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""#223 — control_step on RISC-V: correctness + ABI differential.
+
+After #218 (reachable) + #220 (callee-saved ABI) + #223 (Select, non-param
+locals, sign-extend), gale's `control_step_decide` compiles to RV32. This checks
+it computes the SAME result as wasmtime (and the ARM backend — gale's reference
+`(3000,50,40,0) = 0x00210a55`), reads its `.rodata` table via s11 (the linmem
+base), and preserves the caller's callee-saved registers.
+
+Run:
+  synth compile scripts/repro/control_step.wasm -b riscv -t rv32imac \
+        --all-exports --relocatable -o /tmp/cs_rv.o
+  /tmp/armv/bin/python scripts/repro/control_step_riscv_differential.py /tmp/cs_rv.o
+"""
+import re
+import subprocess
+import sys
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_RISCV, UC_MODE_RISCV32, Uc, UcError
+from unicorn.riscv_const import (
+    UC_RISCV_REG_A0,
+    UC_RISCV_REG_A1,
+    UC_RISCV_REG_A2,
+    UC_RISCV_REG_A3,
+    UC_RISCV_REG_RA,
+    UC_RISCV_REG_S1,
+    UC_RISCV_REG_S2,
+    UC_RISCV_REG_S7,
+    UC_RISCV_REG_S8,
+    UC_RISCV_REG_S11,
+    UC_RISCV_REG_SP,
+)
+
+WASM = "scripts/repro/control_step.wasm"
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/cs_rv.o"
+SYNTH = "./target/debug/synth"
+CODE, LIN, STK, RET = 0x100000, 0x40000, 0x90000, 0x200000
+SENTINELS = {
+    UC_RISCV_REG_S1: 0x1111_1111,
+    UC_RISCV_REG_S2: 0x2222_2222,
+    UC_RISCV_REG_S7: 0x7777_7777,  # non-param locals land in s7/s8 region
+    UC_RISCV_REG_S8: 0x8888_8888,
+}
+VECTORS = [(3000, 50, 40, 0), (0, 0, 0, 0), (1500, 0, 0, 0), (2645, 10, 20, 0), (4000, 200, 30, 7)]
+
+
+def main():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, open(WASM, "rb").read())
+
+    def wt(args):
+        store = wasmtime.Store(engine)
+        inst = wasmtime.Instance(store, module, [])
+        r = inst.exports(store)["control_step_decide"](store, *args) & 0xFFFFFFFF
+        rod = bytes(inst.exports(store)["memory"].read(store, 0x10000, 0x20000))
+        return r, rod
+
+    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
+    syms = {m.group(2): int(m.group(1), 16)
+            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
+    fa = syms["func_0"] if "func_0" in syms else syms["control_step_decide"]
+    code = ELFFile(open(ELF, "rb")).get_section_by_name(".text").data()
+
+    def run(args, rodata):
+        mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+        mu.mem_map(CODE, 0x20000)
+        mu.mem_map(LIN, 0x20000)
+        mu.mem_map(STK - 0x8000, 0x10000)
+        mu.mem_map(RET, 0x1000)
+        mu.mem_write(CODE, code)
+        mu.mem_write(LIN + 0x10000, rodata)
+        mu.reg_write(UC_RISCV_REG_SP, STK)
+        mu.reg_write(UC_RISCV_REG_S11, LIN)  # s11 = __linear_memory_base
+        for r, v in zip((UC_RISCV_REG_A0, UC_RISCV_REG_A1, UC_RISCV_REG_A2, UC_RISCV_REG_A3), args):
+            mu.reg_write(r, v & 0xFFFFFFFF)
+        for r, v in SENTINELS.items():
+            mu.reg_write(r, v)
+        mu.reg_write(UC_RISCV_REG_RA, RET)
+        try:
+            mu.emu_start(CODE + fa, RET, count=2000)
+        except UcError as e:
+            return None, False, str(e)
+        res = mu.reg_read(UC_RISCV_REG_A0) & 0xFFFFFFFF
+        preserved = all((mu.reg_read(r) & 0xFFFFFFFF) == v for r, v in SENTINELS.items())
+        return res, preserved, ""
+
+    fails = 0
+    for v in VECTORS:
+        gt, rodata = wt(v)
+        res, preserved, err = run(v, rodata)
+        ok = res == gt and preserved
+        fails += 0 if ok else 1
+        shown = f"0x{res:08x}" if res is not None else f"ERR({err})"
+        print(f"control_step{v} = {shown}  wasmtime=0x{gt:08x}  s-regs-preserved={preserved}"
+              f"  {'OK' if ok else 'FAIL'}")
+    print("\nRISC-V control_step ORACLE: PASS (correct + ABI-compliant)" if not fails
+          else f"RISC-V control_step ORACLE: FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #223 — the RV32 op gaps blocking gale's real algo functions.

## What

The RV32 selector rejected ops the ARM backend handles. Added:
- **`select`** (ternary) — branch + two moves (RV32 has no cmov), i32 and i64.
- **Non-parameter locals** (`local.get/set/tee`, `idx >= num_params`) — frame-backed: each i32 local gets a stack slot (`sw`/`lw`). Slots at the **bottom** of the frame, the #220 callee-saved spills **above**, in **one unified prologue** (`addi sp,-N` covers both — no competing frames).
- **`i32.extend8_s` / `i32.extend16_s`** — `slli`+`srai`.

## Validation

`control_step_decide` now compiles to RV32 **and runs correctly** — a unicorn RV32 differential matches wasmtime **and the ARM backend**:
```
control_step(3000,50,40,0) = 0x00210a55  wasmtime=0x00210a55  s-regs-preserved=True  OK
... RISC-V control_step ORACLE: PASS (correct + ABI-compliant)
```
It reads its `.rodata` table via `s11` (linmem base) and preserves the caller's callee-saved registers (the #220 frame, now extended with the local slots). All three dissolved modules (control_step, controller_step, flat_flight) compile.

Fixture: `scripts/repro/control_step_riscv_differential.py`. Unit tests `select_lowers_to_branch_223` + `sign_extend_uses_slli_srai_223` + `non_param_local_uses_frame_223`; **163 riscv tests green**, clippy/fmt clean.

## Scope

i32 locals only (i64 locals would need two slots — not hit by the dissolved modules yet); leaf functions per #220.

## Falsification

Wrong if any RV32 function with `select`/non-param-locals/sign-extend returns a value differing from wasmtime, or if the unified frame misaligns a slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)