### PR TITLE
feat(vcr-sel): reg_dead_by_redef recognizes the return terminator — two-move arm reachable (VCR-SEL-004 #7, #428, #242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -648,6 +648,24 @@ artifacts:
       PRECONDITIONS (both, per gale exchange): (1) the two-move arm exercised
       end-to-end [blocked on this deadness follow-on], (2) gale's G474RE DWT-cycle
       run shows no M4-specific regression vs the qemu proxy (gale wiring it).
+      DEADNESS FOLLOW-ON LANDED (#7, 2026-06-23, flag-off / frozen-safe):
+      reg_dead_by_redef now recognizes the function RETURN terminator (`bx lr` /
+      `pop {…,pc}`) — where live-out ⊆ ABI result regs {R0,R1} — so an ABANDONED
+      boolean in R2..R8 (the shape the real selector emits) is proven dead and the
+      two-move arm fuses end-to-end. Verified: the synthetic fixture now lowers to
+      `cmp r0,r1; movlt r4,r0; movge r4,r2` — the `mov{invert(c)}` (movge) arm
+      firing for the FIRST time, semantically identical to the select. Soundness
+      locked by IR unit tests: positive (abandoned boolean + return ⇒ fuse) and the
+      load-bearing negatives that keep it sound — result-reg boolean (d∈{R0,R1}),
+      branch-in-tail, and bx-to-non-LR all still DECLINE (the scan bails on every
+      Label/branch via reg_effect→None, never walking past a join point). Frozen
+      byte gates #445/#446 stay GREEN flag-off (default path byte-identical).
+      STILL OWED / NOT claimed: (a) the two-move arm is reachable + objdump- and
+      IR-correct but NOT yet execution-validated — gale's NEXT gust_codegen_bench
+      (flag-on) exercises it for the first time; watch correctness there. (b) "closes
+      clamp #2" is by the same mechanism but UNVERIFIED locally (no gust_mix.wasm) —
+      gale's bench confirms which clamps now fuse. The flip still gates on both
+      preconditions above (now (1) is unblocked pending that gale bench).
     status: approved
     tags: [codegen, selector, peephole, compare-select, flag-fusion, gale-209, perf, track-b]
     links:

--- a/crates/synth-cli/tests/cmp_select_two_move_coverage.rs
+++ b/crates/synth-cli/tests/cmp_select_two_move_coverage.rs
@@ -1,23 +1,23 @@
-//! VCR-SEL-004 characterization (#428) — the two-move arm is unreachable today.
+//! VCR-SEL-004 (#428) — the two-move arm is now REACHABLE (#7 closed the gap).
 //!
 //! gale's `gust_codegen_bench` on `gust_mix` surfaced two observations: the
 //! cmp→select fusion fired one clamp and declined its sibling, and the two-move
 //! `moveq→mov{invert(c)}` arm never executed end-to-end. Investigation (objdump of
 //! a synthetic two-move fixture) showed a SINGLE root cause: `fuse_cmp_select`'s
-//! `reg_dead_by_redef` requires an explicit downstream *redefinition* of the
-//! boolean before it will delete the `SetCond`. The real selector ABANDONS the
-//! boolean temp after the select (used once, not live-out, never rewritten), so
-//! the guard conservatively declines — for BOTH the declined clamp and every
-//! two-move shape. The two-move arm is therefore effectively unreachable through
-//! the real selector under the current guard.
+//! `reg_dead_by_redef` only deleted the `SetCond` when the boolean was explicitly
+//! *redefined* downstream — but the real selector ABANDONS the boolean temp after
+//! the select (used once, not live-out, never rewritten), so the guard declined
+//! for BOTH the declined clamp and every two-move shape.
 //!
-//! This test LOCKS that finding: the synthetic two-move fixture (`val2` a live
-//! param ⇒ the selector emits `movne dst,v1; moveq dst,v2`) currently fuses ZERO
-//! sites, while an in-place fixture fuses several (so the harness is not vacuously
-//! seeing "0"). When the deadness guard is improved to treat "abandoned +
-//! not-live-out" as dead (the byte-changing VCR-SEL-004 follow-on that also closes
-//! gale's clamp #2), this assertion flips: update the expectation to `> 0` and
-//! re-freeze the differentials.
+//! #7 fixed it: `reg_dead_by_redef` now recognizes the function's RETURN terminator
+//! (`bx lr` / `pop {…,pc}`) — at which the only live-out registers are the ABI
+//! result regs {R0,R1} — so an abandoned boolean in `R2`..`R8` is proven dead and
+//! the two-move arm fuses end-to-end. This test LOCKS the reachability: the
+//! synthetic two-move fixture (`val2` a live param ⇒ `movne dst,v1; moveq dst,v2`)
+//! now fuses exactly 1 site, while an in-place fixture fuses several (non-vacuous).
+//! Frozen-safe: flag-off (default) is byte-identical (gates #445/#446 stay green);
+//! the default-on flip + gale's re-bench (which now exercises the two-move arm for
+//! the first time) remain the separate gated step.
 //!
 //! Measure-only: drives the shipped binary with `SYNTH_CMP_SELECT_FUSE=1`
 //! `SYNTH_FUSE_STATS=1` and parses the `[cmp-select-fuse] N select(s) fused` line.
@@ -81,27 +81,27 @@ fn fused_count(fix: &str) -> usize {
 }
 
 #[test]
-fn two_move_select_arm_currently_declines_428() {
+fn two_move_select_arm_is_reachable_428() {
     // Non-vacuity: an in-place fixture fuses several sites, so the harness
-    // genuinely observes fusion — a "0" on the two-move fixture is real, not a
+    // genuinely observes fusion — a count on the two-move fixture is real, not a
     // parsing/plumbing artifact.
     let in_place = fused_count("control_step.wasm");
     assert!(
         in_place >= 1,
-        "control_step should fuse its in-place clamps (got {in_place}) — if this \
-         is 0 the harness is broken, not the two-move finding"
+        "control_step should fuse its in-place clamps (got {in_place})"
     );
 
-    // The finding: the selector emits the two-move form for this fixture (val2 a
-    // live param), but reg_dead_by_redef declines it (boolean abandoned, not
-    // redefined before return). FLIP TO `>= 1` when the deadness guard recognizes
-    // "abandoned + not-live-out" as dead (VCR-SEL-004 follow-on; re-freeze then).
+    // #7 closed the gap: the selector emits the two-move form for this fixture
+    // (val2 a live param), and reg_dead_by_redef now recognizes the abandoned,
+    // not-live-out boolean as dead at the function's return terminator — so the
+    // two-move `mov{c} … mov{invert(c)}` arm fuses end-to-end. (Previously declined;
+    // see fuse_two_move_abandoned_boolean_before_pop_return in liveness.rs for the
+    // IR-level soundness, and the negatives that keep it sound: result-reg boolean,
+    // branch-in-tail, bx-to-non-LR all still decline.)
     let two_move = fused_count("cmp_select_two_move.wat");
     assert_eq!(
-        two_move, 0,
-        "two-move fixture fused {two_move} sites — the deadness guard now reaches \
-         the two-move arm. This is the EXPECTED future state: flip this assertion \
-         to `>= 1`, exercise the mov{{invert(c)}} arm under a differential, and \
-         re-freeze the frozen fixtures."
+        two_move, 1,
+        "the two-move arm must now be reachable (fused {two_move}, want 1) — if 0, \
+         the #7 deadness fix regressed; if >1 the fixture changed"
     );
 }

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -410,14 +410,55 @@ pub fn fuse_cmp_select(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize
     (result, fusions)
 }
 
-/// True if `d` is provably dead at the start of `rest`: scanning forward, it is
-/// *redefined* (written without first being read) before any read, any
-/// unmodeled-effect op, or the end of the slice. Conservative — anything it
-/// cannot model (a call, a branch, an i64/FP op, running off the end) yields
-/// `false` ("can't prove dead"), so a live-out value (e.g. a result left in R0
-/// and returned) is never mistaken for dead.
+/// True if `op` returns from the function: `Bx LR`, or a `Pop`/`Ldmia` that loads
+/// `PC` (the `pop {…, pc}` epilogue). At such a point the only registers live out
+/// of the function are the ABI result registers — see [`RETURN_VALUE_REGS`].
+///
+/// SOUNDNESS ASSUMPTION: `Bx`/`Pop` are *unconditional* — neither struct carries a
+/// condition field, so the scan reaching one means the return is taken on every
+/// path. A future *predicated* return (`bxne lr`) would break this: the fall-through
+/// edge could still read `d`, yet we'd conclude dead. If such an op is ever added,
+/// it must NOT be treated as a return terminator here.
+fn is_return_terminator(op: &ArmOp) -> bool {
+    match op {
+        ArmOp::Bx { rm } => *rm == Reg::LR,
+        ArmOp::Pop { regs } => regs.contains(&Reg::PC),
+        _ => false,
+    }
+}
+
+/// The registers that may carry a wasm function's result, hence be live at the
+/// return: `R0` (an `i32`/`f32`-in-core result) and `R1` (the high half of an
+/// `i64`/`f64`-in-core result — selector convention "result in (R0,R1)",
+/// instruction_selector.rs). `R2`/`R3` are i64 *operand* inputs, never results,
+/// so a boolean parked in `R2`..`R8` is never live out of a return.
+const RETURN_VALUE_REGS: [Reg; 2] = [Reg::R0, Reg::R1];
+
+/// True if `d` is provably dead at the start of `rest`. Scanning forward through
+/// fully-modeled, straight-line instructions:
+///   - a **read** of `d` ⇒ live (`false`);
+///   - a **redefinition** of `d` (written, not first read) ⇒ dead (`true`);
+///   - a **return terminator** (`Bx LR` / `pop {…,pc}`) reached with `d` not yet
+///     read ⇒ dead iff `d` is not a result register (`d ∉ RETURN_VALUE_REGS`),
+///     because the only live-out at a return is the result reg(s);
+///   - any **unmodeled** op — a call, a *non-return* branch, a `Label` (join
+///     point), an i64/FP op — ⇒ `false` ("can't prove"). This bail is the
+///     soundness lynchpin: the scan never walks past control flow it cannot
+///     reason about, so a value live on some other edge is never mistaken dead.
+///
+/// This is the deadness oracle for [`fuse_cmp_select`]: the original cmp→select
+/// lowering leaves the materialized boolean **abandoned** after the select (used
+/// once, not redefined, not live-out), which the redef-only rule declined — the
+/// return-terminator case recovers exactly that, soundly.
 fn reg_dead_by_redef(d: Reg, rest: &[ArmInstruction]) -> bool {
+    let is_result_reg = RETURN_VALUE_REGS.contains(&d);
     for instr in rest {
+        // Recognize the return BEFORE reg_effect: `pop {…,pc}` is modeled (would
+        // pass through as a plain Pop) and `Bx LR` is unmodeled (would bail) —
+        // either way the function exits here and live-out ⊆ result regs.
+        if is_return_terminator(&instr.op) {
+            return !is_result_reg;
+        }
         match reg_effect(&instr.op) {
             Some(eff) => {
                 if eff.uses.contains(&d) {
@@ -427,10 +468,12 @@ fn reg_dead_by_redef(d: Reg, rest: &[ArmInstruction]) -> bool {
                     return true; // redefined unused ⇒ dead from here back
                 }
             }
-            None => return false, // unmodeled (call/branch/i64/fp) ⇒ can't prove
+            None => return false, // unmodeled (call / non-return branch / label) ⇒ can't prove
         }
     }
-    false // ran off the end without a redef ⇒ possibly live-out
+    // Ran off the end without seeing a return terminator — a malformed/partial
+    // stream; stay conservative.
+    false
 }
 
 /// A constant materialization whose value is **already available** in a live
@@ -3039,8 +3082,11 @@ mod tests {
     }
 
     #[test]
-    fn no_fuse_when_boolean_not_redefined() {
-        // No downstream redefinition of r3 ⇒ cannot prove it dead ⇒ decline.
+    fn no_fuse_when_boolean_not_redefined_and_no_return() {
+        // r3 is neither redefined NOR followed by a recognized return terminator —
+        // the scan runs off the end of the slice, which stays conservative
+        // (`false`): without seeing the function exit we cannot prove r3 not
+        // live-out. (Add a `pop {…,pc}` / `bx lr` and it fuses — see below.)
         let seq = vec![
             cmp(Reg::R1, Reg::R2),
             setcond(Reg::R3, Condition::LT),
@@ -3049,7 +3095,154 @@ mod tests {
             selmov(Reg::R0, Reg::R5, Condition::EQ),
         ];
         let (_out, fused) = fuse_cmp_select(&seq);
-        assert_eq!(fused, 0, "must decline — r3 may be live-out");
+        assert_eq!(fused, 0, "must decline — no redef and no return terminator");
+    }
+
+    // ---- #7: return-terminator deadness (the two-move arm becomes reachable) ----
+
+    /// `pop {regs}` epilogue containing PC — a function return.
+    fn ret_pop() -> ArmInstruction {
+        ins(ArmOp::Pop {
+            regs: vec![Reg::R4, Reg::R5, Reg::PC],
+        })
+    }
+
+    #[test]
+    fn fuse_two_move_abandoned_boolean_before_pop_return() {
+        // The shape the real selector emits: a two-move select whose boolean (r3)
+        // is ABANDONED — never redefined — then a `pop {…,pc}` return. r3 ∉ {R0,R1}
+        // ⇒ not live-out ⇒ dead ⇒ fuse. This is the case #444's redef-only guard
+        // declined; it makes the two-move `mov{invert(c)}` arm reachable.
+        let seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            selmov(Reg::R0, Reg::R5, Condition::EQ),
+            ret_pop(),
+        ];
+        let (out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(fused, 1, "abandoned boolean before a return is dead ⇒ fuse");
+        // movne→movlt (c), moveq→movge (invert c) — the two-move arm exercised.
+        assert!(matches!(
+            out[1].op,
+            ArmOp::SelectMove {
+                cond: Condition::LT,
+                ..
+            }
+        ));
+        assert!(matches!(
+            out[2].op,
+            ArmOp::SelectMove {
+                cond: Condition::GE,
+                ..
+            }
+        ));
+        assert!(!out.iter().any(|i| matches!(i.op, ArmOp::SetCond { .. })));
+    }
+
+    #[test]
+    fn fuse_two_move_abandoned_boolean_before_bx_lr() {
+        // Leaf return via `bx lr` — also a return terminator (reg_effect bails on
+        // Bx, so this only fuses because is_return_terminator recognizes it).
+        let seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            selmov(Reg::R0, Reg::R5, Condition::EQ),
+            ins(ArmOp::Bx { rm: Reg::LR }),
+        ];
+        let (_out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(
+            fused, 1,
+            "bx lr is a return ⇒ abandoned non-result boolean is dead"
+        );
+    }
+
+    #[test]
+    fn no_fuse_two_move_boolean_in_result_reg() {
+        // The boolean is in R0 — a result register, so it COULD be the value the
+        // caller reads at the return. Cannot prove dead ⇒ decline. (This is the
+        // load-bearing `d ∉ {R0,R1}` guard.)
+        let seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R0, Condition::LT),
+            cmp0(Reg::R0),
+            selmov(Reg::R3, Reg::R4, Condition::NE),
+            selmov(Reg::R3, Reg::R5, Condition::EQ),
+            ret_pop(),
+        ];
+        let (_out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(
+            fused, 0,
+            "boolean in a result reg may be live-out ⇒ decline"
+        );
+    }
+
+    #[test]
+    fn no_fuse_two_move_branch_in_tail_before_return() {
+        // A branch sits between the select and the return — the forward scan bails
+        // (reg_effect None) rather than walk past a control-flow split where the
+        // boolean could be live on another edge.
+        let seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            selmov(Reg::R0, Reg::R5, Condition::EQ),
+            ins(ArmOp::B {
+                label: "L".to_string(),
+            }),
+            ret_pop(),
+        ];
+        let (_out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(
+            fused, 0,
+            "a branch in the tail ⇒ can't prove dead ⇒ decline"
+        );
+    }
+
+    #[test]
+    fn no_fuse_two_move_bx_to_non_lr_is_not_a_return() {
+        // `bx rN` (rN≠LR) is a computed jump / tail call, NOT a plain return — its
+        // live-out is not {R0,R1}, so it must stay conservative.
+        let seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            selmov(Reg::R0, Reg::R5, Condition::EQ),
+            ins(ArmOp::Bx { rm: Reg::R7 }),
+        ];
+        let (_out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(fused, 0, "bx to a non-LR reg is not a return ⇒ decline");
+    }
+
+    #[test]
+    fn no_fuse_two_move_label_in_tail_is_a_join_point() {
+        // A Label (a potential branch target / join point) sits between the select
+        // and the return. The forward scan must bail (reg_effect returns None for a
+        // Label) rather than assume the boolean is not live on some incoming edge we
+        // can't see by scanning forward. This LOCKS the soundness lynchpin: if anyone
+        // ever teaches reg_effect a `Label => Some(empty)` arm, the scan would walk
+        // through the join point and this test fails loudly.
+        let seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            selmov(Reg::R0, Reg::R5, Condition::EQ),
+            ins(ArmOp::Label {
+                name: "L".to_string(),
+            }),
+            ret_pop(),
+        ];
+        let (_out, fused) = fuse_cmp_select(&seq);
+        assert_eq!(
+            fused, 0,
+            "a Label (join point) in the tail ⇒ can't prove dead ⇒ decline"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Task #7 — closes the root cause behind gale's gust_codegen_bench coverage gap (#428).

#444's deadness guard (`reg_dead_by_redef`) deleted the `SetCond` only when the boolean was explicitly **redefined** downstream. The real selector **abandons** the boolean temp after the select (used once, not live-out, never rewritten), so the guard declined — both gale's gust_mix **clamp #2** and **every two-move shape**, leaving the two-move `moveq→mov{invert(c)}` arm unreachable.

## Fix

`reg_dead_by_redef` now recognizes the function **return terminator** (`bx lr`, or `pop {…,pc}`). At a return the only live-out registers are the ABI result regs **{R0,R1}** (i32→R0, i64→R0:R1; R2/R3 are i64 *operand* inputs, never results), so an abandoned boolean in R2..R8 is proven dead.

### Soundness
The forward scan still **bails (declines) on every Label and branch** — `reg_effect` returns `None` for them — so it never walks past a join point where the boolean could be live on another edge. The `d ∉ {R0,R1}` guard is load-bearing. Locked by unit tests:
- **positive:** abandoned boolean before `pop {…,pc}` / `bx lr` ⇒ fuses, with `movlt`/`movge` (the invert arm);
- **negatives (keep it sound):** boolean in a result reg (`d∈{R0,R1}`), a branch in the tail, and `bx` to a non-LR reg — all still **decline**.

### Verified end-to-end (objdump)
`scripts/repro/cmp_select_two_move.wat` now lowers to:
```
cmp r0,r1 ; movlt r4,r0 ; movge r4,r2
```
— the `mov{invert(c)}` arm (`movge`) firing **for the first time**, semantically identical to the original select.

## Frozen-safe
`reg_dead_by_redef` is reached **only** via `fuse_cmp_select`, which runs only behind `SYNTH_CMP_SELECT_FUSE` (off by default) — so the shipped default path is byte-identical. **Frozen byte gates #445/#446 stay GREEN flag-off** (verified). 48 test binaries green; fmt + clippy + rivet (0 non-xref) clean.

## NOT claimed (owed by the flip — the separate gated step)
- The two-move arm is reachable + objdump/IR-correct but **not execution-validated** — gale's next `gust_codegen_bench` (flag-on) exercises it for the first time; **correctness to be watched there**.
- "Closes clamp #2" is by the same mechanism but **unverified locally** (no `gust_mix.wasm`); gale's bench confirms which clamps now fuse.
- **No flip, no re-freeze, no tag.** The default-on flip still gates on both preconditions (this unblocks precondition #1, pending that gale bench).

Refs #242, #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)