### PR TITLE
cleanup(riscv): allocator prefers caller-saved (lowest-free, not round-robin) (#230, v0.11.26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.26] - 2026-06-03
+
+**Cleanup: RV32 allocator prefers caller-saved registers (lowest-free, not round-robin).**
+
+Audit-cycle cleanup of the RISC-V temp allocator. `alloc_temp` recycled the pool
+`[t0..t6, s1..s6]` with a monotonic `next_temp` round-robin counter — "fine for
+straight-line code" but, even after #226 made it skip live registers, it kept
+marching *forward* into the callee-saved s-registers instead of reusing a
+just-freed low register. So short-lived expressions needlessly used s-registers
+and paid the #220 save/restore prologue tax.
+
+Now that the vstack liveness is tracked (#226), `alloc_temp` simply returns the
+**lowest-indexed free temp**. The pool lists caller-saved t-registers first, so a
+function stays in them whenever ≤7 values are simultaneously live — the
+callee-saved s-registers become a genuine overflow reserve rather than something
+the round-robin consumed by accident.
+
+- **Behavior frozen, oracle-confirmed bit-identical:** all five differential
+  fixtures — ARM `div_const` 338/338, `control_step` 13/13 (`0x00210a55`),
+  `flight_seam` `0x07FDF307`; RV32 `control_step` (`0x00210a55`),
+  `controller_step` (`0x05ff0000`).
+- **Measured delta:** `controller_step` RV32 `.text` 440 → 368 bytes (−72 B,
+  −18 instructions); callee-saved spills 6 → 0; frame 48 → 16 bytes. Results
+  unchanged (register renaming).
+- The broader local register allocation / constant-CSE work (the Opt-3 perf lever
+  gale flagged in #209) remains separate; this is just the round-robin → lowest-free
+  cleanup.
+
 ## [0.11.25] - 2026-06-03
 
 **RISC-V: fix register allocator clobbering a live value across `select` (#226).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.25"
+version = "0.11.26"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.25"
+version = "0.11.26"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.25"
+version = "0.11.26"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.25"
+version = "0.11.26"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.25",
+    version = "0.11.26",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.25" }
+synth-core = { path = "../synth-core", version = "0.11.26" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.25" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.25" }
+synth-core = { path = "../synth-core", version = "0.11.26" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.26" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -363,9 +363,10 @@ struct Selector {
     ctrl: Vec<ControlFrame>,
     /// Argument registers for the current function's params (a0..a7).
     arg_regs: Vec<Reg>,
-    /// Available temporary registers, recycled in round-robin order.
+    /// Available temporary registers; `alloc_temp` hands out the lowest-indexed
+    /// free one, so the caller-saved `t`-registers (listed first) are preferred
+    /// over the callee-saved `s`-registers.
     temps: Vec<Reg>,
-    next_temp: usize,
     /// #226: set when `alloc_temp` could not find a register that isn't already
     /// holding a live `vstack` value (every temp is pinned). Surfaced as an
     /// `Unsupported` error after lowering so `--all-exports` skips the function
@@ -412,7 +413,6 @@ impl Selector {
             ctrl: Vec::new(),
             arg_regs: Reg::arg_regs(num_params as usize),
             temps,
-            next_temp: 0,
             alloc_exhausted: false,
             next_label: 0,
             emitted_return: false,
@@ -468,25 +468,29 @@ impl Selector {
         live
     }
 
-    /// Allocate a scratch register, recycling the `temps` pool round-robin but
-    /// **skipping any register that still holds a live `vstack` value** (#226).
+    /// Allocate a scratch register: the **lowest-indexed `temps` entry that
+    /// isn't already pinned by a live `vstack` value** (#226 liveness).
     ///
-    /// The previous allocator was blind to the vstack: after handing out all 13
-    /// temps it wrapped around and re-issued a register that an earlier, still
-    /// unconsumed value was pinning — clobbering it. `controller_step` exposed
-    /// this with an `updates<<24` value that stays live across three `select`
-    /// clamps; the long live range got reused as a comparison scratch, losing
-    /// the updates byte. Honoring the live set fixes the whole class.
+    /// The pool lists caller-saved t-registers (`t0..t6`) before callee-saved
+    /// s-registers (`s1..s6`), so "lowest free" keeps a function in the
+    /// caller-saved registers whenever ≤7 values are simultaneously live —
+    /// avoiding the #220 callee-saved save/restore prologue entirely.
+    ///
+    /// This replaces the original round-robin march (a `next_temp` counter that
+    /// only ever advanced). Round-robin was "fine for straight-line code" but,
+    /// even after #226 made it skip live registers, it kept walking *forward*
+    /// into the s-registers instead of reusing a just-freed low register — so
+    /// short-lived expressions needlessly touched callee-saved regs and paid the
+    /// prologue tax. With the vstack liveness already tracked, lowest-free is
+    /// both simpler and strictly tighter; results are identical (register
+    /// renaming), code is equal-or-smaller.
     ///
     /// If every temp is pinned (a genuinely deeper-than-pool expression), record
-    /// `alloc_exhausted` and fall back to round-robin — the caller turns the flag
-    /// into a skip so the function is dropped, never silently miscompiled.
+    /// `alloc_exhausted` — the caller turns the flag into a skip so the function
+    /// is dropped, never silently miscompiled.
     fn alloc_temp(&mut self) -> Reg {
         let live = self.live_regs();
-        let n = self.temps.len();
-        for _ in 0..n {
-            let r = self.temps[self.next_temp % n];
-            self.next_temp += 1;
+        for &r in &self.temps {
             if !live.contains(&r) {
                 return r;
             }
@@ -494,9 +498,7 @@ impl Selector {
         // Every temp is live: cannot allocate without spilling. Flag the
         // function for skip-and-continue rather than emit a clobber.
         self.alloc_exhausted = true;
-        let r = self.temps[self.next_temp % n];
-        self.next_temp += 1;
-        r
+        self.temps[0]
     }
 
     fn push_i32(&mut self, r: Reg) {
@@ -5312,23 +5314,29 @@ mod tests {
     /// stays unchanged; it is wrapped in a balanced prologue/epilogue.
     #[test]
     fn callee_saved_registers_preserved_220() {
-        // filter_axis: ((p0+p1)*980 + p2*20)/1000 — uses enough temps to spill
-        // into the callee-saved s-registers.
+        // Keep 8 values simultaneously live (the 7 caller-saved t-registers can
+        // hold only 7), forcing the lowest-free allocator into the callee-saved
+        // s-registers — then reduce them. This is what now exercises the #220
+        // spill/restore path (a shorter expression stays in t-registers).
         let sel = select(
             &[
-                WasmOp::LocalGet(0),
-                WasmOp::LocalGet(1),
+                WasmOp::I32Const(1),
+                WasmOp::I32Const(2),
+                WasmOp::I32Const(3),
+                WasmOp::I32Const(4),
+                WasmOp::I32Const(5),
+                WasmOp::I32Const(6),
+                WasmOp::I32Const(7),
+                WasmOp::I32Const(8), // 8th live value → spills into s1
                 WasmOp::I32Add,
-                WasmOp::I32Const(980),
-                WasmOp::I32Mul,
-                WasmOp::LocalGet(2),
-                WasmOp::I32Const(20),
-                WasmOp::I32Mul,
                 WasmOp::I32Add,
-                WasmOp::I32Const(1000),
-                WasmOp::I32DivS,
+                WasmOp::I32Add,
+                WasmOp::I32Add,
+                WasmOp::I32Add,
+                WasmOp::I32Add,
+                WasmOp::I32Add,
             ],
-            3,
+            0,
         )
         .unwrap();
         let out = &sel.ops;
@@ -5543,9 +5551,11 @@ mod tests {
     fn alloc_temp_flags_exhaustion_when_all_pinned_226() {
         let mut sel = Selector::new_with_options(0, SelectorOptions::wasm_compliant());
         let n = sel.temps.len();
-        let all: Vec<Reg> = (0..n).map(|_| sel.alloc_temp()).collect();
-        for r in &all {
-            sel.push_i32(*r);
+        // Pin each register as it is allocated, so the next alloc must pick a
+        // different one (lowest-free returns the same reg until it is pinned).
+        for _ in 0..n {
+            let r = sel.alloc_temp();
+            sel.push_i32(r);
         }
         assert!(
             !sel.alloc_exhausted,

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.25" }
+synth-core = { path = "../synth-core", version = "0.11.26" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.25" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.25", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.26" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.26", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.25" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.25" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.25" }
-synth-backend = { path = "../synth-backend", version = "0.11.25" }
+synth-core = { path = "../synth-core", version = "0.11.26" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.26" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.26" }
+synth-backend = { path = "../synth-backend", version = "0.11.26" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.25", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.25", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.25", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.26", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.26", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.26", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.25", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.26", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.25" }
+synth-core = { path = "../synth-core", version = "0.11.26" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.25" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.26" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.25" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.25" }
-synth-opt = { path = "../synth-opt", version = "0.11.25" }
+synth-core = { path = "../synth-core", version = "0.11.26" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.26" }
+synth-opt = { path = "../synth-opt", version = "0.11.26" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.25" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.25" }
-synth-opt = { path = "../synth-opt", version = "0.11.25" }
+synth-core = { path = "../synth-core", version = "0.11.26" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.26" }
+synth-opt = { path = "../synth-opt", version = "0.11.26" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.25", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.26", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Audit-cycle cleanup — issue #230

The RV32 `alloc_temp` recycled the pool `[t0..t6, s1..s6]` with a monotonic `next_temp` round-robin. Even after #226 made it skip live registers, it kept marching **forward** into the callee-saved s-registers instead of reusing a just-freed low register — so short-lived expressions needlessly used s-registers and paid the #220 save/restore prologue tax.

### Why it's now removable
#226 added vstack liveness tracking. With that in place, `alloc_temp` can simply return the **lowest-indexed free temp**; the pool lists caller-saved t-registers first, so a function stays in them whenever ≤7 values are simultaneously live. The s-registers become a genuine overflow reserve rather than something round-robin consumed by accident. The dead `next_temp` field is removed.

### Before / after (measured)
| | before | after |
|---|---|---|
| `controller_step` `.text` | 440 B | **368 B** (−72 B, −18 instrs) |
| callee-saved spills | 6 | **0** |
| frame | 48 B | 16 B |

### Oracle — behavior frozen, verified before opening
All five differential fixtures **bit-identical**:
- ARM: `div_const` 338/338, `control_step` `0x00210a55`, `flight_seam` `0x07FDF307`
- RV32: `control_step` `0x00210a55`, `controller_step` `0x05ff0000`

165 riscv unit tests pass. The **#220 callee-saved-preservation test** was reworked to force s-register usage via 8 simultaneously-live values (a shorter expression now stays in t-registers), so the spill/restore invariant remains genuinely exercised.

### Scope
This is the round-robin → lowest-free revert only. The broader local register allocation + constant-CSE (Opt-3 perf lever, gale #209 / task #78) stays separate.

Closes #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)