### PR TITLE
style: rustfmt the #331 regression-test assertion (CI Format fix)

### DIFF
--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -5405,7 +5405,9 @@ mod tests {
             first
                 .as_ref()
                 .err()
-                .map(|e| e.to_string().contains("all allocatable registers are live on the stack"))
+                .map(|e| e
+                    .to_string()
+                    .contains("all allocatable registers are live on the stack"))
                 .unwrap_or(false),
             "first pass must hit the #331 area-reserved guard (ladder-recoverable Err); got {:?}",
             first.as_ref().map(|i| i.len())


### PR DESCRIPTION
Trivial formatting fix — the #331 regression test's closure assertion exceeded the line width and rustfmt rewraps it. Landed unformatted in #333. No behavior change. Unblocks the CI Format check before tagging v0.11.41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)