### PR TITLE
test(vcr-sel): cmp→select fusion census — blast-radius datum for the flip (VCR-SEL-004, #428, #242)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -439,9 +439,17 @@ fn compile_wasm_to_arm(
     // (control_step 0x00210A55 / flat+inlined flight_algo 0x07FDF307 / divseam).
     // The default-on flip is the held byte-changing step, gated on silicon.
     let arm_instrs = if std::env::var("SYNTH_CMP_SELECT_FUSE").is_ok() {
-        let (out, fused) = synth_synthesis::liveness::fuse_cmp_select(&arm_instrs);
+        // The rewritten stream is identical to `fuse_cmp_select`'s 2-tuple form;
+        // the extra `two_move` count is diagnostic only (the fusion census /
+        // blast-radius datum for the flip decision — #7 made that arm reachable).
+        let (out, fused, two_move) =
+            synth_synthesis::liveness::fuse_cmp_select_with_stats(&arm_instrs);
         if std::env::var("SYNTH_FUSE_STATS").is_ok() {
-            eprintln!("[cmp-select-fuse] {fused} select(s) fused to predicated moves");
+            let in_place = fused - two_move;
+            eprintln!(
+                "[cmp-select-fuse] {fused} select(s) fused to predicated moves \
+                 ({two_move} two-move, {in_place} in-place)"
+            );
         }
         out
     } else {

--- a/crates/synth-cli/tests/cmp_select_fusion_census.rs
+++ b/crates/synth-cli/tests/cmp_select_fusion_census.rs
@@ -1,0 +1,136 @@
+//! VCR-SEL-004 / VCR-ORACLE-001 (#242, #428) — cmp→select fusion CENSUS.
+//!
+//! The blast-radius datum for gale's default-on FLIP decision. The flip turns
+//! `SYNTH_CMP_SELECT_FUSE` on by default (byte-changing, silicon-gated); its
+//! go/no-go rests on three pieces of evidence — gale owns runtime correctness
+//! (`gust_codegen_bench`) and the M4-regression check (G474RE DWT); the synth-side
+//! half is the *blast radius*: across the real frozen fixtures, how many select
+//! sites fuse, split into the in-place single-move form vs the two-move
+//! `mov{c}…mov{invert(c)}` form whose `mov{invert(c)}` arm #7 made reachable.
+//!
+//! HEADLINE FINDING (locked here): on EVERY real frozen fixture the two-move count
+//! is ZERO — all fused sites are the in-place form. #7's two-move arm fires on no
+//! real frozen fixture; its only exercisers are gale's `gust_mix` bench and the
+//! synthetic `cmp_select_two_move.wat`. So the flip's novel-at-runtime path has
+//! *thin real-code coverage* — gale's bench is load-bearing for it, not redundant.
+//!
+//! Frozen-safe: drives the shipped binary with `SYNTH_CMP_SELECT_FUSE=1`
+//! `SYNTH_FUSE_STATS=1` and parses the `[cmp-select-fuse] N … (K two-move, M
+//! in-place)` diagnostic. The flag is OFF by default, so production bytes are
+//! unchanged (the frozen byte gates #445/#446 lock that). This test changes no
+//! emitted bytes; it records a measurement baseline. If a selector change moves
+//! these counts, the census moves and a reviewer sees the blast radius shift.
+
+use std::process::Command;
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture(name: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro")
+        .join(name)
+}
+
+/// Compile `fix` (a frozen fixture) with fusion + stats on; return the summed
+/// `(total, two_move)` across every `[cmp-select-fuse]` line (one per function).
+fn census(fix: &str) -> (usize, usize) {
+    let path = fixture(fix);
+    let out = Command::new(synth())
+        .env("SYNTH_CMP_SELECT_FUSE", "1")
+        .env("SYNTH_FUSE_STATS", "1")
+        .args([
+            "compile",
+            path.to_str().unwrap(),
+            "-o",
+            &format!("/tmp/census_{fix}.elf"),
+            "--target",
+            "cortex-m4",
+            "--all-exports",
+            "--relocatable",
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        out.status.success(),
+        "synth compile failed for {fix}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let mut total = 0usize;
+    let mut two_move = 0usize;
+    for l in combined.lines().filter(|l| l.contains("[cmp-select-fuse]")) {
+        // `[cmp-select-fuse] N select(s) fused to predicated moves (K two-move, M in-place)`
+        let n: usize = l
+            .split("[cmp-select-fuse]")
+            .nth(1)
+            .and_then(|r| r.trim_start().split(' ').next())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| panic!("unparseable fuse line: {l}"));
+        // `… moves (K two-move, …)` — anchor on the "two-move" token and take the
+        // trailing number before it (can't split on '(' — `select(s)` has one too).
+        let k: usize = l
+            .split("two-move")
+            .next()
+            .and_then(|seg| {
+                seg.trim_end()
+                    .rsplit(|c: char| c.is_whitespace() || c == '(')
+                    .find(|s| !s.is_empty())
+            })
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| panic!("unparseable two-move count: {l}"));
+        total += n;
+        two_move += k;
+    }
+    (total, two_move)
+}
+
+/// Per-fixture baseline: `(fixture, total_fused, two_move)`. Measured 2026-06-23
+/// on the v0.12.0 selector. `in_place = total - two_move`.
+const BASELINE: &[(&str, usize, usize)] = &[
+    ("control_step.wasm", 3, 0),
+    ("flight_seam.wasm", 12, 0),
+    ("flight_seam_flat.wasm", 12, 0),
+    ("signed_div_const.wasm", 0, 0),
+];
+
+#[test]
+fn fusion_census_matches_frozen_baseline_428() {
+    let mut grand_total = 0usize;
+    let mut grand_two_move = 0usize;
+    for &(fix, want_total, want_two_move) in BASELINE {
+        let (total, two_move) = census(fix);
+        assert_eq!(
+            (total, two_move),
+            (want_total, want_two_move),
+            "{fix}: fusion census drifted — got (total={total}, two_move={two_move}), \
+             baseline (total={want_total}, two_move={want_two_move}). A selector change \
+             altered the cmp→select blast radius; re-measure and update BASELINE \
+             deliberately (and tell gale — the flip blast radius moved)."
+        );
+        grand_total += total;
+        grand_two_move += two_move;
+    }
+    // Non-vacuity: the lever genuinely reaches real code (not a plumbing no-op).
+    assert!(
+        grand_total >= 1,
+        "expected cmp→select to fuse on the frozen fixtures (got {grand_total})"
+    );
+    // The headline finding: #7's two-move arm fires on NO real frozen fixture.
+    // If this ever becomes non-zero, a real fixture started exercising the
+    // mov{invert(c)} arm — that is GOOD (more real coverage of the flip's novel
+    // path) but must be a deliberate baseline update, and gale should know its
+    // bench is no longer the sole runtime exerciser.
+    assert_eq!(
+        grand_two_move, 0,
+        "a real frozen fixture now exercises the two-move arm ({grand_two_move} sites) — \
+         update BASELINE and notify gale that the flip's runtime path gained real-code \
+         coverage beyond gust_mix"
+    );
+}

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -304,10 +304,27 @@ fn clobbers_flags(op: &ArmOp) -> bool {
 ///    boolean is consumed elsewhere (e.g. stored to a local, or returned in R0).
 /// 4. `dst != D`, keeping the dead-check unambiguous.
 pub fn fuse_cmp_select(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
+    let (out, total, _two_move) = fuse_cmp_select_with_stats(instrs);
+    (out, total)
+}
+
+/// Like [`fuse_cmp_select`] but additionally returns the number of *two-move*
+/// fusions — the predicated-pair form (`mov{c} dst,v1; mov{invert(c)} dst,v2`)
+/// whose `mov{invert(c)}` arm only became reachable through the real selector
+/// once `reg_dead_by_redef` learned the return terminator (#7). `in_place =
+/// total - two_move` is the single-move form (`mov{c} dst,v1`, dst already
+/// holds v2). Diagnostic only: the production path calls the 2-tuple
+/// [`fuse_cmp_select`] wrapper; this split feeds `SYNTH_FUSE_STATS` and the
+/// fusion census (the blast-radius datum for the default-on flip decision).
+/// The rewritten instruction stream is identical to [`fuse_cmp_select`]'s.
+pub fn fuse_cmp_select_with_stats(
+    instrs: &[ArmInstruction],
+) -> (Vec<ArmInstruction>, usize, usize) {
     let n = instrs.len();
     let mut out: Vec<ArmInstruction> = instrs.to_vec();
     let mut delete = vec![false; n];
     let mut fusions = 0usize;
+    let mut two_move = 0usize;
 
     for i in 0..n {
         // [i] must be `SetCond { rd: D, cond: c }`.
@@ -394,12 +411,14 @@ pub fn fuse_cmp_select(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize
                 rm,
                 cond: c.invert(),
             };
+            // The optional `moveq` arm is present ⇒ this is the two-move form.
+            two_move += 1;
         }
         fusions += 1;
     }
 
     if fusions == 0 {
-        return (out, 0);
+        return (out, 0, 0);
     }
     let result: Vec<ArmInstruction> = out
         .into_iter()
@@ -407,7 +426,7 @@ pub fn fuse_cmp_select(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize
         .filter(|(k, _)| !delete[*k])
         .map(|(_, x)| x)
         .collect();
-    (result, fusions)
+    (result, fusions, two_move)
 }
 
 /// True if `op` returns from the function: `Bx LR`, or a `Pop`/`Ldmia` that loads
@@ -3157,6 +3176,39 @@ mod tests {
         assert_eq!(
             fused, 1,
             "bx lr is a return ⇒ abandoned non-result boolean is dead"
+        );
+    }
+
+    #[test]
+    fn fuse_stats_splits_two_move_from_in_place() {
+        // The diagnostic split feeding SYNTH_FUSE_STATS + the fusion census. A
+        // two-move shape (both `movne`/`moveq` present) counts as two_move; an
+        // in-place shape (only `movne`, dst already holds v2) counts as in_place
+        // (= total − two_move). Locks the census's blast-radius arithmetic.
+        let two_move_seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            selmov(Reg::R0, Reg::R5, Condition::EQ),
+            ret_pop(),
+        ];
+        let (_o, total, two_move) = fuse_cmp_select_with_stats(&two_move_seq);
+        assert_eq!((total, two_move), (1, 1), "the moveq arm ⇒ two-move");
+
+        // In-place: no `moveq` — dst (r0) is left holding v2 on the false edge.
+        let in_place_seq = vec![
+            cmp(Reg::R1, Reg::R2),
+            setcond(Reg::R3, Condition::LT),
+            cmp0(Reg::R3),
+            selmov(Reg::R0, Reg::R4, Condition::NE),
+            ret_pop(),
+        ];
+        let (_o2, total2, two_move2) = fuse_cmp_select_with_stats(&in_place_seq);
+        assert_eq!(
+            (total2, two_move2),
+            (1, 0),
+            "single move ⇒ in-place, not two-move"
         );
     }
 


### PR DESCRIPTION
## What

The **synth-side half** of gale's default-on cmp→select flip decision: a CI-gated **census** of how many select sites fuse on the real frozen fixtures, split into the in-place single-move form vs the two-move `mov{c}…mov{invert(c)}` form (the `mov{invert(c)}` arm #7 made reachable through the real selector).

## Headline finding

**The two-move count is ZERO on every real frozen fixture.** All 27 fused sites are the in-place form:

| fixture | total fused | two-move | in-place |
|---|---|---|---|
| control_step | 3 | 0 | 3 |
| flight_seam | 12 | 0 | 12 |
| flight_seam_flat | 12 | 0 | 12 |
| signed_div_const | 0 | 0 | 0 |

#7's two-move arm fires on **no real frozen fixture** — its only exercisers are gale's `gust_mix` bench and the synthetic `cmp_select_two_move.wat`. So the flip's novel-at-runtime path has **thin real-code coverage**: gale's bench is load-bearing for it, not redundant. This sharpens the flip's go/no-go.

## Why frozen-safe (no byte change)

- `liveness.rs`: new `fuse_cmp_select_with_stats` returns the two-move split; `fuse_cmp_select` becomes a thin 2-tuple wrapper, so **every existing caller and unit test is byte-for-byte unchanged**. The rewritten instruction stream is identical.
- `arm_backend.rs`: the `SYNTH_FUSE_STATS` diagnostic now prints the in-place/two-move split. All behind `SYNTH_CMP_SELECT_FUSE` (**off by default**) ⇒ zero shipped-byte change. Frozen byte gates #445/#446 stay green flag-off (re-verified locally).

## Tests

- `fuse_stats_splits_two_move_from_in_place` (IR unit) — locks the split arithmetic.
- `cmp_select_fusion_census` (CLI, drives the binary) — per-fixture `{total, two_move}` baseline + a headline `two_move==0` assertion that fires loudly if a real fixture ever starts exercising the `mov{invert(c)}` arm (which would be *good* — more real coverage — but must be a deliberate baseline bump, and gale should know its bench is no longer the sole runtime exerciser).

Local: 417 synthesis lib tests, frozen byte gates (ARM+RV32 bit-identical), census + two-move coverage all green; fmt + clippy clean; rivet 0 non-xref errors.

Part of the VCR-* north-star program (epic #242). The default-on flip + tag remain the **separate gated step** (gale runtime + G474RE M4-regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)