### PR TITLE
docs: add North Star roadmap (VCR-*) to README + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,33 @@ correspondence), T2 (existence-only), T3 (admitted). The remaining admits are
 division/trap-guard and i64 boundary lemmas tracked in `coq/STATUS.md`.
 All i32 operations (arithmetic, division, comparison, bit-manip, shift/rotate) have T1 proofs.
 
+## North Star (roadmap)
+
+**Replace synth's patch-accreting code generator with foundationally-verified,
+allocator-robust infrastructure — correctness from construction, not an
+ever-growing pile of locally-correct patches.** The recurring greedy fixes
+(reciprocal-mult cost-gate, register-exhaustion hard-fail, the "selector missed
+an op" class #223/#226/#232) are symptoms of two single-pass hand-written
+components: the instruction selector and the register allocator. Filed as the
+phased, parallelizable **VCR-\*** rivet program (epic #242,
+`artifacts/verified-codegen-roadmap.yaml`), built incrementally — behavior
+frozen and oracle-gated every step:
+
+- **Track A (core):** `VCR-RA-001` SSA allocator with spilling (step 1 landed,
+  PR #243: def/use + liveness in `crates/synth-synthesis/src/liveness.rs`) →
+  `VCR-SEL-001` Rocq-discharged verified selector DSL.
+- **Track B (semantics):** `VCR-ISA-001` Sail-generated Rocq ISA model;
+  `VCR-WASM-001` WasmCert-Coq source semantics.
+- **Track C (validation, now):** `VCR-ORACLE-001` coverage-guided,
+  theorem-linked differential oracle.
+- **Gate `VCR-VER-001`:** a previously load-bearing greedy-fix becomes
+  revertable, full differential bit-identical, cycles equal-or-better.
+
+Silicon target (gale #209, G474RE): `flat_flight` 315 cyc vs 99 native (3.18×),
+61 % redundant const materializations, 17 spills — const-CSE + liveness-based
+spilling, pays on ARM and RISC-V at once. See the README "Roadmap — North Star"
+section for the full table.
+
 ## Conventions
 
 - Rust edition 2024, MSRV 1.88

--- a/README.md
+++ b/README.md
@@ -241,6 +241,27 @@ See [coq/STATUS.md](coq/STATUS.md) for the per-file coverage matrix.
 
 The `synth-verify` crate encodes WASM and ARM semantics as Z3 formulas and checks per-rule equivalence. The `--verify` CLI flag invokes this after compilation; `synth verify` provides standalone validation. 53 Z3 verification tests pass in CI.
 
+## Roadmap — North Star
+
+**Replace synth's patch-accreting code generator with foundationally-verified, allocator-robust infrastructure — so correctness comes from construction, not from an ever-growing pile of locally-correct patches.**
+
+The recurring greedy fixes (the reciprocal-multiply cost-gate, the register-exhaustion hard-fail, the "selector missed an op" class behind #223/#226/#232) are all symptoms of one root cause: two single-pass, hand-written components — the **instruction selector** and the **register allocator**. The fix is filed as a phased, parallelizable rivet program (**VCR-\***, [epic #242](https://github.com/pulseengine/synth/issues/242), `artifacts/verified-codegen-roadmap.yaml`), built incrementally alongside the per-issue cadence — never a big-bang rewrite, **behavior frozen and oracle-gated at every step**.
+
+The one-sentence version: moving synth's correctness from *"we patched every bug we found"* to *"the structure makes the bug unrepresentable."*
+
+| Track | Item | What it does | Status |
+|-------|------|--------------|--------|
+| **A — codegen core** | `VCR-RA-001` | SSA register allocator with spilling — kills the exhaustion hard-fail that *forces* the cost-gates | step 1 landed ([#243](https://github.com/pulseengine/synth/pull/243): def/use + liveness primitive) |
+| | `VCR-SEL-001` | Rocq-discharged verified selector DSL — *"ISLE with a proof-assistant backend"*; a missing lowering rule becomes an enumerable coverage gap, not a silent miscompile | proposed |
+| **B — authoritative semantics** | `VCR-ISA-001` | Re-base ARM/RISC-V semantics on Sail-generated Rocq (the official ISA spec) | proposed |
+| | `VCR-WASM-001` | Anchor WASM source semantics on WasmCert-Coq | proposed |
+| **C — validation (now)** | `VCR-ORACLE-001` | Coverage-guided, theorem-linked differential oracle | proposed |
+| **Gate** | `VCR-VER-001` | Success = a previously load-bearing greedy-fix becomes *revertable*, with the full differential bit-identical and cycles equal-or-better | proposed |
+
+**Silicon target for Track A** (gale, #209, on NUCLEO-G474RE): the fully-composed `flat_flight` is 588 B / 180 instrs, **315 cyc vs 99 native (3.18×)** — with **61 % redundant constant materializations** (the int8 saturation clamps `#0x7e`/`#0x7f` re-materialized 6× each) and **17 stack spills**. Both levers — const-CSE/rematerialization-avoidance and liveness-based spill allocation — sit squarely on the allocator track and pay off on ARM *and* RISC-V at once.
+
+**What it buys us:** synth stops being a real-ish compiler held together by oracle-gated patches and becomes a genuinely best-in-class *verified* compiler — and the verified selector DSL is the part that is potentially novel/publishable, not just catching up to Cranelift.
+
 ## Crate Map
 
 | Crate | Purpose |


### PR DESCRIPTION
Documents the verified-codegen north star where contributors and future sessions will see it.

**North Star:** replace synth's patch-accreting code generator with foundationally-verified, allocator-robust infrastructure — correctness from construction, not an ever-growing pile of locally-correct patches. The recurring greedy fixes (reciprocal-mult cost-gate, register-exhaustion hard-fail, the "selector missed an op" class #223/#226/#232) are symptoms of two single-pass hand-written components: the instruction selector and the register allocator.

## Changes
- **README.md** — new "Roadmap — North Star" section after Formal Verification: the thesis, the one-sentence framing ("the structure makes the bug unrepresentable"), the **VCR-\*** track table with statuses, and gale's silicon target for Track A.
- **CLAUDE.md** — a "North Star (roadmap)" pointer after Proof Status so future sessions carry the program context.

## Track table (as documented)
| Track | Item | Status |
|-------|------|--------|
| A core | `VCR-RA-001` SSA allocator w/ spilling | step 1 landed (#243) |
| A core | `VCR-SEL-001` Rocq-discharged verified selector DSL | proposed |
| B semantics | `VCR-ISA-001` Sail→Rocq · `VCR-WASM-001` WasmCert-Coq | proposed |
| C validation | `VCR-ORACLE-001` coverage-guided oracle | proposed |
| Gate | `VCR-VER-001` greedy-fix becomes revertable | proposed |

**Silicon target (gale #209, G474RE):** `flat_flight` 315 cyc vs 99 native (3.18×), 61% redundant const materializations (the `#0x7e`/`#0x7f` clamp constants ×6 each), 17 spills — const-CSE + liveness-based spilling, pays on ARM and RISC-V at once.

Refs epic #242, PR #243, #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)