### PR TITLE
docs(vcr-sel): record fusion census in VCR-SEL-004 — refines the flip criteria (#242, #428)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -660,12 +660,27 @@ artifacts:
       branch-in-tail, and bx-to-non-LR all still DECLINE (the scan bails on every
       Label/branch via reg_effect→None, never walking past a join point). Frozen
       byte gates #445/#446 stay GREEN flag-off (default path byte-identical).
-      STILL OWED / NOT claimed: (a) the two-move arm is reachable + objdump- and
-      IR-correct but NOT yet execution-validated — gale's NEXT gust_codegen_bench
-      (flag-on) exercises it for the first time; watch correctness there. (b) "closes
-      clamp #2" is by the same mechanism but UNVERIFIED locally (no gust_mix.wasm) —
-      gale's bench confirms which clamps now fuse. The flip still gates on both
-      preconditions above (now (1) is unblocked pending that gale bench).
+      CENSUS LANDED (#450, 2026-06-23, flag-off / frozen-safe): a CI-gated fusion
+      census (cmp_select_fusion_census.rs, via additive fuse_cmp_select_with_stats
+      + SYNTH_FUSE_STATS in-place/two-move split) measured the blast radius across
+      the frozen fixtures — 27 fused sites (control_step 3, flight_seam 12,
+      flight_seam_flat 12, signed_div_const 0), ALL in-place. FINDING: the two-move
+      count is ZERO on EVERY real frozen fixture — #7's `mov{invert(c)}` arm fires
+      on no shipped fixture; its only exercisers are gale's gust_mix bench and the
+      synthetic cmp_select_two_move.wat. CONSEQUENCE for the flip criteria: precond
+      (1) "two-move arm exercised end-to-end" can ONLY ever be satisfied by gale's
+      bench — there is no frozen-fixture path to regression-cover this arm, so
+      gale's gust_codegen_bench is the SOLE runtime exerciser (load-bearing, not
+      redundant), and the flip will ship without frozen-differential coverage of its
+      novel path by construction. The census baseline asserts two_move==0 and fires
+      loudly if a future selector change ever gives a real fixture coverage (a
+      deliberate-bump + notify-gale event). STILL OWED / NOT claimed: (a) the
+      two-move arm is reachable + objdump- and IR-correct but NOT execution-validated
+      anywhere except via gale's bench (see census consequence) — watch correctness
+      there. (b) "closes clamp #2" is by the same mechanism but UNVERIFIED locally
+      (no gust_mix.wasm) — gale's bench confirms which clamps now fuse. The flip
+      still gates on both preconditions above (now (1) is unblocked pending that
+      gale bench, which the census confirms is the only possible exerciser).
     status: approved
     tags: [codegen, selector, peephole, compare-select, flag-fusion, gale-209, perf, track-b]
     links:


### PR DESCRIPTION
## What

Records the cmp→select fusion census (#450) and its finding in the durable VCR-SEL-004 roadmap artifact — previously only on issue #428.

## Why it's a real refinement, not bookkeeping

The census measured that #7's two-move `mov{invert(c)}` arm fires on **zero real frozen fixtures** (27 fused sites, all in-place). That changes the *meaning* of the default-on flip's **precondition (1)** — "two-move arm exercised end-to-end":

- There is **no frozen-fixture path** to regression-cover the two-move arm.
- gale's `gust_codegen_bench` is therefore the **sole** runtime exerciser (load-bearing, not redundant).
- The flip will ship **without frozen-differential coverage of its novel path, by construction** — the census baseline (`two_move==0`) is what fires loudly if that ever changes.

This is a load-bearing go/no-go fact for the eventual flip; it belongs in the roadmap, not just an issue comment.

## Scope

Docs-only (`artifacts/verified-codegen-roadmap.yaml`). Zero code, zero emitted bytes. rivet: 0 non-xref errors. Part of the VCR-* north-star program (epic #242). The default-on flip + tag remain the separate gated step (gale runtime + G474RE M4-regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)