### PR TITLE
feat: wire mul/add → mla fusion into codegen — gale flat_flight delta (#257)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -233,6 +233,14 @@ fn compile_wasm_to_arm(
         }
     };
 
+    // #257: fuse `mul` + `add` into `mla`. Runs on the selected stream *before*
+    // branch resolution (it removes instructions, shifting byte offsets) — and is
+    // sound across control flow (the fusion only fires when the mul result is read
+    // solely by the add; see `fuse_mul_add`). A no-op for streams with no fusable
+    // pattern, so existing output stays bit-identical unless a `mul;…;add` pair
+    // qualifies.
+    let (arm_instrs, _fused) = synth_synthesis::liveness::fuse_mul_add(&arm_instrs);
+
     // ISA feature gate: validate that all generated instructions are supported
     // by the target. This catches FPU instructions on no-FPU targets, double-precision
     // instructions on single-precision targets, etc.

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -394,6 +394,30 @@ pub fn eliminate_dead_stores(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>,
     (kept, dead.len())
 }
 
+/// Conservative "does `op` possibly read `reg`": precise via [`reg_effect`] when
+/// modeled; a pure branch/label reads no GP register; a call (`Bl`/`Blx`/…) may
+/// read the AAPCS argument registers `R0..=R3`; anything else unmodeled (`Bx`,
+/// the i64-pair / FP families) is conservatively assumed to read `reg`.
+fn op_may_use(op: &ArmOp, reg: Reg) -> bool {
+    if let Some(e) = reg_effect(op) {
+        return e.uses.contains(&reg);
+    }
+    use ArmOp::*;
+    match op {
+        Label { .. }
+        | B { .. }
+        | BOffset { .. }
+        | BCondOffset { .. }
+        | Bhs { .. }
+        | Blo { .. }
+        | Bcc { .. } => false,
+        Bl { .. } | Blx { .. } | Call { .. } | CallIndirect { .. } => {
+            matches!(reg, Reg::R0 | Reg::R1 | Reg::R2 | Reg::R3)
+        }
+        _ => true,
+    }
+}
+
 /// Fuse `mul` + `add` into `mla` (#257): for an `Add rD, x, Reg(y)` where one
 /// operand is the destination of an earlier `Mul rM, rn, rm`, the result is
 /// `mla rD, rn, rm, other`, and the now-redundant `Mul` is removed. Returns the
@@ -453,12 +477,13 @@ pub fn fuse_mul_add(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
             if !between_ok {
                 continue;
             }
-            // rmul must not be read anywhere after j (dead once fused). An
-            // unmodeled op after j conservatively counts as a possible read.
-            let dead_after = ((j + 1)..n).all(|k| {
-                removed[k] || reg_effect(&instrs[k].op).is_some_and(|e| !e.uses.contains(&rmul))
-            });
-            if !dead_after {
+            // The mul result must be read *only* by this add anywhere in the
+            // function — then removing the mul and folding into the mla is sound
+            // regardless of control flow. `op_may_use` is call/branch-aware
+            // (calls may read R0-R3; pure branches read nothing).
+            let used_elsewhere =
+                (0..n).any(|k| k != j && !removed[k] && op_may_use(&instrs[k].op, rmul));
+            if used_elsewhere {
                 continue;
             }
             rewritten[j] = Some(ArmOp::Mla {

--- a/crates/synth-synthesis/tests/semantic_correctness.rs
+++ b/crates/synth-synthesis/tests/semantic_correctness.rs
@@ -870,17 +870,19 @@ fn add_uses_correct_source_registers() {
     let add = instrs.iter().find(|i| matches!(&i.op, ArmOp::Add { .. }));
     assert!(add.is_some(), "i32.add should produce an ADD instruction");
 
+    // Since #254 (constant-immediate folding), `i32.const 20; i32.add` folds the
+    // 20 into the ADD immediate — `add rd, r(=10), #20`. This is the correct,
+    // improved shape; the original concern (two consts collapsing onto the *same*
+    // source register, a #180-class bug) cannot arise when the second const is an
+    // immediate rather than a register.
     if let ArmOp::Add { rn, op2, .. } = &add.unwrap().op {
-        assert!(
-            matches!(op2, Operand2::Reg(_)),
-            "ADD should use register operand, got {:?}",
-            op2
-        );
-        if let Operand2::Reg(rm) = op2 {
-            assert_ne!(
+        match op2 {
+            Operand2::Imm(c) => assert_eq!(*c, 20, "the second const folds into #20"),
+            Operand2::Reg(rm) => assert_ne!(
                 rn, rm,
-                "ADD source registers should be different (two consts)"
-            );
+                "if not folded, the two const source registers must differ"
+            ),
+            other => panic!("unexpected ADD operand: {other:?}"),
         }
     }
 }


### PR DESCRIPTION
Wires the `fuse_mul_add` pass (#263 foundation) into the backend — the codegen change that emits gale's measured `flat_flight` delta.

## Where
After instruction selection, **before** branch resolution (the fusion removes instructions → shifts byte offsets).

## Soundness refinement (fires on real functions, stays sound)
The mul result must be read **only** by the add anywhere in the function (new `op_may_use` — call/branch-aware: a pure branch reads no GP reg; a call may read R0–R3; `Bx` / i64-pair / FP conservatively assumed to read). The between-mul-and-add check still blocks on any control flow (a branch there breaks the linear mul→add dataflow).

## Measured (oracle repaired this session)
- **`flat_flight` .o: 1891 → 1819 bytes** (~18 muls fused into mla).
- Three frozen differentials **result-identical** — `flight_seam` (exercising the `gyro*980 + accel*20` filter) stays **`0x07FDF307`** with the fusion firing; control_step `0x00210A55`; div_const 338/338.

## Also: fixes a #254 test regression
`add_uses_correct_source_registers`: `i32.const 10; i32.const 20; i32.add` folds the 20 into the ADD immediate since #254 — the test predated that and still asserted a register operand. Missed because #254 was gated with `cargo test --lib` (this is a `tests/` integration test); the full-suite run here surfaced it.

Part of #242 / the lever-#2 portion of #257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)