### PR TITLE
chore(release): v0.11.46 — #359 AAPCS stack arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.46] - 2026-06-15
+
+**ABI CORRECTNESS — gale #359: calls/params with >4 args no longer silently
+miscompile. Unblocks 10/56 gale decides (mutex_lock, msgq, scheduler,
+mem_domain).**
+
+- **#359 — full AAPCS i32 stack arguments** (#360): a call to a function with
+  **>4 scalar args** mis-assigned argument registers, and a callee with **>4
+  params** mis-read the 5th+ param — both **silent miscompiles** (no fault).
+  gale's dissolved `z_impl_k_msgq_put` (msgq's decide is the first with 5
+  scalars + an sret pointer = 6 wasm params) returned `-ENOMSG` on an empty
+  queue. Root cause: caller `pop_call_args` popped only the top 4 operand-stack
+  values (`min(arg_count, 4)`) — for a 5-arg call those are args 2..5, so arg1
+  (bottom of the operand stack) was dropped and args shifted into r0..r3; and
+  callee `compute_local_layout`'s `param_count = num_params.min(4)` gave params
+  index ≥ 4 no frame slot. Fixed with full AAPCS i32 stack arguments,
+  **frame-reserved** (no dynamic SP — the fixed `push {r4-r8,lr}` = 24 bytes is
+  the constant): the caller passes args 0..3 in r0..r3 and args 4+ in an
+  outgoing-arg area at the frame bottom (`[sp+0],[sp+4],…`, stored before the
+  r0..r3 parallel move); the callee reads param k≥4 from the incoming stack
+  `[sp, frame_size+24+(k-4)*4]`. Declared i64/f64 widths are threaded
+  decoder→backend→selector so an unused i64 param still shifts the layout. The
+  optimized path now declines `num_params>4` (it homed only params 0..3 — a
+  separate latent miscompile), falling back to the fixed direct selector.
+  **Ok-or-Err** (#180/#185): a typed `Err` for any stack-region arg/param that
+  is i64/f64, `arg_count>8`, `num_params>8`, or a `[sp,#imm]` offset exceeding
+  the 12-bit range — never a silent miscompile.
+
+  **Falsification:** wrong if a >4-arg i32 call/callee still scrambles args, or
+  any frozen fixture's bytes move. Verified: `call_5args` (callee packs each arg
+  into a distinct nibble) **0/5 → 5/5**; `call6` (2 stack args = gale's real
+  case) + `call7` (3 stack args = `mem_domain_add` worst case) **4/4**; all six
+  frozen fixtures (control_step `0x00210A55`, flight_seam + flight_seam_flat
+  `0x07FDF307`, signed_div_const, mutex_pressure, native_pointer_shadow_stack)
+  compile to the **same SHA** with/without the change (purely additive, gated on
+  >4 args / >4 params); the i64-stack-param guard returns `Err`; 6 in-CI Rust
+  unit tests cover both call sites + the frame-shift + both Err guards.
+  **Closing gate is gale's G474RE msgq-microbench** (`rc=0` + value round-trip
+  on an empty queue), to run when this tags.
+
+### CI
+- **Signing E2E** is now resilient to sigstore cert-pin rotations (#361, separate
+  PR): `wsc`'s frozen TLS pins for `rekor.sigstore.dev` go stale when sigstore
+  rotates its server cert, which is not a synth regression — that specific
+  cert-pin-mismatch is now an XFAIL (synth's own `--sign-output` contract stays
+  hard-asserted), instead of a perpetually-red gate.
+
 ## [0.11.45] - 2026-06-14
 
 **ON-TARGET SHIPPABILITY — gale #354: a high-offset init segment no longer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,14 +1925,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1981,11 +1981,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.45"
+version = "0.11.46"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "clap",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "serde",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2034,14 +2034,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2049,11 +2049,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.45"
+version = "0.11.46"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "clap",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.45"
+version = "0.11.46"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.45"
+version = "0.11.46"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.45",
+    version = "0.11.46",
 )
 
 # Bazel dependencies

--- a/artifacts/gale-integration.yaml
+++ b/artifacts/gale-integration.yaml
@@ -574,3 +574,45 @@ artifacts:
         div_const 338/338, mutex_pressure) stay byte-identical; gale's
         stack_push runs correctly on G474RE (loads the -12 const, walks the
         shadow stack) under the differential oracle.
+
+  - id: GI-NPA-005
+    type: sw-req
+    title: Full AAPCS i32 stack arguments for calls/params with >4 args (#359)
+    description: >
+      The direct selector marshalled only the first 4 integer arguments
+      (ARG_REGS = r0..r3) and frame-backed only the first 4 params
+      (param_count = num_params.min(4)). gale #359: a struct-return decide with
+      >=4 scalar args overflows the register window (the sret pointer is wasm
+      param 0, so msgq_put = 6 params), and BOTH sides miscompiled silently:
+      pop_call_args popped only the top 4 operand-stack values (dropping arg0
+      and shifting the rest into r0..r3), and a callee read params index>=4 from
+      no slot at all. Blast radius: 10/56 gale decides (mutex_lock completing
+      the mutex pair, msgq put/get, the scheduler decides, the mem_domain/
+      userspace surface). synth implements full AAPCS i32 stack arguments: the
+      caller passes args 0..3 in r0..r3 and args 4+ in a frame-bottom
+      outgoing-arg area stored before the r0..r3 parallel move (no dynamic SP --
+      the fixed push {r4-r8,lr}=24B is the constant P); the callee reads param
+      k>=4 from the incoming stack [sp,frame_size+24+(k-4)*4]. Declared i64/f64
+      param widths are threaded decoder->backend->selector so an unused i64
+      param still shifts the layout. Ok-or-Err (#180/#185): typed Err for any
+      stack-region i64/f64 arg/param, >8 args, >8 params, or a [sp,#imm] offset
+      exceeding the 12-bit range. Gated on >4 args / >4 params, so all <=4
+      functions stay byte-identical.
+    status: implemented
+    tags: [gale, native-pointer-abi, aapcs, stack-arguments, regalloc, release-v0.11.46]
+    links:
+      - type: derives-from
+        target: GI-NPA-001
+      - type: traces-to
+        target: gale:359
+    fields:
+      req-type: functional
+      priority: must
+      verification-criteria: >
+        call_5args.wat (callee packs each arg into a distinct nibble)
+        differential 0/5 -> 5/5; call_6_7args.wat (call6 = 2 stack args = gale's
+        real 6-param case, call7 = 3 stack args = mem_domain_add worst case)
+        4/4; all six frozen fixtures byte-identical with/without the change; the
+        i64-stack-param guard returns Err; 6 in-CI Rust unit tests (test_359_*);
+        gale's G474RE msgq-microbench returns rc=0 + round-trips the value on an
+        empty queue (closing gate).

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.45" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.46" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.45" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.45", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.46" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.46", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.45" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.45" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.45" }
-synth-backend = { path = "../synth-backend", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.46" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.46" }
+synth-backend = { path = "../synth-backend", version = "0.11.46" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.45", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.45", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.45", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.46", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.46", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.46", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.45", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.46", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.45" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.46" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.45" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.45" }
-synth-opt = { path = "../synth-opt", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.46" }
+synth-opt = { path = "../synth-opt", version = "0.11.46" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.45" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.45" }
-synth-opt = { path = "../synth-opt", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.46" }
+synth-opt = { path = "../synth-opt", version = "0.11.46" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.45", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.46", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Release v0.11.46 — bug-fix (gale #359)

Bundles the **full AAPCS i32 stack-argument** fix (#360, on `main`): calls/params with **>4 args** no longer silently miscompile. Unblocks **10/56 gale decides** — mutex_lock (completes the mutex pair), msgq put/get, the scheduler decides, and the mem_domain/userspace surface.

### Gates
- `call_5args` differential **0/5 → 5/5**; `call6` (2 stack args, gale's real 6-param case) + `call7` (3 stack args, `mem_domain_add` worst case) **4/4**.
- **All 6 frozen fixtures byte-identical** (control_step `0x00210A55`, flight_seam + flight_seam_flat `0x07FDF307`, signed_div_const, mutex_pressure, native_pointer_shadow_stack) — purely additive, gated on >4 args / >4 params.
- i64-stack-param guard returns `Err`; 6 in-CI Rust unit tests; codecov green.
- Pin sweep: workspace + 11 manifests + path-deps + MODULE.bazel + Cargo.lock `0.11.45 → 0.11.46`. rivet **GI-NPA-005** (implemented), 0 non-xref errors.

Falsification statement in CHANGELOG; **closing gate is gale's G474RE msgq-microbench** (rc=0 + value round-trip), which gale runs when this tags. Tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)