### PR TITLE
test(fixtures): synth#329 multi-value-call × select underflow regression lock

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -367,6 +367,46 @@ artifacts:
         0x07FDF307 / div_const 338/338); gale confirms on-target cycles
         equal-or-better on the five frozen benches; flag-gated until confirmed.
 
+  - id: VCR-SEL-003
+    type: sw-req
+    title: Multi-value-return ABI — multi-result call feeding select (selector op-gap, gale #329)
+    description: >
+      `synth compile --cortex-m --all-exports` silently skips a function when a
+      multi-value `call` result feeds a `select` (falcon-flight func_39; func_30
+      LocalSet one consumer over) — on a module `wasm-tools validate` accepts.
+      Root cause is two-sided and confirmed from source @ v0.11.40: (1) caller —
+      the `Call` arm (instruction_selector.rs ~7252) pushes exactly ONE operand
+      per call regardless of result count (no `func_ret_count` metadata is
+      threaded; only `func_ret_i64` exists), so `select` (pops 3) underflows in
+      `pop_operand`; (2) callee — multi-value return is unimplemented: `$two`
+      emits `movs r4,#10; movs r5,#20; bx lr`, leaving results in r4/r5, not the
+      AAPCS return registers r0/r1. The two sides MUST land together: a
+      caller-only push would compile-but-MISCOMPILE (read r0/r1, callee wrote
+      r4/r5), converting today's safe skip into silent wrong-code. This is the
+      "selector missed an op" class (VCR-SEL-001), not a one-line patch — it
+      needs result-count metadata threaded through both codegen paths, an N-result
+      push at call sites, and multi-result placement in r0..r(N-1) in both the
+      explicit `Return` and the implicit fall-through epilogue. Non-blocking: no
+      shipped wasm-cross-LTO module hits this shape (gale concurs). Regression
+      lock landed in tests/fixtures/multivalue_call_select (PR #330).
+    status: proposed
+    tags: [codegen, selector, instruction-selection, multi-value, abi, op-gap, gale-329, track-a]
+    links:
+      - type: derives-from
+        target: VCR-001
+      - type: traces-to
+        target: VCR-SEL-001
+    fields:
+      req-type: functional
+      priority: should
+      verification-criteria: >
+        repro_call_select.wat compiles AND `f` evaluates to the wasmtime golden
+        (f(1)=10, f(0)=20) on a differential RUN — not merely "it compiles"; the
+        three control fixtures stay compiling; >register-capacity result counts
+        (>4 int results / memory-return-area) stay a clean skip, never a
+        miscompile; the three frozen differentials (control_step 0x00210A55 /
+        flight_seam 0x07FDF307 / div_const 338/338) remain RESULT-identical.
+
   - id: VCR-RA-002
     type: sw-req
     title: Conditional register pool — free R10 when bounds-checking is off (track C)

--- a/tests/fixtures/multivalue_call_select/README.md
+++ b/tests/fixtures/multivalue_call_select/README.md
@@ -8,7 +8,7 @@ spurious underflow on a module `wasm-tools validate` accepts. Surfaced as the
 
 | fixture | wasm-tools | synth today | after fix |
 |---|---|---|---|
-| `repro_call_select.wat` | VALID | **SKIPS** (underflow at select) | compiles, `f` returns hi-word |
+| `repro_call_select.wat` | VALID | **SKIPS** (underflow at select) | compiles; `f(1)=10`, `f(0)=20` (wasmtime golden) |
 | `control_block_select.wat` | VALID | compiles | compiles |
 | `control_single_call_select.wat` | VALID | compiles | compiles |
 | `control_call_drop.wat` | VALID | compiles | compiles |
@@ -17,7 +17,27 @@ The `drop`-vs-`select` split is the discriminator: a multi-result call alone is
 counted correctly (drop sees both), and single-result calls into select work — it
 is specifically the **multi-result-call × select** operand-pop interaction.
 
-Regression lock: the repro must compile (and `f` evaluate correctly) after the
-fix; the three controls must stay compiling. Independently reproduced on
-synth v0.11.40 (gale wasm-cross-LTO side; jess `repro/synth-underflow/` keeps a
-loop-record copy, this is the canonical source fixture).
+Regression lock: the repro must compile **and `f` evaluate to the wasmtime
+golden** (`f(1)=10`, `f(0)=20`) after the fix; the three controls must stay
+compiling. Independently reproduced on synth v0.11.40 (gale wasm-cross-LTO side;
+jess `repro/synth-underflow/` keeps a loop-record copy, this is the canonical
+source fixture).
+
+## The fix is two-sided (do not land a caller-only patch)
+
+Root cause confirmed by source + disassembly on v0.11.40:
+
+1. **Caller** (`instruction_selector.rs`, the `Call` arm): after a `BL` it pushes
+   exactly **one** operand-stack entry per call, regardless of the callee's
+   result count — so `call $two` leaves 1 value where wasm has 2, and `select`
+   (pops 3) underflows in `pop_operand` ("stack underflow: malformed WASM or
+   compiler bug").
+2. **Callee** (`$two`): multi-value return is unimplemented — `$two` compiles to
+   `movs r4,#10; movs r5,#20; bx lr`, leaving its results in **r4/r5**, not the
+   AAPCS return registers **r0/r1**.
+
+Because of (2), a caller-only fix that just pushes both results would **compile
+but miscompile** — the caller would read r0/r1 while the callee wrote r4/r5,
+turning today's *safe skip* into silent wrong-code. The two sides must land
+together and be gated on a differential **run** (the golden above), not on "it
+compiles". Tracked as a multi-value-return ABI item, not a one-line patch.

--- a/tests/fixtures/multivalue_call_select/README.md
+++ b/tests/fixtures/multivalue_call_select/README.md
@@ -1,0 +1,23 @@
+# synth#329 — multi-value-call-result × select underflow
+
+`synth compile --cortex-m --all-exports` silently skips a function when a
+**multi-value `call` result** feeds a **`select`**: the abstract value-stack
+under-counts the call's 2 results to 1, so `select` (which pops 3) reports a
+spurious underflow on a module `wasm-tools validate` accepts. Surfaced as the
+`func_39` skip in the falcon flight core (`func_30` LocalSet is one consumer over).
+
+| fixture | wasm-tools | synth today | after fix |
+|---|---|---|---|
+| `repro_call_select.wat` | VALID | **SKIPS** (underflow at select) | compiles, `f` returns hi-word |
+| `control_block_select.wat` | VALID | compiles | compiles |
+| `control_single_call_select.wat` | VALID | compiles | compiles |
+| `control_call_drop.wat` | VALID | compiles | compiles |
+
+The `drop`-vs-`select` split is the discriminator: a multi-result call alone is
+counted correctly (drop sees both), and single-result calls into select work — it
+is specifically the **multi-result-call × select** operand-pop interaction.
+
+Regression lock: the repro must compile (and `f` evaluate correctly) after the
+fix; the three controls must stay compiling. Independently reproduced on
+synth v0.11.40 (gale wasm-cross-LTO side; jess `repro/synth-underflow/` keeps a
+loop-record copy, this is the canonical source fixture).

--- a/tests/fixtures/multivalue_call_select/control_block_select.wat
+++ b/tests/fixtures/multivalue_call_select/control_block_select.wat
@@ -1,0 +1,7 @@
+;; CONTROL (should COMPILE): block multi-result feeding select works today.
+;; Discriminates: the bug is NOT block/control-flow result seeding.
+(module
+  (func (export "f") (param i32) (result i32)
+    (block (result i32 i32) i32.const 10 i32.const 20)
+    local.get 0
+    select))

--- a/tests/fixtures/multivalue_call_select/control_call_drop.wat
+++ b/tests/fixtures/multivalue_call_select/control_call_drop.wat
@@ -1,0 +1,8 @@
+;; CONTROL (should COMPILE): multi-result call consumed by drop works today.
+;; Discriminates: the multi-result CALL is counted as 2 correctly by `drop`;
+;; only the call-result x select interaction under-counts.
+(module
+  (func $two (result i32 i32) i32.const 10 i32.const 20)
+  (func (export "f") (result i32)
+    call $two
+    drop))

--- a/tests/fixtures/multivalue_call_select/control_single_call_select.wat
+++ b/tests/fixtures/multivalue_call_select/control_single_call_select.wat
@@ -1,0 +1,9 @@
+;; CONTROL (should COMPILE): two single-result calls feeding select work today.
+;; Discriminates: the bug is NOT select-fed-by-calls in general.
+(module
+  (func $one (result i32) i32.const 10)
+  (func (export "f") (param i32) (result i32)
+    call $one
+    call $one
+    local.get 0
+    select))

--- a/tests/fixtures/multivalue_call_select/repro_call_select.wat
+++ b/tests/fixtures/multivalue_call_select/repro_call_select.wat
@@ -3,7 +3,13 @@
 ;;   with "stack underflow at select" — the abstract value-stack under-counts
 ;;   the 2-value call result to 1, so select (pops 3) sees too few operands.
 ;; This is the minimal shape of falcon-flight func_39 (the Select case).
-;; EXPECTED AFTER FIX: compiles; f(a,b) returns a+b+1 (the high word of make()).
+;; EXPECTED AFTER FIX: compiles; `f` is `select(10, 20, cond=local.0)`, so it
+;;   returns 10 when the param is non-zero and 20 when it is zero. Golden from
+;;   wasmtime: f(1)=10, f(0)=20. (NOT "a+b+1" — that was a stray copy of the
+;;   falcon make()/high-word context; this minimal func takes a single param.)
+;; NOTE: the fix is two-sided — the caller must push BOTH call results AND the
+;;   callee must return multi-values in r0:r1 (today `$two` leaves them in
+;;   r4:r5), so a caller-only push would compile-but-miscompile. See synth#329.
 (module
   (func $two (result i32 i32) i32.const 10 i32.const 20)
   (func (export "f") (param i32) (result i32)

--- a/tests/fixtures/multivalue_call_select/repro_call_select.wat
+++ b/tests/fixtures/multivalue_call_select/repro_call_select.wat
@@ -1,0 +1,12 @@
+;; synth#329 reproducer — multi-value CALL result feeding `select`.
+;; wasm-tools: VALID.  synth (v0.11.40, --cortex-m --all-exports): SKIPS 'f'
+;;   with "stack underflow at select" — the abstract value-stack under-counts
+;;   the 2-value call result to 1, so select (pops 3) sees too few operands.
+;; This is the minimal shape of falcon-flight func_39 (the Select case).
+;; EXPECTED AFTER FIX: compiles; f(a,b) returns a+b+1 (the high word of make()).
+(module
+  (func $two (result i32 i32) i32.const 10 i32.const 20)
+  (func (export "f") (param i32) (result i32)
+    call $two          ;; pushes 2
+    local.get 0        ;; pushes 1  -> stack depth 3
+    select))           ;; pops 3 -> synth underflows here


### PR DESCRIPTION
Per your request on #329 — the minimal reproducer + 3 discriminating controls as the canonical regression lock at `tests/fixtures/multivalue_call_select/`.

| fixture | wasm-tools | synth v0.11.40 | after fix |
|---|---|---|---|
| `repro_call_select.wat` | VALID | **SKIPS** (underflow at select) | must compile, `f` returns hi-word |
| `control_block_select.wat` | VALID | compiles | compiles |
| `control_single_call_select.wat` | VALID | compiles | compiles |
| `control_call_drop.wat` | VALID | compiles | compiles |

Behavior re-verified on synth v0.11.40 at commit time (script in the PR description's spirit: `wasm-tools validate` + `synth compile --cortex-m --all-exports` on each). The `drop`-vs-`select` split isolates it to the **multi-value-call-result × select** operand-pop interaction — not block results, not select-fed-by-calls in general.

Fixtures only (no harness wired) — leaving the test wiring to you since the gate belongs in synth's own runner; the README documents the expected red→green so it's a drop-in lock. Closes the fixture half of #329; the falcon `func_39`/`func_30` burndown re-runs when the fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)