### PR TITLE
fix: un-wire default-on mla fusion — regresses on-target until allocator (#277) — v0.11.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.34] - 2026-06-05
+
+**Un-wire the default-on `mul`+`add`→`mla` fusion — it regresses on-target until
+the allocator lands (#277).**
+
+The fusion (v0.11.32, #257) correctly fires on the real `flat_flight`, but gale
+measured a **+2 cyc on-target regression** on the G474RE (255 → 257 cyc), stable
+across re-measures, even though it removes 2 instructions and the seam stays
+`0x07FDF307`. Root cause: over the greedy single-pass selector, folding
+`mul rM,..; add rD,rM,rX` → `mla` **extends the live ranges of the mul inputs**
+to the mla point, and the added register pressure costs more than the
+single-cycle `MLA` saves. The transform is **register-allocation-coupled** —
+net-positive only once a spill-aware allocator chooses registers (VCR-RA-001,
+#272).
+
+- **Fix:** remove the default-on wiring in `arm_backend`. `fuse_mul_add` stays as
+  fully-tested infrastructure in `synth_synthesis::liveness`, to be re-wired
+  *with* the allocator (where it pays off), per the wiring design note.
+- **Restores** `flat_flight` to the pre-fusion v0.11.31 codegen (mul 4 / mla 0 /
+  170 instr / 255 cyc). All three differential fixtures result-identical
+  (`control_step` 0x00210A55, `flight_seam` 0x07FDF307, `div_const` 338/338).
+
+**Lesson (gale's, recorded):** a register-pressure-affecting transform needs an
+**on-target / allocator-aware** gate, not a byte-count gate — `1891→1819 B` read
+as a win while silicon cycles regressed.
+
+**Falsification:** wrong if `flat_flight` is not byte-identical to v0.11.31, or
+any fixture differential diverges.
+
 ## [0.11.33] - 2026-06-05
 
 **Whole-reachable-graph closure now follows `call_indirect` into table functions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.33"
+version = "0.11.34"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.33",
+    version = "0.11.34",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.33" }
+synth-core = { path = "../synth-core", version = "0.11.34" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.33" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.33" }
+synth-core = { path = "../synth-core", version = "0.11.34" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.34" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.33" }
+synth-core = { path = "../synth-core", version = "0.11.34" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.33" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.33", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.34" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.34", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -233,13 +233,19 @@ fn compile_wasm_to_arm(
         }
     };
 
-    // #257: fuse `mul` + `add` into `mla`. Runs on the selected stream *before*
-    // branch resolution (it removes instructions, shifting byte offsets) — and is
-    // sound across control flow (the fusion only fires when the mul result is read
-    // solely by the add; see `fuse_mul_add`). A no-op for streams with no fusable
-    // pattern, so existing output stays bit-identical unless a `mul;…;add` pair
-    // qualifies.
-    let (arm_instrs, _fused) = synth_synthesis::liveness::fuse_mul_add(&arm_instrs);
+    // #257/#277: `mul`+`add`→`mla` fusion is intentionally NOT wired here.
+    // The transform is correct and ready (`synth_synthesis::liveness::fuse_mul_add`,
+    // fully tested), but it is **register-allocation-coupled**: over the current
+    // greedy single-pass selector, folding `mul rM,..; add rD,rM,rX` → `mla`
+    // extends the live ranges of the mul inputs to the mla point, and the added
+    // pressure (extra moves/spills) costs more than the single-cycle MLA saves —
+    // gale measured a +2 cyc on-target REGRESSION (flat_flight 255→257, G474RE)
+    // even though it removes 2 instructions and the seam stays 0x07FDF307. So the
+    // fusion stays unwired until the spill-aware allocator (VCR-RA-001) chooses
+    // registers, at which point it becomes net-positive (per #272's plan and the
+    // wiring design note). Lesson (#277): a register-pressure-affecting transform
+    // needs an on-target/allocator-aware gate, not a byte-count gate, before it
+    // can default on.
 
     // ISA feature gate: validate that all generated instructions are supported
     // by the target. This catches FPU instructions on no-FPU targets, double-precision

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.33" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.33" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.33" }
-synth-backend = { path = "../synth-backend", version = "0.11.33" }
+synth-core = { path = "../synth-core", version = "0.11.34" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.34" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.34" }
+synth-backend = { path = "../synth-backend", version = "0.11.34" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.33", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.33", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.33", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.34", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.34", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.34", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.33", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.34", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.33" }
+synth-core = { path = "../synth-core", version = "0.11.34" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.33" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.34" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.33" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.33" }
-synth-opt = { path = "../synth-opt", version = "0.11.33" }
+synth-core = { path = "../synth-core", version = "0.11.34" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.34" }
+synth-opt = { path = "../synth-opt", version = "0.11.34" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.33" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.33" }
-synth-opt = { path = "../synth-opt", version = "0.11.33" }
+synth-core = { path = "../synth-core", version = "0.11.34" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.34" }
+synth-opt = { path = "../synth-opt", version = "0.11.34" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.33", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.34", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## #277 — the mla fusion regresses on silicon; un-wire it until the allocator

gale measured v0.11.32's `mul`+`add`→`mla` fusion as a **+2 cyc regression** on the G474RE (`flat_flight` 255→257, stable across re-measures) — despite removing 2 instructions and keeping the seam `0x07FDF307`.

**Root cause (gale's, confirmed):** over the greedy single-pass selector, folding `mul rM,..; add rD,rM,rX` → `mla` **extends the live ranges of the mul inputs** to the `mla` point. The added register pressure (extra moves/spills) costs more than the single-cycle `MLA` saves. The transform is **register-allocation-coupled** — net-positive only once a spill-aware allocator chooses registers (VCR-RA-001 / #272).

### Fix
Remove the default-on wiring in `arm_backend`. `fuse_mul_add` stays as fully-tested infrastructure in `synth_synthesis::liveness`, to be re-wired **with** the allocator (where it pays off), per `docs/design/vcr-ra-allocator-wiring.md`.

### Verified
- `flat_flight` restored to pre-fusion v0.11.31 codegen: **mul 4 / mla 0 / 170 instr** (the 255-cyc shape).
- All three differential fixtures result-identical (`control_step` 0x00210A55, `flight_seam` 0x07FDF307, `div_const` 338/338).
- `fuse_mul_add`'s 4 unit tests still pass (function intact); clippy clean (it's `pub` + tested, so no dead-code).

### Lesson (recorded)
A register-pressure-affecting transform needs an **on-target / allocator-aware** gate, not a byte-count gate — `1891→1819 B` read as a win while silicon cycles regressed. This is the concrete evidence behind the north-star's "instruction-selection transforms wait for the allocator" stance.

Ships as **v0.11.34**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)