### PR TITLE
test(vcr-sel): characterize the two-move arm as unreachable — root-cause gale's clamp-#2 decline (VCR-SEL-004, #428, #242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -626,6 +626,28 @@ artifacts:
       fusable NON-in-place select (e.g. `val2` a live param), or the `mov{!c}` path
       reaches silicon never having run (the #204/#206 IR-right/composition-wrong
       lesson). The `br_if`→predicated-branch half is separate deferred work.
+      GALE BENCH + INVESTIGATION (#428, 2026-06-23): gale ran gust_codegen_bench
+      (qemu -icount, M3 proxy): flag-off vs SYNTH_CMP_SELECT_FUSE=1 is CORRECTNESS-
+      IDENTICAL over [0,2047], fn-only 1.05→0.95 ticks, 2.63×→2.375× LLVM, .text
+      132→124 B — a monotonic correctness-preserving win. Two findings: (a) ≤1.3×
+      is the COMBINED program target (VCR-VER-001), NOT this lever's gate — #1's
+      gate is correct+not-slower+smaller, met on qemu; (b) gale's gust_mix clamp #2
+      DECLINED while clamp #1 fused. ROOT CAUSE (verified via objdump of the
+      synthetic two-move fixture scripts/repro/cmp_select_two_move.wat — NOT gale's
+      "narrow dst-match" guess): `reg_dead_by_redef` requires an explicit downstream
+      REDEFINITION of the boolean; the real selector ABANDONS the boolean temp after
+      the select (used once, not live-out, never rewritten), so the guard
+      conservatively declines. This is ONE mechanism unifying BOTH the clamp-#2
+      decline AND the two-move-arm-never-fires gap: the two-move arm is effectively
+      UNREACHABLE through the real selector today. Characterization test
+      (cmp_select_two_move_coverage.rs) locks it (two-move fixture fuses 0,
+      in-place control_step fuses >0). FOLLOW-ON (byte-changing, separate gated
+      step): teach reg_dead_by_redef that "abandoned + not-live-out" is dead — this
+      both closes gale's clamp-#2 coverage AND makes the two-move arm reachable, so
+      the flip's owed two-move differential can finally run end-to-end. FLIP
+      PRECONDITIONS (both, per gale exchange): (1) the two-move arm exercised
+      end-to-end [blocked on this deadness follow-on], (2) gale's G474RE DWT-cycle
+      run shows no M4-specific regression vs the qemu proxy (gale wiring it).
     status: approved
     tags: [codegen, selector, peephole, compare-select, flag-fusion, gale-209, perf, track-b]
     links:

--- a/crates/synth-cli/tests/cmp_select_two_move_coverage.rs
+++ b/crates/synth-cli/tests/cmp_select_two_move_coverage.rs
@@ -1,0 +1,107 @@
+//! VCR-SEL-004 characterization (#428) — the two-move arm is unreachable today.
+//!
+//! gale's `gust_codegen_bench` on `gust_mix` surfaced two observations: the
+//! cmp→select fusion fired one clamp and declined its sibling, and the two-move
+//! `moveq→mov{invert(c)}` arm never executed end-to-end. Investigation (objdump of
+//! a synthetic two-move fixture) showed a SINGLE root cause: `fuse_cmp_select`'s
+//! `reg_dead_by_redef` requires an explicit downstream *redefinition* of the
+//! boolean before it will delete the `SetCond`. The real selector ABANDONS the
+//! boolean temp after the select (used once, not live-out, never rewritten), so
+//! the guard conservatively declines — for BOTH the declined clamp and every
+//! two-move shape. The two-move arm is therefore effectively unreachable through
+//! the real selector under the current guard.
+//!
+//! This test LOCKS that finding: the synthetic two-move fixture (`val2` a live
+//! param ⇒ the selector emits `movne dst,v1; moveq dst,v2`) currently fuses ZERO
+//! sites, while an in-place fixture fuses several (so the harness is not vacuously
+//! seeing "0"). When the deadness guard is improved to treat "abandoned +
+//! not-live-out" as dead (the byte-changing VCR-SEL-004 follow-on that also closes
+//! gale's clamp #2), this assertion flips: update the expectation to `> 0` and
+//! re-freeze the differentials.
+//!
+//! Measure-only: drives the shipped binary with `SYNTH_CMP_SELECT_FUSE=1`
+//! `SYNTH_FUSE_STATS=1` and parses the `[cmp-select-fuse] N select(s) fused` line.
+//! Changes no production code and no emitted bytes (the flag is off by default).
+
+use std::process::Command;
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture(name: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro")
+        .join(name)
+}
+
+/// Compile `fix` with fusion + stats on; return the total `N` across all
+/// `[cmp-select-fuse] N select(s) fused` lines (one per function).
+fn fused_count(fix: &str) -> usize {
+    let path = fixture(fix);
+    let out = Command::new(synth())
+        .env("SYNTH_CMP_SELECT_FUSE", "1")
+        .env("SYNTH_FUSE_STATS", "1")
+        .args([
+            "compile",
+            path.to_str().unwrap(),
+            "-o",
+            &format!("/tmp/cstm_{fix}.elf"),
+            "--target",
+            "cortex-m4",
+            "--all-exports",
+            "--relocatable",
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        out.status.success(),
+        "synth compile failed for {fix}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    combined
+        .lines()
+        .filter(|l| l.contains("[cmp-select-fuse]"))
+        .filter_map(|l| {
+            l.split("[cmp-select-fuse]")
+                .nth(1)?
+                .trim_start()
+                .split(' ')
+                .next()?
+                .parse::<usize>()
+                .ok()
+        })
+        .sum()
+}
+
+#[test]
+fn two_move_select_arm_currently_declines_428() {
+    // Non-vacuity: an in-place fixture fuses several sites, so the harness
+    // genuinely observes fusion — a "0" on the two-move fixture is real, not a
+    // parsing/plumbing artifact.
+    let in_place = fused_count("control_step.wasm");
+    assert!(
+        in_place >= 1,
+        "control_step should fuse its in-place clamps (got {in_place}) — if this \
+         is 0 the harness is broken, not the two-move finding"
+    );
+
+    // The finding: the selector emits the two-move form for this fixture (val2 a
+    // live param), but reg_dead_by_redef declines it (boolean abandoned, not
+    // redefined before return). FLIP TO `>= 1` when the deadness guard recognizes
+    // "abandoned + not-live-out" as dead (VCR-SEL-004 follow-on; re-freeze then).
+    let two_move = fused_count("cmp_select_two_move.wat");
+    assert_eq!(
+        two_move, 0,
+        "two-move fixture fused {two_move} sites — the deadness guard now reaches \
+         the two-move arm. This is the EXPECTED future state: flip this assertion \
+         to `>= 1`, exercise the mov{{invert(c)}} arm under a differential, and \
+         re-freeze the frozen fixtures."
+    );
+}

--- a/scripts/repro/cmp_select_two_move.wat
+++ b/scripts/repro/cmp_select_two_move.wat
@@ -1,0 +1,22 @@
+;; VCR-SEL-004 characterization fixture (#428) — forces the selector's TWO-MOVE
+;; (non-in-place) select form: `val2` is a live param ($lo, read again below), so
+;; the selector emits `cmp; SetCond D; cmp D,#0; movne dst,val1; moveq dst,val2`
+;; (the two-move arm where mov{invert(c)} matters at runtime).
+;;
+;; FINDING (#428, gale gust_codegen_bench follow-up): fuse_cmp_select currently
+;; DECLINES this — the boolean `D` is abandoned after the select (never redefined
+;; before the return), so reg_dead_by_redef cannot prove it dead and conservatively
+;; bails. This is the SAME mechanism that declines gale's gust_mix clamp #2, and it
+;; makes the two-move arm effectively unreachable through the real selector. The
+;; fix (recognize "abandoned + not-live-out" as dead) is a byte-changing VCR-SEL-004
+;; follow-on; when it lands, the characterization test flips to assert fusion.
+(module
+  (memory (export "mem") 1)
+  (func (export "two_move_sel") (param $a i32) (param $b i32) (param $lo i32) (result i32)
+    (local $sel i32)
+    (local.set $sel
+      (select (local.get $a) (local.get $lo)
+              (i32.lt_s (local.get $a) (local.get $b))))
+    (i32.add
+      (i32.mul (local.get $sel) (local.get $lo))
+      (i32.sub (local.get $a) (local.get $b)))))


### PR DESCRIPTION
## What

Investigation + characterization triggered by gale's `gust_codegen_bench` run on #428.

gale confirmed cmp→select (#444) is **correctness-identical over [0,2047]** and a monotonic win (1.05→0.95 ticks, 2.63×→2.375× LLVM, 132→124 B), but surfaced two observations:
1. the fusion fired one `gust_mix` clamp and **declined its sibling**;
2. the two-move `moveq→mov{invert(c)}` arm **never executed end-to-end**.

## Root cause (one mechanism, not gale's guess)

Objdump of a synthetic two-move fixture shows a **single** root cause — **not** the "narrow dst-match" gale hypothesized: `reg_dead_by_redef` requires an explicit downstream **redefinition** of the boolean before deleting the `SetCond`. The real selector **abandons** the boolean temp after the select (used once, not live-out, never rewritten):

```
cmp r0,r1 ; ite lt ; movlt r3,#1 ; movge r3,#0 ; cmp r3,#0 ; movne r4,r0 ; moveq r4,r2
;; r3 never written again before the return -> reg_dead_by_redef bails -> DECLINE
```

This unifies **both** observations: the clamp-#2 decline and the two-move-arm-never-fires gap are the **same** conservative-deadness mechanism — the two-move arm is effectively **unreachable** through the real selector today.

## Adds (frozen-safe — test + fixture + docs, zero production change)

- `scripts/repro/cmp_select_two_move.wat` — forces the selector's two-move form (`val2` a live param).
- `cmp_select_two_move_coverage.rs` — characterization test: two-move fixture fuses **0**, in-place `control_step` fuses **>0** (non-vacuous). Flips to `>= 1` when the guard is fixed.
- **VCR-SEL-004** note: the finding + the unified follow-on (teach `reg_dead_by_redef` that "abandoned + not-live-out" is dead — closes gale's clamp #2 **and** makes the two-move arm reachable) + the two flip preconditions.

## Flip status (unchanged, now sharper)

The default-on flip is held on **two** preconditions: (1) the two-move arm exercised end-to-end — **blocked on the deadness follow-on above** (byte-changing, separate gated step), and (2) gale's G474RE DWT-cycle run shows no M4-specific regression vs the qemu proxy. ≤1.3× is the *combined* VCR-VER-001 target, not this lever's gate.

fmt + clippy + rivet (0 non-xref) clean. Refs #242, #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)