### PR TITLE
chore(release): v0.11.50 — #382 large load/store offset + #378/#381 honesty + GI-MEM-002→verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.50] - 2026-06-19
+
+**LARGE LOAD/STORE OFFSET — #382: a static memory `offset > 0xFFF` (4095) no
+longer skips the function.** Surfaced by the `gust` wasm kernel init (a large
+static struct field store). Bundles the previously-unreleased honesty fixes
+(#378, #381) and promotes the bulk-memory traceability (`GI-MEM-002`) to
+`verified` now that jess's hermetic Renode RT1176 OOB-trap oracle (TEST-PIX-013)
+has confirmed #374 on silicon.
+
+- **#382 — large static load/store offset materialized** (was: function
+  skipped). The optimized (non-relocatable) path lowers a memory access to
+  `MOVW/MOVT R12,#0x20000100; ADD R12,R12,Raddr; LDR/STR [R12,#offset]`. For
+  `offset > 0xFFF` the encoder's `check_ldst_imm12` (#259) correctly **refuses**
+  the imm12 form (it never silently masks to `offset & 0xFFF`), so the whole
+  function was dropped. The `reg_imm` bounds-checked path and the #95 const-fold
+  path were already range-safe; only the optimizer const-base sites bailed.
+  - Fix (`optimizer_bridge::fold_mem_offset`): since both the base and the
+    `offset` are compile-time constants, fold the large offset into the
+    materialized base — `(base+offset)+addr ≡ base+addr+offset` (mod 2³²) — so
+    the access immediate becomes `#0` with **zero added instructions**, and it
+    never emits an `ADD R12,R12,#imm` (which would hit the `rd==rn==R12`
+    no-scratch corner, #350). Applied at all four optimizer memory sites
+    (`MemLoad`, `MemStore`, `MemLoadSubword`, `MemStoreSubword`).
+  - Gated to `offset > 0xFFF`, so small-offset output stays byte-identical
+    (the frozen differential fixtures do not move).
+  - Oracle: `scripts/repro/load_store_big_offset_382_differential.py` 5/5 vs
+    wasmtime — cross-addressed so a *dropped* offset is observable (store via
+    `offset=5000`, read back via an absolute load at `addr+5000` reads 0 if the
+    offset is lost), plus an `i32.store16`/`load16_u` sub-word case. Unit tests
+    `fold_mem_offset_gates_on_imm12_382` + `memstore_large_offset_folds_into_base_382`.
+  - The literal `gust_boot` 10/10-functions integration confirmation is pending
+    `gust.loom.wasm` (not yet available); the differential is the hermetic
+    correctness gate — pure address arithmetic, no trap/timing path it leaves
+    uncovered.
+- **#378 / #381 — honesty hardening** (bundled, both bit-identical, no behavior
+  change): `select_with_stack` no longer guesses a frame offset for an
+  out-of-layout local (returns a loud `Err`), and `encode_operand2` returns
+  `Err` on an un-encodable ARM32 immediate instead of masking to `uval & 0xFF`.
+- **Traceability:** `GI-MEM-002` + `GI-MEM-002-VER-001` promoted
+  `implemented → verified` (jess Renode RT1176 TEST-PIX-013); `GI-MEM-003`
+  (#382) added as `implemented`.
+
+Frozen fixtures byte-identical across all of the above: control_step
+`0x00210A55`, flight_seam `0x07FDF307`, div_const `338/338`.
+
 ## [0.11.49] - 2026-06-19
 
 **BULK-MEMORY — #374: `memory.copy` / `memory.fill` now lower to bounds-checked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,14 +1908,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1964,11 +1964,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.11.49"
+version = "0.11.50"
 
 [[package]]
 name = "synth-cli"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "anyhow",
  "clap",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "anyhow",
  "serde",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2017,14 +2017,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2032,11 +2032,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.11.49"
+version = "0.11.50"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "anyhow",
  "clap",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.11.49"
+version = "0.11.50"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.11.49"
+version = "0.11.50"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.11.49",
+    version = "0.11.50",
 )
 
 # Bazel dependencies

--- a/artifacts/gale-integration.yaml
+++ b/artifacts/gale-integration.yaml
@@ -807,14 +807,20 @@ artifacts:
       UsageFault/HardFault routes to Trap_Handler via the vector table.) The 3
       dead popped operands are reused as walking pointers (only R12 extra), so no
       temp allocation. Frozen-safe (no fixture uses bulk-mem). Ships its own
-      release. Same honesty class as GI-FPU-001/GI-MEM-001.
-    status: implemented
-    tags: [gale, jess, bulk-memory, memory-copy, memory-fill, falcon, release-pending]
+      release. Same honesty class as GI-FPU-001/GI-MEM-001. VERIFIED on silicon
+      via jess's hermetic Renode RT1176 OOB-trap oracle (TEST-PIX-013): an
+      out-of-bounds memory.copy parks PC at Trap_Handler (UDF -> HardFault
+      escalation -> vector table), an in-bounds copy does not false-trap
+      (v0.11.49, tag 39010ce).
+    status: verified
+    tags: [gale, jess, bulk-memory, memory-copy, memory-fill, falcon, silicon-verified, release-v0.11.49]
     links:
       - type: derives-from
         target: GI-005
       - type: traces-to
         target: gale:374
+      - type: traces-to
+        target: jess:TEST-PIX-013
     fields:
       req-type: functional
       priority: must
@@ -840,12 +846,16 @@ artifacts:
       written). Unit tests: wasm_decoder test_decode_bulk_memory_374,
       wasm_stack_check bulk_memory_pops_three_374, instruction_selector
       test_bulk_memory_{fill,copy}_lowers_374. Frozen byte-identity confirmed
-      (the three oracles PASS unchanged — no fixture uses bulk-mem).
-    status: implemented
-    tags: [gale, bulk-memory, verification, differential, unit-test, frozen]
+      (the three oracles PASS unchanged — no fixture uses bulk-mem). Silicon
+      verification closed by jess's Renode RT1176 OOB-trap oracle TEST-PIX-013
+      (the unicorn-blind UDF -> HardFault -> Trap_Handler vector routing).
+    status: verified
+    tags: [gale, jess, bulk-memory, verification, differential, unit-test, frozen, silicon-verified]
     links:
       - type: verifies
         target: GI-MEM-002
+      - type: traces-to
+        target: jess:TEST-PIX-013
     fields:
       method: test
       pass-criteria: >

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.49" }
+synth-core = { path = "../synth-core", version = "0.11.50" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.49" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.49" }
+synth-core = { path = "../synth-core", version = "0.11.50" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.50" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.49" }
+synth-core = { path = "../synth-core", version = "0.11.50" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.49" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.49", optional = true }
+synth-core = { path = "../synth-core", version = "0.11.50" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.50", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.11.49" }
-synth-frontend = { path = "../synth-frontend", version = "0.11.49" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.49" }
-synth-backend = { path = "../synth-backend", version = "0.11.49" }
+synth-core = { path = "../synth-core", version = "0.11.50" }
+synth-frontend = { path = "../synth-frontend", version = "0.11.50" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.50" }
+synth-backend = { path = "../synth-backend", version = "0.11.50" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.49", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.49", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.49", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.11.50", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.11.50", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.11.50", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.11.49", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.11.50", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.11.49" }
+synth-core = { path = "../synth-core", version = "0.11.50" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.11.49" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.50" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.11.49" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.49" }
-synth-opt = { path = "../synth-opt", version = "0.11.49" }
+synth-core = { path = "../synth-core", version = "0.11.50" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.50" }
+synth-opt = { path = "../synth-opt", version = "0.11.50" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.11.49" }
-synth-cfg = { path = "../synth-cfg", version = "0.11.49" }
-synth-opt = { path = "../synth-opt", version = "0.11.49" }
+synth-core = { path = "../synth-core", version = "0.11.50" }
+synth-cfg = { path = "../synth-cfg", version = "0.11.50" }
+synth-opt = { path = "../synth-opt", version = "0.11.50" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.11.49", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.11.50", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## Release v0.11.50

Pin sweep `0.11.49 → 0.11.50` (workspace + `MODULE.bazel` + 9 path-dep version pins + `Cargo.lock`), CHANGELOG, and rivet traceability.

### Ships
- **#382** (merged in #384): large static load/store `offset > 0xFFF` is now materialized into the compile-time-constant base (`optimizer_bridge::fold_mem_offset`) instead of skipping the function. Zero added instructions; gated to `offset > 0xFFF` so small offsets are byte-identical. Differential 5/5 vs wasmtime (cross-addressed, non-vacuous).
- **#378 / #381**: honesty hardening (fail loud instead of guessing a frame offset / masking an un-encodable ARM32 immediate) — both bit-identical, accumulated on main since their merges.
- **Traceability:** `GI-MEM-002` + `GI-MEM-002-VER-001` promoted `implemented → verified` (jess Renode RT1176 OOB-trap oracle TEST-PIX-013, #374 silicon-confirmed). `GI-MEM-003` (#382) added.

### Frozen fixtures byte-identical
control_step `0x00210A55`, flight_seam `0x07FDF307`, div_const `338/338`.

This is a zero-code-delta release commit (pin sweep + docs + rivet); the #382 code already merged and passed full CI in #384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)