### PR TITLE
fix(ci): drop per-crate dependabot entries (#306)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,27 +12,3 @@ updates:
       interval: weekly
     labels:
       - dependencies
-  - package-ecosystem: cargo
-    directory: /crates/synth-abi
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies
-  - package-ecosystem: cargo
-    directory: /crates/synth-analysis
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies
-  - package-ecosystem: cargo
-    directory: /crates/synth-backend-awsm
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies
-  - package-ecosystem: cargo
-    directory: /crates/synth-backend-wasker
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies


### PR DESCRIPTION
Half 1 of #306: the per-crate cargo dependabot directories fail their update jobs weekly (member crates can't move independently against the workspace's exact-version path-dep pins). The root workspace-aware entry covers everything via the shared lockfile. Half 2 (Signing E2E red on every run) is the rekor cert-pin rotation — structural fix in pulseengine/sigil#147 (chain-match semantics), then a wsc release + pin bump here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)