### PR TITLE
feat(selector): fold small constants into i32.or / i32.xor immediates (VCR-RA-001)

### DIFF
--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -5214,22 +5214,53 @@ impl InstructionSelector {
                 }
 
                 I32Or => {
-                    let b = pop_operand(
-                        &mut stack,
-                        &mut next_temp,
-                        &mut instructions,
-                        &mut spill,
-                        &live_params,
-                        idx,
-                    )?;
-                    let a = pop_operand(
-                        &mut stack,
-                        &mut next_temp,
-                        &mut instructions,
-                        &mut spill,
-                        &live_params,
-                        idx,
-                    )?;
+                    // Immediate folding (same shape as I32And, #250): const
+                    // operand 0..=0xFF whose `movw` is at the tail → `orr rd,a,#C`,
+                    // drop the materialization. Encoder ORR-imm hardened in #251.
+                    let fold_imm = foldable_bitwise_imm(wasm_ops, idx).filter(|_| {
+                        matches!(
+                            instructions.last().map(|i| (&i.op, i.source_line)),
+                            Some((ArmOp::Movw { .. }, Some(sl))) if sl == idx - 1
+                        )
+                    });
+                    let (a, op2) = if let Some(c) = fold_imm {
+                        let _b = pop_operand(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        Self::drop_prev_const_materialization(&mut instructions, idx - 1);
+                        let a = pop_operand(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        (a, Operand2::Imm(c))
+                    } else {
+                        let b = pop_operand(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        let a = pop_operand(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        (a, Operand2::Reg(b))
+                    };
                     let dst = if idx == wasm_ops.len() - 1 {
                         Reg::R0
                     } else {
@@ -5239,7 +5270,7 @@ impl InstructionSelector {
                         op: ArmOp::Orr {
                             rd: dst,
                             rn: a,
-                            op2: Operand2::Reg(b),
+                            op2,
                         },
                         source_line: Some(idx),
                     });
@@ -5247,22 +5278,53 @@ impl InstructionSelector {
                 }
 
                 I32Xor => {
-                    let b = pop_operand(
-                        &mut stack,
-                        &mut next_temp,
-                        &mut instructions,
-                        &mut spill,
-                        &live_params,
-                        idx,
-                    )?;
-                    let a = pop_operand(
-                        &mut stack,
-                        &mut next_temp,
-                        &mut instructions,
-                        &mut spill,
-                        &live_params,
-                        idx,
-                    )?;
+                    // Immediate folding (same shape as I32And, #250): const
+                    // operand 0..=0xFF whose `movw` is at the tail → `eor rd,a,#C`,
+                    // drop the materialization. Encoder EOR-imm hardened in #251.
+                    let fold_imm = foldable_bitwise_imm(wasm_ops, idx).filter(|_| {
+                        matches!(
+                            instructions.last().map(|i| (&i.op, i.source_line)),
+                            Some((ArmOp::Movw { .. }, Some(sl))) if sl == idx - 1
+                        )
+                    });
+                    let (a, op2) = if let Some(c) = fold_imm {
+                        let _b = pop_operand(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        Self::drop_prev_const_materialization(&mut instructions, idx - 1);
+                        let a = pop_operand(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        (a, Operand2::Imm(c))
+                    } else {
+                        let b = pop_operand(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        let a = pop_operand(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        (a, Operand2::Reg(b))
+                    };
                     let dst = if idx == wasm_ops.len() - 1 {
                         Reg::R0
                     } else {
@@ -5272,7 +5334,7 @@ impl InstructionSelector {
                         op: ArmOp::Eor {
                             rd: dst,
                             rn: a,
-                            op2: Operand2::Reg(b),
+                            op2,
                         },
                         source_line: Some(idx),
                     });
@@ -14380,6 +14442,41 @@ mod tests {
             !sub_sp,
             "no frame allocation expected for params-only function"
         );
+    }
+
+    /// VCR-RA-001: `i32.or`/`i32.xor` fold a small const operand into the
+    /// `ORR`/`EOR` immediate (same shape as `i32.and`, #250; encoder hardened in
+    /// #251). Drops the `movw`; no register operand.
+    #[test]
+    fn i32_or_xor_fold_small_const_into_immediate() {
+        for op in [WasmOp::I32Or, WasmOp::I32Xor] {
+            let mut selector = fresh_selector();
+            let ops = vec![
+                WasmOp::LocalGet(0),
+                WasmOp::I32Const(0x7e),
+                op.clone(),
+                WasmOp::End,
+            ];
+            let instrs = selector.select_with_stack(&ops, 1).unwrap();
+            let movw_126 = instrs
+                .iter()
+                .filter(|i| matches!(&i.op, ArmOp::Movw { imm16: 126, .. }))
+                .count();
+            let folded = instrs.iter().any(|i| {
+                matches!(
+                    &i.op,
+                    ArmOp::Orr {
+                        op2: Operand2::Imm(126),
+                        ..
+                    } | ArmOp::Eor {
+                        op2: Operand2::Imm(126),
+                        ..
+                    }
+                )
+            });
+            assert_eq!(movw_126, 0, "{op:?}: const must be folded away");
+            assert!(folded, "{op:?}: must use the folded immediate");
+        }
     }
 
     /// VCR-RA-001 immediate folding: `i32.const C (0..=0xFF); i32.and` folds the


### PR DESCRIPTION
Extends #250's `i32.and` immediate folding to `i32.or` and `i32.xor`, now that the encoder's ORR/EOR immediate paths are correct + Ok-or-Err (#251).

## What
When the operand before `i32.or`/`i32.xor` is `i32.const C` (C ∈ 0..=0xFF) with its `movw` cleanly at the tail, fold to `orr`/`eor rd, a, #C` and drop the materialization — same shape as the `And` fold.

Bounded to `0..=0xFF` by the encoder (`ORR`/`EOR`-imm > 0xFF returns `Err` until ThumbExpandImm lands, #251); the fold guard keeps it in range.

## Gate (codegen change)
- clippy clean; **283 lib tests** pass.
- Three frozen differentials stay **result-identical**: control_step `0x00210A55`, flight_seam `0x07FDF307`, div_const `338/338`.
- Test `i32_or_xor_fold_small_const_into_immediate` (both ops fold, no `movw` survives).
- CI fuzz adds totality.

Part of #242. Builds on #250 (fold pattern) + #251 (encoder hardening), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)