### PR TITLE
fix(selector): #313 — reconcile if/else-with-result arms to a single register

### DIFF
--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -472,6 +472,77 @@ fn spill_deepest_reg(
     Ok(true)
 }
 
+/// Reconcile one if-result position between the two arms (#313): make the
+/// else-arm's result register(s) hold the SAME value the then-arm's do, by
+/// emitting `MOV R_then, R_else` (i64: lo and hi) on the ELSE path when the two
+/// arms chose different registers. Emitting NOTHING when they match is what
+/// keeps register-symmetric / control-flow-only if/else byte-identical.
+///
+/// The merged value lives in the then-arm's register afterwards (the caller
+/// pushes the then-result back onto the vstack). These movs are placed between
+/// the else-arm body and `end_label`; the then-path branches over them.
+///
+/// A spilled result on either side only arises under register-exhaustion
+/// spilling (the retry pass, `spill_on_exhaustion`). Rather than risk a
+/// mis-reconciliation there, return the honest exhaustion `Err` — the same
+/// recoverable signal the rest of the allocator uses — so the function is
+/// retried/skipped, never miscompiled.
+fn reconcile_if_result(
+    then_v: &StackVal,
+    else_v: &StackVal,
+    instructions: &mut Vec<ArmInstruction>,
+    line: usize,
+) -> Result<()> {
+    match (then_v, else_v) {
+        (
+            StackVal::Reg {
+                reg: then_lo,
+                is_i64: then_i64,
+            },
+            StackVal::Reg {
+                reg: else_lo,
+                is_i64: else_i64,
+            },
+        ) => {
+            // Both arms must agree on width for a well-typed if-result.
+            if then_i64 != else_i64 {
+                return Err(synth_core::Error::synthesis(
+                    "if/else result width mismatch between arms (#313)".to_string(),
+                ));
+            }
+            if then_lo != else_lo {
+                instructions.push(ArmInstruction {
+                    op: ArmOp::Mov {
+                        rd: *then_lo,
+                        op2: Operand2::Reg(*else_lo),
+                    },
+                    source_line: Some(line),
+                });
+            }
+            if *then_i64 {
+                let then_hi = i64_pair_hi(*then_lo)?;
+                let else_hi = i64_pair_hi(*else_lo)?;
+                if then_hi != else_hi {
+                    instructions.push(ArmInstruction {
+                        op: ArmOp::Mov {
+                            rd: then_hi,
+                            op2: Operand2::Reg(else_hi),
+                        },
+                        source_line: Some(line),
+                    });
+                }
+            }
+            Ok(())
+        }
+        _ => Err(synth_core::Error::synthesis(
+            "if/else result reconciliation with a spilled arm result is not \
+             supported by the current register allocator (#313) — function too \
+             complex; retried/skipped rather than miscompiled"
+                .to_string(),
+        )),
+    }
+}
+
 /// Pop the top operand, returning its `lo` register (#171). If the entry was
 /// spilled, reload it: allocate a fresh consecutive pair and emit
 /// `LDR lo,[sp,slot]; LDR hi,[sp,slot+4]`, freeing the slot.
@@ -5099,6 +5170,20 @@ impl InstructionSelector {
         let mut block_labels: Vec<(String, bool)> = Vec::new();
         // Stack of (else_label, end_label) for if/else blocks
         let mut if_labels: Vec<(String, String)> = Vec::new();
+        // #313: per-if-block operand-stack checkpoint (vstack depth captured at
+        // `If`, after popping the condition). The result arity of an
+        // `if (result …)` is observable as (vstack depth − checkpoint).
+        let mut if_checkpoints: Vec<usize> = Vec::new();
+        // #313: per-if-block reservation of the THEN-arm's result registers.
+        // Captured at `Else` (the then-arm's results, popped off and truncated
+        // back to the checkpoint so the else-arm starts from the same stack
+        // shape) and threaded into the temp/pair/reload allocators across the
+        // else-arm — exactly as those result regs were protected in the buggy
+        // code by sitting on the vstack. Popped at the matching `End`, where
+        // the else-arm's result registers are reconciled INTO the then-arm's
+        // (a `mov R_then, R_else` on the else path when they differ). Each
+        // inner `Vec` is one if-block's then-arm results, top-most-last.
+        let mut if_then_results: Vec<Vec<StackVal>> = Vec::new();
 
         // Map of local index -> register
         let mut local_to_reg: std::collections::HashMap<u32, Reg> =
@@ -5164,7 +5249,23 @@ impl InstructionSelector {
             // Param registers still live at this op — reserved from temp/pair/
             // reload allocation so a constant/result/reload never clobbers a live
             // param (#193).
-            let live_params = live_param_regs(idx);
+            let mut live_params = live_param_regs(idx);
+            // #313: while inside the else-arm of one or more if-blocks, the
+            // then-arm result registers of each enclosing if-block must be
+            // protected from the allocators exactly as they were when they sat
+            // on the vstack in the buggy code (this is what makes the else-arm
+            // allocate byte-identically). Reserve them — and the conventional
+            // hi register of any i64 result — for the duration of the else-arm.
+            for results in &if_then_results {
+                for v in results {
+                    if let StackVal::Reg { reg, is_i64 } = v {
+                        live_params.push(*reg);
+                        if *is_i64 && let Ok(hi) = i64_pair_hi(*reg) {
+                            live_params.push(hi);
+                        }
+                    }
+                }
+            }
             match op {
                 LocalGet(local_idx) => {
                     // Get the register for this local. Three cases:
@@ -6898,6 +6999,13 @@ impl InstructionSelector {
                     // Store both labels: else_label for the if-branch, end_label for the end
                     if_labels.push((else_label.clone(), end_label.clone()));
                     block_labels.push((end_label, false));
+                    // #313: checkpoint the operand-stack depth (the condition is
+                    // already popped). The then-arm runs from here; its results
+                    // are whatever sits ABOVE this depth at `Else`. Reservation
+                    // starts EMPTY — nothing needs protecting during the then-arm
+                    // (it runs first); it is filled at `Else`.
+                    if_checkpoints.push(stack.len());
+                    if_then_results.push(Vec::new());
 
                     // CMP cond_reg, #0
                     instructions.push(ArmInstruction {
@@ -6921,6 +7029,21 @@ impl InstructionSelector {
                 }
 
                 Else => {
+                    // #313: the then-arm's results are the vstack entries above
+                    // the checkpoint. Pop them (top-most last) and truncate the
+                    // vstack back to the checkpoint so the else-arm starts from
+                    // the SAME stack shape the then-arm did. The captured regs
+                    // are reserved across the else-arm (via `if_then_results`,
+                    // merged into `live_params` above) so the else-arm cannot
+                    // clobber them — reproducing the buggy code's incidental
+                    // protection (the then-results were on the vstack) exactly,
+                    // which is what keeps the else-arm allocation byte-identical.
+                    if let Some(&cp) = if_checkpoints.last() {
+                        let then_results: Vec<StackVal> = stack.split_off(cp);
+                        if let Some(slot) = if_then_results.last_mut() {
+                            *slot = then_results;
+                        }
+                    }
                     // End of then-block: jump to end of if
                     if let Some((_, end_label)) = if_labels.last() {
                         instructions.push(ArmInstruction {
@@ -6954,12 +7077,58 @@ impl InstructionSelector {
                             .iter()
                             .any(|i| matches!(&i.op, ArmOp::Label { name } if *name == else_label));
                         if !else_emitted {
-                            // No else clause: emit else label (same as end)
+                            // No else clause: emit else label (same as end).
+                            // A valid if-without-else has arity 0 (no result),
+                            // so there is nothing to reconcile (#313).
                             instructions.push(ArmInstruction {
                                 op: ArmOp::Label { name: else_label },
                                 source_line: Some(idx),
                             });
                             cf.add_instruction();
+                        }
+                        // #313: reconcile the two arms onto a single set of
+                        // result registers. The then-arm's results were captured
+                        // and reserved at `Else` (`if_then_results`); the
+                        // else-arm's results are the vstack entries above the
+                        // checkpoint right now. The `mov R_then, R_else`s emitted
+                        // here sit on the ELSE path (between the else-arm body and
+                        // `end_label`); the then-path's `B end_label` (emitted at
+                        // `Else`) jumps over them, so the then-arm's value is the
+                        // one live at `end_label` on the then path while the else
+                        // path moves its value into the same registers. When the
+                        // two arms already chose the same register, NO `mov` is
+                        // emitted (this is what keeps register-symmetric and
+                        // control-flow-only if/else byte-identical to before).
+                        let then_results = if_then_results.pop().unwrap_or_default();
+                        let checkpoint = if_checkpoints.pop();
+                        if else_emitted {
+                            if let Some(cp) = checkpoint {
+                                // else-arm results above the checkpoint, in the
+                                // same bottom→top order as `then_results`.
+                                let else_results: Vec<StackVal> = stack.split_off(cp);
+                                if else_results.len() == then_results.len() {
+                                    for (then_v, else_v) in
+                                        then_results.iter().zip(else_results.iter())
+                                    {
+                                        reconcile_if_result(
+                                            then_v,
+                                            else_v,
+                                            &mut instructions,
+                                            idx,
+                                        )?;
+                                    }
+                                } else {
+                                    // Arity mismatch between arms (should not
+                                    // happen for valid wasm). Restore what we
+                                    // took rather than silently miscompile;
+                                    // downstream may still Err cleanly.
+                                    stack.extend(else_results);
+                                }
+                            }
+                            // The merged results live in the then-arm's
+                            // registers — push them back onto the vstack so the
+                            // surrounding code (return / outer op) reads them.
+                            stack.extend(then_results);
                         }
                         instructions.push(ArmInstruction {
                             op: ArmOp::Label { name: end_label },
@@ -15530,6 +15699,163 @@ mod tests {
             "must be the retry-ladder exhaustion class, got: {err}"
         );
         assert!(instructions.is_empty(), "no partial sequence on Err");
+    }
+
+    /// #313: an `if (result i32)` with ASYMMETRIC arms must reconcile both
+    /// arms onto a SINGLE result register. The buggy selector left the
+    /// then-arm's result on the vstack across the else-arm and read the
+    /// else-arm's register unconditionally at `End`, so the then-path returned
+    /// a register it never wrote. The fix reconciles: the value live at the
+    /// `if_end` label is the THEN-arm's register, and a `MOV R_then, R_else`
+    /// sits on the else path (between the `else` label and the `if_end` label)
+    /// so the else path moves its result into that same register. Mirrors
+    /// `scripts/repro/u64_unpack_if.wat` (`f`).
+    #[test]
+    fn if_result_asymmetric_arms_reconcile_to_one_register_313() {
+        use WasmOp::*;
+        // param0 = i64 $r. Condition: (wrap(r & 255) == 1). Then: wrap(r>>32).
+        // Else: const 0xDEAD. The two arms land in different registers.
+        let ops: Vec<WasmOp> = vec![
+            LocalGet(0),
+            I64Const(255),
+            I64And,
+            I32WrapI64,
+            I32Const(1),
+            I32Eq,
+            If,
+            LocalGet(0),
+            I64Const(32),
+            I64ShrU,
+            I32WrapI64,
+            Else,
+            I32Const(0xDEAD),
+            End,
+        ];
+        // One i64 param (occupies R0/R1), result i32.
+        let mut sel = fresh_selector();
+        sel.func_ret_i64 = vec![false];
+        let instrs = sel
+            .select_with_stack(&ops, 1)
+            .expect("if-result must compile");
+
+        // Locate the `else` and `if_end` labels.
+        let else_pos = instrs
+            .iter()
+            .position(|i| matches!(&i.op, ArmOp::Label { name } if name.contains("else")))
+            .expect("else label present");
+        let end_pos = instrs
+            .iter()
+            .position(|i| matches!(&i.op, ArmOp::Label { name } if name.contains("if_end")))
+            .expect("if_end label present");
+        assert!(else_pos < end_pos, "else label precedes if_end label");
+
+        // Exactly one reconciliation MOV between the else label and the end
+        // label (the else path moving its result into the then register).
+        let reconcile: Vec<(Reg, Reg)> = instrs[else_pos + 1..end_pos]
+            .iter()
+            .filter_map(|i| match &i.op {
+                ArmOp::Mov {
+                    rd,
+                    op2: Operand2::Reg(rs),
+                } => Some((*rd, *rs)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            reconcile.len(),
+            1,
+            "exactly one reconciliation MOV on the else path, got {reconcile:?}"
+        );
+        let (r_then, r_else) = reconcile[0];
+        assert_ne!(
+            r_then, r_else,
+            "reconciliation only emitted when the arms differ"
+        );
+
+        // The then-path `B if_end` must jump OVER the reconciliation MOV: there
+        // is a branch to the end label emitted before the else label.
+        let then_branch_over = instrs[..else_pos]
+            .iter()
+            .any(|i| matches!(&i.op, ArmOp::B { label } if label.contains("if_end")));
+        assert!(
+            then_branch_over,
+            "then-path branches to if_end, skipping the reconciliation MOV"
+        );
+
+        // The else-arm materialized 0xDEAD into r_else (so it is genuinely the
+        // else result being moved into the then register).
+        let else_makes_dead = instrs[else_pos + 1..end_pos].iter().any(|i| {
+            matches!(&i.op, ArmOp::Mov { rd, op2: Operand2::Imm(v) } if *rd == r_else && *v == 0xDEAD)
+                || matches!(&i.op, ArmOp::Movw { rd, imm16 } if *rd == r_else && *imm16 == 0xDEAD)
+        });
+        assert!(
+            else_makes_dead,
+            "the else arm materializes 0xDEAD into the moved-from register"
+        );
+    }
+
+    /// #313: a control-flow-only / result-less `if/else` (arity 0) gets NO
+    /// reconciliation move — results carried via locals, not the vstack. This
+    /// is the byte-identity guarantee for the frozen fixtures (which have no
+    /// if-with-result). Here both arms only `local.set`, leaving the vstack at
+    /// the checkpoint depth, so `End` emits nothing extra.
+    #[test]
+    fn if_without_result_emits_no_reconciliation_313() {
+        use WasmOp::*;
+        // if (local.get 0) { local.set 1 (const 7) } else { local.set 1 (const 9) }
+        let ops: Vec<WasmOp> = vec![
+            LocalGet(0),
+            If,
+            I32Const(7),
+            LocalSet(1),
+            Else,
+            I32Const(9),
+            LocalSet(1),
+            End,
+            LocalGet(1),
+        ];
+        let instrs = fresh_selector()
+            .select_with_stack(&ops, 2)
+            .expect("arity-0 if must compile");
+        let end_pos = instrs
+            .iter()
+            .position(|i| matches!(&i.op, ArmOp::Label { name } if name.contains("if_end")))
+            .expect("if_end label present");
+        // #313: for an arity-0 if/else the result-reconciliation is a no-op —
+        // `if_then_results` is empty at `End`, so NOTHING is emitted between the
+        // last else-arm instruction and the `if_end` label (the buggy and fixed
+        // selectors are byte-identical here; this is the property the frozen
+        // fixtures depend on). The instruction immediately preceding `if_end` is
+        // therefore the else-arm's own `local.set` store/mov, never a #313 MOV.
+        // We assert the closing structure is `… ; if_end: ; (LocalGet 1 read)`
+        // with no reconciliation slipped in: the only thing after the `else`
+        // label region tied to the merge is the label itself.
+        //
+        // Concretely: there must be exactly one then-arm body MOV (const 7 ->
+        // local) before the else label and one else-arm body MOV (const 9 ->
+        // local) after it, and the two destinations are the SAME register (both
+        // write local 1) — i.e. the arms reconcile themselves through the local,
+        // and `End` adds nothing.
+        let else_pos = instrs
+            .iter()
+            .position(|i| matches!(&i.op, ArmOp::Label { name } if name.contains("else")))
+            .expect("else label present");
+        let dest_of_setlocal = |slice: &[ArmInstruction]| -> Option<Reg> {
+            slice.iter().rev().find_map(|i| match &i.op {
+                ArmOp::Mov {
+                    rd,
+                    op2: Operand2::Reg(_),
+                } => Some(*rd),
+                _ => None,
+            })
+        };
+        let then_local = dest_of_setlocal(&instrs[..else_pos]);
+        let else_local = dest_of_setlocal(&instrs[else_pos + 1..end_pos]);
+        assert!(
+            then_local.is_some() && then_local == else_local,
+            "both arms write the same local register; End adds no reconciliation \
+             (then={then_local:?} else={else_local:?})"
+        );
     }
 
     /// End-to-end fail-then-retry contract (the backend's wrapper): the

--- a/scripts/repro/u64_unpack_if.wat
+++ b/scripts/repro/u64_unpack_if.wat
@@ -1,0 +1,94 @@
+(module
+  ;; #313 minimal: the if-with-result analogue of u64_unpack.wat.
+  ;; Same payload (r = ((a+b+1) << 32) | 1) but the unpack uses an
+  ;; `(if (result i32) …)` with ASYMMETRIC arms instead of `select`.
+  ;; The buggy ARM selector tracked the operand stack textually through
+  ;; both arms with no checkpoint/reconciliation, so `End`/return read the
+  ;; ELSE-arm's register unconditionally — the then-path returned garbage.
+  ;; check_call(3,4) must be 8 (then-arm: r>>32 = a+b+1); was 0xDEAD/garbage.
+  (func (export "check") (param $a i32) (param $b i32) (result i32)
+    (local $r i64)
+    (local.set $r
+      (i64.or
+        (i64.shl
+          (i64.extend_i32_u (i32.add (i32.add (local.get $a) (local.get $b)) (i32.const 1)))
+          (i64.const 32))
+        (i64.const 1)))
+    (if (result i32)
+      (i32.eq
+        (i32.wrap_i64 (i64.and (local.get $r) (i64.const 255)))
+        (i32.const 1))
+      (then (i32.wrap_i64 (i64.shr_u (local.get $r) (i64.const 32))))
+      (else (i32.const 0xDEAD))))
+  ;; post-call form: u64 returned in r0/r1, then unpacked through an if.
+  (func $make (param $a i32) (param $b i32) (result i64)
+    (i64.or
+      (i64.shl
+        (i64.extend_i32_u (i32.add (i32.add (local.get $a) (local.get $b)) (i32.const 1)))
+        (i64.const 32))
+      (i64.const 1)))
+  (func (export "check_call") (param $a i32) (param $b i32) (result i32)
+    (local $r i64)
+    (local.set $r (call $make (local.get $a) (local.get $b)))
+    (if (result i32)
+      (i32.eq
+        (i32.wrap_i64 (i64.and (local.get $r) (i64.const 255)))
+        (i32.const 1))
+      (then (i32.wrap_i64 (i64.shr_u (local.get $r) (i64.const 32))))
+      (else (i32.const 0xDEAD))))
+  (func $make_hot (param $a i32) (param $b i32) (result i64)
+    ;; enough live i32 values to push the if-result destinations into high regs
+    (local $t1 i32) (local $t2 i32) (local $t3 i32)
+    (local.set $t1 (i32.add (local.get $a) (i32.const 3)))
+    (local.set $t2 (i32.mul (local.get $b) (i32.const 5)))
+    (local.set $t3 (i32.xor (local.get $t1) (local.get $t2)))
+    (i64.or
+      (i64.shl
+        (i64.extend_i32_u
+          (i32.add (i32.add (local.get $a) (local.get $b))
+                   (i32.and (local.get $t3) (i32.const 0))))
+        (i64.const 32))
+      (i64.extend_i32_u (i32.add (i32.const 1) (i32.and (local.get $t3) (i32.const 0))))))
+  (func (export "check_hot") (param $a i32) (param $b i32) (result i32)
+    (local $r i64)
+    (local.set $r (call $make_hot (local.get $a) (local.get $b)))
+    (if (result i32)
+      (i32.eq
+        (i32.wrap_i64 (i64.and (local.get $r) (i64.const 255)))
+        (i32.const 1))
+      (then (i32.wrap_i64 (i64.shr_u (local.get $r) (i64.const 32))))
+      (else (i32.const 0xDEAD))))
+  ;; #313 reservation stress: the else-arm builds a DEEP expression with many
+  ;; simultaneously-live i32 temps, driving the round-robin temp allocator
+  ;; toward the THEN-arm's result register. The then-arm result (r>>32) must
+  ;; stay protected across the whole else-arm — if the reservation threading is
+  ;; incomplete, the else-arm clobbers the then register, reconcile sees
+  ;; then==else (no mov), and the then-path silently returns the else value.
+  ;; cond is true when (r & 255) == 1 (it is, by construction), so the then-arm
+  ;; runs and MUST return a+b+1; a wrong reservation makes it return garbage.
+  (func (export "check_press") (param $a i32) (param $b i32) (result i32)
+    (local $r i64)
+    (local.set $r
+      (i64.or
+        (i64.shl
+          (i64.extend_i32_u (i32.add (i32.add (local.get $a) (local.get $b)) (i32.const 1)))
+          (i64.const 32))
+        (i64.const 1)))
+    (if (result i32)
+      (i32.eq
+        (i32.wrap_i64 (i64.and (local.get $r) (i64.const 255)))
+        (i32.const 1))
+      (then (i32.wrap_i64 (i64.shr_u (local.get $r) (i64.const 32))))
+      ;; else: a 7-deep live chain of distinct sub-sums (never reached when the
+      ;; cond is true, but its register demand must NOT touch the then result).
+      (else
+        (i32.add
+          (i32.add
+            (i32.add (i32.add (local.get $a) (i32.const 11))
+                     (i32.add (local.get $b) (i32.const 22)))
+            (i32.add (i32.add (local.get $a) (i32.const 33))
+                     (i32.add (local.get $b) (i32.const 44))))
+          (i32.add
+            (i32.add (i32.add (local.get $a) (i32.const 55))
+                     (i32.add (local.get $b) (i32.const 66)))
+            (i32.add (local.get $a) (local.get $b))))))))

--- a/scripts/repro/u64_unpack_if_differential.py
+++ b/scripts/repro/u64_unpack_if_differential.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# #313 differential: wasmtime ground truth vs unicorn running synth's ARM for
+# the if-with-result variant of u64_unpack. The then-path must return its OWN
+# result (r>>32), not the else-arm's register. check_call(3,4) must be 8.
+#
+# Usage: build the ELF first, then run this script.
+#   synth compile --target cortex-m4 --all-exports --relocatable \
+#       scripts/repro/u64_unpack_if.wat -o /tmp/u64if.elf
+#   python3 scripts/repro/u64_unpack_if_differential.py
+import struct, sys
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_THUMB
+from unicorn.arm_const import (UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R11,
+                               UC_ARM_REG_LR, UC_ARM_REG_SP)
+
+WAT = 'scripts/repro/u64_unpack_if.wat'
+ELF = '/tmp/u64if.elf'
+
+# ground truth
+eng = wasmtime.Engine(); mod = wasmtime.Module(eng, open(WAT, 'rb').read())
+st = wasmtime.Store(eng); inst = wasmtime.Instance(st, mod, [])
+gt = {n: inst.exports(st)[n] for n in ("check", "check_call", "check_hot", "check_press")}
+
+e = ELFFile(open(ELF, 'rb'))
+text = bytearray(e.get_section_by_name('.text').data())
+symtab = [s for s in e.iter_sections() if s['sh_type'] == 'SHT_SYMTAB'][0]
+syms = {s.name: s['st_value'] for s in symtab.iter_symbols()}
+# resolve internal BL relocs (R_ARM_THM_CALL=10)
+rel = e.get_section_by_name('.rel.text')
+if rel:
+    for r in rel.iter_relocations():
+        if r['r_info_type'] == 10:
+            s = symtab.get_symbol(r['r_info_sym'])
+            if s.name in syms:
+                off, target = r['r_offset'], syms[s.name]
+                dd = (target - (off + 4))
+                S_ = (dd >> 24) & 1
+                i1 = (dd >> 23) & 1; i2 = (dd >> 22) & 1
+                j1 = (~(i1 ^ S_)) & 1; j2 = (~(i2 ^ S_)) & 1
+                imm10 = (dd >> 12) & 0x3FF; imm11 = (dd >> 1) & 0x7FF
+                hw1 = 0xF000 | (S_ << 10) | imm10
+                hw2 = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+                struct.pack_into('<HH', text, off, hw1, hw2)
+
+CODE, STK = 0x10000, 0x90000
+mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+mu.mem_map(CODE, 0x10000); mu.mem_write(CODE, bytes(text))
+mu.mem_map(STK, 0x10000)
+RET = CODE + 0xFF00
+mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+ok = True
+for fn in ("check", "check_call", "check_hot", "check_press"):
+    for (a, b) in ((3, 4), (0, 0), (250, 5), (0x7FFFFFFF, 1)):
+        exp = gt[fn](st, a, b) & 0xFFFFFFFF
+        mu.reg_write(UC_ARM_REG_R0, a); mu.reg_write(UC_ARM_REG_R1, b)
+        mu.reg_write(UC_ARM_REG_R11, 0); mu.reg_write(UC_ARM_REG_SP, STK + 0x8000)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        mu.emu_start((CODE + syms[fn]) | 1, RET, timeout=5_000_000)
+        got = mu.reg_read(UC_ARM_REG_R0)
+        m = "OK " if got == exp else "FAIL"
+        if got != exp: ok = False
+        print(f"{m} {fn}({a},{b}) = {got:#x} expect {exp:#x}")
+
+# gale's exact regression: check_call(3,4) must be 8 (was 0xDEAD/garbage).
+exp34 = gt["check_call"](st, 3, 4) & 0xFFFFFFFF
+assert exp34 == 8, f"ground truth sanity: check_call(3,4) should be 8, got {exp34:#x}"
+print(f"#313 gale regression: check_call(3,4) = 8 (ground truth confirms {exp34})")
+
+print("ORACLE:", "PASS" if ok else "FAIL")
+sys.exit(0 if ok else 1)


### PR DESCRIPTION
## Root cause

`select_with_stack`'s `If`/`Else`/`End` lowering (in `crates/synth-synthesis/src/instruction_selector.rs`) tracked the operand stack **textually** through both arms: no checkpoint at `If`, no restore at `Else`, no reconciliation at `End`. For an `if (result …)` with **asymmetric arms**, both arms' results piled onto the vstack and `End`/return read the top — the **else-arm's** register — unconditionally.

At `If` the condition is popped (vstack depth `D`); the then-arm pushes its result at `vstack[D]`. At `Else` nothing happened to the vstack, so `R_then` stayed on it (incidentally protecting it from the else-arm); the else-arm pushed `R_else` at `vstack[D+1]`. At `End` the vstack held `[…, R_then, R_else]` and downstream read `R_else`. The then-path's `B end_label` jumps **over** the else-arm to `end_label`, where `R_else` is never written on that path — so the then-path returned a register it never wrote. A silent miscompile. gale's case: `check_call(3,4)` returned `0` instead of `8`.

## The fix (vstack-checkpoint + reconciliation; **no** decoder/enum change)

- **`If`**: push a checkpoint `= stack.len()` (after popping the condition) and an empty per-block then-result reservation.
- **`Else`**: pop+remember the then-arm's results (vstack entries above the checkpoint) and truncate the vstack back to the checkpoint so the else-arm starts from the same stack shape. **Reserve** those registers across the else-arm (threaded into `live_params`, consulted by the temp/pair/reload allocators) — reproducing exactly the protection they had by sitting on the vstack in the buggy code, which keeps the else-arm allocation **byte-identical**.
- **`End` (if-block)**: reconcile each else-result into the matching then-result register with `MOV R_then, R_else` emitted **before** `end_label` (so it runs on the else path; the then-path's `B end_label` jumps over it). When the two arms already chose the same register, **no `mov`** is emitted; arity-0 (control-flow-only / no-`else`) if/else gets no reconciliation. This is what keeps the frozen fixtures byte-identical. A spilled-arm result returns the recoverable exhaustion `Err` rather than risk a mis-reconciliation.

then-path correctness for arity-1 is **structural** (it branches over the entire else-arm). The reservation's load-bearing role is forcing `R_else` disjoint from `R_then`, which keeps multi-result reconciliation swap-safe by construction and keeps the symmetric path byte-identical.

## Before / after on the repro

Module: `(if (result i32) (i32.eq (i32.wrap_i64 (i64.and (local.get $r) 255)) 1) (then (i32.wrap_i64 (i64.shr_u (local.get $r) 32))) (else 0xDEAD))`, `--target cortex-m4 --all-exports --relocatable`.

**Before (buggy):**
```
54: mov   r5, r3        ; then result -> r5
56: b.n   0x5c
58: movw  r6, #0xdead    ; else result -> r6
5c: mov   r0, r6         ; merge reads r6 UNCONDITIONALLY — then-path returns uninitialized r6
```
**After (fixed):**
```
54: mov   r5, r3         ; then result -> r5
56: b.n   0x5e           ; then-path jumps OVER the reconciliation
58: movw  r6, #0xdead    ; else result -> r6
5c: mov   r5, r6         ; reconciliation on the ELSE path: r6 -> r5
5e: mov   r0, r5         ; merge reads r5 — both paths leave the result in r5
```

## Bit-identity evidence

- `scripts/repro/control_step_differential.py` → `ORACLE: PASS` (0x00210A55), `flight_seam_differential.py` → `MATCH` (0x07FDF307), `div_const_differential.py` → `338/338 PASS`, `mutex_pressure_differential.py` → `ORACLE: PASS`.
- `.text` byte-compare of all four fixtures, pre-fix vs post-fix binary (`cargo clean -p synth-synthesis` forced rebuild; the two binaries have different MD5): **IDENTICAL** (control_step 354 B, flight_seam 1016 B, div_const 232 B, mutex_pressure 182 B). None of the four fixtures contains any `if`, so the change cannot affect their bytes.

## Correctness gate (new regression fixture)

- `scripts/repro/u64_unpack_if.wat` + `u64_unpack_if_differential.py`: the if-with-result analogue of `u64_unpack`. **16/16 cases match wasmtime**, incl. gale's exact regression `check_call(3,4) = 8` (was `0` on the pre-fix binary, which FAILs the oracle). `check_press` is a register-pressure regression guard (heavy else-arm) confirming the then-path stays correct; note it does not by itself demonstrate the reservation prevents an arity-1 miscompile (an ablation showed the then-path is correct without the reservation because it branches over the else-arm — the reservation matters for arity ≥ 2 swap-safety and byte-identity).
- New unit tests `if_result_asymmetric_arms_reconcile_to_one_register_313` and `if_without_result_emits_no_reconciliation_313`; `cargo test -p synth-synthesis --lib` 390 pass.
- `cargo fmt --all -- --check` exit 0; `cargo clippy -p synth-synthesis --all-targets -- -D warnings` clean; `rivet validate` 0 non-xref errors.

## Out of scope (follow-ups)

- **RISC-V selector (`crates/synth-backend-riscv/src/selector.rs`) has the same gap** — `lower_else` truncates the then-arm's results off the vstack (`vstack.truncate(stack_height_at_entry)`) but neither captures them nor reconciles at `lower_end`, so an `if (result …)` returns the else register on the then path (same class, arguably worse — it discards rather than protects). Should be a separate issue.
- Multi-value (arity ≥ 2) if-results aren't exercised here; the reconcile is swap-safe given the reservation's disjointness but the path is untested.
- `br`/`br_if` targeting an if-block's end carrying a result value remains a separate unhandled path (not regressed by this change).

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)