### PR TITLE
feat(selector): fold small constants into i32.and immediates + encoder bound (VCR-RA-001)

### DIFF
--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -8949,6 +8949,36 @@ mod tests {
         assert_eq!(code.len(), 4, "MVE VABS.F32 should be 4 bytes");
     }
 
+    /// VCR-RA-001 / immediate-folding precondition: pins the Thumb-2 `AND`
+    /// immediate encoding for the byte range and documents its bound.
+    ///
+    /// The `And { Operand2::Imm }` encoder packs the low 12 bits straight into
+    /// the `i:imm3:imm8` field WITHOUT applying ThumbExpandImm (the modified-
+    /// immediate expansion). For `imm <= 0xFF` (e.g. gale's int8 clamps
+    /// `#0x7e` / `#0x7f`) that is correct — `i:imm3 = 0000` means "imm8
+    /// zero-extended". So `and r2, r0, #0x7e` encodes to the canonical
+    /// `00 f0 7e 02`. For `imm >= 0x100` the field would need a true
+    /// ThumbExpandImm pattern (rotation / replication), which is NOT
+    /// implemented here — so **immediate folding must gate on `imm <= 0xFF`**
+    /// until the encoder is hardened to ThumbExpandImm/Ok-or-Err (the
+    /// "encoder must be Ok-or-Err, never silently wrong" principle, #180/#185).
+    /// This bound covers the measured `flat_flight` waste (#209).
+    #[test]
+    fn and_immediate_encodes_correctly_in_byte_range_documents_fold_bound() {
+        let encoder = ArmEncoder::new_thumb2();
+        let op = ArmOp::And {
+            rd: Reg::R2,
+            rn: Reg::R0,
+            op2: Operand2::Imm(0x7e),
+        };
+        let code = encoder.encode(&op).unwrap();
+        assert_eq!(
+            code,
+            vec![0x00, 0xf0, 0x7e, 0x02],
+            "and r2, r0, #0x7e must encode to the canonical AND.W T1 (imm8=0x7e)"
+        );
+    }
+
     #[test]
     fn test_encode_mve_different_qregs() {
         let encoder = ArmEncoder::new_thumb2();

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -227,6 +227,23 @@ fn const_divisor(wasm_ops: &[WasmOp], idx: usize) -> Option<i32> {
     }
 }
 
+/// If the operand pushed immediately before a bitwise binop is a constant the
+/// Thumb-2 data-processing immediate encoder handles correctly, return it so the
+/// op can fold the constant into an immediate operand and skip materializing it
+/// into a register (the redundant-materialization waste measured on `flat_flight`,
+/// #209/#248). Bounded to `0..=0xFF`: the encoder's `AND`-immediate path is not
+/// yet ThumbExpandImm-complete and only encodes a single zero-extended byte
+/// correctly (#249).
+fn foldable_bitwise_imm(wasm_ops: &[WasmOp], idx: usize) -> Option<i32> {
+    if idx == 0 {
+        return None;
+    }
+    match wasm_ops[idx - 1] {
+        WasmOp::I32Const(c) if (0..=0xFF).contains(&c) => Some(c),
+        _ => None,
+    }
+}
+
 /// If `c` (read as an unsigned 32-bit divisor) is a power of two `2^k` with
 /// `k >= 1`, return `k` so `i32.div_u` can lower to `LSR rd, rn, #k`.
 ///
@@ -5131,22 +5148,55 @@ impl InstructionSelector {
                 }
 
                 I32And => {
-                    let b = pop_operand(
-                        &mut stack,
-                        &mut next_temp,
-                        &mut instructions,
-                        &mut spill,
-                        &live_params,
-                        idx,
-                    )?;
-                    let a = pop_operand(
-                        &mut stack,
-                        &mut next_temp,
-                        &mut instructions,
-                        &mut spill,
-                        &live_params,
-                        idx,
-                    )?;
+                    // Immediate folding: when the second operand is a small const
+                    // (`i32.const C`, 0..=0xFF) whose `movw` is cleanly at the tail
+                    // (not spilled), fold it as `and rd, a, #C` and drop the
+                    // materialization — eliminating the redundant const load
+                    // (#209/#248). Bounded to 0..=0xFF by the encoder (#249).
+                    let fold_imm = foldable_bitwise_imm(wasm_ops, idx).filter(|_| {
+                        matches!(
+                            instructions.last().map(|i| (&i.op, i.source_line)),
+                            Some((ArmOp::Movw { .. }, Some(sl))) if sl == idx - 1
+                        )
+                    });
+                    let (a, op2) = if let Some(c) = fold_imm {
+                        let _b = pop_operand(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        Self::drop_prev_const_materialization(&mut instructions, idx - 1);
+                        let a = pop_operand(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        (a, Operand2::Imm(c))
+                    } else {
+                        let b = pop_operand(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        let a = pop_operand(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        (a, Operand2::Reg(b))
+                    };
                     let dst = if idx == wasm_ops.len() - 1 {
                         Reg::R0
                     } else {
@@ -5156,7 +5206,7 @@ impl InstructionSelector {
                         op: ArmOp::And {
                             rd: dst,
                             rn: a,
-                            op2: Operand2::Reg(b),
+                            op2,
                         },
                         source_line: Some(idx),
                     });
@@ -14329,6 +14379,72 @@ mod tests {
         assert!(
             !sub_sp,
             "no frame allocation expected for params-only function"
+        );
+    }
+
+    /// VCR-RA-001 immediate folding: `i32.const C (0..=0xFF); i32.and` folds the
+    /// constant into the `AND` immediate and drops the `movw`. Measured delta on
+    /// the clamp pattern: 8 → 6 instructions (both `movw #126` eliminated). The
+    /// first delta-emitting codegen transform on the allocator track.
+    #[test]
+    fn i32_and_folds_small_const_into_immediate() {
+        let mut selector = fresh_selector();
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32Const(0x7e),
+            WasmOp::I32And,
+            WasmOp::LocalGet(0),
+            WasmOp::I32Const(0x7e),
+            WasmOp::I32And,
+            WasmOp::I32Add,
+            WasmOp::End,
+        ];
+        let instrs = selector.select_with_stack(&ops, 1).unwrap();
+        let movw_126 = instrs
+            .iter()
+            .filter(|i| matches!(&i.op, ArmOp::Movw { imm16: 126, .. }))
+            .count();
+        let and_imm_126 = instrs
+            .iter()
+            .filter(|i| {
+                matches!(
+                    &i.op,
+                    ArmOp::And {
+                        op2: Operand2::Imm(126),
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert_eq!(movw_126, 0, "the const materialization must be folded away");
+        assert_eq!(and_imm_126, 2, "both ANDs use the folded immediate");
+    }
+
+    /// A constant beyond the encoder's `AND`-immediate range (> 0xFF) must NOT be
+    /// folded — it stays a register operand, so the encoder never emits a
+    /// silently-wrong modified immediate (#249 bound).
+    #[test]
+    fn i32_and_does_not_fold_out_of_range_const() {
+        let mut selector = fresh_selector();
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32Const(0x140), // 320 > 0xFF
+            WasmOp::I32And,
+            WasmOp::End,
+        ];
+        let instrs = selector.select_with_stack(&ops, 1).unwrap();
+        let and_imm = instrs.iter().any(|i| {
+            matches!(
+                &i.op,
+                ArmOp::And {
+                    op2: Operand2::Imm(_),
+                    ..
+                }
+            )
+        });
+        assert!(
+            !and_imm,
+            "0x140 must stay a register operand, not an immediate"
         );
     }
 


### PR DESCRIPTION
The **first delta-emitting codegen transform** on the allocator track (VCR-RA-001, epic #242). Consolidates the encoder-bound finding (was #249) with the folding that uses it.

## The waste (measured, #248)
`i32.const C; i32.and` lowered to `movw rN,#C; and rD,rA,rN` even when `C` is small enough to be an `AND` immediate — the redundant materialization gale measured on `flat_flight`.

## The fix
When the operand before `i32.and` is `i32.const C` with `C ∈ 0..=0xFF` **and** its `movw` is cleanly at the instruction tail (not spilled), fold to `and rD, rA, #C` and drop the materialization (`foldable_bitwise_imm` + `drop_prev_const_materialization`, mirroring the const-divisor pattern).

## Encoder bound (was #249)
Bounded to `0..=0xFF` because the encoder's `AND`-immediate path isn't yet ThumbExpandImm-complete (`and r2,r0,#0x7e → 00 f0 7e 02` is correct; `≥0x100` would mis-encode). `0..=0xFF` covers gale's int8 clamps. A pinning test documents the safe range; folding is guarded to it, so the encoder never sees an un-encodable immediate.

## Measured delta
`(p & 0x7e) + (p & 0x7e)`: **8 → 6 instructions** — both `movw #126` eliminated, each `AND` uses the immediate. *Better* than const-CSE (no materialization at all).

## Full gate (codegen change)
- 282 lib tests + 20 integration suites pass.
- Three frozen differentials stay **result-identical**: control_step `0x00210A55`, flight_seam `0x07FDF307`, div_const `338/338`.
- Tests: `i32_and_folds_small_const_into_immediate` (folded shape), `i32_and_does_not_fold_out_of_range_const` (`0x140` stays a register operand — the encoder safety bound), `and_immediate_encodes_correctly_in_byte_range...` (encoder).
- CI fuzz (`encoder_no_panic`, `wasm_ops_lower_or_error`) adds totality.

Supersedes #248 (the evidence it pinned is now folded away) and subsumes #249 (the encoder-bound test is included here).

Part of #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)