### PR TITLE
fix(encoder): #350 — lower out-of-range ADD #imm to MOVW/MOVT+ADD instead of erroring

### DIFF
--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -6599,11 +6599,41 @@ impl ArmEncoder {
             bytes.extend_from_slice(&hw2.to_le_bytes());
             Ok(bytes)
         } else {
-            // For larger immediates, would need MOVW/MOVT + ADD
-            // For now, return error
-            Err(synth_core::Error::synthesis(
-                "ADD immediate too large for single instruction",
-            ))
+            // Out-of-range immediate (> 0xFFF): materialize it into a scratch
+            // register, then ADD.W Rd, Rn, scratch. This is the #180/#185
+            // "encoder must produce a legal sequence, not assert" class — see #350.
+            //
+            // Scratch choice (must NEVER equal Rn, or Rn would be clobbered before
+            // the ADD reads it):
+            //   - rd != rn  => use rd itself (rn is untouched, since rd != rn).
+            //   - rd == rn  => use R12/IP (the reserved encoder scratch). rd/rn are
+            //                  never R12 (R12 is non-allocatable), so it can't alias.
+            //
+            // The materialized value is the same whether or not MOVT is emitted, so
+            // the byte length depends only on `imm` (and rd==rn) — the size probe and
+            // the final emit therefore agree (mandatory: the function is encoded twice).
+            let scratch: u32 = if rd_bits == rn_bits {
+                12 // R12/IP — in-place add, can't use rd because rd == rn
+            } else {
+                rd_bits // rn is preserved because rd != rn
+            };
+            // Invariant: the scratch must never alias Rn (would clobber it before
+            // the ADD reads it). Unreachable today (rd/rn are never R12), asserted
+            // to document the contract — #350.
+            debug_assert!(
+                scratch != rn_bits,
+                "ADD #imm lowering scratch must not equal Rn"
+            );
+
+            let lo16 = imm & 0xFFFF;
+            let hi16 = (imm >> 16) & 0xFFFF;
+
+            let mut bytes = self.encode_thumb32_movw_raw(scratch, lo16)?;
+            if hi16 != 0 {
+                bytes.extend_from_slice(&self.encode_thumb32_movt_raw(scratch, hi16)?);
+            }
+            bytes.extend_from_slice(&self.encode_thumb32_add_reg_raw(rd_bits, rn_bits, scratch)?);
+            Ok(bytes)
         }
     }
 
@@ -7666,6 +7696,85 @@ mod tests {
         let instr = u32::from_le_bytes([code[0], code[1], code[2], code[3]]);
         // Verify it's an ADD instruction with correct opcode
         assert_eq!(instr & 0x0FE00000, 0x00800000);
+    }
+
+    /// #350 — `encode_thumb32_add_imm` must lower an out-of-range immediate
+    /// (> 0xFFF) to a legal MOVW(/MOVT) + ADD.W-register sequence instead of
+    /// erroring. The small-imm fast path (imm <= 0xFFF) stays byte-identical.
+    #[test]
+    fn test_encode_add_imm_large_350() {
+        let enc = ArmEncoder::new_thumb2();
+
+        // --- Fast path unchanged: imm <= 0xFFF is a single 4-byte ADD.W ---
+        let small = enc
+            .encode_thumb32_add_imm(&Reg::R0, &Reg::R1, 0x123)
+            .unwrap();
+        assert_eq!(small.len(), 4, "small imm must stay a single instruction");
+
+        // helper: decode a Thumb-2 MOVW/MOVT halfword pair back to its imm16
+        fn movx_imm16(b: &[u8]) -> u32 {
+            let hw1 = u16::from_le_bytes([b[0], b[1]]) as u32;
+            let hw2 = u16::from_le_bytes([b[2], b[3]]) as u32;
+            let imm4 = hw1 & 0xF;
+            let i = (hw1 >> 10) & 1;
+            let imm3 = (hw2 >> 12) & 0x7;
+            let imm8 = hw2 & 0xFF;
+            (imm4 << 12) | (i << 11) | (imm3 << 8) | imm8
+        }
+        fn movx_rd(b: &[u8]) -> u32 {
+            (u16::from_le_bytes([b[2], b[3]]) as u32 >> 8) & 0xF
+        }
+
+        // --- rd != rn: scratch is rd. imm = 70000 = 0x11170 needs MOVW+MOVT. ---
+        // 0x11170: lo16 = 0x1170, hi16 = 0x0001
+        let seq = enc
+            .encode_thumb32_add_imm(&Reg::R12, &Reg::R0, 70000)
+            .unwrap();
+        assert_eq!(seq.len(), 12, "MOVW + MOVT + ADD = 12 bytes");
+        // MOVW r12, #0x1170
+        assert_eq!(u16::from_le_bytes([seq[0], seq[1]]) & 0xFBF0, 0xF240);
+        assert_eq!(movx_rd(&seq[0..4]), 12);
+        assert_eq!(movx_imm16(&seq[0..4]), 0x1170);
+        // MOVT r12, #0x0001
+        assert_eq!(u16::from_le_bytes([seq[4], seq[5]]) & 0xFBF0, 0xF2C0);
+        assert_eq!(movx_rd(&seq[4..8]), 12);
+        assert_eq!(movx_imm16(&seq[4..8]), 0x0001);
+        // ADD.W r12, r0, r12  (EB00 | rn=0 ; rd=12, rm=12)
+        let add1 = u16::from_le_bytes([seq[8], seq[9]]) as u32;
+        let add2 = u16::from_le_bytes([seq[10], seq[11]]) as u32;
+        assert_eq!(add1 & 0xFFF0, 0xEB00);
+        assert_eq!(add1 & 0xF, 0); // rn = r0
+        assert_eq!((add2 >> 8) & 0xF, 12); // rd = r12
+        assert_eq!(add2 & 0xF, 12); // rm = scratch = r12
+        // The materialized scratch must reconstruct exactly 70000.
+        assert_eq!(
+            (movx_imm16(&seq[4..8]) << 16) | movx_imm16(&seq[0..4]),
+            70000
+        );
+
+        // --- imm <= 0xFFFF: MOVT is skipped (MOVW + ADD = 8 bytes). ---
+        let seq16 = enc
+            .encode_thumb32_add_imm(&Reg::R3, &Reg::R0, 0xABCD)
+            .unwrap();
+        assert_eq!(seq16.len(), 8, "imm <= 0xFFFF skips MOVT");
+        assert_eq!(movx_imm16(&seq16[0..4]), 0xABCD);
+        assert_eq!(movx_rd(&seq16[0..4]), 3); // scratch = rd = r3
+
+        // --- rd == rn (in-place add): scratch must be R12, not rd. ---
+        // imm = 0x12345: lo16 = 0x2345, hi16 = 0x0001
+        let inplace = enc
+            .encode_thumb32_add_imm(&Reg::R5, &Reg::R5, 0x12345)
+            .unwrap();
+        assert_eq!(inplace.len(), 12);
+        assert_eq!(movx_rd(&inplace[0..4]), 12, "rd==rn must use R12 scratch");
+        assert_eq!(
+            (movx_imm16(&inplace[4..8]) << 16) | movx_imm16(&inplace[0..4]),
+            0x12345
+        );
+        // ADD.W r5, r5, r12 — rm must be the scratch (12), never rn.
+        let ip_add2 = u16::from_le_bytes([inplace[10], inplace[11]]) as u32;
+        assert_eq!(ip_add2 & 0xF, 12);
+        assert_eq!((ip_add2 >> 8) & 0xF, 5);
     }
 
     #[test]

--- a/scripts/repro/add_imm_large.wat
+++ b/scripts/repro/add_imm_large.wat
@@ -1,0 +1,19 @@
+;; #350 regression — ADD #imm lowering for out-of-range immediates.
+;;
+;; A static store with offset=70000 (> 0xFFF) forces the indexed-address path
+;; `ADD ip, base, #70000`. Before the fix, `encode_thumb32_add_imm` returned
+;; `Err("ADD immediate too large for single instruction")`, so this whole
+;; function failed to compile (empty object). The encoder now lowers it to
+;; `MOVW ip,#0x1170; MOVT ip,#0x0001; ADD.W ip, base, ip` (ip = base + 70000).
+;;
+;; Differential: scripts/repro/add_imm_large_differential.py stores a sentinel
+;; at the large offset and reads it back; the result must match wasmtime.
+(module
+  (memory (export "mem") 2)
+  (func (export "store_load_large") (param i32) (result i32)
+    ;; mem[70000] = param ; return mem[70000]
+    i32.const 0
+    local.get 0
+    i32.store offset=70000
+    i32.const 0
+    i32.load offset=70000))

--- a/scripts/repro/add_imm_large_differential.py
+++ b/scripts/repro/add_imm_large_differential.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""#350 — out-of-range `ADD #imm` lowering (MOVW/MOVT + ADD instead of erroring).
+
+A static store with `offset=70000` (> 0xFFF) forces the indexed-address path
+`ADD ip, base, #70000`. Before the fix, `encode_thumb32_add_imm` returned
+`Err("ADD immediate too large for single instruction")`, so the whole function
+failed to compile (empty object) — exactly the breakage that blocked gale's
+`gale_k_stack_push_decide`. The encoder now lowers it to
+`MOVW ip,#0x1170; MOVT ip,#0x0001; ADD.W ip, base, ip` (ip = base + 70000).
+
+This harness proves the lowered sequence computes the address **correctly**:
+wasmtime is ground truth; unicorn runs synth's ARM (`--relocatable` path) with a
+linear-memory region large enough to hold offset 70000. The function stores its
+param at mem[70000] and reads it back, so a 16-bit-truncated address (the failure
+mode if MOVT were dropped) would land at a different page and diverge.
+
+Run:
+  synth compile scripts/repro/add_imm_large.wat -o /tmp/ail.elf \
+        --target cortex-m4f --all-exports --relocatable
+  /tmp/armv/bin/python scripts/repro/add_imm_large_differential.py /tmp/ail.elf
+
+Exits nonzero on any mismatch.
+"""
+import re
+import subprocess
+import sys
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = "scripts/repro/add_imm_large.wat"
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/ail.elf"
+SYNTH = "./target/debug/synth"
+
+CODE, LIN, STK, RET = 0x200000, 0x40000, 0x180000, 0x300000
+# Linear memory must cover offset 70000 (0x11170) -> map 0x20000 (128 KiB).
+LIN_SIZE = 0x20000
+
+VECTORS = [0, 1, 0xABCD, 99, 0x7FFFFFFF, 0xFFFFFFFF, 0x12345678, 70000]
+
+
+def main():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, wasmtime.wat2wasm(open(WAT).read()))
+
+    def wt(arg):
+        store = wasmtime.Store(engine)
+        inst = wasmtime.Instance(store, module, [])
+        return inst.exports(store)["store_load_large"](store, arg) & 0xFFFFFFFF
+
+    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
+    syms = {m.group(2): int(m.group(1), 16)
+            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
+    fa = syms.get("func_0") or syms.get("store_load_large")
+    text = ELFFile(open(ELF, "rb")).get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+
+    def arm(arg):
+        mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+        mu.mem_map(CODE, 0x10000)
+        mu.mem_map(LIN, LIN_SIZE)
+        mu.mem_map(STK - 0x8000, 0x10000)
+        mu.mem_map(RET, 0x1000)
+        mu.mem_write(CODE, code)
+        mu.reg_write(UC_ARM_REG_SP, STK)
+        mu.reg_write(UC_ARM_REG_R11, LIN)
+        mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        try:
+            mu.emu_start((CODE + fa - base) | 1, RET, count=10000)
+        except UcError as e:
+            return f"ERR:{e}"
+        return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+    fails = 0
+    for v in VECTORS:
+        gt = wt(v)
+        got = arm(v)
+        ok = isinstance(got, int) and got == gt
+        fails += 0 if ok else 1
+        shown = f"0x{got:08X}" if isinstance(got, int) else got
+        print(f"store_load_large(0x{v:08X}) = {shown}  (wasmtime 0x{gt:08X})"
+              f"{'' if ok else '  <-- MISMATCH'}")
+    print(f"\n{len(VECTORS) - fails}/{len(VECTORS)} match")
+    print("ORACLE: PASS" if fails == 0 else f"ORACLE: FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Root cause

`encode_thumb32_add_imm` in `crates/synth-backend/src/arm_encoder.rs` handled only `imm <= 0xFFF`; for anything larger it returned `Err("ADD immediate too large for single instruction")`. The indexed-address path (`ADD ip, base, #off` for a large wasm static/struct offset, e.g. an sret frame slot) then failed the whole function's branch-resolve size probe / emit, so the function was **skipped** and the object came out **empty** — blocking gale's `gale_k_stack_push_decide` (and thus shipping `k_stack_push`).

This is the #180/#185 "encoder must produce a legal sequence, not assert" class.

## The lowering

For `imm > 0xFFF`, materialize the immediate into a scratch register, then `ADD.W rd, rn, scratch`. The scratch **never aliases `rn`** (which would clobber it before the ADD reads it):

- **`rd != rn`** → scratch = **`rd`** (`rn` is untouched since `rd != rn`). This is the `ADD ip, base, #off` case (rd=R12, rn=base∈R0-R8), so scratch=R12.
- **`rd == rn`** (in-place add) → scratch = **R12/IP** (the reserved encoder scratch; rd/rn are never R12 since R12 is non-allocatable, so no alias). Guarded by `debug_assert!(scratch != rn)`.

**MOVT is skipped** when `imm <= 0xFFFF` (just `MOVW scratch; ADD` = 8 bytes). The byte length depends only on `imm`, so the twice-called **size probe and final emit agree**. The `imm <= 0xFFF` fast path is **byte-identical** for existing callers.

## Before / after on the repro

`offset=70000` store, `--target cortex-m4f --all-exports --relocatable`:

- **Before:** `warning: skipping function 'f': ... ADD immediate too large` → `Error: no functions compiled successfully` (exit 1, empty object).
- **After:** compiles (exit 0, 367-byte object). Body decodes to:
  ```
  movw ip, #0x1170
  movt ip, #1
  add.w ip, r0, ip        ; ip = base + 0x11170 = base + 70000
  str.w r1, [fp, ip]
  ```

## Byte-identity evidence (behavior FROZEN)

The four frozen differentials have **byte-identical `.text`** baseline vs fixed (`git stash` the fix → `cargo clean -p synth-backend` → real rebuild → `cmp`; baseline binary verified by the repro still failing), and all four oracles still PASS:

| fixture | reference | byte-cmp | oracle |
|---|---|---|---|
| control_step | 0x00210A55 (13/13) | IDENTICAL | PASS |
| flight_seam | 0x07FDF307 | IDENTICAL | PASS |
| div_const | 338/338 | IDENTICAL | PASS |
| mutex_pressure | 0x77777777bd5b7dc8 | IDENTICAL | PASS |

None emits a `>0xFFF` ADD immediate, so the only-the-error-path change leaves them untouched.

## Regression coverage

- `scripts/repro/add_imm_large.wat` + `add_imm_large_differential.py` — store/load at `offset=70000`; **8/8 match vs wasmtime**. The compiled ELF decodes to the `MOVW/MOVT/ADD` sequence, proving the fixture genuinely exercises the patched path (not a coincidentally-folded offset).
- Encoder unit test `test_encode_add_imm_large_350` — decodes the bytes for 70000 (MOVW+MOVT) and 0xABCD (MOVW only, MOVT skipped), asserts the scratch reconstructs the exact immediate, covers `rd != rn` (scratch=rd) and `rd == rn` (scratch=R12), and that `imm <= 0xFFF` stays a single 4-byte instruction.

## Gates

- `cargo test -p synth-backend -p synth-synthesis --lib` — 390 passed, 0 failed.
- `cargo fmt --all -- --check` — exit 0.
- `cargo clippy -p synth-backend --all-targets -- -D warnings` — clean.
- `rivet validate` — 0 non-xref errors.

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)