### PR TITLE
docs(roadmap): in-tree Pass-1 spill baseline — frozen-safe #390 reproduction (VCR-PERF-001, #242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -832,6 +832,36 @@ artifacts:
           ~4 B/fn. OWNER: prologue minimization (save only clobbered).
       Passes 1+3 dominate. Estimated 1–3 alone bring gust_poll from 816 B toward
       ~300–350 B (≈1.5–1.7× vs LLVM), within the project's 10–20%-overhead thesis.
+
+      IN-TREE Pass-1 BASELINE (2026-06-21, frozen-safe, `scripts/repro/spill_baseline_measure.sh`):
+      gale measured Pass-1 on gust silicon; this reproduces the SAME mechanism on
+      synth's own frozen fixtures so the spill waste is regression-tracked in-tree
+      (zero codegen change — compiles the fixtures, reads emitted ARM via thumb
+      objdump + the existing SYNTH_SHADOW_ALLOC instrumentation). Per fixture:
+      `[sp,#]` spill loads/stores vs peak *value*-pressure (the allocator's
+      distinct-simultaneously-live-values count):
+        - flight_seam_flat: 56 spill ops / 356 insns, peak value-pressure 7 (≤9)
+        - flight_seam:      39 spill ops / 300 insns, peak value-pressure 7–8
+        - control_step:      6 spill ops / 113 insns, peak value-pressure 8
+      FINDING: the spills are SPURIOUS. synth keeps WASM locals frame-resident BY
+      MODEL (local.get→ldr [sp]; local.set→str [sp]), NOT from register pressure —
+      every live value fits the R0–R8 pool (peak ≤9). The value-based SSA allocator
+      (VCR-RA-001, today shadow-only behind SYNTH_SHADOW_ALLOC) promotes them into
+      registers and eliminates the traffic. PRECISION on "the substrate is built
+      side-by-side, UNWIRED": accurate for the spill-ELIMINATING value allocator
+      (`allocate_function` — shadow-logged only). The default-on range-realloc
+      (`reallocate_function`, v0.11.36) is a RENAMER — it never adds/removes
+      instructions, so it provably cannot capture Pass-1; and `apply_const_cse` is
+      flag-gated (SYNTH_CONST_CSE=1, off by default). So Pass-1 is genuinely
+      unrealized in default codegen — #390's headline holds.
+      FORK RESOLUTION (the const-CSE-vs-spill question): const/remat opportunities
+      are 0–2 on these kernels (synth already lowers consts as immediates), while
+      spill-elimination is 56/39/6 — the spill axis is where the bytes are, and it
+      is INDEPENDENT of the const-remat axis. Confirms the spill-elimination wiring
+      (not const-CSE) as the #390 headline lever. DE-RISK NOTE for the wiring step:
+      the frozen fixtures DO exhibit Pass-1 (56 ops on flight_seam_flat), so they
+      are a valid in-tree target — the byte-changing wiring still gates on a
+      deliberate re-freeze + differential + gale on-silicon (never an idle tick).
     status: proposed
     tags: [codegen, perf, regalloc, addressing-mode, size, gale-390, measurement, track-a, silicon]
     links:

--- a/scripts/repro/spill_baseline_measure.sh
+++ b/scripts/repro/spill_baseline_measure.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# VCR-PERF-001 Pass-1 / VCR-RA-010 — in-tree spill-elimination baseline (#390, #242).
+#
+# gale #390 measured the headline size gap on the gust scheduler hot path
+# (gust_poll 816 B / 240 insns vs 208 B / 104 native): "Pass 1 — NO register
+# allocation: every wasm local/operand spilled to a stack slot, the `sched`
+# pointer reloaded from [sp,#0x3c] 10×. ~288 B (47%). THE HEADLINE."
+#
+# This script REPRODUCES that mechanism on synth's OWN frozen fixtures, so the
+# Pass-1 waste is a regression-tracked number in-tree (not only on gale's
+# silicon), and so the eventual spill-eliminating wiring has a measurable target.
+# It changes ZERO codegen bytes — it only compiles the frozen fixtures and reads
+# the emitted ARM + synth's existing SYNTH_SHADOW_ALLOC instrumentation.
+#
+# KEY FINDING (2026-06-21, debug binary): the [sp,#] spills are SPURIOUS. synth
+# keeps WASM locals frame-resident BY MODEL (local.get -> ldr [sp]; local.set ->
+# str [sp]), NOT because of register pressure — the shadow allocator reports peak
+# *value*-pressure 7-8 (<= 9), i.e. every live value fits the R0-R8 pool. A
+# value-based SSA allocator (VCR-RA-001, currently shadow-only behind
+# SYNTH_SHADOW_ALLOC) promotes them into registers and eliminates the spill
+# traffic. The default-on range-realloc (v0.11.36) only RENAMES within segments —
+# it never adds/removes instructions, so it provably cannot capture Pass-1.
+#
+# It also DATA-RESOLVES the const-CSE-vs-spill fork: const/remat opportunities are
+# 0-2 on these kernels (synth already lowers consts as immediates), while spill
+# elimination is 56/39/6 — the spill axis is where the bytes are.
+#
+# Requires: a built `synth` (target/debug/synth) and an ARM disassembler
+# (arm-none-eabi-objdump preferred; llvm-objdump --triple=thumbv7em-none-eabi as
+# fallback). Distinguishes [sp,#] spill slots from [fp/r11] linear-memory access.
+#
+# Run from repo root:
+#   scripts/repro/spill_baseline_measure.sh
+set -euo pipefail
+
+SYNTH="${SYNTH:-./target/debug/synth}"
+FIXTURES=(flight_seam_flat flight_seam control_step)
+
+# Pick a thumb-capable disassembler.
+disasm() { # $1 = elf
+  if command -v arm-none-eabi-objdump >/dev/null 2>&1; then
+    arm-none-eabi-objdump -d -M force-thumb "$1" 2>/dev/null
+  elif command -v llvm-objdump >/dev/null 2>&1; then
+    llvm-objdump -d --triple=thumbv7em-none-eabi "$1" 2>/dev/null
+  else
+    echo "ERROR: need arm-none-eabi-objdump or llvm-objdump on PATH" >&2
+    exit 2
+  fi
+}
+
+[ -x "$SYNTH" ] || { echo "ERROR: build synth first (cargo build) — $SYNTH missing" >&2; exit 2; }
+
+printf '%-18s | %5s | %11s | %12s | %s\n' "fixture" "insns" "spill[sp,#]" "linmem[fp]" "shadow-alloc (peak value-pressure / remat)"
+printf -- '-------------------|-------|-------------|--------------|-------------------------------------------\n'
+
+for fx in "${FIXTURES[@]}"; do
+  wasm="scripts/repro/${fx}.wasm"
+  elf="/tmp/${fx}.spillbase.elf"
+  [ -f "$wasm" ] || { echo "skip $fx (no $wasm)"; continue; }
+
+  # Compile + capture the shadow allocator's verdict (zero byte change either way).
+  shadow=$(SYNTH_SHADOW_ALLOC=1 "$SYNTH" compile "$wasm" -o "$elf" \
+            --target cortex-m4 --all-exports --relocatable 2>&1 \
+            | grep -iE 'shadow-alloc' | tr '\n' ';' | sed 's/\[shadow-alloc\] //g')
+
+  d=$(disasm "$elf")
+  insns=$(echo "$d"  | grep -cE '^\s+[0-9a-f]+:\s' || true)
+  spill=$(echo "$d"  | grep -iE '\b(ldr|str)' | grep -iE '\[sp'        | grep -viE 'push|pop' | wc -l | tr -d ' ')
+  linmem=$(echo "$d" | grep -iE '\b(ldr|str)' | grep -iE '\[(fp|r11)'                        | wc -l | tr -d ' ')
+
+  printf '%-18s | %5s | %11s | %12s | %s\n' "$fx" "$insns" "$spill" "$linmem" "${shadow:0:60}"
+done
+
+cat <<'EOF'
+
+Interpretation:
+  spill[sp,#]  = Pass-1 waste (VCR-PERF-001). SPURIOUS when peak value-pressure
+                 <= 9 — eliminable by the value-based allocator (VCR-RA-001).
+  linmem[fp/r11] = legitimate linear-memory access (r11 = mem base). Not a spill.
+  Kill-criterion: wiring the spill-eliminating allocator drops spill[sp,#] toward
+  0 on these fixtures with peak value-pressure unchanged — then re-freeze +
+  differential + gale on-silicon (the #193/#212/#215 latent-regalloc lesson).
+EOF


### PR DESCRIPTION
## What

Frozen-safe north-star increment (epic #242, VCR-PERF-001 / VCR-RA-010). Reproduces gale #390's **headline Pass-1** waste — "every wasm local/operand spilled to a stack slot, `sched` reloaded 10×, ~288 B / 47%" — on synth's **own frozen fixtures**, so the spill waste is regression-tracked in-tree (not only on gale's gust silicon), and the eventual spill-eliminating wiring has a measurable target.

**Zero codegen change.** Adds:
- `scripts/repro/spill_baseline_measure.sh` — compiles the three frozen fixtures and reads the emitted ARM (thumb objdump) + the existing `SYNTH_SHADOW_ALLOC` instrumentation.
- A roadmap note under VCR-PERF-001 recording the baseline + the finding.

## Measured (debug binary, 2026-06-21)

| fixture | insns | spill `[sp,#]` | linmem `[fp/r11]` | peak value-pressure |
|---|---|---|---|---|
| flight_seam_flat | 356 | **56** | 42 | **7** (≤9) |
| flight_seam | 300 | **39** | 28 | 7–8 |
| control_step | 113 | **6** | 2 | 8 |

## Finding

The `[sp,#]` spills are **spurious**: synth keeps WASM locals frame-resident *by model* (`local.get`→`ldr [sp]`, `local.set`→`str [sp]`), **not** from register pressure — peak *value*-pressure ≤ 9 means every live value fits the R0–R8 pool. The value-based allocator (VCR-RA-001, today shadow-only behind `SYNTH_SHADOW_ALLOC`) eliminates them. The default-on range-realloc (`reallocate_function`, v0.11.36) is a *renamer* — it never adds/removes instructions, so it provably cannot capture Pass-1; `apply_const_cse` is flag-gated. So Pass-1 is genuinely unrealized in default codegen — #390's headline holds.

**Resolves the const-CSE-vs-spill fork with data:** const/remat opportunities are 0–2 on these kernels (synth already lowers consts as immediates), while spill-elimination is 56/39/6. The spill axis is where the bytes are, and it's independent of the const-remat axis.

## Frozen-safe

Script + roadmap note only; frozen fixtures (control_step `0x00210A55`, flat+inlined flight_algo `0x07FDF307`, divseam) byte-identical by construction. The byte-changing wiring remains a **separate gated step** — deliberate re-freeze + differential + gale on-silicon (the #193/#212/#215 latent-regalloc lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)