### PR TITLE
feat: verify_allocation — allocator self-check oracle (#242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -92,11 +92,16 @@ artifacts:
   #    colours (never simplified/spilled, only constrain neighbours) — the
   #    mechanism for synth's reserved regs (R9/R10/R11/R12) + ABI arg pins.
   #    color_graph() now delegates with empty pins. Still unwired.
-  #    Remaining for VCR-RA-001: spill-code insertion (rewrite spilled values to
-  #    stack slots + reload) -> ABI-exit-liveness union -> virtual-reg selector
-  #    output -> oracle-gated wiring (the consequential step that finally removes
-  #    the hard-fail; it CHANGES emitted bytes so needs the full differential
-  #    gate, unlike the unwired-by-construction analysis pieces above).
+  #  - Allocation verifier (wiring plan step 1): verify_allocation(graph, assign)
+  #    -> Ok | Err(SameColor|Unassigned). The self-check the wired allocator runs
+  #    on its own output before emitting (independent of color_graph => real
+  #    cross-check / defense-in-depth). Verified to accept color_graph's own
+  #    output on real codegen. Still unwired. Wiring plan:
+  #    docs/design/vcr-ra-allocator-wiring.md.
+  #    Remaining for VCR-RA-001 (CONSEQUENTIAL, changes emitted bytes, full
+  #    differential gate): spill-cost ranking -> virtual-reg selector output
+  #    (flag default-off) -> spill-code insertion -> wire-in + per-function flip
+  #    where the differential proves no-regression -> delete a hard-fail site.
   - id: VCR-RA-001
     type: sw-req
     title: SSA-based register allocator with spilling (remove the hard-fail)

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -14861,6 +14861,13 @@ mod tests {
                             assert_ne!(colour[&n], colour[&m], "colouring is valid");
                         }
                     }
+                    // Close the loop: the independent verifier accepts the
+                    // producer's colouring of real codegen (defense-in-depth).
+                    assert_eq!(
+                        liveness::verify_allocation(&g, &colour),
+                        Ok(()),
+                        "verify_allocation must accept color_graph's own output"
+                    );
                 }
                 liveness::ColorResult::Spilled(s) => {
                     panic!("real output should fit the 9-register pool, spilled {s:?}")

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -981,6 +981,61 @@ pub fn color_graph_precolored(
     }
 }
 
+// ============================================================================
+// Allocation verifier (VCR-RA-001 wiring step 1 — the self-check oracle)
+//
+// `color_graph` PRODUCES an assignment; `verify_allocation` CHECKS one. The two
+// are independent code paths, so running the checker on the producer's output
+// (or on any externally-supplied assignment — the current physical-register
+// layout, or a future allocator's result) is genuine defense-in-depth. Per the
+// wiring plan (`docs/design/vcr-ra-allocator-wiring.md`) the wired allocator
+// runs this on its own output and refuses to emit on a conflict, so a bad
+// allocation can never be silently lowered. Building the oracle FIRST means
+// every later wiring sub-step lands already gated. Pure check, no codegen.
+// ============================================================================
+
+/// Why an assignment is not a valid colouring of an interference graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllocationConflict {
+    /// Two interfering registers were assigned the same colour — they would
+    /// clobber each other if both lived in that physical register.
+    SameColor { a: Reg, b: Reg, color: usize },
+    /// A graph node has no colour in the assignment.
+    Unassigned(Reg),
+}
+
+/// Verify that `assignment` is a valid colouring of `g`: every node is assigned,
+/// and no two interfering nodes share a colour. `Ok(())` means the assignment is
+/// safe to lower; `Err` pinpoints the first violation (deterministic in register
+/// order). The checker an allocator runs on its own output before emitting.
+pub fn verify_allocation(
+    g: &InterferenceGraph,
+    assignment: &BTreeMap<Reg, usize>,
+) -> Result<(), AllocationConflict> {
+    // Every node must have a colour.
+    for n in g.nodes() {
+        if !assignment.contains_key(&n) {
+            return Err(AllocationConflict::Unassigned(n));
+        }
+    }
+    // No interfering pair may share a colour.
+    for n in g.nodes() {
+        let cn = assignment[&n];
+        for m in g.neighbors(n) {
+            if let Some(&cm) = assignment.get(&m)
+                && cn == cm
+            {
+                return Err(AllocationConflict::SameColor {
+                    a: n,
+                    b: m,
+                    color: cn,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1828,5 +1883,61 @@ mod tests {
             color_graph(&g, 4),
             color_graph_precolored(&g, 4, &BTreeMap::new())
         );
+    }
+
+    // ---- Allocation verifier (verify_allocation) ---------------------------
+
+    #[test]
+    fn verify_allocation_accepts_color_graph_output() {
+        // The producer and the checker must agree: any colouring color_graph
+        // returns verifies clean. (Independent code paths → real cross-check.)
+        for regs in [
+            vec![Reg::R0, Reg::R1, Reg::R2],
+            vec![Reg::R0, Reg::R1, Reg::R2, Reg::R3],
+        ] {
+            let g = clique(&regs);
+            let k = regs.len();
+            match color_graph(&g, k) {
+                ColorResult::Colored(c) => {
+                    assert_eq!(verify_allocation(&g, &c), Ok(()));
+                }
+                ColorResult::Spilled(s) => panic!("clique is k-colourable, got {s:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn verify_allocation_rejects_interfering_same_colour() {
+        // R0—R1 interfere but are both assigned colour 0 → SameColor.
+        let mut g = InterferenceGraph::default();
+        g.add_edge(Reg::R0, Reg::R1);
+        let bad = BTreeMap::from([(Reg::R0, 0usize), (Reg::R1, 0usize)]);
+        match verify_allocation(&g, &bad) {
+            Err(AllocationConflict::SameColor { color, .. }) => assert_eq!(color, 0),
+            other => panic!("expected SameColor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_allocation_rejects_unassigned_node() {
+        // R1 is in the graph but missing from the assignment → Unassigned.
+        let mut g = InterferenceGraph::default();
+        g.add_edge(Reg::R0, Reg::R1);
+        let partial = BTreeMap::from([(Reg::R0, 0usize)]);
+        assert_eq!(
+            verify_allocation(&g, &partial),
+            Err(AllocationConflict::Unassigned(Reg::R1))
+        );
+    }
+
+    #[test]
+    fn verify_allocation_accepts_a_nonadjacent_shared_colour() {
+        // R0 and R2 do NOT interfere (a path R0—R1—R2), so they may share a
+        // colour: {R0:0, R1:1, R2:0} is valid.
+        let mut g = InterferenceGraph::default();
+        g.add_edge(Reg::R0, Reg::R1);
+        g.add_edge(Reg::R1, Reg::R2);
+        let ok = BTreeMap::from([(Reg::R0, 0usize), (Reg::R1, 1usize), (Reg::R2, 0usize)]);
+        assert_eq!(verify_allocation(&g, &ok), Ok(()));
     }
 }


### PR DESCRIPTION
## North-star increment — VCR-RA-001 wiring **step 1** (side-by-side, unwired)

First step of the merged wiring plan (`docs/design/vcr-ra-allocator-wiring.md`): the **checker dual** of `color_graph`. **No codegen path touched.**

### What

`liveness::verify_allocation(graph, assignment) -> Result<(), AllocationConflict>` — `color_graph` *produces* an assignment; this *checks* one, returning `Ok(())` or the first violation:
- `SameColor { a, b, color }` — two interfering registers given the same colour,
- `Unassigned(reg)` — a graph node with no colour.

### Why build the checker first

The two are **independent code paths**, so running the checker on the producer's output — or on any externally-supplied assignment (the current physical-register layout, or a future allocator's result) — is genuine **defense-in-depth**. Per the plan, the wired allocator runs this on its own output and **refuses to emit on a conflict**, so a bad allocation can never be silently lowered. Building the oracle *first* means every later wiring sub-step lands already gated.

### Soundness

Pure check, **zero non-test callers** (note: unrelated to the pre-existing `contracts::regalloc::verify_allocation` in a different module), no emitted-byte path touched ⇒ all frozen differential fixtures (control_step `0x00210a55`, flight_algo `0x07FDF307`, divseam) bit-identical **by construction**.

### Tests

- Accepts `color_graph`'s output on cliques (producer/checker agree).
- Rejects an interfering pair sharing a colour (`SameColor`).
- Rejects an unassigned node (`Unassigned`).
- Accepts a non-adjacent shared colour (path R0—R1—R2, {0,1,0}).
- Extended the real-selector-output test: `verify_allocation` accepts `color_graph`'s colouring of **actual codegen**.

### Verification

`cargo test -p synth-synthesis` (309 lib + suites) green · clippy clean · fmt clean.

Next (consequential, full differential gate): spill-cost ranking → virtual-register selector output (flag default-off) → spill-code insertion → wire-in + per-function flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)