### PR TITLE
chore(release): v0.11.37 — pin sweep + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.37] - 2026-06-11
+
+**RV32 i64 locals + the per-op register-aliasing fix the behavioral oracle
+caught (#312) — the packed-u64 verified-decide pattern is now correct on BOTH
+lanes.**
+
+- **RV32 i64 locals**: 8-byte (8-aligned) frame slots; `local.get/set/tee`
+  emit two `lw`/`sw` (lo at off, hi at off+4) using the existing pair
+  convention; call results from i64-returning callees are tagged as the
+  `a0:a1` pair via the shared decoder result tables (#311); width inference
+  reused from `synth_synthesis::infer_i64_locals` (now `pub`). i64 params
+  stay fail-loud `Unsupported` (the psABI pair-register convention is its own
+  increment).
+- **Per-op alloc pin scope** (the real find): under the lowest-free allocator
+  (#231), back-to-back `alloc_temp` calls within ONE wasm op's expansion
+  returned the SAME register — every i64 pair collapsed to a single reg
+  (`sw t0,0(sp); sw t0,4(sp)`), and popped operands lost clobber protection
+  (the #232 class, generalized). `pop_any` now pins its operands and
+  `alloc_temp` pins its grants for the duration of the op; targeted unpins
+  keep worst-case pressure ≤ 11 of 13 pool registers.
+- NEW committed oracle: `scripts/repro/u64_unpack_riscv_differential.py`
+  (unicorn vs wasmtime) — 4/4 FAIL before the pin-scope fix, 4/4 PASS after;
+  compile-only gating would have shipped the wrong code.
+
+All four existing RV32 differentials PASS (controller_step, filter_axis,
+signed-div-const, control_step); ARM fixtures cmp-bit-identical to v0.11.36;
+175/175 backend-riscv tests.
+
+Falsification: wrong if gale's RV32 funccheck lane disagrees with wasmtime on
+the u64 family or any RV32 baseline regresses. Known + filed separately:
+pre-existing `i64.div_s/rem_s` sign clobber (#317, probe staged).
+
+
 ## [0.11.36] - 2026-06-11
 
 **Four silicon blockers in one tag: the allocator goes default-ON, the mutex

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,14 +1933,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1989,11 +1989,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.36"
+version = "0.11.37"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "anyhow",
  "clap",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "anyhow",
  "serde",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2042,14 +2042,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2057,11 +2057,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.36"
+version = "0.11.37"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "anyhow",
  "clap",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.36"
+version = "0.11.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.36"
+version = "0.11.37"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.36"
+version = "0.11.37"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.36",
+    version = "0.11.37",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.36" }
+synth-core = { path = "../synth-core", version = "0.11.37" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.36" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.36" }
+synth-core = { path = "../synth-core", version = "0.11.37" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.37" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.36" }
+synth-core = { path = "../synth-core", version = "0.11.37" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.36" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.36", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.37" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.37", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.36" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.36" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.36" }
-synth-backend = { path = "../synth-backend", version = "0.11.36" }
+synth-core = { path = "../synth-core", version = "0.11.37" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.37" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.37" }
+synth-backend = { path = "../synth-backend", version = "0.11.37" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.36", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.36", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.36", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.37", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.37", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.37", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.36", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.37", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.36" }
+synth-core = { path = "../synth-core", version = "0.11.37" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.36" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.37" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.36" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.36" }
-synth-opt = { path = "../synth-opt", version = "0.11.36" }
+synth-core = { path = "../synth-core", version = "0.11.37" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.37" }
+synth-opt = { path = "../synth-opt", version = "0.11.37" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.36" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.36" }
-synth-opt = { path = "../synth-opt", version = "0.11.36" }
+synth-core = { path = "../synth-core", version = "0.11.37" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.37" }
+synth-opt = { path = "../synth-opt", version = "0.11.37" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.36", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.37", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Release prep for v0.11.37 (#312 RV32 i64 locals + per-op pin scope; content PR #316).

🤖 Generated with [Claude Code](https://claude.com/claude-code)