### PR TITLE
fix: mla fusion live-range precision — fires on real flat_flight (#257) — v0.11.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.32] - 2026-06-05
+
+**`mul`+`add` → `mla` fusion now fires on the real `flat_flight` (#257 follow-up).**
+
+The fusion shipped in v0.11.31 but fired **zero times** on gale's deployed
+`flat_flight` object (`mul=4, mla=0`, byte-identical to pre-fusion). Root cause:
+the soundness check `used_elsewhere` scanned the **whole function** for any read
+of the mul-result register — but the single-pass allocator *reuses* that register
+(`r8`) for unrelated later values, and the reads of those reincarnations falsely
+blocked every fusion.
+
+- **Fix:** replace the whole-function scan with a **precise live-range check** —
+  the mul result must be dead after the add until the register is next redefined.
+  Reads of a later, unrelated value in the same physical register no longer block
+  the fusion. (Commutativity was already handled; gale's guess was a red herring —
+  the bug was liveness precision.)
+- **Measured on the real object** (`flat_flight.loom.wasm`, `cortex-m4
+  --relocatable`): `mul 4 → 2`, `mla 0 → 2`, `170 → 168` instructions. The two
+  filter products (`gyro*980`, `accel*20`) now fuse as intended.
+- **Behavior-frozen:** all three differential fixtures result-identical
+  (`control_step` 0x00210A55, inlined+flat `flight_algo` **0x07FDF307 with the
+  fusion firing**, `div_const` 338/338).
+- Removes the now-dead `op_may_use` helper; adds a regression test pinning the
+  register-reuse pattern (`mul r8; add r2,r5,r8; movw r8,#980; mul r2,r7,r8`).
+
+**Falsification:** this release is wrong if gale's G474RE reflash shows
+`flat_flight` cycles *not* decreasing, or any fixture differential diverging from
+the hashes above.
+
 ## [0.11.31] - 2026-06-05
 
 **gale codegen pass: a load/store correctness fix + two `flat_flight` instruction-selection wins (#257/#258/#259).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.31"
+version = "0.11.32"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.31",
+    version = "0.11.32",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.31" }
+synth-core = { path = "../synth-core", version = "0.11.32" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.31" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.31" }
+synth-core = { path = "../synth-core", version = "0.11.32" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.32" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.31" }
+synth-core = { path = "../synth-core", version = "0.11.32" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.31" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.31", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.32" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.32", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.31" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.31" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.31" }
-synth-backend = { path = "../synth-backend", version = "0.11.31" }
+synth-core = { path = "../synth-core", version = "0.11.32" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.32" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.32" }
+synth-backend = { path = "../synth-backend", version = "0.11.32" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.31", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.31", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.31", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.32", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.32", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.32", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.31", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.32", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.31" }
+synth-core = { path = "../synth-core", version = "0.11.32" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.31" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.32" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.31" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.31" }
-synth-opt = { path = "../synth-opt", version = "0.11.31" }
+synth-core = { path = "../synth-core", version = "0.11.32" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.32" }
+synth-opt = { path = "../synth-opt", version = "0.11.32" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -395,30 +395,6 @@ pub fn eliminate_dead_stores(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>,
     (kept, dead.len())
 }
 
-/// Conservative "does `op` possibly read `reg`": precise via [`reg_effect`] when
-/// modeled; a pure branch/label reads no GP register; a call (`Bl`/`Blx`/…) may
-/// read the AAPCS argument registers `R0..=R3`; anything else unmodeled (`Bx`,
-/// the i64-pair / FP families) is conservatively assumed to read `reg`.
-fn op_may_use(op: &ArmOp, reg: Reg) -> bool {
-    if let Some(e) = reg_effect(op) {
-        return e.uses.contains(&reg);
-    }
-    use ArmOp::*;
-    match op {
-        Label { .. }
-        | B { .. }
-        | BOffset { .. }
-        | BCondOffset { .. }
-        | Bhs { .. }
-        | Blo { .. }
-        | Bcc { .. } => false,
-        Bl { .. } | Blx { .. } | Call { .. } | CallIndirect { .. } => {
-            matches!(reg, Reg::R0 | Reg::R1 | Reg::R2 | Reg::R3)
-        }
-        _ => true,
-    }
-}
-
 /// Fuse `mul` + `add` into `mla` (#257): for an `Add rD, x, Reg(y)` where one
 /// operand is the destination of an earlier `Mul rM, rn, rm`, the result is
 /// `mla rD, rn, rm, other`, and the now-redundant `Mul` is removed. Returns the
@@ -426,15 +402,19 @@ fn op_may_use(op: &ArmOp, reg: Reg) -> bool {
 ///
 /// Soundness conditions (all checked via [`reg_effect`]; any unmodeled
 /// instruction conservatively blocks a fusion across it):
-///  - the mul result `rM` is **not read** anywhere after the add (its value is
-///    consumed only by the add → the mul is dead once fused),
+///  - the mul result `rM`'s value is **consumed only by the add** — dead after
+///    the add until `rM` is next redefined. This is a precise *live-range*
+///    check, NOT "rM is read nowhere in the function": the single-pass allocator
+///    reuses `rM` for unrelated later values, and reads of those reincarnations
+///    must not block the fusion (#257: the whole-function scan fired zero times
+///    on the real `flat_flight`, where `r8` is recycled across axes),
 ///  - between the mul and the add, `rM` and the mul inputs `rn`/`rm` are
 ///    **neither redefined nor** (for `rM`) **read** — so the `mla` reading
 ///    `rn`/`rm` at the add's position sees the same values,
 ///  - `rM` and the other add operand are distinct, and the mul inputs are not
 ///    `rM` itself.
 ///
-/// Pure function: callers opt in. Not wired into codegen by this change.
+/// Pure function: callers opt in.
 pub fn fuse_mul_add(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
     let n = instrs.len();
     let mut removed = vec![false; n];
@@ -478,14 +458,42 @@ pub fn fuse_mul_add(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
             if !between_ok {
                 continue;
             }
-            // The mul result must be read *only* by this add anywhere in the
-            // function — then removing the mul and folding into the mla is sound
-            // regardless of control flow. `op_may_use` is call/branch-aware
-            // (calls may read R0-R3; pure branches read nothing).
-            let used_elsewhere =
-                (0..n).any(|k| k != j && !removed[k] && op_may_use(&instrs[k].op, rmul));
-            if used_elsewhere {
-                continue;
+            // The mul result must be consumed ONLY by this add: dead after `j`
+            // until `rmul` is next redefined. `between_ok` already proved no read
+            // in (i, j). A whole-function "is rmul read anywhere" scan is WRONG —
+            // the single-pass allocator REUSES `rmul` for unrelated later values,
+            // whose reads would falsely block the fusion (#257: this is exactly
+            // why fusion fired zero times on the real flat_flight, where r8 is
+            // recycled). Scan forward from j+1: a read of `rmul` before any redef
+            // means our value is still live → unsafe; a redef ends its live range
+            // → safe; an op we cannot see through (branch/call/pseudo) is treated
+            // conservatively as a possible later read → unsafe. When `rmul == rd`
+            // the add overwrites it with the (correct) result, so later reads are
+            // of the result, not the dangling product — always safe.
+            if rmul != rd {
+                let mut consumed_only_here = true;
+                for k in (j + 1)..n {
+                    if removed[k] {
+                        continue;
+                    }
+                    match reg_effect(&instrs[k].op) {
+                        Some(e) if e.uses.contains(&rmul) => {
+                            consumed_only_here = false; // still live → unsafe
+                            break;
+                        }
+                        Some(e) if e.defs.contains(&rmul) => break, // redef → dead → safe
+                        Some(_) => {}                               // unrelated → keep scanning
+                        None => {
+                            // Unmodeled (branch/call/pseudo): cannot prove the
+                            // value is dead past it → bail to stay sound.
+                            consumed_only_here = false;
+                            break;
+                        }
+                    }
+                }
+                if !consumed_only_here {
+                    continue;
+                }
             }
             rewritten[j] = Some(ArmOp::Mla {
                 rd,
@@ -1126,6 +1134,54 @@ mod tests {
         let (out, fused) = fuse_mul_add(&seq);
         assert_eq!(fused, 0, "mul result is live after the add → not fusable");
         assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn fuse_mul_add_fires_when_mul_result_is_reused_for_a_new_value_later() {
+        // #257 real flat_flight shape: r8 = r6*r7 is consumed ONLY by the add,
+        // then r8 is REDEFINED (movw) and reused for an unrelated value. The
+        // greedy allocator's reuse of r8 must NOT block the fusion — the old
+        // whole-function "r8 read anywhere?" scan wrongly counted the reads of
+        // the *new* r8 and fired zero times on the deployed object.
+        //   mul r8,r6,r7 ; add r2,r5,r8 ; movw r8,#980 ; mul r2,r7,r8
+        let seq = vec![
+            ins(ArmOp::Mul {
+                rd: Reg::R8,
+                rn: Reg::R6,
+                rm: Reg::R7,
+            }),
+            ins(ArmOp::Add {
+                rd: Reg::R2,
+                rn: Reg::R5,
+                op2: Operand2::Reg(Reg::R8),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R8,
+                imm16: 980,
+            }), // r8 redefined → unrelated value
+            ins(ArmOp::Mul {
+                rd: Reg::R2,
+                rn: Reg::R7,
+                rm: Reg::R8,
+            }), // reads the NEW r8
+        ];
+        let (out, fused) = fuse_mul_add(&seq);
+        assert_eq!(
+            fused, 1,
+            "reuse of r8 for a new value must not block fusion"
+        );
+        assert!(
+            out.iter().any(|i| matches!(
+                &i.op,
+                ArmOp::Mla {
+                    rd: Reg::R2,
+                    rn: Reg::R6,
+                    rm: Reg::R7,
+                    ra: Reg::R5
+                }
+            )),
+            "the op2-operand mul fuses with r5 as the accumulator"
+        );
     }
 
     #[test]

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.31" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.31" }
-synth-opt = { path = "../synth-opt", version = "0.11.31" }
+synth-core = { path = "../synth-core", version = "0.11.32" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.32" }
+synth-opt = { path = "../synth-opt", version = "0.11.32" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.31", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.32", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## #257 follow-up — the mla fusion now actually fires on gale's `flat_flight`

The `mul`+`add`→`mla` fusion shipped in **v0.11.31** but fired **zero times** on gale's deployed `flat_flight` object (`mul=4, mla=0`, byte-identical to pre-fusion). gale [reported](https://github.com/pulseengine/synth/issues/257) it and guessed commutativity wasn't handled — but the pass already tries both operand orders. **The real bug is liveness precision.**

### Root cause

The soundness check `used_elsewhere` scanned the **whole function** for any read of the mul-result register. But the single-pass allocator **reuses** that register (`r8`) for unrelated later values:

```
7e: mul.w r8, r6, r7   ; r8 = accel*20   ← our mul
82: add.w r2, r5, r8   ; consumes r8     ← our add (only real use)
a4: movw  r8, #980     ; r8 REDEFINED to a different value
a8: mul.w r2, r7, r8   ; reads the NEW r8
```

The reads of the *new* `r8` (at `a8`, `e8`, …) falsely blocked the fusion, even though our value is consumed only by the add at `82`.

### Fix

Replace the whole-function scan with a **precise live-range check**: the mul result must be dead after the add until the register is next redefined. Reads of a later, unrelated value in the same physical register no longer block fusion. Sound: `rmul==rd` (in-place accumulate) is always safe; an unmodeled op we can't see through bails conservatively. Removes the now-dead `op_may_use` helper.

### Measured (real object, `flat_flight.loom.wasm`, cortex-m4 `--relocatable`)

| | before | after |
|---|---|---|
| `mul` | 4 | **2** |
| `mla` | 0 | **2** |
| instructions | 170 | **168** |

The two filter products (`gyro*980`, `accel*20`) now fuse as intended.

### Oracle gate (behavior-frozen)

All three differential fixtures **result-identical** (verified, debug binary, `/tmp/armv`):
- `control_step` → ORACLE PASS (0x00210A55)
- `flight_seam` → **0x07FDF307 MATCH** (the frozen flat_flight result, *with the fusion now firing*)
- `div_const` → 338/338 PASS

Full workspace tests green (65 suites) · clippy clean · fmt clean · new regression test pins the register-reuse pattern.

**Falsification:** wrong if gale's G474RE reflash shows `flat_flight` cycles not decreasing, or any fixture differential diverging.

Ships as **v0.11.32** (version swept across 11 crates + MODULE.bazel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)