### PR TITLE
fix(elf): #345 step 2 — link-survivable linmem addressing (literal-pool R_ARM_ABS32, replaces inline MOVW/MOVT-ABS)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -431,6 +431,17 @@ fn compile_wasm_to_arm(
     let mut code = Vec::new();
     let mut relocations = Vec::new();
 
+    // #345: literal-pool address loads. Each `LdrSym` was encoded as a placeholder
+    // `LDR.W rd,[pc,#0]`; record where its instruction sits and what it loads so
+    // we can append a pooled word (carrying the symbol address via R_ARM_ABS32)
+    // and patch the PC-relative offset once the pool position is known.
+    struct PendingLiteral {
+        ldr_offset: u32,
+        symbol: String,
+        addend: i32,
+    }
+    let mut pending_literals: Vec<PendingLiteral> = Vec::new();
+
     for instr in &arm_instrs {
         // Record a relocation for every BL: the encoder emits `bl #0` and
         // relies on a relocation to patch the target. This covers BOTH import
@@ -462,11 +473,72 @@ fn compile_wasm_to_arm(
                 kind: synth_core::backend::RelocKind::MovtAbs,
             });
         }
+        // #345: defer the literal-pool word + reloc + offset patch to the
+        // post-loop pass (the pool address is not yet known).
+        if let ArmOp::LdrSym { symbol, addend, .. } = &instr.op {
+            pending_literals.push(PendingLiteral {
+                ldr_offset: code.len() as u32,
+                symbol: symbol.clone(),
+                addend: *addend,
+            });
+        }
 
         let encoded = encoder
             .encode(&instr.op)
             .map_err(|e| format!("ARM encoding failed: {}", e))?;
         code.extend_from_slice(&encoded);
+    }
+
+    // #345: place the literal pool at the end of this function's `.text`. Gated on
+    // there being at least one `LdrSym` — functions without one are byte-identical
+    // to before (no trailing padding, so downstream `func_offsets` are unchanged
+    // and the frozen differential fixtures stay bit-for-bit equal).
+    if !pending_literals.is_empty() {
+        if !use_thumb2 {
+            return Err("LdrSym literal-pool addressing requires Thumb-2".to_string());
+        }
+        // 4-byte align the pool start (Thumb-2 word loads require it, and
+        // `Align(PC,4)` in the LDR-literal semantics assumes a word-aligned pool).
+        while code.len() % 4 != 0 {
+            code.push(0x00);
+        }
+        // One distinct pooled word per LdrSym (no dedup: different sites carry
+        // different addends, and the REL addend lives in the word).
+        for lit in &pending_literals {
+            let word_offset = code.len() as u32;
+
+            // REL semantics: the linker computes `S + A`, where A is the in-place
+            // value of the relocated word. Initialize the word to the addend so
+            // the final loaded address is `symbol + addend`.
+            code.extend_from_slice(&(lit.addend as u32).to_le_bytes());
+            relocations.push(CodeRelocation {
+                offset: word_offset,
+                symbol: lit.symbol.clone(),
+                kind: synth_core::backend::RelocKind::Abs32,
+            });
+
+            // Patch the placeholder `LDR.W rd,[pc,#imm12]`. Thumb-2 LDR (literal):
+            // address = Align(PC,4) + imm12, with PC = ldr_offset + 4. The pool is
+            // always after the LDR, so U=1 (already set in hw1 = 0xF8DF).
+            let pc = lit.ldr_offset + 4;
+            let aligned_pc = pc & !3u32;
+            let imm12 = word_offset - aligned_pc;
+            if imm12 > 0xFFF {
+                // Wide LDR-literal range is ±4 KB; these function bodies are far
+                // smaller, but fail cleanly rather than miscompile if exceeded.
+                return Err(format!(
+                    "LdrSym literal pool out of range (#345): imm12={} > 4095 \
+                     for symbol {}",
+                    imm12, lit.symbol
+                ));
+            }
+            let hw2_off = (lit.ldr_offset + 2) as usize;
+            let mut hw2 = u16::from_le_bytes([code[hw2_off], code[hw2_off + 1]]);
+            hw2 = (hw2 & 0xF000) | (imm12 as u16); // keep Rt, set imm12
+            let hw2_bytes = hw2.to_le_bytes();
+            code[hw2_off] = hw2_bytes[0];
+            code[hw2_off + 1] = hw2_bytes[1];
+        }
     }
 
     Ok((code, relocations))

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -439,6 +439,15 @@ impl ArmEncoder {
                 0xE3400000 | (((v >> 12) & 0xF) << 16) | (rd_bits << 12) | (v & 0xFFF)
             }
 
+            // #345: LdrSym is the Thumb-2 literal-pool address load. A32 mode is
+            // not used for relocatable native-pointer objects; fail loudly rather
+            // than miscompile if it is ever reached here.
+            ArmOp::LdrSym { .. } => {
+                return Err(synth_core::Error::synthesis(
+                    "LdrSym (literal-pool address load) is Thumb-2-only",
+                ));
+            }
+
             // Compare
             ArmOp::Cmp { rn, op2 } => {
                 let rn_bits = reg_to_bits(rn);
@@ -2811,6 +2820,23 @@ impl ArmEncoder {
             }
             ArmOp::MovtSym { rd, addend, .. } => {
                 self.encode_thumb32_movt_raw(reg_to_bits(rd), ((*addend as u32) >> 16) & 0xffff)
+            }
+
+            // #345: literal-pool address load — emit a PLACEHOLDER `LDR.W rd,
+            // [pc, #0]` (U=1, imm12=0). The backend (arm_backend.rs) places the
+            // 4-byte pool word at the end of the function, records the R_ARM_ABS32
+            // relocation against `symbol+addend`, and patches the imm12 with the
+            // real PC-relative distance once the pool offset is known.
+            // Encoding T2: 1111 1000 1101 1111 | Rt(4) imm12(12), with the literal
+            // base = Align(PC,4) and PC = address of this instruction + 4.
+            ArmOp::LdrSym { rd, .. } => {
+                let rt = reg_to_bits(rd) as u16;
+                let hw1: u16 = 0xF8DF; // LDR.W (literal), U=1
+                let hw2: u16 = rt << 12; // imm12 = 0 placeholder
+                let mut bytes = Vec::with_capacity(4);
+                bytes.extend_from_slice(&hw1.to_le_bytes());
+                bytes.extend_from_slice(&hw2.to_le_bytes());
+                Ok(bytes)
             }
 
             // SetCond: Materialize condition flag into register (0 or 1)

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2620,6 +2620,29 @@ fn build_relocatable_elf(
                 synth_core::backend::RelocKind::ThmCall => ArmRelocationType::ThmCall,
                 synth_core::backend::RelocKind::MovwAbs => ArmRelocationType::MovwAbsNc,
                 synth_core::backend::RelocKind::MovtAbs => ArmRelocationType::MovtAbs,
+                // #345: literal-pool word carrying a symbol address — link-survivable
+                // R_ARM_ABS32 (the linker patches the data word, `S + A`).
+                synth_core::backend::RelocKind::Abs32 => {
+                    // The `LDR rX,[pc,#imm12]` that reads this pooled word had its
+                    // imm12 computed function-locally (`Align(PC,4)+imm12`, with PC
+                    // and the pool offset both relative to the function start). That
+                    // is correct at the function's ABSOLUTE address ONLY if the
+                    // function begins 4-byte-aligned — otherwise `Align()` rounds
+                    // differently and the load lands ±2 bytes off the word. The
+                    // `.text` layout loop 4-aligns every function start (and `.text`
+                    // itself is `with_align(4)`), so this holds; assert it so a
+                    // future layout change that breaks the invariant fails loudly
+                    // rather than miscompiling the pool load (#345, the #212/#215
+                    // "layout change exposes latent fragility" class).
+                    assert_eq!(
+                        func_base % 4,
+                        0,
+                        "#345: function carrying an R_ARM_ABS32 literal-pool reloc \
+                         must start 4-byte-aligned (func_base={func_base}); the \
+                         PC-relative LDR imm12 assumes it"
+                    );
+                    ArmRelocationType::Abs32
+                }
             };
             elf_builder.add_relocation(Relocation {
                 offset: func_base + reloc.offset,
@@ -3895,6 +3918,89 @@ mod tests {
         assert!(
             data > 0 && data < 1024,
             "#345: .data holds only global slots (got {data} bytes)"
+        );
+    }
+
+    /// #345 step 2: the `--native-pointer-abi` linmem-address loads must use the
+    /// link-survivable literal-pool form (`R_ARM_ABS32` on a `.text` data word),
+    /// NOT the inline-immediate `R_ARM_MOVW_ABS_NC`/`R_ARM_MOVT_ABS` pair — the
+    /// latter could be mangled into an undefined instruction in a large Zephyr
+    /// image (USAGE FAULT on G474RE). This test drives the real ELF reloc-emission
+    /// path: a function carrying `RelocKind::Abs32` against `__synth_wasm_data` and
+    /// `__synth_globals` must yield `.rel.text` entries of type R_ARM_ABS32 (2) and
+    /// ZERO MOVW/MOVT-ABS (43/44) against those symbols.
+    #[test]
+    fn native_pointer_linmem_addressing_is_abs32_not_movw_movt_345() {
+        use object::Endianness;
+        use object::read::elf::{FileHeader, SectionHeader};
+
+        // A function whose `.text` ends in two literal-pool words (the LdrSym
+        // form): one for `__synth_wasm_data`, one for `__synth_globals`. Each
+        // word carries its addend in place (REL) and an Abs32 reloc.
+        let mut code = vec![0u8; 8]; // two pooled words at offsets 0 and 4
+        code[0..4].copy_from_slice(&0u32.to_le_bytes()); // __synth_wasm_data + 0
+        code[4..8].copy_from_slice(&0u32.to_le_bytes()); // __synth_globals + 0
+        let func = ElfFunction {
+            name: "decide".to_string(),
+            wasm_index: 0,
+            code,
+            relocations: vec![
+                synth_core::backend::CodeRelocation {
+                    offset: 0,
+                    symbol: "__synth_wasm_data".to_string(),
+                    kind: synth_core::backend::RelocKind::Abs32,
+                },
+                synth_core::backend::CodeRelocation {
+                    offset: 4,
+                    symbol: "__synth_globals".to_string(),
+                    kind: synth_core::backend::RelocKind::Abs32,
+                },
+            ],
+        };
+        let native = NativeGlobalsLayout {
+            globals: vec![(0, 65_536)],
+            sp_init: 65_536,
+        };
+        let elf = build_relocatable_elf(&[func], &[], &[], 131_072, Some(native))
+            .expect("#345: native-pointer literal-pool object builds");
+
+        let header = object::elf::FileHeader32::<Endianness>::parse(&*elf).expect("valid ELF32");
+        let endian = header.endian().expect("endian");
+        let sections = header.sections(endian, &*elf).expect("sections");
+
+        // Collect every relocation type emitted against .text.
+        const R_ARM_ABS32: u32 = 2;
+        const R_ARM_MOVW_ABS_NC: u32 = 43;
+        const R_ARM_MOVT_ABS: u32 = 44;
+        let mut abs32 = 0usize;
+        let mut movw_movt = 0usize;
+        for section in sections.iter() {
+            let name = sections
+                .section_name(endian, section)
+                .map(|n| String::from_utf8_lossy(n).into_owned())
+                .unwrap_or_default();
+            if name != ".rel.text" {
+                continue;
+            }
+            let (rels, _) = section
+                .rel(endian, &*elf)
+                .expect("rel section")
+                .expect("has rel entries");
+            for rel in rels {
+                match rel.r_type(endian) {
+                    R_ARM_ABS32 => abs32 += 1,
+                    R_ARM_MOVW_ABS_NC | R_ARM_MOVT_ABS => movw_movt += 1,
+                    _ => {}
+                }
+            }
+        }
+        assert_eq!(
+            abs32, 2,
+            "#345: both linmem-address loads must be R_ARM_ABS32 literal-pool words"
+        );
+        assert_eq!(
+            movw_movt, 0,
+            "#345: NO inline MOVW/MOVT-ABS relocs may remain on the native-pointer path"
         );
     }
 

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -189,6 +189,13 @@ pub enum RelocKind {
     MovwAbs,
     /// R_ARM_MOVT_ABS — the MOVT half of a symbol-relative address (#237).
     MovtAbs,
+    /// R_ARM_ABS32 — a 32-bit absolute address held in a `.text` literal-pool
+    /// word, loaded via `LDR rX, [pc, #off]` (#345). The link-survivable
+    /// replacement for the inline-immediate MOVW/MOVT-ABS pair: `ld`/bfd patches
+    /// the data word at link time (`S + A`, the addend living in the word, REL
+    /// semantics), which survives placement into a large multi-object image —
+    /// whereas an inline-instruction MOVW_ABS immediate can be mangled.
+    Abs32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -1562,9 +1562,17 @@ impl InstructionSelector {
         }
     }
 
-    /// #237: emit a `symbol + addend` absolute address into `rd` (MOVW+MOVT,
-    /// symbol-relocated) — base-independent addressing for any linker-placed
-    /// region (`__synth_wasm_data` statics, `__synth_globals` slots).
+    /// #237/#345: emit a `symbol + addend` absolute address into `rd` —
+    /// base-independent addressing for any linker-placed region
+    /// (`__synth_wasm_data` statics, `__synth_globals` slots).
+    ///
+    /// #345: this now emits a single link-survivable literal-pool load
+    /// (`LdrSym` → `LDR rd,[pc,#off]` + a pooled word with R_ARM_ABS32) instead
+    /// of the inline-immediate `MovwSym`+`MovtSym` pair. The inline `MOVW_ABS`
+    /// immediate could be mangled into an undefined instruction when linked into
+    /// a large Zephyr image (USAGE FAULT on G474RE); an `R_ARM_ABS32` on a data
+    /// word is what `ld`/bfd patches at link time and survives a big multi-object
+    /// link. The `MovwSym`/`MovtSym` ops remain available for other paths.
     fn emit_sym_addr(
         out: &mut Vec<ArmInstruction>,
         rd: Reg,
@@ -1572,49 +1580,21 @@ impl InstructionSelector {
         addend: i32,
         line: usize,
     ) {
-        for hi in [false, true] {
-            let op = if hi {
-                ArmOp::MovtSym {
-                    rd,
-                    symbol: symbol.to_string(),
-                    addend,
-                }
-            } else {
-                ArmOp::MovwSym {
-                    rd,
-                    symbol: symbol.to_string(),
-                    addend,
-                }
-            };
-            out.push(ArmInstruction {
-                op,
-                source_line: Some(line),
-            });
-        }
+        out.push(ArmInstruction {
+            op: ArmOp::LdrSym {
+                rd,
+                symbol: symbol.to_string(),
+                addend,
+            },
+            source_line: Some(line),
+        });
     }
 
-    /// #237: emit a `__synth_wasm_data + addend` address into `rd` (MOVW+MOVT,
-    /// symbol-relocated) — the base-independent static-data address.
+    /// #237/#345: emit a `__synth_wasm_data + addend` address into `rd` — the
+    /// base-independent static-data address, via the link-survivable literal-pool
+    /// load (see [`Self::emit_sym_addr`] for the #345 rationale).
     fn emit_wasm_data_addr(out: &mut Vec<ArmInstruction>, rd: Reg, addend: i32, line: usize) {
-        for hi in [false, true] {
-            let op = if hi {
-                ArmOp::MovtSym {
-                    rd,
-                    symbol: "__synth_wasm_data".to_string(),
-                    addend,
-                }
-            } else {
-                ArmOp::MovwSym {
-                    rd,
-                    symbol: "__synth_wasm_data".to_string(),
-                    addend,
-                }
-            };
-            out.push(ArmInstruction {
-                op,
-                source_line: Some(line),
-            });
-        }
+        Self::emit_sym_addr(out, rd, "__synth_wasm_data", addend, line);
     }
 
     /// Set the per-function AAPCS argument-count table (issue #195).
@@ -16904,10 +16884,12 @@ mod tests {
             WasmOp::GlobalSet(0),
         ];
         let instrs = sel.select_with_stack(&ops, 0).unwrap();
+        // #345: addresses now load via the link-survivable literal pool (LdrSym),
+        // not the inline MovwSym/MovtSym pair.
         let globals_syms = instrs
             .iter()
             .filter(
-                |i| matches!(&i.op, ArmOp::MovwSym { symbol, .. } if symbol == "__synth_globals"),
+                |i| matches!(&i.op, ArmOp::LdrSym { symbol, .. } if symbol == "__synth_globals"),
             )
             .count();
         assert_eq!(
@@ -16917,10 +16899,19 @@ mod tests {
         let base_syms = instrs
             .iter()
             .filter(
-                |i| matches!(&i.op, ArmOp::MovwSym { symbol, .. } if symbol == "__synth_wasm_data"),
+                |i| matches!(&i.op, ArmOp::LdrSym { symbol, .. } if symbol == "__synth_wasm_data"),
             )
             .count();
         assert_eq!(base_syms, 2, "rebase on read (add) and on write (sub)");
+        // #345: NO inline absolute MOVW/MOVT against these symbols remain.
+        assert!(
+            !instrs.iter().any(|i| matches!(
+                &i.op,
+                ArmOp::MovwSym { symbol, .. } | ArmOp::MovtSym { symbol, .. }
+                    if symbol == "__synth_globals" || symbol == "__synth_wasm_data"
+            )),
+            "no inline MOVW/MOVT-ABS against linmem symbols (#345)"
+        );
         assert!(
             instrs.iter().any(|i| matches!(&i.op, ArmOp::Ldr { .. })),
             "the get LOADS the slot (not a constant)"
@@ -16956,8 +16947,10 @@ mod tests {
             },
             WasmOp::End,
         ];
+        // #345: the address now loads via a link-survivable literal pool (LdrSym),
+        // not the inline MovwSym/MovtSym pair.
         let is_data_sym = |i: &ArmInstruction| {
-            matches!(&i.op, ArmOp::MovwSym { symbol, .. } | ArmOp::MovtSym { symbol, .. }
+            matches!(&i.op, ArmOp::LdrSym { symbol, .. }
                 if symbol == "__synth_wasm_data")
         };
 
@@ -16967,8 +16960,8 @@ mod tests {
         sel.set_native_pointer_abi(true, 65536);
         let on = sel.select_with_stack(&ops, 0).unwrap();
         assert!(
-            on.iter().filter(|i| is_data_sym(i)).count() >= 2,
-            "static store must emit MovwSym+MovtSym __synth_wasm_data. got: {on:#?}"
+            on.iter().filter(|i| is_data_sym(i)).count() >= 1,
+            "static store must emit LdrSym __synth_wasm_data. got: {on:#?}"
         );
 
         // Flag OFF → base-relative, no symbol relocation (frozen behavior).
@@ -17017,18 +17010,28 @@ mod tests {
         sel.set_native_pointer_stack(0, 65536);
         let out = sel.select_with_stack(&ops, 1).unwrap();
 
+        // #345: each materialization is now a single literal-pool load (LdrSym),
+        // not a MovwSym+MovtSym pair.
         let data_syms = out
             .iter()
             .filter(|i| {
-                matches!(&i.op, ArmOp::MovwSym { symbol, .. } | ArmOp::MovtSym { symbol, .. }
+                matches!(&i.op, ArmOp::LdrSym { symbol, .. }
                     if symbol == "__synth_wasm_data")
             })
             .count();
-        // Two materializations × (MovwSym + MovtSym): the SP read and the
-        // static-pointer const.
+        // Two materializations × one LdrSym: the SP read and the static-pointer.
         assert!(
-            data_syms >= 4,
-            "expected SP-read + static-ptr both __synth_wasm_data-relative (>=4 sym ops); got {data_syms}: {out:#?}"
+            data_syms >= 2,
+            "expected SP-read + static-ptr both __synth_wasm_data-relative (>=2 LdrSym); got {data_syms}: {out:#?}"
+        );
+        // #345: no inline absolute MOVW/MOVT against the linmem base remain.
+        assert!(
+            !out.iter().any(|i| matches!(
+                &i.op,
+                ArmOp::MovwSym { symbol, .. } | ArmOp::MovtSym { symbol, .. }
+                    if symbol == "__synth_wasm_data"
+            )),
+            "no inline MOVW/MOVT-ABS against __synth_wasm_data (#345): {out:#?}"
         );
         // The frame-size 16 must remain a plain scalar immediate, never
         // relocated as `__synth_wasm_data`. Since #253/Add-Sub folding it is

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -80,6 +80,9 @@ pub fn reg_effect(op: &ArmOp) -> Option<RegEffect> {
 
         // rd = imm (low half); upper half zeroed — no use
         Movw { rd, .. } | MovwSym { rd, .. } => def_use(vec![*rd], vec![]),
+        // #345: rd = full symbol address loaded from the literal pool — pure def
+        // of rd (NOT an RMW like Movt), no register use.
+        LdrSym { rd, .. } => def_use(vec![*rd], vec![]),
         // rd[31:16] = imm, rd[15:0] preserved — reads and writes rd
         Movt { rd, .. } | MovtSym { rd, .. } => def_use(vec![*rd], vec![*rd]),
 
@@ -1360,6 +1363,12 @@ fn rewrite_op(
             imm16: *imm16,
         },
         MovwSym { rd, symbol, addend } => MovwSym {
+            rd: d(rd),
+            symbol: symbol.clone(),
+            addend: *addend,
+        },
+        // #345: pure def of rd (literal-pool load) — like Movw, not an RMW.
+        LdrSym { rd, symbol, addend } => LdrSym {
             rd: d(rd),
             symbol: symbol.clone(),
             addend: *addend,

--- a/crates/synth-synthesis/src/rules.rs
+++ b/crates/synth-synthesis/src/rules.rs
@@ -258,6 +258,20 @@ pub enum ArmOp {
         addend: i32,
     },
 
+    // #345: link-survivable symbol-address load — `LDR rd, [pc, #off]` reading a
+    // 4-byte literal-pool word (placed at the end of the function's `.text`) that
+    // carries the address of `symbol + addend` via an R_ARM_ABS32 relocation. The
+    // backend places the pool, patches the PC-relative offset, and initializes the
+    // word to the addend (REL: the linker computes `S + A`). This replaces the
+    // fragile inline-immediate MovwSym+MovtSym pair on the `--native-pointer-abi`
+    // static-data (`__synth_wasm_data`) and sp-global (`__synth_globals`) paths,
+    // which `ld` could mangle into an undefined instruction in a large image.
+    LdrSym {
+        rd: Reg,
+        symbol: String,
+        addend: i32,
+    },
+
     // Compare
     Cmp {
         rn: Reg,

--- a/scripts/repro/native_pointer_shadow_stack_differential.py
+++ b/scripts/repro/native_pointer_shadow_stack_differential.py
@@ -40,11 +40,22 @@ def patch_movwt(code, off, value16):
 
 # synth labels its Thumb MOVW/MOVT relocations with the ARM32 type numbers
 # (43/44) — patch them with the THUMB bit layout (what the encoder emitted).
+# #345: the linmem-address loads are now link-survivable literal-pool loads —
+# `LDR rX,[pc,#off]` reading a `.text` word relocated by R_ARM_ABS32 (type 2).
+# Relocate those words in place (REL: final value = symbol_base + in-place addend)
+# so the emulated load sees the real DATA-relative address, exactly as `ld` would.
 MOVW_TYPES, MOVT_TYPES = (43, 47), (44, 48)
+ABS32_TYPE = 2
 rel = e.get_section_by_name(".rel.text")
 symtab = [sec for sec in e.iter_sections() if sec["sh_type"] == "SHT_SYMTAB"][0]
 for r in rel.iter_relocations():
     t = r["r_info_type"]
+    if t == ABS32_TYPE:
+        sym = symtab.get_symbol(r["r_info_sym"])
+        # REL: the addend lives in the pooled word; final = sym_base + addend.
+        (add,) = struct.unpack_from("<I", text, r["r_offset"])
+        struct.pack_into("<I", text, r["r_offset"], (DATA + syms[sym.name] + add) & 0xFFFFFFFF)
+        continue
     if t not in MOVW_TYPES + MOVT_TYPES:
         continue
     sym = symtab.get_symbol(r["r_info_sym"])


### PR DESCRIPTION
## Design decision

Under `--native-pointer-abi`, the selector loaded the `__synth_wasm_data` (linmem base) and `__synth_globals` (sp-global) addresses with **inline-immediate `MOVW`/`MOVT-ABS`** (`R_ARM_MOVW_ABS_NC`/`R_ARM_MOVT_ABS`). gale found that the inline `MOVW_ABS` immediate gets **mangled into an undefined instruction** when linked into a large Zephyr image → **USAGE FAULT on G474RE** (`test_complex_inversion`). The standalone microbench links the identical relocs fine — they are well-formed but **placement/address-fragile in a real image**.

**Fix (chosen): literal-pool load.** Replace the inline `MOVW/MOVT-ABS` pair with `LDR rX, [pc, #off]` reading a 4-byte `.text` word that carries the symbol address via **`R_ARM_ABS32`**. An `R_ARM_ABS32` on a *data word* is what `ld`/bfd patches at link time (`S + A`, REL semantics — the addend lives in the word) and **survives a large multi-object link** — it's how ordinary code references externs. The inline-instruction `MOVW_ABS` immediate is the fragile part.

**Rejected alternatives:**
- **GOT-relative (`R_ARM_GOT_BREL`)** — needs a GOT; overkill for a leaf kernel-linkable object.
- **PC-relative `ADR`/`R_ARM_THM_PC`** — range-limited, and still relative to the *object*, not link-survivable for an *external* symbol.

## Implementation

- New `ArmOp::LdrSym { rd, symbol, addend }` + `RelocKind::Abs32`. The selector's `emit_sym_addr` / `emit_wasm_data_addr` emit one `LdrSym` instead of a `MovwSym`+`MovtSym` pair; `MovwSym`/`MovtSym` remain for other paths.
- The encoder emits a placeholder `LDR.W rd,[pc,#0]`; `arm_backend` places a 4-byte-aligned pool at the function end, initializes each word to the addend (REL), records `R_ARM_ABS32`, and patches the imm12 once the pool offset is known. **The pool pass is gated on `LdrSym` presence** — pool-free functions get no trailing padding, so behavior is frozen.
- `liveness` models `LdrSym` as a pure def of `rd` (+ reg-rewrite arm) so the allocation validator (#242 VCR-RA-003) sees it.
- `main.rs` maps `RelocKind::Abs32 → ArmRelocationType::Abs32`, and **asserts any function carrying an Abs32 reloc starts 4-byte-aligned** (the PC-relative LDR imm12 is computed function-locally and assumes it; the `.text` layout loop already 4-aligns every function and `.text` is `with_align(4)` — the assert makes the coupling explicit, defending the #212/#215 "layout change exposes latent fragility" class).

## Reloc histogram — mutex object (`k_mutex_unlock.dissolved.wasm`, `--native-pointer-abi --relocatable`)

| | before | after |
|---|---|---|
| `R_ARM_MOVW_ABS_NC` | 11 | **0** |
| `R_ARM_MOVT_ABS` | 11 | **0** |
| `R_ARM_ABS32` | 0 | **11** (3 `__synth_globals` + 8 `__synth_wasm_data`) |
| `R_ARM_THM_CALL` | 12 | 12 |

Step 1 still holds: `.data` = 4, `.bss` = NOBITS (65536, file size 0). Every `ldr.w rX,[pc,#N]` target lands exactly on an `R_ARM_ABS32` reloc word (11/11 bijection). Addend multiset **byte-identical** pre/post: `6×0 + 5×65536`.

## Gate evidence (real exit codes)

1. **Relocs fixed**: 22 inline MOVW/MOVT-ABS → 11 R_ARM_ABS32, 0 inline ABS remaining; step-1 section shape preserved. ✅
2. **Native-pointer fixtures correct**: `native_pointer_shadow_stack_differential.py` **ORACLE: PASS** (round-trips 7 / -123456 / 0x7FFFFFFF through the moved shadow-stack pointer + static pointer; SP slot restored to 4096). `native_pointer_static.wat` (1 ABS32, 1 `ldr.w [pc]`, `.data`=260) and `native_pointer_bss.wat` (1 ABS32, `.bss`=4 NOBITS) compile clean, 0 MOVW/MOVT-ABS each. ✅
3. **Four frozen differentials byte-identical**: `.text` `cmp` pre-vs-post (real rebuild) **byte-identical** for control_step / flight_seam / div_const / mutex_pressure; differential scripts PASS (control_step 0x00210A55-class, flight_seam 0x07FDF307, div_const 338/338, mutex_pressure all OK). They never use `--native-pointer-abi`, so `LdrSym` never fires. ✅
4. **Tests**: `cargo test -p synth-cli --bins` (26 ok) + `-p synth-synthesis --lib` (390 ok) + backend/core green. New regression test `native_pointer_linmem_addressing_is_abs32_not_movw_movt_345` (ELF carries 2×R_ARM_ABS32, 0 MOVW/MOVT) + strengthened the #237 selector tests to assert `LdrSym` + no inline MOVW/MOVT-ABS. ✅
5. `cargo fmt --all -- --check` (0), `clippy -D warnings` on all 4 crates (0), `rivet validate` 0 non-xref errors. ✅

## Honesty note

This is **reloc-shape + value-differential verified, not silicon-verified** — gale's G474RE Zephyr-link loop is the real gate. I also **extended the oracle** (`native_pointer_shadow_stack_differential.py`) to relocate the new ABS32 pool words in place (REL: `sym_base + in-place addend`), exactly as `ld` would; the independent round-trip values are what keep that honest.

Closes #345 (completes both steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)