### PR TITLE
fix: #237 globals/sizing + #311 i64 pair tagging — both silicon blockers (v0.11.36)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -174,6 +174,8 @@ fn compile_wasm_to_arm(
         selector.set_relocatable(config.relocatable);
         // #237: native-pointer ABI — wasm statics become __synth_wasm_data-relative.
         selector.set_native_pointer_abi(config.native_pointer_abi, config.linear_memory_bytes);
+        // #311: i64 call results are register PAIRS — tag them.
+        selector.set_result_types(config.func_ret_i64.clone(), config.type_ret_i64.clone());
         // Stack-pointer promotion is meaningful only under the native-pointer ABI;
         // gating here keeps every non-native compile (all frozen fixtures) on the
         // legacy R9 globals-table path, bit-identical.

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -2913,10 +2913,26 @@ impl ArmEncoder {
                 // Helper: encode SetCond (ITE + MOV #1 + MOV #0) for given condition
                 let encode_setcond = |cond_bits: u16, rd_bits: u16| -> Vec<u8> {
                     let mut b = encode_ite(cond_bits);
-                    let mov_one: u16 = 0x2001 | (rd_bits << 8);
-                    let mov_zero: u16 = 0x2000 | (rd_bits << 8);
-                    b.extend_from_slice(&mov_one.to_le_bytes());
-                    b.extend_from_slice(&mov_zero.to_le_bytes());
+                    if rd_bits < 8 {
+                        let mov_one: u16 = 0x2001 | (rd_bits << 8);
+                        let mov_zero: u16 = 0x2000 | (rd_bits << 8);
+                        b.extend_from_slice(&mov_one.to_le_bytes());
+                        b.extend_from_slice(&mov_zero.to_le_bytes());
+                    } else {
+                        // #311: rd >= R8 — the 16-bit MOV imm8 form has a 3-bit
+                        // rd field; rd_bits<<8 overflows into bit 11 and
+                        // TRANSMUTES the MOV into CMP (0x2001|0x0800 = 0x2801 =
+                        // CMP r0,#1): the boolean dies in the flags and the
+                        // consumer reads a stale register. Use the 32-bit
+                        // MOV.W (T2: F04F 0000|rd<<8|imm8) — IT-legal,
+                        // flag-preserving. Same class as H-CODE-9 / #180.
+                        for imm in [1u16, 0u16] {
+                            let hw1: u16 = 0xF04F;
+                            let hw2: u16 = (rd_bits << 8) | imm;
+                            b.extend_from_slice(&hw1.to_le_bytes());
+                            b.extend_from_slice(&hw2.to_le_bytes());
+                        }
+                    }
                     b
                 };
 
@@ -3077,18 +3093,38 @@ impl ArmEncoder {
                 bytes.extend_from_slice(&hw1.to_le_bytes());
                 bytes.extend_from_slice(&hw2.to_le_bytes());
 
-                // CMP rd, #0 (16-bit): 0010 1 Rd 0000 0000
-                let cmp_instr: u16 = 0x2800 | ((rd_bits as u16) << 8);
-                bytes.extend_from_slice(&cmp_instr.to_le_bytes());
+                // CMP rd, #0 — 16-bit form only for r0-r7 (3-bit rd field);
+                // high registers take CMP.W (T2: F1B0|rn 0F00|imm8). This was
+                // H-CODE-9: rd_bits<<8 overflowing the field compared the
+                // WRONG register. Same hardening as the #311 SetCond fix.
+                if rd_bits < 8 {
+                    let cmp_instr: u16 = 0x2800 | ((rd_bits as u16) << 8);
+                    bytes.extend_from_slice(&cmp_instr.to_le_bytes());
+                } else {
+                    let hw1: u16 = 0xF1B0 | (rd_bits as u16);
+                    let hw2: u16 = 0x0F00;
+                    bytes.extend_from_slice(&hw1.to_le_bytes());
+                    bytes.extend_from_slice(&hw2.to_le_bytes());
+                }
 
-                // ITE EQ; MOV rd, #1; MOV rd, #0
+                // ITE EQ; MOV rd, #1; MOV rd, #0 (32-bit MOV.W for rd >= R8,
+                // #311 — see I64SetCond)
                 let mask = 0xC_u16; // ITE EQ mask: firstcond[0]=0, mask=0xC
                 let ite_instr: u16 = 0xBF00 | mask;
                 bytes.extend_from_slice(&ite_instr.to_le_bytes());
-                let mov_one: u16 = 0x2001 | ((rd_bits as u16) << 8);
-                let mov_zero: u16 = 0x2000 | ((rd_bits as u16) << 8);
-                bytes.extend_from_slice(&mov_one.to_le_bytes());
-                bytes.extend_from_slice(&mov_zero.to_le_bytes());
+                if rd_bits < 8 {
+                    let mov_one: u16 = 0x2001 | ((rd_bits as u16) << 8);
+                    let mov_zero: u16 = 0x2000 | ((rd_bits as u16) << 8);
+                    bytes.extend_from_slice(&mov_one.to_le_bytes());
+                    bytes.extend_from_slice(&mov_zero.to_le_bytes());
+                } else {
+                    for imm in [1u16, 0u16] {
+                        let hw1: u16 = 0xF04F;
+                        let hw2: u16 = ((rd_bits as u16) << 8) | imm;
+                        bytes.extend_from_slice(&hw1.to_le_bytes());
+                        bytes.extend_from_slice(&hw2.to_le_bytes());
+                    }
+                }
 
                 Ok(bytes)
             }
@@ -7258,6 +7294,62 @@ mod tests {
     /// (`0x2c00`), so the boolean was never written — gale's `has_waiter` kept a
     /// stale value and the binary-sem WAKE dispatch read garbage. High Rd must
     /// use the 32-bit `MOV.W` (T2). Verify the bytes, not the IR.
+    /// #311: the SAME high-Rd MOVS→CMP transmutation as #204, but in the
+    /// i64 comparison expansions (I64SetCond / I64SetCondZ) — missed by the
+    /// #204 hardening. With rd=R8 the boolean died in the flags
+    /// (`ite eq; cmpeq r0,#1; cmpne r0,#0`), so gale's packed-u64 select
+    /// read a stale register on silicon. High Rd must take MOV.W / CMP.W.
+    #[test]
+    fn test_encode_i64setcond_high_reg_uses_mov_w_311() {
+        use synth_synthesis::{ArmOp, Condition, Reg};
+        let enc = ArmEncoder::new_thumb2();
+        let bytes = enc
+            .encode(&ArmOp::I64SetCond {
+                rd: Reg::R8,
+                rn_lo: Reg::R2,
+                rn_hi: Reg::R3,
+                rm_lo: Reg::R6,
+                rm_hi: Reg::R7,
+                cond: Condition::EQ,
+            })
+            .unwrap();
+        // The 32-bit MOV.W immediate (T2) first halfword is 0xF04F; the
+        // 16-bit transmuted forms would contain 0x2801/0x2800 (CMP r0,#1/#0).
+        let halfwords: Vec<u16> = bytes
+            .chunks(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        assert!(
+            halfwords.iter().filter(|&&h| h == 0xF04F).count() == 2,
+            "high rd must use two MOV.W (T2) encodings, got {halfwords:04x?}"
+        );
+        assert!(
+            !halfwords.contains(&0x2801) && !halfwords.contains(&0x2800),
+            "no transmuted 16-bit CMP imm: {halfwords:04x?}"
+        );
+
+        let bytes_z = enc
+            .encode(&ArmOp::I64SetCondZ {
+                rd: Reg::R8,
+                rn_lo: Reg::R2,
+                rn_hi: Reg::R3,
+            })
+            .unwrap();
+        let hw_z: Vec<u16> = bytes_z
+            .chunks(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        assert!(
+            hw_z.iter().filter(|&&h| h == 0xF04F).count() == 2,
+            "SetCondZ high rd MOV.W: {hw_z:04x?}"
+        );
+        // CMP.W rd,#0 (T2) first halfword: 0xF1B0 | rd
+        assert!(
+            hw_z.contains(&(0xF1B0 | 8)),
+            "SetCondZ high rd must use CMP.W: {hw_z:04x?}"
+        );
+    }
+
     #[test]
     fn test_encode_setcond_high_reg_uses_mov_w_204() {
         use synth_synthesis::{ArmOp, Condition, Reg};

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1754,6 +1754,8 @@ fn compile_all_exports(
         all_data_segments, // #237: active data segments, for --native-pointer-abi
         stack_pointer_global_opt, // #237: (index, init) of the SP global, if any
         all_globals, // #237: every defined global (index, init) — slot region under --native-pointer-abi
+        all_func_ret_i64, // #311: per-function returns-i64 (pair tagging)
+        all_type_ret_i64, // #311: per-type returns-i64 (call_indirect)
     ) = if path.extension().is_some_and(|ext| ext == "wast") {
         info!("Parsing WAST (extracting all modules)...");
         let contents = String::from_utf8(file_bytes).context("WAST file is not valid UTF-8")?;
@@ -1847,6 +1849,8 @@ fn compile_all_exports(
             Vec::new(), // #237: data segments not threaded for WAST (single-module .wasm path covers it)
             None,       // #237: SP-global promotion is single-module .wasm only
             Vec::new(), // #237: globals slot region is single-module .wasm only
+            Vec::new(), // #311: WAST runs the fixture suite; i32-only
+            Vec::new(),
         )
     } else {
         let wasm_bytes = if path.extension().is_some_and(|ext| ext == "wat") {
@@ -1907,6 +1911,8 @@ fn compile_all_exports(
             data_segs,
             sp_global,
             globals,
+            module.func_ret_i64,
+            module.type_ret_i64,
         )
     };
 
@@ -1974,6 +1980,8 @@ fn compile_all_exports(
         // #237: register-promote the stack-pointer global (only consulted under
         // native_pointer_abi) so the dissolved object needs no R9 globals table.
         stack_pointer_global: stack_pointer_global_opt,
+        func_ret_i64: all_func_ret_i64.clone(),
+        type_ret_i64: all_type_ret_i64.clone(),
         ..CompileConfig::default()
     };
 

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2369,8 +2369,8 @@ fn build_relocatable_elf(
                     f.relocations
                         .iter()
                         .filter(|&r| {
-                            (r.symbol == "__synth_wasm_data"
-                                && matches!(r.kind, synth_core::RelocKind::MovwAbs))
+                            r.symbol == "__synth_wasm_data"
+                                && matches!(r.kind, synth_core::RelocKind::MovwAbs)
                         })
                         .map(|r| {
                             let lo = thm_imm16(&f.code, r.offset as usize);

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1753,6 +1753,7 @@ fn compile_all_exports(
         type_arg_counts,
         all_data_segments, // #237: active data segments, for --native-pointer-abi
         stack_pointer_global_opt, // #237: (index, init) of the SP global, if any
+        all_globals, // #237: every defined global (index, init) — slot region under --native-pointer-abi
     ) = if path.extension().is_some_and(|ext| ext == "wast") {
         info!("Parsing WAST (extracting all modules)...");
         let contents = String::from_utf8(file_bytes).context("WAST file is not valid UTF-8")?;
@@ -1845,6 +1846,7 @@ fn compile_all_exports(
             merged_type_arg_counts,
             Vec::new(), // #237: data segments not threaded for WAST (single-module .wasm path covers it)
             None,       // #237: SP-global promotion is single-module .wasm only
+            Vec::new(), // #237: globals slot region is single-module .wasm only
         )
     } else {
         let wasm_bytes = if path.extension().is_some_and(|ext| ext == "wat") {
@@ -1873,6 +1875,13 @@ fn compile_all_exports(
         // linmem extent gates the "plausible stack top" heuristic.
         let linmem_bytes = memories.first().map(|m| m.initial_bytes()).unwrap_or(0);
         let sp_global = identify_stack_pointer_global(&module.globals, linmem_bytes);
+        // #237: every defined global gets a materialized slot under the
+        // native-pointer ABI (init defaults to 0 for non-i32.const inits).
+        let globals: Vec<(u32, i32)> = module
+            .globals
+            .iter()
+            .map(|g| (g.index, g.init_i32.unwrap_or(0)))
+            .collect();
         // #235: compile not just the exports but every internal (non-imported)
         // function reachable from them via `call`. A loom-dissolved export can
         // retain a non-inlinable callee (e.g. a panic helper from an overflow
@@ -1897,6 +1906,7 @@ fn compile_all_exports(
             type_arg_counts,
             data_segs,
             sp_global,
+            globals,
         )
     };
 
@@ -2114,6 +2124,15 @@ fn compile_all_exports(
             &all_imports,
             &all_data_segments,
             all_memories.first().map(|m| m.initial_bytes()).unwrap_or(0),
+            // #237: used-extent sizing + globals slots, native-pointer ABI only.
+            if native_pointer_abi {
+                Some(NativeGlobalsLayout {
+                    globals: all_globals.clone(),
+                    sp_init: stack_pointer_global_opt.map(|(_, v)| v).unwrap_or(0),
+                })
+            } else {
+                None
+            },
         )?
     } else if cortex_m {
         build_multi_func_cortex_m_elf(&compiled_funcs, &all_memories, target_spec)?
@@ -2243,11 +2262,25 @@ fn build_multi_func_simple_elf(funcs: &[ElfFunction]) -> Result<Vec<u8>> {
 /// Produced when the WASM module has imports — the resulting .o needs to be linked
 /// with the Kiln bridge (which provides `__meld_dispatch_import` etc.) to create
 /// a final firmware binary.
+/// #237: native-pointer-ABI layout for the wasm data region — used-extent
+/// sizing (gale: 64 KiB-page granularity is RAM-prohibitive on the MCUs this
+/// targets) plus materialized global slots appended after the used extent.
+struct NativeGlobalsLayout {
+    /// Every defined global: (index, i32 init value). Slot `idx` lives at
+    /// `__synth_globals + idx*4`; slots hold wasm OFFSETS (the selector
+    /// rebases the SP global to an absolute pointer on read), so plain init
+    /// bytes suffice — no data relocations.
+    globals: Vec<(u32, i32)>,
+    /// The shadow-stack top (the SP global's init); the region must cover it.
+    sp_init: i32,
+}
+
 fn build_relocatable_elf(
     funcs: &[ElfFunction],
     imports: &[ImportEntry],
     data_segments: &[(u32, Vec<u8>)],
     linear_memory_bytes: u32,
+    native_globals: Option<NativeGlobalsLayout>,
 ) -> Result<Vec<u8>> {
     use std::collections::HashMap;
 
@@ -2289,11 +2322,105 @@ fn build_relocatable_elf(
     let needs_wasm_data = funcs
         .iter()
         .flat_map(|f| &f.relocations)
-        .any(|r| r.symbol == "__synth_wasm_data");
+        .any(|r| r.symbol == "__synth_wasm_data" || r.symbol == "__synth_globals");
     let emit_wasm_data = needs_wasm_data && linear_memory_bytes > 0;
+    // #237 (gale, mutex-on-silicon): under the native-pointer ABI the region
+    // is sized to the USED extent — data-segment end + shadow stack (the SP
+    // global's init is the stack top; the stack grows down inside the
+    // region) — not the declared 64 KiB pages, which overflow small-MCU RAM
+    // (131072 B .bss for an 830-byte module on a 128 KiB part). Materialized
+    // global slots follow at `__synth_globals = __synth_wasm_data +
+    // used_extent`, initialized from the wasm global section, which is what
+    // makes `global.set` real and the shadow-stack pointer start at its top
+    // instead of 0.
+    let native_layout = native_globals.filter(|_| emit_wasm_data);
+    // Decode a Thumb MOVW/MOVT imm16 from little-endian code bytes (the REL
+    // addend lives in the instruction).
+    fn thm_imm16(code: &[u8], off: usize) -> u32 {
+        let hw1 = u16::from_le_bytes([code[off], code[off + 1]]) as u32;
+        let hw2 = u16::from_le_bytes([code[off + 2], code[off + 3]]) as u32;
+        ((hw1 & 0xF) << 12) | (((hw1 >> 10) & 1) << 11) | (((hw2 >> 12) & 0x7) << 8) | (hw2 & 0xFF)
+    }
+    let used_extent: u32 = native_layout
+        .as_ref()
+        .map(|ng| {
+            let data_end = data_segments
+                .iter()
+                .map(|(off, d)| off + d.len() as u32)
+                .max()
+                .unwrap_or(0);
+            let sp_top = ng.sp_init.max(0) as u32;
+            // Layout-bound globals: wasm-ld emits __data_end/__heap_base as
+            // i32 globals whose inits mark the static-region extent — the
+            // linker's own answer to "how much is used".
+            let global_top = ng
+                .globals
+                .iter()
+                .map(|&(_, v)| v.max(0) as u32)
+                .filter(|&v| v <= linear_memory_bytes)
+                .max()
+                .unwrap_or(0);
+            // Static-access addends: every `__synth_wasm_data + A` the
+            // selector relocated marks a touched address; cover A plus an
+            // i64's width.
+            let static_top = funcs
+                .iter()
+                .flat_map(|f| {
+                    f.relocations.iter().filter_map(|r| {
+                        (r.symbol == "__synth_wasm_data"
+                            && matches!(r.kind, synth_core::RelocKind::MovwAbs))
+                        .then(|| {
+                            let lo = thm_imm16(&f.code, r.offset as usize);
+                            // The paired MOVT immediately follows (emit order).
+                            let hi = f
+                                .relocations
+                                .iter()
+                                .find(|m| {
+                                    m.offset == r.offset + 4
+                                        && matches!(m.kind, synth_core::RelocKind::MovtAbs)
+                                })
+                                .map(|m| thm_imm16(&f.code, m.offset as usize))
+                                .unwrap_or(0);
+                            (hi << 16) | lo
+                        })
+                    })
+                })
+                .map(|a: u32| a.saturating_add(8))
+                .max()
+                .unwrap_or(0);
+            data_end
+                .max(sp_top)
+                .max(global_top)
+                .max(static_top)
+                .max(4)
+                .min(linear_memory_bytes)
+                .next_multiple_of(4)
+        })
+        .unwrap_or(linear_memory_bytes);
+    let globals_bytes: u32 = native_layout
+        .as_ref()
+        .and_then(|ng| ng.globals.iter().map(|(i, _)| (i + 1) * 4).max())
+        .unwrap_or(0);
     if emit_wasm_data {
-        let size = linear_memory_bytes as usize;
-        let section = if data_segments.is_empty() {
+        let size = (used_extent + globals_bytes) as usize;
+        let section = if let Some(ng) = &native_layout {
+            // Native-pointer ABI: PROGBITS covering used extent + global
+            // slots (init values must reach the device, so NOBITS is out;
+            // the used extent is small by construction).
+            let mut blob = vec![0u8; size];
+            for (off, d) in data_segments {
+                blob[*off as usize..*off as usize + d.len()].copy_from_slice(d);
+            }
+            for (idx, init) in &ng.globals {
+                let at = (used_extent + idx * 4) as usize;
+                blob[at..at + 4].copy_from_slice(&init.to_le_bytes());
+            }
+            Section::new(".data", ElfSectionType::ProgBits)
+                .with_flags(SectionFlags::ALLOC | SectionFlags::WRITE)
+                .with_addr(0)
+                .with_align(4)
+                .with_data(blob)
+        } else if data_segments.is_empty() {
             // Pure zero-init (BSS) — NOBITS, no bytes in the object.
             Section::new(".bss", ElfSectionType::NoBits)
                 .with_flags(SectionFlags::ALLOC | SectionFlags::WRITE)
@@ -2303,7 +2430,7 @@ fn build_relocatable_elf(
         } else {
             // Initialized data present — PROGBITS covering the whole memory,
             // segments placed at their offsets, the rest zero.
-            let mut blob = vec![0u8; size];
+            let mut blob = vec![0u8; linear_memory_bytes as usize];
             for (off, d) in data_segments {
                 blob[*off as usize..*off as usize + d.len()].copy_from_slice(d);
             }
@@ -2373,6 +2500,17 @@ fn build_relocatable_elf(
         elf_builder.add_symbol(data_sym);
         sym_count += 1;
         sym_indices.insert("__synth_wasm_data".to_string(), sym_count);
+        // #237: the globals slot region sits right after the used extent.
+        if native_layout.is_some() {
+            let globals_sym = Symbol::new("__synth_globals")
+                .with_value(used_extent)
+                .with_binding(SymbolBinding::Global)
+                .with_type(SymbolType::Object)
+                .with_section(5);
+            elf_builder.add_symbol(globals_sym);
+            sym_count += 1;
+            sym_indices.insert("__synth_globals".to_string(), sym_count);
+        }
     }
 
     let mut import_label_to_field: HashMap<String, String> = HashMap::new();

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2366,10 +2366,13 @@ fn build_relocatable_elf(
             let static_top = funcs
                 .iter()
                 .flat_map(|f| {
-                    f.relocations.iter().filter_map(|r| {
-                        (r.symbol == "__synth_wasm_data"
-                            && matches!(r.kind, synth_core::RelocKind::MovwAbs))
-                        .then(|| {
+                    f.relocations
+                        .iter()
+                        .filter(|&r| {
+                            (r.symbol == "__synth_wasm_data"
+                                && matches!(r.kind, synth_core::RelocKind::MovwAbs))
+                        })
+                        .map(|r| {
                             let lo = thm_imm16(&f.code, r.offset as usize);
                             // The paired MOVT immediately follows (emit order).
                             let hi = f
@@ -2383,7 +2386,6 @@ fn build_relocatable_elf(
                                 .unwrap_or(0);
                             (hi << 16) | lo
                         })
-                    })
                 })
                 .map(|a: u32| a.saturating_add(8))
                 .max()

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -134,6 +134,11 @@ pub struct CompileConfig {
     /// top) and the init value doubles as the static-data base that separates
     /// pointer consts (`>= init`) from frame-size scalars (`< init`).
     pub stack_pointer_global: Option<(u32, i32)>,
+    /// #311: per-function (full index) / per-type "returns i64" — the call
+    /// lowering must tag i64 results as a register pair or the hi half is
+    /// invisible to liveness.
+    pub func_ret_i64: Vec<bool>,
+    pub type_ret_i64: Vec<bool>,
 }
 
 impl CompileConfig {
@@ -165,6 +170,8 @@ impl Default for CompileConfig {
             native_pointer_abi: false,
             linear_memory_bytes: 0,
             stack_pointer_global: None,
+            func_ret_i64: Vec::new(),
+            type_ret_i64: Vec::new(),
         }
     }
 }

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -97,6 +97,12 @@ pub struct DecodedModule {
     /// Used by `call_indirect`, whose callee arg count comes from the static
     /// type index (issue #195).
     pub type_arg_counts: Vec<u32>,
+    /// #311: whether each *function* (full index, imports first) returns i64 —
+    /// the call lowering must tag the result as a register PAIR (r0:r1) or the
+    /// hi half is invisible to liveness and the next constant clobbers it.
+    pub func_ret_i64: Vec<bool>,
+    /// #311: whether each *function type* returns i64 (for `call_indirect`).
+    pub type_ret_i64: Vec<bool>,
     /// Defined globals with their initializers (#237). Empty if the module has
     /// no global section. Used by the native-pointer ABI to make a global whose
     /// initializer is a linear-memory address (e.g. `$__stack_pointer`)
@@ -125,6 +131,8 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     // arg count (indexed by full function index: imports first, then locals).
     let mut type_arg_counts: Vec<u32> = Vec::new();
     let mut func_arg_counts: Vec<u32> = Vec::new();
+    let mut type_ret_i64: Vec<bool> = Vec::new();
+    let mut func_ret_i64: Vec<bool> = Vec::new();
     let mut elem_func_indices: Vec<u32> = Vec::new();
 
     for payload in Parser::new(0).parse_all(wasm_bytes) {
@@ -137,13 +145,18 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                 for rec_group in reader {
                     let rec_group = rec_group.context("Failed to parse type")?;
                     for sub_ty in rec_group.types() {
-                        let count = match &sub_ty.composite_type.inner {
-                            wasmparser::CompositeInnerType::Func(func_ty) => {
-                                func_ty.params().len() as u32
-                            }
-                            _ => 0,
+                        let (count, ret_i64) = match &sub_ty.composite_type.inner {
+                            wasmparser::CompositeInnerType::Func(func_ty) => (
+                                func_ty.params().len() as u32,
+                                func_ty
+                                    .results()
+                                    .first()
+                                    .is_some_and(|t| *t == wasmparser::ValType::I64),
+                            ),
+                            _ => (0, false),
                         };
                         type_arg_counts.push(count);
+                        type_ret_i64.push(ret_i64);
                     }
                 }
             }
@@ -158,6 +171,12 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                             // full function index (imports come first).
                             func_arg_counts
                                 .push(type_arg_counts.get(type_idx as usize).copied().unwrap_or(0));
+                            func_ret_i64.push(
+                                type_ret_i64
+                                    .get(type_idx as usize)
+                                    .copied()
+                                    .unwrap_or(false),
+                            );
                             (ImportKind::Function(type_idx), idx)
                         }
                         wasmparser::TypeRef::Memory(_) => (ImportKind::Memory, 0),
@@ -182,6 +201,12 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                     let type_idx = ty.context("Failed to parse function type index")?;
                     func_arg_counts
                         .push(type_arg_counts.get(type_idx as usize).copied().unwrap_or(0));
+                    func_ret_i64.push(
+                        type_ret_i64
+                            .get(type_idx as usize)
+                            .copied()
+                            .unwrap_or(false),
+                    );
                 }
             }
             Payload::MemorySection(reader) => {
@@ -293,6 +318,8 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
         num_imported_funcs,
         func_arg_counts,
         type_arg_counts,
+        func_ret_i64,
+        type_ret_i64,
         globals,
         elem_func_indices,
     })

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -8809,6 +8809,15 @@ impl InstructionSelector {
         // Reload-aware (#171): a spilled final result is reloaded before the
         // AAPCS return-value move. Past the op loop, so use wasm_ops.len() as
         // the synthetic source line for any reload.
+        // #311 defect 3 (gale): an i64 RESULT is the (lo, hi) pair and BOTH
+        // halves must reach r0:r1 — the single-register move silently dropped
+        // the hi whenever the final value transited registers other than
+        // r0/r1 (decide() returned (0,0) where the contract says (0,1)).
+        // Capture the width BEFORE peek (which returns only the lo register).
+        let result_is_i64 = matches!(
+            stack.last(),
+            Some(StackVal::Reg { is_i64: true, .. }) | Some(StackVal::Spilled { is_i64: true, .. })
+        );
         let result_reg = if stack.is_empty() {
             None
         } else {
@@ -8821,16 +8830,32 @@ impl InstructionSelector {
                 wasm_ops.len(),
             )?)
         };
-        if let Some(result_reg) = result_reg
-            && result_reg != Reg::R0
-        {
-            instructions.push(ArmInstruction {
-                op: ArmOp::Mov {
-                    rd: Reg::R0,
-                    op2: Operand2::Reg(result_reg),
-                },
-                source_line: None,
-            });
+        if let Some(result_reg) = result_reg {
+            // lo move FIRST: for a consecutive pair (hi = lo+1) the only
+            // overlap case is lo == R1 (hi == R2), where r1 must be READ by
+            // the lo move before the hi move WRITES it — lo-first is safe for
+            // every possible pair (hi == R0 would require lo == "R-1").
+            if result_reg != Reg::R0 {
+                instructions.push(ArmInstruction {
+                    op: ArmOp::Mov {
+                        rd: Reg::R0,
+                        op2: Operand2::Reg(result_reg),
+                    },
+                    source_line: None,
+                });
+            }
+            if result_is_i64 {
+                let hi = i64_pair_hi(result_reg)?;
+                if hi != Reg::R1 {
+                    instructions.push(ArmInstruction {
+                        op: ArmOp::Mov {
+                            rd: Reg::R1,
+                            op2: Operand2::Reg(hi),
+                        },
+                        source_line: None,
+                    });
+                }
+            }
         }
         if layout.frame_size > 0 {
             instructions.push(ArmInstruction {
@@ -15422,6 +15447,47 @@ mod tests {
     /// segment becomes `__synth_wasm_data`-relative (MovwSym/MovtSym), so a
     /// `base=0` host-pointer trampoline doesn't mis-resolve it. Without the flag
     /// (and for an out-of-range/runtime address) it stays base-relative.
+    #[test]
+    fn test_311_i64_return_moves_both_halves() {
+        // #311 defect 3 (gale): when a function's final i64 lands outside
+        // r0:r1, the return epilogue must move BOTH halves — the single-reg
+        // move dropped the hi (decide() returned (0,0), contract (0,1)).
+        // Three i64 consts force the final Or's destination pair off r0/r1.
+        let db = RuleDatabase::new();
+        let mut sel = InstructionSelector::new(db.rules().to_vec());
+        let ops = vec![
+            WasmOp::I64Const(1),
+            WasmOp::I64Const(2),
+            WasmOp::I64Const(3),
+            WasmOp::I64Or,
+            WasmOp::I64Or,
+        ];
+        let instrs = sel.select_with_stack(&ops, 0).unwrap();
+        // The epilogue's return moves: r0 <- lo, r1 <- hi of a CONSECUTIVE
+        // pair that is not already (r0, r1).
+        let mov_to = |rd: Reg| {
+            instrs.iter().rev().find_map(|i| match &i.op {
+                ArmOp::Mov {
+                    rd: d,
+                    op2: Operand2::Reg(src),
+                } if *d == rd => Some(*src),
+                _ => None,
+            })
+        };
+        let lo_src = mov_to(Reg::R0).expect("epilogue must move the lo half into r0");
+        let hi_src = mov_to(Reg::R1)
+            .expect("epilogue must move the HI half into r1 (the dropped-hi defect)");
+        assert_eq!(
+            i64_pair_hi(lo_src).unwrap(),
+            hi_src,
+            "the two moves must carry one consecutive pair (got {lo_src:?}/{hi_src:?})"
+        );
+        assert_ne!(
+            lo_src,
+            Reg::R0,
+            "premise: the pair transited high registers"
+        );
+    }
     #[test]
     fn test_311_i64_call_result_tagged_as_pair() {
         // #311 (gale, k_sem_give silent wrong-code): an i64-returning call

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -760,9 +760,14 @@ struct LocalLayout {
 ///   encoder, in both cases corrupting the caller's stack or the callee's
 ///   own callee-saved-register spill).
 /// - Epilogue: `add sp, sp, #frame_size` before popping registers.
-fn compute_local_layout(wasm_ops: &[WasmOp], num_params: u32) -> LocalLayout {
+fn compute_local_layout(
+    wasm_ops: &[WasmOp],
+    num_params: u32,
+    func_ret_i64: &[bool],
+    type_ret_i64: &[bool],
+) -> LocalLayout {
     use std::collections::{BTreeSet, HashMap};
-    let i64_set = infer_i64_locals(wasm_ops);
+    let i64_set = infer_i64_locals(wasm_ops, func_ret_i64, type_ret_i64);
 
     // Collect non-param local indices, in ascending order for deterministic layout.
     let mut used: BTreeSet<u32> = BTreeSet::new();
@@ -881,7 +886,11 @@ fn compute_local_layout(wasm_ops: &[WasmOp], num_params: u32) -> LocalLayout {
 /// Without this, the spilled-local store/load path would emit a single
 /// 4-byte STR/LDR for i64 locals, dropping the upper half — corrupting
 /// any function that returns or uses a u64-packed FFI struct.
-fn infer_i64_locals(wasm_ops: &[WasmOp]) -> std::collections::HashSet<u32> {
+fn infer_i64_locals(
+    wasm_ops: &[WasmOp],
+    func_ret_i64: &[bool],
+    type_ret_i64: &[bool],
+) -> std::collections::HashSet<u32> {
     use WasmOp::*;
     let mut i64_locals: std::collections::HashSet<u32> = std::collections::HashSet::new();
     let mut vstack: Vec<bool> = Vec::new(); // true = i64
@@ -945,6 +954,36 @@ fn infer_i64_locals(wasm_ops: &[WasmOp]) -> std::collections::HashSet<u32> {
                 let v2 = vstack.pop();
                 let v1 = vstack.pop();
                 vstack.push(v1.or(v2).unwrap_or(false));
+            }
+            // #311: a call's result width comes from the callee's signature —
+            // without this, an i64-returning call feeding `local.set` left the
+            // local inferred as i32 (4-byte slot, single-word store: the hi
+            // half of gale's packed u64 decision was silently dropped).
+            Call(func_idx) => {
+                let (pops, pushes) = wasm_stack_effect(op);
+                for _ in 0..pops {
+                    vstack.pop();
+                }
+                let w = func_ret_i64
+                    .get(*func_idx as usize)
+                    .copied()
+                    .unwrap_or(false);
+                for _ in 0..pushes {
+                    vstack.push(w);
+                }
+            }
+            CallIndirect { type_index, .. } => {
+                let (pops, pushes) = wasm_stack_effect(op);
+                for _ in 0..pops {
+                    vstack.pop();
+                }
+                let w = type_ret_i64
+                    .get(*type_index as usize)
+                    .copied()
+                    .unwrap_or(false);
+                for _ in 0..pushes {
+                    vstack.push(w);
+                }
             }
             _ => {
                 let (pops, pushes) = wasm_stack_effect(op);
@@ -1240,6 +1279,10 @@ pub struct InstructionSelector {
     /// `global.get` materializes `__synth_wasm_data + init` (the real stack top),
     /// `global.set` is dead (no wasm reader; host imports don't touch wasm SP).
     sp_global: Option<(u32, i32)>,
+    /// #311: whether function `i` (full wasm index) returns i64.
+    func_ret_i64: Vec<bool>,
+    /// #311: whether type `i` returns i64 (`call_indirect`).
+    type_ret_i64: Vec<bool>,
     /// AAPCS argument count per function, indexed by the *full* WASM function
     /// index (imports first, then locals). Plumbed from the frontend's type +
     /// function sections (issue #195). `func_arg_counts[i]` = number of integer
@@ -1281,6 +1324,8 @@ impl InstructionSelector {
             linear_memory_bytes: 0,
             wasm_data_base: 0,
             sp_global: None,
+            func_ret_i64: Vec::new(),
+            type_ret_i64: Vec::new(),
             func_arg_counts: Vec::new(),
             type_arg_counts: Vec::new(),
             fpu: None,
@@ -1305,6 +1350,8 @@ impl InstructionSelector {
             linear_memory_bytes: 0,
             wasm_data_base: 0,
             sp_global: None,
+            func_ret_i64: Vec::new(),
+            type_ret_i64: Vec::new(),
             func_arg_counts: Vec::new(),
             type_arg_counts: Vec::new(),
             fpu: None,
@@ -1359,6 +1406,13 @@ impl InstructionSelector {
     /// #237: register the stack-pointer global discovered by the backend. Its
     /// initializer doubles as the static-data base (`wasm_data_base`), so const
     /// addresses at/above it relocate while frame-size scalars below it don't.
+    /// #311: register per-function / per-type i64-result tables so call
+    /// results are tagged as register pairs (hi half visible to liveness).
+    pub fn set_result_types(&mut self, func_ret_i64: Vec<bool>, type_ret_i64: Vec<bool>) {
+        self.func_ret_i64 = func_ret_i64;
+        self.type_ret_i64 = type_ret_i64;
+    }
+
     pub fn set_native_pointer_stack(&mut self, sp_index: u32, sp_init: i32) {
         self.sp_global = Some((sp_index, sp_init));
         if sp_init >= 0 {
@@ -4702,6 +4756,7 @@ impl InstructionSelector {
         local_to_reg: &std::collections::HashMap<u32, Reg>,
         layout: &LocalLayout,
         spill: &mut SpillState,
+        ret_i64: bool,
         idx: usize,
     ) -> Result<StackVal> {
         // If R0 (the return value) is among the preserved registers, its slot
@@ -4711,9 +4766,24 @@ impl InstructionSelector {
         // spill the result to the i64 frame area and return a `Spilled` value
         // that is reloaded when popped — this is what lets `z_impl_k_sem_give`
         // (i64 + several calls) compile rather than be skipped.
-        let r0_preserved = preserved.iter().any(|&(r, _)| r == Reg::R0);
+        //
+        // #311: an i64 result occupies the R0:R1 PAIR. It must be tagged i64 on
+        // the operand stack (so liveness sees the hi half and the next constant
+        // materialization cannot land in R1 — gale's k_sem_give silent
+        // wrong-code), and any restoration touching R0 OR R1 forces the pair
+        // through the spill path (the single-free-callee-saved move cannot
+        // carry both halves).
+        let r0_preserved = preserved
+            .iter()
+            .any(|&(r, _)| r == Reg::R0 || (ret_i64 && r == Reg::R1));
         let result = if r0_preserved {
-            match self.free_callee_saved(stack, local_to_reg, layout) {
+            match (!ret_i64)
+                .then(|| self.free_callee_saved(stack, local_to_reg, layout))
+                .transpose()
+                .ok()
+                .flatten()
+                .ok_or(())
+            {
                 Ok(free) => {
                     instructions.push(ArmInstruction {
                         op: ArmOp::Mov {
@@ -4756,6 +4826,8 @@ impl InstructionSelector {
                     }
                 }
             }
+        } else if ret_i64 {
+            StackVal::i64(Reg::R0)
         } else {
             StackVal::i32(Reg::R0)
         };
@@ -4831,7 +4903,8 @@ impl InstructionSelector {
         });
 
         // Compute non-param local layout (offsets + total frame size).
-        let layout = compute_local_layout(wasm_ops, num_params);
+        let layout =
+            compute_local_layout(wasm_ops, num_params, &self.func_ret_i64, &self.type_ret_i64);
         // Allocate stack space for non-param locals so they don't alias the
         // callee-saved-register spill area (which immediately follows SP
         // after Push above).
@@ -4895,7 +4968,7 @@ impl InstructionSelector {
             }
         }
 
-        let i64_locals = infer_i64_locals(wasm_ops);
+        let i64_locals = infer_i64_locals(wasm_ops, &self.func_ret_i64, &self.type_ret_i64);
 
         // #193/#210: a register-backed param (call-free function — call functions
         // frame-back via param_slots) lives in r0..r3 and is NOT on the operand
@@ -6852,6 +6925,12 @@ impl InstructionSelector {
                     }
                     cf.add_instruction();
 
+                    // #311: tag an i64 result as the R0:R1 pair.
+                    let ret_i64 = self
+                        .func_ret_i64
+                        .get(*func_idx as usize)
+                        .copied()
+                        .unwrap_or(false);
                     let result_reg = self.restore_caller_saved(
                         &mut instructions,
                         &preserved,
@@ -6859,6 +6938,7 @@ impl InstructionSelector {
                         &local_to_reg,
                         &layout,
                         &mut spill,
+                        ret_i64,
                         idx,
                     )?;
                     // Push the call's return value as a live operand (spilled to
@@ -6963,6 +7043,12 @@ impl InstructionSelector {
                         source_line: Some(idx),
                     });
                     cf.add_instruction();
+                    // #311: tag an i64 result as the R0:R1 pair (static type).
+                    let ret_i64 = self
+                        .type_ret_i64
+                        .get(*type_index as usize)
+                        .copied()
+                        .unwrap_or(false);
                     let result_reg = self.restore_caller_saved(
                         &mut instructions,
                         &preserved,
@@ -6970,6 +7056,7 @@ impl InstructionSelector {
                         &local_to_reg,
                         &layout,
                         &mut spill,
+                        ret_i64,
                         idx,
                     )?;
                     stack.push(result_reg);
@@ -14477,7 +14564,7 @@ mod tests {
     fn test_compute_local_layout_no_locals() {
         // Function with only params and no LocalGet/Set produces zero frame.
         let ops = vec![WasmOp::LocalGet(0), WasmOp::LocalGet(1), WasmOp::I32Add];
-        let layout = compute_local_layout(&ops, 2);
+        let layout = compute_local_layout(&ops, 2, &[], &[]);
         assert_eq!(layout.frame_size, 0);
         assert!(layout.locals.is_empty());
     }
@@ -14490,7 +14577,7 @@ mod tests {
             WasmOp::LocalSet(1),
             WasmOp::LocalGet(1),
         ];
-        let layout = compute_local_layout(&ops, 1);
+        let layout = compute_local_layout(&ops, 1, &[], &[]);
         assert!(layout.locals.contains_key(&1));
         let (off, is_i64) = layout.locals[&1];
         assert_eq!(off, 0);
@@ -14507,7 +14594,7 @@ mod tests {
             WasmOp::LocalSet(0),
             WasmOp::LocalGet(0),
         ];
-        let layout = compute_local_layout(&ops, 0);
+        let layout = compute_local_layout(&ops, 0, &[], &[]);
         let (off, is_i64) = layout.locals[&0];
         assert_eq!(off, 0);
         assert!(is_i64);
@@ -14527,7 +14614,7 @@ mod tests {
             WasmOp::I64Const(2),
             WasmOp::LocalSet(1),
         ];
-        let layout = compute_local_layout(&ops, 0);
+        let layout = compute_local_layout(&ops, 0, &[], &[]);
         let (off0, is_i64_0) = layout.locals[&0];
         let (off1, is_i64_1) = layout.locals[&1];
         assert_eq!(off0, 0);
@@ -14549,7 +14636,7 @@ mod tests {
             WasmOp::I32Add,
             WasmOp::LocalSet(2),
         ];
-        let layout = compute_local_layout(&ops, 2);
+        let layout = compute_local_layout(&ops, 2, &[], &[]);
         // Only idx 2 should be in the layout.
         assert!(!layout.locals.contains_key(&0));
         assert!(!layout.locals.contains_key(&1));
@@ -14560,7 +14647,7 @@ mod tests {
     fn test_infer_i64_locals_from_localset() {
         // i64.const → local.set marks that local as i64.
         let ops = vec![WasmOp::I64Const(7), WasmOp::LocalSet(3)];
-        let i64_locals = infer_i64_locals(&ops);
+        let i64_locals = infer_i64_locals(&ops, &[], &[]);
         assert!(i64_locals.contains(&3));
     }
 
@@ -14569,7 +14656,7 @@ mod tests {
         // local.tee preserves the value on the stack and stores to local —
         // its width should be inferred from what's on the stack.
         let ops = vec![WasmOp::I64Const(99), WasmOp::LocalTee(2), WasmOp::Drop];
-        let i64_locals = infer_i64_locals(&ops);
+        let i64_locals = infer_i64_locals(&ops, &[], &[]);
         assert!(i64_locals.contains(&2));
     }
 
@@ -14577,7 +14664,7 @@ mod tests {
     fn test_infer_i64_locals_does_not_flag_i32_locals() {
         // i32 ops should not produce i64 locals.
         let ops = vec![WasmOp::I32Const(1), WasmOp::LocalSet(0)];
-        let i64_locals = infer_i64_locals(&ops);
+        let i64_locals = infer_i64_locals(&ops, &[], &[]);
         assert!(!i64_locals.contains(&0));
     }
 
@@ -14590,7 +14677,7 @@ mod tests {
             WasmOp::I64Add,
             WasmOp::LocalSet(5),
         ];
-        let i64_locals = infer_i64_locals(&ops);
+        let i64_locals = infer_i64_locals(&ops, &[], &[]);
         assert!(i64_locals.contains(&5));
     }
 
@@ -15335,6 +15422,48 @@ mod tests {
     /// segment becomes `__synth_wasm_data`-relative (MovwSym/MovtSym), so a
     /// `base=0` host-pointer trampoline doesn't mis-resolve it. Without the flag
     /// (and for an out-of-range/runtime address) it stays base-relative.
+    #[test]
+    fn test_311_i64_call_result_tagged_as_pair() {
+        // #311 (gale, k_sem_give silent wrong-code): an i64-returning call
+        // leaves its result in the R0:R1 PAIR. The result must be i64-tagged
+        // on the operand stack so liveness covers R1 — the mask constants of
+        // the following unpack must NOT materialize into the live pair.
+        let db = RuleDatabase::new();
+        let mut sel = InstructionSelector::new(db.rules().to_vec());
+        sel.set_func_arg_counts(vec![0, 0], vec![]);
+        sel.set_result_types(vec![false, true], vec![]);
+        let ops = vec![
+            WasmOp::Call(1),       // returns i64 in r0:r1
+            WasmOp::I64Const(255), // pair const — must avoid r0/r1
+            WasmOp::I64And,
+            WasmOp::I32WrapI64,
+        ];
+        let instrs = sel.select_with_stack(&ops, 0).unwrap();
+        let bl_at = instrs
+            .iter()
+            .position(|i| matches!(&i.op, ArmOp::Bl { .. }))
+            .expect("call emitted");
+        let clobbers_pair = instrs[bl_at + 1..]
+            .iter()
+            .any(|i| matches!(&i.op, ArmOp::Movw { rd, .. } if *rd == Reg::R0 || *rd == Reg::R1));
+        assert!(
+            !clobbers_pair,
+            "mask constants must not materialize into the live u64 pair r0/r1"
+        );
+    }
+
+    #[test]
+    fn test_311_call_fed_i64_local_inferred() {
+        // The second half of #311: `local.set` fed by an i64-returning call
+        // must mark the local i64 (8-byte slot, both halves stored) — without
+        // the result-type table the hi word was silently dropped.
+        let ops = vec![WasmOp::Call(1), WasmOp::LocalSet(0)];
+        let with_table = infer_i64_locals(&ops, &[false, true], &[]);
+        assert!(with_table.contains(&0), "call-fed local inferred i64");
+        let without = infer_i64_locals(&ops, &[], &[]);
+        assert!(!without.contains(&0), "no table -> conservative i32");
+    }
+
     #[test]
     fn test_237_globals_live_in_materialized_slots_under_native_pointer_abi() {
         // #237 (gale, mutex-on-silicon): global.get/set go through

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -1366,6 +1366,37 @@ impl InstructionSelector {
         }
     }
 
+    /// #237: emit a `symbol + addend` absolute address into `rd` (MOVW+MOVT,
+    /// symbol-relocated) — base-independent addressing for any linker-placed
+    /// region (`__synth_wasm_data` statics, `__synth_globals` slots).
+    fn emit_sym_addr(
+        out: &mut Vec<ArmInstruction>,
+        rd: Reg,
+        symbol: &str,
+        addend: i32,
+        line: usize,
+    ) {
+        for hi in [false, true] {
+            let op = if hi {
+                ArmOp::MovtSym {
+                    rd,
+                    symbol: symbol.to_string(),
+                    addend,
+                }
+            } else {
+                ArmOp::MovwSym {
+                    rd,
+                    symbol: symbol.to_string(),
+                    addend,
+                }
+            };
+            out.push(ArmInstruction {
+                op,
+                source_line: Some(line),
+            });
+        }
+    }
+
     /// #237: emit a `__synth_wasm_data + addend` address into `rd` (MOVW+MOVT,
     /// symbol-relocated) — the base-independent static-data address.
     fn emit_wasm_data_addr(out: &mut Vec<ArmInstruction>, rd: Reg, addend: i32, line: usize) {
@@ -7216,18 +7247,50 @@ impl InstructionSelector {
                 }
 
                 GlobalGet(global_idx) => {
-                    // #237: under the native-pointer ABI, reading the stack-pointer
-                    // global yields the real stack top — `__synth_wasm_data + init`
-                    // — register-promoted, so the dissolved object needs no runtime
-                    // R9 globals table. Frame arithmetic on this real pointer keeps
-                    // the base; SP-relative loads become true memory accesses.
-                    if let Some((sp_idx, sp_init)) = self.sp_global
-                        && *global_idx == sp_idx
-                    {
+                    // #237 (gale, mutex-on-silicon): under the native-pointer ABI,
+                    // globals live in MATERIALIZED slots (`__synth_globals + idx*4`,
+                    // emitted into the object's .data with their wasm init values)
+                    // — mutable state that survives global.set, unlike the earlier
+                    // constant promotion whose paired dropped-store miscompiled any
+                    // multi-function module that moves the shadow-stack pointer.
+                    // Slots hold wasm OFFSETS (no data relocation needed); the SP
+                    // global is rebased to an absolute pointer on read so address
+                    // arithmetic and [r11=0 + addr] accesses see host pointers.
+                    if self.native_pointer_abi {
                         let dst = alloc_temp_safe(&mut next_temp, &stack, &live_params)?;
-                        Self::emit_wasm_data_addr(&mut instructions, dst, sp_init, idx);
+                        Self::emit_sym_addr(
+                            &mut instructions,
+                            dst,
+                            "__synth_globals",
+                            (*global_idx as i32) * 4,
+                            idx,
+                        );
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Ldr {
+                                rd: dst,
+                                addr: MemAddr::imm(dst, 0),
+                            },
+                            source_line: Some(idx),
+                        });
                         cf.add_instruction();
                         stack.push(StackVal::i32(dst));
+                        if let Some((sp_idx, _)) = self.sp_global
+                            && *global_idx == sp_idx
+                        {
+                            // dst is on the operand stack now, so the base temp
+                            // cannot alias it.
+                            let base = alloc_temp_safe(&mut next_temp, &stack, &live_params)?;
+                            Self::emit_wasm_data_addr(&mut instructions, base, 0, idx);
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Add {
+                                    rd: dst,
+                                    rn: dst,
+                                    op2: Operand2::Reg(base),
+                                },
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                        }
                         continue;
                     }
                     // Load global value from globals table (R9 = globals base).
@@ -7254,15 +7317,51 @@ impl InstructionSelector {
                         &live_params,
                         idx,
                     )?;
-                    // #237: a write to the register-promoted stack-pointer global is
-                    // dead in a leaf, balanced function — the only readers are this
-                    // function's own `global.get`s (which re-materialize the init
-                    // address) and host imports (which never touch wasm SP). Pop the
-                    // operand (preserving stack discipline) and drop the store.
-                    if let Some((sp_idx, _)) = self.sp_global
-                        && *global_idx == sp_idx
-                    {
-                        let _ = val;
+                    // #237 (gale, mutex-on-silicon): under the native-pointer ABI
+                    // the store is REAL — write the value into the global's
+                    // materialized slot. The earlier "dropped store" leaf
+                    // assumption miscompiled multi-function modules whose callees
+                    // re-read the moved shadow-stack pointer. The SP global's
+                    // absolute pointer is rebased back to a wasm offset before the
+                    // store (slots hold offsets; no data relocation needed).
+                    if self.native_pointer_abi {
+                        let mut reserved = live_params.clone();
+                        reserved.push(val);
+                        let stored = if let Some((sp_idx, _)) = self.sp_global
+                            && *global_idx == sp_idx
+                        {
+                            let base = alloc_temp_safe(&mut next_temp, &stack, &reserved)?;
+                            Self::emit_wasm_data_addr(&mut instructions, base, 0, idx);
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Sub {
+                                    rd: base,
+                                    rn: val,
+                                    op2: Operand2::Reg(base),
+                                },
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                            base
+                        } else {
+                            val
+                        };
+                        reserved.push(stored);
+                        let slot = alloc_temp_safe(&mut next_temp, &stack, &reserved)?;
+                        Self::emit_sym_addr(
+                            &mut instructions,
+                            slot,
+                            "__synth_globals",
+                            (*global_idx as i32) * 4,
+                            idx,
+                        );
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Str {
+                                rd: stored,
+                                addr: MemAddr::imm(slot, 0),
+                            },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
                         continue;
                     }
                     instructions.push(ArmInstruction {
@@ -15236,6 +15335,62 @@ mod tests {
     /// segment becomes `__synth_wasm_data`-relative (MovwSym/MovtSym), so a
     /// `base=0` host-pointer trampoline doesn't mis-resolve it. Without the flag
     /// (and for an out-of-range/runtime address) it stays base-relative.
+    #[test]
+    fn test_237_globals_live_in_materialized_slots_under_native_pointer_abi() {
+        // #237 (gale, mutex-on-silicon): global.get/set go through
+        // `__synth_globals` slots — the set is a REAL store (the dropped-store
+        // leaf assumption miscompiled gmutex), the get reads the CURRENT value,
+        // and the SP global is rebased absolute-on-read / offset-on-write.
+        let db = RuleDatabase::new();
+        let mut sel = InstructionSelector::new(db.rules().to_vec());
+        sel.set_native_pointer_abi(true, 65536);
+        sel.set_native_pointer_stack(0, 4096);
+        let ops = vec![
+            WasmOp::GlobalGet(0),
+            WasmOp::I32Const(16),
+            WasmOp::I32Sub,
+            WasmOp::GlobalSet(0),
+        ];
+        let instrs = sel.select_with_stack(&ops, 0).unwrap();
+        let globals_syms = instrs
+            .iter()
+            .filter(
+                |i| matches!(&i.op, ArmOp::MovwSym { symbol, .. } if symbol == "__synth_globals"),
+            )
+            .count();
+        assert_eq!(
+            globals_syms, 2,
+            "one slot address for the get, one for the set"
+        );
+        let base_syms = instrs
+            .iter()
+            .filter(
+                |i| matches!(&i.op, ArmOp::MovwSym { symbol, .. } if symbol == "__synth_wasm_data"),
+            )
+            .count();
+        assert_eq!(base_syms, 2, "rebase on read (add) and on write (sub)");
+        assert!(
+            instrs.iter().any(|i| matches!(&i.op, ArmOp::Ldr { .. })),
+            "the get LOADS the slot (not a constant)"
+        );
+        assert!(
+            instrs.iter().any(|i| matches!(&i.op, ArmOp::Str { .. })),
+            "the set STORES to the slot (not dropped)"
+        );
+        assert!(
+            !instrs
+                .iter()
+                .any(|i| { reg_effect_touches(&i.op, Reg::R9) }),
+            "no R9 globals-table access under the native-pointer ABI"
+        );
+    }
+
+    fn reg_effect_touches(op: &ArmOp, reg: Reg) -> bool {
+        crate::liveness::reg_effect(op)
+            .map(|e| e.defs.contains(&reg) || e.uses.contains(&reg))
+            .unwrap_or(false)
+    }
+
     #[test]
     fn test_237_static_store_is_symbol_relative_under_native_pointer_abi() {
         let db = RuleDatabase::new();

--- a/crates/synth-synthesis/tests/semantic_correctness_i64.rs
+++ b/crates/synth-synthesis/tests/semantic_correctness_i64.rs
@@ -460,6 +460,27 @@ fn find_i64_result(instrs: &[ArmInstruction]) -> Option<I64Result> {
             _ => {}
         }
     }
+    // #311 defect 3: the return epilogue now moves a function-final i64 pair
+    // into the AAPCS result registers (mov r0, lo; mov r1, hi). When those
+    // moves are present for the pair we tracked, the OBSERVABLE result lives
+    // in r0:r1 — and the hi move may legitimately overwrite the old pair's
+    // registers, so reading the pre-move location is wrong. Follow the moves.
+    if let Some(p) = &last_pair {
+        let lo_moved = instrs.iter().any(
+            |i| matches!(&i.op, ArmOp::Mov { rd: Reg::R0, op2: Operand2::Reg(s) } if *s == p.lo),
+        );
+        if lo_moved || p.lo == Reg::R0 {
+            let hi_moved = instrs.iter().any(|i| {
+                matches!(&i.op, ArmOp::Mov { rd: Reg::R1, op2: Operand2::Reg(s) } if *s == p.hi)
+            });
+            if hi_moved || p.hi == Reg::R1 {
+                return Some(I64Result {
+                    lo: Reg::R0,
+                    hi: Reg::R1,
+                });
+            }
+        }
+    }
     last_pair
 }
 
@@ -983,6 +1004,20 @@ fn find_extend_i32u_pair(instrs: &[ArmInstruction]) -> Option<(Reg, Reg)> {
             }
             ArmOp::Movw { rd, imm16: 0 } => {
                 if let Some(lo) = last_mov_rd.take() {
+                    // #311 defect 3: follow the return epilogue's pair moves (mov r0, lo;
+                    // mov r1, hi) — reading the pre-move registers is wrong once the hi move
+                    // legitimately overwrites them.
+                    if let Some((lo, hi)) = found {
+                        let lo_moved = instrs.iter().any(|i| {
+            matches!(&i.op, ArmOp::Mov { rd: Reg::R0, op2: Operand2::Reg(s) } if *s == lo)
+        });
+                        let hi_moved = instrs.iter().any(|i| {
+            matches!(&i.op, ArmOp::Mov { rd: Reg::R1, op2: Operand2::Reg(s) } if *s == hi)
+        });
+                        if (lo_moved || lo == Reg::R0) && (hi_moved || hi == Reg::R1) {
+                            return Some((Reg::R0, Reg::R1));
+                        }
+                    }
                     found = Some((lo, *rd));
                 }
             }
@@ -993,6 +1028,20 @@ fn find_extend_i32u_pair(instrs: &[ArmInstruction]) -> Option<(Reg, Reg)> {
                     last_mov_rd = None;
                 }
             }
+        }
+    }
+    // #311 defect 3: follow the return epilogue's pair moves (mov r0, lo;
+    // mov r1, hi) — reading the pre-move registers is wrong once the hi move
+    // legitimately overwrites them.
+    if let Some((lo, hi)) = found {
+        let lo_moved = instrs.iter().any(
+            |i| matches!(&i.op, ArmOp::Mov { rd: Reg::R0, op2: Operand2::Reg(s) } if *s == lo),
+        );
+        let hi_moved = instrs.iter().any(
+            |i| matches!(&i.op, ArmOp::Mov { rd: Reg::R1, op2: Operand2::Reg(s) } if *s == hi),
+        );
+        if (lo_moved || lo == Reg::R0) && (hi_moved || hi == Reg::R1) {
+            return Some((Reg::R0, Reg::R1));
         }
     }
     found

--- a/scripts/repro/native_pointer_shadow_stack.wat
+++ b/scripts/repro/native_pointer_shadow_stack.wat
@@ -1,0 +1,17 @@
+(module
+  ;; #237 (gale, mutex-on-silicon): the gmutex shadow-stack shape — a mutable
+  ;; __stack_pointer global initialized by wasm-ld to the stack top (4096),
+  ;; moved down for a frame, stored through, read back, and restored.
+  (memory (export "memory") 1)
+  (global $__stack_pointer (mut i32) (i32.const 4096))
+  (data (i32.const 4096) "\2a\00\00\00")
+  (func (export "frame_roundtrip") (param $v i32) (result i32)
+    (local $sp i32)
+    ;; prologue: sp = SP - 16; SP = sp
+    (local.set $sp (i32.sub (global.get $__stack_pointer) (i32.const 16)))
+    (global.set $__stack_pointer (local.get $sp))
+    ;; spill v into the frame, read it back
+    (i32.store (local.get $sp) (local.get $v))
+    ;; epilogue: SP = sp + 16
+    (global.set $__stack_pointer (i32.add (local.get $sp) (i32.const 16)))
+    (i32.load (local.get $sp))))

--- a/scripts/repro/native_pointer_shadow_stack_differential.py
+++ b/scripts/repro/native_pointer_shadow_stack_differential.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""#237 shadow-stack differential: the gmutex frame shape under --native-pointer-abi.
+
+Compile:
+  synth compile scripts/repro/native_pointer_shadow_stack.wat -o /tmp/np_ss.elf \
+        --target cortex-m4 --native-pointer-abi --all-exports --relocatable
+Run:
+  /tmp/armv/bin/python scripts/repro/native_pointer_shadow_stack_differential.py /tmp/np_ss.elf
+
+Asserts: frame_roundtrip(v) == v (the store through the moved shadow-stack
+pointer lands INSIDE __synth_wasm_data, not at 0xFFFFFFF4), and the
+__synth_globals SP slot is restored to its init (4096) on return.
+"""
+import struct, sys
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_THUMB
+from unicorn.arm_const import (UC_ARM_REG_R0, UC_ARM_REG_R11, UC_ARM_REG_LR,
+                               UC_ARM_REG_SP, UC_ARM_REG_PC)
+
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/np_ss.elf"
+CODE, DATA, STK = 0x10000, 0x40000, 0x90000
+
+e = ELFFile(open(ELF, "rb"))
+text = bytearray(e.get_section_by_name(".text").data())
+data = bytearray(e.get_section_by_name(".data").data())
+
+syms = {}
+for sec in e.iter_sections():
+    if sec["sh_type"] == "SHT_SYMTAB":
+        for s in sec.iter_symbols():
+            syms[s.name] = s["st_value"]
+
+def patch_movwt(code, off, value16):
+    hw1, hw2 = struct.unpack_from("<HH", code, off)
+    imm4, i = (value16 >> 12) & 0xF, (value16 >> 11) & 1
+    imm3, imm8 = (value16 >> 8) & 0x7, value16 & 0xFF
+    hw1 = (hw1 & ~0x040F) | (i << 10) | imm4
+    hw2 = (hw2 & ~0x70FF) | (imm3 << 12) | imm8
+    struct.pack_into("<HH", code, off, hw1, hw2)
+
+# synth labels its Thumb MOVW/MOVT relocations with the ARM32 type numbers
+# (43/44) — patch them with the THUMB bit layout (what the encoder emitted).
+MOVW_TYPES, MOVT_TYPES = (43, 47), (44, 48)
+rel = e.get_section_by_name(".rel.text")
+symtab = [sec for sec in e.iter_sections() if sec["sh_type"] == "SHT_SYMTAB"][0]
+for r in rel.iter_relocations():
+    t = r["r_info_type"]
+    if t not in MOVW_TYPES + MOVT_TYPES:
+        continue
+    sym = symtab.get_symbol(r["r_info_sym"])
+    # addend is encoded in the instruction's current imm16 (REL, not RELA)
+    hw1, hw2 = struct.unpack_from("<HH", text, r["r_offset"])
+    add = ((hw1 & 0xF) << 12) | (((hw1 >> 10) & 1) << 11) | (((hw2 >> 12) & 0x7) << 8) | (hw2 & 0xFF)
+    target = DATA + syms[sym.name] + add
+    patch_movwt(text, r["r_offset"], (target & 0xFFFF) if t in MOVW_TYPES else (target >> 16) & 0xFFFF)
+
+mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+for base, blob in ((CODE, text), (DATA, data)):
+    mu.mem_map(base, 0x10000)
+    mu.mem_write(base, bytes(blob))
+mu.mem_map(STK, 0x10000)
+
+entry = CODE + syms["frame_roundtrip"]
+RET = CODE + 0xFFF0  # mapped pad inside the code mapping (gotcha from #220)
+mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+ok = True
+for v in (7, -123456, 0x7FFFFFFF):
+    mu.reg_write(UC_ARM_REG_R0, v & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_R11, 0)          # native deref: r11 = 0
+    mu.reg_write(UC_ARM_REG_SP, STK + 0x8000)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    mu.emu_start(entry | 1, RET, timeout=5_000_000)
+    got = mu.reg_read(UC_ARM_REG_R0)
+    exp = v & 0xFFFFFFFF
+    sp_slot = struct.unpack("<i", mu.mem_read(DATA + syms["__synth_globals"], 4))[0]
+    line = f"frame_roundtrip({v}) = {got:#x} (expect {exp:#x}), SP slot after = {sp_slot} (expect 4096)"
+    print(line)
+    ok &= (got == exp) and (sp_slot == 4096)
+print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+sys.exit(0 if ok else 1)

--- a/scripts/repro/u64_unpack.wat
+++ b/scripts/repro/u64_unpack.wat
@@ -30,4 +30,25 @@
       (i32.const 0xDEAD)
       (i32.eq
         (i32.wrap_i64 (i64.and (local.get $r) (i64.const 255)))
+        (i32.const 1))))  (func $make_hot (param $a i32) (param $b i32) (result i64)
+    ;; enough live i32 values to push the final or destinations into high regs
+    (local $t1 i32) (local $t2 i32) (local $t3 i32)
+    (local.set $t1 (i32.add (local.get $a) (i32.const 3)))
+    (local.set $t2 (i32.mul (local.get $b) (i32.const 5)))
+    (local.set $t3 (i32.xor (local.get $t1) (local.get $t2)))
+    (i64.or
+      (i64.shl
+        (i64.extend_i32_u
+          (i32.add (i32.add (local.get $a) (local.get $b))
+                   (i32.and (local.get $t3) (i32.const 0))))
+        (i64.const 32))
+      (i64.extend_i32_u (i32.add (i32.const 1) (i32.and (local.get $t3) (i32.const 0))))))
+  (func (export "check_hot") (param $a i32) (param $b i32) (result i32)
+    (local $r i64)
+    (local.set $r (call $make_hot (local.get $a) (local.get $b)))
+    (select
+      (i32.wrap_i64 (i64.shr_u (local.get $r) (i64.const 32)))
+      (i32.const 0xDEAD)
+      (i32.eq
+        (i32.wrap_i64 (i64.and (local.get $r) (i64.const 255)))
         (i32.const 1)))))

--- a/scripts/repro/u64_unpack.wat
+++ b/scripts/repro/u64_unpack.wat
@@ -1,0 +1,33 @@
+(module
+  ;; #311 minimal: i64 unpack — mask/shift constants vs the live u64 pair.
+  ;; Inlined form (loom did this): r = ((a+b+1) << 32) | 1; check action/val.
+  (func (export "check") (param $a i32) (param $b i32) (result i32)
+    (local $r i64)
+    (local.set $r
+      (i64.or
+        (i64.shl
+          (i64.extend_i32_u (i32.add (i32.add (local.get $a) (local.get $b)) (i32.const 1)))
+          (i64.const 32))
+        (i64.const 1)))
+    (select
+      (i32.wrap_i64 (i64.shr_u (local.get $r) (i64.const 32)))
+      (i32.const 0xDEAD)
+      (i32.eq
+        (i32.wrap_i64 (i64.and (local.get $r) (i64.const 255)))
+        (i32.const 1))))
+  ;; post-call form: u64 returned in r0/r1, then unpacked.
+  (func $make (param $a i32) (param $b i32) (result i64)
+    (i64.or
+      (i64.shl
+        (i64.extend_i32_u (i32.add (i32.add (local.get $a) (local.get $b)) (i32.const 1)))
+        (i64.const 32))
+      (i64.const 1)))
+  (func (export "check_call") (param $a i32) (param $b i32) (result i32)
+    (local $r i64)
+    (local.set $r (call $make (local.get $a) (local.get $b)))
+    (select
+      (i32.wrap_i64 (i64.shr_u (local.get $r) (i64.const 32)))
+      (i32.const 0xDEAD)
+      (i32.eq
+        (i32.wrap_i64 (i64.and (local.get $r) (i64.const 255)))
+        (i32.const 1)))))

--- a/scripts/repro/u64_unpack_differential.py
+++ b/scripts/repro/u64_unpack_differential.py
@@ -8,7 +8,7 @@ from unicorn.arm_const import (UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R11,
 # ground truth
 eng = wasmtime.Engine(); mod = wasmtime.Module(eng, open('/tmp/u64repro.wat','rb').read())
 st = wasmtime.Store(eng); inst = wasmtime.Instance(st, mod, [])
-gt = {n: inst.exports(st)[n] for n in ("check","check_call")}
+gt = {n: inst.exports(st)[n] for n in ("check","check_call","check_hot")}
 
 e = ELFFile(open('/tmp/u64.elf','rb'))
 text = bytearray(e.get_section_by_name('.text').data())
@@ -42,7 +42,7 @@ RET = CODE + 0xFF00
 mu.mem_write(RET, b"\x00\xbf\x00\xbf")
 
 ok = True
-for fn in ("check","check_call"):
+for fn in ("check","check_call","check_hot"):
     for (a,b) in ((3,4),(0,0),(250,5),(0x7FFFFFFF,1)):
         exp = gt[fn](st, a, b) & 0xFFFFFFFF
         mu.reg_write(UC_ARM_REG_R0, a); mu.reg_write(UC_ARM_REG_R1, b)

--- a/scripts/repro/u64_unpack_differential.py
+++ b/scripts/repro/u64_unpack_differential.py
@@ -1,0 +1,57 @@
+import struct, sys
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_THUMB
+from unicorn.arm_const import (UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R11,
+                               UC_ARM_REG_LR, UC_ARM_REG_SP)
+
+# ground truth
+eng = wasmtime.Engine(); mod = wasmtime.Module(eng, open('/tmp/u64repro.wat','rb').read())
+st = wasmtime.Store(eng); inst = wasmtime.Instance(st, mod, [])
+gt = {n: inst.exports(st)[n] for n in ("check","check_call")}
+
+e = ELFFile(open('/tmp/u64.elf','rb'))
+text = bytearray(e.get_section_by_name('.text').data())
+symtab = [s for s in e.iter_sections() if s['sh_type']=='SHT_SYMTAB'][0]
+syms = {s.name: s['st_value'] for s in symtab.iter_symbols()}
+# resolve internal BL relocs (R_ARM_THM_CALL=10)
+rel = e.get_section_by_name('.rel.text')
+if rel:
+    for r in rel.iter_relocations():
+        if r['r_info_type'] == 10:
+            s = symtab.get_symbol(r['r_info_sym'])
+            if s.name in syms:
+                off, target = r['r_offset'], syms[s.name]
+                pc = off + 4
+                d = (target - pc) & 0xFFFFFFFF
+                # encode Thumb BL imm
+                dd = (target - pc)
+                S_ = (dd >> 24) & 1
+                i1 = (dd >> 23) & 1; i2 = (dd >> 22) & 1
+                j1 = (~(i1 ^ S_)) & 1; j2 = (~(i2 ^ S_)) & 1
+                imm10 = (dd >> 12) & 0x3FF; imm11 = (dd >> 1) & 0x7FF
+                hw1 = 0xF000 | (S_ << 10) | imm10
+                hw2 = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+                struct.pack_into('<HH', text, off, hw1, hw2)
+
+CODE, STK = 0x10000, 0x90000
+mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+mu.mem_map(CODE, 0x10000); mu.mem_write(CODE, bytes(text))
+mu.mem_map(STK, 0x10000)
+RET = CODE + 0xFF00
+mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+ok = True
+for fn in ("check","check_call"):
+    for (a,b) in ((3,4),(0,0),(250,5),(0x7FFFFFFF,1)):
+        exp = gt[fn](st, a, b) & 0xFFFFFFFF
+        mu.reg_write(UC_ARM_REG_R0, a); mu.reg_write(UC_ARM_REG_R1, b)
+        mu.reg_write(UC_ARM_REG_R11, 0); mu.reg_write(UC_ARM_REG_SP, STK+0x8000)
+        mu.reg_write(UC_ARM_REG_LR, RET|1)
+        mu.emu_start((CODE+syms[fn])|1, RET, timeout=5_000_000)
+        got = mu.reg_read(UC_ARM_REG_R0)
+        m = "OK " if got==exp else "FAIL"
+        if got!=exp: ok=False
+        print(f"{m} {fn}({a},{b}) = {got:#x} expect {exp:#x}")
+print("ORACLE:", "PASS" if ok else "FAIL")
+sys.exit(0 if ok else 1)

--- a/scripts/repro/u64_unpack_inlined.wat
+++ b/scripts/repro/u64_unpack_inlined.wat
@@ -1,0 +1,50 @@
+(module $u64.wasm
+  (type (;0;) (func (param i32 i32) (result i64)))
+  (type (;1;) (func (param i32 i32) (result i32)))
+  (table (;0;) 1 1 funcref)
+  (memory (;0;) 1)
+  (global $__stack_pointer (;0;) (mut i32) i32.const 65536)
+  (export "memory" (memory 0))
+  (export "check" (func $check))
+  (func $make (;0;) (type 0) (param i32 i32) (result i64)
+    local.get 0
+    local.get 1
+    i32.add
+    i32.const 1
+    i32.add
+    i64.extend_i32_u
+    i64.const 32
+    i64.shl
+    i64.const 1
+    i64.or
+  )
+  (func $check (;1;) (type 1) (param i32 i32) (result i32)
+    (local i64 i32 i32)
+    local.get 0
+    local.get 1
+    local.set 4
+    local.set 3
+    local.get 3
+    local.get 4
+    i32.add
+    i32.const 1
+    i32.add
+    i64.extend_i32_u
+    i64.const 32
+    i64.shl
+    i64.const 1
+    i64.or
+    local.tee 2
+    i64.const 32
+    i64.shr_u
+    i32.wrap_i64
+    i32.const 57005
+    local.get 2
+    i64.const 255
+    i64.and
+    i64.const 1
+    i64.eq
+    select
+  )
+  (@custom "target_features" (after code) "\08+\0bbulk-memory+\0fbulk-memory-opt+\16call-indirect-overlong+\0amultivalue+\0fmutable-globals+\13nontrapping-fptoint+\0freference-types+\08sign-ext")
+)


### PR DESCRIPTION
## What (both #237 asks, one PR)

gale narrowed the gmutex BUS FAULT to `str.w` at `0xFFFFFFF4 = (SP=0) − 12` with `r11=0`. Two root causes fixed:

**1. Globals were not real.** The old promotion returned a *constant* for `global.get($sp)` and silently **dropped** `global.set($sp)` (leaf-only assumption) — any multi-function dissolution that moves the shadow-stack pointer miscompiled. Now every defined global lives in a **materialized slot** (`__synth_globals + idx*4`, emitted into `.data` with its wasm init — the SP slot starts at the wasm-ld stack top). Slots hold wasm *offsets* (no data relocations); the SP global is rebased absolute-on-read / offset-on-write. `global.set` is a real store.

**2. RAM-prohibitive sizing.** The region is now sized to the **used extent** under `--native-pointer-abi`: max(data-segment end, shadow-stack top, layout-bound global inits, every relocated static addend +8) — global slots appended after. Repro sizes: bss/static **65536 → 264 B**, shadow-stack **65536 → 4104 B** (vs gale's 131072 B for an 830-byte module).

## Oracle

| check | result |
|---|---|
| NEW shadow-stack unicorn differential (the gmutex frame shape: get/sub/set, store through moved pointer, restore) | **PASS** — 3 vectors roundtrip with `r11=0`, SP slot restores to init |
| non-native fixtures | `cmp` **bit-identical** (legacy path untouched); differentials PASS |
| tests / clippy | 339/339 lib + 56 CLI, clean |

The used-extent's own gate caught a real bug during development: the first version sized the bss repro to 4 B while it stores at const 256 — the addend-scan term exists because of that.

## Falsification

Wrong if gale's gmutex oracle still faults (a base-coverage class we haven't seen), if any module touches linear memory beyond the computed used extent at runtime (heap-using modules are out of dissolution scope — say so if falcon needs them), or if `k_mutex_unlock` ≠ native semantics on the G474RE. gale's staged `remeasure_wasm_lto.sh` is the decisive check — the `.bss` no longer needs the manual 64 KB patch.

Closes the GI-NPA-003 blocker path. Release: rides **v0.11.36** with #309 (gale gets one tag for everything).

🤖 Generated with [Claude Code](https://claude.com/claude-code)