### PR TITLE
test(vcr-oracle): frozen-codegen .text byte gate in cargo CI (VCR-ORACLE-001, #242)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,6 +2091,7 @@ dependencies = [
  "object",
  "scry-sai-core",
  "serde_json",
+ "sha2 0.11.0",
  "synth-backend",
  "synth-backend-awsm",
  "synth-backend-riscv",

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -408,6 +408,23 @@ artifacts:
       witness that the hand-written ARM/RISC-V model matches silicon (validating
       the proof's assumptions). Can start immediately and feeds every other
       track.
+      FIRST SLICE LANDED (2026-06-23): the frozen-fixture BYTE gate
+      (`crates/synth-cli/tests/frozen_codegen_bytes.rs`) — compiles each frozen
+      fixture (control_step / flight_seam / flight_seam_flat / signed_div_const)
+      flag-off and asserts a locked SHA-256 of its `.text`, promoting the
+      previously OUT-OF-CI "stay bit-identical" invariant (asserted only by the
+      `scripts/repro/*_differential.py` unicorn scripts, never run by cargo CI nor
+      the Renode bazel suite) into a cargo-CI gate. It is the LOCALLY-VERIFIABLE
+      complement to the python differentials (derivable + checkable with `cargo
+      test`, no emulator) — guards against ACCIDENTAL drift (e.g. the open
+      dependabot wasmparser 0.248->0.252 / wat bumps shifting decode). SCOPE BOUND:
+      this proves byte-IDENTITY, NOT result-identity — it is NOT the execution
+      differential the VCR-SEL-004 default-on flip owes (that flip deliberately
+      changes these bytes and must prove the RESULT survives; this gate will
+      correctly FAIL it and demand a deliberate re-freeze). STILL PROPOSED (the
+      bulk): coverage-guided fixture generation, MC/DC rule coverage, the
+      theorem-linked result-identity differential, and the execution harness
+      (unicorn/qemu — synth-qemu shells to a qemu-system binary CI lacks).
     status: proposed
     tags: [oracle, differential, coverage, mcdc, validation, track-c]
     links:

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -54,6 +54,11 @@ wast.workspace = true
 
 [dev-dependencies]
 object.workspace = true
+# VCR-ORACLE-001 (#242) — the frozen-codegen byte gate hashes each fixture's
+# `.text` to lock it against accidental drift (e.g. a dependabot parser bump
+# shifting lowering). Already in the lock tree; test-only ⇒ no production pull,
+# no MODULE.bazel pin (Bazel globs src/ only).
+sha2 = "0.11"
 # VCR-DBG-001 step 4 (#394) — oracle B parses the EMITTED `.debug_line` back with
 # gimli::read to prove the section is real debugger-readable DWARF (addresses in
 # `.text` range, lines non-zero). Test-only; the production read+emit lives in

--- a/crates/synth-cli/tests/frozen_codegen_bytes.rs
+++ b/crates/synth-cli/tests/frozen_codegen_bytes.rs
@@ -1,0 +1,148 @@
+//! VCR-ORACLE-001 (#242) — frozen-codegen `.text` byte gate, in cargo CI.
+//!
+//! The repo's frozen result-identity invariants (control_step `0x00210A55`,
+//! flat+inlined flight_algo `0x07FDF307`, the div seam) are asserted ONLY by the
+//! out-of-CI `scripts/repro/*_differential.py` unicorn scripts — which need
+//! wasmtime + unicorn + pyelftools and are never run by `cargo test` nor the
+//! Renode bazel suite. So `spill_baseline_pressure_390.rs`'s load-bearing aside
+//! ("the frozen differential hashes already fail on any codegen byte change") is,
+//! in cargo CI, NOT actually enforced: an accidental lowering change — e.g. a
+//! dependabot `wasmparser`/`wat` bump that shifts decode, or a flag flipped on by
+//! mistake — could alter a frozen fixture's machine code and every cargo gate
+//! would stay green.
+//!
+//! This closes that hole with a **byte gate**: compile each frozen fixture with
+//! the shipped (flag-off) config the differentials use, extract the `.text`
+//! section, and assert its SHA-256 matches a locked golden. It is the
+//! **locally-verifiable** complement to the python differentials — derivable and
+//! checkable with `cargo test` alone (no emulator), which the operating contract
+//! ("a verifier you didn't run isn't a verifier") prefers over wiring an
+//! unrunnable-here Python gate into CI.
+//!
+//! WHAT IT IS NOT. This proves byte-IDENTITY, not result-identity. It is NOT the
+//! execution differential the VCR-SEL-004 cmp→select default-on flip owes — that
+//! flip *deliberately* changes these bytes and must prove the RESULT is unchanged
+//! across the change (run the ELF, assert `0x00210A55`); this gate will correctly
+//! FAIL on that flip and demand a deliberate re-freeze. Different invariant,
+//! different purpose. Byte gate ⇒ catch accidental drift + force deliberate
+//! re-freeze. It does not reduce the flip's owed work.
+//!
+//! DETERMINISM. synth is a cross-compiler: `.text` is a pure function of (wasm,
+//! target, flags), independent of the host. So these goldens (derived on macOS)
+//! must match Linux CI. If a host actually diverged, this fails LOUD on its own
+//! first CI run — self-correcting, never a shipped landmine.
+//!
+//! RE-FREEZING. When a codegen change is intentional, update the golden HERE
+//! **and** re-run the `scripts/repro/*_differential.py` result checks on the same
+//! commit — the two must move together. A bare golden bump with no differential
+//! re-run is the anti-pattern this gate exists to prevent.
+
+use std::process::Command;
+
+use object::{Object, ObjectSection};
+use sha2::{Digest, Sha256};
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture(name: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro")
+        .join(name)
+}
+
+/// Compile a frozen fixture with the exact config the `.py` differentials use
+/// (`--target cortex-m4 --all-exports --relocatable`), return the SHA-256 hex of
+/// its `.text` and the section length. `SYNTH_CMP_SELECT_FUSE` is explicitly
+/// removed so an enabled-in-the-environment flag can never silently re-freeze the
+/// gate — it locks the SHIPPED, flag-off lowering.
+fn text_sha256(wasm: &str) -> (String, usize) {
+    let path = fixture(wasm);
+    let out = Command::new(synth())
+        .env_remove("SYNTH_CMP_SELECT_FUSE")
+        .env_remove("SYNTH_CONST_CSE")
+        .args([
+            "compile",
+            path.to_str().unwrap(),
+            "-o",
+            &format!("/tmp/frozenbytes_{wasm}.elf"),
+            "--target",
+            "cortex-m4",
+            "--all-exports",
+            "--relocatable",
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        out.status.success(),
+        "synth compile failed for {wasm}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let bytes = std::fs::read(format!("/tmp/frozenbytes_{wasm}.elf")).expect("read elf");
+    let obj = object::File::parse(&*bytes).expect("parse elf");
+    let text = obj
+        .section_by_name(".text")
+        .expect("frozen fixture must have a .text section");
+    let data = text.data().expect("read .text");
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+    (hex, data.len())
+}
+
+/// THE GATE. Each frozen fixture's `.text` must hash to its locked golden. The
+/// length is asserted too, so a re-freeze prints the size delta (a quick read on
+/// "how much codegen moved") and a hash collision can't pass on a wrong length.
+///
+/// Goldens derived on main @ ef97f86 (post-#444 cmp→select, flag-off), 2026-06-23.
+#[test]
+fn frozen_fixtures_text_is_bit_identical_oracle_001() {
+    // (fixture, golden sha256 of .text, golden .text length). These are the
+    // canonical frozen perf fixtures (the ones spill_baseline_390 + the .py
+    // differentials cover): control_step ↔ 0x00210A55, flight_seam_flat ↔
+    // flat+inlined flight_algo 0x07FDF307, plus flight_seam and the div seam.
+    let cases = [
+        (
+            "control_step.wasm",
+            "5efa58ca2667fb2f910b5ebf0ef8020a7fc1b9224f3ec070e9e0028de9d83a57",
+            354usize,
+        ),
+        (
+            "flight_seam.wasm",
+            "1f39b77b65f0695693deda9ee56e3a7fb3af4127858a8ac6c3ce0fd3398de516",
+            1016,
+        ),
+        (
+            "flight_seam_flat.wasm",
+            "f6244f35f932aac7661b9ed1cbf70dc1b5353a9f5c03178ebad3a38a891d7b8f",
+            1240,
+        ),
+        (
+            "signed_div_const.wasm",
+            "b277453b7829a5b2c64527131298d89fa63f5641231b1d4c7336675e8cdab9b0",
+            34,
+        ),
+    ];
+
+    for (wasm, golden, golden_len) in cases {
+        let (got, len) = text_sha256(wasm);
+        assert_eq!(
+            len, golden_len,
+            "{wasm}: .text length changed ({len} vs locked {golden_len}) — codegen \
+             moved. If intentional, re-freeze the golden HERE and re-run \
+             scripts/repro/*_differential.py on this commit (they move together)."
+        );
+        assert_eq!(
+            got, golden,
+            "{wasm}: .text SHA-256 changed — a frozen fixture's machine code drifted \
+             with no deliberate re-freeze. This is the gate working: either a \
+             codegen change leaked in (investigate — dep bump? flag? selector?), or \
+             it is intentional, in which case update the golden HERE and re-run the \
+             scripts/repro/*_differential.py result checks (control_step 0x00210A55 \
+             / flight_algo 0x07FDF307) on the SAME commit."
+        );
+    }
+}


### PR DESCRIPTION
## What

Promotes the frozen-fixture **bit-identical** invariant from out-of-CI `.py` scripts into a **cargo-CI gate** (VCR-ORACLE-001 first slice, epic #242).

The frozen result-identity values (control_step `0x00210A55`, flat+inlined flight_algo `0x07FDF307`, the div seam) are asserted **only** by `scripts/repro/*_differential.py` (unicorn + wasmtime + pyelftools) — which `cargo test` never runs, nor does the Renode bazel suite. So `spill_baseline_pressure_390.rs`'s aside *"the frozen differential hashes already fail on any codegen byte change"* was, in cargo CI, **not enforced**: an accidental lowering change (e.g. the open dependabot **wasmparser 0.248→0.252** / wat bumps shifting decode, or a flag flipped on by mistake) could alter a frozen fixture's machine code with every cargo gate staying green.

`frozen_codegen_bytes.rs` closes it: compile each frozen fixture flag-off with the differentials' config (`--target cortex-m4 --all-exports --relocatable`), extract `.text` via `object`, assert a locked SHA-256.

## Why a byte gate (and why not the Python gate in CI)

The operating contract is *"a verifier you didn't run isn't a verifier."* The `.py` differentials can't be run locally here (missing wasmtime/unicorn/pyelftools), so wiring them into CI means landing a gate validatable only by push-and-watch. A pure-Rust byte gate is **compile-and-hash locally** — that local verifiability is the reason to prefer it. (`synth-qemu` shells to a `qemu-system` binary CI lacks, so a result gate via it isn't cheap here.)

## Scope bound — what this is NOT

Proves **byte-identity**, not **result-identity**. It is **not** the execution differential the VCR-SEL-004 cmp→select default-on flip owes: that flip *deliberately* changes these bytes and must prove the *result* survives (run the ELF, assert `0x00210A55`). This gate will correctly **fail** that flip and demand a deliberate re-freeze. **It does not reduce the flip's owed work.**

## Frozen-safe + validation

- New dev-dep `sha2` (already in the lock tree) + a new test — **zero production code, zero emitted-byte change.**
- Non-vacuity verified: a tampered golden **fails loud** with a re-freeze message; restored → green.
- fmt + clippy + rivet (0 non-xref) clean.
- Goldens derived on main `@ ef97f86`. Determinism self-correcting: synth's `.text` is host-independent, so a host divergence fails loud on first CI run rather than shipping a landmine.
- Re-freeze discipline encoded in the assertion message: update the golden **and** re-run `scripts/repro/*_differential.py` on the same commit — they move together.

Refs #242. Baseline v0.12.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)