### PR TITLE
chore(release): v0.11.36 — pin sweep + changelog

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "pulseengine-claude@pulseengine-eu": true
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.36] - 2026-06-11
+
+**Four silicon blockers in one tag: the allocator goes default-ON, the mutex
+shadow-stack works, and the entire packed-u64 verified-decide pattern is
+correct (#209/#237/#311, VCR-RA-001 step 3a).**
+
+- **Range re-allocation DEFAULT-ON** (#309): the value-range re-colouring pass
+  (wiring step 3a) is on for every compile after gale's on-target gate cleared
+  it (byte-identical on flat_flight/controller/control_step, cycle-neutral +
+  smaller where it fires). Opt out with `SYNTH_RANGE_REALLOC=0`; stats via
+  `SYNTH_REALLOC_STATS=1`.
+- **Dead callee-saved-save elimination** (#309): prologue/epilogue save lists
+  shrink to the callee-saved registers the re-allocated body still touches
+  (leaf-only, SP-untouched, even-count-padded) — `push {r4-r8,lr}` overhead
+  (~12 cyc on a 37-cyc leaf) removed where the body packs into low registers.
+- **Native-pointer ABI: materialized global slots + used-extent sizing**
+  (#310, gale #237): every defined global lives at `__synth_globals + idx*4`
+  in `.data`, initialized from the wasm global section — `global.set` is a
+  real store (the old promotion DROPPED stores to the shadow-stack pointer),
+  and the SP global starts at the wasm-ld stack top instead of 0 (the
+  0xFFFFFFF4 bus fault). The region is sized to the USED extent (data end /
+  stack top / layout globals / static addends) instead of declared 64 KiB
+  pages: 131072 B -> ~4 KiB for gale's 830-byte module.
+- **i64 pair correctness, all three legs** (#310, gale #311): (1) call results
+  are pair-tagged (decoder result-type tables -> liveness sees r1, constants
+  can no longer materialize into the live u64 pair; i64-local inference models
+  call widths so both halves spill); (2) the encoder's I64SetCond/I64SetCondZ
+  high-rd MOVS->CMP transmutation is fixed with 32-bit MOV.W/CMP.W — closing
+  STPA hazard H-CODE-9; (3) the return epilogue moves BOTH halves of an i64
+  result into r0:r1 (lo-first, safe for every consecutive pair).
+
+Falsification: this release is wrong if gale's staged lanes disagree — the sem
+unicorn check (count 0->1) and gmutex oracle on the G474RE are the decisive
+gates, plus cycle-neutrality on the rebaselined suite (241/150/151/37). New
+committed oracles: u64_unpack(+inlined).wat differentials,
+native_pointer_shadow_stack differential, test_311_* + shrink_saves_* tests.
+
+
 ## [0.11.35] - 2026-06-09
 
 **In-place select + spill-cost ranking — the first VCR codegen-quality release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,14 +1933,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1989,11 +1989,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.35"
+version = "0.11.36"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "anyhow",
  "clap",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "anyhow",
  "serde",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2042,14 +2042,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2057,11 +2057,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.35"
+version = "0.11.36"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "anyhow",
  "clap",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.35"
+version = "0.11.36"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.35"
+version = "0.11.36"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.35",
+    version = "0.11.36",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.35" }
+synth-core = { path = "../synth-core", version = "0.11.36" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.35" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.35" }
+synth-core = { path = "../synth-core", version = "0.11.36" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.36" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.35" }
+synth-core = { path = "../synth-core", version = "0.11.36" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.35" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.35", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.36" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.36", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.35" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.35" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.35" }
-synth-backend = { path = "../synth-backend", version = "0.11.35" }
+synth-core = { path = "../synth-core", version = "0.11.36" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.36" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.36" }
+synth-backend = { path = "../synth-backend", version = "0.11.36" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.35", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.35", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.35", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.36", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.36", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.36", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.35", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.36", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.35" }
+synth-core = { path = "../synth-core", version = "0.11.36" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.35" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.36" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.35" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.35" }
-synth-opt = { path = "../synth-opt", version = "0.11.35" }
+synth-core = { path = "../synth-core", version = "0.11.36" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.36" }
+synth-opt = { path = "../synth-opt", version = "0.11.36" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.35" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.35" }
-synth-opt = { path = "../synth-opt", version = "0.11.35" }
+synth-core = { path = "../synth-core", version = "0.11.36" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.36" }
+synth-opt = { path = "../synth-opt", version = "0.11.36" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.35", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.36", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Release prep for v0.11.36 (realloc default-ON + prologue shrink + #237 globals/sizing + 3× #311 i64 pair fixes). Content PRs merged: #309 #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)