### PR TITLE
fix(selector): #359 — full AAPCS i32 stack arguments (calls/params with >4 args)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -75,7 +75,20 @@ impl Backend for ArmBackend {
         let mut functions = Vec::new();
         for func in &exports {
             let name = func.export_name.clone().unwrap();
-            let compiled = self.compile_function(&name, &func.ops, config)?;
+            // #359: copy THIS function's declared param widths into the config so
+            // `compile_function` (which carries no function index) can refuse a
+            // 64-bit param on the AAPCS stack-argument path. Cheap clone only when
+            // a signature table is present and this function has a width entry —
+            // otherwise reuse the shared config (every existing module unchanged).
+            let func_config = match config.func_params_i64.get(func.index as usize) {
+                Some(p) if !p.is_empty() => Some(CompileConfig {
+                    current_func_params_i64: p.clone(),
+                    ..config.clone()
+                }),
+                _ => None,
+            };
+            let cfg = func_config.as_ref().unwrap_or(config);
+            let compiled = self.compile_function(&name, &func.ops, cfg)?;
             functions.push(compiled);
         }
 
@@ -184,6 +197,9 @@ fn compile_wasm_to_arm(
         selector.set_native_pointer_abi(config.native_pointer_abi, config.linear_memory_bytes);
         // #311: i64 call results are register PAIRS — tag them.
         selector.set_result_types(config.func_ret_i64.clone(), config.type_ret_i64.clone());
+        // #359: declared param widths of THIS function, so the AAPCS stack-arg
+        // path can refuse 64-bit params (Ok-or-Err). Empty ⇒ assume i32.
+        selector.set_params_i64(config.current_func_params_i64.clone());
         // Stack-pointer promotion is meaningful only under the native-pointer ABI;
         // gating here keeps every non-native compile (all frozen fixtures) on the
         // legacy R9 globals-table path, bit-identical.

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1756,6 +1756,7 @@ fn compile_all_exports(
         all_globals, // #237: every defined global (index, init) — slot region under --native-pointer-abi
         all_func_ret_i64, // #311: per-function returns-i64 (pair tagging)
         all_type_ret_i64, // #311: per-type returns-i64 (call_indirect)
+        all_func_params_i64, // #359: per-function declared param widths (stack-arg ABI)
     ) = if path.extension().is_some_and(|ext| ext == "wast") {
         info!("Parsing WAST (extracting all modules)...");
         let contents = String::from_utf8(file_bytes).context("WAST file is not valid UTF-8")?;
@@ -1851,6 +1852,7 @@ fn compile_all_exports(
             Vec::new(), // #237: globals slot region is single-module .wasm only
             Vec::new(), // #311: WAST runs the fixture suite; i32-only
             Vec::new(),
+            Vec::new(), // #359: WAST fixture suite is i32-only — no stack params
         )
     } else {
         let wasm_bytes = if path.extension().is_some_and(|ext| ext == "wat") {
@@ -1913,6 +1915,7 @@ fn compile_all_exports(
             globals,
             module.func_ret_i64,
             module.type_ret_i64,
+            module.func_params_i64,
         )
     };
 
@@ -1982,6 +1985,10 @@ fn compile_all_exports(
         stack_pointer_global: stack_pointer_global_opt,
         func_ret_i64: all_func_ret_i64.clone(),
         type_ret_i64: all_type_ret_i64.clone(),
+        // #359: indexed declared param widths (per full function index) — the
+        // source of truth for the AAPCS stack-argument refusal. The per-function
+        // `current_func_params_i64` is derived from this in the compile loop.
+        func_params_i64: all_func_params_i64.clone(),
         ..CompileConfig::default()
     };
 
@@ -2009,7 +2016,23 @@ fn compile_all_exports(
         // output object. Callers that need it get a link error naming the
         // missing symbol, which is far more actionable than a whole-module
         // failure on dead-weight pulled in by `--whole-archive`.
-        let compiled = match backend.compile_function(&name, &func.ops, &config) {
+        // #359: tell the backend the CURRENT function's declared param widths
+        // (indexed by full function index). The AAPCS stack-argument path needs
+        // the declared widths — an unused i64 param still shifts the layout, so
+        // op-stream inference cannot reconstruct them. Cheap per-function clone
+        // (`compile_function` is a shared trait method with no function index).
+        let func_config = if all_func_params_i64
+            .get(func.index as usize)
+            .is_some_and(|p| !p.is_empty())
+        {
+            CompileConfig {
+                current_func_params_i64: all_func_params_i64[func.index as usize].clone(),
+                ..config.clone()
+            }
+        } else {
+            config.clone()
+        };
+        let compiled = match backend.compile_function(&name, &func.ops, &func_config) {
             Ok(c) => c,
             Err(e) => {
                 eprintln!(

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -139,6 +139,22 @@ pub struct CompileConfig {
     /// invisible to liveness.
     pub func_ret_i64: Vec<bool>,
     pub type_ret_i64: Vec<bool>,
+    /// #359: declared parameter widths per *function* (full index, imports
+    /// first): `func_params_i64[f][k]` is true when param `k` of function `f` is
+    /// i64/f64. The AAPCS stack-argument path needs the *declared* widths
+    /// (op-stream inference can't see an unused i64 param that still shifts the
+    /// incoming-stack layout). The source of truth — a per-function driver loop
+    /// (`compile_module` / the CLI loop) indexes it by `func.index` and copies
+    /// the slice into [`current_func_params_i64`] before each `compile_function`.
+    /// Empty → every param assumed i32 (the legacy path; keeps every function
+    /// with <=4 params, or all-i32 params, byte-identical).
+    pub func_params_i64: Vec<Vec<bool>>,
+    /// #359: declared parameter widths of the function CURRENTLY being compiled
+    /// — `current_func_params_i64[k]` is true when param `k` is i64/f64. Set per
+    /// function (a cheap clone of the config) from [`func_params_i64`] by the
+    /// driver loop, because `compile_function` is shared across backends and
+    /// carries no function index. Empty → assume i32.
+    pub current_func_params_i64: Vec<bool>,
 }
 
 impl CompileConfig {
@@ -172,6 +188,8 @@ impl Default for CompileConfig {
             stack_pointer_global: None,
             func_ret_i64: Vec::new(),
             type_ret_i64: Vec::new(),
+            func_params_i64: Vec::new(),
+            current_func_params_i64: Vec::new(),
         }
     }
 }

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -103,6 +103,11 @@ pub struct DecodedModule {
     pub func_ret_i64: Vec<bool>,
     /// #311: whether each *function type* returns i64 (for `call_indirect`).
     pub type_ret_i64: Vec<bool>,
+    /// #359: declared parameter widths per *function* (full index, imports
+    /// first): `func_params_i64[f][k]` is true when param `k` is i64/f64. The
+    /// AAPCS stack-argument path needs the declared widths — op-stream inference
+    /// can't see an unused i64 param that still shifts the incoming-stack layout.
+    pub func_params_i64: Vec<Vec<bool>>,
     /// Defined globals with their initializers (#237). Empty if the module has
     /// no global section. Used by the native-pointer ABI to make a global whose
     /// initializer is a linear-memory address (e.g. `$__stack_pointer`)
@@ -133,6 +138,9 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     let mut func_arg_counts: Vec<u32> = Vec::new();
     let mut type_ret_i64: Vec<bool> = Vec::new();
     let mut func_ret_i64: Vec<bool> = Vec::new();
+    // #359: declared param widths per type / per function (full index).
+    let mut type_params_i64: Vec<Vec<bool>> = Vec::new();
+    let mut func_params_i64: Vec<Vec<bool>> = Vec::new();
     let mut elem_func_indices: Vec<u32> = Vec::new();
 
     for payload in Parser::new(0).parse_all(wasm_bytes) {
@@ -145,18 +153,33 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                 for rec_group in reader {
                     let rec_group = rec_group.context("Failed to parse type")?;
                     for sub_ty in rec_group.types() {
-                        let (count, ret_i64) = match &sub_ty.composite_type.inner {
+                        let (count, ret_i64, params_i64) = match &sub_ty.composite_type.inner {
                             wasmparser::CompositeInnerType::Func(func_ty) => (
                                 func_ty.params().len() as u32,
                                 func_ty
                                     .results()
                                     .first()
                                     .is_some_and(|t| *t == wasmparser::ValType::I64),
+                                // #359: i64/f64 params occupy 8 bytes / a register
+                                // pair under AAPCS. f32/f64 are not in scope for the
+                                // stack-arg path (refused), but mark both 64-bit
+                                // float and i64 so the guard catches them.
+                                func_ty
+                                    .params()
+                                    .iter()
+                                    .map(|t| {
+                                        matches!(
+                                            t,
+                                            wasmparser::ValType::I64 | wasmparser::ValType::F64
+                                        )
+                                    })
+                                    .collect::<Vec<bool>>(),
                             ),
-                            _ => (0, false),
+                            _ => (0, false, Vec::new()),
                         };
                         type_arg_counts.push(count);
                         type_ret_i64.push(ret_i64);
+                        type_params_i64.push(params_i64);
                     }
                 }
             }
@@ -176,6 +199,12 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                                     .get(type_idx as usize)
                                     .copied()
                                     .unwrap_or(false),
+                            );
+                            func_params_i64.push(
+                                type_params_i64
+                                    .get(type_idx as usize)
+                                    .cloned()
+                                    .unwrap_or_default(),
                             );
                             (ImportKind::Function(type_idx), idx)
                         }
@@ -206,6 +235,12 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                             .get(type_idx as usize)
                             .copied()
                             .unwrap_or(false),
+                    );
+                    func_params_i64.push(
+                        type_params_i64
+                            .get(type_idx as usize)
+                            .cloned()
+                            .unwrap_or_default(),
                     );
                 }
             }
@@ -320,6 +355,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
         type_arg_counts,
         func_ret_i64,
         type_ret_i64,
+        func_params_i64,
         globals,
         elem_func_indices,
     })

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -10692,6 +10692,70 @@ mod tests {
         );
     }
 
+    /// #359: the CallIndirect path (distinct from direct Call) must also stack-
+    /// pass args beyond the 4th — store the 5th arg to the outgoing region.
+    #[test]
+    fn test_359_call_indirect_fifth_arg_on_stack() {
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        // type 0 takes 5 i32 args (CallIndirect reads the count from the type).
+        selector.set_func_arg_counts(Vec::new(), vec![5]);
+        let wasm_ops = vec![
+            WasmOp::I32Const(10),
+            WasmOp::I32Const(20),
+            WasmOp::I32Const(30),
+            WasmOp::I32Const(40),
+            WasmOp::I32Const(50), // arg4 → outgoing stack
+            WasmOp::I32Const(0),  // table index (popped first)
+            WasmOp::CallIndirect {
+                type_index: 0,
+                table_index: 0,
+            },
+        ];
+        let r = selector.select_with_stack(&wasm_ops, 0);
+        // Either it lowers with the 5th arg on the outgoing stack, or it returns a
+        // typed Err — NEVER a silent drop. (CallIndirect dispatch may be Unsupported
+        // on some configs; the contract is Ok-or-Err.)
+        if let Ok(arm) = r
+            && let Some(bl) = arm
+                .iter()
+                .position(|i| matches!(&i.op, ArmOp::Bl { .. } | ArmOp::Blx { .. }))
+        {
+            assert!(
+                arm[..bl].iter().any(|i| matches!(&i.op, ArmOp::Str { addr, .. } if addr.base == Reg::SP && addr.offset == 0)),
+                "CallIndirect 5th arg must be stored to the outgoing stack: {arm:#?}"
+            );
+        }
+    }
+
+    /// #359: a non-param local AND a >4-arg call coexist — the outgoing-arg area
+    /// sits at the frame bottom, so the local's slot is shifted up by it. Must
+    /// still compile (exercises the frame-shift) and the call must stack-pass arg4.
+    #[test]
+    fn test_359_local_coexists_with_stack_arg_call() {
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        selector.set_func_arg_counts(vec![0, 0, 0, 5], Vec::new());
+        let wasm_ops = vec![
+            WasmOp::I32Const(7),
+            WasmOp::LocalSet(0), // a non-param local (idx 0, num_params=0)
+            WasmOp::I32Const(10),
+            WasmOp::I32Const(20),
+            WasmOp::I32Const(30),
+            WasmOp::I32Const(40),
+            WasmOp::I32Const(50),
+            WasmOp::Call(3),
+            WasmOp::LocalGet(0), // read the local back (its slot was shifted up)
+        ];
+        let arm = selector.select_with_stack(&wasm_ops, 0).unwrap();
+        assert!(
+            arm.iter().any(
+                |i| matches!(&i.op, ArmOp::Str { addr, .. } if addr.base == Reg::SP && addr.offset == 0)
+            ),
+            "the 5-arg call must still store arg4 to the outgoing region: {arm:#?}"
+        );
+    }
+
     /// #195 + #188 compose: gale's `z_impl_k_sem_give` shape — a value is live
     /// across a call that ALSO takes an argument. Both must hold: (a) the arg is
     /// passed in R0, and (b) the live value (param0) is preserved across the

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -163,6 +163,13 @@ impl StackVal {
     fn i64(reg: Reg) -> Self {
         StackVal::Reg { reg, is_i64: true }
     }
+    /// Width of this operand-stack value.
+    #[inline]
+    fn is_i64(&self) -> bool {
+        match self {
+            StackVal::Reg { is_i64, .. } | StackVal::Spilled { is_i64, .. } => *is_i64,
+        }
+    }
 }
 
 /// Number of i64 spill slots reserved in the frame (#171). Each is 8 bytes
@@ -813,6 +820,13 @@ struct LocalLayout {
     /// never clobbered in its home reg between reads. Appended last so existing
     /// local/spill offsets are unchanged.
     param_slots: std::collections::HashMap<u32, (i32, bool)>,
+    /// #359: frame slot (offset from SP) per incoming stack-passed param the fn
+    /// references — wasm param indices in `[4, num_params)` that AAPCS delivers
+    /// on the caller's stack (not in r0..r3). Computed AFTER `frame_size` is
+    /// finalized: such a param sits at `[sp, frame_size + 24 + (k-4)*4]` (24 =
+    /// the fixed `push {r4-r8,lr}`). i32-only; an i64/f64 stack param is an
+    /// Ok-or-Err refusal at the use site. Empty unless `num_params > 4`.
+    incoming_params: std::collections::HashMap<u32, i32>,
     /// Whether the `i64_spill_base` area was actually reserved
     /// (`has_i64 || force_spill_area`). Mirrored into
     /// [`SpillState::area_reserved`]; see that field for why (#326).
@@ -841,6 +855,7 @@ fn compute_local_layout(
     type_ret_i64: &[bool],
     force_spill_area: bool,
     force_param_backing: bool,
+    outgoing_arg_bytes: i32,
 ) -> LocalLayout {
     use std::collections::{BTreeSet, HashMap};
     let i64_set = infer_i64_locals(wasm_ops, func_ret_i64, type_ret_i64);
@@ -859,7 +874,14 @@ fn compute_local_layout(
     }
 
     let mut locals: HashMap<u32, (i32, bool)> = HashMap::new();
-    let mut offset: i32 = 0;
+    // #359: reserve the AAPCS outgoing stack-argument region at the BOTTOM of
+    // the frame (offset 0). Every other frame field accumulates from `offset`,
+    // so initializing it to `outgoing_arg_bytes` shifts locals, spill_base,
+    // i64_spill_base and param_slots up by exactly that amount. When 0 (no call
+    // passes >4 args), the frame is byte-identical to before. `outgoing_arg_bytes`
+    // is always a multiple of 8 (rounded by the caller) so the downstream
+    // `offset % 8` alignment checks are preserved exactly.
+    let mut offset: i32 = outgoing_arg_bytes;
     for &idx in &used {
         let is_i64 = i64_set.contains(&idx);
         // i64 locals require 8-byte alignment.
@@ -955,12 +977,38 @@ fn compute_local_layout(
     // Round frame to 8-byte multiple for AAPCS SP alignment.
     let frame_size = (offset + 7) & !7;
 
+    // #359: locate the incoming stack-passed params (wasm idx in [4, num_params)
+    // that AAPCS delivers on the caller's stack). After `push {r4-r8,lr}` (24
+    // bytes) + `sub sp,#frame_size`, param k sits at
+    // `[sp, frame_size + 24 + (k-4)*4]`. Only the params actually referenced are
+    // recorded. Empty when num_params <= 4. i32-only is enforced at the use site
+    // (Ok-or-Err) — the offset is the same regardless of width.
+    let mut incoming_params: HashMap<u32, i32> = HashMap::new();
+    if num_params > 4 {
+        const FIXED_PUSH_BYTES: i32 = 24; // push {r4,r5,r6,r7,r8,lr}
+        let mut used_incoming: BTreeSet<u32> = BTreeSet::new();
+        for op in wasm_ops {
+            let k = match op {
+                WasmOp::LocalGet(idx) | WasmOp::LocalSet(idx) | WasmOp::LocalTee(idx) => *idx,
+                _ => continue,
+            };
+            if (4..num_params).contains(&k) {
+                used_incoming.insert(k);
+            }
+        }
+        for &k in &used_incoming {
+            let off = frame_size + FIXED_PUSH_BYTES + (k as i32 - 4) * 4;
+            incoming_params.insert(k, off);
+        }
+    }
+
     LocalLayout {
         locals,
         frame_size,
         spill_base,
         i64_spill_base,
         param_slots,
+        incoming_params,
         spill_area_reserved: has_i64,
     }
 }
@@ -1377,6 +1425,11 @@ pub struct InstructionSelector {
     func_ret_i64: Vec<bool>,
     /// #311: whether type `i` returns i64 (`call_indirect`).
     type_ret_i64: Vec<bool>,
+    /// #359: declared param widths of the function being compiled —
+    /// `params_i64[k]` true ⇒ param `k` is i64/f64. The AAPCS stack-argument
+    /// path refuses (Ok-or-Err) when any param is 64-bit. Empty ⇒ assume i32
+    /// (the legacy path; every function with <=4 i32 params is byte-identical).
+    params_i64: Vec<bool>,
     /// AAPCS argument count per function, indexed by the *full* WASM function
     /// index (imports first, then locals). Plumbed from the frontend's type +
     /// function sections (issue #195). `func_arg_counts[i]` = number of integer
@@ -1443,6 +1496,7 @@ impl InstructionSelector {
             sp_global: None,
             func_ret_i64: Vec::new(),
             type_ret_i64: Vec::new(),
+            params_i64: Vec::new(),
             func_arg_counts: Vec::new(),
             type_arg_counts: Vec::new(),
             fpu: None,
@@ -1471,6 +1525,7 @@ impl InstructionSelector {
             sp_global: None,
             func_ret_i64: Vec::new(),
             type_ret_i64: Vec::new(),
+            params_i64: Vec::new(),
             func_arg_counts: Vec::new(),
             type_arg_counts: Vec::new(),
             fpu: None,
@@ -1553,6 +1608,13 @@ impl InstructionSelector {
     pub fn set_result_types(&mut self, func_ret_i64: Vec<bool>, type_ret_i64: Vec<bool>) {
         self.func_ret_i64 = func_ret_i64;
         self.type_ret_i64 = type_ret_i64;
+    }
+
+    /// #359: register the declared parameter widths of the function about to be
+    /// compiled so the AAPCS stack-argument path can refuse 64-bit params
+    /// (Ok-or-Err). Empty ⇒ all params assumed i32 (the legacy path).
+    pub fn set_params_i64(&mut self, params_i64: Vec<bool>) {
+        self.params_i64 = params_i64;
     }
 
     pub fn set_native_pointer_stack(&mut self, sp_index: u32, sp_init: i32) {
@@ -4737,7 +4799,27 @@ impl InstructionSelector {
         arg_count: u32,
         idx: usize,
     ) -> Result<Vec<Reg>> {
-        let n = (arg_count as usize).min(ARG_REGS.len());
+        // #359: pop ALL `arg_count` operands (previously only the top 4, which
+        // for a >4-arg call dropped arg0 and shifted args into r0..r3). After the
+        // reverse, `srcs[0..N]` == arg0..argN-1; the caller marshals srcs[0..4]
+        // into r0..r3 and stores srcs[4..N] to the outgoing stack region.
+        let n = arg_count as usize;
+        // #359 Ok-or-Err (#180/#185): a stack-passed arg (index >= 4) that is i64
+        // would be stored as a single 4-byte STR (silent lo-half truncation) —
+        // the register conversion below discards width. Refuse before popping.
+        // The top of `stack` is the LAST arg, so arg index k sits at
+        // `stack[stack.len() - n + k]`.
+        if n > ARG_REGS.len() && stack.len() >= n {
+            let base = stack.len() - n;
+            for k in ARG_REGS.len()..n {
+                if stack[base + k].is_i64() {
+                    return Err(synth_core::Error::synthesis(format!(
+                        "#359: call arg {k} is passed on the stack and is i64/f64; \
+                         only i32 stack args are supported"
+                    )));
+                }
+            }
+        }
         let mut srcs: Vec<Reg> = Vec::with_capacity(n);
         for _ in 0..n {
             let r = pop_operand(stack, next_temp, instructions, spill, &[], idx)?;
@@ -4745,6 +4827,44 @@ impl InstructionSelector {
         }
         srcs.reverse();
         Ok(srcs)
+    }
+
+    /// #359: spill the stack-passed call arguments (index >= 4) into the
+    /// outgoing-argument region at the bottom of the current frame, BEFORE
+    /// caller-saved preservation, the CallIndirect table-index relocation, and
+    /// the r0..r3 parallel move. The popped arg registers are NOT in
+    /// `stack_live_regs`, so any of those later steps could otherwise clobber a
+    /// stack-arg source; storing first (there is no dynamic SP, so `[sp,#imm]` is
+    /// valid the instant after the pop) closes every clobber window.
+    ///
+    /// `arg_srcs[k]` for k in 4..N goes to `[sp, (k-4)*4]`. Returns the count of
+    /// instructions emitted (for the cf counter). Ok-or-Err (#180/#185): refuses
+    /// when a computed `[sp,#imm]` offset exceeds the 12-bit (4095) immediate.
+    fn emit_stack_args(
+        &self,
+        instructions: &mut Vec<ArmInstruction>,
+        arg_srcs: &[Reg],
+        idx: usize,
+    ) -> Result<usize> {
+        let mut emitted = 0;
+        for (k, &src) in arg_srcs.iter().enumerate().skip(ARG_REGS.len()) {
+            let off = (k as i32 - ARG_REGS.len() as i32) * 4;
+            if off > 4095 {
+                return Err(synth_core::Error::synthesis(format!(
+                    "#359: outgoing stack-arg offset {off} exceeds the 12-bit \
+                     [sp,#imm] range"
+                )));
+            }
+            instructions.push(ArmInstruction {
+                op: ArmOp::Str {
+                    rd: src,
+                    addr: MemAddr::imm(Reg::SP, off),
+                },
+                source_line: Some(idx),
+            });
+            emitted += 1;
+        }
+        Ok(emitted)
     }
 
     /// #195: Emit the cycle-safe parallel move of call arguments into R0–R3.
@@ -5094,6 +5214,72 @@ impl InstructionSelector {
         // a panic deep in the selector's pop sequence (see PR #117).
         synth_core::wasm_stack_check::check_no_underflow(wasm_ops)?;
 
+        // #359: AAPCS stack arguments. We pass params index>=4 on the outgoing
+        // stack and read incoming params index>=4 from the caller's stack. The
+        // frame-reserved (no dynamic SP) scheme this implements bounds the count:
+        // refuse functions with more than 8 scalar params (the [sp,#imm] offsets
+        // and the outgoing-region size stay small and in-range). Ok-or-Err — this
+        // repo is never silently wrong (#180/#185).
+        if num_params > 8 {
+            return Err(synth_core::Error::synthesis(format!(
+                "#359: function has {num_params} params; the AAPCS stack-argument \
+                 path supports at most 8 scalar params"
+            )));
+        }
+        // #359 Ok-or-Err (#180/#185): the register-homing + incoming-stack-slot
+        // scheme assumes every param is a 4-byte i32. A 64-bit param (i64/f64)
+        // occupies a register PAIR / 8-byte stack slot and shifts which params
+        // land on the stack — even an UNUSED one. Declared widths (not op-stream
+        // inference, which can't see an unused i64 param) drive this refusal.
+        // Gated on num_params>4: a <=4-param function never touches the stack-arg
+        // path, so the legacy i64-param handling (param_slots) is unchanged and
+        // every existing fixture stays byte-identical. Empty `params_i64`
+        // (no signature plumbed, e.g. unit tests) ⇒ assume i32.
+        if num_params > 4 && self.params_i64.iter().take(num_params as usize).any(|&w| w) {
+            return Err(synth_core::Error::synthesis(format!(
+                "#359: function has {num_params} params including a 64-bit (i64/f64) \
+                 param; the AAPCS stack-argument path supports only i32 params"
+            )));
+        }
+
+        // #359: size of the outgoing stack-argument region = the max over all
+        // Call/CallIndirect sites of `max(0, arg_count - 4) * 4`, rounded up to 8.
+        // Reserved at the BOTTOM of the frame (offset 0) by `compute_local_layout`.
+        // 0 when every call passes <=4 args — the frame is then byte-identical to
+        // the pre-#359 layout. `saturating_sub` avoids the u32 underflow that would
+        // otherwise inflate the region for every small-arg call.
+        let mut max_stack_args: u32 = 0;
+        for op in wasm_ops {
+            let arg_count = match op {
+                Call(func_idx) => {
+                    // Meld dispatch imports take no AAPCS args (index in R0).
+                    let is_import = *func_idx < self.num_imports;
+                    if is_import && !self.relocatable {
+                        0
+                    } else {
+                        self.func_arg_counts
+                            .get(*func_idx as usize)
+                            .copied()
+                            .unwrap_or(0)
+                    }
+                }
+                CallIndirect { type_index, .. } => self
+                    .type_arg_counts
+                    .get(*type_index as usize)
+                    .copied()
+                    .unwrap_or(0),
+                _ => continue,
+            };
+            if arg_count > 8 {
+                return Err(synth_core::Error::synthesis(format!(
+                    "#359: call passes {arg_count} args; the AAPCS stack-argument \
+                     path supports at most 8 scalar args"
+                )));
+            }
+            max_stack_args = max_stack_args.max(arg_count.saturating_sub(4));
+        }
+        let outgoing_arg_bytes = ((max_stack_args as i32) * 4 + 7) & !7;
+
         let mut instructions = Vec::new();
 
         // Function prologue: save callee-saved registers and LR, then
@@ -5117,7 +5303,22 @@ impl InstructionSelector {
             &self.type_ret_i64,
             self.spill_on_exhaustion,
             self.param_backing_on_exhaustion,
+            outgoing_arg_bytes,
         );
+        // #359 Ok-or-Err (#180/#185): an incoming stack-passed param is read via
+        // `ldr rd,[sp,#off]` where `off = frame_size + 24 + (k-4)*4` and
+        // `frame_size` is unbounded (a function with a large locals frame). The
+        // Thumb-2 `ldr [sp,#imm]` immediate is 12-bit (0..4095); refuse rather
+        // than silently emit an out-of-range encoding. Checked once here over the
+        // finalized layout instead of at each use site.
+        if let Some(&max_off) = layout.incoming_params.values().max()
+            && max_off > 4095
+        {
+            return Err(synth_core::Error::synthesis(format!(
+                "#359: incoming stack-param offset {max_off} exceeds the 12-bit \
+                 [sp,#imm] range (frame too large for the stack-argument path)"
+            )));
+        }
         // Allocate stack space for non-param locals so they don't alias the
         // callee-saved-register spill area (which immediately follows SP
         // after Push above).
@@ -5248,12 +5449,35 @@ impl InstructionSelector {
             }
             match op {
                 LocalGet(local_idx) => {
+                    // #359: an incoming stack-passed param (idx in [4,num_params))
+                    // is i32 by construction — a 64-bit param is refused up front
+                    // in `select_with_stack` (declared-width guard), so this path
+                    // only ever sees i32 stack params.
                     // Get the register for this local. Three cases:
                     //  1. Param in register — use the cached mapping.
                     //  2. Spilled i64 local — load both halves via I64Ldr.
                     //  3. Spilled i32 local — single Ldr.
                     let (reg, val_is_i64) =
-                        if let Some(&(off, is_i64)) = layout.param_slots.get(local_idx) {
+                        if let Some(&off) = layout.incoming_params.get(local_idx) {
+                            // #359: read the incoming stack-passed param into a
+                            // fresh temp pushed on the vstack — NOT register-homed.
+                            let dst = alloc_temp_or_spill(
+                                &mut next_temp,
+                                &mut stack,
+                                &mut instructions,
+                                &mut spill,
+                                &live_params,
+                                idx,
+                            )?;
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Ldr {
+                                    rd: dst,
+                                    addr: MemAddr::imm(Reg::SP, off),
+                                },
+                                source_line: Some(idx),
+                            });
+                            (dst, false)
+                        } else if let Some(&(off, is_i64)) = layout.param_slots.get(local_idx) {
                             // #204/#193: frame-backed param — reload from its slot.
                             if is_i64 {
                                 let (dst_lo, dst_hi) = alloc_consecutive_pair(
@@ -7338,6 +7562,16 @@ impl InstructionSelector {
                         idx,
                     )?;
 
+                    // #359: store args index>=4 to the outgoing stack region
+                    // BEFORE preservation and the r0..r3 move (their sources are
+                    // already popped, so the move could otherwise clobber them).
+                    let n_stack_args = self.emit_stack_args(&mut instructions, &arg_srcs, idx)?;
+                    for _ in 0..n_stack_args {
+                        cf.add_instruction();
+                    }
+                    // Only the first <=4 args are marshalled into r0..r3.
+                    let reg_srcs = &arg_srcs[..arg_srcs.len().min(ARG_REGS.len())];
+
                     // ── #188: caller-saved preservation across the call ──
                     // A BL clobbers R0–R3 and R12. Any live value (operand-stack
                     // temp or param) residing in one of those registers and needed
@@ -7358,7 +7592,7 @@ impl InstructionSelector {
                     // parallel move so chains/swaps among R0–R3 are handled.
                     let n_arg_moves = self.emit_arg_moves(
                         &mut instructions,
-                        &arg_srcs,
+                        reg_srcs,
                         &stack_live_regs(&stack),
                         &local_to_reg,
                         &layout,
@@ -7448,6 +7682,17 @@ impl InstructionSelector {
                         idx,
                     )?;
 
+                    // #359: store args index>=4 to the outgoing stack region
+                    // BEFORE the table-index relocation (free_callee_saved below
+                    // could pick an R4–R8 reg still holding a stack-arg source),
+                    // preservation, and the r0..r3 move. The popped arg regs are
+                    // not in stack_live_regs, so storing first closes the window.
+                    let n_stack_args = self.emit_stack_args(&mut instructions, &arg_srcs, idx)?;
+                    for _ in 0..n_stack_args {
+                        cf.add_instruction();
+                    }
+                    let reg_srcs = &arg_srcs[..arg_srcs.len().min(ARG_REGS.len())];
+
                     // #195: the arg moves write R0–R3, but the `CallIndirect`
                     // expansion reads `table_idx_reg` to compute the branch
                     // target (and clobbers R12). When there are args to marshal,
@@ -7457,7 +7702,7 @@ impl InstructionSelector {
                     // marshalling so every `free_callee_saved` call avoids it,
                     // then pop it back off just before emitting the call.
                     let mut table_pushed = false;
-                    if !arg_srcs.is_empty() {
+                    if !reg_srcs.is_empty() {
                         let safe = self.free_callee_saved(
                             &stack_live_regs(&stack),
                             &local_to_reg,
@@ -7494,7 +7739,7 @@ impl InstructionSelector {
                     // index on the stack keeps the scratch picker away from it.
                     let n_arg_moves = self.emit_arg_moves(
                         &mut instructions,
-                        &arg_srcs,
+                        reg_srcs,
                         &stack_live_regs(&stack),
                         &local_to_reg,
                         &layout,
@@ -7669,7 +7914,19 @@ impl InstructionSelector {
                         &live_params,
                         idx,
                     )?;
-                    if let Some(&(off, is_i64)) = layout.param_slots.get(local_idx) {
+                    if let Some(&off) = layout.incoming_params.get(local_idx) {
+                        // #359: write to the incoming stack-passed param's slot.
+                        // i32 by construction — a 64-bit param is refused up front
+                        // in `select_with_stack`.
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Str {
+                                rd: val,
+                                addr: MemAddr::imm(Reg::SP, off),
+                            },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    } else if let Some(&(off, is_i64)) = layout.param_slots.get(local_idx) {
                         // #204/#193: frame-backed param — store to its slot.
                         let op = if is_i64 {
                             ArmOp::I64Str {
@@ -7749,7 +8006,19 @@ impl InstructionSelector {
                         &live_params,
                         idx,
                     )?;
-                    if let Some(&(off, is_i64)) = layout.param_slots.get(local_idx) {
+                    if let Some(&off) = layout.incoming_params.get(local_idx) {
+                        // #359: write to the incoming stack-passed param's slot;
+                        // value stays on the operand stack (peek kept it). i32 by
+                        // construction — a 64-bit param is refused up front.
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Str {
+                                rd: val,
+                                addr: MemAddr::imm(Reg::SP, off),
+                            },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    } else if let Some(&(off, is_i64)) = layout.param_slots.get(local_idx) {
                         // #204/#193: frame-backed param — store to its slot; value
                         // stays on the operand stack (peek kept it).
                         let op = if is_i64 {
@@ -15198,7 +15467,7 @@ mod tests {
     fn test_compute_local_layout_no_locals() {
         // Function with only params and no LocalGet/Set produces zero frame.
         let ops = vec![WasmOp::LocalGet(0), WasmOp::LocalGet(1), WasmOp::I32Add];
-        let layout = compute_local_layout(&ops, 2, &[], &[], false, false);
+        let layout = compute_local_layout(&ops, 2, &[], &[], false, false, 0);
         assert_eq!(layout.frame_size, 0);
         assert!(layout.locals.is_empty());
     }
@@ -15211,7 +15480,7 @@ mod tests {
             WasmOp::LocalSet(1),
             WasmOp::LocalGet(1),
         ];
-        let layout = compute_local_layout(&ops, 1, &[], &[], false, false);
+        let layout = compute_local_layout(&ops, 1, &[], &[], false, false, 0);
         assert!(layout.locals.contains_key(&1));
         let (off, is_i64) = layout.locals[&1];
         assert_eq!(off, 0);
@@ -15228,7 +15497,7 @@ mod tests {
             WasmOp::LocalSet(0),
             WasmOp::LocalGet(0),
         ];
-        let layout = compute_local_layout(&ops, 0, &[], &[], false, false);
+        let layout = compute_local_layout(&ops, 0, &[], &[], false, false, 0);
         let (off, is_i64) = layout.locals[&0];
         assert_eq!(off, 0);
         assert!(is_i64);
@@ -15248,7 +15517,7 @@ mod tests {
             WasmOp::I64Const(2),
             WasmOp::LocalSet(1),
         ];
-        let layout = compute_local_layout(&ops, 0, &[], &[], false, false);
+        let layout = compute_local_layout(&ops, 0, &[], &[], false, false, 0);
         let (off0, is_i64_0) = layout.locals[&0];
         let (off1, is_i64_1) = layout.locals[&1];
         assert_eq!(off0, 0);
@@ -15270,7 +15539,7 @@ mod tests {
             WasmOp::I32Add,
             WasmOp::LocalSet(2),
         ];
-        let layout = compute_local_layout(&ops, 2, &[], &[], false, false);
+        let layout = compute_local_layout(&ops, 2, &[], &[], false, false, 0);
         // Only idx 2 should be in the layout.
         assert!(!layout.locals.contains_key(&0));
         assert!(!layout.locals.contains_key(&1));
@@ -15530,6 +15799,7 @@ mod tests {
             spill_base: None,
             i64_spill_base: 0,
             param_slots: std::collections::HashMap::new(),
+            incoming_params: std::collections::HashMap::new(),
             spill_area_reserved,
         }
     }

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -10603,6 +10603,95 @@ mod tests {
         );
     }
 
+    /// #359: a call with 5 i32 args must pass args 0..3 in r0..r3 AND arg4 on the
+    /// outgoing stack at [sp,#0] (frame-bottom outgoing region) — NOT drop arg0.
+    /// Pre-fix `pop_call_args` popped only the top 4 (args 1..4), dropping arg0.
+    #[test]
+    fn test_359_fifth_arg_passed_on_outgoing_stack() {
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        // func_3 takes 5 i32 args.
+        selector.set_func_arg_counts(vec![0, 0, 0, 5], Vec::new());
+        let wasm_ops = vec![
+            WasmOp::I32Const(10),
+            WasmOp::I32Const(20),
+            WasmOp::I32Const(30),
+            WasmOp::I32Const(40),
+            WasmOp::I32Const(50), // arg4 → outgoing stack
+            WasmOp::Call(3),
+        ];
+        let arm = selector.select_with_stack(&wasm_ops, 0).unwrap();
+        let bl_pos = arm
+            .iter()
+            .position(|i| matches!(&i.op, ArmOp::Bl { .. }))
+            .expect("a BL must be emitted");
+        // arg4 stored to the outgoing region at [sp,#0] before the BL.
+        let stores_outgoing = arm[..bl_pos]
+            .iter()
+            .any(|i| matches!(&i.op, ArmOp::Str { addr, .. } if addr.base == Reg::SP && addr.offset == 0));
+        assert!(
+            stores_outgoing,
+            "5th arg must be stored to the outgoing stack [sp,#0] before the BL: {arm:#?}"
+        );
+        // r0 must still be written (arg0 NOT dropped).
+        assert!(
+            arm[..bl_pos].iter().any(|i| matches!(
+                &i.op,
+                ArmOp::Mov { rd: Reg::R0, .. } | ArmOp::Movw { rd: Reg::R0, .. }
+            )),
+            "arg0 must reach r0 (not be dropped): {arm:#?}"
+        );
+    }
+
+    /// #359: a function with 5 params must read its 5th param (index 4) from the
+    /// INCOMING stack (above the frame), not from a register. Pre-fix it had no
+    /// slot at all (`param_count = num_params.min(4)`).
+    #[test]
+    fn test_359_fifth_param_read_from_incoming_stack() {
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        // 5-param function that returns its 5th param.
+        let wasm_ops = vec![WasmOp::LocalGet(4)];
+        let arm = selector.select_with_stack(&wasm_ops, 5).unwrap();
+        // The 5th param is read via Ldr [sp, #off] with off above the frame.
+        assert!(
+            arm.iter()
+                .any(|i| matches!(&i.op, ArmOp::Ldr { addr, .. } if addr.base == Reg::SP)),
+            "5th param must be loaded from the incoming stack: {arm:#?}"
+        );
+    }
+
+    /// #359 Ok-or-Err: a 64-bit param in the stack region (>4 params, param i64)
+    /// is NOT lowered (AAPCS pair math differs) — it must return Err, never a
+    /// silent miscompile (#180/#185).
+    #[test]
+    fn test_359_i64_stack_param_errs() {
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        selector.set_params_i64(vec![false, false, false, false, true]); // param4 = i64
+        let wasm_ops = vec![WasmOp::LocalGet(0)];
+        let r = selector.select_with_stack(&wasm_ops, 5);
+        assert!(
+            r.is_err(),
+            "a 5-param function with an i64 param must Err, not lower: {r:?}"
+        );
+    }
+
+    /// #359 Ok-or-Err: more than 8 call args exceeds the verified range → Err.
+    #[test]
+    fn test_359_too_many_args_errs() {
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        selector.set_func_arg_counts(vec![0, 0, 0, 9], Vec::new());
+        let mut wasm_ops: Vec<WasmOp> = (0..9).map(|n| WasmOp::I32Const(n)).collect();
+        wasm_ops.push(WasmOp::Call(3));
+        let r = selector.select_with_stack(&wasm_ops, 0);
+        assert!(
+            r.is_err(),
+            "a 9-arg call must Err (verified range is ≤8): {r:?}"
+        );
+    }
+
     /// #195 + #188 compose: gale's `z_impl_k_sem_give` shape — a value is live
     /// across a call that ALSO takes an argument. Both must hold: (a) the arg is
     /// passed in R0, and (b) the live value (param0) is preserved across the

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -10683,7 +10683,7 @@ mod tests {
         let db = RuleDatabase::new();
         let mut selector = InstructionSelector::new(db.rules().to_vec());
         selector.set_func_arg_counts(vec![0, 0, 0, 9], Vec::new());
-        let mut wasm_ops: Vec<WasmOp> = (0..9).map(|n| WasmOp::I32Const(n)).collect();
+        let mut wasm_ops: Vec<WasmOp> = (0..9).map(WasmOp::I32Const).collect();
         wasm_ops.push(WasmOp::Call(3));
         let r = selector.select_with_stack(&wasm_ops, 0);
         assert!(

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -2231,6 +2231,19 @@ impl OptimizerBridge {
             ));
         }
 
+        // #359: this lowering homes only params 0..4 in R0..R3 (see the
+        // `addr < num_params && addr < 4` Load map below); a 5th+ param arrives
+        // on the AAPCS incoming stack and would be silently read from a garbage
+        // temp register. Decline functions with >4 params so they fall back to
+        // the direct selector, which implements the stack-argument path (#359).
+        if num_params > 4 {
+            return Err(synth_core::Error::synthesis(
+                "optimized path declines functions with >4 params (no AAPCS \
+                 stack-argument model — see #359); falling back to direct selector"
+                    .to_string(),
+            ));
+        }
+
         let mut arm_instrs = Vec::new();
         let mut vreg_to_arm: HashMap<u32, Reg> = HashMap::new();
 

--- a/scripts/repro/call_5args.wat
+++ b/scripts/repro/call_5args.wat
@@ -1,0 +1,13 @@
+(module
+  (memory (export "memory") 1)
+  (global $sp (mut i32) (i32.const 65536))
+  ;; callee packs each arg into a distinct nibble: a | b<<4 | c<<8 | d<<12 | e<<16.
+  ;; Any dropped/shifted/mis-assigned argument changes the result.
+  (func $callee (param i32 i32 i32 i32 i32) (result i32)
+    (i32.or
+      (i32.or
+        (i32.or (local.get 0) (i32.shl (local.get 1) (i32.const 4)))
+        (i32.or (i32.shl (local.get 2) (i32.const 8)) (i32.shl (local.get 3) (i32.const 12))))
+      (i32.shl (local.get 4) (i32.const 16))))
+  (func (export "caller") (param i32 i32 i32 i32 i32) (result i32)
+    (call $callee (local.get 0) (local.get 1) (local.get 2) (local.get 3) (local.get 4))))

--- a/scripts/repro/call_5args_differential.py
+++ b/scripts/repro/call_5args_differential.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""#359 differential: a 5-argument call must pass ALL five args (caller/callee agree).
+
+The callee packs each arg into a distinct nibble (a | b<<4 | c<<8 | d<<12 | e<<16),
+so ANY dropped / shifted / mis-assigned argument changes the result — unlike a
+"return arg1" probe, this catches a wrong outgoing-stack slot or a wrong
+incoming-param offset on the 5th arg too.
+
+Compile:
+  synth compile scripts/repro/call_5args.wat -o /tmp/c5.o \
+        --target cortex-m4f --native-pointer-abi --all-exports --relocatable
+Run:
+  /tmp/armv2/bin/python scripts/repro/call_5args_differential.py /tmp/c5.o
+
+Ground truth is the wasm semantics (computed directly). Unicorn runs synth's
+ARM. Before the #359 fix the caller drops arg1 and never stack-passes arg5, so
+the result diverges; after, it matches for every vector.
+"""
+import struct
+import sys
+
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_THUMB
+from unicorn.arm_const import (
+    UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3,
+    UC_ARM_REG_R11, UC_ARM_REG_LR, UC_ARM_REG_SP, UC_ARM_REG_PC,
+)
+
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/c5.o"
+CODE, DATA, STK = 0x10000, 0x40000, 0x90000
+RET_PAD = CODE + 0x4000  # a mapped, even (ARM) address LR points at; we stop there
+
+e = ELFFile(open(ELF, "rb"))
+text = bytearray(e.get_section_by_name(".text").data())
+symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+syms = {s.name: s["st_value"] for s in symtab.iter_symbols()}
+
+
+def encode_thm_bl(pc, target):
+    """Thumb-2 BL: encode (target - (pc+4)) as the S/J1/J2/imm10/imm11 form."""
+    off = target - (pc + 4)
+    off &= 0x1FFFFFF  # 25-bit signed range
+    s = (off >> 24) & 1
+    i1 = (off >> 23) & 1
+    i2 = (off >> 22) & 1
+    imm10 = (off >> 12) & 0x3FF
+    imm11 = (off >> 1) & 0x7FF
+    j1 = (~i1 & 1) ^ s
+    j2 = (~i2 & 1) ^ s
+    hw1 = 0xF000 | (s << 10) | imm10
+    hw2 = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+    return hw1, hw2
+
+
+# Resolve the internal THM_CALL (caller -> func_N): patch the BL in place so the
+# emulated branch lands on the callee, exactly as `ld` would.
+rel = e.get_section_by_name(".rel.text")
+for r in rel.iter_relocations():
+    t = r["r_info_type"]
+    if t in (10, 30):  # R_ARM_THM_CALL / R_ARM_THM_JUMP24
+        sym = symtab.get_symbol(r["r_info_sym"])
+        target = CODE + (syms[sym.name] & ~1)  # clear thumb bit
+        off = r["r_offset"]
+        pc = CODE + off
+        hw1, hw2 = encode_thm_bl(pc, target)
+        struct.pack_into("<HH", text, off, hw1, hw2)
+    else:
+        raise SystemExit(f"unexpected reloc type {t}; harness only handles THM_CALL")
+
+
+def run_caller(a, b, c, d, ee):
+    uc = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    uc.mem_map(CODE, 0x10000)
+    uc.mem_map(DATA, 0x10000)
+    uc.mem_map(STK, 0x10000)
+    uc.mem_write(CODE, bytes(text))
+    sp = STK + 0x8000
+    # AAPCS: args 1..4 in r0..r3, arg5 (ee) on the incoming stack at [sp].
+    sp -= 8  # keep 8-byte alignment; arg5 at [sp+0]
+    uc.mem_write(sp, struct.pack("<I", ee & 0xFFFFFFFF))
+    uc.reg_write(UC_ARM_REG_SP, sp)
+    uc.reg_write(UC_ARM_REG_R0, a & 0xFFFFFFFF)
+    uc.reg_write(UC_ARM_REG_R1, b & 0xFFFFFFFF)
+    uc.reg_write(UC_ARM_REG_R2, c & 0xFFFFFFFF)
+    uc.reg_write(UC_ARM_REG_R3, d & 0xFFFFFFFF)
+    uc.reg_write(UC_ARM_REG_R11, DATA)  # linmem base
+    uc.reg_write(UC_ARM_REG_LR, RET_PAD | 1)
+    entry = CODE + (syms["caller"] & ~1)
+    uc.emu_start(entry | 1, RET_PAD, timeout=0, count=2000)
+    return uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def expected(a, b, c, d, ee):
+    return (a | (b << 4) | (c << 8) | (d << 12) | (ee << 16)) & 0xFFFFFFFF
+
+
+VECTORS = [
+    (1, 2, 3, 4, 5),
+    (15, 14, 13, 12, 11),
+    (9, 0, 7, 0, 3),
+    (0, 0, 0, 0, 1),   # only arg5 set — catches a dropped/zeroed 5th arg
+    (1, 0, 0, 0, 0),   # only arg1 set — catches the historical arg1 drop
+]
+
+ok = 0
+for v in VECTORS:
+    got = run_caller(*v)
+    exp = expected(*v)
+    flag = "OK" if got == exp else "MISMATCH"
+    if got == exp:
+        ok += 1
+    print(f"caller{v} = 0x{got:05X}  (expect 0x{exp:05X})  {flag}")
+
+print(f"\n{ok}/{len(VECTORS)} match")
+print("ORACLE: PASS" if ok == len(VECTORS) else "ORACLE: FAIL")
+sys.exit(0 if ok == len(VECTORS) else 1)

--- a/scripts/repro/call_6_7args.wat
+++ b/scripts/repro/call_6_7args.wat
@@ -1,0 +1,18 @@
+(module
+  (memory (export "memory") 1)
+  (global $sp (mut i32) (i32.const 65536))
+  ;; 6-param callee: packs a|b<<4|c<<8|d<<12|e<<16|f<<20 (2 stack args: e,f)
+  (func $c6 (param i32 i32 i32 i32 i32 i32) (result i32)
+    (i32.or (i32.or (i32.or (local.get 0) (i32.shl (local.get 1) (i32.const 4)))
+                    (i32.or (i32.shl (local.get 2) (i32.const 8)) (i32.shl (local.get 3) (i32.const 12))))
+            (i32.or (i32.shl (local.get 4) (i32.const 16)) (i32.shl (local.get 5) (i32.const 20)))))
+  ;; 7-param callee: + g<<24 (3 stack args: e,f,g) — gale's mem_domain_add worst case
+  (func $c7 (param i32 i32 i32 i32 i32 i32 i32) (result i32)
+    (i32.or (i32.or (i32.or (i32.or (local.get 0) (i32.shl (local.get 1) (i32.const 4)))
+                            (i32.or (i32.shl (local.get 2) (i32.const 8)) (i32.shl (local.get 3) (i32.const 12))))
+                    (i32.or (i32.shl (local.get 4) (i32.const 16)) (i32.shl (local.get 5) (i32.const 20))))
+            (i32.shl (local.get 6) (i32.const 24))))
+  (func (export "call6") (param i32 i32 i32 i32 i32 i32) (result i32)
+    (call $c6 (local.get 0)(local.get 1)(local.get 2)(local.get 3)(local.get 4)(local.get 5)))
+  (func (export "call7") (param i32 i32 i32 i32 i32 i32 i32) (result i32)
+    (call $c7 (local.get 0)(local.get 1)(local.get 2)(local.get 3)(local.get 4)(local.get 5)(local.get 6))))

--- a/scripts/repro/call_6_7args_differential.py
+++ b/scripts/repro/call_6_7args_differential.py
@@ -1,0 +1,38 @@
+import struct, sys
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_THUMB
+from unicorn.arm_const import *
+ELF=sys.argv[1] if len(sys.argv)>1 else "/tmp/cm.o"; CODE,DATA,STK=0x10000,0x40000,0x90000; RET=CODE+0x4000
+e=ELFFile(open(ELF,"rb")); text=bytearray(e.get_section_by_name(".text").data())
+st=[s for s in e.iter_sections() if s["sh_type"]=="SHT_SYMTAB"][0]
+syms={s.name:s["st_value"] for s in st.iter_symbols()}
+def bl(pc,t):
+    o=(t-(pc+4))&0x1FFFFFF; s=(o>>24)&1;i1=(o>>23)&1;i2=(o>>22)&1
+    im10=(o>>12)&0x3FF;im11=(o>>1)&0x7FF;j1=(~i1&1)^s;j2=(~i2&1)^s
+    return 0xF000|(s<<10)|im10, 0xD000|(j1<<13)|(j2<<11)|im11
+for r in e.get_section_by_name(".rel.text").iter_relocations():
+    if r["r_info_type"] in (10,30):
+        sym=st.get_symbol(r["r_info_sym"]); tgt=CODE+(syms[sym.name]&~1); off=r["r_offset"]
+        h1,h2=bl(CODE+off,tgt); struct.pack_into("<HH",text,off,h1,h2)
+def run(entry, args):
+    uc=Uc(UC_ARCH_ARM,UC_MODE_THUMB)
+    for b in (CODE,DATA,STK): uc.mem_map(b,0x10000)
+    uc.mem_write(CODE,bytes(text)); sp=STK+0x8000
+    stackargs=args[4:]  # params 4+ on incoming stack
+    sp-=((len(stackargs)*4+7)&~7) if stackargs else 0
+    for k,v in enumerate(stackargs): uc.mem_write(sp+k*4, struct.pack("<I",v&0xFFFFFFFF))
+    uc.reg_write(UC_ARM_REG_SP,sp)
+    for k,reg in enumerate([UC_ARM_REG_R0,UC_ARM_REG_R1,UC_ARM_REG_R2,UC_ARM_REG_R3]):
+        if k<len(args): uc.reg_write(reg,args[k]&0xFFFFFFFF)
+    uc.reg_write(UC_ARM_REG_R11,DATA); uc.reg_write(UC_ARM_REG_LR,RET|1)
+    uc.emu_start((CODE+(syms[entry]&~1))|1, RET, count=4000)
+    return uc.reg_read(UC_ARM_REG_R0)&0xFFFFFFFF
+ok=0;tot=0
+for (entry,args) in [("call6",(1,2,3,4,5,6)),("call6",(15,0,0,0,0,9)),("call7",(1,2,3,4,5,6,7)),("call7",(0,0,0,0,0,0,15))]:
+    exp=0
+    for k,v in enumerate(args): exp|=(v&0xF)<<(4*k)
+    exp&=0xFFFFFFFF; got=run(entry,list(args)); tot+=1
+    f="OK" if got==exp else "MISMATCH"; ok+=(got==exp)
+    print(f"{entry}{args} = 0x{got:07X} (expect 0x{exp:07X}) {f}")
+print(f"\n{ok}/{tot} match"); print("ORACLE: PASS" if ok==tot else "ORACLE: FAIL")
+sys.exit(0 if ok==tot else 1)


### PR DESCRIPTION
## What

Fixes gale **#359**: a call to a function with **>4 scalar args** mis-assigned argument registers, and a callee with **>4 params** mis-read the 5th+ param — both **silent miscompiles**. gale's dissolved `z_impl_k_msgq_put` (msgq's decide is the first with 5 args) returned `-ENOMSG` on an empty queue. The 3 working primitives (sem/mutex/stack) all have ≤3-arg decides, which hid this.

### Root cause
- **Caller:** `pop_call_args` popped only the top 4 operand-stack values (`min(arg_count,4)`); for a 5-arg call those are args 2..5, so **arg1 (bottom of the operand stack) was dropped** and args shifted into r0..r3.
- **Callee:** `compute_local_layout`'s `param_count = num_params.min(4)` gave params index≥4 **no frame slot**, so `local.get/set` of the 5th+ param read garbage.

## Fix — full AAPCS i32 stack arguments, frame-reserved (no dynamic SP)
The prologue's fixed `push {r4-r8,lr}` = 24 bytes is the constant `P`.
- **Caller** (gate: a call with `arg_count>4`): pop ALL args; reserve an outgoing-arg area at the **bottom of the frame**, store args 5..N there at `[sp+0],[sp+4],…` **before** the r0..r3 parallel move; first 4 → r0..r3.
- **Callee** (gate: `num_params>4`): map param `k∈[4,num_params)` to the incoming slot `[sp, frame_size+24+(k-4)*4]`. i64/f64 declared widths threaded decoder → backend → selector so an unused i64 param still shifts the layout.
- **Optimized path:** declines `num_params>4` (it homed only params 0..3 — a separate latent silent miscompile), falling back to the fixed direct selector.

**Ok-or-Err (#180/#185):** `Err` for any stack-region arg/param that's i64/f64, `arg_count>8`, `num_params>8`, or a `[sp,#imm]` offset exceeding the 12-bit range.

## Verification (independently re-run)
- `scripts/repro/call_5args.wat` (callee packs args into distinct nibbles, so any drop/shift diverges) + unicorn differential: **0/5 → 5/5**.
- **BYTE-IDENTICAL** (purely additive, gated) — all six compile to the same SHA with/without the change: control_step `0x00210A55`, flight_seam + flight_seam_flat `0x07FDF307`, signed_div_const, mutex_pressure, native_pointer_shadow_stack.
- i64-5th-arg guard fires (`Err`, skip-and-continue). synth-synthesis suite green; fmt + clippy `-D warnings` clean.

**Falsification:** wrong if a >4-arg i32 call/callee still scrambles args (the differential drops below 5/5), or any frozen fixture's SHA moves. **Closing gate is gale's G474RE msgq-microbench** (rc=0 + value round-trip on an empty queue), to run when this lands. Target release: **v0.11.46**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)