### PR TITLE
test(vcr-ra): probe reallocator preserves cross-call callee-saved values (#390, #242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -176,6 +176,26 @@ artifacts:
       control_step 0x00210A55 + flight_seam 0x07FDF307 preserved; flight_seam
       sp-traffic 39→5, .text 902→798 B. ARM-only (RV32 untouched). The default-on
       flip is a separate gated step (re-freeze + G474RE silicon), like cmp→select.
+
+      LEAF-ONLY LIFT — REALLOCATOR-SAFETY PROBE (2026-06-24, #390, fast-follow #1):
+      the empirical question the leaf-only gate was set on — can the post-selection
+      range-reallocator move a promoted local's callee-saved home to a CALLER-saved
+      register that an intervening `bl` would clobber? RESOLVED: NO, by construction.
+      reallocate_function FLUSHES its segment at every non-straight-line op
+      (liveness.rs:2341), and `Bl` has reg_effect→None, so a call SPLITS segments;
+      the pre-call segment's live-out (the cross-call value) is its last-opened
+      range per register ⇒ PINNED to its original register (liveness.rs:2371). The
+      reallocator never renames across a call. Pinned by the unit test
+      `reallocate_function_preserves_callee_saved_value_across_call` (constructs the
+      exact promotion+call shape under interior pressure; r5 stays r5, not remapped
+      to a caller-saved reg). This is the specific mechanism the v1 advisor flagged;
+      it is safe. HONEST REMAINING GAP before lifting the gate: this validates the
+      reallocator pass in isolation; the LIFT still needs an end-to-end WITH-CALL
+      differential (flag-on execution oracle over the full selector-seed +
+      preserve_caller_saved + realloc pipeline, like local_promote_i32) before the
+      gate comes off — flag-off stays bit-identical, but flag-on for call-containing
+      functions is new codegen wiring = a SEPARATE gated step, not an idle-tick
+      change. This pass landed only the frozen-safe probe + finding.
     status: implemented
     tags: [codegen, register-allocation, ssa, regalloc2, track-a, release-v0.11.40]
     links:

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -4867,6 +4867,75 @@ mod tests {
     }
 
     #[test]
+    fn reallocate_function_preserves_callee_saved_value_across_call() {
+        // VCR-RA local-promotion fast-follow (#390, #242): the empirical question
+        // the leaf-only v1 gate (PR #458) was set on — can the range-reallocator
+        // move a promoted local's callee-saved home to a CALLER-saved register
+        // that an intervening `bl` would clobber? This probes the reallocator
+        // directly with the exact shape promotion+call produces.
+        //
+        // r5 carries a value DEFINED before a `Bl` and READ after it (a promoted
+        // local live across a call). Segment A also has interior pressure (r6/r7)
+        // to tempt the lowest-free colourer. The `Bl` is non-straight-line, so it
+        // FLUSHES the segment (reallocate_function:2341) — segment A and segment B
+        // are coloured independently, and r5's range in A is the last-opened range
+        // for r5 ⇒ pinned as a live-out to its ORIGINAL register. So r5 must stay
+        // r5 (callee-saved, survives the bl by AAPCS) across the boundary.
+        use crate::rules::Reg::*;
+        let seq = vec![
+            ins(ArmOp::Movw { rd: R5, imm16: 42 }), // promoted local -> r5 (callee-saved)
+            ins(ArmOp::Movw { rd: R6, imm16: 1 }),  // interior pressure
+            ins(ArmOp::Add {
+                rd: R6,
+                rn: R6,
+                op2: Operand2::Reg(R6),
+            }), // r6 dies here
+            ins(ArmOp::Bl {
+                label: "helper".into(),
+            }), // clobbers r0-r3,r12 — SPLITS segments
+            ins(ArmOp::Add {
+                rd: R0,
+                rn: R5,
+                op2: Operand2::Imm(7),
+            }), // read r5 AFTER the call
+        ];
+        let pool = [R0, R1, R2, R3, R4, R5, R6, R7, R8];
+        let (out, stats) = reallocate_function(&seq, &pool);
+
+        // Structure preserved; the Bl passed through untouched at the boundary.
+        assert_eq!(out.len(), seq.len());
+        assert_eq!(
+            stats.segments, 2,
+            "the Bl splits the function into two segments"
+        );
+        assert!(matches!(&out[3].op, ArmOp::Bl { label } if label == "helper"));
+
+        // The cross-call value's definition stays in a CALLEE-saved register
+        // (r4..r8) — NOT remapped to a caller-saved reg the bl clobbers.
+        let def_reg = match &out[0].op {
+            ArmOp::Movw { rd, .. } => *rd,
+            other => panic!("unexpected def op {other:?}"),
+        };
+        assert!(
+            matches!(def_reg, R4 | R5 | R6 | R7 | R8),
+            "cross-call value must stay callee-saved, got {def_reg:?}"
+        );
+        // And the post-call read reads that SAME register (the value survived).
+        match &out[4].op {
+            ArmOp::Add { rn, .. } => assert_eq!(
+                *rn, def_reg,
+                "post-call read must read the preserved register"
+            ),
+            other => panic!("unexpected read op {other:?}"),
+        }
+        // Specifically r5 (the live-out pin keeps the original register).
+        assert_eq!(
+            def_reg, R5,
+            "live-out pinned to its original callee-saved reg"
+        );
+    }
+
+    #[test]
     fn reallocate_function_keeps_reserved_registers_identity() {
         // A load through R11 (memory base, outside the pool): R11 must stay
         // R11 even though everything else is fair game.


### PR DESCRIPTION
## What

The **#1 fast-follow** to local-promotion v1 (#458), landed **frozen-safe** (test + docs only, zero codegen change). Resolves — empirically — the question the **leaf-only** gate was set on.

## The question

v1 declines functions with calls because the advisor flagged: the post-selection range-reallocator might move a promoted local's **callee-saved** home to a **caller-saved** register that an intervening `bl` clobbers (observed r5→r3 in a call-free fixture). Every v1 fixture is call-free, so the differential couldn't see it.

## Finding: the reallocator cannot do this, by construction

`reallocate_function` **flushes its segment at every non-straight-line op** (`liveness.rs:2341`), and `Bl` has `reg_effect → None`, so a **call splits segments**. The pre-call segment's live-out (the cross-call value) is its last-opened range per register and is **pinned to its original register** (`liveness.rs:2371`). The reallocator never renames across a call.

`reallocate_function_preserves_callee_saved_value_across_call` constructs the exact promotion+call shape under interior register pressure and asserts the cross-call value stays in its callee-saved register (r5) — not remapped to a caller-saved reg. **Passes** (432 liveness tests green).

## Honest remaining gap (why this doesn't lift the gate yet)

This validates the **reallocator pass in isolation**. Lifting the leaf-only gate still needs an **end-to-end with-call differential** (flag-on execution oracle over the full selector-seed + `preserve_caller_saved` + realloc pipeline, like `local_promote_i32`). That is byte-changing flag-on codegen = a **separate gated step**, not an idle-tick change. This PR lands only the frozen-safe probe + the recorded finding.

## Frozen-safe

No codegen change — frozen byte gates bit-identical (control_step `0x00210A55` / flight_seam `0x07FDF307` paths untouched); fmt + clippy + rivet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)