### PR TITLE
fix(riscv): i64 locals + per-op alloc pin scope — packed-u64 decide on RV32 (#312)

### DIFF
--- a/crates/synth-backend-riscv/src/backend.rs
+++ b/crates/synth-backend-riscv/src/backend.rs
@@ -6,7 +6,7 @@
 //! Track B2/B3/B4 deliverable.
 
 use crate::elf_builder::{RiscVElfBuilder, RiscVElfFunction};
-use crate::selector::{RvBoundsMode, SelectorOptions, select_with_options};
+use crate::selector::{RvBoundsMode, SelectorOptions, select_with_result_types};
 use synth_core::backend::{
     Backend, BackendCapabilities, BackendError, CompilationResult, CompileConfig, CompiledFunction,
     SafetyBounds,
@@ -82,7 +82,7 @@ impl Backend for RiscVBackend {
             let compiled = compile_function_with_opts(&name, &func.ops, config, opts)?;
             elf_funcs.push(RiscVElfFunction {
                 name: compiled.name.clone(),
-                ops: compile_to_riscv_ops(&func.ops, opts, &compiled)?,
+                ops: compile_to_riscv_ops(&func.ops, config, opts, &compiled)?,
             });
             functions.push(compiled);
         }
@@ -152,8 +152,16 @@ fn compile_function_with_opts(
     ensure_supported_target(&config.target)?;
 
     let num_params = count_params(ops);
-    let selection = select_with_options(ops, num_params, opts)
-        .map_err(|e| BackendError::CompilationFailed(format!("RISC-V selector: {e}")))?;
+    // #312: pass the decoder's "returns i64" tables down so call-fed i64
+    // locals get 8-byte frame slots and i64 call results the a0:a1 pair.
+    let selection = select_with_result_types(
+        ops,
+        num_params,
+        opts,
+        &config.func_ret_i64,
+        &config.type_ret_i64,
+    )
+    .map_err(|e| BackendError::CompilationFailed(format!("RISC-V selector: {e}")))?;
 
     // Encode the function via the ELF builder's per-function pipeline so
     // we benefit from label resolution. We discard the ELF and keep the
@@ -258,12 +266,19 @@ fn encode_function_bytes(f: &RiscVElfFunction) -> Result<Vec<u8>, BackendError> 
 /// arch-neutral, so this re-derives it on demand for ELF emission.
 fn compile_to_riscv_ops(
     ops: &[WasmOp],
+    config: &CompileConfig,
     opts: SelectorOptions,
     _compiled: &CompiledFunction,
 ) -> Result<Vec<crate::riscv_op::RiscVOp>, BackendError> {
     let num_params = count_params(ops);
-    let selection = select_with_options(ops, num_params, opts)
-        .map_err(|e| BackendError::CompilationFailed(format!("RISC-V selector: {e}")))?;
+    let selection = select_with_result_types(
+        ops,
+        num_params,
+        opts,
+        &config.func_ret_i64,
+        &config.type_ret_i64,
+    )
+    .map_err(|e| BackendError::CompilationFailed(format!("RISC-V selector: {e}")))?;
     Ok(selection.ops)
 }
 
@@ -367,7 +382,12 @@ mod tests {
             wasm_ops: ops.clone(),
             relocations: Vec::new(),
         };
-        let rv = compile_to_riscv_ops(&ops, SelectorOptions::wasm_compliant(), &dummy).unwrap();
+        let cfg = CompileConfig {
+            target: TargetSpec::riscv32imac(),
+            ..Default::default()
+        };
+        let rv =
+            compile_to_riscv_ops(&ops, &cfg, SelectorOptions::wasm_compliant(), &dummy).unwrap();
         // First two ops should move param regs into temporaries (immediate 0).
         assert!(matches!(
             rv[0],

--- a/crates/synth-backend-riscv/src/lib.rs
+++ b/crates/synth-backend-riscv/src/lib.rs
@@ -33,6 +33,6 @@ pub use register::{Reg, RegClass};
 pub use riscv_op::{Branch, Csr, RiscVOp};
 pub use selector::{
     RiscVSelection, RvBoundsMode, SelectorError, SelectorOptions, select_simple,
-    select_with_options,
+    select_with_options, select_with_result_types,
 };
 pub use startup::{RiscVStartupGenerator, StartupConfig};

--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -393,6 +393,23 @@ struct Selector {
     /// rather than emitting a clobbering allocation (honest skip, not a silent
     /// miscompile — the same discipline as the ARM regalloc-exhaustion path).
     alloc_exhausted: bool,
+    /// #312: registers pinned for the duration of the *current wasm op's*
+    /// lowering. Covers the two holes `live_regs()` (vstack liveness) cannot
+    /// see, both opened by the #231 lowest-free allocator:
+    ///
+    /// 1. **Popped operands** leave the vstack before the multi-instruction
+    ///    expansion that reads them finishes — without pinning, a scratch
+    ///    `alloc_temp` lands on a popped operand and clobbers it mid-sequence
+    ///    (the #232 signed-div guard bug, generalized).
+    /// 2. **Scratch already handed out for this op** isn't on the vstack
+    ///    either, so two back-to-back `alloc_temp` calls returned the *same*
+    ///    register — every `(lo, hi)` i64 pair collapsed to one register.
+    ///
+    /// `pop_*` pins what it pops, `alloc_temp_avoiding` pins what it returns,
+    /// and `lower_one` clears the set at the start of each op. High-pressure
+    /// lowerings (`i64.div_s`, shifts/rotates, clz/ctz/popcnt) `unpin` scratch
+    /// as it dies to stay inside the 13-register pool.
+    op_pinned: Vec<Reg>,
     /// Counter for generating unique labels (L0, L1, ...).
     next_label: u32,
     /// Tracks whether we already emitted the function-final return.
@@ -448,6 +465,7 @@ impl Selector {
             arg_regs: Reg::arg_regs(num_params as usize),
             temps,
             alloc_exhausted: false,
+            op_pinned: Vec::new(),
             next_label: 0,
             emitted_return: false,
             options,
@@ -544,16 +562,18 @@ impl Selector {
         self.alloc_temp_avoiding(&[])
     }
 
-    /// Like [`alloc_temp`], but also avoids the registers in `avoid` — operands
-    /// that have been *popped off the vstack* into local variables but are still
-    /// live (so `live_regs` no longer covers them). The signed-division guard is
-    /// the motivating case (#232): it pops the dividend/divisor, then needs
-    /// scratch registers for its `INT_MIN`/`-1` comparison constants that must
-    /// not land on the still-live dividend before the `div` reads it.
+    /// Like [`alloc_temp`], but also avoids the registers in `avoid`.
+    ///
+    /// #312: beyond the vstack-live set (#226) and the explicit `avoid` list
+    /// (#232), this also skips — and adds the returned register to — the
+    /// per-op `op_pinned` set, so (a) operands popped earlier in the current
+    /// op's lowering are never clobbered by its own scratch, and (b) two
+    /// allocations within one op never alias each other.
     fn alloc_temp_avoiding(&mut self, avoid: &[Reg]) -> Reg {
         let live = self.live_regs();
         for &r in &self.temps {
-            if !live.contains(&r) && !avoid.contains(&r) {
+            if !live.contains(&r) && !avoid.contains(&r) && !self.op_pinned.contains(&r) {
+                self.pin(r);
                 return r;
             }
         }
@@ -561,6 +581,20 @@ impl Selector {
         // skip-and-continue rather than emit a clobber.
         self.alloc_exhausted = true;
         self.temps[0]
+    }
+
+    /// Pin `r` for the remainder of the current wasm op's lowering (#312).
+    fn pin(&mut self, r: Reg) {
+        if !self.op_pinned.contains(&r) {
+            self.op_pinned.push(r);
+        }
+    }
+
+    /// Release registers whose value is dead for the rest of the current op —
+    /// used by the high-pressure lowerings (i64 div/shift/rotate, clz/ctz/
+    /// popcnt) so their fully-pinned peak stays inside the 13-register pool.
+    fn unpin(&mut self, regs: &[Reg]) {
+        self.op_pinned.retain(|r| !regs.contains(r));
     }
 
     fn push_i32(&mut self, r: Reg) {
@@ -572,9 +606,21 @@ impl Selector {
     }
 
     fn pop_any(&mut self, op: &WasmOp) -> Result<VstackVal, SelectorError> {
-        self.vstack
+        let v = self
+            .vstack
             .pop()
-            .ok_or_else(|| SelectorError::StackUnderflow(op.clone()))
+            .ok_or_else(|| SelectorError::StackUnderflow(op.clone()))?;
+        // #312: a popped operand leaves `live_regs` but is still read by the
+        // remainder of this op's expansion — pin it so scratch allocations
+        // can't land on it (clobber class of #232, generalized).
+        match v {
+            VstackVal::I32(r) => self.pin(r),
+            VstackVal::I64 { lo, hi } => {
+                self.pin(lo);
+                self.pin(hi);
+            }
+        }
+        Ok(v)
     }
 
     /// Pop the top of stack and assert it's an i32. Errors with
@@ -641,6 +687,9 @@ impl Selector {
 
     fn lower_one(&mut self, op: &WasmOp) -> Result<(), SelectorError> {
         use WasmOp::*;
+        // #312: per-op pin scope — operands popped and scratch allocated while
+        // lowering `op` stay pinned until the next op starts.
+        self.op_pinned.clear();
         match op {
             // ─── Locals ─────────────────────────────────────────────────
             LocalGet(idx) => self.lower_local_get(*idx, op)?,
@@ -2153,7 +2202,8 @@ impl Selector {
     /// fill is the sign bit, materialised once via `sra hi, 31`).
     fn lower_i64_shift(&mut self, op: &WasmOp, kind: ShiftKind) -> Result<(), SelectorError> {
         // rhs is the i64 shift amount; only its low limb is relevant.
-        let ((vlo, vhi), (samt, _samt_hi)) = self.pop_pair_i64(op)?;
+        let ((vlo, vhi), (samt, samt_hi)) = self.pop_pair_i64(op)?;
+        self.unpin(&[samt_hi]); // #312: the amount's high limb is never read
         // s = shamt & 63 — clamp to the 0..=63 window wasm guarantees.
         let s = self.alloc_temp();
         self.out.push(RiscVOp::Andi {
@@ -2190,6 +2240,7 @@ impl Selector {
             rs2: Reg::ZERO,
             label: big_label.clone(),
         });
+        self.unpin(&[s, test]); // #312: both dead after the bit-5 branch
 
         // ── small case: shamt < 32 ───────────────────────────────────────
         // `inv = 31 - s_lo` is the complementary shift used to extract the
@@ -2237,6 +2288,7 @@ impl Selector {
                     rs1: hi_shifted,
                     rs2: carry,
                 });
+                self.unpin(&[carry, hi_shifted]); // #312: arm-local scratch
             }
             ShiftKind::ShrS | ShiftKind::ShrU => {
                 // hi' = hi >> s  (sra for shr_s, srl for shr_u)
@@ -2277,6 +2329,7 @@ impl Selector {
                     rs1: lo_shifted,
                     rs2: carry,
                 });
+                self.unpin(&[carry, lo_shifted]); // #312: arm-local scratch
             }
         }
         self.out.push(RiscVOp::Jal {
@@ -2331,6 +2384,7 @@ impl Selector {
             }
         }
         self.out.push(RiscVOp::Label { name: done_label });
+        self.unpin(&[s_lo, inv]); // #312: shift scratch dead past the join
         self.push_i64(res_lo, res_hi);
         Ok(())
     }
@@ -2347,7 +2401,8 @@ impl Selector {
     /// than a 64-bit shift (which the shift helper would treat as `shamt &
     /// 63 == 0` anyway — but computing it explicitly keeps the intent clear).
     fn lower_i64_rotate(&mut self, op: &WasmOp, left: bool) -> Result<(), SelectorError> {
-        let ((vlo, vhi), (namt, _namt_hi)) = self.pop_i64_then_amount(op)?;
+        let ((vlo, vhi), (namt, namt_hi)) = self.pop_i64_then_amount(op)?;
+        self.unpin(&[namt_hi]); // #312: the amount's high limb is never read
         // n = amount & 63
         let n = self.alloc_temp();
         self.out.push(RiscVOp::Andi {
@@ -2355,6 +2410,7 @@ impl Selector {
             rs1: namt,
             imm: 63,
         });
+        self.unpin(&[namt]); // #312: dead once masked into n
         // comp = (64 - n) & 63  — the complementary rotate distance.
         let comp = self.alloc_temp();
         self.out.push(RiscVOp::Addi {
@@ -2380,6 +2436,7 @@ impl Selector {
         } else {
             self.emit_i64_shift_inline(vlo, vhi, amt_a, ShiftKind::ShrU)
         };
+        self.unpin(&[amt_a]); // #312: n is dead after the first shift
         let (b_lo, b_hi) = if left {
             self.emit_i64_shift_inline(vlo, vhi, amt_b, ShiftKind::ShrU)
         } else {
@@ -2450,6 +2507,7 @@ impl Selector {
             rs2: Reg::ZERO,
             label: big_label.clone(),
         });
+        self.unpin(&[s, test]); // #312: both dead after the bit-5 branch
         // small case
         let inv = self.alloc_temp();
         self.out.push(RiscVOp::Addi {
@@ -2491,6 +2549,7 @@ impl Selector {
                     rs1: hi_shifted,
                     rs2: carry,
                 });
+                self.unpin(&[carry, hi_shifted]); // #312: arm-local scratch
             }
             ShiftKind::ShrS | ShiftKind::ShrU => {
                 self.out.push(if kind == ShiftKind::ShrS {
@@ -2528,6 +2587,7 @@ impl Selector {
                     rs1: lo_shifted,
                     rs2: carry,
                 });
+                self.unpin(&[carry, lo_shifted]); // #312: arm-local scratch
             }
         }
         self.out.push(RiscVOp::Jal {
@@ -2575,6 +2635,7 @@ impl Selector {
             }
         }
         self.out.push(RiscVOp::Label { name: done_label });
+        self.unpin(&[s_lo, inv]); // #312: shift scratch dead past the join
         (res_lo, res_hi)
     }
 
@@ -2607,6 +2668,7 @@ impl Selector {
             rs1: hi_clz,
             imm: 0,
         });
+        self.unpin(&[hi_clz]); // #312: dead once copied into result
         self.out.push(RiscVOp::Jal {
             rd: Reg::ZERO,
             label: done.clone(),
@@ -2649,6 +2711,7 @@ impl Selector {
             rs1: lo_ctz,
             imm: 0,
         });
+        self.unpin(&[lo_ctz]); // #312: dead once copied into result
         self.out.push(RiscVOp::Jal {
             rd: Reg::ZERO,
             label: done.clone(),
@@ -2749,6 +2812,9 @@ impl Selector {
                 rs1: x,
                 rs2: add,
             });
+            // #312: the probe scratch is dead at the end of each step — release
+            // it so the five unrolled steps reuse three registers, not fifteen.
+            self.unpin(&[probe, is_zero, add]);
         }
         // After the five probes, n is 31 for an all-zero input (each window
         // contributed) and the true count for anything else. Correct the
@@ -2765,6 +2831,8 @@ impl Selector {
             rs1: n,
             rs2: is_src_zero,
         });
+        // #312: only the result survives this helper.
+        self.unpin(&[x, n, is_src_zero]);
         result
     }
 
@@ -2831,6 +2899,8 @@ impl Selector {
             rs1: ctz,
             rs2: corr,
         });
+        // #312: only the result survives this helper.
+        self.unpin(&[neg, iso, clz_iso, thirty_one, ctz, is_src_zero, corr]);
         result
     }
 
@@ -2925,6 +2995,8 @@ impl Selector {
             rs1: x,
             shamt: 24,
         });
+        // #312: only the result survives this helper.
+        self.unpin(&[m1, m2, m4, m8, x, t, a, b]);
         result
     }
 
@@ -3411,6 +3483,7 @@ impl Selector {
         });
         self.out.push(RiscVOp::Ebreak);
         self.out.push(RiscVOp::Label { name: div_ok });
+        self.unpin(&[zero_or]); // #312: dead after the zero-divisor branch
 
         // ── Trap 2: signed INT64_MIN / -1 overflow (div_s only) ──────────
         // INT64_MIN = 0x8000_0000_0000_0000 → lo == 0, hi == 0x8000_0000.
@@ -3459,6 +3532,7 @@ impl Selector {
             // dividend == INT64_MIN and divisor == -1 → overflow, trap.
             self.out.push(RiscVOp::Ebreak);
             self.out.push(RiscVOp::Label { name: sdiv_ok });
+            self.unpin(&[tmin_hi, neg1]); // #312: guard constants are dead
         }
 
         if !signed {
@@ -3489,9 +3563,13 @@ impl Selector {
         // would also work, but the operands here came from `alloc_temp`, so
         // we just negate into fresh temps and branch-select.
         let (nabs_lo, nabs_hi) = self.emit_i64_abs(nl, nh, nsign);
+        self.unpin(&[nl, nh]); // #312: dividend halves replaced by |dividend|
         let (dabs_lo, dabs_hi) = self.emit_i64_abs(dl, dh, dsign);
+        self.unpin(&[dl, dh]); // #312: divisor halves replaced by |divisor|
 
         self.emit_i64_udiv_inline((nabs_lo, nabs_hi), (dabs_lo, dabs_hi));
+        // #312: the core copied its inputs into the fixed DIV_* registers.
+        self.unpin(&[nabs_lo, nabs_hi, dabs_lo, dabs_hi]);
         let (mag_lo, mag_hi) = self.copy_div_result(want_rem);
 
         // Result sign:
@@ -3583,6 +3661,8 @@ impl Selector {
             rs1: res_hi,
             rs2: borrow,
         });
+        // #312: only the result pair survives this helper.
+        self.unpin(&[xl, xh, borrow]);
         (res_lo, res_hi)
     }
 
@@ -5687,7 +5767,11 @@ mod tests {
             sel.push_i32(r);
         }
         // Spin the allocator well past the pool size; it must dodge all three.
+        // #312: allocations within one op pin their result (so pairs never
+        // alias) — clear the per-op scope each iteration, as `lower_one` does
+        // at every op boundary.
         for _ in 0..(sel.temps.len() * 3) {
+            sel.op_pinned.clear();
             let r = sel.alloc_temp();
             assert!(
                 !pinned.contains(&r),
@@ -5769,6 +5853,63 @@ mod tests {
         assert!(
             sel.alloc_exhausted,
             "all temps pinned → exhaustion flagged for skip-and-continue"
+        );
+    }
+
+    /// #312: within one op's lowering, back-to-back `alloc_temp` calls (an
+    /// i64 `(lo, hi)` pair) must never alias, and freshly allocated scratch
+    /// must never land on an operand popped earlier in the same op. Before
+    /// the per-op pin scope, lowest-free (#231) collapsed every i64 pair to
+    /// a single register — `check(3,4)` returned 0x0 on the u64-unpack
+    /// oracle because each pair's hi write destroyed its own lo.
+    #[test]
+    fn i64_pair_registers_never_alias_312() {
+        // i64.const: lo/hi must be two registers.
+        let mut sel = Selector::new_with_options(0, SelectorOptions::wasm_compliant());
+        sel.lower_one(&WasmOp::I64Const(5)).unwrap();
+        let Some(&VstackVal::I64 { lo, hi }) = sel.vstack.last() else {
+            panic!("i64.const must push an i64 pair");
+        };
+        assert_ne!(lo, hi, "i64.const pair collapsed to one register");
+
+        // i64.extend_i32_u: the fresh hi (= 0) must not land on the popped
+        // src, which becomes the pair's lo.
+        let mut sel = Selector::new_with_options(0, SelectorOptions::wasm_compliant());
+        sel.lower_one(&WasmOp::I32Const(7)).unwrap();
+        sel.lower_one(&WasmOp::I64ExtendI32U).unwrap();
+        let Some(&VstackVal::I64 { lo, hi }) = sel.vstack.last() else {
+            panic!("i64.extend_i32_u must push an i64 pair");
+        };
+        assert_ne!(lo, hi, "extend_i32_u zeroed hi on top of its own lo");
+    }
+
+    /// #312: an i64 local.get must load the two frame words into two distinct
+    /// registers (the repro loaded both `0(sp)` and `4(sp)` into the same reg).
+    #[test]
+    fn i64_local_get_loads_distinct_pair_312() {
+        let sel = select(
+            &[
+                WasmOp::I64Const(1),
+                WasmOp::LocalSet(0),
+                WasmOp::LocalGet(0),
+            ],
+            0,
+        )
+        .unwrap();
+        let frame_loads: Vec<Reg> = sel
+            .ops
+            .iter()
+            .filter_map(|op| match op {
+                RiscVOp::Lw {
+                    rd, rs1: Reg::SP, ..
+                } => Some(*rd),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(frame_loads.len(), 2, "i64 local.get loads both slot words");
+        assert_ne!(
+            frame_loads[0], frame_loads[1],
+            "i64 local.get pair collapsed to one register"
         );
     }
 

--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -169,13 +169,33 @@ pub fn select_simple(
 
 /// Same as [`select`], but lets the caller dial in safety options.
 /// Phase 1 of `docs/binary-safety-design.md` §3.1 / §3.3.
+///
+/// No module signature info: i64-returning calls / call-fed i64 locals are
+/// inferred as i32 (pre-#312 behaviour). Prefer [`select_with_result_types`]
+/// when the decoder's per-function/per-type tables are available.
 pub fn select_with_options(
     wasm_ops: &[WasmOp],
     num_params: u32,
     options: SelectorOptions,
 ) -> Result<RiscVSelection, SelectorError> {
+    select_with_result_types(wasm_ops, num_params, options, &[], &[])
+}
+
+/// Same as [`select_with_options`], plus the decoder's "returns i64" tables
+/// (#312, mirroring ARM #311): `func_ret_i64[full_func_idx]` /
+/// `type_ret_i64[type_idx]`. They drive (a) the i64-local width inference for
+/// call-fed locals and (b) tagging an i64 call result as the `a0:a1` pair.
+pub fn select_with_result_types(
+    wasm_ops: &[WasmOp],
+    num_params: u32,
+    options: SelectorOptions,
+    func_ret_i64: &[bool],
+    type_ret_i64: &[bool],
+) -> Result<RiscVSelection, SelectorError> {
     let mut ctx = Selector::new_with_options(num_params, options);
-    ctx.compute_local_layout(wasm_ops, num_params); // #223
+    ctx.func_ret_i64 = func_ret_i64.to_vec();
+    ctx.type_ret_i64 = type_ret_i64.to_vec();
+    ctx.compute_local_layout(wasm_ops, num_params); // #223 / #312
     ctx.lower_seq(wasm_ops)?;
     // #226: if any allocation ran out of registers that weren't pinning a live
     // vstack value, the function needs spilling we don't yet do — skip it rather
@@ -379,12 +399,26 @@ struct Selector {
     emitted_return: bool,
     /// Phase-1 safety options (bounds-check policy, signed-div overflow trap).
     options: SelectorOptions,
-    /// #223: non-parameter local `idx` → byte offset within the stack frame
-    /// (the locals region, laid out first at `0..local_frame_bytes`). The #220
-    /// callee-saved spills go after it; the unified prologue opens both.
-    local_offsets: std::collections::HashMap<u32, i32>,
-    /// Bytes reserved for non-parameter locals (4 per i32 local, 16-aligned).
+    /// #223: non-parameter local `idx` → `(byte offset, is_i64)` within the
+    /// stack frame (the locals region, laid out first at
+    /// `0..local_frame_bytes`). The #220 callee-saved spills go after it; the
+    /// unified prologue opens both. #312: i64 locals get an 8-byte,
+    /// 8-byte-aligned slot (lo word at `off`, hi word at `off+4`).
+    local_offsets: std::collections::HashMap<u32, (i32, bool)>,
+    /// Bytes reserved for non-parameter locals (4 per i32, 8 per i64).
     local_frame_bytes: i32,
+    /// #312: every local index (param or not) inferred as i64 by
+    /// `synth_synthesis::infer_i64_locals`. Param entries are used only to
+    /// bail out honestly — the RV32 i64-*param* ABI (an i64 param occupies an
+    /// aligned even/odd a-register pair per the psABI) is not modeled yet.
+    i64_locals: std::collections::HashSet<u32>,
+    /// #312: per-function "returns i64" table (full wasm function index,
+    /// imports first). Empty = treat every call result as i32 (legacy).
+    func_ret_i64: Vec<bool>,
+    /// #312: per-type "returns i64" table, for `call_indirect`. Only consulted
+    /// by the width inference today — call_indirect itself is still
+    /// `Unsupported` in this selector.
+    type_ret_i64: Vec<bool>,
 }
 
 impl Selector {
@@ -419,14 +453,23 @@ impl Selector {
             options,
             local_offsets: std::collections::HashMap::new(),
             local_frame_bytes: 0,
+            i64_locals: std::collections::HashSet::new(),
+            func_ret_i64: Vec::new(),
+            type_ret_i64: Vec::new(),
         }
     }
 
-    /// #223: lay out the non-parameter locals referenced by `wasm_ops` into the
-    /// stack frame, one 4-byte i32 slot each, at offsets `0,4,8,…`. The slots
-    /// sit at the bottom of the frame; the #220 callee-saved spills go above.
+    /// #223 + #312: lay out the non-parameter locals referenced by `wasm_ops`
+    /// into the stack frame in ascending-index order: 4-byte slots for i32
+    /// locals, 8-byte 8-aligned slots for i64 locals (width via the shared
+    /// `infer_i64_locals` inference — the same one the ARM selector uses, so
+    /// call-fed i64 locals are covered through `func_ret_i64`/`type_ret_i64`).
+    /// The slots sit at the bottom of the frame; the #220 callee-saved spills
+    /// go above.
     fn compute_local_layout(&mut self, wasm_ops: &[WasmOp], num_params: u32) {
         use std::collections::BTreeSet;
+        self.i64_locals =
+            synth_synthesis::infer_i64_locals(wasm_ops, &self.func_ret_i64, &self.type_ret_i64);
         let mut used: BTreeSet<u32> = BTreeSet::new();
         for op in wasm_ops {
             match op {
@@ -438,10 +481,19 @@ impl Selector {
                 _ => {}
             }
         }
-        for (slot, idx) in used.into_iter().enumerate() {
-            self.local_offsets.insert(idx, (slot as i32) * 4);
+        let mut offset: i32 = 0;
+        for idx in used {
+            let is_i64 = self.i64_locals.contains(&idx);
+            // i64 slots are 8-byte aligned so off/off+4 never straddle a
+            // larger-aligned neighbour (and stay friendly to a future ld/sd
+            // peephole on RV64).
+            if is_i64 && (offset % 8) != 0 {
+                offset += 4;
+            }
+            self.local_offsets.insert(idx, (offset, is_i64));
+            offset += if is_i64 { 8 } else { 4 };
         }
-        self.local_frame_bytes = self.local_offsets.len() as i32 * 4;
+        self.local_frame_bytes = offset;
     }
 
     fn fresh_label(&mut self, prefix: &str) -> String {
@@ -895,31 +947,56 @@ impl Selector {
     // ────────── Locals ──────────
 
     fn lower_local_get(&mut self, idx: u32, op: &WasmOp) -> Result<(), SelectorError> {
-        let dst = self.alloc_temp();
         if (idx as usize) < self.arg_regs.len() {
+            // #312: param handling is i32-only (one a-register per param). An
+            // i64 param occupies an aligned even/odd a-register pair per the
+            // RV32 psABI — not modeled yet, so bail honestly (skip-and-continue
+            // under --all-exports) rather than read half the value.
+            if self.i64_locals.contains(&idx) {
+                return Err(SelectorError::Unsupported(op.clone()));
+            }
+            let dst = self.alloc_temp();
             // mv dst, arg
             self.out.push(RiscVOp::Addi {
                 rd: dst,
                 rs1: self.arg_regs[idx as usize],
                 imm: 0,
             });
+            self.push_i32(dst);
         } else {
             // #223: non-param local — load from its frame slot (lw dst, off(sp)).
-            let off = self.local_slot(idx, op)?;
-            self.out.push(RiscVOp::Lw {
-                rd: dst,
-                rs1: Reg::SP,
-                imm: off,
-            });
+            // #312: an i64 local loads both words of its 8-byte slot
+            // (lo at off, hi at off+4) into a fresh register pair.
+            let (off, is_i64) = self.local_slot(idx, op)?;
+            if is_i64 {
+                let lo = self.alloc_temp();
+                let hi = self.alloc_temp();
+                self.out.push(RiscVOp::Lw {
+                    rd: lo,
+                    rs1: Reg::SP,
+                    imm: off,
+                });
+                self.out.push(RiscVOp::Lw {
+                    rd: hi,
+                    rs1: Reg::SP,
+                    imm: off + 4,
+                });
+                self.push_i64(lo, hi);
+            } else {
+                let dst = self.alloc_temp();
+                self.out.push(RiscVOp::Lw {
+                    rd: dst,
+                    rs1: Reg::SP,
+                    imm: off,
+                });
+                self.push_i32(dst);
+            }
         }
-        // Phase 1: locals are always treated as i32. i64 locals would need
-        // two slots and live outside the scope of this PR.
-        self.push_i32(dst);
         Ok(())
     }
 
-    /// #223: byte offset of a non-parameter local within the stack frame.
-    fn local_slot(&self, idx: u32, op: &WasmOp) -> Result<i32, SelectorError> {
+    /// #223: `(byte offset, is_i64)` of a non-parameter local's frame slot.
+    fn local_slot(&self, idx: u32, op: &WasmOp) -> Result<(i32, bool), SelectorError> {
         self.local_offsets
             .get(&idx)
             .copied()
@@ -927,8 +1004,12 @@ impl Selector {
     }
 
     fn lower_local_set(&mut self, idx: u32, op: &WasmOp) -> Result<(), SelectorError> {
-        let src = self.pop_i32(op)?;
         if (idx as usize) < self.arg_regs.len() {
+            // #312: i64 params are unsupported — see lower_local_get.
+            if self.i64_locals.contains(&idx) {
+                return Err(SelectorError::Unsupported(op.clone()));
+            }
+            let src = self.pop_i32(op)?;
             // mv arg, src
             self.out.push(RiscVOp::Addi {
                 rd: self.arg_regs[idx as usize],
@@ -938,35 +1019,56 @@ impl Selector {
             Ok(())
         } else {
             // #223: non-param local — store to its frame slot (sw src, off(sp)).
-            let off = self.local_slot(idx, op)?;
-            self.out.push(RiscVOp::Sw {
-                rs1: Reg::SP,
-                rs2: src,
-                imm: off,
-            });
+            // #312: an i64 local stores both halves of the pair (lo at off,
+            // hi at off+4); the slot width came from `infer_i64_locals`, so
+            // the pop below doubles as a type check.
+            let (off, is_i64) = self.local_slot(idx, op)?;
+            if is_i64 {
+                let (lo, hi) = self.pop_i64(op)?;
+                self.out.push(RiscVOp::Sw {
+                    rs1: Reg::SP,
+                    rs2: lo,
+                    imm: off,
+                });
+                self.out.push(RiscVOp::Sw {
+                    rs1: Reg::SP,
+                    rs2: hi,
+                    imm: off + 4,
+                });
+            } else {
+                let src = self.pop_i32(op)?;
+                self.out.push(RiscVOp::Sw {
+                    rs1: Reg::SP,
+                    rs2: src,
+                    imm: off,
+                });
+            }
             Ok(())
         }
     }
 
     fn lower_local_tee(&mut self, idx: u32, op: &WasmOp) -> Result<(), SelectorError> {
-        // tee = set + get; the value remains on the stack. Phase 1 only
-        // handles i32 locals — see lower_local_set for the same restriction.
+        // tee = set + get; the value remains on the stack.
         let top = self
             .vstack
             .last()
             .copied()
             .ok_or_else(|| SelectorError::StackUnderflow(op.clone()))?;
-        let src = match top {
-            VstackVal::I32(r) => r,
-            other => {
-                return Err(SelectorError::StackTypeMismatch {
-                    op: op.clone(),
-                    expected: "i32",
-                    found: other.type_name(),
-                });
-            }
-        };
         if (idx as usize) < self.arg_regs.len() {
+            // #312: i64 params are unsupported — see lower_local_get.
+            if self.i64_locals.contains(&idx) {
+                return Err(SelectorError::Unsupported(op.clone()));
+            }
+            let src = match top {
+                VstackVal::I32(r) => r,
+                other => {
+                    return Err(SelectorError::StackTypeMismatch {
+                        op: op.clone(),
+                        expected: "i32",
+                        found: other.type_name(),
+                    });
+                }
+            };
             self.out.push(RiscVOp::Addi {
                 rd: self.arg_regs[idx as usize],
                 rs1: src,
@@ -975,13 +1077,36 @@ impl Selector {
             Ok(())
         } else {
             // #223: tee = store to the frame slot, value stays on the vstack.
-            let off = self.local_slot(idx, op)?;
-            self.out.push(RiscVOp::Sw {
-                rs1: Reg::SP,
-                rs2: src,
-                imm: off,
-            });
-            Ok(())
+            // #312: i64 tee stores both halves (lo at off, hi at off+4).
+            let (off, is_i64) = self.local_slot(idx, op)?;
+            match (is_i64, top) {
+                (true, VstackVal::I64 { lo, hi }) => {
+                    self.out.push(RiscVOp::Sw {
+                        rs1: Reg::SP,
+                        rs2: lo,
+                        imm: off,
+                    });
+                    self.out.push(RiscVOp::Sw {
+                        rs1: Reg::SP,
+                        rs2: hi,
+                        imm: off + 4,
+                    });
+                    Ok(())
+                }
+                (false, VstackVal::I32(src)) => {
+                    self.out.push(RiscVOp::Sw {
+                        rs1: Reg::SP,
+                        rs2: src,
+                        imm: off,
+                    });
+                    Ok(())
+                }
+                (expected_i64, other) => Err(SelectorError::StackTypeMismatch {
+                    op: op.clone(),
+                    expected: if expected_i64 { "i64" } else { "i32" },
+                    found: other.type_name(),
+                }),
+            }
         }
     }
 
@@ -1609,8 +1734,21 @@ impl Selector {
 
         // Return value lands in a0 (AAPCS). Push it back as a new vreg.
         // Real multi-result returns (wasm 2.0) would push (a0, a1) here.
-        // Treated as i32 — i64-returning calls are v0.4 scope.
-        self.push_i32(Reg::A0);
+        // #312 (mirrors ARM #311): when the callee's signature says it returns
+        // i64, the result is the a0 (lo) : a1 (hi) pair — tag it as such so a
+        // following `local.set` of an i64 local stores both words instead of
+        // tripping the i32 type check. An absent table entry keeps the legacy
+        // i32 tagging.
+        if self
+            .func_ret_i64
+            .get(func_idx as usize)
+            .copied()
+            .unwrap_or(false)
+        {
+            self.push_i64(Reg::A0, Reg::A1);
+        } else {
+            self.push_i32(Reg::A0);
+        }
         Ok(())
     }
 
@@ -5664,5 +5802,200 @@ mod tests {
         ]);
         // I64Add emits its add/sltu/add/add quartet → at least 3 Add ops.
         assert!(count(&out, |op| matches!(op, RiscVOp::Add { .. })) >= 3);
+    }
+
+    // -------- #312: i64 locals (two-word frame slots) --------
+
+    /// Count Sw ops against the frame (`sp`-based) at byte offset `imm`.
+    fn count_sw_sp(out: &[RiscVOp], at: i32) -> usize {
+        count(
+            out,
+            |op| matches!(op, RiscVOp::Sw { rs1: Reg::SP, imm, .. } if *imm == at),
+        )
+    }
+
+    /// Count Lw ops against the frame (`sp`-based) at byte offset `imm`.
+    fn count_lw_sp(out: &[RiscVOp], at: i32) -> usize {
+        count(
+            out,
+            |op| matches!(op, RiscVOp::Lw { rs1: Reg::SP, imm, .. } if *imm == at),
+        )
+    }
+
+    /// #312: `local.set` + `local.get` of an i64 local round-trips through a
+    /// two-word frame slot — sw/lw at `off` (lo) and `off+4` (hi).
+    #[test]
+    fn i64_local_set_get_roundtrip_two_words_312() {
+        let out = s(
+            &[
+                WasmOp::I64Const(0x1122_3344_5566_7788),
+                WasmOp::LocalSet(0),
+                WasmOp::LocalGet(0),
+                WasmOp::Drop,
+                WasmOp::End,
+            ],
+            0,
+        );
+        // The only sp-relative traffic at 0/4 is the local slot (no s-regs are
+        // written by this tiny body, so the #220 spills don't interfere).
+        assert_eq!(count_sw_sp(&out, 0), 1, "lo store at off 0: {out:?}");
+        assert_eq!(count_sw_sp(&out, 4), 1, "hi store at off 4: {out:?}");
+        assert_eq!(count_lw_sp(&out, 0), 1, "lo load at off 0: {out:?}");
+        assert_eq!(count_lw_sp(&out, 4), 1, "hi load at off 4: {out:?}");
+    }
+
+    /// #312: `local.tee` of an i64 local (the exact op the issue's repro
+    /// refused with "expected i32, found i64") stores both words and keeps
+    /// the pair on the vstack.
+    #[test]
+    fn i64_local_tee_stores_both_words_and_keeps_value_312() {
+        let out = s(
+            &[
+                WasmOp::I64Const(7),
+                WasmOp::LocalTee(0),
+                WasmOp::I64Const(1),
+                WasmOp::I64Add, // consumes the teed pair → it stayed on the stack
+                WasmOp::Drop,
+                WasmOp::End,
+            ],
+            0,
+        );
+        assert_eq!(count_sw_sp(&out, 0), 1, "tee lo store at off 0: {out:?}");
+        assert_eq!(count_sw_sp(&out, 4), 1, "tee hi store at off 4: {out:?}");
+        assert!(count(&out, |op| matches!(op, RiscVOp::Add { .. })) >= 3);
+    }
+
+    /// #312: width inference — a local fed by an i64-producing op (not just an
+    /// i64.const) gets the 8-byte slot.
+    #[test]
+    fn i64_local_inferred_from_i64_producing_op_312() {
+        let out = s(
+            &[
+                WasmOp::I64Const(1),
+                WasmOp::I64Const(2),
+                WasmOp::I64Add,
+                WasmOp::LocalSet(0),
+                WasmOp::LocalGet(0),
+                WasmOp::Drop,
+                WasmOp::End,
+            ],
+            0,
+        );
+        assert_eq!(count_sw_sp(&out, 0), 1);
+        assert_eq!(count_sw_sp(&out, 4), 1);
+        assert_eq!(count_lw_sp(&out, 0), 1);
+        assert_eq!(count_lw_sp(&out, 4), 1);
+    }
+
+    /// #312: mixed i32/i64 layout — the i64 local after an i32 local is padded
+    /// up to 8-byte alignment (i32 at 0, i64 at 8/12 — not 4/8).
+    #[test]
+    fn i64_local_slot_is_8_byte_aligned_after_i32_local_312() {
+        let out = s(
+            &[
+                WasmOp::I32Const(9),
+                WasmOp::LocalSet(0), // i32 local → off 0
+                WasmOp::I64Const(5),
+                WasmOp::LocalSet(1), // i64 local → aligned to off 8
+                WasmOp::LocalGet(1),
+                WasmOp::Drop,
+                WasmOp::LocalGet(0),
+                WasmOp::Drop,
+                WasmOp::End,
+            ],
+            0,
+        );
+        assert_eq!(count_sw_sp(&out, 0), 1, "i32 local at off 0: {out:?}");
+        assert_eq!(count_sw_sp(&out, 4), 0, "off 4 is padding: {out:?}");
+        assert_eq!(count_sw_sp(&out, 8), 1, "i64 lo at off 8: {out:?}");
+        assert_eq!(count_sw_sp(&out, 12), 1, "i64 hi at off 12: {out:?}");
+        assert_eq!(count_lw_sp(&out, 8), 1);
+        assert_eq!(count_lw_sp(&out, 12), 1);
+    }
+
+    /// #312 (mirrors ARM #311): an i64-returning call's result is the a0:a1
+    /// pair; a call-fed local gets the 8-byte slot and both words stored.
+    #[test]
+    fn call_fed_i64_local_stores_a0_a1_pair_312() {
+        let out = select_with_result_types(
+            &[
+                WasmOp::I32Const(1),
+                WasmOp::I32Const(2),
+                WasmOp::Call(0),
+                WasmOp::LocalSet(0),
+                WasmOp::LocalGet(0),
+                WasmOp::Drop,
+                WasmOp::End,
+            ],
+            0,
+            SelectorOptions::wasm_compliant(),
+            &[true], // func 0 returns i64
+            &[],
+        )
+        .unwrap()
+        .ops;
+        // lo (a0) at off 0, hi (a1) at off 4.
+        assert!(
+            count(&out, |op| matches!(
+                op,
+                RiscVOp::Sw {
+                    rs1: Reg::SP,
+                    rs2: Reg::A0,
+                    imm: 0
+                }
+            )) == 1,
+            "a0 (lo) stored at off 0: {out:?}"
+        );
+        assert!(
+            count(&out, |op| matches!(
+                op,
+                RiscVOp::Sw {
+                    rs1: Reg::SP,
+                    rs2: Reg::A1,
+                    imm: 4
+                }
+            )) == 1,
+            "a1 (hi) stored at off 4: {out:?}"
+        );
+        assert_eq!(count_lw_sp(&out, 0), 1);
+        assert_eq!(count_lw_sp(&out, 4), 1);
+    }
+
+    /// #312: without the result-type table the same call result stays i32 —
+    /// the legacy behaviour `select_with_options` callers rely on.
+    #[test]
+    fn call_result_defaults_to_i32_without_tables_312() {
+        let r = select(
+            &[
+                WasmOp::I32Const(1),
+                WasmOp::I32Const(2),
+                WasmOp::Call(0),
+                WasmOp::LocalSet(0),
+                WasmOp::LocalGet(0),
+                WasmOp::Drop,
+                WasmOp::End,
+            ],
+            0,
+        )
+        .unwrap()
+        .ops;
+        assert_eq!(count_sw_sp(&r, 0), 1, "single-word store: {r:?}");
+        assert_eq!(count_sw_sp(&r, 4), 0, "no hi-word store: {r:?}");
+    }
+
+    /// #312: i64 *params* are not modeled (an i64 param needs an a-register
+    /// pair per the RV32 psABI) — the selector must bail with `Unsupported`
+    /// (skip-and-continue under --all-exports), never store half the value.
+    #[test]
+    fn i64_param_local_is_unsupported_312() {
+        let r = select(
+            &[WasmOp::I64Const(5), WasmOp::LocalSet(0), WasmOp::End],
+            1, // local 0 is a param
+        );
+        assert!(
+            matches!(r, Err(SelectorError::Unsupported(_))),
+            "i64 param must skip honestly, got: {:?}",
+            r.map(|sel| sel.ops)
+        );
     }
 }

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -886,7 +886,11 @@ fn compute_local_layout(
 /// Without this, the spilled-local store/load path would emit a single
 /// 4-byte STR/LDR for i64 locals, dropping the upper half — corrupting
 /// any function that returns or uses a u64-packed FFI struct.
-fn infer_i64_locals(
+///
+/// `pub` because the RV32 selector (`synth-backend-riscv`) reuses the same
+/// inference for its i64 frame-slot layout (#312 — the RISC-V analogue of
+/// the ARM #311 fix); the wasm op stream and width rules are ISA-neutral.
+pub fn infer_i64_locals(
     wasm_ops: &[WasmOp],
     func_ret_i64: &[bool],
     type_ret_i64: &[bool],

--- a/crates/synth-synthesis/src/lib.rs
+++ b/crates/synth-synthesis/src/lib.rs
@@ -16,7 +16,7 @@ pub use control_flow::{
 };
 pub use instruction_selector::{
     ArmInstruction, BoundsCheckConfig, InstructionSelector, RegisterState, SelectionStats,
-    validate_instructions, validate_instructions_with_helium,
+    infer_i64_locals, validate_instructions, validate_instructions_with_helium,
 };
 pub use optimizer_bridge::{OptimizationConfig, OptimizationStats, OptimizerBridge};
 pub use pattern_matcher::{

--- a/scripts/repro/u64_unpack_riscv_differential.py
+++ b/scripts/repro/u64_unpack_riscv_differential.py
@@ -1,0 +1,29 @@
+import sys
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UC_ARCH_RISCV, UC_MODE_RISCV32
+from unicorn.riscv_const import (UC_RISCV_REG_A0, UC_RISCV_REG_A1, UC_RISCV_REG_RA,
+                                 UC_RISCV_REG_SP)
+eng = wasmtime.Engine(); mod = wasmtime.Module(eng, open('scripts/repro/u64_unpack_inlined.wat','rb').read())
+st = wasmtime.Store(eng); inst = wasmtime.Instance(st, mod, [])
+gt = inst.exports(st)["check"]
+e = ELFFile(open('/tmp/u64_rv32.elf','rb'))
+text = e.get_section_by_name('.text').data()
+symtab = [s for s in e.iter_sections() if s['sh_type']=='SHT_SYMTAB'][0]
+syms = {s.name: s['st_value'] for s in symtab.iter_symbols()}
+CODE, STK = 0x10000, 0x90000
+mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+mu.mem_map(CODE, 0x10000); mu.mem_write(CODE, text); mu.mem_map(STK, 0x10000)
+RET = CODE + 0xFF00
+mu.mem_write(RET, b"\x13\x00\x00\x00")  # nop pad (mapped RA target, #220 gotcha)
+ok = True
+for (a,b) in ((3,4),(0,0),(250,5),(0x7FFFFFFF,1)):
+    exp = gt(st, a, b) & 0xFFFFFFFF
+    mu.reg_write(UC_RISCV_REG_A0, a); mu.reg_write(UC_RISCV_REG_A1, b)
+    mu.reg_write(UC_RISCV_REG_SP, STK + 0x8000); mu.reg_write(UC_RISCV_REG_RA, RET)
+    mu.emu_start(CODE + syms["check"], RET, timeout=5_000_000)
+    got = mu.reg_read(UC_RISCV_REG_A0)
+    print(f'{"OK " if got==exp else "FAIL"} check({a},{b}) = {got:#x} expect {exp:#x}')
+    ok &= got == exp
+print("ORACLE:", "PASS" if ok else "FAIL")
+sys.exit(0 if ok else 1)


### PR DESCRIPTION
## What

Two commits, one verified outcome — the RV32 lane of the packed-u64 verified-decide pattern works:

1. **i64 locals (`d533ce7`)** — 8-byte frame slots (8-aligned), two-`lw`/`sw` `local.get/set/tee`, `a0:a1` call-result pair tagging via the shared decoder result tables, width inference reused from `synth_synthesis::infer_i64_locals` (now `pub`). i64 *params* deliberately stay `Unsupported` (no psABI pair-register guessing this increment).
2. **Per-op alloc pin scope (`991459f`)** — the behavioral oracle exposed a **latent systemic hole** under the #231 lowest-free allocator: within one wasm op's multi-instruction expansion, back-to-back `alloc_temp` calls returned the *same* register (every i64 pair collapsed: `sw t0,0(sp); sw t0,4(sp)`), and popped operands lost protection (#232 was a point fix of this exact class). Now: `pop_any` pins its operands, `alloc_temp` pins its grants, the set clears at each op boundary; targeted unpins keep peak pressure ≤ 11/13 in the worst lowering.

## Oracle

| gate | result |
|---|---|
| NEW `u64_unpack_riscv_differential.py` (unicorn vs wasmtime) | **4/4 PASS** — failed 4/4 before `991459f` (all-zero results) |
| 4 existing RV32 differentials (controller_step / filter_axis / signed-div / control_step) | PASS, s-regs preserved |
| synth-backend-riscv tests | 175/175 (+9 new) |
| ARM fixtures | `cmp` **bit-identical** to v0.11.36 main |
| workspace build / clippy / fmt | clean |

The compile-only gate would have shipped wrong code — the committed behavioral lane is the artifact that caught it.

## Discovered, filed separately

RV32 `i64.div_s/rem_s` has a **pre-existing** sign-clobber miscompile (sign temps land in the udiv core's fixed t4/t5; probe oracle 6/6 FAIL, also non-executable on the parent commit — strictly not introduced here). Issue follows.

## Falsification

Wrong if gale's RV32 funccheck lane disagrees with wasmtime on the u64 repro family, or any existing RV32 baseline regresses. Release: **v0.11.37**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)