### PR TITLE
perf: in-place select — elide keep-val2 move (#209, VCR-SEL-002)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.33"
+version = "0.11.34"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.33"
+version = "0.11.34"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.33"
+version = "0.11.34"
 
 [[package]]
 name = "tempfile"

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -6991,7 +6991,25 @@ impl InstructionSelector {
                         &live_params,
                         idx,
                     )?;
-                    let dst = alloc_temp_safe(&mut next_temp, &stack, &live_params)?;
+                    // #209/VCR-SEL-002 — in-place select. `val2` is consumed by
+                    // this op, so when it is a free temp (not a live param reg,
+                    // and distinct from cond/val1) we reuse ITS register as `dst`
+                    // and keep its value via the EQ fall-through — only ONE
+                    // conditional move is needed (cond != 0 overrides with val1).
+                    // This is exactly what native emits for a clamp `(x>k)?k:x`
+                    // and removes one `SelectMove` per select, the dominant cost
+                    // in flat_flight's saturation chain. The three guards rule out
+                    // the cases where overwriting val2's register is observable:
+                    //   - live param  → #193 param-clobber class
+                    //   - val2==cond  → cmp consumed cond, but a later read can't
+                    //   - val2==val1  → degenerate; fresh dst keeps it simple
+                    // Falls back to the fresh-dst two-move form otherwise.
+                    let in_place = !live_params.contains(&val2) && val2 != cond_reg && val2 != val1;
+                    let dst = if in_place {
+                        val2
+                    } else {
+                        alloc_temp_safe(&mut next_temp, &stack, &live_params)?
+                    };
 
                     // CMP cond, #0 — sets the flags FIRST, before anything writes
                     // `dst`. The previous lowering put a `MOV dst, val1` between
@@ -6999,10 +7017,12 @@ impl InstructionSelector {
                     // `MOVS` for low registers and SETS the flags, clobbering the
                     // comparison whenever the allocator picked a low `dst` — which
                     // mis-computed gale's br_table index so the binary-semaphore
-                    // WAKE path never ran. Both `SelectMove`s below are `IT;MOV`
+                    // WAKE path never ran. The `SelectMove`s below are `IT;MOV`
                     // (the flag-preserving 0x46xx MOV), so neither disturbs the
                     // flags and exactly one fires — correct under any aliasing of
                     // dst with cond/val1/val2 (cond is already consumed by CMP).
+                    // In the in-place case there is NO instruction between the CMP
+                    // and the conditional move, so the flags are likewise intact.
                     instructions.push(ArmInstruction {
                         op: ArmOp::Cmp {
                             rn: cond_reg,
@@ -7023,16 +7043,19 @@ impl InstructionSelector {
                     });
                     cf.add_instruction();
 
-                    // cond == 0 → dst = val2
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::SelectMove {
-                            rd: dst,
-                            rm: val2,
-                            cond: Condition::EQ,
-                        },
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
+                    // cond == 0 → dst = val2. Skipped when dst already IS val2
+                    // (in-place): the EQ branch is a no-op move on itself.
+                    if !in_place {
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::SelectMove {
+                                rd: dst,
+                                rm: val2,
+                                cond: Condition::EQ,
+                            },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    }
                     stack.push(StackVal::i32(dst));
                 }
 
@@ -10017,12 +10040,15 @@ mod tests {
         });
         assert!(has_cmp, "Select should emit CMP for condition");
 
-        // Should contain SelectMove for conditional assignment
+        // Should contain the NE override SelectMove (cond != 0 -> dst = val1).
+        // The in-place select (#209/VCR-SEL-002) reuses val2's register as dst
+        // and elides the EQ "keep val2" move, so NE is the form present in both
+        // the in-place and the fresh-dst fallback lowerings.
         let has_select_move = arm_instrs.iter().any(|i| {
             matches!(
                 &i.op,
                 ArmOp::SelectMove {
-                    cond: Condition::EQ,
+                    cond: Condition::NE,
                     ..
                 }
             )
@@ -11562,17 +11588,64 @@ mod tests {
         });
         assert!(has_cmp, "Select should emit CMP condition, #0");
 
-        // Should have SelectMove EQ (conditional override)
+        // Should have the NE override SelectMove. With in-place select
+        // (#209/VCR-SEL-002), val2 (the const-20 temp) is reused as dst and the
+        // EQ "keep" move is elided; the NE override is present in both forms.
         let has_select_move = instrs.iter().any(|i| {
             matches!(
                 &i.op,
                 ArmOp::SelectMove {
-                    cond: Condition::EQ,
+                    cond: Condition::NE,
                     ..
                 }
             )
         });
-        assert!(has_select_move, "Select should emit SelectMove with EQ");
+        assert!(has_select_move, "Select should emit SelectMove with NE");
+    }
+
+    #[test]
+    fn test_select_in_place_elides_keep_move_209() {
+        // #209/VCR-SEL-002: when val2 is a free temp (here the const-20 temp,
+        // not a live param, distinct from cond/val1), the select reuses val2's
+        // register as dst and keeps it via the EQ fall-through — so exactly ONE
+        // SelectMove (the NE override) is emitted, not two. Result-identity is
+        // verified on-target by the flight_seam / control_step differentials;
+        // this pins the structural win (one fewer IT;MOV per qualifying select).
+        let mut selector = fresh_selector();
+        let wasm_ops = vec![
+            WasmOp::I32Const(10), // val1
+            WasmOp::I32Const(20), // val2 — reusable temp
+            WasmOp::I32Const(1),  // cond
+            WasmOp::Select,
+        ];
+        let instrs = selector.select_with_stack(&wasm_ops, 0).unwrap();
+
+        let ne = instrs
+            .iter()
+            .filter(|i| {
+                matches!(
+                    &i.op,
+                    ArmOp::SelectMove {
+                        cond: Condition::NE,
+                        ..
+                    }
+                )
+            })
+            .count();
+        let eq = instrs
+            .iter()
+            .filter(|i| {
+                matches!(
+                    &i.op,
+                    ArmOp::SelectMove {
+                        cond: Condition::EQ,
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert_eq!(ne, 1, "in-place select emits exactly one NE override move");
+        assert_eq!(eq, 0, "in-place select elides the EQ keep-val2 move");
     }
 
     #[test]
@@ -11624,12 +11697,14 @@ mod tests {
             "Should have 1 STR to global 2 at [R9, #8]"
         );
 
-        // Should have select logic
+        // Should have select logic — the NE override is emitted in both the
+        // in-place (#209/VCR-SEL-002) and fresh-dst forms (the EQ "keep val2"
+        // move is what in-place elides when val2's register is reused as dst).
         let has_select_move = instrs.iter().any(|i| {
             matches!(
                 &i.op,
                 ArmOp::SelectMove {
-                    cond: Condition::EQ,
+                    cond: Condition::NE,
                     ..
                 }
             )


### PR DESCRIPTION
## What

The stack selector's `Select` lowering emitted **three** instructions into a fresh `dst`:

```
cmp cond, #0
selectmove dst, val1, NE     ; cond != 0 -> dst = val1
selectmove dst, val2, EQ     ; cond == 0 -> dst = val2
```

Since `select` *consumes* all three operands, `val2`'s register is dead after the op. We reuse it as `dst`, so the EQ "keep val2" branch becomes a no-op move on itself and is **elided** — leaving exactly one conditional move (the NE override), which is what native emits for a clamp `(x>k)?k:x`. Each removed `SelectMove` is one fewer `IT;MOV`: **−2 bytes and −1 cycle** (the M4 executes a predicated-false MOV).

## Soundness

In-place only when `val2` is safely overwritable, else fall back to the original two-move form:
- **not a live param register** — the #193 param-clobber class
- **distinct from `cond`** — already consumed by the CMP
- **distinct from `val1`** — degenerate; fresh dst keeps it simple

No instruction sits between the CMP and the conditional move in the in-place path, so the flags survive (the same property the two-move form relied on to avoid a flag-clobbering MOVS).

## Oracle — RESULT-identical on every frozen differential

This is an optimization: **bytes change, results do not.**

| fixture | result | status |
|---|---|---|
| control_step | 13/13 → `0x00210A55` | PASS |
| flight_seam inlined | `0x07FDF307` | MATCH |
| flight_seam flat | `0x07FDF307` | MATCH |
| div_const | 338/338 | PASS |

## Measured `.text` reduction

| fixture | before | after | Δ |
|---|---|---|---|
| control_step | 378 B | 354 B | −24 (−6.3%) |
| flight_seam inlined | 1058 B | 1020 B | −38 (−3.6%) |
| flight_seam flat | 1294 B | 1244 B | −50 (−3.9%) |

## Tests

- Updated `test_control_flow_select` / `test_select_stack_mode_with_constants` / `test_select_with_global_values` to assert the **NE override** (emitted in both forms; the EQ move is what in-place elides).
- New `test_select_in_place_elides_keep_move_209` pins one-NE-zero-EQ for a reusable `val2`.
- 323/323 `synth-synthesis` lib tests pass, clippy clean.

## Falsification

This change is wrong if any module produces a different *result* than wasmtime where `val2`'s register was actually still needed after the select — i.e. the live-param / aliasing guards missed a case. Watched by the four differentials above + gale on-target against the 5 frozen baselines.

Traceability: VCR-SEL-002 (filed in #282). Part of the #209 codegen-quality program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)