### PR TITLE
docs(vcr-mem): cite meld v0.34.0 ADR-4 — multi-memory commitment shipped upstream (VCR-MEM-002, #242, #406)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -1326,6 +1326,15 @@ artifacts:
       retained SECONDARY) where a miscomputed address lands in a neighbour's
       sub-range and only the MPU catches it. meld emits the multi-memory
       structure + cross-memory ops today ⇒ SYNTH IS THE REMAINING GATE.
+      SHIPPED UPSTREAM (meld v0.34.0, 2026-06-23): the #300 decision is now
+      formalized as meld ADR-4 (safety/adr/ADR-4-inter-component-isolation-model)
+      and released — model 2 is the committed structural-isolation path, meld
+      guarantees `MultiMemory` output STABLE as synth's lowering target (adjusts
+      only if synth hits an unconsumable shape), and ADR-4 names this synth-side
+      lowering (synth#404/#369) as the committed remaining work, anchored on
+      meld's gating tests (`test_multi_memory_result_copy_adapter`, SR-21/SR-23).
+      No synth build impact (no cargo dep on meld); the synth obligation is the
+      staged byte-changing track below, unchanged in scope.
 
       Today synth is single-memory: the memory index is DROPPED at the IR level
       (the load/store `WasmOp` variants carry no `memory_index` — wasm_op.rs),


### PR DESCRIPTION
## What

Cross-repo trace sync triggered by **meld v0.34.0** (2026-06-23).

meld shipped the dissolved-MCU inter-component isolation commitment and formalized it as **ADR-4** (`safety/adr/ADR-4-inter-component-isolation-model.md`):
- model 2 (structural multi-memory isolation) is the **committed** path;
- meld guarantees `MemoryStrategy::MultiMemory` output **stable as synth's lowering target** (adjusts only if synth hits an unconsumable shape);
- ADR-4 names the synth-side lowering (synth#404/#369) as the committed remaining gate, anchored on meld's gating tests (`test_multi_memory_result_copy_adapter`, SR-21/SR-23).

This updates **VCR-MEM-002**'s provenance from "meld#300 *decision* (2026-06-21)" to the now-**released + ADR-documented** upstream state, so synth's roadmap trace reflects that synth is the sole remaining gate with a stable upstream target.

## Scope

**Docs-only / frozen-safe** — no code, no emitted bytes. **No scope change**: the synth obligation remains the staged, gated, **byte-changing** multi-memory lowering (memidx-through-IR → per-memory bases → cross-memory ops → expose base/size for MPU), explicitly *not* an idle-tick increment. synth has no cargo dependency on meld, so no build impact.

rivet 0 non-xref errors. Acknowledged on #406 (which had no prior on-issue ack).

Refs #242, #406; upstream meld v0.34.0 / ADR-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)