### PR TITLE
feat(vcr-mem): #383 layer-2 substrate — scry shadow-stack-depth proof verified in-tree (scry-sai-core v1.12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -167,6 +167,15 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
@@ -281,7 +290,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -383,6 +392,15 @@ checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -467,6 +485,16 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -500,13 +528,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
  "ctutils",
  "zeroize",
 ]
@@ -644,6 +682,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,7 +782,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1120,7 +1168,7 @@ version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02"
 dependencies = [
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -1297,7 +1345,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest",
+ "digest 0.11.3",
  "hmac",
 ]
 
@@ -1732,6 +1780,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "scry-sai-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0401e01d66f970c7a1d2bc3c66357667b34201f4770c3cd2daacd0c19c3d5b02"
+dependencies = [
+ "scry-sai-interval",
+ "scry-sai-octagon",
+ "scry-sai-provenance",
+ "scry-sai-taint",
+ "sha2 0.10.9",
+ "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "scry-sai-interval"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671f099b30046a1e90d6a49d8ea792f2b70359f431c312fba3f9f67ab2643920"
+
+[[package]]
+name = "scry-sai-octagon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d421f0f11657a6ab94d9c04e311a63621c598804cfb2b1c300b831e16c4b6b"
+
+[[package]]
+name = "scry-sai-provenance"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b4a57106fa4bdff9483459b5347438d36119e296898392913c563dbf8696bb"
+
+[[package]]
+name = "scry-sai-taint"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8e63d81c38be72e55ee16dc4ed775f87e82655201559d37ca55ff9094c8bb4"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,8 +1885,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1810,8 +1907,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1973,6 +2070,7 @@ dependencies = [
  "anyhow",
  "clap",
  "object",
+ "scry-sai-core",
  "serde_json",
  "synth-backend",
  "synth-backend-awsm",
@@ -1995,7 +2093,7 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror",
  "wasmparser 0.248.0",
  "wat",
@@ -2389,6 +2487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,6 +2644,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -54,3 +54,9 @@ wast.workspace = true
 
 [dev-dependencies]
 object.workspace = true
+# VCR-MEM-001 (#383) layer-2 substrate: scry's sound shadow-stack-depth analysis,
+# verified in-tree against a real module. DEV-dependency only — the production
+# binary does not pull scry until the gated consumption step (the .bss shrink /
+# prologue elision) lands. Test-only ⇒ Bazel (which globs src/ only) never sees
+# it, so no MODULE.bazel pin is needed yet. See scry#51.
+scry-sai-core = "1.12"

--- a/crates/synth-cli/tests/scry_shadow_stack_budget.rs
+++ b/crates/synth-cli/tests/scry_shadow_stack_budget.rs
@@ -1,0 +1,69 @@
+//! VCR-MEM-001 (#383) layer-2 substrate — scry shadow-stack-depth proof, in-tree.
+//!
+//! Proves, in CI against the REAL gust-family module, that synth can obtain a
+//! SOUND worst-case shadow-stack budget from scry (`scry-sai-core` v1.12, the
+//! crates.io library finalized in scry#51 / scry PR #53). This is the layer-2
+//! "proof the budget is sufficient" half of #383 — the half scry owns:
+//!
+//!   - layer-1 (synth-side): the ELF `.bss` retarget mechanics that consume the
+//!     budget — still silicon-gated on gale's `--stack-first` answer.
+//!   - layer-2 (scry-side, THIS): `analyze().stack_usage.max_stack_bytes` is the
+//!     proven depth; `function_summaries[].recursive` is the honest-fail gate;
+//!     `reachable_from_exports` (new in v1.12) prunes provably-dead deep paths.
+//!
+//! This is the UNWIRED substrate (the VCR-RA "build side-by-side, frozen-safe"
+//! pattern): a DEV-dependency exercised only by this test, so the production
+//! `synth` binary does not pull scry and no codegen byte changes — the frozen
+//! fixtures are bit-identical by construction. When the gated consumption step
+//! lands, this call graduates to a feature-gated production dependency.
+//!
+//! The numbers below are the measurement recorded in VCR-MEM-001: synth reserves
+//! 65536 bytes for `msgq_put`'s shadow stack (the full declared page); scry
+//! proves the true worst case is 32 bytes — a 2048× over-reservation the layer-1
+//! retarget will collapse.
+
+use scry_analyze_core::{AnalysisConfig, StackBound, analyze};
+
+/// Absolute path to a repo fixture (tests run with CWD = the crate dir).
+fn fixture(rel: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+#[test]
+fn scry_proves_msgq_shadow_stack_budget_383() {
+    let bytes = std::fs::read(fixture("scripts/repro/msgq_put_359.wasm"))
+        .expect("the #359/#383 gust-family fixture is in-tree");
+
+    let cfg = AnalysisConfig {
+        widening_threshold: None,
+        emit_diagnostics: false,
+        taint_policy: None,
+    };
+    let r = analyze(bytes, cfg).expect("scry analyzes a valid Core module");
+
+    // (1) PROVEN BUDGET — the layer-1 retarget will reserve this instead of the
+    //     full 65536-byte declared page. Bytes(32) is the recorded measurement.
+    assert_eq!(
+        r.stack_usage.max_stack_bytes,
+        StackBound::Bytes(32),
+        "scry's proven worst-case shadow-stack depth for msgq_put"
+    );
+
+    // (2) HONEST-FAIL GATE — no reachable recursion cycle, so the bound is a real
+    //     number (not Unbounded). A recursive module would flip this and synth
+    //     would refuse rather than under-reserve.
+    assert!(
+        !r.function_summaries.iter().any(|s| s.recursive),
+        "msgq_put has no reachable recursion → the budget is a finite proof"
+    );
+
+    // (3) REACHABILITY (v1.12 FEAT-022) — a sound superset; non-empty here, and
+    //     synth may prune any function absent from it. Confirms the dedicated
+    //     call exists in the consumed API (it was absent in v1.11).
+    assert!(
+        !r.reachable_from_exports.is_empty(),
+        "reachable_from_exports is the sound superset synth prunes against"
+    );
+}


### PR DESCRIPTION
## North Star (VCR-MEM-001 / #383 layer-2) — scry v1.12 just released on crates.io

Wires the **layer-2 "proof the shadow-stack budget is sufficient"** half of #383 as the **unwired substrate** (the VCR-RA build-side-by-side, frozen-safe pattern). scry owns this half; synth consumes it.

`scry-sai-core` v1.12 enters as a **dev-dependency** exercised only by a new integration test. Why dev-dep:
- Layer-2 **consumption** (the `.bss` shrink / prologue elision) is still gated on gale's `--stack-first` answer and is byte-changing — the production `synth` binary doesn't need scry yet.
- **Dev-dep ⇒ frozen-safe**: scry is absent from synth-cli's normal deps (verified — production binary builds without it), zero codegen change, **zero `src/` changes** → frozen fixtures bit-identical by construction.
- **Zero Bazel risk**: every Bazel target globs `src/**` only (never `tests/`), so a test-only dep needs **no `MODULE.bazel` pin/repin** — the wasm-family-bump CI-redding hazard is sidestepped.
- **`Cargo.lock` purely additive**: 0 names removed, 13 added (scry's subgraph); no synth production dep version moves.

## What the test asserts (on the real gust module `msgq_put_359.wasm`)

```
stack_usage.max_stack_bytes == Bytes(32)   ← synth reserves 65536 (2048× over)
no function_summaries[].recursive           ← honest-fail gate: a finite proof
reachable_from_exports non-empty            ← v1.12 FEAT-022 dedicated call
```

This locks the `AnalysisResult` shape (breaks early if scry changes it), documents the exact call the wiring will make, and is the CI-verified foundation.

## Not in this PR (the gated next step)

The **production wiring** — graduate the dep to feature-gated, consume `max_stack_bytes` in the layer-1 retarget (shrink the reservation) or #390 pass-3 (elide the prologue), add the `MODULE.bazel` pin. That's the byte-changing increment, gated on gale silicon. This PR does **not** claim #383 fixed.

Local: 32 synth-cli tests + the new substrate test green; production-dep isolation verified; fmt + clippy clean; no `MODULE.bazel.lock` churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)