### PR TITLE
chore(clippy): use std::hint::black_box (criterion deprecated its re-export)

### DIFF
--- a/crates/synth-opt/benches/optimization_bench.rs
+++ b/crates/synth-opt/benches/optimization_bench.rs
@@ -1,4 +1,5 @@
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use synth_cfg::CfgBuilder;
 use synth_opt::*;
 


### PR DESCRIPTION
CI's stable clippy now flags `use of deprecated function criterion::black_box` in `optimization_bench.rs`, failing `-D warnings` on **every** open PR (#342, the dependabot PRs) — a queue-wide block unrelated to any change under test. Fix: import `black_box` from `std::hint` (version-independent, canonical). Unblocks the merge queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)