### PR TITLE
chore(docs): fix proof-count drift (→291 Qed/9 Admitted), document RISC-V backend, .gitignore gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,10 @@ vendor.log
 result
 result-*
 .direnv/
+
+# Bazel symlink forest (reappears on any `bazel build`)
+/bazel-*
+
+# Stray ELF/object output at repo root (e.g. `synth compile ... -o output.elf`)
+/*.elf
+output.elf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-Synth is a WebAssembly-to-ARM Cortex-M compiler with mechanized correctness proofs in Rocq (formerly Coq). It produces bare-metal ELF binaries for embedded targets.
+Synth is a WebAssembly-to-ARM Cortex-M and RISC-V (RV32IMAC) compiler with mechanized correctness proofs in Rocq (formerly Coq). It produces bare-metal ELF binaries for embedded targets.
 
 Part of [PulseEngine](https://github.com/pulseengine): synth (compiler) + [loom](https://github.com/pulseengine/loom) (WASM optimizer) + [meld](https://github.com/pulseengine/meld) (platform).
 
@@ -28,6 +28,7 @@ bazel test //tests/...             # Renode ARM Cortex-M4 emulation tests
 | `synth-core` | Shared types, error handling, `Backend` trait, WASM decoder |
 | `synth-frontend` | WASM Component Model parser and validator |
 | `synth-backend` | ARM Thumb-2 encoder, ELF builder, vector table, linker scripts, MPU |
+| `synth-backend-riscv` | RISC-V RV32IMAC backend (selector, encoder, relocatable ELF) — qemu_riscv32 / ESP32-C3 |
 | `synth-backend-awsm` | aWsm backend integration (WASM→native via aWsm) |
 | `synth-backend-wasker` | Wasker backend integration (WASM→Rust transpiler) |
 | `synth-synthesis` | WASM→ARM instruction selection, peephole optimizer, pattern matcher |
@@ -87,9 +88,10 @@ cd coq && make proofs
 
 ### Proof Status
 
-See `coq/STATUS.md` for the complete coverage matrix. Current: 233 Qed / 10 Admitted.
-Proofs are tiered: T1 (35 result-correspondence), T2 (142 existence-only), T3 (10 admitted).
-7 new admits from aligning Compilation.v with actual compiler (trap guards, MOVW+MOVT constants).
+See `coq/STATUS.md` for the complete coverage matrix. Current: 291 Qed / 9 Admitted
+(+2 `admit.` tactics) across `coq/Synth/`. Proofs are tiered: T1 (result-
+correspondence), T2 (existence-only), T3 (admitted). The remaining admits are
+division/trap-guard and i64 boundary lemmas tracked in `coq/STATUS.md`.
 All i32 operations (arithmetic, division, comparison, bit-manip, shift/rotate) have T1 proofs.
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 | ELF output with vector table | Implemented | Thumb bit set on symbols; not linked on real hardware |
 | Linker scripts (STM32, nRF52840, generic) | Implemented | Generated, not tested with real boards |
 | Cross-compilation (`--link` flag) | Implemented | Requires `arm-none-eabi-gcc` in PATH; not CI-tested |
-| Rocq mechanized proofs | 233 Qed / 10 Admitted | i32 T1 proofs; division/constant proofs re-admitted for trap guard alignment |
+| Rocq mechanized proofs | 291 Qed / 9 Admitted | i32 T1 proofs; division/constant proofs re-admitted for trap guard alignment |
 | Z3 translation validation | 53 tests passing | Covers i32 arithmetic and comparison rules |
 | WebAssembly spec test suite | 227/257 compile | Compilation only — not executed on emulator |
 
@@ -203,7 +203,7 @@ Per the [PulseEngine Verification Guide](https://pulseengine.eu/guides/VERIFICAT
 
 | Track | Status | Coverage |
 |-------|--------|----------|
-| **Rocq** | Partial | 233 Qed / 10 Admitted — division proofs re-admitted for trap guard alignment |
+| **Rocq** | Partial | 291 Qed / 9 Admitted — division proofs re-admitted for trap guard alignment |
 | **Kani** | Starting | 18 bounded model checking harnesses for ARM encoder |
 | **Verus** | Starting | 8 spec functions in `synth-synthesis/src/contracts.rs`; Bazel integration via `rules_verus` |
 | **Lean** | Not started | — |
@@ -215,7 +215,7 @@ See `artifacts/verification-gaps.yaml` for the detailed gap analysis (VG-001 thr
 Mechanized proofs in Rocq 9 show that `compile_wasm_to_arm` preserves WASM semantics for each operation. The proof suite lives in `coq/Synth/` and covers ARM instruction semantics, WASM stack-machine semantics, and per-operation correctness theorems.
 
 ```
-233 Qed  /  10 Admitted
+291 Qed / 9 Admitted
   T1: 35 result-correspondence (ARM output = WASM result)  — i32 only
   T2: 142 existence-only (ARM execution succeeds, no result claim)
   T3: 10 admitted (4 division trap guards, 1 constant encoding, 2 examples,

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -1,6 +1,6 @@
 # Rocq Proof Suite — Honest Status
 
-**Last Updated:** May 2026 (v0.11.0: i64 and/or/xor T1 closed — TRUE i64 T1 PARITY, 0 i64 admits)
+**Last Updated: 2026-06-04 (v0.11.x; recount: 291 Qed / 9 Admitted, +2 admit.)
 
 ## v0.11.0 outcome: true i64 T1 parity
 
@@ -112,7 +112,7 @@ umbrella #147).
 | **T3: Admitted** | Not yet proven | 13 |
 | **Infrastructure** | Properties of integers, states, flag lemmas | 65 |
 
-**Total: 244 Qed / 8 Admitted across all files**
+**Total: 291 Qed / 9 Admitted (+2 admit.) across all files** (recount 2026-06-04)
 
 v0.10.0 PR 1: +2 T1 Qed (i64_add_correct, i64_sub_correct) and +9
 infrastructure Qed (combine_i32_unsigned, carry_split_add,

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -95,7 +95,7 @@ Some ops compile to `[]` (empty program) in the model, which is honest but trivi
 | Memory | 0 | 8 | 0 | LDR/STR + VLDR/VSTR |
 | Control/other | 6 | 29 | 0 | Simple ops, nop, drop, locals, globals |
 | ArmRefinement | 0 | 0 | 2 | Sail integration placeholders |
-| **Total** | **39** | **143** | **2** | **237 Qed / 2 Admitted** |
+| **Total** | **39** | **143** | **2** | **291 Qed / 9 Admitted** |
 
 Tier definitions:
 - **T1: Result Correspondence** -- ARM output register = WASM result value (strongest)
@@ -116,7 +116,7 @@ See [coq/STATUS.md](/coq/STATUS.md) for the full breakdown.
 | WASM semantics encoding | Y | 30+ operations modeled |
 | ARM semantics encoding | Y | 20+ instructions modeled |
 | Counterexample generation | Y | Reports failing inputs |
-| Rocq proof suite | P | 237 Qed, 2 Admitted; 39 result-correspondence proofs |
+| Rocq proof suite | P | 291 Qed, 9 Admitted; 39 result-correspondence proofs |
 | Sail ARM semantics | R | Evaluated, not implemented |
 
 ---
@@ -128,7 +128,7 @@ See [coq/STATUS.md](/coq/STATUS.md) for the full breakdown.
 | ARM Cortex-M4 (Thumb-2) | Y | Primary target, code generation works |
 | ARM Cortex-M (generic) | Y | Vector table, startup, AAPCS ABI |
 | ARM Cortex-M4F (FPU) | Y | VFP single-precision (f32) support |
-| RISC-V | N | Not implemented |
+| RISC-V | Y | RV32IMAC backend (selector+encoder+ELF); qemu_riscv32 / ESP32-C3 validated (v0.11.21+) |
 
 ---
 

--- a/docs/status/PROJECT_STATUS.md
+++ b/docs/status/PROJECT_STATUS.md
@@ -34,7 +34,7 @@ Synth is a WebAssembly-to-ARM Cortex-M compiler with mechanized correctness proo
 
 ### Rocq (Coq) Proofs
 
-233 Qed / 10 Admitted across all `.v` files in `coq/Synth/`.
+291 Qed / 9 Admitted across all `.v` files in `coq/Synth/`.
 
 | Tier | Meaning | Count |
 |------|---------|-------|


### PR DESCRIPTION
A repository-cleanliness audit (doc drift + clutter) surfaced verified mismatches between the docs and reality.

## Documentation drift (proof counts) — verified `grep coq/Synth/` = **291 Qed / 9 Admitted (+2 admit.)**
Stale in **7 places**, all corrected:
- `CLAUDE.md:90` (233/10), `README.md` ×3 (121/206/218, 233/10), `coq/STATUS.md:115` (244/8 — and self-inconsistent with its own `:18`/`:106` tables), `docs/status/PROJECT_STATUS.md:37` (233/10), `docs/status/FEATURE_MATRIX.md` ×2 (237/2).

## RISC-V backend was undocumented in the primary context file
- `CLAUDE.md` never mentioned `synth-backend-riscv` or RISC-V at all — the entire v0.11.21–v0.11.28 arc. Added to the crate map + the "What This Is" summary.
- `docs/status/FEATURE_MATRIX.md:131` said `RISC-V | Not implemented` — **false** since v0.11.21 (rv32imac, qemu_riscv32-validated). Flipped to implemented.

## .gitignore gaps (clutter)
`bazel-*` (the symlink forest) and root `*.elf` (`output.elf` reappeared as untracked cruft) were **not** ignored. Added `/bazel-*` and `/*.elf`.

Docs + `.gitignore` only — no code change.

### Noted, NOT auto-fixed (need your call)
- **5 stale agent worktrees** under `.claude/worktrees/` (~40 MB, locked, May-30) — `git worktree remove --force` is destructive and some may be live; left for manual review.
- **`scripts/repro/` orphans:** `wake_path_differential.py` has no `wake_path.wasm`/`.wat` fixture (likely dead); `control_step.wat` is missing (only `.wasm`); `div_const.wasm` is missing (only `.wat`). Tracked files — reconcile or delete deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)