### PR TITLE
feat: interference graph — VCR-RA-001 colouring input (#242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -78,7 +78,13 @@ artifacts:
   #    (the interference-graph substrate). Pure analysis, zero codegen callers,
   #    so every frozen fixture stays bit-identical by construction. Leaf-only,
   #    label-form scope; declines (None) on calls/offset/computed branches.
-  #    Remaining for VCR-RA-001: interference graph -> colouring -> spill/reload.
+  #  - Interference graph: interference_graph() derives per-instruction liveness
+  #    from cfg_liveness (backward from each block's live_out) and builds the
+  #    undirected "cannot share a physical register" graph — defs interfere with
+  #    everything live-after + with co-defs (Umull rdlo/rdhi). This is the
+  #    colouring input. Still unwired. Exposes interferes/neighbors/degree.
+  #    Remaining for VCR-RA-001: graph-colouring (Chaitin/Briggs simplify+select)
+  #    -> spill/reload -> ABI-exit-liveness union -> oracle-gated wiring.
   - id: VCR-RA-001
     type: sw-req
     title: SSA-based register allocator with spilling (remove the hard-fail)

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -14836,6 +14836,17 @@ mod tests {
                 instrs.len(),
                 "blocks cover the whole stream"
             );
+
+            // The interference graph over the same real output must be
+            // structurally sound: undirected (symmetric) and self-loop-free.
+            let g = liveness::interference_graph(&instrs)
+                .expect("cfg_liveness succeeded, so interference_graph must too");
+            for n in g.nodes() {
+                assert!(!g.interferes(n, n), "no register interferes with itself");
+                for m in g.neighbors(n) {
+                    assert!(g.interferes(m, n), "interference is symmetric");
+                }
+            }
         }
     }
 

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -753,6 +753,110 @@ pub fn cfg_liveness(instrs: &[ArmInstruction]) -> Option<CfgLiveness> {
     })
 }
 
+// ============================================================================
+// Interference graph (VCR-RA-001 — the colouring input)
+//
+// A graph-colouring register allocator asks: which registers are *simultaneously
+// live*, and therefore cannot share one physical register? That relation is the
+// interference graph, read directly off the per-instruction liveness derived
+// from [`cfg_liveness`]. Walking each block backward from its `live_out`, a
+// register *defined* at an instruction interferes with everything live
+// immediately *after* that instruction (they coexist), and co-defined registers
+// (e.g. `Umull`'s `rdlo`/`rdhi`) interfere with each other. The precision payoff:
+// in `add r3, r1, r2` the inputs die at the add, so `r3` does NOT interfere with
+// `r1`/`r2` and may reuse one of their registers — a naive "all operands
+// interfere" graph would forbid that.
+//
+// Pure analysis, no codegen callers: it informs a future allocator, it does not
+// (yet) drive one, so emitted bytes are unchanged.
+// ============================================================================
+
+/// Undirected register interference graph: `a` and `b` are adjacent iff they are
+/// ever simultaneously live (so a colouring must give them different physical
+/// registers).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct InterferenceGraph {
+    adj: BTreeMap<Reg, BTreeSet<Reg>>,
+}
+
+impl InterferenceGraph {
+    fn node(&mut self, r: Reg) {
+        self.adj.entry(r).or_default();
+    }
+
+    fn add_edge(&mut self, a: Reg, b: Reg) {
+        if a == b {
+            return;
+        }
+        self.adj.entry(a).or_default().insert(b);
+        self.adj.entry(b).or_default().insert(a);
+    }
+
+    /// Do `a` and `b` interfere (cannot share a physical register)?
+    pub fn interferes(&self, a: Reg, b: Reg) -> bool {
+        self.adj.get(&a).is_some_and(|s| s.contains(&b))
+    }
+
+    /// Registers that interfere with `r`.
+    pub fn neighbors(&self, r: Reg) -> impl Iterator<Item = Reg> + '_ {
+        self.adj.get(&r).into_iter().flat_map(|s| s.iter().copied())
+    }
+
+    /// Interference degree of `r` — the lower bound on distinct registers its
+    /// neighbourhood needs; `degree(r) < k` guarantees `r` is `k`-colourable
+    /// (the Chaitin/Briggs simplify criterion).
+    pub fn degree(&self, r: Reg) -> usize {
+        self.adj.get(&r).map_or(0, |s| s.len())
+    }
+
+    /// All registers mentioned in the graph (interfering or not).
+    pub fn nodes(&self) -> impl Iterator<Item = Reg> + '_ {
+        self.adj.keys().copied()
+    }
+
+    /// Total number of (undirected) interference edges.
+    pub fn edge_count(&self) -> usize {
+        self.adj.values().map(|s| s.len()).sum::<usize>() / 2
+    }
+}
+
+/// Build the interference graph of `instrs`, or `None` if [`cfg_liveness`]
+/// declines (a construct outside the modeled leaf-only, label-form scope). Sound
+/// by construction: a non-`None` graph is complete for the whole function.
+pub fn interference_graph(instrs: &[ArmInstruction]) -> Option<InterferenceGraph> {
+    let cfg = cfg_liveness(instrs)?;
+    let mut g = InterferenceGraph::default();
+
+    for (bi, b) in cfg.blocks.iter().enumerate() {
+        // `live` = registers live immediately AFTER the instruction being
+        // processed; seeded with the block's live-out and walked backward.
+        let mut live = cfg.live_out[bi].clone();
+        for idx in (b.start..b.end).rev() {
+            let eff = reg_effect(&instrs[idx].op).unwrap_or_default();
+            // Each def interferes with everything live after this instruction
+            // and with its co-defs; record defs/uses as nodes regardless.
+            for (i, d) in eff.defs.iter().enumerate() {
+                g.node(*d);
+                for r in &live {
+                    g.add_edge(*d, *r);
+                }
+                for d2 in &eff.defs[i + 1..] {
+                    g.add_edge(*d, *d2);
+                }
+            }
+            // live_before = (live − defs) ∪ uses
+            for d in &eff.defs {
+                live.remove(d);
+            }
+            for u in &eff.uses {
+                g.node(*u);
+                live.insert(*u);
+            }
+        }
+    }
+    Some(g)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1328,6 +1432,130 @@ mod tests {
             1,
             "an unconditional branch has exactly one successor (no fallthrough)"
         );
+    }
+
+    // ---- Interference graph (interference_graph) ---------------------------
+
+    #[test]
+    fn interference_simultaneously_live_regs_interfere() {
+        // movw r1,#5 ; movw r2,#7 ; add r3,r1,r2
+        // r1 and r2 are both live at the add → they interfere. r3 is defined
+        // when nothing else is live-out → it interferes with NOTHING (it may
+        // reuse r1's or r2's register: the precision a naive graph would lose).
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 5,
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R2,
+                imm16: 7,
+            }),
+            ins(ArmOp::Add {
+                rd: Reg::R3,
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            }),
+        ];
+        let g = interference_graph(&seq).expect("analyzable");
+        assert!(g.interferes(Reg::R1, Reg::R2), "r1,r2 overlap at the add");
+        assert!(
+            !g.interferes(Reg::R1, Reg::R3),
+            "r3 is defined after r1 dies → no interference (reuse allowed)"
+        );
+        assert!(!g.interferes(Reg::R2, Reg::R3));
+        assert_eq!(g.edge_count(), 1, "the only edge is r1—r2");
+        assert_eq!(g.degree(Reg::R1), 1);
+        assert_eq!(g.degree(Reg::R3), 0);
+    }
+
+    #[test]
+    fn interference_sequential_reuse_does_not_interfere() {
+        // movw r1,#5 ; mov r0,r1 ; movw r1,#9 ; mov r2,r1
+        // The first r1 dies into r0 before r1 is redefined → the two distinct
+        // live ranges of r1 don't add a self-edge, and r0/r2 never coexist.
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 5,
+            }),
+            ins(ArmOp::Mov {
+                rd: Reg::R0,
+                op2: Operand2::Reg(Reg::R1),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 9,
+            }),
+            ins(ArmOp::Mov {
+                rd: Reg::R2,
+                op2: Operand2::Reg(Reg::R1),
+            }),
+        ];
+        let g = interference_graph(&seq).expect("analyzable");
+        assert!(
+            !g.interferes(Reg::R0, Reg::R2),
+            "r0 and r2 have disjoint live ranges"
+        );
+    }
+
+    #[test]
+    fn interference_co_defs_interfere() {
+        // umull r0,r1,r2,r3 — the two result registers must be distinct, so the
+        // co-defined r0 and r1 interfere even though neither is otherwise live.
+        let seq = vec![ins(ArmOp::Umull {
+            rdlo: Reg::R0,
+            rdhi: Reg::R1,
+            rn: Reg::R2,
+            rm: Reg::R3,
+        })];
+        let g = interference_graph(&seq).expect("analyzable");
+        assert!(
+            g.interferes(Reg::R0, Reg::R1),
+            "umull's rdlo and rdhi must not share a register"
+        );
+    }
+
+    #[test]
+    fn interference_value_live_across_a_branch_interferes_with_both_paths() {
+        // r5 live across a conditional; a fresh def on each path while r5 is
+        // still live must interfere with r5.
+        //   movw r5,#42 ; bcc NE,"skip"
+        //   mov r6,r5            (r6 defined while r5 live → interfere)
+        //   Label skip ; add r7,r5,r5
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R5,
+                imm16: 42,
+            }),
+            ins(ArmOp::Bcc {
+                cond: Condition::NE,
+                label: "skip".into(),
+            }),
+            ins(ArmOp::Mov {
+                rd: Reg::R6,
+                op2: Operand2::Reg(Reg::R5),
+            }),
+            ins(ArmOp::Label {
+                name: "skip".into(),
+            }),
+            ins(ArmOp::Add {
+                rd: Reg::R7,
+                rn: Reg::R5,
+                op2: Operand2::Reg(Reg::R5),
+            }),
+        ];
+        let g = interference_graph(&seq).expect("analyzable");
+        // r6 is defined where r5 is still live (r5 reaches the add on the other
+        // path) → they interfere.
+        assert!(g.interferes(Reg::R5, Reg::R6), "r6 defined while r5 live");
+    }
+
+    #[test]
+    fn interference_declines_when_liveness_declines() {
+        // A call is outside the CFG scope → cfg_liveness declines → so does this.
+        let seq = vec![ins(ArmOp::Bl { label: "f".into() })];
+        assert_eq!(interference_graph(&seq), None);
     }
 
     #[test]


### PR DESCRIPTION
## North-star increment — VCR-RA-001 (side-by-side, unwired)

Builds directly on the just-merged CFG-liveness substrate (#268) with the next allocator piece. **No codegen path touched.**

### What

`liveness::interference_graph()` derives **per-instruction** liveness from `cfg_liveness` (walking each block backward from its `live_out`) and constructs the undirected **"cannot share a physical register"** graph a graph-colouring allocator consumes.

Construction (standard, precise):
- a register **defined** at an instruction interferes with everything live immediately **after** it (they coexist), and with its **co-defs** (so `Umull`'s `rdlo`/`rdhi` get distinct registers).
- **precision payoff:** in `add r3, r1, r2` the inputs die at the add, so `r3` does *not* interfere with `r1`/`r2` and may reuse one of their registers — a naive "all operands interfere" graph would forbid that reuse.

`InterferenceGraph` exposes `interferes` / `neighbors` / `degree` / `nodes` / `edge_count`. (`degree` is the Chaitin/Briggs simplify criterion: `degree < k` ⇒ `k`-colourable.)

### Soundness

Returns `None` exactly when `cfg_liveness` declines (out-of-scope construct), so a non-`None` graph is complete for the whole function. **Pure analysis, zero non-test callers, no emitted-byte path touched** ⇒ every frozen differential fixture (control_step `0x00210a55`, flight_algo `0x07FDF307`, divseam) is bit-identical **by construction**.

### Tests

- 5 interference units: simultaneously-live interfere; sequential reuse does **not**; co-defs interfere; live-across-branch interferes on both paths; declines when liveness declines.
- Extended the real-selector-output test to assert the graph over **actual codegen** is symmetric + self-loop-free.

### Verification

`cargo test -p synth-synthesis` (297 lib + suites) green · clippy clean · fmt clean.

Remaining for VCR-RA-001: graph-colouring (simplify/select) → spill/reload → ABI-exit-liveness union → the oracle-gated wiring step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)