### PR TITLE
chore(release): v0.11.44 — #350 ADD #imm out-of-range lowering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.44] - 2026-06-14
+
+**ENCODER ROBUSTNESS — gale #350: out-of-range `ADD #imm` now lowers instead of
+failing the whole function (and the lowering is panic-free under fuzz).**
+
+- **#350 — lower out-of-range `ADD #imm` to `MOVW(/MOVT)+ADD-reg`** (#351):
+  `encode_thumb32_add_imm` returned `Err("ADD immediate too large for single
+  instruction")` for any `imm > 0xFFF`, so a function using the indexed-address
+  path `ADD ip, base, #off` with `off > 0xFFF` (e.g. `i32.store offset=70000`,
+  as in gale's struct-return `gale_k_stack_push_decide`) failed to compile —
+  emitting an empty object. The encoder now materializes the immediate into a
+  scratch register (`MOVW ip,#lo16; MOVT ip,#hi16; ADD.W rd, rn, ip`, MOVT
+  skipped when `imm ≤ 0xFFFF`), picking the scratch so it never aliases `Rn`
+  (`rd` when `rd != rn`, else `R12`). Size-probe-consistent: the byte length
+  depends only on `imm` and `rd==rn`, so the twice-encoded function agrees. The
+  `#180`/`#185` "encoder produces a legal sequence, never asserts" class.
+- **#350 follow-up — `rd==rn==R12` returns `Err`, not a panic** (#352): the
+  lowering's in-place scratch is `R12`, which the `encoder_no_panic` fuzz harness
+  can alias by feeding `Add{rd=R12, rn=R12, imm>0xFFF}` (arbitrary registers).
+  An interim `debug_assert!` documenting "scratch ≠ Rn" therefore *panicked* under
+  the fuzz's debug-assertions profile, breaking the Ok-or-Err contract. Replaced
+  with a real `return Err` — the only register configuration the lowering cannot
+  serve (no free scratch). Real codegen never emits `rd==rn==R12` (R12 is
+  non-allocatable), so this is a **no-op for emitted code**: the #350 repro
+  compiles to the same SHA256 with and without the guard. Fuzz: 2.46M execs,
+  no panic.
+
+  **Falsification:** wrong if `synth compile` of a wasm function with a
+  `≥0x1000`-byte static offset (`scripts/repro/add_imm_large.wat`) emits an empty
+  object or an address-truncated store (`add_imm_large_differential.py` would
+  drop below 8/8 vs wasmtime); or if `cargo +nightly fuzz run encoder_no_panic`
+  panics on any input. The four frozen behavior differentials (control_step
+  0x00210A55, flight_seam 0x07FDF307, div_const 338/338, mutex_pressure) stay
+  **byte-identical** — the change only adds a previously-erroring lowering path
+  and an adversarial-only `Err` guard.
+
 ## [0.11.43] - 2026-06-14
 
 **ON-TARGET SHIPPABILITY — gale #345: dissolved `--relocatable` objects are now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,14 +1925,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1981,11 +1981,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.43"
+version = "0.11.44"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "anyhow",
  "clap",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "anyhow",
  "serde",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2034,14 +2034,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2049,11 +2049,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.43"
+version = "0.11.44"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "anyhow",
  "clap",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.43"
+version = "0.11.44"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.43"
+version = "0.11.44"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.43",
+    version = "0.11.44",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.43" }
+synth-core = { path = "../synth-core", version = "0.11.44" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.43" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.43" }
+synth-core = { path = "../synth-core", version = "0.11.44" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.44" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.43" }
+synth-core = { path = "../synth-core", version = "0.11.44" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.43" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.43", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.44" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.44", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.43" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.43" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.43" }
-synth-backend = { path = "../synth-backend", version = "0.11.43" }
+synth-core = { path = "../synth-core", version = "0.11.44" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.44" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.44" }
+synth-backend = { path = "../synth-backend", version = "0.11.44" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.43", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.43", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.43", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.44", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.44", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.44", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.43", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.44", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.43" }
+synth-core = { path = "../synth-core", version = "0.11.44" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.43" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.44" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.43" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.43" }
-synth-opt = { path = "../synth-opt", version = "0.11.43" }
+synth-core = { path = "../synth-core", version = "0.11.44" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.44" }
+synth-opt = { path = "../synth-opt", version = "0.11.44" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.43" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.43" }
-synth-opt = { path = "../synth-opt", version = "0.11.43" }
+synth-core = { path = "../synth-core", version = "0.11.44" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.44" }
+synth-opt = { path = "../synth-opt", version = "0.11.44" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.43", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.44", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Release v0.11.44 — bug-fix (gale #350)

Bundles the encoder robustness fix for gale #350, already landed on `main`:

- **#351** — `encode_thumb32_add_imm` lowers `imm > 0xFFF` to `MOVW(/MOVT)+ADD-reg` instead of erroring. Previously a function with an indexed-address store at `offset > 0xFFF` (e.g. `i32.store offset=70000`, gale's struct-return `gale_k_stack_push_decide`) failed to compile → empty object.
- **#352** — the `rd==rn==R12` lowering path returns `Err` instead of a `debug_assert` panic, restoring the `encoder_no_panic` Ok-or-Err fuzz contract. Byte-identical for real codegen (R12 is non-allocatable; same SHA256 on the #350 repro with/without the guard).

### Gates
- `synth-backend` lib **201 passed**; `cargo +nightly fuzz run encoder_no_panic` → **2.46M execs, no panic**.
- #350 repro `add_imm_large_differential.py` → **8/8 vs wasmtime, ORACLE PASS**.
- Frozen differentials (control_step `0x00210A55`, flight_seam `0x07FDF307`, div_const 338/338, mutex_pressure) **byte-identical**.
- Pin sweep: workspace + 11 crate manifests + path-dep pins + MODULE.bazel + Cargo.lock all `0.11.43 → 0.11.44`.

Falsification statement in CHANGELOG. Tag pushed after this merges green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)