### PR TITLE
docs(changelog): correct v0.11.51 shrink confirmation scope — qemu-8KB, not on-silicon (#383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,11 @@ NOBITS `.bss` reservation accordingly, unblocking the 8 KiB STM32F100 gust boot.
   - Verification: flag-off byte-identical on `msgq_put_359` (the native-pointer
     path); the native-pointer differential passes; flag-on runtime exercised on
     `native_pointer_shadow_stack` (the store through the re-based SP lands
-    in-region). gale confirmed on-silicon (issue #383 closed COMPLETED).
+    in-region). **qemu + 8 KB-constrained-link confirmed** by gale (cortex-m3
+    `lm3s6965evb`): the gust kernel dissolves to `.bss` 4240, links into 8 KB
+    (~4.8 KB used, was un-linkable), boots and runs 5000 poll rounds with correct
+    values (`gust_mix(1024)=1500`, `pwm=1522`). Physical STM32F100 reflash is
+    pending hardware — NOT literal-silicon-confirmed (gale #383).
   - Tests `shadow_stack_shrink_383.rs`; tracked `VCR-MEM-001`.
 
 - **Cross-backend op-parity oracle** (#387, `VCR-SEL-005`): the ARM-vs-RISC-V


### PR DESCRIPTION
## What

gale's runtime confirmation of the v0.11.51 shadow-stack shrink (#383) was **qemu + an 8 KB-constrained link** (cortex-m3 `lm3s6965evb`: dissolves to bss 4240, links into 8 KB ~4.8 KB used, boots + 5000 poll rounds with correct values) — **not** a physical STM32F100 reflash (gale's bench is a 128 KB G474RE).

The v0.11.51 notes said *"confirmed on-silicon"* — an overclaim gale explicitly asked to correct. This restates exactly what was verified: **qemu-8KB-confirmed; physical F100 reflash pending hardware.**

The feature is confirmed working; only the confirmation **scope** wording is fixed. The GitHub release v0.11.51 body is being corrected to match.

Refs: gale#383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)