### PR TITLE
docs(rivet): wire scry cross-repo traceability — SCRY-001/REQ-011 + FEAT-023/REQ-012

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -932,6 +932,11 @@ artifacts:
         target: VCR-001
       - type: refines
         target: VCR-RA-001
+      # scry SCRY-001 soundness contract (scry REQ-011, tagged scry-001): the
+      # over-approximation facts (resolved-targets, recursive) this consumes are
+      # HINTS — VCR-RA-003 re-validates — but the narrowing path (B) rests on it.
+      - type: traces-to
+        target: scry:REQ-011
     fields:
       req-type: functional
       priority: should
@@ -1057,6 +1062,11 @@ artifacts:
         target: VCR-001
       - type: traces-to
         target: VCR-RA-010
+      # scry SCRY-001 soundness contract (filed 2026-06-20 as scry REQ-011,
+      # tagged scry-001): resolved-targets ⊇ concrete + recursive ⇒ reachable
+      # cycle; reach_superset mechanized. The footprint proof rests on it.
+      - type: traces-to
+        target: scry:REQ-011
     fields:
       req-type: functional
       priority: should

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -1210,6 +1210,12 @@ artifacts:
         target: VCR-DBG-001
       - type: constrained-by
         target: VCR-RA-010
+      # scry FEAT-023 / REQ-012 (shipped v1.13.0, 2026-06-20): per-program-point
+      # `operand_stack: Vec<AbstractValue>`. A decision's CONDITION values live on
+      # the operand stack, so this is the granularity the MC/DC reconciler needs
+      # to classify a folded/eliminated branch precisely (synth#396 / witness#109).
+      - type: traces-to
+        target: scry:REQ-012
     fields:
       req-type: functional
       priority: should

--- a/rivet.yaml
+++ b/rivet.yaml
@@ -69,3 +69,9 @@ externals:
     path: /Volumes/Home/git/pulseengine/gale
     ref: main
     prefix: gale
+
+  scry:
+    git: https://github.com/pulseengine/scry.git
+    path: /Volumes/Home/git/pulseengine/scry
+    ref: main
+    prefix: scry


### PR DESCRIPTION
Wires synth's two scry dependencies as cross-repo traceability now that both contracts are filed/shipped.

- **SCRY-001 = `scry:REQ-011`** (shipped scry v1.12.0): soundness contract — `resolved-targets ⊇ concrete`, `recursive ⇒ reachable cycle` (`reach_superset` mechanized). `traces-to` from **VCR-MEM-001** (shadow-stack footprint, #383) and **VCR-RA-010** (regalloc oracle).
- **FEAT-023 = `scry:REQ-012`** (shipped scry v1.13.0, 2026-06-20): per-program-point `operand_stack: Vec<AbstractValue>` — the operand-stack granularity the MC/DC reconciler needs (a decision's condition values live on the operand stack). `traces-to` from **VCR-COV-001** (#396 / witness#109).

Adds `scry` to `rivet.yaml` externals. Cross-repo links resolve locally against the scry checkout and are the CI-tolerated `targets 'x:y' which does not exist` form remotely — **non-xref ERROR = 0** (like `gale:`/`kiln:`/`sigil:`). No dep pin bump needed (`scry-sai-core "1.12"` caret-resolves to 1.13; new field read-by-name). Docs only; frozen-fixture-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)