### PR TITLE
test(vcr-ra): broaden validator real-codegen completeness gate to full ARM suite (#242, VCR-RA-003)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -484,6 +484,12 @@ artifacts:
         selector output exceeds ~5% of segments, its completeness is too weak
         and the approach is re-evaluated (CompCert tested relative
         completeness empirically; so will synth).
+        PROGRESS (criteria 1 + 3): the empirical real-codegen completeness gate
+        (realloc_on_repro_fixture_streams_has_zero_validator_rejects) now spans
+        the FULL ARM frozen suite — 32 functions / 57 segments across 10
+        fixtures (was 3) — with 0 validator-attributable declines (0% << the 5%
+        kill-criterion, which is now asserted explicitly, not just the stronger
+        0 pin). v2 (Rocq-mechanized soundness) remains the open step.
 
   - id: VCR-RA-004
     type: sw-req

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -5362,10 +5362,24 @@ mod tests {
         let root = concat!(env!("CARGO_MANIFEST_DIR"), "/../../scripts/repro");
         let mut total = ReallocStats::default();
         let mut selected_fns = 0usize;
+        // The full ARM frozen/differential suite (one form per program; the
+        // _riscv harnesses and the sp_global/native-pointer-ABI fixtures —
+        // native_pointer_*, mutex_pressure — are out of this selector config's
+        // scope and excluded; the high_pressure_* fixtures intentionally
+        // exhaust the first pass and `continue`-skip here). Broadening from the
+        // original 3 streams turns the "0 validator-rejects" guarantee into a
+        // whole-suite property (VCR-RA-003 criteria 1 + 3 on real codegen).
         for name in [
             "control_step.wasm",
             "div_const.wat",
             "flight_seam_flat.wasm",
+            "flight_seam.wasm",
+            "controller_step.wasm",
+            "filter_axis.wasm",
+            "signed_div_const.wasm",
+            "u64_unpack.wat",
+            "u64_unpack_inlined.wat",
+            "reachable_helper.wasm",
         ] {
             let bytes = std::fs::read(format!("{root}/{name}"))
                 .unwrap_or_else(|e| panic!("read fixture {name}: {e}"));
@@ -5401,9 +5415,33 @@ mod tests {
             "the pass must actually fire on the fixtures (segments={})",
             total.segments
         );
+        println!(
+            "[VCR-RA-003 real-codegen completeness] {selected_fns} fns, \
+             {} segments: {} reallocated, {} declined ({} validator-rejected), \
+             {} need spill",
+            total.segments,
+            total.reallocated,
+            total.declined,
+            total.validator_rejects,
+            total.needs_spill
+        );
+        // Criterion 1: the validator accepted real rewrites (the pass fired).
+        // Criterion 3 (roadmap kill-criterion): validator-attributable declines
+        // must stay below ~5% of segments before the approach is re-evaluated.
+        // Enforce the criterion explicitly AND pin the current stronger truth
+        // (0) — so a regression that merely stays under 5% is still caught.
+        let pct = (total.validator_rejects as f64) / (total.segments as f64) * 100.0;
+        assert!(
+            pct < 5.0,
+            "validator-attributable decline rate {pct:.1}% exceeds the VCR-RA-003 \
+             5% kill-criterion ({} of {} segments) — validator completeness on \
+             real selector output has regressed",
+            total.validator_rejects,
+            total.segments
+        );
         assert_eq!(
             total.validator_rejects, 0,
-            "validator-attributable declines on the fixture streams \
+            "validator-attributable declines on the full ARM frozen suite \
              (criterion: <5% of {} segments; current truth and the pinned \
              value: 0)",
             total.segments


### PR DESCRIPTION
## What

North-Star roadmap increment on **VCR-RA-003** (the Rideau/Leroy backward-dataflow allocation validator). No new gale signal this cycle → advance the feature roadmap with a bounded, bit-identical, locally-gated step.

The validator v1 is already wired default-on (`arm_backend.rs:329`), unit-tested, and mutation-tested (≥95% kill). But its documented invariant — *"`validator_rejects` must be 0 on the frozen fixtures"* — was exercised on real selector output for **only 3 fixtures**. Across the rest of production codegen it was unguarded.

This broadens `realloc_on_repro_fixture_streams_has_zero_validator_rejects` to the **full ARM frozen/differential suite (10 fixtures)** and enforces the roadmap's own **≤5%-decline kill-criterion explicitly**, in addition to the stronger `== 0` pin.

## Empirical result (real selector output)

```
32 fns, 57 segments: 43 reallocated, 14 declined (0 validator-rejected), 0 need spill
```

Decline rate **0% ≪ 5%**. The validator accepts every rewrite the pass produces across the whole ARM suite — its completeness on real codegen is now a **whole-suite, regression-guarded property**. That's the prerequisite for trusting it as the gate under future *byte-changing* allocator work (R10 pool, wiring) — mis-allocations get caught mechanically here instead of weeks later on silicon.

## Safety / scope

- **Bit-identical by construction** — test + artifact-note only; no codegen path touched. The frozen fixtures' bytes are unchanged.
- Excludes the `_riscv` harnesses and the `sp_global`/native-pointer-ABI + exhaustion fixtures (out of this selector config's scope; they `continue`-skip).
- `v2` (Rocq-mechanized soundness of the validator) remains the open VCR-RA-003 step.

## Gates

- `cargo test -p synth-synthesis --lib` → 387 passed
- `cargo fmt --check` + `cargo clippy -p synth-synthesis --all-targets -D warnings` → clean
- `rivet validate` → 0 non-xref errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)