### PR TITLE
chore(release): v0.11.35 — pin sweep + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.35] - 2026-06-09
+
+**In-place select + spill-cost ranking — the first VCR codegen-quality release
+(#209/#242, VCR-SEL-002).**
+
+- **In-place select (#283):** the stack selector's `Select` lowering reuses
+  `val2`'s register as the destination when `val2` is a consumed temp (not a
+  live param, distinct from cond/val1), eliding the `EQ` "keep val2"
+  conditional move — one `IT;MOV` per qualifying select instead of two, which
+  is what native emits for a clamp `(x>k)?k:x`. Falls back to the fresh-dst
+  two-move form when the guards don't hold (#193 param-clobber class).
+  Measured `.text`: control_step 378→354 B (−6.3 %), flight_seam inlined
+  1058→1020 B (−3.6 %), flat 1294→1244 B (−3.9 %). All four differential
+  fixtures RESULT-identical (control_step 13/13 `0x00210A55`, flight_seam
+  inlined+flat `0x07FDF307`, div_const 338/338).
+- **Spill-cost ranking (#285, VCR-RA-001 wiring step 2):** the Chaitin/Briggs
+  colourer picks optimistic spill candidates by cost/degree (cost = def+use
+  occurrence count) instead of degree-only; the uncosted API reproduces the
+  historic choice exactly. Pure and unwired — fixture ELFs bit-identical.
+- **Allocator substrate (#279–#281, unwired/flag-gated):** SelectMove/Select
+  modeled in `reg_effect`; allocator driver + `SYNTH_SHADOW_ALLOC` shadow
+  pass; const-CSE rematerialization-avoidance behind `SYNTH_CONST_CSE`.
+- **VCR traceability (#282, #284):** VCR-SEL-002/VCR-RA-002 filed;
+  tool-qualification top-of-V (VCR-TQ-001/002: DO-178C/ISO 26262/IEC 61508/
+  EN 50128 classification + evidence pillars); release-plan tags
+  (`release-vX.Y`, queryable via `rivet list --filter`).
+
+Falsification: this release is wrong if any module produces a different
+*result* than wasmtime where `val2`'s register was still needed after a select
+— watched by the four differentials and gale's on-target baselines
+(filter_axis 37 / control_step 158 / flat_flight 255 / controller_step 162).
+
 ## [0.11.34] - 2026-06-05
 
 **Un-wire the default-on `mul`+`add`→`mla` fusion — it regresses on-target until

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,14 +1890,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1946,11 +1946,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.34"
+version = "0.11.35"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "anyhow",
  "serde",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,14 +1999,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2014,11 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.34"
+version = "0.11.35"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.34"
+version = "0.11.35"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.34"
+version = "0.11.35"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.34",
+    version = "0.11.35",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.34" }
+synth-core = { path = "../synth-core", version = "0.11.35" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.34" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.34" }
+synth-core = { path = "../synth-core", version = "0.11.35" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.35" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.34" }
+synth-core = { path = "../synth-core", version = "0.11.35" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.34" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.34", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.35" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.35", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.34" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.34" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.34" }
-synth-backend = { path = "../synth-backend", version = "0.11.34" }
+synth-core = { path = "../synth-core", version = "0.11.35" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.35" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.35" }
+synth-backend = { path = "../synth-backend", version = "0.11.35" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.34", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.34", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.34", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.35", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.35", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.35", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.34", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.35", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.34" }
+synth-core = { path = "../synth-core", version = "0.11.35" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.34" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.35" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.34" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.34" }
-synth-opt = { path = "../synth-opt", version = "0.11.34" }
+synth-core = { path = "../synth-core", version = "0.11.35" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.35" }
+synth-opt = { path = "../synth-opt", version = "0.11.35" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.34" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.34" }
-synth-opt = { path = "../synth-opt", version = "0.11.34" }
+synth-core = { path = "../synth-core", version = "0.11.35" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.35" }
+synth-opt = { path = "../synth-opt", version = "0.11.35" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.34", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.35", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Release prep for **v0.11.35** (in-place select + spill-cost ranking — first VCR codegen-quality release).

- Pin sweep: `[workspace.package].version`, every `crates/*/Cargo.toml` path-dep `version =`, `MODULE.bazel` → 0.11.35 (mandatory pre-tag ritual).
- CHANGELOG: promoted the v0.11.35 section with measured deltas + falsification statement.

Scope (rivet): `rivet list --filter '(has-tag "release-v0.11.35")'` → VCR-SEL-002. Content PRs already merged: #283 #285 #282 #284 (+#279–#281 substrate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)