### PR TITLE
chore(release): v0.11.43 — #345 on-target shippability (linmem .bss + link-survivable relocs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.43] - 2026-06-14
+
+**ON-TARGET SHIPPABILITY — gale #345: dissolved `--relocatable` objects are now
+MCU-shippable and link-survivable (both fix steps bundled).**
+
+- **#345 step 1 — zero-init wasm linmem → `.bss`** (#347): a dissolved
+  `--relocatable --native-pointer-abi` object emitted the entire wasm
+  linear-memory reservation as a SHT_PROGBITS `.data` section — ~64 KB of
+  mostly-zero bytes, a non-starter on a 128 KB-RAM MCU. Now the zero-init
+  reservation rides a SHT_NOBITS `.bss` (zero file bytes; the host loader zeroes
+  it, preserving wasm zero-init semantics), with only the materialized
+  `__synth_globals` slots in a tiny PROGBITS `.data`. Initialized `(data)`
+  segments stay PROGBITS. Measured on the dissolved `k_mutex_unlock`: `.data`
+  **65548 → 4 bytes**.
+- **#345 step 2 — link-survivable linmem addressing** (#348): the
+  `__synth_wasm_data`/`__synth_globals` addresses were loaded with inline-immediate
+  `MOVW`/`MOVT-ABS` (`R_ARM_MOVW_ABS_NC`/`MOVT_ABS`), whose instruction-immediate
+  form gets mangled into an undefined instruction when linked into a large Zephyr
+  image (G474RE USAGE FAULT). Replaced with a **literal-pool load** — `LDR rX,
+  [pc, #off]` from a `.text` word carrying `R_ARM_ABS32` (which `ld`/bfd patches
+  in a data word and survives a large multi-object link). Mutex object: **22
+  inline `MOVW/MOVT-ABS` → 0; 11 link-survivable `R_ARM_ABS32`**. (A new
+  `LdrSym` literal-pool op, wired through the encoder + reg_effect; a defensive
+  `func_base % 4 == 0` assert makes the imm12 alignment coupling explicit.)
+  Together these unblock the 51 struct-return decide drop-ins + jess PR #60.
+  The four frozen differentials (control_step 0x00210A55, flight_seam
+  0x07FDF307, div_const 338/338, mutex_pressure) stay **byte-identical** (the
+  whole change is gated on `--native-pointer-abi`).
+
+  **Falsification:** wrong if a dissolved `--native-pointer-abi --relocatable`
+  object still carries a 64 KB PROGBITS `.data` or any inline
+  `R_ARM_MOVW_ABS_NC`/`MOVT_ABS` against `__synth_wasm_data`; or if gale's
+  G474RE `mutex_api` (`CONFIG_GALE_WASM_LTO_MUTEX=y`) still links to a USAGE
+  FAULT. (Reloc-shape + value-differential verified in-tree; gale's silicon
+  link-test is the final gate.)
+
 ## [0.11.42] - 2026-06-14
 
 **IF/ELSE-WITH-RESULT RECONCILIATION BUG-FIX — gale #313: asymmetric arms

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,14 +1925,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1981,11 +1981,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.42"
+version = "0.11.43"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "anyhow",
  "clap",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "anyhow",
  "serde",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2034,14 +2034,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2049,11 +2049,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.42"
+version = "0.11.43"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "anyhow",
  "clap",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.42"
+version = "0.11.43"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.42"
+version = "0.11.43"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.42"
+version = "0.11.43"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.42",
+    version = "0.11.43",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.42" }
+synth-core = { path = "../synth-core", version = "0.11.43" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.42" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.42" }
+synth-core = { path = "../synth-core", version = "0.11.43" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.43" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.42" }
+synth-core = { path = "../synth-core", version = "0.11.43" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.42" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.42", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.43" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.43", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.42" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.42" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.42" }
-synth-backend = { path = "../synth-backend", version = "0.11.42" }
+synth-core = { path = "../synth-core", version = "0.11.43" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.43" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.43" }
+synth-backend = { path = "../synth-backend", version = "0.11.43" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.42", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.42", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.42", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.43", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.43", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.43", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.42", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.43", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.42" }
+synth-core = { path = "../synth-core", version = "0.11.43" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.42" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.43" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.42" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.42" }
-synth-opt = { path = "../synth-opt", version = "0.11.42" }
+synth-core = { path = "../synth-core", version = "0.11.43" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.43" }
+synth-opt = { path = "../synth-opt", version = "0.11.43" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.42" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.42" }
-synth-opt = { path = "../synth-opt", version = "0.11.42" }
+synth-core = { path = "../synth-core", version = "0.11.43" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.43" }
+synth-opt = { path = "../synth-opt", version = "0.11.43" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.42", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.43", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Bundles both **#345** fix steps (clean-room verified) — dissolved `--relocatable --native-pointer-abi` objects are now MCU-shippable and link-survivable, unblocking the **51 struct-return decide drop-ins + jess PR #60**.

| mutex object | v0.11.42 | v0.11.43 |
|---|---|---|
| `.data` | 65548 (PROGBITS) | **4** |
| `.bss` | 0 | **65536 (NOBITS)** |
| inline `MOVW/MOVT-ABS` | 22 | **0** |
| `R_ARM_ABS32` (literal-pool) | 0 | **11** |

- #347 (step 1): zero-init linmem → `.bss`.
- #348 (step 2): inline MOVW/MOVT-ABS → literal-pool `LDR [pc]`+`R_ARM_ABS32` (link-survivable).
- Frozen differentials (control_step `0x00210A55`, flight_seam `0x07FDF307`, div_const 338/338) **byte-identical**; native_pointer round-trip PASS; 390 tests + fmt/clippy/rivet clean.

**Falsification:** a dissolved native-pointer object still carrying 64 KB PROGBITS `.data` or inline `MOVW/MOVT-ABS` against `__synth_wasm_data`; or gale's G474RE `mutex_api` still USAGE-FAULTing. Reloc-shape + value verified in-tree; gale's silicon link-test is the final gate. Pin sweep `0.11.42 → 0.11.43`. Closes #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)