### PR TITLE
feat(vcr-sel): cross-backend op-parity oracle — gate RV32-vs-ARM op-gaps (VCR-SEL-005, #242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -207,6 +207,32 @@ artifacts:
       proofs are already Admitted (coq/STATUS.md), blocked upstream by the flat
       exec_program's no-op BCondOffset (see VCR-ISA-001). So div/rem SEL coverage
       depends on VCR-ISA-001's real-control-flow executor, not on this track.
+
+      MOTIVATION-1 RE-SCOPED — "selector missed an op" silent-drop is already
+      structurally closed (measured 2026-06-20). The original framing ("a missing
+      rule is a silent miscompile the DSL enumerates away") is now only partly a
+      DSL job, because the existing selectors no longer silent-drop:
+        - ARM select_default (instruction_selector.rs:1799→4189) is an EXHAUSTIVE
+          match over WasmOp with NO `_ =>` wildcard (the SIMD and
+          MemoryCopy|MemoryFill arms `return Err`). A newly-added WasmOp variant is
+          a COMPILE error, not a silent NOP — exhaustiveness checking IS coverage
+          enumeration for ARM. select_with_stack's `_ =>` (10057) delegates to
+          select_default, so every op is Ok-or-typed-Err: no drop path.
+        - RISC-V selector.rs:911 `other => Err(SelectorError::Unsupported(op))` is a
+          RUNTIME typed loud-skip — kills silent WRONG-CODE but, unlike ARM, is not
+          compile-checked, so a new op silently DIVERGES (loud-skipped on RV32,
+          lowered on ARM) rather than failing the build.
+        - Clean split of the cited #223/#226/#232 class: the REGALLOC subset (#226
+          alloc_temp live-value clobber) is owned by VCR-RA-001 and already landed;
+          the OP-GAP subset (#223/#232 "RV32 rejected ops ARM handles") is NOT a
+          silent drop — it is a CROSS-BACKEND PARITY gap (ARM lowers X; RV32
+          loud-declines X) that no oracle covers today and gale, not a gate, caught.
+      So VCR-SEL-001's remaining value is NOT silent-drop prevention (the compiler
+      + typed-Err terminals own that). It is: (i) correctness-by-construction of the
+      lowering rules; (ii) collapsing the two/three-selector accretion
+      (select_default / select_with_stack / optimizer_bridge) into one verified
+      source; and (iii) cross-backend op-parity — the concrete near-term increment,
+      tracked as VCR-SEL-005 below.
     status: approved
     tags: [codegen, selector, isle, verified-dsl, rocq, track-a, novel, release-v0.12.1]
     links:
@@ -235,6 +261,62 @@ artifacts:
         functions directly, and synth's existing T1 tactic suite
         (synth_binop_proof family vs exec_indexed) IS that direct path — the
         DSL pays off only when rule count amortizes its cost.
+
+  - id: VCR-SEL-005
+    type: sw-req
+    title: Cross-backend op-parity oracle
+    description: >
+      A test-time gate (crates/synth-backend-riscv/tests/cross_backend_op_parity.rs,
+      cross_backend_integer_op_parity_242) that lowers a curated set of
+      self-contained, minimally-valid WasmOp sequences on BOTH the ARM (Thumb-2)
+      and RISC-V (RV32IMAC) selectors and asserts integer-core PARITY: an op the
+      ARM selector lowers must be lowered-or-explicitly-ledgered by the RV32
+      selector. This is the concrete near-term increment of VCR-SEL-001: the
+      VCR-SEL-001 pilot measurement (2026-06-20) established that "selector missed
+      an op" is no longer a silent miscompile (ARM select_default is an exhaustive
+      WasmOp match; RV32 ends dispatch with a typed Unsupported Err), so the
+      residual #223/#232 risk is purely cross-backend DIVERGENCE — ARM lowers op
+      X, RV32 loud-declines it, and the function silently compiles on one target
+      and is skipped on the other. Historically that gap was found only by gale on
+      qemu; this oracle surfaces it as a gate.
+
+      The ledger (KNOWN_DIVERGENCES) is bidirectional: a NEW divergence not in the
+      ledger fails the build (a fresh op-gap, owned here not on silicon), and a
+      ledgered divergence that has CLOSED also fails (a stale entry the fix must
+      delete) — so a parity claim cannot outlive the gap it documents, and a
+      landed RV32 lowering is forced to retire its ledger line.
+
+      FIRST MEASUREMENT (2026-06-20, first run): the oracle found FIVE
+      ARM-lowers / RV32-declines integer op-gaps, all the Zbb bit-manipulation
+      class — i32.rotl, i32.rotr, i32.clz, i32.ctz, i32.popcnt. RV32IMAC and
+      rv32imc (incl. ESP32-C3) do not include Zbb, so there is no single native
+      instruction; ARM lowers them via sequences (ROR/CLZ/RBIT, and a software
+      sequence for popcount which ARMv7-M also lacks natively), proving they are
+      sequence-lowerable on RV32 too (as Select already is). Recorded as tracked
+      deferrals under this requirement. NOTE the i64 bit-manip analogues
+      (i64.clz/i64.popcnt) came back at PARITY — not flagged. SCOPE: integer core
+      only; float (VFP) and SIMD (Helium) parity is a separate, large, known gap
+      and is intentionally NOT asserted by this oracle.
+
+      FOLLOW-UP (the work this oracle drives): implement the five RV32 sequence
+      lowerings, each differential-validated against wasmtime per the established
+      bug-loop discipline; landing each one retires its ledger entry via the
+      stale-entry check.
+    status: implemented
+    tags: [codegen, selector, riscv, parity, oracle, track-a, release-v0.11.51]
+    links:
+      - type: derives-from
+        target: VCR-001
+      - type: traces-to
+        target: VCR-SEL-001
+    fields:
+      req-type: functional
+      priority: should
+      verification-criteria: >
+        cross_backend_integer_op_parity_242 is green: every integer-core probe is
+        at ARM/RV32 parity OR carries a reasoned KNOWN_DIVERGENCES entry, with the
+        at-parity floor (>=30 common-core ops) guarding against a construction
+        regression that would let "everything errors" masquerade as parity.
 
   # ---------------------------------------------------------------------------
   # Track B — authoritative semantics (independent; parallel with Track A)

--- a/crates/synth-backend-riscv/tests/cross_backend_op_parity.rs
+++ b/crates/synth-backend-riscv/tests/cross_backend_op_parity.rs
@@ -1,0 +1,293 @@
+//! VCR-SEL-005 — cross-backend op-parity oracle (North Star, epic #242).
+//!
+//! WHY THIS EXISTS. The "selector missed an op" bug class (#223 Select +
+//! non-param locals + sign-extend; #232) was never a *silent* miscompile —
+//! both selectors fail honestly on an op they don't lower (ARM `select_default`
+//! is an exhaustive `match` over `WasmOp`; RISC-V `selector.rs` ends op-dispatch
+//! with `other => Err(SelectorError::Unsupported)`). The actual defect was
+//! **cross-backend divergence**: ARM lowered an op that RV32 loud-declined, so a
+//! function compiled on Cortex-M but was skipped on RISC-V — and nothing caught
+//! that until gale ran it on qemu. The VCR-SEL-001 measurement (2026-06-20)
+//! confirmed silent-drop is structurally closed on both backends, which
+//! re-pointed the verified-selector value at exactly this: an op-PARITY gate.
+//!
+//! WHAT IT ASSERTS. For a curated set of self-contained, minimally-valid
+//! `WasmOp` sequences, lower each on BOTH backends and classify Ok / Err. The
+//! common integer core must be at **parity** (both Ok or both Err). Every
+//! legitimate difference lives in [`KNOWN_DIVERGENCES`] with a written reason.
+//! The test fails in BOTH directions:
+//!   * a divergence NOT in the ledger  → a new #223-class op-gap, surfaced as a
+//!     gate here instead of by gale on silicon;
+//!   * a ledgered divergence that has CLOSED → stale entry, delete it (keeps the
+//!     ledger honest — a parity claim must not outlive the gap it documents).
+//!
+//! SCOPE (no silent cap — the divergence is recorded, not hidden). This oracle
+//! covers the INTEGER core where the #223/#232 op-gaps lived: i32/i64
+//! arithmetic, bitwise, shift/rotate, compare, sign-extend, Select, the
+//! width conversions, locals, and integer memory. Float (f32/f64) and SIMD
+//! (v128) parity is a separate, large, known gap (ARM has VFP/Helium lowerings
+//! RV32 does not); it is intentionally out of this first oracle's scope and is
+//! tracked separately, NOT asserted here.
+
+use synth_backend_riscv::selector::select as riscv_select;
+use synth_synthesis::{BoundsCheckConfig, InstructionSelector, RuleDatabase, WasmOp, WasmOp::*};
+
+/// Does the ARM (Thumb-2) stack-tracking selector lower this sequence?
+///
+/// Construction mirrors the real call site (`arm_backend.rs`): standard rule DB,
+/// no inline bounds guard, no-FPU Cortex-M4 target (integer lowering is
+/// FPU-independent; pinning the target keeps the classification deterministic).
+fn arm_lowers(ops: &[WasmOp], num_params: u32) -> bool {
+    let db = RuleDatabase::with_standard_rules();
+    let mut sel =
+        InstructionSelector::with_bounds_check(db.rules().to_vec(), BoundsCheckConfig::None);
+    sel.set_target(None, "thumbv7em-none-eabi");
+    sel.select_with_stack(ops, num_params).is_ok()
+}
+
+/// Does the RISC-V (RV32IMAC) selector lower this sequence?
+fn riscv_lowers(ops: &[WasmOp], num_params: u32) -> bool {
+    riscv_select(ops, num_params).is_ok()
+}
+
+/// One parity probe: a human label, the parameter count, and a self-contained
+/// minimally-valid op sequence that exercises the op named by `label`.
+struct Case {
+    label: &'static str,
+    num_params: u32,
+    ops: Vec<WasmOp>,
+}
+
+fn c(label: &'static str, num_params: u32, ops: Vec<WasmOp>) -> Case {
+    Case {
+        label,
+        num_params,
+        ops,
+    }
+}
+
+/// Ledger of KNOWN ARM-vs-RISC-V parity differences. Key = the `Case::label`;
+/// value = WHY the two backends disagree today. Two legitimate entry kinds —
+/// both must carry a concrete reason, never a hand-wave:
+///   * PERMANENT ISA divergence — one ISA structurally cannot express the op
+///     in this target slice (e.g. ARM Helium SIMD has no RV32IMAC analogue).
+///     Out of this integer oracle's scope; none here.
+///   * TRACKED DEFERRAL — a #223-class op-gap that is named, reasoned, and
+///     pointed at a tracking requirement. The ledger entry IS the "file it":
+///     it makes the gap a gated, owned fact instead of a silicon surprise.
+///     When the RV32 lowering lands, the stale-entry check (below) FAILS until
+///     this line is deleted — so a deferral cannot quietly outlive its fix.
+///
+/// MEASURED 2026-06-20 (first oracle run): the RV32 selector loud-declines five
+/// integer bit-manipulation ops the ARM selector lowers. All five are the Zbb
+/// class (rotate / count-leading-zeros / count-trailing-zeros / popcount); the
+/// RV32IMAC and rv32imc target slices do NOT include Zbb, so there is no single
+/// native instruction. ARM lowers them via sequences (ROR/CLZ/RBIT — and a
+/// software sequence for popcount, which ARMv7-M also lacks natively), proving
+/// they are sequence-lowerable on RV32 too (as `Select` already is). Tracked as
+/// deferrals under VCR-SEL-005 (artifacts/verified-codegen-roadmap.yaml) — the
+/// concrete op-by-op follow-up this oracle exists to drive.
+fn known_divergences() -> &'static [(&'static str, &'static str)] {
+    &[
+        (
+            "i32.rotl",
+            "Zbb rol absent on RV32IMAC/rv32imc; RV32 seq-lowering deferred — VCR-SEL-005",
+        ),
+        (
+            "i32.rotr",
+            "Zbb ror absent on RV32IMAC/rv32imc; RV32 seq-lowering deferred — VCR-SEL-005",
+        ),
+        (
+            "i32.clz",
+            "Zbb clz absent on RV32IMAC/rv32imc; RV32 seq-lowering deferred — VCR-SEL-005",
+        ),
+        (
+            "i32.ctz",
+            "Zbb ctz absent on RV32IMAC/rv32imc; RV32 seq-lowering deferred — VCR-SEL-005",
+        ),
+        (
+            "i32.popcnt",
+            "Zbb cpop absent on RV32IMAC/rv32imc; RV32 seq-lowering deferred — VCR-SEL-005",
+        ),
+    ]
+}
+
+/// The curated integer-core parity set. Each sequence is valid in isolation:
+/// constants supply every operand the op pops, so a lowering failure is an
+/// op-coverage fact, not a stack-underflow artifact.
+fn cases() -> Vec<Case> {
+    vec![
+        // ---- i32 arithmetic / bitwise (single-instruction binops) ----
+        c("i32.add", 0, vec![I32Const(3), I32Const(5), I32Add]),
+        c("i32.sub", 0, vec![I32Const(9), I32Const(4), I32Sub]),
+        c("i32.mul", 0, vec![I32Const(3), I32Const(5), I32Mul]),
+        c("i32.and", 0, vec![I32Const(6), I32Const(3), I32And]),
+        c("i32.or", 0, vec![I32Const(6), I32Const(3), I32Or]),
+        c("i32.xor", 0, vec![I32Const(6), I32Const(3), I32Xor]),
+        // ---- i32 shift / rotate (rotate is the scratch-using class) ----
+        c("i32.shl", 0, vec![I32Const(1), I32Const(4), I32Shl]),
+        c("i32.shr_s", 0, vec![I32Const(-16), I32Const(2), I32ShrS]),
+        c("i32.shr_u", 0, vec![I32Const(16), I32Const(2), I32ShrU]),
+        c("i32.rotl", 0, vec![I32Const(1), I32Const(3), I32Rotl]),
+        c("i32.rotr", 0, vec![I32Const(1), I32Const(3), I32Rotr]),
+        // ---- i32 unary bit-counts ----
+        c("i32.clz", 0, vec![I32Const(1), I32Clz]),
+        c("i32.ctz", 0, vec![I32Const(8), I32Ctz]),
+        c("i32.popcnt", 0, vec![I32Const(7), I32Popcnt]),
+        // ---- i32 sign-extend (the #223 class) ----
+        c("i32.extend8_s", 0, vec![I32Const(200), I32Extend8S]),
+        c("i32.extend16_s", 0, vec![I32Const(40000), I32Extend16S]),
+        // ---- i32 div / rem (trap-guarded) ----
+        c("i32.div_s", 0, vec![I32Const(-9), I32Const(2), I32DivS]),
+        c("i32.div_u", 0, vec![I32Const(9), I32Const(2), I32DivU]),
+        c("i32.rem_s", 0, vec![I32Const(-9), I32Const(2), I32RemS]),
+        c("i32.rem_u", 0, vec![I32Const(9), I32Const(2), I32RemU]),
+        // ---- i32 comparison ----
+        c("i32.eqz", 0, vec![I32Const(0), I32Eqz]),
+        c("i32.eq", 0, vec![I32Const(3), I32Const(3), I32Eq]),
+        c("i32.ne", 0, vec![I32Const(3), I32Const(4), I32Ne]),
+        c("i32.lt_s", 0, vec![I32Const(-1), I32Const(1), I32LtS]),
+        c("i32.lt_u", 0, vec![I32Const(1), I32Const(2), I32LtU]),
+        c("i32.gt_s", 0, vec![I32Const(2), I32Const(1), I32GtS]),
+        c("i32.ge_u", 0, vec![I32Const(2), I32Const(2), I32GeU]),
+        // ---- Select (the #223 class) ----
+        c(
+            "select",
+            0,
+            vec![I32Const(10), I32Const(20), I32Const(1), Select],
+        ),
+        // ---- locals (the #223 non-param-local class) ----
+        c("local.get(param)", 1, vec![LocalGet(0)]),
+        c(
+            "local.set+get(param)",
+            1,
+            vec![I32Const(42), LocalSet(0), LocalGet(0)],
+        ),
+        c("local.tee(param)", 1, vec![I32Const(42), LocalTee(0)]),
+        // ---- integer memory (i32, sub-word) ----
+        c(
+            "i32.load",
+            0,
+            vec![
+                I32Const(0),
+                I32Load {
+                    offset: 0,
+                    align: 2,
+                },
+            ],
+        ),
+        c(
+            "i32.store",
+            0,
+            vec![
+                I32Const(0),
+                I32Const(42),
+                I32Store {
+                    offset: 0,
+                    align: 2,
+                },
+            ],
+        ),
+        c(
+            "i32.load8_u",
+            0,
+            vec![
+                I32Const(0),
+                I32Load8U {
+                    offset: 0,
+                    align: 0,
+                },
+            ],
+        ),
+        c(
+            "i32.store8",
+            0,
+            vec![
+                I32Const(0),
+                I32Const(42),
+                I32Store8 {
+                    offset: 0,
+                    align: 0,
+                },
+            ],
+        ),
+        // ---- i64 arithmetic / bitwise ----
+        c("i64.add", 0, vec![I64Const(3), I64Const(5), I64Add]),
+        c("i64.sub", 0, vec![I64Const(9), I64Const(4), I64Sub]),
+        c("i64.mul", 0, vec![I64Const(3), I64Const(5), I64Mul]),
+        c("i64.and", 0, vec![I64Const(6), I64Const(3), I64And]),
+        c("i64.or", 0, vec![I64Const(6), I64Const(3), I64Or]),
+        c("i64.xor", 0, vec![I64Const(6), I64Const(3), I64Xor]),
+        // ---- i64 shift ----
+        c("i64.shl", 0, vec![I64Const(1), I64Const(4), I64Shl]),
+        c("i64.shr_u", 0, vec![I64Const(16), I64Const(2), I64ShrU]),
+        // ---- i64 unary / compare ----
+        c("i64.clz", 0, vec![I64Const(1), I64Clz]),
+        c("i64.popcnt", 0, vec![I64Const(7), I64Popcnt]),
+        c("i64.eqz", 0, vec![I64Const(0), I64Eqz]),
+        c("i64.eq", 0, vec![I64Const(3), I64Const(3), I64Eq]),
+        c("i64.lt_s", 0, vec![I64Const(-1), I64Const(1), I64LtS]),
+        // ---- width conversions (i32<->i64) ----
+        c("i64.extend_i32_s", 0, vec![I32Const(-1), I64ExtendI32S]),
+        c("i64.extend_i32_u", 0, vec![I32Const(-1), I64ExtendI32U]),
+        c("i32.wrap_i64", 0, vec![I64Const(0x1_0000_0001), I32WrapI64]),
+    ]
+}
+
+#[test]
+fn cross_backend_integer_op_parity_242() {
+    let ledger: std::collections::HashMap<&str, &str> =
+        known_divergences().iter().copied().collect();
+
+    let mut unexpected: Vec<String> = Vec::new(); // diverged but not ledgered
+    let mut stale: Vec<String> = Vec::new(); // ledgered but no longer diverging
+    let mut at_parity = 0usize;
+
+    for case in cases() {
+        let a = arm_lowers(&case.ops, case.num_params);
+        let r = riscv_lowers(&case.ops, case.num_params);
+        let ledgered = ledger.get(case.label);
+
+        match (a == r, ledgered) {
+            (true, None) => at_parity += 1,
+            (true, Some(_reason)) => stale.push(format!(
+                "  {} — ledgered as a divergence but BOTH backends now agree \
+                 (arm_ok={a}, riscv_ok={r}); delete the KNOWN_DIVERGENCES entry",
+                case.label
+            )),
+            (false, Some(_reason)) => { /* known, explained divergence — OK */ }
+            (false, None) => unexpected.push(format!(
+                "  {} — arm_lowers={a}, riscv_lowers={r} (cross-backend op-gap; \
+                 the #223 class). Either implement the missing lowering, or add a \
+                 KNOWN_DIVERGENCES entry with a reason.",
+                case.label
+            )),
+        }
+    }
+
+    // Floor: the curated set must actually be exercising both backends, so a
+    // construction regression (e.g. every case erroring on a stack-underflow
+    // artifact) can't masquerade as "all at parity".
+    assert!(
+        at_parity >= 30,
+        "parity oracle exercised too few common-core ops ({at_parity}); the \
+         curated set or the selector construction regressed"
+    );
+
+    assert!(
+        unexpected.is_empty() && stale.is_empty(),
+        "cross-backend op-parity ledger is out of date:\n\
+         NEW UNEXPLAINED DIVERGENCES (the #223 op-gap class):\n{}\n\
+         STALE LEDGER ENTRIES (close them):\n{}",
+        if unexpected.is_empty() {
+            "  (none)".into()
+        } else {
+            unexpected.join("\n")
+        },
+        if stale.is_empty() {
+            "  (none)".into()
+        } else {
+            stale.join("\n")
+        },
+    );
+}


### PR DESCRIPTION
## North Star (VCR-SEL-005, epic #242) — Track A

Continues VCR-SEL-001. The pilot measurement (PR #386) established that the **"selector missed an op" silent-drop class is structurally closed** on both backends:
- ARM `select_default` is an **exhaustive `match` over `WasmOp`** (no `_ =>`) → a new op variant is a *compile error*, not a silent NOP.
- RV32 `selector.rs` ends op-dispatch with `other => Err(SelectorError::Unsupported)` → a runtime *loud-skip*.

So the residual #223/#232 risk is **cross-backend divergence**: ARM lowers an op the RV32 selector loud-declines, so a function compiles on Cortex-M but is skipped on RISC-V — historically caught only by gale on qemu, never by a gate.

## What this lands

`crates/synth-backend-riscv/tests/cross_backend_op_parity.rs` — `cross_backend_integer_op_parity_242` lowers a curated integer-core set of self-contained, minimally-valid `WasmOp` sequences on **both** selectors and asserts parity. The `KNOWN_DIVERGENCES` ledger is **bidirectional**:
- a divergence **not** in the ledger fails the build (a fresh op-gap, owned here not on silicon);
- a ledgered divergence that has **closed** also fails (a stale entry the fix must delete) — a parity claim can't outlive the gap it documents, and a landed RV32 lowering is forced to retire its line.

## First measurement (first run)

Found **5 real op-gaps**, all the **Zbb** bit-manipulation class — `i32.rotl`, `i32.rotr`, `i32.clz`, `i32.ctz`, `i32.popcnt`. RV32IMAC / rv32imc (incl. ESP32-C3) lack Zbb, so no single native instruction; ARM lowers them via sequences (ARMv7-M also lacks a native popcount, yet `arm_lowers(i32.popcnt)=true`), proving they're sequence-lowerable on RV32 too (as `Select` already is). Recorded as tracked deferrals under VCR-SEL-005. The `i64` bit-manip analogues came back **at parity** — not flagged.

**Scope:** integer core only (where #223/#232 lived). Float (VFP) / SIMD (Helium) parity is a separate, large, known gap — intentionally not asserted here.

**Follow-up the oracle drives:** implement the 5 RV32 sequence lowerings, each differential-validated against wasmtime; landing each retires its ledger entry via the stale-check.

## Safety

Test + roadmap (`artifacts/verified-codegen-roadmap.yaml`) only — **zero codegen change**; the frozen differential fixtures (control_step `0x00210A55`, flat+inlined flight_algo `0x07FDF307`, divseam) are bit-identical by construction. Full `synth-backend-riscv` suite green (175 + parity); fmt + clippy clean; rivet validate has 0 non-xref errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)