### PR TITLE
chore(release): v0.11.31 — gale codegen pass (#257/#258/#259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.31] - 2026-06-05
+
+**gale codegen pass: a load/store correctness fix + two `flat_flight` instruction-selection wins (#257/#258/#259).**
+
+Three gale-reported items from the wasm-cross-LTO silicon work, all behavior-frozen
+against the differential fixtures (`control_step` 0x00210A55, inlined+flat
+`flight_algo` 0x07FDF307, `div_const` 338/338 — all result-identical).
+
+- **Load/store `imm12` offset bounds check (#259, correctness).** The eight
+  thumb32 load/store immediate-offset encoders masked `offset & 0xFFF` and emitted
+  unconditionally — for `offset >= 4096` the access silently targeted the wrong
+  address. They now error (forcing register-offset addressing), closing the
+  load/store sibling of the #253/#255 silent-miscompile class. Defensive: the
+  selector already materializes large offsets, so no live breakage.
+- **`cmp`/`cmn` immediate folding (#258, lever #3).** A compare against a constant
+  bound now folds into `cmp a, #C` (positive) or `cmn a, #|C|` (negative) instead
+  of materializing the bound into a register — the int8 clamps cost 18 IT-blocks
+  vs native's 6.
+- **`mul` + `add` → `mla` fusion (#257, lever #2).** The flight filter's
+  `gyro*980 + accel*20` lowered as separate `mul` then `add`; it now fuses to a
+  single `mla`. New `ArmOp::Mla` + a liveness-driven, control-flow-sound fusion
+  pass (`fuse_mul_add`: fires only when the mul result is read solely by the add).
+  Measured: `flat_flight` text 1891 → 1819 bytes (~18 muls fused), `flight_seam`
+  still 0x07FDF307 with the fusion firing.
+
+**Falsification:** this release is wrong if a load/store with `offset >= 4096`
+emits a truncated (wrong) address instead of erroring, or if any `mul;add`
+fusion / `cmp`/`cmn` fold changes a frozen differential's result. Verified: all
+three fixtures result-identical; the fusion's measured byte delta lands only on
+the filter sites; new encoder/fusion unit tests cover the bounds + soundness
+declines.
+
 ## [0.11.30] - 2026-06-05
 
 **Self-contained native-pointer ABI: register-promote the stack-pointer global so a dissolved leaf seam runs with no host runtime (#237).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.30"
+version = "0.11.31"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.30"
+version = "0.11.31"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.30"
+version = "0.11.31"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.30"
+version = "0.11.31"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.30",
+    version = "0.11.31",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.30" }
+synth-core = { path = "../synth-core", version = "0.11.31" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.30" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.30" }
+synth-core = { path = "../synth-core", version = "0.11.31" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.31" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.30" }
+synth-core = { path = "../synth-core", version = "0.11.31" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.30" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.30", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.31" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.31", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.30" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.30" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.30" }
-synth-backend = { path = "../synth-backend", version = "0.11.30" }
+synth-core = { path = "../synth-core", version = "0.11.31" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.31" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.31" }
+synth-backend = { path = "../synth-backend", version = "0.11.31" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.30", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.30", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.30", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.31", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.31", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.31", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.30", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.31", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.30" }
+synth-core = { path = "../synth-core", version = "0.11.31" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.30" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.31" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.30" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.30" }
-synth-opt = { path = "../synth-opt", version = "0.11.30" }
+synth-core = { path = "../synth-core", version = "0.11.31" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.31" }
+synth-opt = { path = "../synth-opt", version = "0.11.31" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.30" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.30" }
-synth-opt = { path = "../synth-opt", version = "0.11.30" }
+synth-core = { path = "../synth-core", version = "0.11.31" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.31" }
+synth-opt = { path = "../synth-opt", version = "0.11.31" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.30", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.31", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Release prep for **v0.11.31** — three gale-reported codegen items, all behavior-frozen (differentials result-identical):

- **#259** load/store `imm12` offset bounds check (correctness — closes the load/store sibling of the #253/#255 silent-miscompile class)
- **#258** `cmp`/`cmn` immediate folding (flat_flight lever #3)
- **#257** `mul`+`add` → `mla` fusion (lever #2; measured `flat_flight` 1891 → 1819 B)

Pin sweep 0.11.30 → 0.11.31 (25 pins + MODULE.bazel), Cargo.lock regenerated, CHANGELOG with falsification statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)