### PR TITLE
chore(release): v0.11.41 — #331 spill-slot collision bug-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.41] - 2026-06-13
+
+**SPILL-SLOT COLLISION BUG-FIX — gale #331: dissolved `k_mutex_unlock`
+silently miscompiled into a silicon deadlock; now fixed.**
+
+- **Spill-slot / param-home collision** (#331): on a function with no i64
+  (`has_i64 == false`), `compute_local_layout` set `i64_spill_base` to the same
+  offset where the `#204 param_slots` are appended, so the i64 spill pool
+  **aliased** the param home slots. `restore_caller_saved`'s call-result park
+  called `spill.alloc()` without the `area_reserved` guard the arg-move-cycle
+  resolver already used, parking `z_unpend_first_thread`'s result onto the live
+  mutex-ptr arg's home slot — the no-waiter `lock_count = 0` store then reloaded
+  the clobbered slot and wrote `linmem[0+12]` instead of `mutex+12`, deadlocking
+  the G474RE (`owner=0, lock_count=1`). Fix: mirror the resolver's
+  `area_reserved` guard at the result-park, so the first pass returns the
+  ladder-recoverable exhaustion `Err` and the backend retry reserves the i64
+  pool — relocating the param home slots above it so the park is non-aliasing
+  and the function compiles **correctly** (not skipped). Verified on gale's exact
+  committed module (`scripts/repro/synth-331/`): kill-criterion satisfied
+  (no-waiter `lock_count` base = mutex pointer), all frozen differentials
+  bit-identical. Regression test `synth_331_call_result_not_parked_on_live_param_home_slot`.
+- **Multi-value-call × select regression lock** (#329/#330): the minimal
+  reproducer + 3 discriminating controls committed as
+  `tests/fixtures/multivalue_call_select/`; the multi-value-return ABI itself is
+  tracked as VCR-SEL-003 (the selector still cleanly *skips* that shape).
+- **VCR-RA-003 validator completeness gate broadened** (#332): the real-codegen
+  zero-validator-rejects gate now spans the full ARM frozen suite (32 functions
+  / 57 segments across 10 fixtures, was 3); the ≤5% decline kill-criterion is
+  now asserted explicitly. Records the v-next "validate slot non-aliasing"
+  extension (the layer #331 lived in).
+
 ## [0.11.40] - 2026-06-11
 
 **THE ALLOCATOR ACCEPTANCE RELEASE — VCR-RA-001's five criteria are all met,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,14 +1933,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1989,11 +1989,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.40"
+version = "0.11.41"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "anyhow",
  "clap",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "anyhow",
  "serde",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2042,14 +2042,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2057,11 +2057,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.40"
+version = "0.11.41"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "anyhow",
  "clap",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.40"
+version = "0.11.41"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.40"
+version = "0.11.41"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.40",
+    version = "0.11.41",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.40" }
+synth-core = { path = "../synth-core", version = "0.11.41" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.40" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.40" }
+synth-core = { path = "../synth-core", version = "0.11.41" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.41" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.40" }
+synth-core = { path = "../synth-core", version = "0.11.41" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.40" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.40", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.41" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.41", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.40" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.40" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.40" }
-synth-backend = { path = "../synth-backend", version = "0.11.40" }
+synth-core = { path = "../synth-core", version = "0.11.41" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.41" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.41" }
+synth-backend = { path = "../synth-backend", version = "0.11.41" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.40", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.40", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.40", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.41", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.41", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.41", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.40", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.41", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.40" }
+synth-core = { path = "../synth-core", version = "0.11.41" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.40" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.41" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.40" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.40" }
-synth-opt = { path = "../synth-opt", version = "0.11.40" }
+synth-core = { path = "../synth-core", version = "0.11.41" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.41" }
+synth-opt = { path = "../synth-opt", version = "0.11.41" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.40" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.40" }
-synth-opt = { path = "../synth-opt", version = "0.11.40" }
+synth-core = { path = "../synth-core", version = "0.11.41" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.41" }
+synth-opt = { path = "../synth-opt", version = "0.11.41" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.40", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.41", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Bug-fix release cutting **v0.11.41**. Headline: **#331** — the dissolved `k_mutex_unlock` spill-slot collision that silently miscompiled into a G474RE deadlock (fixed in #333, merged).

## Contents since v0.11.40
- **#331 / #333** — call result must not park on a live param's home slot (spill-slot/param-home aliasing when `has_i64==false`). Verified on gale's committed module (kill-criterion satisfied); frozen differentials bit-identical.
- **#329 / #330** — multi-value-call × select regression lock (fixtures); the ABI itself tracked as VCR-SEL-003.
- **#332** — VCR-RA-003 validator real-codegen completeness gate broadened to the full ARM frozen suite (32 fns / 57 segments); ≤5% decline criterion asserted.

## Release mechanics
- Workspace pin sweep `0.11.40 → 0.11.41`: all 11 manifests + `MODULE.bazel` + `Cargo.lock`.
- CHANGELOG `[0.11.41]` entry added.
- `cargo check -p synth-cli` green · `rivet validate` 0 non-xref errors.
- On merge: tag `v0.11.41` → release workflow publishes crates.io + GitHub Release. Closes #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)