### PR TITLE
chore(release): v0.11.38 — pin sweep + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.38] - 2026-06-11
+
+**The first register-exhaustion hard-fail becomes recoverable
+(#242, VCR-RA-001 steps 3b-lite + 4 substrate).**
+
+- **Spill-on-exhaustion retry**: when `alloc_temp_safe` would hard-fail
+  ("register exhaustion: all allocatable registers are live on the stack"),
+  the function is re-selected with spilling enabled — the deepest
+  stack-resident value moves to a frame slot (existing #171 `Spilled`
+  reload-on-pop machinery) and selection continues. Bit-identity for every
+  currently-compiling function is STRUCTURAL: the unmodified first pass runs
+  for everyone; only the exact exhaustion error triggers the fresh-selector
+  retry (which also forces the spill-area reservation that i32-only frames
+  lacked). Honest bound: 8 spill slots cap simultaneous spills; the i64
+  consecutive-pair and call-result hard-fail sites remain (next increments).
+- **Cycle-safe parallel-move resolver** (`synth_synthesis::parallel_move`,
+  VCR-RA-004): chains leaf-first, cycles broken via move-set-filtered scratch
+  or a self-bracketing stack-scratch pair; property-tested across 6000
+  deterministic sequentializations + directed swap/cycle cases with a
+  structural size bound. Pure substrate for upcoming spill/reload insertion.
+- NEW committed oracle: `scripts/repro/high_pressure_i32.wat` +
+  unicorn-vs-wasmtime differential — hard `Err` on v0.11.37, compiles and
+  passes 6/6 on this release.
+
+All fixtures sha256-identical to v0.11.37; differentials PASS (13/13,
+338/338, 0x07FDF307). gale's v0.11.36/37 scorecard verified everything
+shipped (filter −8 cyc, #311 closed on silicon, #237 sizing confirmed).
+
+Falsification: wrong if any previously-compiling module's bytes change, or
+the high-pressure lane disagrees with wasmtime. The reciprocal-mult
+cost-gate revert experiment (VCR-VER-001 evidence) is now runnable.
+
+
 ## [0.11.37] - 2026-06-11
 
 **RV32 i64 locals + the per-op register-aliasing fix the behavioral oracle

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,14 +1933,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1989,11 +1989,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.37"
+version = "0.11.38"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "anyhow",
  "clap",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "anyhow",
  "serde",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2042,14 +2042,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2057,11 +2057,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.37"
+version = "0.11.38"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "anyhow",
  "clap",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.37"
+version = "0.11.38"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.37"
+version = "0.11.38"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.37",
+    version = "0.11.38",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.37" }
+synth-core = { path = "../synth-core", version = "0.11.38" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.37" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.37" }
+synth-core = { path = "../synth-core", version = "0.11.38" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.38" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.37" }
+synth-core = { path = "../synth-core", version = "0.11.38" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.37" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.37", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.38" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.38", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.37" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.37" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.37" }
-synth-backend = { path = "../synth-backend", version = "0.11.37" }
+synth-core = { path = "../synth-core", version = "0.11.38" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.38" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.38" }
+synth-backend = { path = "../synth-backend", version = "0.11.38" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.37", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.37", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.37", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.38", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.38", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.38", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.37", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.38", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.37" }
+synth-core = { path = "../synth-core", version = "0.11.38" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.37" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.38" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.37" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.37" }
-synth-opt = { path = "../synth-opt", version = "0.11.37" }
+synth-core = { path = "../synth-core", version = "0.11.38" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.38" }
+synth-opt = { path = "../synth-opt", version = "0.11.38" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.37" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.37" }
-synth-opt = { path = "../synth-opt", version = "0.11.37" }
+synth-core = { path = "../synth-core", version = "0.11.38" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.38" }
+synth-opt = { path = "../synth-opt", version = "0.11.38" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.37", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.38", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Release prep for v0.11.38 (spill-on-exhaustion retry #320 + parallel-move resolver #319).

🤖 Generated with [Claude Code](https://claude.com/claude-code)