### PR TITLE
feat(vcr-sel): cmp→select → IT-block predication fusion, flag-off (VCR-SEL-004, #242, #428)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -572,7 +572,39 @@ artifacts:
       0x07FDF307 / divseam) result-identical, differential oracle, then gale's
       `benches/gust/src/bin/gust_codegen_bench.rs` (≤1.3× fn-only) is the agreed
       on-silicon kill-criterion.
-    status: proposed
+      IMPLEMENTATION LANDED — SELECT HALF ONLY (2026-06-23, flag-off /
+      frozen-safe). SCOPE: this PR lands the `select`→`movCC` half of the
+      title's "select/br_if" fusion. The `br_if`→predicated-BRANCH half (a
+      comparison sole-consumed by a conditional branch → keep NZCV, emit a single
+      `bCC`) is NOT done — `fuse_cmp_select` matches only `SelectMove` consumers;
+      branch consumers are unmodeled by `reg_effect` and never match. That half
+      is a deferred follow-up (split candidate). The late peephole is
+      `synth_synthesis::liveness::fuse_cmp_select` — deletes the
+      `SetCond D,c` + select's `cmp D,#0` and retargets the predicated moves to
+      `c` / `invert(c)` (the textbook predicated clamp). Wired into arm_backend.rs
+      AFTER range-realloc, BEHIND `SYNTH_CMP_SELECT_FUSE=1` (default-off => a literal
+      no-op => the three frozen differentials stay bit-identical, un-rerun). Proven
+      sound by construction: flags reused only when nothing clobbers them in the
+      `SetCond`->`cmp` window (`clobbers_flags` allowlist), and the bool deleted
+      only when provably dead (`reg_dead_by_redef`, R0-live-out safe). Validation
+      this step: 8 liveness unit tests (positive incl. the gust_mix x2 in-place
+      clamp, 5 negative guards), 3 encoder byte-tests (all 10 IT conditions),
+      rewrite-count>0 on real fixtures (control_step 3, flight_algo/controller 5-6),
+      and an arm-none-eabi-objdump diff confirming `cmp r0,#19; movcc r5,r6` is
+      emitted in place of the 5-insn materialize+re-test, with the unsafe sites
+      (bool reused) correctly DECLINED. STILL OWED by the default-on flip step
+      (NOT done here, deliberately deferred): execution-level differential under the
+      flag (VCR-ORACLE-001 Rust unicorn harness) + gale's `gust_codegen_bench` on
+      G474RE; only then does the flag flip default-on and the tag cut. EMPIRICAL
+      GAP the flip differential MUST close: every fused site on the real fixtures
+      was the IN-PLACE single-move form (`movCC`), so the two-move
+      `moveq→mov{invert(c)}` path — the only place `invert()` matters at RUNTIME —
+      has executed in unit/encoder tests but NEVER selector→fusion→encoder→exec on
+      a real function. The flip's differential must include a fixture that forces a
+      fusable NON-in-place select (e.g. `val2` a live param), or the `mov{!c}` path
+      reaches silicon never having run (the #204/#206 IR-right/composition-wrong
+      lesson). The `br_if`→predicated-branch half is separate deferred work.
+    status: approved
     tags: [codegen, selector, peephole, compare-select, flag-fusion, gale-209, perf, track-b]
     links:
       - type: derives-from

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -418,6 +418,36 @@ fn compile_wasm_to_arm(
         }
     }
 
+    // VCR-SEL-004 cmp→select → IT-block predication fusion (#242). The selector
+    // lowers a `select` whose condition is a comparison to a *materialize then
+    // re-test* sequence (`cmp a,b; SetCond D,c; cmp D,#0; movne dst,v1; moveq
+    // dst,v2`); this collapses it onto the comparison's own flags — deleting the
+    // `SetCond` and the `cmp D,#0` and retargeting the predicated moves to `c` /
+    // `invert(c)` — yielding the textbook predicated clamp (`cmp a,b; movc dst,v1;
+    // mov{!c} dst,v2`). −2 instructions per fused select. gale #428 measured this
+    // as the #1 hot-path size/cycle lever on the gust_mix clamp chain.
+    //
+    // Run LATE: after range re-allocation (so the dead-D proof sees final register
+    // identities) and before encode. Removal-only + rename-only ⇒ no spill
+    // regression and labels/branch offsets are unaffected. Each fusion is proven
+    // sound (flags reused only when nothing clobbers them in the window; the
+    // boolean deleted only when provably dead) — see `fuse_cmp_select`.
+    //
+    // BEHIND `SYNTH_CMP_SELECT_FUSE=1` while it is validated against the
+    // differential oracle + gale's on-target gust_codegen_bench (G474RE). Off by
+    // default ⇒ a literal no-op ⇒ every fixture stays bit-identical
+    // (control_step 0x00210A55 / flat+inlined flight_algo 0x07FDF307 / divseam).
+    // The default-on flip is the held byte-changing step, gated on silicon.
+    let arm_instrs = if std::env::var("SYNTH_CMP_SELECT_FUSE").is_ok() {
+        let (out, fused) = synth_synthesis::liveness::fuse_cmp_select(&arm_instrs);
+        if std::env::var("SYNTH_FUSE_STATS").is_ok() {
+            eprintln!("[cmp-select-fuse] {fused} select(s) fused to predicated moves");
+        }
+        out
+    } else {
+        arm_instrs
+    };
+
     // ISA feature gate: validate that all generated instructions are supported
     // by the target. This catches FPU instructions on no-FPU targets, double-precision
     // instructions on single-precision targets, etc.

--- a/crates/synth-backend/tests/cmp_select_predication_encoding.rs
+++ b/crates/synth-backend/tests/cmp_select_predication_encoding.rs
@@ -1,0 +1,75 @@
+//! VCR-SEL-004 — `SelectMove` Thumb-2 encoding must be correct for ALL 10
+//! conditions, not just the EQ/NE the selector emits today.
+//!
+//! The cmp→select fusion (`synth_synthesis::liveness::fuse_cmp_select`) retargets
+//! the two predicated moves of a `select` from EQ/NE onto the comparison's own
+//! condition and its inverse — so a fused clamp newly emits `SelectMove` with
+//! LT/GE, LO/HS, GT/LE, HI/LS. This is the "verify bytes, not IR" gate (#180/#185):
+//! the unit tests in liveness.rs prove the right *ops* are produced; this proves
+//! the *encoder* turns each into a correct, independent `IT <cond>; MOV{cond}`.
+//!
+//! Each `SelectMove` is its OWN single-Then IT block (mask 0x8) — the two moves of
+//! a fused pair are two separate IT blocks, never a hardware ITE — so retargeting
+//! their conditions needs no encoder change. These byte assertions lock that.
+
+use synth_backend::ArmEncoder;
+use synth_synthesis::rules::{ArmOp, Condition, Reg};
+
+fn enc(rd: Reg, rm: Reg, cond: Condition) -> Vec<u8> {
+    ArmEncoder::new_thumb2()
+        .encode(&ArmOp::SelectMove { rd, rm, cond })
+        .expect("encode SelectMove")
+}
+
+#[test]
+fn select_move_signed_pair_lt_ge_bytes() {
+    // movlt r4, r5 : IT LT (0xBFB8) ; MOV r4,r5 (0x462C)
+    assert_eq!(
+        enc(Reg::R4, Reg::R5, Condition::LT),
+        vec![0xB8, 0xBF, 0x2C, 0x46]
+    );
+    // movge r4, r5 : IT GE (0xBFA8) ; MOV r4,r5 (0x462C)
+    assert_eq!(
+        enc(Reg::R4, Reg::R5, Condition::GE),
+        vec![0xA8, 0xBF, 0x2C, 0x46]
+    );
+}
+
+#[test]
+fn select_move_unsigned_pair_lo_hs_bytes() {
+    // movlo r4, r6 : IT LO (0xBF38) ; MOV r4,r6 (0x4634)
+    assert_eq!(
+        enc(Reg::R4, Reg::R6, Condition::LO),
+        vec![0x38, 0xBF, 0x34, 0x46]
+    );
+    // movhs r4, r6 : IT HS (0xBF28) ; MOV r4,r6 (0x4634)
+    assert_eq!(
+        enc(Reg::R4, Reg::R6, Condition::HS),
+        vec![0x28, 0xBF, 0x34, 0x46]
+    );
+}
+
+#[test]
+fn select_move_all_ten_conditions_are_distinct_single_then_it_blocks() {
+    use Condition::*;
+    let conds = [EQ, NE, LT, LE, GT, GE, LO, LS, HI, HS];
+    let mut seen = std::collections::BTreeSet::new();
+    for c in conds {
+        let bytes = enc(Reg::R0, Reg::R1, c);
+        assert_eq!(bytes.len(), 4, "{c:?}: IT + MOV is 4 bytes");
+        // IT halfword = 0xBF00 | (cond4 << 4) | 0x8 (single Then, mask 0x8).
+        let it = u16::from_le_bytes([bytes[0], bytes[1]]);
+        assert_eq!(it & 0xFF0F, 0xBF08, "{c:?}: not a single-Then IT block");
+        // The encoded firstcond must be unique per condition.
+        let firstcond = (it >> 4) & 0xF;
+        assert!(
+            seen.insert(firstcond),
+            "{c:?}: duplicate IT firstcond {firstcond:#x}"
+        );
+    }
+    assert_eq!(
+        seen.len(),
+        10,
+        "all 10 conditions encode to distinct firstcond"
+    );
+}

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -18,7 +18,7 @@
 //! codegen yet: it is pure analysis, so it cannot change emitted bytes.
 
 use crate::instruction_selector::ArmInstruction;
-use crate::rules::{ArmOp, MemAddr, Operand2, Reg};
+use crate::rules::{ArmOp, Condition, MemAddr, Operand2, Reg};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// The register read/write effect of a single instruction.
@@ -239,6 +239,198 @@ pub fn local_dead_defs(instrs: &[ArmInstruction]) -> Option<Vec<usize>> {
         }
     }
     Some(dead)
+}
+
+/// Conservative NZCV-clobber predicate: `true` if `op` *might* write the
+/// condition flags. Used by [`fuse_cmp_select`] to prove the flags set by a
+/// comparison survive to the predicated moves once the intervening `SetCond` +
+/// `cmp rd,#0` are deleted.
+///
+/// `reg_effect` deliberately does NOT model the flag side-effect (it tracks only
+/// GP registers), so this is a separate, intentionally tight allowlist: only the
+/// instructions we are *certain* leave NZCV untouched return `false`. Everything
+/// else — flag-setting compares (`Cmp`/`Cmn`/`Tst`), the S-form arithmetic, every
+/// unmodeled / pseudo / control-flow op — is treated as a clobber. The only ops
+/// that legitimately appear between a `SetCond` and its select's `cmp` are
+/// register-resident-operand reloads (loads/stores), which this admits.
+fn clobbers_flags(op: &ArmOp) -> bool {
+    use ArmOp::*;
+    // Allowlist of definitely-flag-preserving ops. NOT included: `Mov` (a low-reg
+    // `MOV #imm` is `MOVS` and sets flags), `SelectMove` (only ever appears AFTER
+    // the select's cmp, never inside the window), arithmetic of any kind.
+    !matches!(
+        op,
+        Ldr { .. }
+            | Ldrb { .. }
+            | Ldrsb { .. }
+            | Ldrh { .. }
+            | Ldrsh { .. }
+            | Str { .. }
+            | Strb { .. }
+            | Strh { .. }
+            | Push { .. }
+            | Pop { .. }
+            | Nop
+    )
+}
+
+/// VCR-SEL-004 — cmp→select → IT-block predication fusion.
+///
+/// The selector lowers `(select v1 v2 (i32.lt_s a b))` to a *materialize then
+/// re-test* sequence: the comparison emits `cmp a,b; SetCond D,LT` (D ← 0/1), and
+/// the select then emits `cmp D,#0; movne dst,v1; moveq dst,v2`. The `SetCond`
+/// and the select's `cmp D,#0` are pure overhead — the original comparison
+/// already set NZCV, and each `SelectMove` is an independent flag-preserving
+/// `IT;MOV` (arm_encoder.rs:4231). This pass collapses the pair: it deletes the
+/// `SetCond D,c` and the `cmp D,#0`, and retargets the predicated moves onto the
+/// comparison's own flags — `movne→mov{c}` (fires iff `c` held → v1) and
+/// `moveq→mov{invert(c)}` (fires iff `c` did not → v2). Net: −2 instructions and
+/// the redundant flag round-trip removed, per select.
+///
+/// Returns the rewritten stream and the number of fusions applied (0 ⇒
+/// bit-identical to the input). Removal-only + rename-only, so it is run LATE,
+/// after register re-allocation (final register identities) and before encode.
+///
+/// **Soundness** — a fusion fires only when all hold (else that site is skipped):
+/// 1. `[i-1]` is a flag-setting `Cmp`/`Cmn` (the comparison whose flags we reuse;
+///    `SetCond` is always emitted immediately after its compare, so this is the
+///    comparison that produced `c`).
+/// 2. No flag-clobbering op (per [`clobbers_flags`]) and no read/write of `D` sits
+///    between the `SetCond` and the select's `cmp D,#0` — so the reused flags and
+///    the value of `D` both survive the window (only operand reloads may appear).
+/// 3. `D` is provably **dead** after the select: scanning forward, it is
+///    *redefined* (written without being read) before any use, any unmodeled op,
+///    or any branch/end-of-block. This refuses to delete a `SetCond` whose 0/1
+///    boolean is consumed elsewhere (e.g. stored to a local, or returned in R0).
+/// 4. `dst != D`, keeping the dead-check unambiguous.
+pub fn fuse_cmp_select(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
+    let n = instrs.len();
+    let mut out: Vec<ArmInstruction> = instrs.to_vec();
+    let mut delete = vec![false; n];
+    let mut fusions = 0usize;
+
+    for i in 0..n {
+        // [i] must be `SetCond { rd: D, cond: c }`.
+        let (d, c) = match instrs[i].op {
+            ArmOp::SetCond { rd, cond } => (rd, cond),
+            _ => continue,
+        };
+        // (1) the immediately-preceding op set the flags we will reuse.
+        if i == 0 || !matches!(instrs[i - 1].op, ArmOp::Cmp { .. } | ArmOp::Cmn { .. }) {
+            continue;
+        }
+        // (2) walk to the select's `cmp D,#0`, allowing only flag-safe ops that
+        // neither read nor write D in between.
+        let mut j = i + 1;
+        let mut window_ok = true;
+        let cmp_idx = loop {
+            if j >= n {
+                window_ok = false;
+                break j;
+            }
+            if matches!(&instrs[j].op,
+                ArmOp::Cmp { rn, op2: Operand2::Imm(0) } if *rn == d)
+            {
+                break j;
+            }
+            if clobbers_flags(&instrs[j].op) {
+                window_ok = false;
+                break j;
+            }
+            match reg_effect(&instrs[j].op) {
+                Some(eff) if !eff.uses.contains(&d) && !eff.defs.contains(&d) => {}
+                _ => {
+                    window_ok = false;
+                    break j;
+                }
+            }
+            j += 1;
+        };
+        if !window_ok {
+            continue;
+        }
+        // (next) `movne dst,v1`.
+        let ne_idx = cmp_idx + 1;
+        let (dst, v1) = match instrs.get(ne_idx).map(|x| &x.op) {
+            Some(ArmOp::SelectMove {
+                rd,
+                rm,
+                cond: Condition::NE,
+            }) => (*rd, *rm),
+            _ => continue,
+        };
+        if dst == d {
+            continue;
+        }
+        // optional `moveq dst,v2` (the in-place select omits it).
+        let eq_idx = match instrs.get(ne_idx + 1).map(|x| &x.op) {
+            Some(ArmOp::SelectMove {
+                rd,
+                cond: Condition::EQ,
+                ..
+            }) if *rd == dst => Some(ne_idx + 1),
+            _ => None,
+        };
+        // (3) D must be dead after the select block: a redefinition (def, no use)
+        // strictly before any use / unmodeled op / branch / end.
+        let after = eq_idx.unwrap_or(ne_idx) + 1;
+        if !reg_dead_by_redef(d, &instrs[after..]) {
+            continue;
+        }
+
+        // Commit: delete SetCond and the select's cmp; retarget the moves.
+        delete[i] = true;
+        delete[cmp_idx] = true;
+        out[ne_idx].op = ArmOp::SelectMove {
+            rd: dst,
+            rm: v1,
+            cond: c,
+        };
+        if let Some(eq) = eq_idx
+            && let ArmOp::SelectMove { rd, rm, .. } = out[eq].op
+        {
+            out[eq].op = ArmOp::SelectMove {
+                rd,
+                rm,
+                cond: c.invert(),
+            };
+        }
+        fusions += 1;
+    }
+
+    if fusions == 0 {
+        return (out, 0);
+    }
+    let result: Vec<ArmInstruction> = out
+        .into_iter()
+        .enumerate()
+        .filter(|(k, _)| !delete[*k])
+        .map(|(_, x)| x)
+        .collect();
+    (result, fusions)
+}
+
+/// True if `d` is provably dead at the start of `rest`: scanning forward, it is
+/// *redefined* (written without first being read) before any read, any
+/// unmodeled-effect op, or the end of the slice. Conservative — anything it
+/// cannot model (a call, a branch, an i64/FP op, running off the end) yields
+/// `false` ("can't prove dead"), so a live-out value (e.g. a result left in R0
+/// and returned) is never mistaken for dead.
+fn reg_dead_by_redef(d: Reg, rest: &[ArmInstruction]) -> bool {
+    for instr in rest {
+        match reg_effect(&instr.op) {
+            Some(eff) => {
+                if eff.uses.contains(&d) {
+                    return false; // read before redef ⇒ live
+                }
+                if eff.defs.contains(&d) {
+                    return true; // redefined unused ⇒ dead from here back
+                }
+            }
+            None => return false, // unmodeled (call/branch/i64/fp) ⇒ can't prove
+        }
+    }
+    false // ran off the end without a redef ⇒ possibly live-out
 }
 
 /// A constant materialization whose value is **already available** in a live
@@ -2616,6 +2808,248 @@ mod tests {
             op,
             source_line: None,
         }
+    }
+
+    // ---- VCR-SEL-004 cmp→select → IT-block predication ---------------------
+
+    fn cmp(rn: Reg, rm: Reg) -> ArmInstruction {
+        ins(ArmOp::Cmp {
+            rn,
+            op2: Operand2::Reg(rm),
+        })
+    }
+    fn cmp0(rn: Reg) -> ArmInstruction {
+        ins(ArmOp::Cmp {
+            rn,
+            op2: Operand2::Imm(0),
+        })
+    }
+    fn setcond(rd: Reg, cond: Condition) -> ArmInstruction {
+        ins(ArmOp::SetCond { rd, cond })
+    }
+    fn selmov(rd: Reg, rm: Reg, cond: Condition) -> ArmInstruction {
+        ins(ArmOp::SelectMove { rd, rm, cond })
+    }
+    /// A pure redefinition of `rd` (def, no use) — makes a prior value provably
+    /// dead, standing in for the register reuse that follows a consumed temp.
+    fn redef(rd: Reg) -> ArmInstruction {
+        ins(ArmOp::Movw { rd, imm16: 0 })
+    }
+
+    #[test]
+    fn invert_is_exhaustive_and_involutive() {
+        use Condition::*;
+        let pairs = [(EQ, NE), (LT, GE), (GT, LE), (LO, HS), (HI, LS)];
+        for (a, b) in pairs {
+            assert_eq!(a.invert(), b, "{a:?}.invert()");
+            assert_eq!(b.invert(), a, "{b:?}.invert()");
+        }
+        // Involution over every variant.
+        for c in [EQ, NE, LT, LE, GT, GE, LO, LS, HI, HS] {
+            assert_eq!(c.invert().invert(), c, "invert∘invert on {c:?}");
+            assert_ne!(c.invert(), c, "a condition is never its own inverse");
+        }
+    }
+
+    #[test]
+    fn fuse_cmp_select_signed_two_move_form() {
+        // cmp r1,r2 ; SetCond r3,LT ; cmp r3,#0 ; movne r0,r4 ; moveq r0,r5 ; <redef r3>
+        let seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            selmov(Reg::R0, Reg::R5, Condition::EQ),
+            redef(Reg::R3),
+        ];
+        let (out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(fused, 1);
+        // SetCond + cmp r3,#0 deleted ⇒ 6 → 4.
+        assert_eq!(out.len(), 4);
+        assert!(matches!(out[0].op, ArmOp::Cmp { rn: Reg::R1, .. }));
+        // movne→movlt (c), moveq→movge (invert c).
+        assert!(matches!(
+            out[1].op,
+            ArmOp::SelectMove {
+                rd: Reg::R0,
+                rm: Reg::R4,
+                cond: Condition::LT
+            }
+        ));
+        assert!(matches!(
+            out[2].op,
+            ArmOp::SelectMove {
+                rd: Reg::R0,
+                rm: Reg::R5,
+                cond: Condition::GE
+            }
+        ));
+        // no SetCond and no `cmp _,#0` survive.
+        assert!(!out.iter().any(|i| matches!(i.op, ArmOp::SetCond { .. })));
+        assert!(!out.iter().any(|i| matches!(
+            &i.op,
+            ArmOp::Cmp {
+                op2: Operand2::Imm(0),
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn fuse_cmp_select_unsigned_condition() {
+        // unsigned `<` lowers to LO; inverse is HS.
+        let seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LO),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            selmov(Reg::R0, Reg::R5, Condition::EQ),
+            redef(Reg::R3),
+        ];
+        let (out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(fused, 1);
+        assert!(matches!(
+            out[1].op,
+            ArmOp::SelectMove {
+                cond: Condition::LO,
+                ..
+            }
+        ));
+        assert!(matches!(
+            out[2].op,
+            ArmOp::SelectMove {
+                cond: Condition::HS,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn fuse_cmp_select_gust_mix_back_to_back_inplace_clamps() {
+        // The literal gust_mix shape: clamp r4 to [r6, r5] via two in-place
+        // selects (single predicated move each, no `moveq`):
+        //   cmp r4,r5 ; SetCond r3,GT ; cmp r3,#0 ; movne r4,r5   (upper clamp)
+        //   cmp r4,r6 ; SetCond r3,LT ; cmp r3,#0 ; movne r4,r6   (lower clamp)
+        // r3 is dead between (clamp 2's SetCond redefines it) and after (redef).
+        let seq = vec![
+            cmp(Reg::R4, Reg::R5),
+            setcond(Reg::R3, Condition::GT),
+            cmp0(Reg::R3),
+            selmov(Reg::R4, Reg::R5, Condition::NE),
+            cmp(Reg::R4, Reg::R6),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R4, Reg::R6, Condition::NE),
+            redef(Reg::R3),
+        ];
+        let (out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(fused, 2, "both clamps fuse");
+        // 9 → 5 (two SetCond + two cmp,#0 removed).
+        assert_eq!(out.len(), 5);
+        // The textbook predicated clamps: movgt r4,r5 and movlt r4,r6.
+        assert!(matches!(
+            out[1].op,
+            ArmOp::SelectMove {
+                rm: Reg::R5,
+                cond: Condition::GT,
+                ..
+            }
+        ));
+        assert!(matches!(
+            out[3].op,
+            ArmOp::SelectMove {
+                rm: Reg::R6,
+                cond: Condition::LT,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn no_fuse_when_d_is_live_downstream() {
+        // r3 (the boolean) is READ after the select ⇒ SetCond cannot be deleted.
+        let seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            selmov(Reg::R0, Reg::R5, Condition::EQ),
+            ins(ArmOp::Add {
+                rd: Reg::R7,
+                rn: Reg::R3, // reads the boolean
+                op2: Operand2::Imm(1),
+            }),
+        ];
+        let (out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(fused, 0, "must decline — boolean is consumed");
+        assert_eq!(out.len(), seq.len());
+    }
+
+    #[test]
+    fn no_fuse_when_flags_clobbered_in_window() {
+        // A flag-setting op sits between SetCond and the select's cmp ⇒ the
+        // comparison's flags would not survive ⇒ decline.
+        let seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LT),
+            ins(ArmOp::Subs {
+                rd: Reg::R6,
+                rn: Reg::R6,
+                op2: Operand2::Reg(Reg::R7),
+            }),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            selmov(Reg::R0, Reg::R5, Condition::EQ),
+            redef(Reg::R3),
+        ];
+        let (_out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(fused, 0, "must decline — flags clobbered in the window");
+    }
+
+    #[test]
+    fn no_fuse_when_predecessor_not_a_compare() {
+        // SetCond not preceded by a flag-setting compare ⇒ no flags to reuse.
+        let seq = vec![
+            ins(ArmOp::Mov {
+                rd: Reg::R1,
+                op2: Operand2::Imm(5),
+            }),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            selmov(Reg::R0, Reg::R5, Condition::EQ),
+            redef(Reg::R3),
+        ];
+        let (_out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(fused, 0, "must decline — predecessor is not Cmp/Cmn");
+    }
+
+    #[test]
+    fn no_fuse_when_dst_aliases_boolean() {
+        // dst == D: refuse (keeps the dead-check unambiguous).
+        let seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R3, Reg::R4, Condition::NE),
+            redef(Reg::R3),
+        ];
+        let (_out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(fused, 0, "must decline — dst aliases the boolean register");
+    }
+
+    #[test]
+    fn no_fuse_when_boolean_not_redefined() {
+        // No downstream redefinition of r3 ⇒ cannot prove it dead ⇒ decline.
+        let seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            selmov(Reg::R0, Reg::R5, Condition::EQ),
+        ];
+        let (_out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(fused, 0, "must decline — r3 may be live-out");
     }
 
     #[test]

--- a/crates/synth-synthesis/src/rules.rs
+++ b/crates/synth-synthesis/src/rules.rs
@@ -1666,6 +1666,32 @@ pub enum Condition {
     HS, // Greater than or equal unsigned (C == 1)
 }
 
+impl Condition {
+    /// The logical negation of this condition over the SAME NZCV flags: the
+    /// condition that holds exactly when `self` does not. Used by the cmp→select
+    /// fusion (VCR-SEL-004) — when a `SetCond rd, c; cmp rd,#0; movne v1; moveq
+    /// v2` is collapsed onto the comparison's own flags, the `moveq` (which fired
+    /// when the boolean was 0, i.e. `c` was false) must become `mov{invert(c)}`.
+    ///
+    /// Exhaustive over all 10 conditions (5 complementary pairs); the inverses
+    /// follow directly from the NZCV predicates on the enum:
+    /// EQ↔NE, LT↔GE, GT↔LE, LO↔HS, HI↔LS.
+    pub fn invert(self) -> Condition {
+        match self {
+            Condition::EQ => Condition::NE,
+            Condition::NE => Condition::EQ,
+            Condition::LT => Condition::GE,
+            Condition::GE => Condition::LT,
+            Condition::GT => Condition::LE,
+            Condition::LE => Condition::GT,
+            Condition::LO => Condition::HS,
+            Condition::HS => Condition::LO,
+            Condition::HI => Condition::LS,
+            Condition::LS => Condition::HI,
+        }
+    }
+}
+
 /// ARM register
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Reg {


### PR DESCRIPTION
## What

Adds the late peephole **`fuse_cmp_select`** (VCR-SEL-004, epic #242) — the cmp→select half of gale's #1 hot-path size/cycle lever (#428).

The selector lowers a `select` whose condition is a comparison to a *materialize-then-re-test* sequence:
```
cmp a,b ; SetCond D,c ; cmp D,#0 ; movne dst,v1 ; moveq dst,v2
```
The `SetCond` and the select's `cmp D,#0` are pure overhead — the comparison already set NZCV, and each `SelectMove` is an independent flag-preserving `IT;MOV`. The peephole collapses the pair onto the comparison's own flags (delete `SetCond` + `cmp D,#0`, retarget the moves to `c` / `invert(c)`), yielding the **textbook predicated clamp**:
```
cmp a,b ; movc dst,v1 ; mov{!c} dst,v2     (−2 instructions / fused select)
```

Real-fixture objdump (control_step), flag-on:
```
flag-off: cmp r0,#19 ; movcc.w r8,#1 ; movcs.w r8,#0 ; cmp.w r8,#0 ; movne r5,r6   (5 insns)
flag-on:  cmp r0,#19 ; movcc r5,r6                                                  (2 insns)
```

## Scope — **select half only**

The artifact title is "select/br_if". This PR lands the **`select`→`movCC`** half. The `br_if`→predicated-**branch** half is **not** done (branch consumers are unmodeled by `reg_effect` and never match) — deferred follow-up. Artifact note scoped accordingly.

## Sound by construction (each guard has a negative unit test)

- flags reused only when nothing clobbers them in the `SetCond`→`cmp` window (`clobbers_flags` — tight ldr/str/push/pop/nop allowlist);
- the boolean deleted only when **provably dead** — a downstream redefinition before any read / unmodeled op / branch / end (`reg_dead_by_redef`, so an R0 return value is never mistaken for dead);
- `[i-1]` must be the flag-setting compare; `dst != D`.

Plus `Condition::invert()` (exhaustive over all 10 conditions).

## Frozen-safe / gated

Wired into `arm_backend.rs` **after** range-realloc (final register identities for the dead-D proof) and before encode, **behind `SYNTH_CMP_SELECT_FUSE=1`**. Default-off ⇒ a literal no-op ⇒ the three frozen differentials (control_step `0x00210A55` / flat+inlined flight_algo `0x07FDF307` / divseam) stay **bit-identical, un-rerun**.

## Validation (this step)

- 8 liveness unit tests — positive incl. the gust_mix ×2 in-place clamp; 5 negative guards (D live, flag-clobber in window, predecessor not a compare, dst aliases D, no redef);
- 3 encoder byte-tests — all 10 `IT <cond>; MOV` conditions, exact bytes for the LT/GE + LO/HS pairs fusion newly produces;
- rewrite-count > 0 on real fixtures (control_step 3, flight_algo/controller 5–6, filter_axis 0 — correctly nothing to fuse);
- arm-none-eabi-objdump diff confirms the predicated clamp replaces the 5-insn materialize+re-test, and unsafe sites (boolean reused) **correctly decline**.

## Deliberately deferred (owed by the default-on flip step — NOT done here)

- **Execution-level differential** under the flag (VCR-ORACLE-001 Rust unicorn harness, task #6) + gale's `gust_codegen_bench` on G474RE (≤1.3× fn-only) — the agreed on-silicon kill-criterion. **Only then does the flag flip default-on and the tag cut.**
- Empirical gap that differential must close: every fused site on the real fixtures was the **in-place single-move** form, so the two-move `moveq→mov{invert(c)}` path (where `invert()` matters at runtime) has run in unit/encoder tests but never selector→fusion→encoder→exec on a real function. The flip's differential must include a fixture forcing a **non-in-place** select (e.g. `val2` a live param). (#204/#206 IR-right/composition-wrong lesson.)
- `br_if`→predicated-branch half (separate follow-up).

Refs #242, #428. Baseline v0.12.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)