### PR TITLE
fix(dwarf): adapt LineProgram::new to gimli 0.33 6-arg signature (#436 fallout)

### DIFF
--- a/crates/synth-core/src/dwarf_line.rs
+++ b/crates/synth-core/src/dwarf_line.rs
@@ -206,10 +206,14 @@ pub fn emit_debug_sections(table: &[(u64, u32)], text_sym: usize) -> Vec<Emitted
     // high_pc one past the last mapped address.
     let high_pc = table.iter().map(|&(a, _)| a).max().unwrap_or(0) + 1;
 
+    // gimli 0.33 split the comp-dir/file args: (working_dir, source_dir,
+    // source_file, source_file_info). source_dir = None ⇒ the file sits in
+    // working_dir, matching the previous single-dir behaviour.
     let mut program = LineProgram::new(
         encoding,
         gimli::LineEncoding::default(),
         LineString::String(b"/synth".to_vec()),
+        None,
         LineString::String(b"synth.wasm".to_vec()),
         None,
     );

--- a/crates/synth-core/tests/dwarf_emit_roundtrip_step4.rs
+++ b/crates/synth-core/tests/dwarf_emit_roundtrip_step4.rs
@@ -88,10 +88,12 @@ fn emit_dwarf(table: &[(u64, u32)]) -> HashMap<String, Vec<u8>> {
         address_size: 4,
     };
     let mut dwarf = DwarfUnit::new(encoding);
+    // gimli 0.33: (working_dir, source_dir, source_file, source_file_info).
     let mut program = LineProgram::new(
         encoding,
         gimli::LineEncoding::default(),
         LineString::String(b"/synth".to_vec()),
+        None,
         LineString::String(b"dwarf_coherent.rs".to_vec()),
         None,
     );


### PR DESCRIPTION
## Urgent — main is red

Dependabot #436 (gimli 0.31→0.33) inserted a `source_dir: Option<LineString>` parameter into `LineProgram::new` (now 6 args). Both DWARF emit call sites still used the 0.31 5-arg form, so **main fails to compile (E0061)**.

VCR-DBG-001 PR C (#430) could not catch this: it branched before #436 and its CI ran against the gimli 0.31 lockfile. GitHub's merge is **textual, not semantic**, so the clean merge produced a broken main. (Both PR B's emitter and PR C's were affected — #436 itself merged red against PR B's code.)

## Fix

Both call sites (`dwarf_line.rs` emitter + the step-4 roundtrip test) get `source_dir = None` (file in working_dir, matching prior behaviour). The Writer/`Address` API is unchanged in 0.33, so PR C's `RelocWriter` + relocation capture are unaffected.

## Verified locally
- `cargo build --workspace --exclude synth-verify` ✅
- `cargo clippy -p synth-core -p synth-cli -p synth-backend --all-targets` clean ✅
- All 4 `dwarf_debug_line_emit_394` oracles (incl. the relocate-at-nonzero-base correctness test) + the step-4 roundtrip green against gimli 0.33 ✅
- fmt clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)