### PR TITLE
fix(encoder): #350 follow-up — ADD #imm rd==rn==R12 returns Err, not panic

### DIFF
--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -6618,12 +6618,18 @@ impl ArmEncoder {
                 rd_bits // rn is preserved because rd != rn
             };
             // Invariant: the scratch must never alias Rn (would clobber it before
-            // the ADD reads it). Unreachable today (rd/rn are never R12), asserted
-            // to document the contract — #350.
-            debug_assert!(
-                scratch != rn_bits,
-                "ADD #imm lowering scratch must not equal Rn"
-            );
+            // the ADD reads it). Unreachable in real codegen (rd/rn are never R12,
+            // which is reserved encoder scratch), but the encoder is also driven by
+            // the `encoder_no_panic` fuzz harness with ARBITRARY registers — incl.
+            // rd==rn==R12, which makes scratch (R12) alias Rn. The encoder contract
+            // (#180/#185) is Ok-or-Err, never a panic, so return a typed error
+            // instead of asserting. #350 follow-up.
+            if scratch == rn_bits {
+                return Err(synth_core::Error::synthesis(format!(
+                    "ADD #imm: cannot lower #{imm:#x} for Rd==Rn==R12 — no free scratch \
+                     register (R12 is the reserved encoder scratch and aliases Rn here)"
+                )));
+            }
 
             let lo16 = imm & 0xFFFF;
             let hi16 = (imm >> 16) & 0xFFFF;
@@ -7775,6 +7781,29 @@ mod tests {
         let ip_add2 = u16::from_le_bytes([inplace[10], inplace[11]]) as u32;
         assert_eq!(ip_add2 & 0xF, 12);
         assert_eq!((ip_add2 >> 8) & 0xF, 5);
+    }
+
+    /// #350 follow-up — the `encoder_no_panic` fuzz harness drives the encoder
+    /// with ARBITRARY registers, including the one case the in-place lowering
+    /// cannot serve: rd==rn==R12. There the scratch (R12, the reserved encoder
+    /// register) would alias Rn and clobber it before the ADD reads it. The
+    /// encoder contract (#180/#185) is Ok-or-Err, never a panic — so this must
+    /// return Err, not assert. (Real codegen never emits rd==rn==R12 because R12
+    /// is non-allocatable; this guards only the fuzz/adversarial path.)
+    #[test]
+    fn test_encode_add_imm_large_rd_rn_r12_errs_not_panics_350() {
+        let enc = ArmEncoder::new_thumb2();
+        // Out-of-range imm with rd==rn==R12: no free scratch -> Err.
+        let r = enc.encode_thumb32_add_imm(&Reg::R12, &Reg::R12, 70000);
+        assert!(
+            r.is_err(),
+            "rd==rn==R12 with out-of-range imm must Err (no free scratch), got {r:?}"
+        );
+        // Small imm with rd==rn==R12 still takes the single-instruction fast path
+        // (no scratch needed) and must succeed — the guard is scoped to the
+        // out-of-range lowering only.
+        let small = enc.encode_thumb32_add_imm(&Reg::R12, &Reg::R12, 0x10);
+        assert!(small.is_ok(), "small imm needs no scratch, must stay Ok");
     }
 
     #[test]


### PR DESCRIPTION
## What

Fix-forward for a CI failure that landed with #351 (the #350 ADD-#imm lowering): `encoder_no_panic` fuzz went red.

#351 added `debug_assert!(scratch != rn_bits)` to *document* that the in-place lowering's scratch (R12) never aliases Rn in real codegen. But `ArmEncoder::encode` is also driven by the `encoder_no_panic` fuzz harness with **arbitrary** registers — including `Add{rd=R12, rn=R12, imm>0xFFF}`, where the scratch (R12) *does* alias Rn. With debug-assertions on (cargo-fuzz's profile), the assert fires → **panic**, violating the #180/#185 "encoder is Ok-or-Err, never panic" contract.

## Fix

Replace the `debug_assert!` with a real `return Err`. The lowering genuinely cannot serve `rd==rn==R12` — there is no free scratch (R12 is the reserved encoder scratch; using it would clobber Rn before the ADD reads it), so a typed `Err` is the honest outcome. The register allocator never emits `rd==rn==R12` (R12 is non-allocatable), so this is a **no-op for real codegen**.

## Verification

- **Byte-identity (proves zero codegen impact):** the #350 repro `scripts/repro/add_imm_large.wat` compiles to the **same SHA256** with and without this change → the frozen behavior fixtures (control_step `0x00210a55`, flight_algo `0x07FDF307`, divseam) are provably untouched.
- **Fuzz:** `cargo +nightly fuzz run encoder_no_panic -- -max_total_time=60` → **2,469,661 execs, DONE clean, no crash artifact** (was: fail).
- **#350 still fixed:** unicorn differential `add_imm_large_differential.py` → **8/8 match wasmtime, ORACLE PASS**.
- **New regression test** `test_encode_add_imm_large_rd_rn_r12_errs_not_panics_350`: `rd==rn==R12` + out-of-range imm → `Err`; small imm (no scratch needed) → `Ok`.
- `synth-backend` lib: **201 passed**; `fmt` + `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)