### PR TITLE
feat: reachable-graph closure follows call_indirect into table functions (#275) — v0.11.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.33] - 2026-06-05
+
+**Whole-reachable-graph closure now follows `call_indirect` into table functions
+(#275, foundation — see the honest scope note).**
+
+`--all-exports` compiled the closure of the exports over **direct** `call`
+(#235), but a function reached only through `call_indirect` (a table entry) was
+invisible to that closure and left out of the ELF — so a module that dispatches
+through a function table is not self-contained.
+
+- **Decoder:** parse the Element section (`elem_func_indices` on `DecodedModule`)
+  — the function indices that populate the table, i.e. the possible
+  `call_indirect` targets. Empty for modules with no element section, so their
+  output is byte-identical.
+- **Closure:** `reachable_from_exports` now unions in every table function once a
+  reachable function performs a `call_indirect` (a sound over-approximation —
+  any table entry could be the dynamic callee), then keeps following their direct
+  calls transitively. Verified on a minimal indirect-call module: the
+  call-only-via-table target is now compiled into the object (was absent).
+- **Behavior-frozen:** the three differential fixtures stay result-identical
+  (`control_step` 0x00210A55, `flight_seam` 0x07FDF307, `div_const` 338/338) —
+  they use no element section, so the closure is unchanged.
+
+**Scope / known remaining (not in this release).** This lands the *reachability*
+half. `call_indirect` **dispatch** in the `select_with_stack` (`--all-exports`)
+path is still incomplete: the indirect call is currently dropped during
+selection, and the encoder's table-base expansion uses R11 — which collides with
+synth's R11 = linear-memory-base ABI. So a module using indirect dispatch now has
+its table functions *present* in the ELF but the indirect call itself is not yet
+wired end-to-end. Modules using only **direct** calls are fully self-contained.
+Tracked for a follow-up.
+
+**Falsification:** wrong if a module using only direct `call` still omits a
+reachable internal callee, or if any fixture differential diverges.
+
 ## [0.11.32] - 2026-06-05
 
 **`mul`+`add` → `mla` fusion now fires on the real `flat_flight` (#257 follow-up).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.31"
+version = "0.11.33"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.31"
+version = "0.11.33"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.31"
+version = "0.11.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.31"
+version = "0.11.33"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.32"
+version = "0.11.33"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.32",
+    version = "0.11.33",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.32" }
+synth-core = { path = "../synth-core", version = "0.11.33" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.32" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.32" }
+synth-core = { path = "../synth-core", version = "0.11.33" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.33" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.32" }
+synth-core = { path = "../synth-core", version = "0.11.33" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.32" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.32", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.33" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.33", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.32" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.32" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.32" }
-synth-backend = { path = "../synth-backend", version = "0.11.32" }
+synth-core = { path = "../synth-core", version = "0.11.33" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.33" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.33" }
+synth-backend = { path = "../synth-backend", version = "0.11.33" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.32", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.32", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.32", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.33", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.33", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.33", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.32", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.33", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1671,6 +1671,7 @@ fn identify_stack_pointer_global(globals: &[WasmGlobal], linmem_bytes: u32) -> O
 fn reachable_from_exports(
     funcs: &[FunctionOps],
     num_imports: u32,
+    elem_func_indices: &[u32],
 ) -> std::collections::BTreeSet<u32> {
     let pos_by_index: std::collections::HashMap<u32, usize> = funcs
         .iter()
@@ -1679,6 +1680,10 @@ fn reachable_from_exports(
         .collect();
     let mut reachable: std::collections::BTreeSet<u32> = std::collections::BTreeSet::new();
     let mut work: Vec<u32> = Vec::new();
+    // #275: the first `call_indirect` reached makes every table function a
+    // possible target. Add them all once (sound over-approximation — any table
+    // entry could be the dynamic callee), then keep following their direct calls.
+    let mut table_included = false;
     for f in funcs {
         if f.export_name.is_some() && reachable.insert(f.index) {
             work.push(f.index);
@@ -1687,11 +1692,19 @@ fn reachable_from_exports(
     while let Some(idx) = work.pop() {
         if let Some(&p) = pos_by_index.get(&idx) {
             for op in &funcs[p].ops {
-                if let WasmOp::Call(target) = op
-                    && *target >= num_imports
-                    && reachable.insert(*target)
-                {
-                    work.push(*target);
+                match op {
+                    WasmOp::Call(target) if *target >= num_imports && reachable.insert(*target) => {
+                        work.push(*target);
+                    }
+                    WasmOp::CallIndirect { .. } if !table_included => {
+                        table_included = true;
+                        for &t in elem_func_indices {
+                            if t >= num_imports && reachable.insert(t) {
+                                work.push(t);
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
         }
@@ -1855,6 +1868,7 @@ fn compile_all_exports(
         let imports = module.imports;
         let num_imports = module.num_imported_funcs;
         let data_segs = module.data_segments; // #237: capture before `functions` is moved
+        let elem_func_indices = module.elem_func_indices; // #275: call_indirect targets
         // #237: identify the stack-pointer global for native-pointer promotion.
         // linmem extent gates the "plausible stack top" heuristic.
         let linmem_bytes = memories.first().map(|m| m.initial_bytes()).unwrap_or(0);
@@ -1867,7 +1881,7 @@ fn compile_all_exports(
         // num_imports) stay external — the linker resolves them. A module whose
         // exports call no internal function (every leaf fixture) yields exactly
         // the exports, so existing output stays bit-identical.
-        let reachable = reachable_from_exports(&module.functions, num_imports);
+        let reachable = reachable_from_exports(&module.functions, num_imports, &elem_func_indices);
         // Preserve definition order; keep exports + reachable internal callees.
         let exports: Vec<_> = module
             .functions
@@ -3542,7 +3556,7 @@ mod tests {
             fop(2, Some("caller"), vec![WasmOp::Call(1), WasmOp::Call(0)]),
             fop(3, None, vec![WasmOp::I32Const(9)]),
         ];
-        let r = reachable_from_exports(&funcs, 1); // num_imports = 1
+        let r = reachable_from_exports(&funcs, 1, &[]); // num_imports = 1
         assert!(r.contains(&2), "the export itself is reachable");
         assert!(
             r.contains(&1),
@@ -3555,6 +3569,61 @@ mod tests {
         );
     }
 
+    /// #275: a function reached only through `call_indirect` (a table entry,
+    /// not a direct `call`) must be pulled into the reachable set — otherwise
+    /// the binary is not self-contained and faults on hardware. Table entries
+    /// that are NOT possible targets here (only those in the element segment)
+    /// are included; an unreferenced internal stays out.
+    #[test]
+    fn reachable_from_exports_follows_call_indirect_into_table_275() {
+        // 0 = exported caller, does a call_indirect; 1 = table target (in elem,
+        // reached only indirectly); 2 = direct callee of the table target;
+        // 3 = dead internal (not in the table, never called).
+        let funcs = vec![
+            fop(
+                0,
+                Some("run"),
+                vec![
+                    WasmOp::I32Const(0),
+                    WasmOp::CallIndirect {
+                        type_index: 0,
+                        table_index: 0,
+                    },
+                ],
+            ),
+            fop(1, None, vec![WasmOp::Call(2)]),
+            fop(2, None, vec![WasmOp::I32Const(42)]),
+            fop(3, None, vec![WasmOp::I32Const(9)]),
+        ];
+        // elem segment puts function 1 in the table.
+        let r = reachable_from_exports(&funcs, 0, &[1]);
+        assert!(r.contains(&0), "the export itself");
+        assert!(
+            r.contains(&1),
+            "the call_indirect target (table entry) is pulled in (#275)"
+        );
+        assert!(
+            r.contains(&2),
+            "and its transitive direct callee follows too"
+        );
+        assert!(!r.contains(&3), "a non-table, uncalled internal stays out");
+    }
+
+    /// Without a `call_indirect`, table entries are NOT force-included — a module
+    /// that never dispatches indirectly keeps the tight direct-call closure.
+    #[test]
+    fn reachable_from_exports_ignores_table_when_no_call_indirect_275() {
+        let funcs = vec![
+            fop(0, Some("run"), vec![WasmOp::I32Const(1)]),
+            fop(1, None, vec![WasmOp::I32Const(42)]), // in table, but never indirectly called
+        ];
+        let r = reachable_from_exports(&funcs, 0, &[1]);
+        assert!(
+            !r.contains(&1),
+            "no call_indirect → table entry not pulled in"
+        );
+    }
+
     /// A module whose exports call no internal function yields exactly the
     /// exports — so existing leaf-fixture output stays bit-identical.
     #[test]
@@ -3564,7 +3633,7 @@ mod tests {
             fop(1, Some("b"), vec![WasmOp::LocalGet(0)]),
             fop(2, None, vec![WasmOp::I32Const(7)]), // dead helper
         ];
-        let r = reachable_from_exports(&funcs, 0);
+        let r = reachable_from_exports(&funcs, 0, &[]);
         assert_eq!(
             r.into_iter().collect::<Vec<_>>(),
             vec![0, 1],

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -102,6 +102,13 @@ pub struct DecodedModule {
     /// initializer is a linear-memory address (e.g. `$__stack_pointer`)
     /// self-contained rather than table-relative.
     pub globals: Vec<WasmGlobal>,
+    /// Function indices that populate any table via an element segment (#275).
+    /// These are the possible `call_indirect` targets — a function reached only
+    /// through the table is invisible to direct-`call` reachability, so the
+    /// whole-graph closure must treat every table entry as reachable once any
+    /// reachable function performs a `call_indirect`. Empty for modules with no
+    /// element section (every leaf/direct-call module), keeping output identical.
+    pub elem_func_indices: Vec<u32>,
 }
 
 /// Decode a WASM binary and extract functions, memory, and data segments
@@ -118,6 +125,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     // arg count (indexed by full function index: imports first, then locals).
     let mut type_arg_counts: Vec<u32> = Vec::new();
     let mut func_arg_counts: Vec<u32> = Vec::new();
+    let mut elem_func_indices: Vec<u32> = Vec::new();
 
     for payload in Parser::new(0).parse_all(wasm_bytes) {
         let payload = payload.context("Failed to parse WASM payload")?;
@@ -222,6 +230,37 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                     }
                 }
             }
+            Payload::ElementSection(reader) => {
+                // #275: collect every function index that initializes a table.
+                // These are the `call_indirect` targets the direct-call closure
+                // cannot see; `reachable_from_exports` unions them in when a
+                // reachable function does a `call_indirect`. Both element forms
+                // are handled: a flat function-index list, and the const-expr
+                // form whose `ref.func` entries name the functions.
+                for elem in reader {
+                    let elem = elem.context("Failed to parse element segment")?;
+                    match elem.items {
+                        wasmparser::ElementItems::Functions(funcs) => {
+                            for f in funcs {
+                                elem_func_indices
+                                    .push(f.context("Failed to parse element func index")?);
+                            }
+                        }
+                        wasmparser::ElementItems::Expressions(_, exprs) => {
+                            for expr in exprs {
+                                let expr = expr.context("Failed to parse element expr")?;
+                                for op in expr.get_operators_reader() {
+                                    if let wasmparser::Operator::RefFunc { function_index } =
+                                        op.context("Failed to parse element op")?
+                                    {
+                                        elem_func_indices.push(function_index);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             Payload::ExportSection(exports) => {
                 for export in exports {
                     let export = export.context("Failed to parse export")?;
@@ -255,6 +294,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
         func_arg_counts,
         type_arg_counts,
         globals,
+        elem_func_indices,
     })
 }
 

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.32" }
+synth-core = { path = "../synth-core", version = "0.11.33" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.32" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.33" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.32" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.32" }
-synth-opt = { path = "../synth-opt", version = "0.11.32" }
+synth-core = { path = "../synth-core", version = "0.11.33" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.33" }
+synth-opt = { path = "../synth-opt", version = "0.11.33" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.32" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.32" }
-synth-opt = { path = "../synth-opt", version = "0.11.32" }
+synth-core = { path = "../synth-core", version = "0.11.33" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.33" }
+synth-opt = { path = "../synth-opt", version = "0.11.33" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.32", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.33", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## #275 — reachable-graph closure now includes `call_indirect` targets

`--all-exports` compiled the closure over **direct** `call` (#235), but a function reached only through `call_indirect` (a table entry) was invisible and left out of the ELF. gale's falcon: 280 functions → 24 symbols.

### Reproduced (minimal)
```wat
(func $internal_only (result i32) i32.const 42)
(elem (i32.const 0) $internal_only)
(func (export "run") (result i32) i32.const 0 call_indirect (type $t))
```
Before: `--all-exports` emits only `run`. After: `run` + `func_0` (the table target).

### Fix
- **Decoder:** parse the Element section → `elem_func_indices` (the possible `call_indirect` targets). Empty for modules with no element section → byte-identical output.
- **Closure:** `reachable_from_exports` unions in every table function once a reachable function does a `call_indirect` (sound over-approximation), then follows their direct calls transitively.

### Behavior-frozen
All three differential fixtures result-identical (`control_step` 0x00210A55, `flight_seam` 0x07FDF307, `div_const` 338/338) — no element section, closure unchanged. 65 workspace test suites green · clippy clean · 2 new reachability tests.

### ⚠️ Honest scope — this is the reachability half only

While building this I found `call_indirect` **dispatch** in the `select_with_stack` (`--all-exports`) path is **incomplete**:
1. The indirect call is **dropped during selection** — the minimal repro's `run` lowers to `movs r4,#0; bx lr` (index computed, no call).
2. The encoder's table-base expansion (`arm_encoder.rs:2573`) loads via `[R11, R12]` using **R11 as table base — which collides with synth's R11 = linear-memory-base ABI**.

So a module using indirect dispatch now has its table functions **present** in the ELF, but the indirect call itself is **not yet wired end-to-end**. **Direct-call** modules are fully self-contained. The dispatch fix is a tracked follow-up (and I need the falcon wasm to do it right — see the issue thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)