### PR TITLE
fix(#369): unsupported decoder ops loud-skip, never silently drop (GI-FPU-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.46] - 2026-06-17
+
+**CORRECTNESS — #369: an op the backend cannot lower now LOUD-SKIPS its
+function instead of being silently dropped into a wrong-value miscompile.**
+
+- **#369 / GI-FPU-001 — unsupported decoder ops no longer silently drop**
+  (#371): `convert_operator` returns `None` for any operator it can't lower, and
+  the caller previously **dropped it silently** — leaving the operand stack wrong
+  and the function a silent miscompile (`f32.add(a,b)` lowered to `mov r0,r1`,
+  returning an operand instead of the sum; the same `_ => None` line drops
+  `memory.copy`). Per the #180/#185 contract, an unsupported op must surface
+  loudly. `FunctionOps` now carries `unsupported: Option<String>`;
+  `decode_function_body` records the first value-affecting op that decodes to
+  `None` (everything except the intentional `Nop`/`Unreachable`); and the
+  compile loop **loud-skips** a flagged function (warning naming the op + symbol
+  absent → a caller gets a link error), reusing the #168 `skipped_funcs` path. An
+  all-skipped module errors loudly rather than emitting an empty object. Covers
+  scalar f32/f64 (#369, jess AFD-024/AFD-008), bulk-memory (`memory.copy`/
+  `fill`), and any other decoder-dropped value-affecting op — the honest interim
+  until real VFP (GI-FPU-002) and bulk-memory lowering land.
+
+  **Falsification:** a module whose only function uses a scalar `f32`/`f64` op
+  (or `memory.copy`) no longer produces an object containing that function — it
+  is reported skipped and absent. A pure-integer module is byte-identical to
+  before: the three frozen oracles stay bit-identical (control_step `0x00210A55`
+  13/13, flight_seam `0x07FDF307`, div_const 338/338); no fixture uses floats.
+
 ## [0.11.45] - 2026-06-14
 
 **ON-TARGET SHIPPABILITY — gale #354: a high-offset init segment no longer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,14 +1908,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1964,11 +1964,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.45"
+version = "0.11.46"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "clap",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "serde",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2017,14 +2017,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2032,11 +2032,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.45"
+version = "0.11.46"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "clap",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.45"
+version = "0.11.46"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.45"
+version = "0.11.46"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.45",
+    version = "0.11.46",
 )
 
 # Bazel dependencies

--- a/artifacts/gale-integration.yaml
+++ b/artifacts/gale-integration.yaml
@@ -607,9 +607,12 @@ artifacts:
       fixture uses floats (zero `f32.`/`f64.` in scripts/repro/*.wat), so
       every frozen differential stays byte-identical. Shippable independently
       of GI-FPU-002 (the hard-float feature); bundles naturally with the
-      memory.copy-drop fix (same decoder catch-all).
-    status: proposed
-    tags: [gale, fpu, float, correctness, silent-miscompile, ok-or-err, release-pending]
+      memory.copy-drop fix (same decoder catch-all). IMPLEMENTED in v0.11.46
+      (#371): FunctionOps.unsupported flag + decode_function_body recording +
+      compile-loop loud-skip; f32/f64 module loud-skips (was silent mov r0,r1);
+      3 frozen oracles byte-identical; unit test; covers memory.copy too.
+    status: implemented
+    tags: [gale, fpu, float, correctness, silent-miscompile, ok-or-err, release-v0.11.46]
     links:
       - type: derives-from
         target: GI-002
@@ -668,3 +671,27 @@ artifacts:
         re-test; cortex-m7 (sp) and cortex-m7dp (dp) outputs DIFFER (FPU mode
         consulted); all frozen fixtures stay byte-identical (no float content,
         unaffected); soft-float retained and unchanged for cortex-m3.
+
+  - id: GI-FPU-VER-001
+    type: sw-verification
+    title: "Unsupported-op loud-skip (#369) — unit test + frozen byte-identity"
+    description: >
+      Verifies GI-FPU-001 (v0.11.46, #371). Unit test
+      `test_369_scalar_float_op_flags_function_unsupported_not_dropped`
+      (crates/synth-core/src/wasm_decoder.rs) asserts a scalar `f32.add` flags
+      its function `unsupported` (naming `F32Add`) while a pure-integer function
+      stays clean. Manual: an f32/f64 module compiled for cortex-m7dp loud-skips
+      both functions (symbol absent; warning names the op) where it previously
+      emitted the silent `mov r0,r1` stub. Frozen byte-identity confirmed: the
+      three differential oracles (control_step 0x00210A55 13/13, flight_seam
+      0x07FDF307, div_const 338/338) PASS unchanged (no fixture uses floats).
+    status: implemented
+    tags: [gale, fpu, verification, unit-test, frozen, release-v0.11.46]
+    links:
+      - type: verifies
+        target: GI-FPU-001
+    fields:
+      method: test
+      pass-criteria: >
+        cargo test test_369 green; f32 module emits no fadd/dmul symbol;
+        control_step / flight_seam / div_const differentials byte-identical.

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.45" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.46" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.45" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.45", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.46" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.46", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.45" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.45" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.45" }
-synth-backend = { path = "../synth-backend", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.46" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.46" }
+synth-backend = { path = "../synth-backend", version = "0.11.46" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.45", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.45", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.45", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.46", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.46", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.46", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.45", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.46", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2032,6 +2032,22 @@ fn compile_all_exports(
         } else {
             config.clone()
         };
+        // #369: the decoder flagged a value-affecting op it cannot lower (e.g.
+        // scalar f32/f64, bulk-memory). Lowering would have SILENTLY DROPPED it
+        // and miscompiled the function (wrong value, no diagnostic). Loud-skip
+        // instead — honest degradation: the symbol is absent, so a caller gets a
+        // link error naming it rather than a silently-wrong result. (#180/#185
+        // "unsupported op must Err, never silently continue".)
+        if let Some(reason) = &func.unsupported {
+            eprintln!(
+                "warning: skipping function '{name}': contains an unsupported \
+                 operator ({reason}) the {} backend cannot lower — emitting no \
+                 code for it rather than a silent miscompile (#369)",
+                backend.name()
+            );
+            skipped_funcs.push((name.clone(), format!("unsupported operator: {reason}")));
+            continue;
+        }
         let compiled = match backend.compile_function(&name, &func.ops, &func_config) {
             Ok(c) => c,
             Err(e) => {
@@ -3943,6 +3959,7 @@ mod tests {
             index,
             export_name: export.map(String::from),
             ops,
+            unsupported: None,
         }
     }
 

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -335,7 +335,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                 }
             }
             Payload::CodeSectionEntry(body) => {
-                let ops = decode_function_body(&body)?;
+                let (ops, unsupported) = decode_function_body(&body)?;
                 let actual_index = num_imported_funcs + func_index;
                 let export_name = export_names.get(&actual_index).cloned();
 
@@ -343,6 +343,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                     index: actual_index,
                     export_name,
                     ops,
+                    unsupported,
                 });
                 func_index += 1;
             }
@@ -396,7 +397,7 @@ pub fn decode_wasm_functions(wasm_bytes: &[u8]) -> Result<Vec<FunctionOps>> {
                 }
             }
             Payload::CodeSectionEntry(body) => {
-                let ops = decode_function_body(&body)?;
+                let (ops, unsupported) = decode_function_body(&body)?;
                 let actual_index = num_imported_funcs + func_index;
                 let export_name = export_names.get(&actual_index).cloned();
 
@@ -404,6 +405,7 @@ pub fn decode_wasm_functions(wasm_bytes: &[u8]) -> Result<Vec<FunctionOps>> {
                     index: actual_index,
                     export_name,
                     ops,
+                    unsupported,
                 });
                 func_index += 1;
             }
@@ -423,11 +425,26 @@ pub struct FunctionOps {
     pub export_name: Option<String>,
     /// The WASM operations in this function body
     pub ops: Vec<WasmOp>,
+    /// `Some(reason)` when the body contained a value-affecting operator the
+    /// decoder cannot lower (e.g. scalar f32/f64 — #369, bulk-memory
+    /// memory.copy/fill). Such an op would otherwise be silently *dropped*
+    /// (`convert_operator` → `None`), leaving the operand stack wrong and the
+    /// function a silent miscompile. The compile path LOUD-SKIPS a flagged
+    /// function (diagnostic + symbol absent → link error names it) instead —
+    /// the #180/#185 "unsupported op must Err, never silently continue"
+    /// contract. `None` once every op decoded or was intentionally ignorable
+    /// (Nop/Unreachable).
+    pub unsupported: Option<String>,
 }
 
-/// Decode a single function body to WasmOp sequence
-fn decode_function_body(body: &wasmparser::FunctionBody) -> Result<Vec<WasmOp>> {
+/// Decode a single function body to WasmOp sequence.
+///
+/// Returns the ops plus `Some(reason)` if any operator was a value-affecting
+/// op the decoder cannot lower (so the function must be loud-skipped, #369 —
+/// not silently miscompiled by dropping the op).
+fn decode_function_body(body: &wasmparser::FunctionBody) -> Result<(Vec<WasmOp>, Option<String>)> {
     let mut ops = Vec::new();
+    let mut unsupported: Option<String> = None;
 
     let ops_reader = body.get_operators_reader()?;
     for op_result in ops_reader {
@@ -435,10 +452,24 @@ fn decode_function_body(body: &wasmparser::FunctionBody) -> Result<Vec<WasmOp>> 
 
         if let Some(wasm_op) = convert_operator(&op) {
             ops.push(wasm_op);
+        } else if unsupported.is_none() && !is_intentionally_ignored(&op) {
+            // The op was DROPPED by `convert_operator` (`_ => None`) and is not
+            // an intentional no-op (Nop/Unreachable) — record it so the
+            // function is loud-skipped rather than silently miscompiled (#369).
+            unsupported = Some(format!("{op:?}"));
         }
     }
 
-    Ok(ops)
+    Ok((ops, unsupported))
+}
+
+/// Operators that `convert_operator` returns `None` for *on purpose* — they
+/// carry no value-affecting semantics for our backend, so dropping them is
+/// correct (NOT a silent miscompile). Everything else that decodes to `None`
+/// is an unsupported op that must loud-skip its function (#369).
+fn is_intentionally_ignored(op: &wasmparser::Operator) -> bool {
+    use wasmparser::Operator::*;
+    matches!(op, Nop | Unreachable)
 }
 
 /// Convert a wasmparser Operator to our WasmOp enum
@@ -1359,6 +1390,45 @@ mod tests {
 
         assert_eq!(functions.len(), 1);
         assert!(functions[0].ops.contains(&WasmOp::F32x4Add));
+    }
+
+    #[test]
+    fn test_369_scalar_float_op_flags_function_unsupported_not_dropped() {
+        // #369: a scalar f32/f64 op the decoder can't lower must FLAG the
+        // function (-> loud skip), never be silently dropped (which left a
+        // `mov r0,r1` wrong-value stub). A pure-integer function stays clean.
+        let wat = r#"
+            (module
+                (func (export "fadd") (param f32 f32) (result f32)
+                    local.get 0 local.get 1 f32.add)
+                (func (export "iadd") (param i32 i32) (result i32)
+                    local.get 0 local.get 1 i32.add))
+        "#;
+        let wasm = wat::parse_str(wat).expect("parse");
+        let functions = decode_wasm_functions(&wasm).expect("decode");
+        let fadd = functions
+            .iter()
+            .find(|f| f.export_name.as_deref() == Some("fadd"))
+            .unwrap();
+        let iadd = functions
+            .iter()
+            .find(|f| f.export_name.as_deref() == Some("iadd"))
+            .unwrap();
+        assert!(
+            fadd.unsupported.is_some(),
+            "f32.add must flag the function unsupported (loud-skip), got {:?}",
+            fadd.unsupported
+        );
+        assert!(
+            fadd.unsupported.as_deref().unwrap().contains("F32Add"),
+            "diagnostic should name the op: {:?}",
+            fadd.unsupported
+        );
+        assert!(
+            iadd.unsupported.is_none(),
+            "a pure-integer function must NOT be flagged: {:?}",
+            iadd.unsupported
+        );
     }
 
     #[test]

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.45" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.46" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.45" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.45" }
-synth-opt = { path = "../synth-opt", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.46" }
+synth-opt = { path = "../synth-opt", version = "0.11.46" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.45" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.45" }
-synth-opt = { path = "../synth-opt", version = "0.11.45" }
+synth-core = { path = "../synth-core", version = "0.11.46" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.46" }
+synth-opt = { path = "../synth-opt", version = "0.11.46" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.45", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.46", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Closes the silent-miscompile half of #369 (and the same class for memory.copy / any decoder-dropped op). jess tracks it as AFD-024/AFD-008.

## Problem
`convert_operator` returns `None` for any op it can't lower, and the caller **silently dropped it** — leaving the operand stack wrong and the function a silent miscompile. `f32.add(a,b)` lowered to `mov r0,r1` (returns an operand, not the sum); the same `_ => None` line drops `memory.copy`. Per the #180/#185 contract, an unsupported op must surface loudly, never silently continue.

## Fix
- `wasm_decoder.rs`: `FunctionOps` gains `unsupported: Option<String>`; `decode_function_body` records the first value-affecting op that decodes to `None` (everything except the intentional `Nop`/`Unreachable`, via `is_intentionally_ignored`).
- `main.rs` compile loop: a flagged function is **LOUD-SKIPPED** (warning naming the op + symbol absent → caller gets a link error), reusing the #168 `skipped_funcs` path, before selection. An all-skipped module errors loudly rather than emitting nothing.

General: covers scalar f32/f64 (#369), bulk-memory (`memory.copy`/`fill`), and any other decoder-dropped value-affecting op. Honest interim until real VFP (GI-FPU-002) and bulk-memory lowering land.

## Verification
- f32/f64 module now **loud-skips** (was the silent `mov r0,r1`); symbol absent.
- **All three frozen oracles byte-identical**: control_step `0x00210A55` 13/13, flight_seam `0x07FDF307`, div_const 338/338 (no fixture uses floats).
- New unit test `test_369_scalar_float_op_flags_function_unsupported_not_dropped`; fmt + clippy clean.

**Falsification:** a module whose only function uses a scalar `f32`/`f64` op (or `memory.copy`) no longer produces an object containing that function — it is reported skipped and absent. A pure-integer module is byte-identical to before.

Refs #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)