### PR TITLE
docs(vcr-perf): record gale #428 v0.12.0 gust_mix re-measurement — cmp→select is #1 (#242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -555,6 +555,23 @@ artifacts:
       flag-liveness rework. Byte-changing → deliberate fixture re-freeze. The
       companion finding (21% [sp] spill density on the sem path) is the VCR-RA
       allocator track, not this item.
+      RE-CONFIRMED on v0.12.0 (gale #428, 2026-06-23): with loom v1.1.16's
+      inline+DCE merging the gust_mix export wrapper (loom#228), gale isolated the
+      gap to synth — gust_mix 2.81× → 2.63× LLVM (fn-only 1.125 → 1.05 ticks/call),
+      frame 24 B → 8 B; "synth is now the SOLE remaining factor." The merged
+      gust_mix lowered by synth 0.12.0 still shows the materialized-bool clamps
+      (`cmp r4,r5; ite lt; movlt #1; movge #0; cmp #0; it ne; movne` ×2). gale
+      re-ranks THIS (#4 cmp→select → IT-block predication) as the HIGHEST single
+      win (~7 insns → 2-3, ×2 here), ahead of (3) immediate folding (`lsl #8` /
+      `uxth` for the `movw r5,#8; lsl` and `movw r3,#0xffff; and` it also flagged)
+      and (1) wiring the now-CI-gated allocator (#441) to drop the 6-reg leaf
+      prologue. v0.12.0 shipped the DWARF (#440) + spill-pressure CI-gate (#441,
+      regalloc GROUNDWORK/measurement — NOT a lowering fix) but not this. This is
+      the NEXT DEDICATED GATED RELEASE (not an idle-tick increment): implement the
+      late peephole, re-freeze the three frozen differentials (0x00210A55 /
+      0x07FDF307 / divseam) result-identical, differential oracle, then gale's
+      `benches/gust/src/bin/gust_codegen_bench.rs` (≤1.3× fn-only) is the agreed
+      on-silicon kill-criterion.
     status: proposed
     tags: [codegen, selector, peephole, compare-select, flag-fusion, gale-209, perf, track-b]
     links:
@@ -878,6 +895,13 @@ artifacts:
       value-based allocator (VCR-RA-001) wiring must beat. Sibling of
       `scry_const_remat_signal.rs` (the const-remat axis); together they CI-gate
       both #390 levers.
+      GAP RE-MEASURED on v0.12.0 (gale #428, 2026-06-23): loom v1.1.16 inline+DCE
+      (loom#228) merged the gust_mix wrapper → gap 2.81× → 2.63× LLVM, "synth is
+      the SOLE remaining factor." gale re-ranks the levers (cmp→select predication
+      #1, then immediate folding, then allocator wiring) — detail + the
+      `gust_codegen_bench` kill-criterion recorded under VCR-SEL-004. The
+      byte-changing wiring of these levers stays the next DEDICATED gated release,
+      not an idle tick.
     status: proposed
     tags: [codegen, perf, regalloc, addressing-mode, size, gale-390, measurement, track-a, silicon]
     links:


### PR DESCRIPTION
## Respond-and-record pass for gale #428 (the per-function cycle gap)

gale #428 (2026-06-23): with loom v1.1.16's inline+DCE merging the `gust_mix` export wrapper (loom#228), the gap dropped **2.81× → 2.63× LLVM** (fn-only 1.125 → 1.05 ticks/call, frame 24 B → 8 B) — **"synth is now the sole remaining factor."** The merged `gust_mix` lowered by **synth 0.12.0** still shows every issue: the materialized-bool clamps (`cmp; ite lt; movlt #1; movge #0; cmp #0; it ne; movne` ×2), register shifts that should be `lsl #8`, `movw+and` that should be `uxth`, and the 6-reg leaf prologue.

gale re-ranks the levers: **(4) cmp→select → IT-block predication = the highest single win** (VCR-SEL-004), then (3) immediate folding, then (1) wiring the now-CI-gated allocator (#441) to shrink the prologue.

## What this records (docs-only, zero codegen change)
- **VCR-SEL-004** gets the v0.12.0 re-confirmation: the 2.63× / synth-sole-factor measurement, the fresh disassembly, the re-ranked priority, and gale's `benches/gust/src/bin/gust_codegen_bench.rs` (≤1.3× fn-only) as the **agreed on-silicon kill-criterion** (it lives on gale's side).
- **VCR-PERF-001** gets a pointer to it.
- Frames v0.12.0's **#441 honestly** as regalloc **groundwork/measurement — not a lowering fix** (matching gale's own wording), avoiding any progress-on-the-gap overclaim.

## Why this is the whole pass
The actual lowering fixes are **byte-changing codegen** — the next *dedicated gated release* (implement → re-freeze `0x00210A55`/`0x07FDF307`/divseam result-identical → differential → gale silicon via `gust_codegen_bench`), not an idle-tick cram. This pass records the new silicon data and scopes that step; the predication itself is done focused, not rushed at a session tail.

rivet non-xref = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)