### PR TITLE
feat(abi): self-contained native-pointer ABI — register-promote stack-pointer global (v0.11.30, #237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.30] - 2026-06-04
+
+**Self-contained native-pointer ABI: register-promote the stack-pointer global so a dissolved leaf seam runs with no host runtime (#237).**
+
+v0.11.29 made wasm *statics* base-independent under `--native-pointer-abi`, but a
+real loom-dissolved seam (gale's `mutex_m.loom.wasm`) also reads its **stack
+pointer** from a wasm global — `(global $__stack_pointer (mut i32) 65536)` — and
+synth lowered `global.get`/`global.set` as `[R9, idx*4]`, a load from a globals
+table that a runtime is expected to populate. A drop-in object has no such
+runtime, so `R9` is garbage and the stack mis-addresses.
+
+**Fix (opt-in `--native-pointer-abi`):**
+- The decoder now captures each global's `i32.const` initializer + mutability
+  (previously discarded).
+- The CLI identifies the stack-pointer global (mutable `i32` whose init is a
+  plausible stack top) and threads it through `CompileConfig`.
+- The selector register-promotes it: `global.get $sp` materializes
+  `__synth_wasm_data + init` (MOVW/MOVT) — the real stack top — and frame
+  arithmetic carries that base, so SP-relative loads become true memory
+  accesses. `global.set $sp` is dead in a leaf, balanced function and is
+  dropped. The SP init doubles as the static-data base that separates pointer
+  consts (`>= base`, e.g. a `&static_spinlock` call arg → relocated) from
+  frame-size scalars (`< base`, e.g. `i32.const 16` → plain immediate).
+
+**Falsification:** this release is wrong if, for a leaf host-pointer seam compiled
+with `--native-pointer-abi`, the emitted object retains any `R9`-relative globals
+access, or a frame-size constant is emitted as a `__synth_wasm_data` relocation.
+Verified on `mutex_m.loom.wasm`: 12 `__synth_wasm_data` MOVW/MOVT relocations
+(SP read + every spinlock pointer arg), **0 R9 references**, all imports +
+internal callees proper `THM_CALL` relocs. Frozen `control_step` fixture stays
+bit-identical (13/13, ORACLE PASS) — every new path is gated behind the flag.
+
 ## [0.11.29] - 2026-06-04
 
 **`--native-pointer-abi`: wasm statics as base-independent `.data`, so host-pointer drop-ins work on silicon (#237).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.29"
+version = "0.11.30"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.29"
+version = "0.11.30"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.29"
+version = "0.11.30"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.29"
+version = "0.11.30"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.29",
+    version = "0.11.30",
 )
 
 # Bazel dependencies

--- a/artifacts/gale-integration.yaml
+++ b/artifacts/gale-integration.yaml
@@ -328,3 +328,191 @@ artifacts:
         Messages transfer correctly via gale-verified msgq; MPU fault
         triggered on cross-component access; gale MQ index arithmetic
         proven correct via Verus proofs.
+
+  # ---------------------------------------------------------------------------
+  # Native-pointer ABI: host-pointer "dissolution" for loom-inlined seams
+  # (synth #181 design / #237 implementation). Lets a loom-dissolved WASM seam
+  # compile to a native-linkable object that drops into a gale/Zephyr C build
+  # with no synth runtime: host pointers stay base=0 (native *ptr deref) while
+  # wasm linear memory is relocated against __synth_wasm_data.
+  # ---------------------------------------------------------------------------
+
+  - id: GI-NPA-001
+    type: system-req
+    title: Native-pointer ABI for host-pointer drop-in seams
+    description: >
+      Under the opt-in `--native-pointer-abi`, synth shall compile a
+      loom-dissolved WASM seam (e.g. gale's mutex_m.loom.wasm
+      z_impl_k_mutex_unlock) into a native-linkable ELF object that runs
+      with NO synth runtime. A host `*ptr` argument shall deref natively
+      (linear-memory base = 0, set by the caller trampoline), while every
+      wasm-resident static (a `(data)` byte or a zero-init variable such as
+      a `static k_spinlock`) shall be addressed base-independently via a
+      single `__synth_wasm_data` section symbol (R_ARM_MOVW_ABS_NC +
+      R_ARM_MOVT_ABS). The object shall carry no dependency on a
+      runtime-populated globals table (no R9-relative globals access).
+    status: implemented
+    tags: [gale, native-pointer-abi, host-integration, loom, dissolution]
+    links:
+      - type: refines
+        target: GI-001
+      - type: derives-from
+        target: BR-003
+      - type: traces-to
+        target: gale:SYSREQ-MUT-001
+    fields:
+      req-type: interface
+      priority: must
+      verification-criteria: >
+        gale's mutex_m.loom.wasm compiled with --native-pointer-abi
+        --relocatable --all-exports yields an object with __synth_wasm_data
+        MOVW/MOVT relocations, zero R9 references, and all imports/internal
+        callees as THM_CALL relocations; default (no-flag) output unchanged.
+
+  - id: GI-NPA-002
+    type: sw-req
+    title: Register-promote the stack-pointer global (self-contained SP)
+    description: >
+      A loom-dissolved seam reads its stack pointer from a wasm global
+      `(global $__stack_pointer (mut i32) (i32.const N))`. Under
+      `--native-pointer-abi` synth shall register-promote this global rather
+      than lower it as a runtime globals-table access: `global.get $sp`
+      materializes `__synth_wasm_data + N` (MOVW/MOVT, the real stack top),
+      `global.set $sp` is eliminated as dead in a leaf, balanced function,
+      and the global's initializer N doubles as the static-data base that
+      separates pointer constants (`>= N`, relocated) from frame-size /
+      offset scalars (`< N`, plain immediate). The decoder shall capture
+      each global's initializer + mutability to enable this. This promotion
+      is gated on the presence of a stack-pointer global (without one the
+      base is 0 and the value/address split is undecidable, so the
+      transform is unsound and shall not fire).
+    status: implemented
+    tags: [gale, native-pointer-abi, stack-pointer, register-promotion]
+    links:
+      - type: derives-from
+        target: GI-NPA-001
+    fields:
+      req-type: functional
+      priority: must
+      verification-criteria: >
+        Unit tests test_237_stack_pointer_global_is_register_promoted and
+        test_decode_captures_global_initializer pass; gmutex object shows
+        the SP read as __synth_wasm_data-relative with no R9 access.
+
+  - id: GI-NPA-003
+    type: sw-req
+    title: Non-leaf stack-pointer persistence across internal calls (planned)
+    description: >
+      Extend GI-NPA-002 beyond the leaf, balanced case: a non-leaf function
+      that makes an internal WASM call across a persisted stack-pointer
+      change must keep the promoted SP value in a callee-saved register that
+      survives the call (the wasm global outliving a single `global.get`).
+      This is the analogue of the RISC-V leaf-only -> non-leaf arc and is
+      the next increment to be implemented alongside gale once a non-leaf
+      host-pointer seam is exercised. Until then, synth covers leaf seams
+      (gale's exported mutex/sem seams, whose only calls are host imports).
+    status: proposed
+    tags: [gale, native-pointer-abi, non-leaf, follow-up, planned]
+    links:
+      - type: derives-from
+        target: GI-NPA-001
+    fields:
+      req-type: functional
+      priority: should
+      verification-criteria: >
+        A non-leaf host-pointer seam compiled with --native-pointer-abi
+        preserves the promoted SP across internal wasm calls and matches the
+        wasmtime reference under the differential oracle.
+
+  - id: GI-NPA-VER-001
+    type: sys-verification
+    title: "Object-level oracle: gmutex self-containment (clean-room confirmed)"
+    description: >
+      Independent (clean-room) verification that the native-pointer ABI
+      produces a self-contained object for gale's mutex_m.loom.wasm. A fresh
+      build compiled gmutex with --native-pointer-abi --relocatable
+      --all-exports and adjudicated: (C1) the SP read is materialized via
+      R_ARM_MOVW_ABS_NC + R_ARM_MOVT_ABS vs __synth_wasm_data; (C2) zero R9
+      references in the disassembly; (C3) __synth_wasm_data defined in .bss;
+      (C5) no __synth_wasm_data relocations without the flag (opt-in);
+      (C7) 12 __synth_wasm_data relocations total. All confirmed by an
+      isolated oracle subagent; control_step frozen fixture bit-identical.
+    status: implemented
+    tags: [gale, native-pointer-abi, oracle, clean-room, differential]
+    links:
+      - type: verifies
+        target: GI-NPA-001
+    fields:
+      method: analysis
+      preconditions:
+        - "synth binary built (cargo build -p synth-cli)"
+        - "arm-none-eabi-objdump available"
+        - "gale mutex_m.loom.wasm at /tmp/gmutex.wasm"
+      steps:
+        - "Compile gmutex with --native-pointer-abi --relocatable --all-exports"
+        - "objdump -r: confirm __synth_wasm_data MOVW/MOVT relocs (count 12)"
+        - "objdump -d: confirm zero r9 references"
+        - "objdump -t: confirm __synth_wasm_data in .bss"
+        - "Compile without the flag: confirm zero __synth_wasm_data relocs"
+      pass-criteria: >
+        C1, C2, C3, C5, C7 all CONFIRMED by an independent oracle;
+        control_step frozen fixture stays bit-identical (13/13,
+        control_step_differential.py ORACLE PASS).
+
+  - id: GI-NPA-VER-002
+    type: sw-verification
+    title: "Unit tests: global capture + stack-pointer register-promotion"
+    description: >
+      Unit-level verification of the SP register-promotion mechanism:
+      test_decode_captures_global_initializer (decoder captures the global
+      initializer + mutability), test_237_stack_pointer_global_is_register_promoted
+      (global.get $sp relocates to __synth_wasm_data, the static-pointer const
+      relocates, the frame-size const 16 stays a plain immediate, and the
+      promoted global never touches R9), and
+      test_237_static_store_is_symbol_relative_under_native_pointer_abi (the
+      gating that keeps the value/address split sound when no SP global is
+      present).
+    status: implemented
+    tags: [gale, native-pointer-abi, unit-test, soundness]
+    links:
+      - type: verifies
+        target: GI-NPA-002
+    fields:
+      method: test
+      preconditions:
+        - "cargo test workspace"
+      steps:
+        - "cargo test -p synth-core test_decode_captures_global_initializer"
+        - "cargo test -p synth-synthesis test_237_stack_pointer_global_is_register_promoted"
+        - "cargo test -p synth-synthesis test_237_static_store_is_symbol_relative_under_native_pointer_abi"
+      pass-criteria: >
+        All three tests report 'test result: ok'.
+
+  - id: GI-NPA-VER-003
+    type: sys-verification
+    title: "On-target differential: dissolved gmutex vs native reference (planned)"
+    description: >
+      End-to-end verification that the native-pointer-ABI object, linked
+      with gale's host trampoline (push {r11,lr}; mov.w r11,#0; bl; pop)
+      and the kiln bridge, executes correctly on the target / emulator and
+      matches the native reference behavior (native ref 124) for
+      z_impl_k_mutex_unlock. This is the gale-side validation step that
+      closes synth #237 together with GI-NPA-003 (non-leaf support).
+    status: proposed
+    tags: [gale, native-pointer-abi, on-target, differential, planned]
+    links:
+      - type: verifies
+        target: GI-NPA-001
+    fields:
+      method: simulation
+      preconditions:
+        - "gmutex object compiled with --native-pointer-abi"
+        - "gale host trampoline + kiln bridge"
+        - "qemu/Renode Cortex-M4 or hardware"
+      steps:
+        - "Link gmutex.o + kiln_bridge.o + gale trampoline"
+        - "Execute z_impl_k_mutex_unlock under emulation"
+        - "Compare result/side-effects against the native reference (124)"
+      pass-criteria: >
+        Linked dissolved seam runs with no runtime and matches the native
+        reference behavior; no MPU fault from mis-addressed statics or stack.

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.29" }
+synth-core = { path = "../synth-core", version = "0.11.30" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.29" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.29" }
+synth-core = { path = "../synth-core", version = "0.11.30" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.30" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.29" }
+synth-core = { path = "../synth-core", version = "0.11.30" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.29" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.29", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.30" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.30", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -174,6 +174,14 @@ fn compile_wasm_to_arm(
         selector.set_relocatable(config.relocatable);
         // #237: native-pointer ABI — wasm statics become __synth_wasm_data-relative.
         selector.set_native_pointer_abi(config.native_pointer_abi, config.linear_memory_bytes);
+        // Stack-pointer promotion is meaningful only under the native-pointer ABI;
+        // gating here keeps every non-native compile (all frozen fixtures) on the
+        // legacy R9 globals-table path, bit-identical.
+        if config.native_pointer_abi
+            && let Some((sp_idx, sp_init)) = config.stack_pointer_global
+        {
+            selector.set_native_pointer_stack(sp_idx, sp_init);
+        }
         selector
             .select_with_stack(wasm_ops, num_params)
             .map_err(|e| format!("instruction selection failed: {}", e))

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.29" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.29" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.29" }
-synth-backend = { path = "../synth-backend", version = "0.11.29" }
+synth-core = { path = "../synth-core", version = "0.11.30" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.30" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.30" }
+synth-backend = { path = "../synth-backend", version = "0.11.30" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.29", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.29", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.29", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.30", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.30", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.30", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.29", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.30", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -18,7 +18,9 @@ use synth_core::SafetyManifest;
 use synth_core::backend::{Backend, BackendRegistry, CompileConfig, SafetyBounds};
 use synth_core::target::TargetSpec;
 use synth_core::wasm_decoder::ImportEntry;
-use synth_synthesis::{FunctionOps, WasmMemory, WasmOp, decode_wasm_functions, decode_wasm_module};
+use synth_synthesis::{
+    FunctionOps, WasmGlobal, WasmMemory, WasmOp, decode_wasm_functions, decode_wasm_module,
+};
 use tracing::{Level, info};
 use wast::parser::{self, ParseBuffer};
 use wast::{Wast, WastDirective};
@@ -1648,6 +1650,24 @@ fn extract_module_from_wast(contents: &str) -> Result<Vec<u8>> {
 /// resolves. Used so `--all-exports --relocatable` emits a self-contained object
 /// containing every internal callee a dissolved export needs (e.g. a panic
 /// helper loom left un-inlined), instead of leaving it as an undefined symbol.
+/// #237: identify the wasm stack-pointer global for the native-pointer ABI.
+///
+/// The stack-pointer global is the mutable `i32` global whose initializer is a
+/// plausible stack top: a positive constant no larger than the linear-memory
+/// extent (the SP starts at the boundary between the descending stack and the
+/// static-data region). When several qualify, the highest initializer wins —
+/// the stack pointer sits at the top of the wasm address space. Returns
+/// `(index, init_value)`, or `None` if the module has no such global (in which
+/// case the legacy R9 globals-table path is used).
+fn identify_stack_pointer_global(globals: &[WasmGlobal], linmem_bytes: u32) -> Option<(u32, i32)> {
+    globals
+        .iter()
+        .filter(|g| g.mutable)
+        .filter_map(|g| g.init_i32.map(|v| (g.index, v)))
+        .filter(|&(_, v)| v > 0 && (v as u32) <= linmem_bytes)
+        .max_by_key(|&(_, v)| v)
+}
+
 fn reachable_from_exports(
     funcs: &[FunctionOps],
     num_imports: u32,
@@ -1719,6 +1739,7 @@ fn compile_all_exports(
         func_arg_counts,
         type_arg_counts,
         all_data_segments, // #237: active data segments, for --native-pointer-abi
+        stack_pointer_global_opt, // #237: (index, init) of the SP global, if any
     ) = if path.extension().is_some_and(|ext| ext == "wast") {
         info!("Parsing WAST (extracting all modules)...");
         let contents = String::from_utf8(file_bytes).context("WAST file is not valid UTF-8")?;
@@ -1810,6 +1831,7 @@ fn compile_all_exports(
             merged_func_arg_counts,
             merged_type_arg_counts,
             Vec::new(), // #237: data segments not threaded for WAST (single-module .wasm path covers it)
+            None,       // #237: SP-global promotion is single-module .wasm only
         )
     } else {
         let wasm_bytes = if path.extension().is_some_and(|ext| ext == "wat") {
@@ -1833,6 +1855,10 @@ fn compile_all_exports(
         let imports = module.imports;
         let num_imports = module.num_imported_funcs;
         let data_segs = module.data_segments; // #237: capture before `functions` is moved
+        // #237: identify the stack-pointer global for native-pointer promotion.
+        // linmem extent gates the "plausible stack top" heuristic.
+        let linmem_bytes = memories.first().map(|m| m.initial_bytes()).unwrap_or(0);
+        let sp_global = identify_stack_pointer_global(&module.globals, linmem_bytes);
         // #235: compile not just the exports but every internal (non-imported)
         // function reachable from them via `call`. A loom-dissolved export can
         // retain a non-inlinable callee (e.g. a panic helper from an overflow
@@ -1856,6 +1882,7 @@ fn compile_all_exports(
             func_arg_counts,
             type_arg_counts,
             data_segs,
+            sp_global,
         )
     };
 
@@ -1920,6 +1947,9 @@ fn compile_all_exports(
         // become __synth_wasm_data-relative across the whole linear memory.
         native_pointer_abi,
         linear_memory_bytes: all_memories.first().map(|m| m.initial_bytes()).unwrap_or(0),
+        // #237: register-promote the stack-pointer global (only consulted under
+        // native_pointer_abi) so the dissolved object needs no R9 globals table.
+        stack_pointer_global: stack_pointer_global_opt,
         ..CompileConfig::default()
     };
 

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -127,6 +127,13 @@ pub struct CompileConfig {
     /// static → symbol-relative; any address beyond it is a runtime host pointer
     /// → `[R11=0 + addr]`.
     pub linear_memory_bytes: u32,
+
+    /// #237: the wasm stack-pointer global as `(index, init_value)`, if the
+    /// module has one. Under `native_pointer_abi` the backend register-promotes
+    /// it: `global.get` materializes `__synth_wasm_data + init` (the real stack
+    /// top) and the init value doubles as the static-data base that separates
+    /// pointer consts (`>= init`) from frame-size scalars (`< init`).
+    pub stack_pointer_global: Option<(u32, i32)>,
 }
 
 impl CompileConfig {
@@ -157,6 +164,7 @@ impl Default for CompileConfig {
             relocatable: false,
             native_pointer_abi: false,
             linear_memory_bytes: 0,
+            stack_pointer_global: None,
         }
     }
 }

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -47,6 +47,21 @@ pub struct WasmMemory {
     pub shared: bool,
 }
 
+/// A WASM global's declaration — its initial value and mutability (#237).
+/// Needed so the native-pointer ABI can recognize a global whose initializer is
+/// a linear-memory address (e.g. `$__stack_pointer = 65536`) and make it
+/// `__synth_wasm_data`-relative, rather than reading it from an R9 globals table
+/// the self-contained drop-in object can't rely on.
+#[derive(Debug, Clone)]
+pub struct WasmGlobal {
+    /// Global index (defined globals; imported globals are not counted here).
+    pub index: u32,
+    /// The `i32.const` initializer value (other init exprs decode to `None`).
+    pub init_i32: Option<i32>,
+    /// Whether the global is mutable.
+    pub mutable: bool,
+}
+
 impl WasmMemory {
     /// Get initial size in bytes
     pub fn initial_bytes(&self) -> u32 {
@@ -82,6 +97,11 @@ pub struct DecodedModule {
     /// Used by `call_indirect`, whose callee arg count comes from the static
     /// type index (issue #195).
     pub type_arg_counts: Vec<u32>,
+    /// Defined globals with their initializers (#237). Empty if the module has
+    /// no global section. Used by the native-pointer ABI to make a global whose
+    /// initializer is a linear-memory address (e.g. `$__stack_pointer`)
+    /// self-contained rather than table-relative.
+    pub globals: Vec<WasmGlobal>,
 }
 
 /// Decode a WASM binary and extract functions, memory, and data segments
@@ -89,6 +109,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     let mut functions = Vec::new();
     let mut memories = Vec::new();
     let mut data_segments = Vec::new();
+    let mut globals: Vec<WasmGlobal> = Vec::new();
     let mut imports = Vec::new();
     let mut func_index = 0u32;
     let mut num_imported_funcs = 0u32;
@@ -166,6 +187,26 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                     });
                 }
             }
+            Payload::GlobalSection(reader) => {
+                // #237: capture each defined global's i32 initializer + mutability.
+                // The init is a const expr; we only decode a leading `i32.const`
+                // (the shape `$__stack_pointer`/data-layout globals use). Anything
+                // else (global.get, f32/f64, etc.) records `init_i32: None` and is
+                // left to the table-relative path.
+                for (idx, global) in reader.into_iter().enumerate() {
+                    let global = global.context("Failed to parse global")?;
+                    let mut init_i32 = None;
+                    let mut ops = global.init_expr.get_operators_reader();
+                    if let Ok(wasmparser::Operator::I32Const { value }) = ops.read() {
+                        init_i32 = Some(value);
+                    }
+                    globals.push(WasmGlobal {
+                        index: idx as u32,
+                        init_i32,
+                        mutable: global.ty.mutable,
+                    });
+                }
+            }
             Payload::DataSection(reader) => {
                 for data in reader {
                     let data = data.context("Failed to parse data segment")?;
@@ -213,6 +254,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
         num_imported_funcs,
         func_arg_counts,
         type_arg_counts,
+        globals,
     })
 }
 
@@ -1231,5 +1273,30 @@ mod tests {
         let ops = &functions[0].ops;
         assert!(ops.contains(&WasmOp::I32x4Add));
         assert!(ops.contains(&WasmOp::I32x4Mul));
+    }
+
+    /// #237: the decoder captures a global's `i32.const` initializer + mutability,
+    /// so the native-pointer ABI can recognize the stack-pointer global.
+    #[test]
+    fn test_decode_captures_global_initializer() {
+        let wat = r#"
+            (module
+                (memory 2)
+                (global $__stack_pointer (mut i32) (i32.const 65536))
+                (global $immutable_const i32 (i32.const 7))
+                (func (export "f") (result i32) global.get 0)
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
+        let module = decode_wasm_module(&wasm).expect("Failed to decode");
+
+        assert_eq!(module.globals.len(), 2, "both globals captured");
+        let sp = &module.globals[0];
+        assert_eq!(sp.index, 0);
+        assert_eq!(sp.init_i32, Some(65536), "stack-pointer init captured");
+        assert!(sp.mutable, "stack pointer is mutable");
+        let c = &module.globals[1];
+        assert_eq!(c.init_i32, Some(7));
+        assert!(!c.mutable, "second global is immutable");
     }
 }

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.29" }
+synth-core = { path = "../synth-core", version = "0.11.30" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.29" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.30" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.29" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.29" }
-synth-opt = { path = "../synth-opt", version = "0.11.29" }
+synth-core = { path = "../synth-core", version = "0.11.30" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.30" }
+synth-opt = { path = "../synth-opt", version = "0.11.30" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -1194,6 +1194,20 @@ pub struct InstructionSelector {
     /// (initialized `(data)` + zero-init/BSS). A const address below this is a
     /// static (symbol-relative under the flag).
     linear_memory_bytes: u32,
+    /// #237: the lowest wasm address that is a *static-data* address rather than
+    /// a scalar/offset. When a module carries a stack-pointer global, its
+    /// initializer (e.g. `65536`) is simultaneously the stack top and the base
+    /// of the static-data region: addresses `>= wasm_data_base` are pointers
+    /// (relocated to `__synth_wasm_data + C`), values `< wasm_data_base` are
+    /// frame sizes / field offsets (`i32.const 16`) and stay plain immediates.
+    /// Defaults to `0` (relocate everything inside linear memory) for modules
+    /// with no stack-pointer global.
+    wasm_data_base: u32,
+    /// #237: the stack-pointer global `(index, init_value)`, if identified. Under
+    /// the native-pointer ABI a leaf, balanced function register-promotes it:
+    /// `global.get` materializes `__synth_wasm_data + init` (the real stack top),
+    /// `global.set` is dead (no wasm reader; host imports don't touch wasm SP).
+    sp_global: Option<(u32, i32)>,
     /// AAPCS argument count per function, indexed by the *full* WASM function
     /// index (imports first, then locals). Plumbed from the frontend's type +
     /// function sections (issue #195). `func_arg_counts[i]` = number of integer
@@ -1233,6 +1247,8 @@ impl InstructionSelector {
             relocatable: false,
             native_pointer_abi: false,
             linear_memory_bytes: 0,
+            wasm_data_base: 0,
+            sp_global: None,
             func_arg_counts: Vec::new(),
             type_arg_counts: Vec::new(),
             fpu: None,
@@ -1255,6 +1271,8 @@ impl InstructionSelector {
             relocatable: false,
             native_pointer_abi: false,
             linear_memory_bytes: 0,
+            wasm_data_base: 0,
+            sp_global: None,
             func_arg_counts: Vec::new(),
             type_arg_counts: Vec::new(),
             fpu: None,
@@ -1299,7 +1317,21 @@ impl InstructionSelector {
         if !self.native_pointer_abi {
             return None;
         }
-        (addr < self.linear_memory_bytes).then_some(addr as i32)
+        // A const is a static-data *address* only within
+        // `[wasm_data_base, linear_memory_bytes)`. The lower bound excludes
+        // frame sizes / field offsets (`i32.const 16`) that live below the
+        // stack-pointer init; the upper bound excludes runtime host pointers.
+        (self.wasm_data_base <= addr && addr < self.linear_memory_bytes).then_some(addr as i32)
+    }
+
+    /// #237: register the stack-pointer global discovered by the backend. Its
+    /// initializer doubles as the static-data base (`wasm_data_base`), so const
+    /// addresses at/above it relocate while frame-size scalars below it don't.
+    pub fn set_native_pointer_stack(&mut self, sp_index: u32, sp_init: i32) {
+        self.sp_global = Some((sp_index, sp_init));
+        if sp_init >= 0 {
+            self.wasm_data_base = sp_init as u32;
+        }
     }
 
     /// #237: emit a `__synth_wasm_data + addend` address into `rd` (MOVW+MOVT,
@@ -4935,6 +4967,23 @@ impl InstructionSelector {
                 I32Const(val) => {
                     let dst = alloc_temp_safe(&mut next_temp, &stack, &live_params)?;
                     let uval = *val as u32;
+                    // #237: under the native-pointer ABI, when a stack-pointer
+                    // global establishes a real static-data base, a const at/above
+                    // it is a wasm pointer (e.g. a `&static_spinlock` argument),
+                    // not a scalar — emit it as `__synth_wasm_data + uval` so it
+                    // resolves at link time independent of any runtime base. This
+                    // is gated on `sp_global`: without one the base is 0 and every
+                    // const (including stored *values*) would look like an address,
+                    // which is unsound — those modules use the positional
+                    // load/store promotion only.
+                    if self.sp_global.is_some()
+                        && let Some(addend) = self.static_data_addend(uval)
+                    {
+                        Self::emit_wasm_data_addr(&mut instructions, dst, addend, idx);
+                        cf.add_instruction();
+                        stack.push(StackVal::i32(dst));
+                        continue;
+                    }
                     let inverted = !uval;
                     if uval <= 0xFFFF {
                         // 0..65535: MOVW handles the full 16-bit range
@@ -6955,6 +7004,20 @@ impl InstructionSelector {
                 }
 
                 GlobalGet(global_idx) => {
+                    // #237: under the native-pointer ABI, reading the stack-pointer
+                    // global yields the real stack top — `__synth_wasm_data + init`
+                    // — register-promoted, so the dissolved object needs no runtime
+                    // R9 globals table. Frame arithmetic on this real pointer keeps
+                    // the base; SP-relative loads become true memory accesses.
+                    if let Some((sp_idx, sp_init)) = self.sp_global
+                        && *global_idx == sp_idx
+                    {
+                        let dst = alloc_temp_safe(&mut next_temp, &stack, &live_params)?;
+                        Self::emit_wasm_data_addr(&mut instructions, dst, sp_init, idx);
+                        cf.add_instruction();
+                        stack.push(StackVal::i32(dst));
+                        continue;
+                    }
                     // Load global value from globals table (R9 = globals base).
                     // Each i32 global occupies 4 bytes at offset index * 4.
                     let dst = alloc_temp_safe(&mut next_temp, &stack, &live_params)?;
@@ -6979,6 +7042,17 @@ impl InstructionSelector {
                         &live_params,
                         idx,
                     )?;
+                    // #237: a write to the register-promoted stack-pointer global is
+                    // dead in a leaf, balanced function — the only readers are this
+                    // function's own `global.get`s (which re-materialize the init
+                    // address) and host imports (which never touch wasm SP). Pop the
+                    // operand (preserving stack discipline) and drop the store.
+                    if let Some((sp_idx, _)) = self.sp_global
+                        && *global_idx == sp_idx
+                    {
+                        let _ = val;
+                        continue;
+                    }
                     instructions.push(ArmInstruction {
                         op: ArmOp::Str {
                             rd: val,
@@ -14588,6 +14662,62 @@ mod tests {
         assert!(
             !oor.iter().any(is_data_sym),
             "an address outside any data segment stays base-relative. got: {oor:#?}"
+        );
+    }
+
+    /// #237: register-promote the stack-pointer global so a dissolved leaf object
+    /// is self-contained (no R9 globals table). Mirrors gmutex's prologue:
+    /// `global.get $sp; i32.const 16; i32.sub; global.set $sp` plus a
+    /// `i32.const 65536` static-pointer call argument. Asserts:
+    ///  - `global.get $sp` materializes `__synth_wasm_data + init` (MovwSym/MovtSym)
+    ///  - the static-pointer const (>= data_base) is relocated likewise
+    ///  - the frame-size const `16` (< data_base) stays a plain `Movw` immediate
+    ///  - the promoted global never touches the R9 globals table
+    #[test]
+    fn test_237_stack_pointer_global_is_register_promoted() {
+        let db = RuleDatabase::new();
+        // (memory 2) = 131072 bytes; (global $sp (mut i32) 65536).
+        let ops = vec![
+            WasmOp::GlobalGet(0),    // read SP → real stack top
+            WasmOp::I32Const(16),    // frame size (scalar, must stay immediate)
+            WasmOp::I32Sub,          // SP - 16
+            WasmOp::GlobalSet(0),    // write SP (dead in leaf-balanced)
+            WasmOp::I32Const(65536), // &static_spinlock (pointer, must relocate)
+            WasmOp::End,
+        ];
+        let mut sel = InstructionSelector::new(db.rules().to_vec());
+        sel.set_relocatable(true);
+        sel.set_native_pointer_abi(true, 131072);
+        sel.set_native_pointer_stack(0, 65536);
+        let out = sel.select_with_stack(&ops, 1).unwrap();
+
+        let data_syms = out
+            .iter()
+            .filter(|i| {
+                matches!(&i.op, ArmOp::MovwSym { symbol, .. } | ArmOp::MovtSym { symbol, .. }
+                    if symbol == "__synth_wasm_data")
+            })
+            .count();
+        // Two materializations × (MovwSym + MovtSym): the SP read and the
+        // static-pointer const.
+        assert!(
+            data_syms >= 4,
+            "expected SP-read + static-ptr both __synth_wasm_data-relative (>=4 sym ops); got {data_syms}: {out:#?}"
+        );
+        // The frame-size 16 must remain a plain immediate, never relocated.
+        assert!(
+            out.iter()
+                .any(|i| matches!(&i.op, ArmOp::Movw { imm16: 16, .. })),
+            "frame size 16 must stay a plain Movw immediate: {out:#?}"
+        );
+        // The promoted SP global must not read/write the R9 globals table.
+        let touches_r9 = out.iter().any(|i| match &i.op {
+            ArmOp::Ldr { addr, .. } | ArmOp::Str { addr, .. } => addr.base == Reg::R9,
+            _ => false,
+        });
+        assert!(
+            !touches_r9,
+            "register-promoted SP global must not touch the R9 globals table: {out:#?}"
         );
     }
 }

--- a/crates/synth-synthesis/src/lib.rs
+++ b/crates/synth-synthesis/src/lib.rs
@@ -27,7 +27,7 @@ pub use rules::{
     RuleDatabase, ShiftType, SynthesisRule, VfpReg, WasmOp,
 };
 pub use wasm_decoder::{
-    DecodedModule, FunctionOps, WasmMemory, decode_wasm_functions, decode_wasm_module,
+    DecodedModule, FunctionOps, WasmGlobal, WasmMemory, decode_wasm_functions, decode_wasm_module,
 };
 
 // Stub for PoC

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.29" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.29" }
-synth-opt = { path = "../synth-opt", version = "0.11.29" }
+synth-core = { path = "../synth-core", version = "0.11.30" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.30" }
+synth-opt = { path = "../synth-opt", version = "0.11.30" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.29", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.30", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Part of #237 — the self-contained global-promotion the v0.11.29 substrate set up

v0.11.29 (#238) made wasm **statics** base-independent under `--native-pointer-abi`. But a real loom-dissolved seam — gale's `mutex_m.loom.wasm` — also reads its **stack pointer** from a wasm global:

```wat
(global $__stack_pointer (mut i32) (i32.const 65536))
...
global.get $__stack_pointer   ;; synth lowered this as [R9, idx*4]
i32.const 16  i32.sub  local.tee 1  global.set $__stack_pointer
```

synth lowered `global.get`/`global.set` as `Ldr/Str [R9, idx*4]` — a load from a globals table a **runtime** is expected to populate. A drop-in object has no runtime, so `R9` is garbage and the stack mis-addresses.

## Fix (opt-in `--native-pointer-abi`)

- **Decoder** captures each global's `i32.const` initializer + mutability (`WasmGlobal`; `DecodedModule.globals`) — previously discarded entirely.
- **CLI** identifies the stack-pointer global (mutable `i32` whose init is a plausible stack top, `0 < init ≤ linmem`) and threads it through `CompileConfig`.
- **Selector** register-promotes it:
  - `global.get $sp` → materialize `__synth_wasm_data + init` (MOVW/MOVT), the **real** stack top. Frame arithmetic carries that base, so SP-relative loads become true memory accesses.
  - `global.set $sp` → **dead** in a leaf, balanced function (only readers are this function's own `global.get`, which re-materialize, and host imports, which never touch wasm SP). Pop operand, drop the store.
  - The SP init **doubles as the static-data base**: a const `≥ base` is a wasm pointer (`&static_spinlock` call arg → relocated); a const `< base` is a frame size / field offset (`i32.const 16` → plain immediate). Gated on `sp_global` being present — without a base every const (incl. stored *values*) would look like an address, which is unsound (caught by an existing test).

## Oracle — `mutex_m.loom.wasm`, object-level

```
12 × R_ARM_MOVW/MOVT_ABS  __synth_wasm_data   (SP read + every spinlock ptr arg)
 0 × R9 references                            (no globals-table dependency)
 N × R_ARM_THM_CALL        k_spin_lock/...     (imports + internal callees)
 __synth_wasm_data  → .bss (NOBITS)
```

**Frozen fixtures:** `control_step` bit-identical, 13/13 ORACLE PASS — every new path is gated behind `--native-pointer-abi`.

## Falsification

Wrong if, for a leaf host-pointer seam compiled with `--native-pointer-abi`, the object retains any `R9`-relative globals access, or a frame-size constant is emitted as a `__synth_wasm_data` relocation.

## Scope / follow-up

**Leaf + balanced-SP only** — same staging as the RISC-V leaf-only arc. A non-leaf function that makes an internal wasm call across a persisted SP change (the global outliving a single `global.get`) needs a promoted-SP register that survives the call; that's the next increment. gmutex's exported seam is leaf (its only calls are host imports), so the named oracle is fully covered. Leaving #237 open for the on-target differential (native ref 124, emulated) + the non-leaf follow-up.

## Tests

- `test_decode_captures_global_initializer` (synth-core)
- `test_237_stack_pointer_global_is_register_promoted` (synth-synthesis): SP read + static-ptr relocate, frame-size 16 stays immediate, no R9 touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)