### PR TITLE
feat(#374): lower memory.copy/memory.fill (bulk-memory) — bounds-checked, trap-correct + v0.11.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.49] - 2026-06-19
+
+**BULK-MEMORY — #374: `memory.copy` / `memory.fill` now lower to bounds-checked
+byte loops, closing the largest remaining falcon on-target gap (19 sites: 11
+fill + 8 copy).** Self-contained, value-level differential vs wasmtime (16/16);
+falcon-v1.56 silicon confirmation gates closing #374.
+
+- **#374 — `memory.copy` / `memory.fill` lowered** (was unsupported): like the
+  scalar floats (#369) and the former `i64.load/store` (#372), bulk-memory fell
+  through the decoder `_ => None` and (since v0.11.46 / GI-FPU-001) **loud-skipped
+  the whole function**. Unlike #372 the lowering did not exist at all — no
+  `WasmOp` variant, no decoder arm, no selector handler. Added:
+  - `WasmOp::MemoryCopy` / `MemoryFill` + decoder arms for **memory 0** (a
+    non-zero memory index still loud-skips — the GI-FPU-001 honesty contract);
+  - stack effect `pop 3, push 0`;
+  - optimizer **decline → direct-selector fallback** (the `#120/#188/#372`
+    pattern; the optimized path has no bulk-mem IR opcode);
+  - a bounds-checked byte-loop lowering in `select_with_stack`:
+    `memory.fill(dst,val,len)` → `STRB` loop writing the **low byte** of `val`;
+    `memory.copy(dst,src,len)` → a **memmove** byte loop whose direction follows
+    `dst`/`src` order (`dst > src` copies **backward**, so overlapping copies
+    don't corrupt the source). Under `--safety-bounds software` an **inline
+    `UDF`**, guarded by a local skip branch, traps **end-exclusive** (`off+len >
+    size`, or a `u32` overflow; `off+len == size` is in-bounds) to match
+    wasmtime. (A body branch to the external `Trap_Handler` is only relocated in
+    `--relocatable` mode, not in the self-contained image, so the trap is a
+    self-contained `UDF`; on silicon UsageFault/HardFault routes to
+    `Trap_Handler` via the vector table.) The three dead popped operands are
+    reused as walking pointers — only `R12` extra, no temp allocation.
+  - **Falsification:** `scripts/repro/bulk_memory_374_differential.py` runs 16
+    discriminating vectors against wasmtime (forward, overlap `dst>src`
+    backward, overlap `dst<src` forward, self-copy, `len==0`, `dst+len==size` &
+    `src+len==size` boundaries that must **not** trap, OOB `dst`/`src` that
+    **must** trap, fill with high bits set → only low byte written), comparing
+    the full 64 KiB image **and** the trap outcome — **16/16**. Were the
+    direction logic, the pop order, or the end-exclusive bound wrong, a vector
+    flips. The RISC-V backend continues to loud-skip bulk-mem (symbol absent,
+    warning names the op) — the silent-drop class is not reintroduced.
+  - **Frozen-safe:** `control_step` `0x00210A55` (13/13), `flight_seam`
+    `0x07FDF307`, `div_const` 338/338 stay byte-identical (no fixture uses
+    bulk-mem; the change is purely additive). rivet `GI-MEM-002` (+`VER-001`).
+
 ## [0.11.48] - 2026-06-18
 
 **ON-TARGET — #359 closed on silicon (G474RE `rc=0`): the dissolved msgq

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,14 +1908,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1964,11 +1964,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.48"
+version = "0.11.49"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "anyhow",
  "clap",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "anyhow",
  "serde",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2017,14 +2017,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2032,11 +2032,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.48"
+version = "0.11.49"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "anyhow",
  "clap",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.48"
+version = "0.11.49"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.48"
+version = "0.11.49"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.48",
+    version = "0.11.49",
 )
 
 # Bazel dependencies

--- a/artifacts/gale-integration.yaml
+++ b/artifacts/gale-integration.yaml
@@ -785,3 +785,69 @@ artifacts:
         div_const 338/338) byte-identical; native_pointer_shadow_stack
         differential PASS; 32 cli tests green; gale G474RE silicon rc=0 +
         val=0xABCD round-trip on an empty queue (was rc=-35/val=0x0).
+
+  - id: GI-MEM-002
+    type: sw-req
+    title: Lower memory.copy/memory.fill (bulk-memory) — bounds-checked, trap-correct (#374)
+    description: >
+      gale/jess #374 (surfaced by the GI-FPU-001 loud-skip): memory.copy/
+      memory.fill were unsupported (`_ => None`) — 19 falcon sites (11 fill,
+      8 copy), the largest remaining bulk-mem gap. Unlike #372 the lowering did
+      NOT exist: no WasmOp::MemoryCopy/MemoryFill, no decoder arm, no selector
+      handler. IMPLEMENTED (next release): WasmOp::MemoryCopy/MemoryFill +
+      decoder arms (memory 0 only; non-zero memory index loud-skips) + stack
+      effect (pop 3, push 0) + optimizer decline->direct fallback (#120/#188/#372
+      pattern) + a bounds-checked byte-loop lowering in select_with_stack. fill
+      = STRB loop (low byte of val); copy = memmove byte loop with direction by
+      dst/src order (dst>src copies backward). Bounds (Software mode) trap via an
+      inline UDF guarded by a LOCAL skip branch — end-EXCLUSIVE (`off+len>size`
+      or u32-overflow trap; `==size` ok), matching wasmtime. (An external
+      Trap_Handler branch is only relocated in --relocatable mode, not the
+      self-contained image, so a self-contained UDF is used; on silicon
+      UsageFault/HardFault routes to Trap_Handler via the vector table.) The 3
+      dead popped operands are reused as walking pointers (only R12 extra), so no
+      temp allocation. Frozen-safe (no fixture uses bulk-mem). Ships its own
+      release. Same honesty class as GI-FPU-001/GI-MEM-001.
+    status: implemented
+    tags: [gale, jess, bulk-memory, memory-copy, memory-fill, falcon, release-pending]
+    links:
+      - type: derives-from
+        target: GI-005
+      - type: traces-to
+        target: gale:374
+    fields:
+      req-type: functional
+      priority: must
+      verification-criteria: >
+        scripts/repro/bulk_memory_374_differential.py: 16/16 vs wasmtime
+        (forward, overlap dst>src backward, overlap dst<src forward, self-copy,
+        len==0, dst+len==size & src+len==size boundaries NO trap, OOB dst/src
+        TRAP, low-byte fill); the three frozen fixtures (control_step 0x00210A55,
+        flight_seam 0x07FDF307, div_const 338/338) byte-identical; gale falcon
+        silicon round-trip (falcon-v1.56.fused.wasm) before verified.
+
+  - id: GI-MEM-002-VER-001
+    type: sw-verification
+    title: "Bulk-memory copy/fill (#374) — numeric differential + frozen byte-identity"
+    description: >
+      Verifies GI-MEM-002. scripts/repro/bulk_memory_374_differential.py runs
+      wasmtime (ground truth) vs unicorn (synth Thumb-2, --safety-bounds
+      software) over 16 DISCRIMINATING vectors comparing the full 64 KiB image
+      AND trap outcome: copy non-overlap (asymmetric, catches pop-order swap),
+      overlap dst>src (backward), overlap dst<src (forward), dst==src, len==0 at
+      dst==size, dst+len==size & src+len==size boundaries (must NOT trap), OOB
+      dst+len/src+len (must TRAP), fill with high bits set (only low byte
+      written). Unit tests: wasm_decoder test_decode_bulk_memory_374,
+      wasm_stack_check bulk_memory_pops_three_374, instruction_selector
+      test_bulk_memory_{fill,copy}_lowers_374. Frozen byte-identity confirmed
+      (the three oracles PASS unchanged — no fixture uses bulk-mem).
+    status: implemented
+    tags: [gale, bulk-memory, verification, differential, unit-test, frozen]
+    links:
+      - type: verifies
+        target: GI-MEM-002
+    fields:
+      method: test
+      pass-criteria: >
+        bulk_memory_374_differential.py 16/16; cargo test 374/bulk_memory green;
+        control_step / flight_seam / div_const differentials byte-identical.

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.48" }
+synth-core = { path = "../synth-core", version = "0.11.49" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.48" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.48" }
+synth-core = { path = "../synth-core", version = "0.11.49" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.49" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.48" }
+synth-core = { path = "../synth-core", version = "0.11.49" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.48" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.48", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.49" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.49", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.48" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.48" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.48" }
-synth-backend = { path = "../synth-backend", version = "0.11.48" }
+synth-core = { path = "../synth-core", version = "0.11.49" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.49" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.49" }
+synth-backend = { path = "../synth-backend", version = "0.11.49" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.48", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.48", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.48", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.49", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.49", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.49", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.48", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.49", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -714,6 +714,18 @@ fn convert_operator(op: &wasmparser::Operator) -> Option<WasmOp> {
         MemorySize { mem, .. } => Some(WasmOp::MemorySize(*mem)),
         MemoryGrow { mem, .. } => Some(WasmOp::MemoryGrow(*mem)),
 
+        // Bulk memory (#374). The backend supports a single linear memory
+        // (memory 0); any non-zero memory index falls through to `_ => None` and
+        // loud-skips the function (GI-FPU-001 honesty contract) rather than
+        // miscompiling a multi-memory copy. memory.copy reads dst/src memories;
+        // memory.fill one. The selector lowers these to a bounds-checked byte
+        // loop (see select_with_stack).
+        MemoryCopy {
+            dst_mem: 0,
+            src_mem: 0,
+        } => Some(WasmOp::MemoryCopy),
+        MemoryFill { mem: 0 } => Some(WasmOp::MemoryFill),
+
         // ========================================================================
         // v128 SIMD operations (WASM SIMD proposal, 0xFD prefix)
         // ========================================================================
@@ -1140,6 +1152,29 @@ mod tests {
 
         assert_eq!(functions.len(), 1);
         assert!(functions[0].ops.contains(&WasmOp::MemoryGrow(0)));
+    }
+
+    #[test]
+    fn test_decode_bulk_memory_374() {
+        // #374: memory.copy / memory.fill on the single linear memory decode to
+        // the new WasmOp variants (was `_ => None` -> loud-skip).
+        let wat = r#"
+            (module
+                (memory 1)
+                (func (export "cpy") (param i32 i32 i32)
+                    local.get 0 local.get 1 local.get 2 memory.copy)
+                (func (export "fil") (param i32 i32 i32)
+                    local.get 0 local.get 1 local.get 2 memory.fill)
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
+        let functions = decode_wasm_functions(&wasm).expect("Failed to decode");
+        assert_eq!(functions.len(), 2);
+        assert!(functions[0].ops.contains(&WasmOp::MemoryCopy));
+        assert!(functions[1].ops.contains(&WasmOp::MemoryFill));
+        // Neither function is flagged unsupported (they now lower).
+        assert!(functions[0].unsupported.is_none());
+        assert!(functions[1].unsupported.is_none());
     }
 
     #[test]

--- a/crates/synth-core/src/wasm_op.rs
+++ b/crates/synth-core/src/wasm_op.rs
@@ -85,6 +85,12 @@ pub enum WasmOp {
     MemorySize(u32), // returns current memory size in pages (memory index)
     MemoryGrow(u32), // grow memory by N pages, returns previous size or -1 (memory index)
 
+    // Bulk memory (#374) — single linear memory (memory 0) only; the decoder
+    // loud-skips any non-zero memory index. Each pops (dst, src/val, len) = 3
+    // i32 operands and pushes nothing.
+    MemoryCopy, // memory.copy: copy `len` bytes from `src` to `dst` (memmove semantics)
+    MemoryFill, // memory.fill: set `len` bytes at `dst` to the low byte of `val`
+
     // More ops
     Drop,
     Select,

--- a/crates/synth-core/src/wasm_stack_check.rs
+++ b/crates/synth-core/src/wasm_stack_check.rs
@@ -158,6 +158,11 @@ fn stack_effect_or_bail(op: &WasmOp) -> StackEffect {
         // memory.grow: pops page count, pushes previous size or -1
         MemoryGrow(_) => modeled(1, 1),
 
+        // ---- bulk memory (#374) -----------------------------------------
+        // memory.copy(dst, src, len) and memory.fill(dst, val, len) each pop
+        // three i32 operands and push nothing.
+        MemoryCopy | MemoryFill => modeled(3, 0),
+
         // ---- select / nop / unreachable ---------------------------------
         // select: pops two values and a condition (i32), pushes one value
         Select => modeled(3, 1),
@@ -238,6 +243,30 @@ mod tests {
     fn drop_at_empty_stack_is_underflow() {
         let err = check_no_underflow(&[WasmOp::Drop]).unwrap_err();
         assert!(matches!(err, Error::ValidationError(_)));
+    }
+
+    #[test]
+    fn bulk_memory_pops_three_374() {
+        // memory.copy / memory.fill pop 3, push 0: three pushed operands then the
+        // op must balance to depth 0.
+        for op in [WasmOp::MemoryCopy, WasmOp::MemoryFill] {
+            let ok = vec![
+                WasmOp::I32Const(0),
+                WasmOp::I32Const(0),
+                WasmOp::I32Const(0),
+                op.clone(),
+            ];
+            assert!(check_no_underflow(&ok).is_ok(), "{op:?} with 3 operands");
+            // only two operands -> underflow
+            let bad = vec![WasmOp::I32Const(0), WasmOp::I32Const(0), op.clone()];
+            assert!(
+                matches!(
+                    check_no_underflow(&bad).unwrap_err(),
+                    Error::ValidationError(_)
+                ),
+                "{op:?} with 2 operands must underflow"
+            );
+        }
     }
 
     #[test]

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.48" }
+synth-core = { path = "../synth-core", version = "0.11.49" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.48" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.49" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.48" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.48" }
-synth-opt = { path = "../synth-opt", version = "0.11.48" }
+synth-core = { path = "../synth-core", version = "0.11.49" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.49" }
+synth-opt = { path = "../synth-opt", version = "0.11.49" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -4171,6 +4171,20 @@ impl InstructionSelector {
                     self.target_name
                 )));
             }
+
+            // Bulk memory (#374). `select_default` is the blind-alloc fallback —
+            // it round-robins rd/rn/rm without tracking the operand stack, so it
+            // cannot correctly pop the 3 operands (dst, src/val, len) a copy/fill
+            // needs. The real lowering lives in `select_with_stack`; here we
+            // honestly loud-skip (the GI-FPU-001 / #372 contract) rather than emit
+            // a wrong 3-operand sequence from mis-allocated registers.
+            MemoryCopy | MemoryFill => {
+                return Err(synth_core::Error::synthesis(format!(
+                    "bulk-memory {wasm_op:?} is lowered only by the stack-tracking \
+                     selector (select_with_stack); select_default cannot pop its \
+                     3 operands"
+                )));
+            }
         };
         Ok(instrs)
     }
@@ -9716,6 +9730,335 @@ impl InstructionSelector {
                     stack.push(StackVal::i32(dst));
                 }
 
+                // Bulk memory (#374): memory.fill / memory.copy. Both pop three
+                // i32 operands (dst, val/src, len) and push nothing, so all three
+                // popped registers are DEAD after the op — we reuse them as walking
+                // pointers and the byte buffer, needing only R12 as extra scratch
+                // (no temp allocation). Lowered to a bounds-checked byte loop:
+                //   - bounds (Software mode only, mirroring the store helper): trap
+                //     iff `off + len` overflows u32 OR `off + len > size` (R10, in
+                //     bytes). End-EXCLUSIVE, so a zero-length op at `off == size`
+                //     and an access ending exactly at `size` do NOT trap (matches
+                //     wasmtime). Trap target is the established "Trap_Handler".
+                //   - addresses are R11-relative (R11 = linear-memory base);
+                //     R10 = size in bytes.
+                // None/Mpu/Masking emit just the loop (Masking does NOT wrap each
+                // byte address — a documented gap; Software is the safe default).
+                MemoryFill => {
+                    let len = pop_operand(
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    )?;
+                    let val = pop_operand(
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    )?;
+                    let dst = pop_operand(
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    )?;
+                    let loop_label = self.alloc_label("memfill_loop");
+                    let done_label = self.alloc_label("memfill_done");
+                    let software = matches!(self.bounds_check, BoundsCheckConfig::Software);
+                    let mut ops: Vec<ArmOp> = Vec::new();
+                    // R12 = dst + len (wasm offset of one-past-end); ADDS sets carry
+                    // on u32 overflow.
+                    ops.push(ArmOp::Adds {
+                        rd: Reg::R12,
+                        rn: dst,
+                        op2: Operand2::Reg(len),
+                    });
+                    if software {
+                        // Trap (inline UDF) iff `dst+len` overflows u32 OR
+                        // `dst+len > size` (end-EXCLUSIVE, so `== size` is ok). The
+                        // trap is a self-contained `UDF` guarded by a LOCAL skip
+                        // branch — a body branch to the external `Trap_Handler` is
+                        // only relocated in `--relocatable` mode, not in the
+                        // self-contained image; `UDF` faults to UsageFault/HardFault
+                        // which the vector table routes to `Trap_Handler` on real
+                        // silicon (matching wasmtime's trap).
+                        let ovf_ok = self.alloc_label("memfill_ovf_ok");
+                        let size_ok = self.alloc_label("memfill_size_ok");
+                        // no overflow => carry clear (LO) => skip the trap
+                        ops.push(ArmOp::Bcc {
+                            cond: Condition::LO,
+                            label: ovf_ok.clone(),
+                        });
+                        ops.push(ArmOp::Udf { imm: 0 });
+                        ops.push(ArmOp::Label { name: ovf_ok });
+                        // size >= end (HS after `CMP size,end`) => in bounds => skip
+                        ops.push(ArmOp::Cmp {
+                            rn: Reg::R10,
+                            op2: Operand2::Reg(Reg::R12),
+                        });
+                        ops.push(ArmOp::Bcc {
+                            cond: Condition::HS,
+                            label: size_ok.clone(),
+                        });
+                        ops.push(ArmOp::Udf { imm: 0 });
+                        ops.push(ArmOp::Label { name: size_ok });
+                    }
+                    // R12 = base + (dst+len) = absolute end pointer; dst = base + dst
+                    // = absolute start pointer. `len` is dead after the Adds above.
+                    ops.push(ArmOp::Add {
+                        rd: Reg::R12,
+                        rn: Reg::R11,
+                        op2: Operand2::Reg(Reg::R12),
+                    });
+                    ops.push(ArmOp::Add {
+                        rd: dst,
+                        rn: Reg::R11,
+                        op2: Operand2::Reg(dst),
+                    });
+                    ops.push(ArmOp::Label {
+                        name: loop_label.clone(),
+                    });
+                    ops.push(ArmOp::Cmp {
+                        rn: dst,
+                        op2: Operand2::Reg(Reg::R12),
+                    });
+                    ops.push(ArmOp::Bcc {
+                        cond: Condition::HS,
+                        label: done_label.clone(),
+                    });
+                    // STRB writes only the low byte of `val` (free high-bit mask).
+                    ops.push(ArmOp::Strb {
+                        rd: val,
+                        addr: MemAddr::imm(dst, 0),
+                    });
+                    ops.push(ArmOp::Add {
+                        rd: dst,
+                        rn: dst,
+                        op2: Operand2::Imm(1),
+                    });
+                    ops.push(ArmOp::B {
+                        label: loop_label.clone(),
+                    });
+                    ops.push(ArmOp::Label {
+                        name: done_label.clone(),
+                    });
+                    for op in ops {
+                        instructions.push(ArmInstruction {
+                            op,
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    }
+                }
+
+                MemoryCopy => {
+                    let len = pop_operand(
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    )?;
+                    let src = pop_operand(
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    )?;
+                    let dst = pop_operand(
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    )?;
+                    let fwd_loop = self.alloc_label("memcpy_fwd");
+                    let bwd_setup = self.alloc_label("memcpy_bwd");
+                    let bwd_loop = self.alloc_label("memcpy_bwd_loop");
+                    let done_label = self.alloc_label("memcpy_done");
+                    let software = matches!(self.bounds_check, BoundsCheckConfig::Software);
+                    let mut ops: Vec<ArmOp> = Vec::new();
+                    if software {
+                        // Both `dst+len` and `src+len` must be in bounds
+                        // (end-exclusive; overflow or `> size` traps, `== size` is
+                        // ok). Inline UDF guarded by LOCAL skip branches — see
+                        // MemoryFill above for why an external Trap_Handler branch
+                        // is not used in the self-contained image.
+                        for (base_reg, tag) in [(dst, "memcpy_dst"), (src, "memcpy_src")] {
+                            let ovf_ok = self.alloc_label(&format!("{tag}_ovf_ok"));
+                            let size_ok = self.alloc_label(&format!("{tag}_size_ok"));
+                            ops.push(ArmOp::Adds {
+                                rd: Reg::R12,
+                                rn: base_reg,
+                                op2: Operand2::Reg(len),
+                            });
+                            ops.push(ArmOp::Bcc {
+                                cond: Condition::LO,
+                                label: ovf_ok.clone(),
+                            });
+                            ops.push(ArmOp::Udf { imm: 0 });
+                            ops.push(ArmOp::Label { name: ovf_ok });
+                            ops.push(ArmOp::Cmp {
+                                rn: Reg::R10,
+                                op2: Operand2::Reg(Reg::R12),
+                            });
+                            ops.push(ArmOp::Bcc {
+                                cond: Condition::HS,
+                                label: size_ok.clone(),
+                            });
+                            ops.push(ArmOp::Udf { imm: 0 });
+                            ops.push(ArmOp::Label { name: size_ok });
+                        }
+                    }
+                    // memmove direction: overlapping `dst > src` MUST copy backward
+                    // (a forward loop would overwrite source bytes before reading
+                    // them). `dst <= src` (incl. non-overlap) copies forward. The
+                    // compare is on wasm offsets, monotone under +R11.
+                    ops.push(ArmOp::Cmp {
+                        rn: dst,
+                        op2: Operand2::Reg(src),
+                    });
+                    ops.push(ArmOp::Bcc {
+                        cond: Condition::HI,
+                        label: bwd_setup.clone(),
+                    });
+                    // ---- forward: sptr=R11+src, dptr=R11+dst, dend=dptr+len ----
+                    ops.push(ArmOp::Add {
+                        rd: src,
+                        rn: Reg::R11,
+                        op2: Operand2::Reg(src),
+                    });
+                    ops.push(ArmOp::Add {
+                        rd: dst,
+                        rn: Reg::R11,
+                        op2: Operand2::Reg(dst),
+                    });
+                    ops.push(ArmOp::Add {
+                        rd: Reg::R12,
+                        rn: dst,
+                        op2: Operand2::Reg(len),
+                    });
+                    // `len` dead from here; reused as the byte buffer below.
+                    ops.push(ArmOp::Label {
+                        name: fwd_loop.clone(),
+                    });
+                    ops.push(ArmOp::Cmp {
+                        rn: dst,
+                        op2: Operand2::Reg(Reg::R12),
+                    });
+                    ops.push(ArmOp::Bcc {
+                        cond: Condition::HS,
+                        label: done_label.clone(),
+                    });
+                    ops.push(ArmOp::Ldrb {
+                        rd: len,
+                        addr: MemAddr::imm(src, 0),
+                    });
+                    ops.push(ArmOp::Strb {
+                        rd: len,
+                        addr: MemAddr::imm(dst, 0),
+                    });
+                    ops.push(ArmOp::Add {
+                        rd: src,
+                        rn: src,
+                        op2: Operand2::Imm(1),
+                    });
+                    ops.push(ArmOp::Add {
+                        rd: dst,
+                        rn: dst,
+                        op2: Operand2::Imm(1),
+                    });
+                    ops.push(ArmOp::B {
+                        label: fwd_loop.clone(),
+                    });
+                    // ---- backward: walk from one-past-end down to dlo (exclusive) ----
+                    ops.push(ArmOp::Label {
+                        name: bwd_setup.clone(),
+                    });
+                    // R12 = dlo = R11 + dst (lowest dst byte; exclusive lower bound)
+                    ops.push(ArmOp::Add {
+                        rd: Reg::R12,
+                        rn: Reg::R11,
+                        op2: Operand2::Reg(dst),
+                    });
+                    // dst = R11 + dst + len (one past highest dst byte)
+                    ops.push(ArmOp::Add {
+                        rd: dst,
+                        rn: dst,
+                        op2: Operand2::Reg(len),
+                    });
+                    ops.push(ArmOp::Add {
+                        rd: dst,
+                        rn: Reg::R11,
+                        op2: Operand2::Reg(dst),
+                    });
+                    // src = R11 + src + len (one past highest src byte); `len` dead after
+                    ops.push(ArmOp::Add {
+                        rd: src,
+                        rn: src,
+                        op2: Operand2::Reg(len),
+                    });
+                    ops.push(ArmOp::Add {
+                        rd: src,
+                        rn: Reg::R11,
+                        op2: Operand2::Reg(src),
+                    });
+                    ops.push(ArmOp::Label {
+                        name: bwd_loop.clone(),
+                    });
+                    // dptr <= dlo => all bytes copied
+                    ops.push(ArmOp::Cmp {
+                        rn: dst,
+                        op2: Operand2::Reg(Reg::R12),
+                    });
+                    ops.push(ArmOp::Bcc {
+                        cond: Condition::LS,
+                        label: done_label.clone(),
+                    });
+                    ops.push(ArmOp::Sub {
+                        rd: dst,
+                        rn: dst,
+                        op2: Operand2::Imm(1),
+                    });
+                    ops.push(ArmOp::Sub {
+                        rd: src,
+                        rn: src,
+                        op2: Operand2::Imm(1),
+                    });
+                    ops.push(ArmOp::Ldrb {
+                        rd: len,
+                        addr: MemAddr::imm(src, 0),
+                    });
+                    ops.push(ArmOp::Strb {
+                        rd: len,
+                        addr: MemAddr::imm(dst, 0),
+                    });
+                    ops.push(ArmOp::B {
+                        label: bwd_loop.clone(),
+                    });
+                    ops.push(ArmOp::Label {
+                        name: done_label.clone(),
+                    });
+                    for op in ops {
+                        instructions.push(ArmInstruction {
+                            op,
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    }
+                }
+
                 // For other operations, fall back to default behavior.
                 // Stack tracking is approximate after this point: select_default
                 // uses its own register allocator and doesn't update the virtual stack.
@@ -14121,6 +14464,63 @@ mod tests {
             .iter()
             .any(|i| matches!(&i.op, ArmOp::MemorySize { .. }));
         assert!(has_mem_size, "Should contain MemorySize instruction");
+    }
+
+    #[test]
+    fn test_bulk_memory_fill_lowers_374() {
+        // #374: memory.fill(dst,val,len) lowers to a byte loop — a STRB inside a
+        // labelled loop (Label + backward B). Previously loud-skipped.
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        let wasm_ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::LocalGet(2),
+            WasmOp::MemoryFill,
+            WasmOp::End,
+        ];
+        let arm = selector.select_with_stack(&wasm_ops, 3).unwrap();
+        assert!(
+            arm.iter().any(|i| matches!(&i.op, ArmOp::Strb { .. })),
+            "fill must store bytes"
+        );
+        assert!(
+            arm.iter().any(|i| matches!(&i.op, ArmOp::Label { .. })),
+            "fill must emit a loop label"
+        );
+    }
+
+    #[test]
+    fn test_bulk_memory_copy_lowers_374() {
+        // #374: memory.copy lowers to a memmove byte loop with a direction branch
+        // (forward/backward) — LDRB + STRB and multiple loop labels.
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        let wasm_ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::LocalGet(2),
+            WasmOp::MemoryCopy,
+            WasmOp::End,
+        ];
+        let arm = selector.select_with_stack(&wasm_ops, 3).unwrap();
+        assert!(
+            arm.iter().any(|i| matches!(&i.op, ArmOp::Ldrb { .. })),
+            "copy must load bytes"
+        );
+        assert!(
+            arm.iter().any(|i| matches!(&i.op, ArmOp::Strb { .. })),
+            "copy must store bytes"
+        );
+        // forward + backward loops + direction => at least two labels
+        let labels = arm
+            .iter()
+            .filter(|i| matches!(&i.op, ArmOp::Label { .. }))
+            .count();
+        assert!(
+            labels >= 2,
+            "copy must emit forward+backward loop labels, got {labels}"
+        );
     }
 
     #[test]

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -2073,6 +2073,21 @@ impl OptimizerBridge {
             )));
         }
 
+        // #374: bulk-memory `memory.copy`/`memory.fill` have no IR opcode in the
+        // optimized path (the `Opcode` enum has no bulk-mem). Decline so the
+        // backend falls back to the direct selector, which lowers them to a
+        // bounds-checked byte loop (select_with_stack). Same decline pattern as
+        // #120/#188/#372.
+        if let Some(bulk_op) = wasm_ops
+            .iter()
+            .find(|op| matches!(op, WasmOp::MemoryCopy | WasmOp::MemoryFill))
+        {
+            return Err(Error::UnsupportedInstruction(format!(
+                "optimized lowering path does not support bulk-memory \
+                 ops ({bulk_op:?}); the direct instruction selector lowers them — issue #374"
+            )));
+        }
+
         // Issue #178/#180: the optimized linear-memory miscompilation was
         // root-caused to the Thumb encoder, NOT this lowering — `ArmOp::Add`
         // (and `Adds`/`Subs`) unconditionally used the 16-bit form, whose 3-bit

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.48" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.48" }
-synth-opt = { path = "../synth-opt", version = "0.11.48" }
+synth-core = { path = "../synth-core", version = "0.11.49" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.49" }
+synth-opt = { path = "../synth-opt", version = "0.11.49" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.48", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.49", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }

--- a/scripts/repro/bulk_memory_374.wat
+++ b/scripts/repro/bulk_memory_374.wat
@@ -1,0 +1,5 @@
+(module
+  (memory 1)
+  (func (export "cpy") (param i32 i32 i32) local.get 0 local.get 1 local.get 2 memory.copy)
+  (func (export "fil") (param i32 i32 i32) local.get 0 local.get 1 local.get 2 memory.fill)
+  (func (export "ld32") (param i32) (result i32) local.get 0 i32.load))

--- a/scripts/repro/bulk_memory_374_diff.wat
+++ b/scripts/repro/bulk_memory_374_diff.wat
@@ -1,0 +1,6 @@
+(module
+  (memory 1)
+  (export "memory" (memory 0))
+  (func (export "cpy") (param i32 i32 i32) local.get 0 local.get 1 local.get 2 memory.copy)
+  (func (export "fil") (param i32 i32 i32) local.get 0 local.get 1 local.get 2 memory.fill)
+  (func (export "ld32") (param i32) (result i32) local.get 0 i32.load))

--- a/scripts/repro/bulk_memory_374_differential.py
+++ b/scripts/repro/bulk_memory_374_differential.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""#374 — memory.copy / memory.fill (bulk-memory) numeric differential.
+
+synth had no bulk-memory lowering: `memory.copy`/`memory.fill` fell through the
+decoder `_ => None` and (since v0.11.46/GI-FPU-001) loud-skipped the whole
+function — 19 falcon sites. This adds the WasmOp variants + decoder arms + stack
+effect (pop 3, push 0) + a bounds-checked byte-loop lowering in
+`select_with_stack` (memmove-direction copy, low-byte fill, end-exclusive OOB
+trap matching wasmtime).
+
+This harness is the value-level gate (no silicon needed, like #372): **wasmtime
+is ground truth**; **unicorn** runs synth's Thumb-2 output. Compiled with
+`--safety-bounds software` so the OOB vectors exercise the inline trap. For each
+vector both engines start from the SAME deterministic memory pattern; we compare
+the FULL 64 KiB image AND the trap/no-trap outcome.
+
+The vectors are chosen to DISCRIMINATE the likely lowering bugs (not just "a copy
+happened"):
+  - copy non-overlap dst<src, distinct values   -> catches a pop-order swap
+  - copy overlap dst>src                          -> forces backward copy
+  - copy overlap dst<src                          -> forward correct
+  - copy dst==src                                 -> self copy (no-op)
+  - len==0 at dst==size                           -> no-op, must NOT trap
+  - dst+len==size / src+len==size (boundary)      -> must NOT trap (end-exclusive)
+  - dst+len>size / src+len>size                   -> must TRAP
+  - fill val with high bits set                   -> only low byte written (STRB)
+
+Run:
+  synth compile scripts/repro/bulk_memory_374_diff.wat -o /tmp/bmd.elf \
+        --target cortex-m7dp --all-exports --safety-bounds software
+  /tmp/n374venv/bin/python scripts/repro/bulk_memory_374_differential.py /tmp/bmd.elf
+Exits nonzero on any mismatch.
+"""
+import re
+import subprocess
+import sys
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import (
+    UC_ARCH_ARM,
+    UC_ERR_INSN_INVALID,
+    UC_HOOK_CODE,
+    UC_MODE_THUMB,
+    Uc,
+    UcError,
+)
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R10,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WASM = "scripts/repro/bulk_memory_374_diff.wat"
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/bmd.elf"
+SYNTH = "./target/release/synth"
+
+MEM_BYTES = 0x10000  # 1 page = 64 KiB (matches the wat `(memory 1)`)
+CODE, LIN, STK, RET = 0x200000, 0x400000, 0x90000, 0x300000
+
+
+def pattern():
+    return bytes((i * 31 + 7) & 0xFF for i in range(MEM_BYTES))
+
+
+# (fn, dst, b/src, len, expect_trap)
+VECTORS = [
+    # ---- memory.copy ----
+    ("cpy", 100, 200, 16, False),     # non-overlap dst<src (asymmetric distinct)
+    ("cpy", 1000, 1004, 16, False),   # overlap dst<src -> forward
+    ("cpy", 2004, 2000, 16, False),   # overlap dst>src -> backward (the landmine)
+    ("cpy", 4000, 4000, 32, False),   # dst==src self copy
+    ("cpy", 500, 800, 0, False),      # len 0 no-op
+    ("cpy", MEM_BYTES, 0, 0, False),  # len 0 at dst==size, must NOT trap
+    ("cpy", MEM_BYTES - 16, 0, 16, False),  # dst+len==size boundary, no trap
+    ("cpy", 0, MEM_BYTES - 16, 16, False),  # src+len==size boundary, no trap
+    ("cpy", MEM_BYTES - 10, 0, 16, True),   # dst+len>size -> trap
+    ("cpy", 0, MEM_BYTES - 10, 16, True),   # src+len>size -> trap
+    # ---- memory.fill ----
+    ("fil", 300, 0xAB, 20, False),         # normal
+    ("fil", 5000, 0x12345678, 10, False),  # high bits set -> only low byte 0x78
+    ("fil", 700, 0x00, 0, False),          # len 0 no-op
+    ("fil", MEM_BYTES, 0xAB, 0, False),    # len 0 at dst==size, must NOT trap
+    ("fil", MEM_BYTES - 16, 0xFF, 16, False),  # boundary, no trap
+    ("fil", MEM_BYTES - 10, 0xFF, 16, True),   # OOB -> trap
+]
+
+
+def main():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, open(_wasm_bytes_path(), "rb").read())
+
+    def wasmtime_run(fn, a, b, c):
+        store = wasmtime.Store(engine)
+        inst = wasmtime.Instance(store, module, [])
+        mem = inst.exports(store)["memory"]
+        mem.write(store, pattern(), 0)
+        try:
+            inst.exports(store)[fn](store, a, b, c)
+            trapped = False
+        except wasmtime.Trap:
+            trapped = True
+        img = bytes(mem.read(store, 0, MEM_BYTES))
+        return trapped, img
+
+    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
+    syms = {m.group(2): int(m.group(1), 16)
+            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
+    trap_sym = syms["Trap_Handler"]
+    text = ELFFile(open(ELF, "rb")).get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    trap_addr = CODE + trap_sym - base
+
+    def unicorn_run(fn, a, b, c):
+        fa = syms[fn]
+        mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+        mu.mem_map(CODE, 0x10000)
+        mu.mem_map(LIN, MEM_BYTES)        # exactly 1 page: any OOB write faults
+        mu.mem_map(STK - 0x8000, 0x10000)
+        mu.mem_map(RET, 0x1000)
+        mu.mem_write(CODE, code)
+        mu.mem_write(LIN, pattern())
+        mu.reg_write(UC_ARM_REG_SP, STK)
+        mu.reg_write(UC_ARM_REG_R11, LIN)        # linear-memory base
+        mu.reg_write(UC_ARM_REG_R10, MEM_BYTES)  # memory size (bytes) for bounds
+        mu.reg_write(UC_ARM_REG_R0, a & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R1, b & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R2, c & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        trapped = [False]
+
+        def hook(uc, address, size, ud):
+            if address == trap_addr:
+                trapped[0] = True
+                uc.emu_stop()
+        mu.hook_add(UC_HOOK_CODE, hook)
+        try:
+            mu.emu_start((CODE + fa - base) | 1, RET, count=200000)
+        except UcError as e:
+            # The inline bounds trap is a `UDF` -> UC_ERR_INSN_INVALID: that IS
+            # the wasm trap (on silicon UsageFault/HardFault routes to
+            # Trap_Handler). Any OTHER fault (e.g. READ/WRITE_UNMAPPED) means a
+            # bounds bug let an out-of-bounds access through — report as ERR so it
+            # never silently counts as a match.
+            if e.errno == UC_ERR_INSN_INVALID:
+                return True, bytes(mu.mem_read(LIN, MEM_BYTES))
+            return f"ERR:{e}", b""
+        img = bytes(mu.mem_read(LIN, MEM_BYTES))
+        return trapped[0], img
+
+    fails = 0
+    for (fn, a, b, c, exp_trap) in VECTORS:
+        gt_trap, gt_img = wasmtime_run(fn, a, b, c)
+        sy_trap, sy_img = unicorn_run(fn, a, b, c)
+        assert gt_trap == exp_trap, f"vector expectation wrong for {fn}({a},{b},{c})"
+        if isinstance(sy_trap, str):  # ERR
+            ok = False
+            detail = sy_trap
+        elif gt_trap:
+            # Both must trap; on trap wasm leaves memory unchanged (bounds checked
+            # up front), and so does synth (bounds before the loop).
+            ok = sy_trap and sy_img == gt_img
+            detail = f"trap synth={sy_trap} wasmtime={gt_trap}"
+        else:
+            ok = (not sy_trap) and sy_img == gt_img
+            if sy_img != gt_img:
+                diff = next((i for i in range(MEM_BYTES) if sy_img[i] != gt_img[i]), -1)
+                detail = (f"mem differs @{diff}: synth=0x{sy_img[diff]:02x} "
+                          f"wasmtime=0x{gt_img[diff]:02x}")
+            else:
+                detail = "image identical"
+        fails += 0 if ok else 1
+        print(f"{fn}(dst={a},{'src' if fn=='cpy' else 'val'}={b},len={c}) "
+              f"trap={exp_trap}: {'OK' if ok else 'MISMATCH'}  [{detail}]")
+    print(f"\n{len(VECTORS) - fails}/{len(VECTORS)} match")
+    print("ORACLE: PASS" if fails == 0 else f"ORACLE: FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+def _wasm_bytes_path():
+    # wat2wasm the harness module once.
+    out = "/tmp/bmd.wasm"
+    subprocess.run(["wat2wasm", WASM, "-o", out], check=True)
+    return out
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## #374 — bulk-memory lowering (`memory.copy` / `memory.fill`)

Closes the largest remaining falcon on-target gap: **19 sites (11 `memory.fill` + 8 `memory.copy`)**. Like the scalar floats (#369) and the former `i64.load/store` (#372), bulk-memory fell through the decoder `_ => None` and (since v0.11.46 / GI-FPU-001) **loud-skipped the whole function**. Unlike #372 the lowering did not exist at all.

### What landed
- `WasmOp::MemoryCopy` / `MemoryFill` + decoder arms (**memory 0** only — a non-zero memory index still loud-skips, preserving the GI-FPU-001 honesty contract)
- stack effect `pop 3, push 0`
- optimizer **decline → direct-selector fallback** (`#120/#188/#372` pattern)
- bounds-checked byte-loop lowering in `select_with_stack`:
  - `fill` → `STRB` loop writing the **low byte** of `val`
  - `copy` → **memmove** byte loop; `dst > src` copies **backward** so overlapping copies don't corrupt the source
  - `--safety-bounds software`: **inline `UDF`** guarded by a local skip branch, **end-exclusive** trap (`off+len > size` or `u32` overflow; `== size` ok), matching wasmtime. (Self-contained image doesn't relocate a body `Trap_Handler` branch, so `UDF`; on silicon UsageFault/HardFault routes to `Trap_Handler` via the vector table.)
  - 3 dead popped operands reused as walking pointers — only `R12` extra, no temp allocation

### Verification
- **`scripts/repro/bulk_memory_374_differential.py`: 16/16 vs wasmtime** over discriminating vectors (forward, overlap `dst>src` backward, overlap `dst<src` forward, self-copy, `len==0`, `dst+len==size` & `src+len==size` boundaries NO-trap, OOB `dst`/`src` TRAP, low-byte fill) — compares full 64 KiB image **and** trap outcome.
- **Frozen-safe:** `control_step` `0x00210A55` (13/13), `flight_seam` `0x07FDF307`, `div_const` 338/338 byte-identical.
- Unit tests: decoder / stack-check / selector (`*_374`).
- RISC-V continues to loud-skip bulk-mem (symbol absent, warning names the op) — silent-drop class **not** reintroduced.
- `cargo test --workspace --exclude synth-verify` green; fmt + clippy clean; rivet `GI-MEM-002` (+`VER-001`), non-xref errors 0.

### Release gate
v0.11.49 is prepped (pin sweep + CHANGELOG). **Holding the tag for gale's `falcon-v1.56.fused.wasm` G474RE round-trip** before closing #374 — the one path unicorn can't see is `UDF → UsageFault/HardFault → vector-table → Trap_Handler` (the in-bounds copy/fill loop is the high-fidelity, solidly-verified part).

🤖 Generated with [Claude Code](https://claude.com/claude-code)