### PR TITLE
chore(release): v0.11.45 — #354 per-region .bss/.data split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.45] - 2026-06-14
+
+**ON-TARGET SHIPPABILITY — gale #354: a high-offset init segment no longer
+defeats the `.bss` split. Native-pointer mixed-memory modules (`stack`/`msgq`
+decides) ship a bounded `.data` instead of a 64 KiB PROGBITS blob.**
+
+- **#354 — per-region `.bss`/`.data` split for high-offset init segments**
+  (#356): the #345 zero-init split was binary
+  (`split_linmem_bss = native_layout.is_some() && data_segments.is_empty()`), so
+  ANY initialized `(data)` segment fell to the one-PROGBITS arm. A small
+  `.rodata` const at a HIGH linmem offset (gale's `stack_push`: a 12-byte
+  `0xfffffff4` = -12/-ENOMEM at offset 65536, above the 64 KiB shadow stack)
+  dragged the whole zero gap into a **65552-byte PROGBITS `.data`**
+  (MCU-unshippable; `msgq` was 65556). `build_relocatable_elf` now splits the
+  mixed case PER REGION using per-region **symbols**: the zero reservation is a
+  NOBITS `.bss` (`__synth_wasm_data`); each init segment is packed into a small
+  PROGBITS `.data` under its own `__synth_wasm_seg_K`; and every
+  `__synth_wasm_data + C` static reloc whose addend `C` lands in segment K is
+  retargeted to `__synth_wasm_seg_K + (C - seg_off_K)` — both the symbol AND the
+  in-place REL addend word in `.text` (`R_ARM_ABS32` is `S + A`). Per-region
+  *symbols* (not just sections) let the linker place the sections
+  independently — a single base symbol + selector-baked addends can't span the
+  link gap (the fragility the #345 code comment deferred). The selector is
+  untouched. **Safe-by-construction gate:** the split fires only when every init
+  segment sits at offset `>= wasm_data_base` (the SP-global init — the exact
+  static-vs-frame boundary the selector already uses) AND every
+  `__synth_wasm_data` reloc is the retargetable `Abs32` form; otherwise it falls
+  back to the one-PROGBITS arm (fat but always correct, never mis-addressed).
+  Measured on the `high_offset_init_segment_354` repro: `.data` **65552 → 16
+  bytes**, `.bss` 65548 NOBITS; the reloc retargets to `__synth_wasm_seg_0` with
+  the in-place addend rewritten 65544 → 8. This is the mixed-case deferred in the
+  #345 comment coming due — NOT a v0.11.44 regression; #350 just made
+  `stack_push` compile far enough to expose it.
+
+  **Falsification:** wrong if a native-pointer module with a `(data)` segment at
+  offset `>= wasm_data_base` still emits a 64 KiB PROGBITS `.data`; or if the
+  retargeted symbol/addend mis-resolves the const (the `native_pointer_shadow_stack`
+  differential would drop below ORACLE PASS). The non-mixed paths stay
+  byte-identical: `control_step` (non-native, `0x00210A55`) and
+  `native_pointer_bss` (the #345 all-zero NOBITS `.bss` shape) compile to the
+  same SHA with/without the change; the four frozen differentials (control_step
+  `0x00210A55`, flight_seam `0x07FDF307`, div_const 338/338, mutex_pressure)
+  stay green. **Closing gate is gale's on-target run** — `stack`/`msgq` `.data`
+  bounded + `stack_pop` shim+silicon end-to-end, to run when this tags; synth-side
+  is not marked verified alone.
+
 ## [0.11.44] - 2026-06-14
 
 **ENCODER ROBUSTNESS — gale #350: out-of-range `ADD #imm` now lowers instead of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,14 +1925,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1981,11 +1981,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.44"
+version = "0.11.45"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "anyhow",
  "clap",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "anyhow",
  "serde",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2034,14 +2034,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2049,11 +2049,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.44"
+version = "0.11.45"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "anyhow",
  "clap",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.44"
+version = "0.11.45"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.44"
+version = "0.11.45"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.44",
+    version = "0.11.45",
 )
 
 # Bazel dependencies

--- a/artifacts/gale-integration.yaml
+++ b/artifacts/gale-integration.yaml
@@ -541,9 +541,15 @@ artifacts:
       access against the symbol of the region the offset falls in. Sound
       only if init-data accesses are statically separable from the zero
       region (the rodata const is reached only by a static address, never by
-      a dynamic pointer that also walks the shadow stack) — to be confirmed
-      against gale's stack_push.loom.wasm before implementation.
-    status: proposed
+      a dynamic pointer that also walks the shadow stack) — the split fires
+      only when every init segment sits at offset >= wasm_data_base (the
+      SP-global init the selector uses for static-vs-frame), else it falls back
+      to the one-PROGBITS arm (correct, never mis-addressed). Implemented in
+      #356 (v0.11.45): per-region symbols (__synth_wasm_seg_K) + in-place REL
+      addend retargeting in build_relocatable_elf; selector untouched. On-target
+      confirmation (stack/msgq .data bounded + stack_pop shim+silicon) is gale's
+      gate, run when v0.11.45 tags.
+    status: implemented
     tags: [gale, native-pointer-abi, bss, elf, mcu-shippability, release-v0.11.45]
     links:
       - type: derives-from

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.44" }
+synth-core = { path = "../synth-core", version = "0.11.45" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.44" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.44" }
+synth-core = { path = "../synth-core", version = "0.11.45" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.45" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.44" }
+synth-core = { path = "../synth-core", version = "0.11.45" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.44" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.44", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.45" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.45", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.44" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.44" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.44" }
-synth-backend = { path = "../synth-backend", version = "0.11.44" }
+synth-core = { path = "../synth-core", version = "0.11.45" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.45" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.45" }
+synth-backend = { path = "../synth-backend", version = "0.11.45" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.44", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.44", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.44", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.45", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.45", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.45", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.44", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.45", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.44" }
+synth-core = { path = "../synth-core", version = "0.11.45" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.44" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.45" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.44" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.44" }
-synth-opt = { path = "../synth-opt", version = "0.11.44" }
+synth-core = { path = "../synth-core", version = "0.11.45" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.45" }
+synth-opt = { path = "../synth-opt", version = "0.11.45" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.44" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.44" }
-synth-opt = { path = "../synth-opt", version = "0.11.44" }
+synth-core = { path = "../synth-core", version = "0.11.45" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.45" }
+synth-opt = { path = "../synth-opt", version = "0.11.45" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.44", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.45", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Release v0.11.45 — feature (gale #354)

Bundles the per-region `.bss`/`.data` split for high-offset init segments (#356, on `main`): native-pointer mixed-memory modules (`stack`/`msgq` decides) now ship a **bounded `.data`** instead of a 64 KiB PROGBITS blob.

- **#354 / #356** — `build_relocatable_elf` splits the mixed case per region using per-region **symbols** (`__synth_wasm_seg_K`): zero reservation → NOBITS `.bss`; each init segment → small PROGBITS `.data`; static relocs whose addend lands in a segment are retargeted (symbol + in-place REL addend word). Safe-by-construction gate (offset ≥ `wasm_data_base` + Abs32-only); falls back to one-PROGBITS otherwise. Selector untouched.

### Gates
- Repro `.data` **65552 → 16 B**, `.bss` NOBITS; reloc → `__synth_wasm_seg_0`, addend 65544 → 8 (clean-room CONFIRMED).
- **Byte-identical** to main: `control_step` (non-native) + `native_pointer_bss` (#345 all-zero shape). Four frozen differentials green (control_step `0x00210A55`, flight_seam `0x07FDF307`, div_const 338/338, mutex_pressure). `native_pointer_shadow_stack` differential ORACLE PASS.
- Pin sweep: workspace + 11 crate manifests + path-deps + MODULE.bazel + Cargo.lock `0.11.44 → 0.11.45`. rivet GI-NPA-004 → implemented (0 non-xref errors).

Falsification statement in CHANGELOG; **closing gate is gale's on-target run** (`stack`/`msgq` `.data` bounded + `stack_pop` shim+silicon), which gale runs when this tags. Tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)