### PR TITLE
chore(release): v0.11.42 — #313 if/else-with-result reconciliation bug-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.42] - 2026-06-14
+
+**IF/ELSE-WITH-RESULT RECONCILIATION BUG-FIX — gale #313: asymmetric arms
+silently miscompiled (then-path returned garbage); now fixed.**
+
+- **if/else-with-result register reconciliation** (#313): `select_with_stack`'s
+  `If`/`Else`/`End` lowering tracked the operand stack textually through both
+  arms with no checkpoint at `If`, no restore at `Else`, and no reconciliation at
+  `End`. For an `if (result …)` with asymmetric arms the two arms' results piled
+  onto the vstack and `End` read the top (the else-arm's register)
+  **unconditionally**, so the then-path — which branches over the else-arm —
+  returned a register it never wrote (silent wrong-code, the #311/#331 class).
+  Fix: checkpoint the vstack depth at `If`; at `Else` capture the then-arm's
+  result registers and reserve them across the else-arm (reproducing the buggy
+  code's incidental on-vstack protection, which is what keeps register-symmetric
+  if/else byte-identical); at `End` reconcile the else-arm's result into the
+  then-arm's register with a `MOV R_then, R_else` on the else path, emitting
+  **nothing** when the arms already agree. No decoder/enum change — the result
+  arity is observable from the vstack depth. A spilled or width-mismatched arm
+  returns the ladder-recoverable exhaustion `Err` (retried/skipped, never
+  miscompiled). Regression fixture `scripts/repro/u64_unpack_if.wat` +
+  differential (`check_call(3,4) = 8`, was 0); the four frozen differentials
+  (control_step 0x00210A55, flight_seam 0x07FDF307, div_const 338/338,
+  mutex_pressure) stay **byte-identical** (none contains an `if`-with-result).
+
+  **Falsification:** this fix is wrong if a re-decode of any `if (result …)` with
+  asymmetric arms still shows `End`/return reading the else-arm's register on the
+  then path, or if `check_call(3,4)` on `u64_unpack_if.wat` returns anything but
+  8 on silicon. (The RISC-V selector has the same gap — tracked as #343, not
+  fixed here.)
+
+- **CI: `std::hint::black_box`** (#344): criterion (bumped to 0.8.2 in #339)
+  deprecated `criterion::black_box`; stable-clippy's `-D warnings` then failed
+  the synth-opt bench on every PR. Imported `black_box` from `std::hint`.
+
 ## [0.11.41] - 2026-06-13
 
 **SPILL-SLOT COLLISION BUG-FIX — gale #331: dissolved `k_mutex_unlock`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,14 +1943,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1999,11 +1999,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.41"
+version = "0.11.42"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "anyhow",
  "serde",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2052,14 +2052,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2067,11 +2067,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.41"
+version = "0.11.42"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.41"
+version = "0.11.42"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.41"
+version = "0.11.42"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.41",
+    version = "0.11.42",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.41" }
+synth-core = { path = "../synth-core", version = "0.11.42" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.41" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.41" }
+synth-core = { path = "../synth-core", version = "0.11.42" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.42" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.41" }
+synth-core = { path = "../synth-core", version = "0.11.42" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.41" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.41", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.42" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.42", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.41" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.41" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.41" }
-synth-backend = { path = "../synth-backend", version = "0.11.41" }
+synth-core = { path = "../synth-core", version = "0.11.42" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.42" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.42" }
+synth-backend = { path = "../synth-backend", version = "0.11.42" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.41", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.41", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.41", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.42", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.42", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.42", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.41", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.42", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.41" }
+synth-core = { path = "../synth-core", version = "0.11.42" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.41" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.42" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.41" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.41" }
-synth-opt = { path = "../synth-opt", version = "0.11.41" }
+synth-core = { path = "../synth-core", version = "0.11.42" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.42" }
+synth-opt = { path = "../synth-opt", version = "0.11.42" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.41" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.41" }
-synth-opt = { path = "../synth-opt", version = "0.11.41" }
+synth-core = { path = "../synth-core", version = "0.11.42" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.42" }
+synth-opt = { path = "../synth-opt", version = "0.11.42" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.41", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.42", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Bug-fix release cutting **v0.11.42**. Headline: **#313** — the `if (result …)` asymmetric-arm reconciliation miscompile (then-path returned garbage), fixed in #342 (clean-room verified).

## Contents since v0.11.41
- **#313 / #342** — if/else-with-result register reconciliation. Checkpoint vstack at `If`, reserve then-arm results across the else-arm, reconcile onto one register at `End`. Clean-room verified: repro correct (`check_call(3,4)=8`), 4 frozen differentials **byte-identical** (none contains an if-result), 390 tests, fmt/clippy/rivet clean.
- **#344** — CI `std::hint::black_box` (criterion 0.8.2 from #339 deprecated `criterion::black_box`, which `-D warnings` then failed queue-wide).
- **#343 filed** — the RISC-V selector has the same if/else-result gap (not fixed here).

## Falsification (the new behavior)
Wrong if a re-decode of any `if (result …)` with asymmetric arms still shows `End`/return reading the else-arm register on the then path, or if `check_call(3,4)` on `u64_unpack_if.wat` returns anything but 8 on silicon.

## Mechanics
Pin sweep `0.11.41 → 0.11.42` (11 manifests + `MODULE.bazel` + `Cargo.lock`); CHANGELOG `[0.11.42]`. `cargo build` green, `rivet validate` 0 non-xref errors, 4 differentials + #313 regression PASS on main. On merge: tag `v0.11.42` → release workflow. Closes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)