### PR TITLE
feat(synthesis): const-CSE detection + function-wide application (VCR-RA-001)

### DIFF
--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -221,6 +221,81 @@ pub fn local_dead_defs(instrs: &[ArmInstruction]) -> Option<Vec<usize>> {
     Some(dead)
 }
 
+/// A constant materialization whose value is **already available** in a live
+/// register at that point — a redundant re-derivation (const-CSE opportunity).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedundantConst {
+    /// Index of the redundant materialization in the instruction stream.
+    pub index: usize,
+    /// The constant value being (re-)materialized.
+    pub value: i32,
+    /// A register that already holds `value` at this point.
+    pub available_in: Reg,
+}
+
+/// If `op` is a single-instruction constant materialization, the `(rd, value)`
+/// it produces. Only the 16-bit `Movw` / immediate `Mov` forms are recognized —
+/// these are the ones the hot paths re-materialize (saturation clamps `#0x7e` /
+/// `#0x7f`, shift amounts, `#0`). A `Movt` builds the high half of a 32-bit
+/// constant; it is deliberately *not* recognized here and instead invalidates
+/// the tracked value (handled by the caller via `reg_effect`), so a
+/// `Movw;Movt` pair is never mistaken for a pure 16-bit constant.
+fn const_materialization(op: &ArmOp) -> Option<(Reg, i32)> {
+    match op {
+        ArmOp::Movw { rd, imm16 } => Some((*rd, *imm16 as i32)),
+        ArmOp::Mov {
+            rd,
+            op2: Operand2::Imm(v),
+        } => Some((*rd, *v)),
+        _ => None,
+    }
+}
+
+/// Redundant constant materializations within a straight-line block: each
+/// instruction that re-derives a constant **already resident** in a register
+/// (not clobbered since). This is the analysis behind const-CSE /
+/// rematerialization-avoidance — the dominant hot-path waste gale measured on
+/// `flat_flight` (the int8 clamps `#0x7e` / `#0x7f` materialized 6× each,
+/// 61% of all constant loads redundant, #209). It is the *forward* dual of
+/// [`local_dead_defs`]: that finds a write with no later read; this finds a
+/// write whose value was already computed.
+///
+/// Pure detection — it reports the opportunity; the eventual fix (keep the
+/// constant resident across its uses) is the register allocator's job
+/// (VCR-RA-001). Returns `None` if the region is not a single straight-line
+/// block of fully-modeled instructions, so a result is never a wrong answer.
+pub fn redundant_const_defs(instrs: &[ArmInstruction]) -> Option<Vec<RedundantConst>> {
+    let mut held: Vec<(Reg, i32)> = Vec::new(); // registers with a known constant
+    let mut out = Vec::new();
+
+    for (i, instr) in instrs.iter().enumerate() {
+        if !is_straight_line(&instr.op) {
+            return None;
+        }
+        let eff = reg_effect(&instr.op)?;
+
+        if let Some((rd, v)) = const_materialization(&instr.op) {
+            // Already available in some register? → redundant re-derivation.
+            if let Some(&(r, _)) = held.iter().find(|&&(_, val)| val == v) {
+                out.push(RedundantConst {
+                    index: i,
+                    value: v,
+                    available_in: r,
+                });
+            }
+            // `rd` now holds `v` (drop any prior fact about rd first).
+            held.retain(|&(r, _)| r != rd);
+            held.push((rd, v));
+        } else {
+            // Any register this instruction writes loses its known constant.
+            for d in &eff.defs {
+                held.retain(|&(r, _)| r != *d);
+            }
+        }
+    }
+    Some(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -328,6 +403,116 @@ mod tests {
             }),
         ];
         assert_eq!(local_dead_defs(&seq), Some(vec![]));
+    }
+
+    #[test]
+    fn redundant_const_flags_rematerialization_while_resident() {
+        // movw r0,#0x7e ; add r2,r1,r0 ; movw r3,#0x7e
+        // The second 0x7e is redundant — r0 still holds it.
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R0,
+                imm16: 0x7e,
+            }),
+            ins(ArmOp::Add {
+                rd: Reg::R2,
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R0),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R3,
+                imm16: 0x7e,
+            }),
+        ];
+        let r = redundant_const_defs(&seq).unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].index, 2);
+        assert_eq!(r[0].value, 0x7e);
+        assert_eq!(r[0].available_in, Reg::R0);
+    }
+
+    #[test]
+    fn redundant_const_respects_clobber() {
+        // movw r0,#0x7e ; movw r0,#0x10 ; movw r1,#0x7e
+        // r0 was overwritten, so 0x7e is NOT resident → the last is not redundant.
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R0,
+                imm16: 0x7e,
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R0,
+                imm16: 0x10,
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 0x7e,
+            }),
+        ];
+        assert_eq!(redundant_const_defs(&seq), Some(vec![]));
+    }
+
+    #[test]
+    fn redundant_const_counts_flat_flight_clamp_pattern() {
+        // The measured flat_flight waste: one int8 clamp bound (#0x7e) loaded
+        // into a fresh register 6 times with the first still live throughout.
+        // 5 of the 6 are redundant.
+        let mut seq = Vec::new();
+        for k in 0..6u32 {
+            seq.push(ins(ArmOp::Movw {
+                rd: [Reg::R0, Reg::R1, Reg::R2, Reg::R3, Reg::R4, Reg::R5][k as usize],
+                imm16: 0x7e,
+            }));
+            // a consumer that keeps the earlier value live (reads R0)
+            seq.push(ins(ArmOp::Add {
+                rd: Reg::R6,
+                rn: Reg::R6,
+                op2: Operand2::Reg(Reg::R0),
+            }));
+        }
+        let r = redundant_const_defs(&seq).unwrap();
+        assert_eq!(r.len(), 5, "5 of 6 clamp materializations are redundant");
+        assert!(
+            r.iter()
+                .all(|c| c.value == 0x7e && c.available_in == Reg::R0)
+        );
+    }
+
+    #[test]
+    fn redundant_const_movt_pair_is_not_a_pure_const() {
+        // movw r0,#7 ; movt r0,#1  (r0 = 0x10007) ; movw r1,#7
+        // After Movt, r0 no longer holds the pure 16-bit 7 → last is NOT redundant.
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R0,
+                imm16: 7,
+            }),
+            ins(ArmOp::Movt {
+                rd: Reg::R0,
+                imm16: 1,
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 7,
+            }),
+        ];
+        assert_eq!(redundant_const_defs(&seq), Some(vec![]));
+    }
+
+    #[test]
+    fn redundant_const_declines_on_branch() {
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R0,
+                imm16: 0x7e,
+            }),
+            ins(ArmOp::BOffset { offset: 4 }),
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 0x7e,
+            }),
+        ];
+        assert_eq!(redundant_const_defs(&seq), None);
     }
 
     #[test]

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -296,6 +296,68 @@ pub fn redundant_const_defs(instrs: &[ArmInstruction]) -> Option<Vec<RedundantCo
     Some(out)
 }
 
+/// Aggregate analysis of a whole (possibly branchy) function.
+///
+/// The per-block detectors ([`local_dead_defs`], [`redundant_const_defs`]) only
+/// reason over a single straight-line block and decline (`None`) on any branch.
+/// Real functions (e.g. `flat_flight`, with its `br_table` clamps) are a
+/// sequence of such blocks separated by control flow. This splits the stream
+/// into **maximal straight-line, fully-modeled segments** — a non-straight-line
+/// op (branch/call) or an op with no precise [`reg_effect`] ends the current
+/// segment — runs both detectors per segment, and reports global indices.
+///
+/// This is **sound by construction**: a constant resident at the end of one
+/// segment is *not* assumed resident in the next (state is reset at every
+/// boundary), so cross-block redundancy is under-reported rather than
+/// over-reported, and an instruction that can't be modeled never lands inside a
+/// segment. It never returns `None` — it analyzes whatever is analyzable and
+/// counts the rest as skipped.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FunctionAnalysis {
+    /// Global indices of dead stores (overwritten before use within a segment).
+    pub dead_defs: Vec<usize>,
+    /// Redundant constant materializations (value already resident), global idx.
+    pub redundant_consts: Vec<RedundantConst>,
+    /// Number of maximal straight-line analyzable segments found.
+    pub segments: usize,
+    /// Instructions that ended a segment (branch/call/unmodeled) — not analyzed.
+    pub skipped: usize,
+}
+
+pub fn analyze_function(instrs: &[ArmInstruction]) -> FunctionAnalysis {
+    let mut report = FunctionAnalysis::default();
+    let mut seg_start = 0usize;
+
+    // Flush [seg_start, end) as one segment, offsetting indices to global.
+    let flush = |report: &mut FunctionAnalysis, start: usize, end: usize| {
+        if end <= start {
+            return;
+        }
+        let seg = &instrs[start..end];
+        report.segments += 1;
+        if let Some(d) = local_dead_defs(seg) {
+            report.dead_defs.extend(d.into_iter().map(|i| i + start));
+        }
+        if let Some(rc) = redundant_const_defs(seg) {
+            report.redundant_consts.extend(rc.into_iter().map(|mut c| {
+                c.index += start;
+                c
+            }));
+        }
+    };
+
+    for (i, instr) in instrs.iter().enumerate() {
+        let analyzable = is_straight_line(&instr.op) && reg_effect(&instr.op).is_some();
+        if !analyzable {
+            flush(&mut report, seg_start, i);
+            report.skipped += 1;
+            seg_start = i + 1;
+        }
+    }
+    flush(&mut report, seg_start, instrs.len());
+    report
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -497,6 +559,69 @@ mod tests {
             }),
         ];
         assert_eq!(redundant_const_defs(&seq), Some(vec![]));
+    }
+
+    #[test]
+    fn analyze_function_segments_across_a_branch() {
+        // Segment 1: movw r0,#0x7e ; movw r1,#0x7e (r1 redundant)
+        // <branch boundary>
+        // Segment 2: movw r2,#0x7e ; movw r3,#0x7e (r3 redundant — fresh state)
+        // The per-block detector would decline on the whole stream (branch);
+        // analyze_function finds the redundancy in BOTH segments.
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R0,
+                imm16: 0x7e,
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 0x7e,
+            }),
+            ins(ArmOp::BOffset { offset: 8 }),
+            ins(ArmOp::Movw {
+                rd: Reg::R2,
+                imm16: 0x7e,
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R3,
+                imm16: 0x7e,
+            }),
+        ];
+        // whole-stream per-block detector declines:
+        assert_eq!(redundant_const_defs(&seq), None);
+        // function-wide analysis finds both:
+        let a = analyze_function(&seq);
+        assert_eq!(a.segments, 2);
+        assert_eq!(a.skipped, 1, "the branch is the skipped boundary");
+        let idxs: Vec<usize> = a.redundant_consts.iter().map(|c| c.index).collect();
+        assert_eq!(
+            idxs,
+            vec![1, 4],
+            "global indices of the two redundant loads"
+        );
+    }
+
+    #[test]
+    fn analyze_function_resets_state_at_boundary() {
+        // movw r0,#5 ; <branch> ; movw r1,#5
+        // r0's #5 must NOT be considered resident after the branch → not redundant.
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R0,
+                imm16: 5,
+            }),
+            ins(ArmOp::BOffset { offset: 4 }),
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 5,
+            }),
+        ];
+        let a = analyze_function(&seq);
+        assert!(
+            a.redundant_consts.is_empty(),
+            "no cross-boundary redundancy may be claimed"
+        );
+        assert_eq!(a.segments, 2);
     }
 
     #[test]


### PR DESCRIPTION
Two analysis increments on the verified-codegen **allocator track** (VCR-RA-001, epic #242), building on the liveness primitive from #243. Pure analysis — **not wired into codegen** → emitted bytes unchanged.

## 1. Redundant-constant detection (const-CSE analysis)
`redundant_const_defs()`: within a straight-line block, the constant materializations that re-derive a value **already resident** in a register (not clobbered since) — the **forward dual** of `local_dead_defs` (which finds a write with no later read; this finds a write whose value was already computed).

Targets gale's #1 measured lever (#209): the int8 saturation clamps `#0x7e` / `#0x7f` re-materialized **6× each**, **61% of all constant loads redundant** on `flat_flight`. A test reproduces that exact pattern → **5 of 6 flagged redundant**. Recognizes the single-instruction const forms (`Movw` 16-bit, `Mov #imm`); a `Movw;Movt` pair is correctly **not** a pure 16-bit const.

## 2. Function-wide application
`analyze_function()`: the per-block detectors decline (`None`) on any branch; real functions (`flat_flight`'s `br_table` clamps) are a sequence of straight-line blocks. This splits the stream into **maximal straight-line, fully-modeled segments**, runs both detectors per segment, and reports global indices + segment/skip counts. **Sound by construction:** state resets at every boundary → cross-block redundancy is under-reported, never over-reported. This is what lets the detector be pointed at `flat_flight` and yield a real function-wide count instead of declining on the first branch.

## Verification
- 7 new tests total (5 const-CSE incl. the `flat_flight` 6×-clamp pattern; 2 function-wide incl. across-a-branch + boundary-reset soundness).
- Full synth-synthesis lib suite: **276 passed**.
- **control_step `0x00210A55` ORACLE PASS** (bit-identical).

## Side-by-side discipline
Both halves of gale's dominant waste are now *detectable* on real functions without changing a byte. gale confirmed (#209) the Track-A baseline is frozen and byte-identical off merged `main` — "ready to reflash the moment [code] emits a delta." The **transform** (allocator keeps the clamp bounds resident; or DCE deletes a dead store) migrates in as a separate oracle-gated step under `VCR-VER-001`.

Part of #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)