### PR TITLE
fix(rivet): migrate artifact statuses to current schema enum (unblocks CI)

### DIFF
--- a/artifacts/anti-pinch-example.yaml
+++ b/artifacts/anti-pinch-example.yaml
@@ -128,7 +128,7 @@ artifacts:
       arithmetic produces correct results (no overflow, no truncation).
       The Zephyr application (main.c) simulates motor current and injects
       a jam event at ~70% position.
-    status: planned
+    status: proposed
     tags: [anti-pinch, renode, simulation, verification]
     links:
       - type: verifies

--- a/artifacts/code-review-findings.yaml
+++ b/artifacts/code-review-findings.yaml
@@ -25,7 +25,7 @@ artifacts:
       (implementation-defined behavior on Cortex-M). The instruction_selector.rs
       path correctly emits the trap guard, creating an inconsistency between
       two synthesis paths for the same operation.
-    status: open
+    status: proposed
     tags: [critical, wasm-spec, division, trap, rules-rs]
     links:
       - type: verifies
@@ -54,7 +54,7 @@ artifacts:
       value of 256 is silently encoded as 0, producing RSB Rd, Rn, #0 instead
       of RSB Rd, Rn, #256. The caller receives no error and the generated code
       computes wrong results for any RSB with immediate > 255.
-    status: open
+    status: proposed
     tags: [critical, arm-encoding, truncation, immediate]
     links:
       - type: verifies
@@ -83,7 +83,7 @@ artifacts:
       of 260 is silently encoded as 4 (260 & 0xFF = 4), causing the load to
       access memory at a completely wrong address. This produces silent data
       corruption with no compile-time or runtime error.
-    status: open
+    status: proposed
     tags: [critical, arm-encoding, truncation, offset]
     links:
       - type: verifies
@@ -112,7 +112,7 @@ artifacts:
       WebAssembly linear memory size for bounds checks. Writing to R10 corrupts
       the bounds check comparison value, causing bounds checks to use a wrong
       memory size for all subsequent memory accesses.
-    status: open
+    status: proposed
     tags: [critical, register-allocation, memory-safety]
     links:
       - type: verifies
@@ -141,7 +141,7 @@ artifacts:
       Overwriting R11 with a temporary value causes all subsequent memory
       operations to read/write at a completely wrong memory location,
       potentially corrupting arbitrary system memory.
-    status: open
+    status: proposed
     tags: [critical, register-allocation, memory-safety]
     links:
       - type: verifies
@@ -172,7 +172,7 @@ artifacts:
       (address < memory_size) but reads 3 bytes past the linear memory end.
       The _access_size parameter is declared in the function signature but
       never used in the computation.
-    status: open
+    status: proposed
     tags: [high, memory-safety, bounds-checking]
     links:
       - type: verifies
@@ -202,7 +202,7 @@ artifacts:
       starting at the 5th temporary), those registers are clobbered without
       being saved. If the function is called from another compiled function
       or from the runtime, the caller's values in those registers are lost.
-    status: open
+    status: proposed
     tags: [high, calling-convention, register-preservation]
     links:
       - type: verifies
@@ -231,7 +231,7 @@ artifacts:
       8-byte aligned. STRD/LDRD instructions require 8-byte alignment and
       will fault. Cortex-M hardware exception entry also assumes 8-byte
       aligned SP.
-    status: open
+    status: proposed
     tags: [high, calling-convention, stack-alignment, aapcs]
     links:
       - type: verifies
@@ -259,7 +259,7 @@ artifacts:
       division appears in the middle of a function (followed by more
       operations), POP {PC} causes the function to return immediately after
       the division, skipping all subsequent instructions.
-    status: open
+    status: proposed
     tags: [high, arm-encoding, control-flow, i64-division]
     links:
       - type: verifies
@@ -288,7 +288,7 @@ artifacts:
       compiled function. After i32.popcnt executes, R11 contains garbage,
       and all subsequent LDR/STR [R11, ...] memory accesses use the wrong
       base address, reading from or writing to arbitrary memory.
-    status: open
+    status: proposed
     tags: [high, arm-encoding, register-clobber, memory-safety]
     links:
       - type: verifies
@@ -318,7 +318,7 @@ artifacts:
       either a wrong register comparison or an invalid instruction encoding.
       Since I64Eqz delegates to I64SetCondZ, all i64.eqz operations are
       affected when the result register is a high register.
-    status: open
+    status: proposed
     tags: [high, arm-encoding, register-encoding, i64]
     links:
       - type: verifies

--- a/artifacts/compilation-chain.yaml
+++ b/artifacts/compilation-chain.yaml
@@ -267,7 +267,7 @@ artifacts:
       produce firmware.elf as output. This reduces the manual steps from
       three commands to one. Stage 1 (meld fuse) and stage 5 (deployment)
       remain external.
-    status: planned
+    status: proposed
     tags: [compilation-chain, cli, orchestration, pipeline]
     links:
       - type: derives-from
@@ -299,7 +299,7 @@ artifacts:
       (relocation entries for BL instructions targeting import symbols).
       The ELF shall be linkable by any ARM ELF-compatible linker without
       requiring synth-specific tooling.
-    status: planned
+    status: proposed
     tags: [compilation-chain, elf, relocatable, meld-sections]
     links:
       - type: derives-from

--- a/artifacts/component-model.yaml
+++ b/artifacts/component-model.yaml
@@ -176,7 +176,7 @@ artifacts:
       RTOS (e.g., gale tasks on gale targets, Zephyr threads on Zephyr
       targets). Synth generates the call stubs; kiln provides the runtime
       implementation.
-    status: planned
+    status: proposed
     tags: [component-model, rfc46, async, kiln-dependency]
     links:
       - type: derives-from
@@ -217,7 +217,7 @@ artifacts:
       for spec-compliant behavior. This extension anticipates the Component
       Model spec's planned 'recursive' effect on function types
       (Concurrency.md TODO).
-    status: planned
+    status: proposed
     tags: [component-model, reentrance, fusion, meld-interop, extension]
     links:
       - type: derives-from
@@ -361,7 +361,7 @@ artifacts:
       stub, (3) canonical ABI lift of return values. The stub generation
       shall be driven by the WIT interface type signatures extracted during
       frontend parsing.
-    status: planned
+    status: proposed
     tags: [component-model, codegen, import-dispatch, synth-synthesis]
     links:
       - type: derives-from
@@ -386,7 +386,7 @@ artifacts:
       signatures before beginning synthesis. Signature mismatches
       (parameter count, parameter types, return types) shall produce
       a compile-time error with the expected vs actual signature.
-    status: planned
+    status: proposed
     tags: [component-model, validation, abi-stability, synth-cli]
     links:
       - type: derives-from
@@ -438,7 +438,7 @@ artifacts:
       exercise type size computation, field alignment, string encoding,
       and discriminant layout across both implementations. Required by
       kiln:SR-24 (shared wit-bindgen fixtures).
-    status: planned
+    status: proposed
     tags: [canonical-abi, cross-toolchain, integration]
     links:
       - type: verifies
@@ -458,7 +458,7 @@ artifacts:
       that successfully executes with kiln-builtins host intrinsics on a
       Cortex-M4 target (Renode emulation). Validates the full BA RFC #46
       pipeline: component -> meld fuse -> synth compile -> kiln execute.
-    status: planned
+    status: proposed
     tags: [rfc46, end-to-end, integration, cross-toolchain]
     links:
       - type: verifies

--- a/artifacts/cross-compilation.yaml
+++ b/artifacts/cross-compilation.yaml
@@ -319,7 +319,7 @@ artifacts:
       shall be captured and re-emitted with synth context (which symbol
       is unresolved, which object needs it). Non-zero exit codes from
       the linker shall propagate as synth errors.
-    status: planned
+    status: proposed
     tags: [cross-compilation, cli, subprocess, linker]
     links:
       - type: derives-from
@@ -349,7 +349,7 @@ artifacts:
       the weak default. The weak symbol shall be emitted in a separate
       .text.synth.defaults section that can be gc-collected when not
       needed.
-    status: planned
+    status: proposed
     tags: [cross-compilation, weak-symbol, memory-base, bare-metal]
     links:
       - type: derives-from
@@ -376,7 +376,7 @@ artifacts:
       When using ld.lld, the mapping adds --target=thumbv7em-none-eabihf
       for Cortex-M4F targets. The mapping is configured via the
       TargetSpec and HardwareCapabilities structs.
-    status: planned
+    status: proposed
     tags: [cross-compilation, target-triple, linker-flags]
     links:
       - type: derives-from

--- a/artifacts/e2e-verification.yaml
+++ b/artifacts/e2e-verification.yaml
@@ -29,7 +29,7 @@ artifacts:
       host function with the correct argument, (4) the host function
       executes and produces observable output (UART print). This is the
       simplest possible end-to-end test of the import dispatch mechanism.
-    status: planned
+    status: proposed
     tags: [e2e, poc, import-dispatch, renode]
     links:
       - type: verifies
@@ -117,7 +117,7 @@ artifacts:
       This validates the WASI Preview 2 dispatch compatibility (CM-004)
       and the generic import dispatch mechanism (KB-001) for a real-world
       use case.
-    status: planned
+    status: proposed
     tags: [e2e, wasi, stdout, renode]
     links:
       - type: verifies
@@ -159,7 +159,7 @@ artifacts:
       is within the linear memory region, (3) the string bytes are written
       correctly at the allocated address, (4) the import receives the
       correct (ptr, len) pair.
-    status: planned
+    status: proposed
     tags: [e2e, wasi, cabi-realloc, canonical-abi]
     links:
       - type: verifies
@@ -201,7 +201,7 @@ artifacts:
       the integration test that validates the full PulseEngine compilation
       story: component authoring -> meld composition -> synth AOT ->
       kiln runtime -> embedded execution.
-    status: planned
+    status: proposed
     tags: [e2e, component-model, round-trip, rfc46, integration]
     links:
       - type: verifies
@@ -250,7 +250,7 @@ artifacts:
       counterpart of CM-VER-002 (cross-toolchain ABI compatibility).
       Exercises both the lower path (guest -> host) and lift path
       (host -> guest return values).
-    status: planned
+    status: proposed
     tags: [e2e, component-model, abi-compatibility, canonical-abi]
     links:
       - type: verifies
@@ -291,7 +291,7 @@ artifacts:
       All tests use Renode via rules_renode for hermetic ARM emulation.
       The test suite shall be gated on kiln-builtins.a being available
       (via Bazel external dependency or pre-built artifact).
-    status: planned
+    status: proposed
     tags: [e2e, ci, bazel, regression, renode]
     links:
       - type: verifies
@@ -376,7 +376,7 @@ artifacts:
       in startup sequence, (2) MOV R11, R0 follows the BL, (3) weak symbol
       fallback emits correct default (0x20000000), (4) FPU initialization
       precedes memory base call when VFP is enabled.
-    status: planned
+    status: proposed
     tags: [e2e, unit-test, startup, memory-base, synth-backend]
     links:
       - type: verifies

--- a/artifacts/gale-integration.yaml
+++ b/artifacts/gale-integration.yaml
@@ -211,7 +211,7 @@ artifacts:
       the stubs target __meld_dispatch_import with the appropriate import
       index. For Phase 2 (per-import direct dispatch), the stubs target
       __meld_import_N with arguments directly in R0-R3.
-    status: planned
+    status: proposed
     tags: [gale, codegen, import-stub, wit]
     links:
       - type: derives-from
@@ -240,7 +240,7 @@ artifacts:
       CONFIG_GALE_KERNEL_MUTEX=y in addition to CONFIG_PRINTK=y and
       CONFIG_CONSOLE=y. This simplifies the Zephyr project setup for
       applications using both synth and gale.
-    status: planned
+    status: proposed
     tags: [gale, zephyr, kconfig, cli]
     links:
       - type: derives-from
@@ -272,7 +272,7 @@ artifacts:
       results via printk. This validates that libgale_ffi.a and synth
       assembly link without symbol conflicts and execute correctly
       together.
-    status: planned
+    status: proposed
     tags: [gale, integration-test, zephyr, co-deployment]
     links:
       - type: verifies
@@ -306,7 +306,7 @@ artifacts:
       operations use gale-verified index arithmetic, (2) MPU fault
       occurs if one component accesses the other's memory, (3) correct
       values are transferred end-to-end.
-    status: planned
+    status: proposed
     tags: [gale, integration-test, isolation, multi-component]
     links:
       - type: verifies

--- a/artifacts/kiln-builtins-api.yaml
+++ b/artifacts/kiln-builtins-api.yaml
@@ -242,7 +242,7 @@ artifacts:
       from ret buffer. The stub shall be emitted inline at each call site
       for single-use imports and as a shared trampoline for imports called
       more than once in the same function.
-    status: planned
+    status: proposed
     tags: [kiln-builtins, codegen, import-stub, synth-synthesis]
     links:
       - type: derives-from
@@ -274,7 +274,7 @@ artifacts:
       R2+R3). This mode is selected via a synth CLI flag
       (--import-dispatch=direct) and is the recommended default for
       embedded targets.
-    status: planned
+    status: proposed
     tags: [kiln-builtins, codegen, per-import, direct-dispatch]
     links:
       - type: derives-from
@@ -306,7 +306,7 @@ artifacts:
       in the WASM module. The signature_hash shall be computed from the
       WASM function type signature (param types, result types) using
       FNV-1a hashing.
-    status: planned
+    status: proposed
     tags: [kiln-builtins, elf-section, synth-backend, emission]
     links:
       - type: derives-from
@@ -337,7 +337,7 @@ artifacts:
       path (__meld_dispatch_import). The type definition shall be shared
       between synth (for codegen) and kiln-builtins (for runtime) via a
       common header or WIT definition.
-    status: planned
+    status: proposed
     tags: [kiln-builtins, value-type, c-abi, rfc46]
     links:
       - type: derives-from
@@ -367,7 +367,7 @@ artifacts:
       (5) branch to user code. For bare-metal targets without
       kiln-builtins, a weak symbol default returning 0x20000000 shall
       be provided in the synth-generated startup code.
-    status: planned
+    status: proposed
     tags: [kiln-builtins, startup, memory-base, reset-handler]
     links:
       - type: derives-from

--- a/artifacts/loom-integration.yaml
+++ b/artifacts/loom-integration.yaml
@@ -203,7 +203,7 @@ artifacts:
       Verify that the --loom flag produces the expected error when the
       loom feature is not enabled, and that --loom-compat correctly
       modifies the optimization pipeline.
-    status: planned
+    status: proposed
     tags: [loom, verification, cli]
     links:
       - type: verifies
@@ -226,7 +226,7 @@ artifacts:
     description: >
       Verify that loom-optimized WASM modules produce functionally
       equivalent ARM output compared to unoptimized compilation.
-    status: planned
+    status: proposed
     tags: [loom, verification, equivalence]
     links:
       - type: verifies

--- a/artifacts/verification-gaps.yaml
+++ b/artifacts/verification-gaps.yaml
@@ -17,7 +17,7 @@ artifacts:
       generate_load/store_with_bounds_check, division trap guard sequences,
       encode_thumb32_movw/movt, and SDIV/UDIV encoders. Full Verus macro
       integration pending rules_verus + verus_strip Bazel integration.
-    status: in-progress
+    status: approved
     tags: [verification-gap, verus]
     links:
       - type: derives-from
@@ -37,7 +37,7 @@ artifacts:
       admits are in VFP floating-point semantics (f32/f64 operations).
       Only i32 operations have T1 result-correspondence proofs. i64, f32,
       f64, and SIMD instruction selection has NO mechanized proofs.
-    status: in-progress
+    status: approved
     tags: [verification-gap, rocq, float]
     links:
       - type: derives-from
@@ -67,7 +67,7 @@ artifacts:
       verification track. Synth has no Lean proofs. This track would
       provide independent verification of instruction selection correctness
       using Lean's simp/omega/decide tactics.
-    status: planned
+    status: proposed
     tags: [verification-gap, lean]
     links:
       - type: derives-from
@@ -114,7 +114,7 @@ artifacts:
       (instruction_selector.rs, ~6000 lines) have not been translated.
       The existing Rocq proofs verify a separate Rocq model of
       compile_wasm_to_arm, not the actual Rust implementation.
-    status: planned
+    status: proposed
     tags: [verification-gap, rocq, coq-of-rust]
     links:
       - type: derives-from
@@ -139,7 +139,7 @@ artifacts:
       synth-synthesis/src/contracts.rs defines formal invariants for
       regalloc, encoding, memory, and division subsystems. Remaining
       functions (select_with_stack, encode_thumb, build_elf) still need specs.
-    status: in-progress
+    status: approved
     tags: [verification-gap, verus, specs]
     links:
       - type: derives-from
@@ -160,7 +160,7 @@ artifacts:
       temporaries, allocated registers don't conflict with live values,
       spilled values are correctly reloaded. These invariants are
       tested empirically but not formally proven.
-    status: planned
+    status: proposed
     tags: [verification-gap, verus, register-allocator]
     links:
       - type: derives-from
@@ -192,7 +192,7 @@ artifacts:
       No formal verification ensures these operations are within bounds.
       Kani harnesses partially address this via kani::assume() constraints
       but don't cover all code paths.
-    status: planned
+    status: proposed
     tags: [verification-gap, kani, overflow]
     links:
       - type: derives-from


### PR DESCRIPTION
## Why CI is red on main (and on every open PR)

CI installs rivet via `cargo install --git .../rivet --branch main` — **unpinned**. rivet **0.15.0** promoted the artifact `status` enum check from WARN to **ERROR**, so the required **Rivet Validation** gate went red on **unchanged** artifacts. This blocks all merges (#227, #228).

Reproduced locally by installing the same rivet (`--branch main`, 0.15.0): **48 status-enum ERRORs**, e.g.
```
ERROR: [VG-008]  status 'planned'     is not an allowed value
ERROR: [CR-C1]   status 'open'        is not an allowed value
ERROR: [VG-001]  status 'in-progress' is not an allowed value
```
allowed: `draft, proposed, approved, implemented, verified, released, deprecated, rejected`.

## Fix — conservative status migration (never inflates a claim)

| was | → | rationale |
|---|---|---|
| `planned` | `proposed` | intended work, not started |
| `open` | `proposed` | raised/unresolved finding or constraint |
| `in-progress` | `approved` | accepted and underway; **not** yet implemented/verified |

48 entries across `artifacts/*.yaml`. **Verified 0 non-xref errors under rivet 0.15.0** (the CI gate's exact logic).

Nothing maps toward `implemented`/`verified`/`released` — no traceability claim is strengthened, only relabeled to the current enum.

## Out of scope (noted follow-ups)
- `req-type: non-functional` and `method: test` remain **WARN** (non-blocking) under 0.15.0 — separate migration.
- The unpinned `--branch main` rivet install will drift again on the next schema change; **pinning rivet** is a CI-hygiene follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)