### PR TITLE
fix(#382): materialize large static load/store offset (> imm12) — never skip the function

### DIFF
--- a/artifacts/gale-integration.yaml
+++ b/artifacts/gale-integration.yaml
@@ -851,3 +851,72 @@ artifacts:
       pass-criteria: >
         bulk_memory_374_differential.py 16/16; cargo test 374/bulk_memory green;
         control_step / flight_seam / div_const differentials byte-identical.
+
+  - id: GI-MEM-003
+    type: sw-req
+    title: "Large static load/store offset (> imm12) materialized, not skipped (#382)"
+    description: >
+      gust's kernel init (a large static struct field store) compiled to a
+      memory access with a static `offset > 0xFFF` (4095). The optimized
+      (non-relocatable) ARM path lowers a memory op to `MOVW/MOVT R12,#0x20000100;
+      ADD R12,R12,Raddr; LDR/STR [R12,#offset]`; the encoder's check_ldst_imm12
+      (#259) correctly REFUSES the imm12 form for offset > 4095 (it never
+      silently masks to offset&0xFFF), so the whole function was SKIPPED — gust
+      could not compile. (The `reg_imm` bounds-checked path and the #95 const-fold
+      path were already range-safe: the former self-materializes the offset via
+      encode_thumb32_add_imm, the latter is gated `eff <= 0xFFF`. Only the
+      optimizer-path const-base sites bailed.) IMPLEMENTED (next release):
+      optimizer_bridge::fold_mem_offset folds the large CONSTANT offset into the
+      compile-time-CONSTANT base — `(base+offset)+addr == base+addr+offset`
+      (mod 2^32) — so the access immediate becomes #0 with ZERO added
+      instructions and never an `ADD R12,R12,#imm` (which would hit the
+      rd==rn==R12 no-scratch corner, #350). Applied at all four optimizer memory
+      sites (MemLoad, MemStore, MemLoadSubword, MemStoreSubword). Gated to
+      offset > 0xFFF so small-offset output stays byte-identical. Frozen-safe.
+      Same honesty class as GI-FPU-001/GI-MEM-001/GI-MEM-002 — fail/skip honestly
+      was already correct (#259); this makes the previously-skipped case compile
+      correctly.
+    status: implemented
+    tags: [gale, gust, codegen, load-store, offset, encoder, release-pending]
+    links:
+      - type: derives-from
+        target: GI-005
+      - type: traces-to
+        target: gale:382
+    fields:
+      req-type: functional
+      priority: must
+      verification-criteria: >
+        scripts/repro/load_store_big_offset_382_differential.py: 5/5 vs wasmtime
+        (cross-addressed store offset=5000 read back via absolute load at
+        addr+5000, and the symmetric load-offset and sub-word half-word cases —
+        a dropped offset reads 0, not the stored value); the four skipped repro
+        functions now compile; the three frozen fixtures (control_step
+        0x00210A55, flight_seam 0x07FDF307, div_const 338/338) byte-identical;
+        gust_boot 10/10 functions compile PENDING gust.loom.wasm (integration
+        confirmation, not a correctness gate the differential leaves open).
+
+  - id: GI-MEM-003-VER-001
+    type: sw-verification
+    title: "Large load/store offset (#382) — differential + frozen byte-identity"
+    description: >
+      Verifies GI-MEM-003. scripts/repro/load_store_big_offset_382_differential.py
+      runs wasmtime (ground truth) vs unicorn (synth Thumb-2, optimized absolute
+      base) over a cross-addressed call program: a value stored via offset=5000 is
+      read back through an ABSOLUTE load (offset=0, never-folded path) at addr+5000
+      — so a silently-dropped offset reads 0, not the value (non-vacuous). Also a
+      symmetric offset-load and an i32.store16/load16_u sub-word case. Unit tests:
+      optimizer_bridge fold_mem_offset_gates_on_imm12_382 (boundary 0xFFF vs
+      0x1000) and memstore_large_offset_folds_into_base_382 (no STR immediate
+      > imm12; base materialized as 0x20001488). Frozen byte-identity confirmed.
+    status: implemented
+    tags: [gale, gust, codegen, verification, differential, unit-test, frozen]
+    links:
+      - type: verifies
+        target: GI-MEM-003
+    fields:
+      method: test
+      pass-criteria: >
+        load_store_big_offset_382_differential.py 5/5; cargo test 382 green
+        (fold_mem_offset_gates_on_imm12_382, memstore_large_offset_folds_into_base_382);
+        control_step / flight_seam / div_const differentials byte-identical.

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -21,6 +21,31 @@ use synth_opt::{
     Instruction, Opcode, OptResult, PassManager, PeepholeOptimization, Reg as OptReg,
 };
 
+/// #382: fold a static memory offset that exceeds the 12-bit load/store
+/// immediate range into the compile-time-constant linear-memory base.
+///
+/// The optimized path materializes the linear-memory base as a constant
+/// (`MOVW/MOVT R12, #base`), adds the dynamic index (`ADD R12, R12, Raddr`),
+/// and then accesses `[R12, #offset]`. When the wasm `offset` is `> 0xFFF` the
+/// encoder's `check_ldst_imm12` (#259) correctly REFUSES the imm12 form (it
+/// never silently masks to `offset & 0xFFF`), so the function was skipped.
+///
+/// Because `base` is a compile-time constant and `offset` is too, their sum is
+/// also constant: `(base + offset) + addr ≡ base + addr + offset (mod 2^32)`.
+/// Folding the offset into the materialized base keeps the access immediate at
+/// `#0` with ZERO added instructions and never produces an `ADD R12, R12, #imm`
+/// (which would hit the `rd==rn==R12` no-scratch corner — #350).
+///
+/// Gated to `offset > 0xFFF` so existing small-offset output stays
+/// byte-identical (the frozen differential fixtures must not move).
+fn fold_mem_offset(base: u32, offset: u32) -> (u32, i32) {
+    if offset > 0xFFF {
+        (base.wrapping_add(offset), 0)
+    } else {
+        (base, offset as i32)
+    }
+}
+
 /// Optimization configuration
 #[derive(Debug, Clone)]
 pub struct OptimizationConfig {
@@ -4620,8 +4645,10 @@ impl OptimizerBridge {
                     );
                     vreg_to_arm.insert(dest.0, rd);
 
-                    // Linear memory base address: 0x20000100 (in SRAM, above stack area)
-                    let base: u32 = 0x20000100;
+                    // Linear memory base 0x20000100 (SRAM, above stack area).
+                    // #382: fold a large static offset (> imm12) into the
+                    // compile-time-constant base so the access immediate is 0.
+                    let (base, mem_off) = fold_mem_offset(0x20000100, *offset);
                     let base_lo = (base & 0xFFFF) as u16;
                     let base_hi = ((base >> 16) & 0xFFFF) as u16;
 
@@ -4643,7 +4670,7 @@ impl OptimizerBridge {
                     // Load from [base + wasm_addr + static_offset]
                     arm_instrs.push(ArmOp::Ldr {
                         rd,
-                        addr: crate::rules::MemAddr::imm(Reg::R12, *offset as i32),
+                        addr: crate::rules::MemAddr::imm(Reg::R12, mem_off),
                     });
                     last_result_vreg = Some(dest.0);
                 }
@@ -4654,8 +4681,10 @@ impl OptimizerBridge {
                     let r_addr = get_arm_reg(addr, &vreg_to_arm, &spilled_vregs)?;
                     let r_src = get_arm_reg(src, &vreg_to_arm, &spilled_vregs)?;
 
-                    // Linear memory base address: 0x20000100 (in SRAM, above stack area)
-                    let base: u32 = 0x20000100;
+                    // Linear memory base 0x20000100 (SRAM, above stack area).
+                    // #382: fold a large static offset (> imm12) into the
+                    // compile-time-constant base so the access immediate is 0.
+                    let (base, mem_off) = fold_mem_offset(0x20000100, *offset);
                     let base_lo = (base & 0xFFFF) as u16;
                     let base_hi = ((base >> 16) & 0xFFFF) as u16;
 
@@ -4677,7 +4706,7 @@ impl OptimizerBridge {
                     // Store to [base + wasm_addr + static_offset]
                     arm_instrs.push(ArmOp::Str {
                         rd: r_src,
-                        addr: crate::rules::MemAddr::imm(Reg::R12, *offset as i32),
+                        addr: crate::rules::MemAddr::imm(Reg::R12, mem_off),
                     });
                     // MemStore does not produce a value
                 }
@@ -4706,7 +4735,9 @@ impl OptimizerBridge {
                     );
                     vreg_to_arm.insert(dest.0, rd);
 
-                    let base: u32 = 0x20000100;
+                    // #382: fold a large static offset (> imm12) into the
+                    // compile-time-constant base so the access immediate is 0.
+                    let (base, mem_off) = fold_mem_offset(0x20000100, *offset);
                     let base_lo = (base & 0xFFFF) as u16;
                     let base_hi = ((base >> 16) & 0xFFFF) as u16;
                     arm_instrs.push(ArmOp::Movw {
@@ -4722,7 +4753,7 @@ impl OptimizerBridge {
                         rn: Reg::R12,
                         op2: Operand2::Reg(r_addr),
                     });
-                    let addr_mem = crate::rules::MemAddr::imm(Reg::R12, *offset as i32);
+                    let addr_mem = crate::rules::MemAddr::imm(Reg::R12, mem_off);
                     let sub_op = match (*width, *signed) {
                         (1, false) => ArmOp::Ldrb { rd, addr: addr_mem },
                         (1, true) => ArmOp::Ldrsb { rd, addr: addr_mem },
@@ -4749,7 +4780,9 @@ impl OptimizerBridge {
                     let r_addr = get_arm_reg(addr, &vreg_to_arm, &spilled_vregs)?;
                     let r_src = get_arm_reg(src, &vreg_to_arm, &spilled_vregs)?;
 
-                    let base: u32 = 0x20000100;
+                    // #382: fold a large static offset (> imm12) into the
+                    // compile-time-constant base so the access immediate is 0.
+                    let (base, mem_off) = fold_mem_offset(0x20000100, *offset);
                     let base_lo = (base & 0xFFFF) as u16;
                     let base_hi = ((base >> 16) & 0xFFFF) as u16;
                     arm_instrs.push(ArmOp::Movw {
@@ -4765,7 +4798,7 @@ impl OptimizerBridge {
                         rn: Reg::R12,
                         op2: Operand2::Reg(r_addr),
                     });
-                    let addr_mem = crate::rules::MemAddr::imm(Reg::R12, *offset as i32);
+                    let addr_mem = crate::rules::MemAddr::imm(Reg::R12, mem_off);
                     let sub_op = match *width {
                         1 => ArmOp::Strb {
                             rd: r_src,
@@ -6169,6 +6202,83 @@ mod tests {
         assert!(
             !has_runtime_shift,
             "IR-level: i64.shr_u with constant 32 should NOT emit ArmOp::I64ShrU; got: {:#?}",
+            arm
+        );
+    }
+
+    #[test]
+    fn fold_mem_offset_gates_on_imm12_382() {
+        // Small offsets (<= 0xFFF) are left in the access immediate so existing
+        // output stays byte-identical; large offsets fold into the const base.
+        assert_eq!(fold_mem_offset(0x2000_0100, 100), (0x2000_0100, 100));
+        assert_eq!(fold_mem_offset(0x2000_0100, 0xFFF), (0x2000_0100, 0xFFF));
+        // Boundary: 0x1000 (4096) is the first offset that must fold.
+        assert_eq!(fold_mem_offset(0x2000_0100, 0x1000), (0x2000_1100, 0));
+        assert_eq!(fold_mem_offset(0x2000_0100, 5000), (0x2000_1488, 0));
+        // Arithmetic identity holds: (base + off) + 0 == base + off.
+        let (b, imm) = fold_mem_offset(0x2000_0100, 5000);
+        assert_eq!(
+            b.wrapping_add(imm as u32),
+            0x2000_0100u32.wrapping_add(5000)
+        );
+    }
+
+    #[test]
+    fn memstore_large_offset_folds_into_base_382() {
+        // #382: a MemStore with offset > imm12 must NOT emit a `[R12, #offset]`
+        // whose immediate exceeds 0xFFF (the encoder would refuse it and the
+        // function would be skipped). The offset is folded into the MOVW/MOVT
+        // base instead, leaving the access immediate at 0.
+        let bridge = OptimizerBridge::new();
+        let instrs = vec![
+            Instruction {
+                id: 0,
+                opcode: Opcode::Const {
+                    dest: OptReg(0),
+                    value: 0,
+                },
+                block_id: 0,
+                is_dead: false,
+            },
+            Instruction {
+                id: 1,
+                opcode: Opcode::Const {
+                    dest: OptReg(1),
+                    value: 0xDEAD,
+                },
+                block_id: 0,
+                is_dead: false,
+            },
+            Instruction {
+                id: 2,
+                opcode: Opcode::MemStore {
+                    src: OptReg(1),
+                    addr: OptReg(0),
+                    offset: 5000,
+                },
+                block_id: 0,
+                is_dead: false,
+            },
+        ];
+        let arm = bridge.ir_to_arm(&instrs, 0).expect("valid IR lowers");
+        // No load/store may carry an immediate > 0xFFF.
+        for op in &arm {
+            if let ArmOp::Str { addr, .. } = op {
+                assert!(
+                    addr.offset.unsigned_abs() <= 0xFFF,
+                    "STR immediate {:#x} exceeds imm12 — offset was not folded: {:#?}",
+                    addr.offset,
+                    arm
+                );
+            }
+        }
+        // The base must be materialized as 0x20000100 + 5000 = 0x20001488.
+        let has_folded_base = arm
+            .iter()
+            .any(|op| matches!(op, ArmOp::Movw { imm16, .. } if *imm16 == 0x1488));
+        assert!(
+            has_folded_base,
+            "expected MOVW #0x1488 (0x20000100 + 5000 low half); got: {:#?}",
             arm
         );
     }

--- a/scripts/repro/load_store_big_offset_382.wat
+++ b/scripts/repro/load_store_big_offset_382.wat
@@ -1,0 +1,29 @@
+;; #382 — load/store with a static offset > 0xFFF (4095) must MATERIALIZE the
+;; offset, not skip the function. The optimized (non-relocatable) path lowers a
+;; memory access to `MOVW/MOVT R12,#base; ADD R12,R12,Raddr; LDR/STR [R12,#off]`.
+;; When `off > 0xFFF` the encoder's check_ldst_imm12 (#259) REFUSES the imm12
+;; form (it never silently masks to off&0xFFF), so the whole function was
+;; dropped. Fix (optimizer_bridge::fold_mem_offset): fold the large constant
+;; offset into the compile-time-constant base — `(base+off)+addr == base+addr+off`
+;; — keeping the access immediate at #0 with zero added instructions.
+;; Surfaced by the gust kernel (a large static struct field store lands beyond
+;; the 12-bit imm range).
+;;
+;; The differential proves the offset is actually APPLIED (not dropped) by
+;; cross-addressing: store via offset=5000 and read the SAME byte back via an
+;; absolute load at addr+5000 (and the symmetric load-offset case). Addresses are
+;; param-derived (dynamic) so issue-#95 const-address folding does not apply.
+(module
+  (memory 1)
+  ;; word
+  (func (export "store_off") (param $a i32) (param $v i32)
+    local.get $a local.get $v (i32.store offset=5000))
+  (func (export "load_abs") (param $a i32) (result i32)
+    local.get $a (i32.load offset=0))
+  (func (export "load_off") (param $a i32) (result i32)
+    local.get $a (i32.load offset=5000))
+  ;; half-word (sub-word path)
+  (func (export "store_h_off") (param $a i32) (param $v i32)
+    local.get $a local.get $v (i32.store16 offset=5000))
+  (func (export "load_hu_abs") (param $a i32) (result i32)
+    local.get $a (i32.load16_u offset=0)))

--- a/scripts/repro/load_store_big_offset_382_differential.py
+++ b/scripts/repro/load_store_big_offset_382_differential.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""#382 — large static load/store offset (> imm12) differential oracle.
+
+The optimized (non-relocatable) ARM path materializes the linear-memory base as
+a compile-time constant (`MOVW/MOVT R12,#0x20000100`), adds the dynamic index
+(`ADD R12,R12,Raddr`), then accesses `[R12,#offset]`. For `offset > 0xFFF` the
+encoder's check_ldst_imm12 (#259) refuses the imm12 form (never masking), so the
+whole function was skipped. Fix: `optimizer_bridge::fold_mem_offset` folds the
+large constant offset into the constant base (access immediate becomes #0).
+
+This harness runs the SAME call sequence under wasmtime (ground truth) and under
+unicorn (synth's emitted ARM, absolute base), and compares. It is constructed so
+a *dropped* offset is observable, not just a self-consistent roundtrip: a value
+stored via `offset=5000` is read back through an ABSOLUTE load at `addr+5000`
+(and symmetrically an `offset=5000` load reads a byte written absolutely). If the
+store/load silently dropped the +5000, these cross-addressed reads diverge from
+wasmtime.
+
+Run (rebuild synth first):
+  /tmp/n374venv/bin/python scripts/repro/load_store_big_offset_382_differential.py
+
+Exits nonzero on mismatch so it can gate a release.
+"""
+import re
+import subprocess
+import sys
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_SP,
+)
+
+WAT = "scripts/repro/load_store_big_offset_382.wat"
+WASM = "/tmp/ls382.wasm"
+ELF = "/tmp/ls382_diff.elf"
+SYNTH = "./target/debug/synth"
+
+# Absolute linear-memory base the optimized path materializes (optimizer_bridge).
+LIN_BASE = 0x20000100
+
+# The call program: a list of (fn, args, expects_result). Cross-addressed so a
+# dropped +5000 offset is observable. Run identically on both engines.
+PROGRAM = [
+    ("store_off", (0, 0xDEADBEEF), False),     # write word at addr 0, +5000 -> byte 5000
+    ("load_abs", (5000,), True),               # absolute read of byte 5000  -> 0xDEADBEEF
+    ("load_off", (0,), True),                  # offset read of addr 0 +5000 -> 0xDEADBEEF
+    ("store_off", (16, 0x12345678), False),    # byte 5016
+    ("load_abs", (5016,), True),               # -> 0x12345678
+    ("store_h_off", (40, 0xBEEF), False),      # half-word at byte 5040
+    ("load_hu_abs", (5040,), True),            # -> 0x0000BEEF
+    ("load_off", (40,), True),                 # NB: load word at 5040 (BEEF + next bytes)
+]
+
+
+def run_wasmtime():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, open(WASM, "rb").read())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    exports = inst.exports(store)
+    results = []
+    for fn, args, want in PROGRAM:
+        r = exports[fn](store, *args)
+        if want:
+            results.append(r & 0xFFFFFFFF)
+    return results
+
+
+def run_unicorn():
+    subprocess.run(
+        [SYNTH, "compile", WASM, "-t", "cortex-m4", "--all-exports", "-o", ELF],
+        check=True, capture_output=True,
+    )
+    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
+    syms = {m.group(2): int(m.group(1), 16)
+            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
+    text = ELFFile(open(ELF, "rb")).get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+
+    CODE, LIN, STK = 0x10000, LIN_BASE & ~0xFFFF, 0x30000000
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x10000)
+    mu.mem_map(LIN, 0x10000)          # covers LIN_BASE .. LIN_BASE+0xFEFF (byte 5040 OK)
+    mu.mem_map(STK - 0x8000, 0x10000)
+    mu.mem_write(CODE, code)
+    RET = 0x1F00 | 1
+
+    results = []
+    for fn, args, want in PROGRAM:
+        for i, a in enumerate(args):
+            mu.reg_write(UC_ARM_REG_R0 + i, a & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_SP, STK)
+        mu.reg_write(UC_ARM_REG_LR, RET)
+        try:
+            mu.emu_start((CODE + syms[fn] - base) | 1, RET & ~1, count=2000)
+        except UcError as e:
+            return f"ERR in {fn}{args}: {e}"
+        if want:
+            results.append(mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF)
+    return results
+
+
+def main():
+    subprocess.run(["wat2wasm", WAT, "-o", WASM], check=True)
+    gt = run_wasmtime()
+    got = run_unicorn()
+    print(f"wasmtime (ground truth): {[f'0x{x:08X}' for x in gt]}")
+    if isinstance(got, str):
+        print(f"synth ARM             : {got}")
+        print("MISMATCH  <-- #382")
+        sys.exit(1)
+    print(f"synth ARM             : {[f'0x{x:08X}' for x in got]}")
+    ok = got == gt
+    print(f"\n{len(got)}/{len(gt)} match" if ok
+          else f"\nMISMATCH  <-- #382 (got {got} vs {gt})")
+    print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

gust's kernel init compiled a memory access with a static `offset > 0xFFF` (4095). The optimized (non-relocatable) ARM path lowers a memory op to `MOVW/MOVT R12,#0x20000100; ADD R12,R12,Raddr; LDR/STR [R12,#offset]`; the encoder's `check_ldst_imm12` (#259) correctly **refuses** the imm12 form for `offset > 4095` (it never silently masks to `offset & 0xFFF`), so the whole function was **skipped** — gust could not compile.

Root cause is narrow. The `reg_imm` bounds-checked path already self-materializes via `encode_thumb32_add_imm`, and the #95 const-fold path is range-gated (`eff <= 0xFFF`). Only the **optimizer-path const-base** sites bailed.

## Fix

`optimizer_bridge::fold_mem_offset` folds the large **constant** offset into the compile-time-**constant** base — `(base+offset)+addr ≡ base+addr+offset` (mod 2³²) — so the access immediate becomes `#0` with **zero added instructions**, and never an `ADD R12,R12,#imm` (which would hit the `rd==rn==R12` no-scratch corner, #350). Applied at all four optimizer memory sites (`MemLoad`, `MemStore`, `MemLoadSubword`, `MemStoreSubword`). Gated to `offset > 0xFFF` so small-offset output stays byte-identical.

Before: `movw ip,#0x100; movt ip,#0x2000; add ip,ip,r0; str [ip,#5000]` → encoder refuses → **function skipped**.
After: `movw ip,#0x1488; movt ip,#0x2000; add ip,ip,r0; str [ip]` (0x20000100+5000 = 0x20001488, imm `#0`).

## Oracle evidence

- `scripts/repro/load_store_big_offset_382_differential.py` **5/5** vs wasmtime — cross-addressed: a value stored via `offset=5000` is read back through an **absolute** load (`offset=0`, never-folded path) at `addr+5000`, so a silently-dropped offset reads `0`, not the value (**non-vacuous**); plus symmetric offset-load and `i32.store16`/`load16_u` sub-word cases.
- unit tests `fold_mem_offset_gates_on_imm12_382` (boundary `0xFFF` vs `0x1000`) + `memstore_large_offset_folds_into_base_382` (no STR immediate > imm12; base materialized as `0x20001488`).
- frozen fixtures **byte-identical**: control_step `0x00210A55` (13/13), flight_seam `0x07FDF307`, div_const `338/338`.
- full workspace `cargo test` green; `cargo fmt --check` + `clippy -D warnings` clean.

## Honest scope note

The literal gust kill-criterion ("gust_boot 10/10 functions compile") is **pending `gust.loom.wasm`** (not yet available) — that's an *integration confirmation*, not a correctness gate the differential leaves open: this is pure address arithmetic with no trap/timing/regalloc-pressure path, and unicorn executes the exact emitted Thumb-2 bytes against wasmtime. gust_boot confirmation will be picked up by the issue-hunt loop when the wasm lands.

rivet: `GI-MEM-003` + `GI-MEM-003-VER-001` (gale:382).

🤖 Generated with [Claude Code](https://claude.com/claude-code)