### PR TITLE
fix(#378): fail honestly on out-of-layout local — never guess a frame offset

### DIFF
--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -5579,24 +5579,19 @@ impl InstructionSelector {
                             });
                             (dst, false)
                         } else {
-                            // Local not in layout (shouldn't happen for valid wasm,
-                            // but fall back to legacy behaviour for compatibility).
-                            let dst = alloc_temp_or_spill(
-                                &mut next_temp,
-                                &mut stack,
-                                &mut instructions,
-                                &mut spill,
-                                &live_params,
-                                idx,
-                            )?;
-                            instructions.push(ArmInstruction {
-                                op: ArmOp::Ldr {
-                                    rd: dst,
-                                    addr: MemAddr::imm(Reg::SP, (*local_idx as i32 - 4) * 4),
-                                },
-                                source_line: Some(idx),
-                            });
-                            (dst, false)
+                            // #378 honesty: a local absent from the computed frame
+                            // layout is either malformed wasm (out-of-range index,
+                            // which validation should have rejected) or a
+                            // layout-computation bug. Either way, FAIL HONESTLY —
+                            // a loud `Err` loud-skips the function — rather than
+                            // GUESS a frame offset `(local_idx-4)*4` and silently
+                            // miscompile. Same never-guess contract as GI-FPU-001
+                            // (decoder) and #180/#185 (encoder Ok-or-Err).
+                            return Err(synth_core::Error::synthesis(format!(
+                                "local.get {local_idx} (op {idx}) is absent from the \
+                                 computed frame layout — refusing to guess a stack \
+                                 offset (would silently miscompile)"
+                            )));
                         };
                     stack.push(StackVal::Reg {
                         reg,
@@ -8072,15 +8067,14 @@ impl InstructionSelector {
                         });
                         cf.add_instruction();
                     } else {
-                        // Fall-through for compatibility (shouldn't happen).
-                        instructions.push(ArmInstruction {
-                            op: ArmOp::Str {
-                                rd: val,
-                                addr: MemAddr::imm(Reg::SP, (*local_idx as i32 - 4) * 4),
-                            },
-                            source_line: Some(idx),
-                        });
-                        cf.add_instruction();
+                        // #378 honesty: refuse to guess a frame offset for a local
+                        // absent from the layout — fail loud (loud-skip) rather than
+                        // silently store to a guessed address. See LocalGet above.
+                        return Err(synth_core::Error::synthesis(format!(
+                            "local.set {local_idx} (op {idx}) is absent from the \
+                             computed frame layout — refusing to guess a stack \
+                             offset (would silently miscompile)"
+                        )));
                     }
                 }
 
@@ -8162,15 +8156,14 @@ impl InstructionSelector {
                         });
                         cf.add_instruction();
                     } else {
-                        // Fall-through for compatibility.
-                        instructions.push(ArmInstruction {
-                            op: ArmOp::Str {
-                                rd: val,
-                                addr: MemAddr::imm(Reg::SP, (*local_idx as i32 - 4) * 4),
-                            },
-                            source_line: Some(idx),
-                        });
-                        cf.add_instruction();
+                        // #378 honesty: refuse to guess a frame offset for a local
+                        // absent from the layout — fail loud (loud-skip) rather than
+                        // silently store to a guessed address. See LocalGet above.
+                        return Err(synth_core::Error::synthesis(format!(
+                            "local.tee {local_idx} (op {idx}) is absent from the \
+                             computed frame layout — refusing to guess a stack \
+                             offset (would silently miscompile)"
+                        )));
                     }
                 }
 


### PR DESCRIPTION
Closes #378.

## Fail honestly, never guess

`select_with_stack`'s `LocalGet`/`LocalSet`/`LocalTee` handlers emitted a **guessed** stack offset `(local_idx-4)*4` for a local absent from the computed frame layout ("shouldn't happen for valid wasm, fall back to legacy behaviour"). That guess is the pre-#204/#223 layout — wrong under the current `compute_local_layout` — so if the branch ever fired it would **silently load/store the wrong stack slot** rather than fail. Same silent-miscompile family as the decoder `_ => None` (#369/#374) and the encoder index-drop (#206).

All three sites now return a loud `Err` (loud-skips the function), naming the local index — the GI-FPU-001 / #180 "never emit plausible-but-wrong output" contract.

## Verification

- **Frozen bit-identical** — control_step `0x00210A55`, flight_seam `0x07FDF307`, div_const 338/338 (the branch is dead on valid input, so no emitted code changes).
- **Full workspace suite green** (`cargo test --workspace --exclude synth-verify`) with **no test triggering the new `Err`** — proving the path was unreachable defensive code that could only ever have silently miscompiled.
- fmt + clippy clean.

No cycle/size delta — this is correctness/honesty hardening, not an optimization (which is why it's not an oracle-gate cleanup filing). One reversible change, three symmetric sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)