### PR TITLE
docs(dwarf): step-3 de-risk — op_offsets vs DWARF address-space mismatch (VCR-DBG-001, #394, #242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -1193,7 +1193,29 @@ artifacts:
           MODULE.bazel pin (Bazel globs src/ only), zero codegen change, frozen
           fixtures bit-identical. The PRODUCTION gimli dep + MODULE.bazel pin
           land with the EMITTER (step 4), as a feature-loop release step — not
-          an idle-tick increment. NEXT: step (3) compose op_offsets × line-rows.
+          an idle-tick increment.
+        - step (3) compose — DE-RISK FINDING 2026-06-21 (offset-space probe,
+          since removed): the two address spaces DO NOT trivially align, and
+          step 3 must reconcile them BEFORE any join is correct (a guessed join
+          yields silently-wrong source lines — worse than none for a debugger).
+          Measured on k_mutex_unlock.dissolved.wasm: synth's `op_offsets` are
+          MODULE-relative (fn0 0x137..0x13a, fn1 0x140..0x1bd, fn2 0x1c0..0x1c5,
+          fn3 0x1cb..0x288; code section at module 0x86), but the `.debug_line`
+          row addresses are 0x03 / 0x94 / 0x98 — far below ANY op_offset and not
+          reconcilable by the constant code-section base. Two compounding causes:
+          (a) DWARF-for-wasm addresses use a CODE-section-relative convention,
+          not module-relative — op_offsets need normalizing into it (subtract the
+          code-section content base, per-function body-offset aware); and
+          (b) this FIXTURE is meld-DISSOLVED and its `.debug_*` describe Rust
+          std/core glue (panicking.rs/int_macros.rs/macros.rs/traits.rs) against
+          what looks like the PRE-fusion layout — i.e. incoherent with the bytes
+          synth compiles. CONCLUSION: step 3 needs (i) the exact DWARF-for-wasm
+          address convention pinned + an op_offsets→DWARF-address normalizer, and
+          (ii) a COHERENCE-CHECKED fixture — ideally a direct rustc→wasm
+          (non-dissolved) module whose `.debug_line` describes its own code — or
+          a meld-remapped dissolved module verified coherent. Until then the join
+          is unbounded for an idle tick. Acquire/build a coherent-DWARF fixture
+          as the first sub-step of the dedicated step-3 work.
     status: approved
     tags: [toolchain, dwarf, debuggability, elf, meld-coordination, feature-loop, release-v0.12.0, synth-394]
     links:


### PR DESCRIPTION
## What

Frozen-safe north-star increment (epic #242, VCR-DBG-001). Records an empirical de-risk finding that re-scopes DWARF Tier-1 **step 3 (compose)** — discovered by probing whether synth's `op_offsets` (step 1) align with the input wasm's `.debug_line` addresses (step 2) on `k_mutex_unlock.dissolved.wasm`.

## Finding: the two address spaces do not align

| space | values |
|---|---|
| synth `op_offsets` (module-relative) | fn0 `0x137..0x13a`, fn1 `0x140..0x1bd`, fn2 `0x1c0..0x1c5`, fn3 `0x1cb..0x288` (code section at module `0x86`) |
| `.debug_line` row addresses | `0x03`, `0x94`, `0x98` |

The DWARF addresses are far **below** any op_offset and don't reconcile by the constant code-section base. Two compounding causes:
- **(a)** DWARF-for-wasm uses a **code-section-relative** address convention — op_offsets need normalizing into it.
- **(b)** this fixture is **meld-dissolved**; its `.debug_*` describe Rust std/core glue (`panicking.rs`/`int_macros.rs`) against the **pre-fusion** layout — incoherent with the bytes synth compiles.

## Why this matters

A naive `op_offsets × line-rows` join would emit **silently-wrong source lines** — worse than emitting none for a debugger. So step 3 must first pin the exact DWARF-for-wasm convention + an `op_offsets → DWARF-address` normalizer, and use a **coherence-checked fixture** (direct `rustc→wasm`, or a verified meld-remapped one). Not landable as an idle-tick guess.

## Frozen-safe

Docs-only (roadmap note); zero codegen; frozen fixtures bit-identical; rivet non-xref errors 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)