### PR TITLE
test(vcr-oracle): execution-validate the cmp→select two-move arm in CI (VCR-ORACLE-001, #428, #242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,3 +228,35 @@ jobs:
       - name: Run Renode emulation tests
         run: bazel test //tests/renode/... --test_tag_filters=wast || [ $? -eq 4 ]
         timeout-minutes: 10
+
+  cmp-select-oracle:
+    name: cmp-select two-move execution oracle
+    # VCR-ORACLE-001 (#242, #428): EXECUTE the cmp->select two-move arm under
+    # unicorn (faithful Thumb-2 IT-block predication) and diff flag-off vs flag-on
+    # vs wasmtime. This is the runtime validation gale's #428 measurement showed no
+    # real fixture provides (the two-move arm is reachable but runtime-dead on real
+    # code). Isolated job: unicorn/wasmtime are pip-installed here ONLY, so the main
+    # `cargo test --workspace` gate is NOT taxed with a C-library build graph.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Run two-move execution oracle
+        run: python scripts/repro/cmp_select_two_move_differential.py

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -681,8 +681,46 @@ artifacts:
       (no gust_mix.wasm) — gale's bench confirms which clamps now fuse. The flip
       still gates on both preconditions above (now (1) is unblocked pending that
       gale bench, which the census confirms is the only possible exerciser).
+      GALE CORRECTION + EXECUTION ORACLE (#428, 2026-06-23): gale ran flag-on
+      gust_mix on gust_codegen_bench and the census CONSEQUENCE above was WRONG on
+      one point — gust_mix does NOT exercise the two-move arm either. Both its
+      clamps (incl the now-fusing clamp #2) lower to the IN-PLACE single-move form
+      (`it; movlt`, dst preloaded with the false-case value); there is no
+      `mov{invert(c)}` anywhere in flag-on gust_mix. So the two-move arm is exercised
+      by NOTHING real — gale's bench included — and the SOLE exerciser is the
+      synthetic cmp_select_two_move.wat. (#449 win still confirmed: 2.375x -> 2.125x
+      LLVM, correctness-identical [0,2047], .text 132 -> 116 B.) RESOLUTION of precond
+      (1): rather than the empirically-unsatisfiable "a real fixture exercises it",
+      the synthetic is now EXECUTED, not just disassembled — scripts/repro/
+      cmp_select_two_move_differential.py runs two_move_sel under unicorn (faithful
+      Thumb-2 IT predication) flag-off vs flag-on vs wasmtime across a sweep that
+      straddles the compare (both movlt and the movge=mov{invert(c)} arm fire; 7/11
+      vectors hit movge incl signed-compare + i32-wrap edges). Result: 11/11
+      off==on==wasmtime, the mov{invert(c)} arm runtime-validated for the FIRST time.
+      CI-gated as an isolated job (cmp-select-oracle, unicorn pip-installed there
+      only so cargo test --workspace is untaxed) = VCR-ORACLE-001 first deliverable.
+      Non-vacuity guards: aborts unless flag-on has >=1 two-move fusion AND the sweep
+      hits both arms. GALE EXHAUSTIVE SWEEP (#428, 2026-06-23, gale PR #102
+      gale_decider_diff): independently covers precond (1) from the OTHER angle —
+      behavioral equivalence on the WHOLE real primitive set. All 8 verified gale
+      deciders (sem give/take, msgq put/get, mutex lock/unlock, event post/wait)
+      dissolved loom->synth, every decision over each decider's full input domain
+      folded into one FNV-1a checksum, 10,596 cases three-way: native-gale-wasm-ref
+      == dissolved-0.12.0-flag-off == dissolved-flag-ON = 0x88e73178d232bcf5 (ALL
+      identical). Proves (a) native==dissolved (no 0.12.0/loom-1.1.16 codegen
+      regression) and (b) flag-off==flag-on changes ZERO decisions across the real
+      primitive set (not just gust_mix); fusion fired widely (dissolved .text
+      2574->2502 B). These deciders, like gust_mix, mostly lower single-move in-place
+      — so the sweep is broad BEHAVIORAL coverage but does NOT exercise the two-move
+      opcode; that unique runtime coverage stays the synthetic oracle above. TOGETHER
+      they cover precond (1) both ways: exhaustive real-workload equivalence (gale)
+      + the two-move opcode executed (synthetic). gale's harness is a reusable gate,
+      re-run on each synth bump. Precond (1) now MET (synthetic execution + gale
+      exhaustive sweep); precond (2) (G474RE silicon no-regression) still OWED —
+      gale's bench is thumbv7m/qemu today — flip stays held on it (user call
+      2026-06-23: keep the silicon gate; close the exec gap first).
     status: approved
-    tags: [codegen, selector, peephole, compare-select, flag-fusion, gale-209, perf, track-b]
+    tags: [codegen, selector, peephole, compare-select, flag-fusion, gale-209, perf, track-b, vcr-oracle-001]
     links:
       - type: derives-from
         target: VCR-001

--- a/scripts/repro/cmp_select_two_move_differential.py
+++ b/scripts/repro/cmp_select_two_move_differential.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""VCR-SEL-004 / VCR-ORACLE-001 (#428, #242) — EXECUTION-validate the two-move arm.
+
+gale's gust_codegen_bench follow-up (#428) proved that no real fixture — gust_mix
+included — exercises the cmp→select *two-move* form (`mov{c} dst,v1; mov{invert(c)}
+dst,v2`). Every fused site on real code is the in-place single-move form. The only
+thing that exercises the `mov{invert(c)}` arm anywhere is this synthetic fixture,
+and until now it had only ever been IR-unit- and objdump-checked — NEVER executed.
+
+This harness closes that gap: it runs `two_move_sel` under unicorn (faithful Thumb-2
+IT-block predication) in BOTH flag-off (unfused) and flag-on (#7 fused, two-move)
+builds and asserts both equal wasmtime ground truth across an input sweep. The sweep
+deliberately straddles the comparison so BOTH predicated arms fire:
+
+    sel = (a <_s b) ? a : lo          ; movlt (c=LT)  fires when a <  b
+    result = sel*lo + (a - b)         ; movge (inv c) fires when a >= b  <-- the arm
+
+NON-VACUITY: the run aborts unless (1) the flag-on build reports >=1 two-move fusion
+(SYNTH_FUSE_STATS), and (2) the sweep contains at least one a<b vector AND at least
+one a>=b vector — otherwise the `mov{invert(c)}` arm would never execute and the
+"validation" would be theater.
+
+Run (needs wasmtime + unicorn + pyelftools, e.g. a venv):
+  python scripts/repro/cmp_select_two_move_differential.py
+
+Exits nonzero on any mismatch or vacuity failure.
+"""
+import re
+import subprocess
+import sys
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WASM = "scripts/repro/cmp_select_two_move.wat"
+SYNTH = "./target/debug/synth"
+ELF_OFF, ELF_ON = "/tmp/two_move_off.elf", "/tmp/two_move_on.elf"
+CODE, LIN, STK, RET = 0x200000, 0x40000, 0x90000, 0x300000
+
+# (a, b, lo). Straddles a<b (movlt, sel=a) and a>=b (movge / mov{invert(c)}, sel=lo),
+# including i32.lt_s SIGNED edges (negatives) and i32 wrap (mul/sub overflow).
+VECTORS = [
+    (10, 20, 5),       # a<b   -> sel=a
+    (0, 100, 7),       # a<b   -> sel=a
+    (-5, 0, 3),        # a<b   (signed) -> sel=a
+    (-2147483648, 2147483647, 9),  # a<b extreme
+    (20, 10, 5),       # a>=b  -> sel=lo   (movge arm)
+    (5, 5, 3),         # a==b  -> sel=lo   (movge arm)
+    (100, 0, 7),       # a>=b  -> sel=lo
+    (-3, -10, 2),      # a>=b  (signed) -> sel=lo
+    (2147483647, -2147483648, 4),  # a>=b extreme -> wrap in mul/sub
+    (123, 45, 0),      # lo=0  -> sel*lo=0
+    (0, 0, 0),         # all zero
+]
+
+
+def to_s32(x):
+    x &= 0xFFFFFFFF
+    return x - 0x100000000 if x & 0x80000000 else x
+
+
+def arm_branch(a, b):
+    """Which predicated arm fires: 'movlt' (a<b, sel=a) or 'movge' (a>=b, sel=lo)."""
+    return "movlt" if to_s32(a) < to_s32(b) else "movge"
+
+
+def compile_elf(out, fused):
+    env = {"PATH": "/usr/bin:/bin"}
+    if fused:
+        env["SYNTH_CMP_SELECT_FUSE"] = "1"
+        env["SYNTH_FUSE_STATS"] = "1"
+    r = subprocess.run(
+        [SYNTH, "compile", WASM, "-o", out, "--target", "cortex-m4",
+         "--all-exports", "--relocatable"],
+        capture_output=True, text=True, env={**env},
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed (fused={fused}): {r.stderr}")
+    two_move = 0
+    for line in (r.stdout + r.stderr).splitlines():
+        if "[cmp-select-fuse]" in line:
+            m = re.search(r"\((\d+) two-move", line)
+            if m:
+                two_move += int(m.group(1))
+    return two_move
+
+
+def load(elf):
+    # The fixture has exactly ONE function (two_move_sel), so it is at .text
+    # offset 0 — no disasm symbol-table round-trip needed (that subprocess's
+    # output format is environment-sensitive; the single-function invariant is
+    # not). fa == sh_addr ⇒ the unicorn entry is CODE + (fa - base) == CODE.
+    text = ELFFile(open(elf, "rb")).get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    if not code:
+        sys.exit(f"{elf}: .text is empty")
+    return code, base, base
+
+
+def run_arm(code, base, fa, a, b, lo):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x10000)
+    mu.mem_map(LIN, 0x20000)
+    mu.mem_map(STK - 0x8000, 0x10000)
+    mu.mem_map(RET, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_ARM_REG_SP, STK)
+    mu.reg_write(UC_ARM_REG_R11, LIN)
+    mu.reg_write(UC_ARM_REG_R0, a & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_R1, b & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_R2, lo & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    try:
+        mu.emu_start((CODE + fa - base) | 1, RET, count=10000)
+    except UcError as e:
+        return f"ERR:{e}"
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def main():
+    # Non-vacuity (1): the flag-on build must actually contain a two-move fusion.
+    compile_elf(ELF_OFF, fused=False)
+    two_move = compile_elf(ELF_ON, fused=True)
+    if two_move < 1:
+        sys.exit(f"VACUOUS: flag-on build has 0 two-move fusions "
+                 f"(the mov{{invert(c)}} arm is not even present)")
+
+    # Non-vacuity (2): the sweep must straddle the compare so both arms fire.
+    arms = {arm_branch(a, b) for (a, b, _lo) in VECTORS}
+    if arms != {"movlt", "movge"}:
+        sys.exit(f"VACUOUS: sweep exercises only {arms}; need both movlt and movge")
+
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, open(WASM, "rb").read())
+
+    def wt(a, b, lo):
+        store = wasmtime.Store(engine)
+        inst = wasmtime.Instance(store, module, [])
+        return inst.exports(store)["two_move_sel"](store, a, b, lo) & 0xFFFFFFFF
+
+    off = load(ELF_OFF)
+    on = load(ELF_ON)
+
+    fails = 0
+    movge_checked = 0
+    for (a, b, lo) in VECTORS:
+        gt = wt(a, b, lo)
+        r_off = run_arm(*off, a, b, lo)
+        r_on = run_arm(*on, a, b, lo)
+        arm = arm_branch(a, b)
+        ok = isinstance(r_off, int) and isinstance(r_on, int) and r_off == gt and r_on == gt
+        # The crucial cases: a>=b runs the mov{invert(c)} arm flag-on.
+        if arm == "movge" and isinstance(r_on, int) and r_on == gt:
+            movge_checked += 1
+        fails += 0 if ok else 1
+        so = f"0x{r_off:08X}" if isinstance(r_off, int) else r_off
+        sn = f"0x{r_on:08X}" if isinstance(r_on, int) else r_on
+        print(f"two_move_sel{(a, b, lo)} [{arm}] off={so} on={sn} "
+              f"wasmtime=0x{gt:08X}{'' if ok else '  <-- MISMATCH'}")
+
+    print(f"\n{len(VECTORS) - fails}/{len(VECTORS)} match (off==on==wasmtime); "
+          f"{two_move} two-move fusion(s); {movge_checked} mov{{invert(c)}}-arm vectors validated")
+    if movge_checked < 1:
+        sys.exit("VACUOUS: no a>=b vector validated the mov{invert(c)} arm at runtime")
+    print("ORACLE: PASS" if fails == 0 else f"ORACLE: FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Closes the **two-move arm execution gap** that holds the cmp→select default-on flip — the first VCR-ORACLE-001 deliverable.

gale's #428 measurement proved the two-move `mov{invert(c)}` arm is *reachable but runtime-dead on all real code*: `gust_mix` included fuses as the **in-place** single-move form, not two-move. So the synthetic `cmp_select_two_move.wat` is its **only** exerciser — and it had only ever been IR/objdump-checked, **never executed**. This runs it.

## How

- **`scripts/repro/cmp_select_two_move_differential.py`** — runs `two_move_sel` under **unicorn** (faithful Thumb-2 IT-block predication) in flag-off (unfused) vs flag-on (#7 fused, two-move) vs **wasmtime** ground truth, across a sweep that **straddles the compare** so both predicated arms fire.
  - **Non-vacuity guards** (the trap that would make this theater): aborts unless (1) the flag-on build reports ≥1 two-move fusion *and* (2) the sweep hits both `movlt` *and* the `movge`=`mov{invert(c)}` arm.
  - Result: **11/11 `off==on==wasmtime`**, 7 vectors validate the `mov{invert(c)}` arm (incl. signed-compare and i32-wrap edges) — first-ever runtime validation of that arm.
- **`.github/workflows/ci.yml`** — isolated **`cmp-select-oracle`** job that pip-installs unicorn/wasmtime *there only*, so `cargo test --workspace` is **not** taxed with unicorn's C-library build graph.
- **roadmap** — corrects the #451 census note (`gust_mix` does *not* exercise the two-move arm — gale's measurement) and records flip **precondition (1) now MET** via synthetic execution; **precondition (2)** (G474RE silicon no-regression) still owed → flip stays held on it (user decision 2026-06-23: keep the silicon gate, close the exec gap first).

## Scope / safety

New test script + isolated CI job + docs. **Zero production code, zero emitted-byte change.** rivet 0 non-xref errors. Part of the VCR-* north-star (epic #242). The byte-changing default-on flip remains the separate gated step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)