### PR TITLE
docs(vcr-ra): close the leaf-only-lift end-to-end gap empirically (#390, #242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -196,6 +196,24 @@ artifacts:
       gate comes off — flag-off stays bit-identical, but flag-on for call-containing
       functions is new codegen wiring = a SEPARATE gated step, not an idle-tick
       change. This pass landed only the frozen-safe probe + finding.
+
+      LEAF-ONLY LIFT — END-TO-END GAP CLOSED EMPIRICALLY (2026-06-24, #390,
+      fast-follow #1 cont.): the with-call fixture scripts/repro/
+      local_promote_cross_call.wat (exported `cross_call` holds an i32 local `acc`
+      live across a `bl` to `$helper`; acc satisfies every v1 promotion predicate
+      except leaf-only). With leaf-only ON it compiles byte-IDENTICAL flag-on vs
+      flag-off (promotion declines — the gate holds end-to-end, frozen-safe). Under
+      a THROWAWAY leaf-only lift (experiment reverted, NOT committed), promotion
+      runs on the call fn and objdump confirms the FULL pipeline is correct: acc is
+      promoted to r4 (`mov r4,r3`), survives the `bl func_0` by AAPCS, and is read
+      back from r4 AFTER the call (`adds r6,r4,r0`) — NOT remapped to a caller-saved
+      reg, exactly as the #459 reallocator-isolation proof predicted. So the
+      end-to-end with-call promotion is correctness-ready. REMAINING to lift the
+      gate (the byte-changing gated step, NOT this tick): make the committed lift PR
+      (a) remove the leaf-only early-return, (b) add a with-call EXECUTION
+      differential (resolve the internal BL, run flag-on vs wasmtime) as the gate,
+      (c) re-freeze + G474RE silicon. This pass landed the frozen-safe fixture +
+      finding; flag-off bit-identical, no codegen change.
     status: implemented
     tags: [codegen, register-allocation, ssa, regalloc2, track-a, release-v0.11.40]
     links:

--- a/scripts/repro/local_promote_cross_call.wat
+++ b/scripts/repro/local_promote_cross_call.wat
@@ -1,0 +1,31 @@
+;; VCR-RA local-promotion with-call scenario (#390, epic #242).
+;;
+;; The exported `cross_call` holds an i32 local `acc` LIVE ACROSS a call to
+;; `$helper`. `acc` is write-before-read, all accesses at control-flow depth 0,
+;; i32, >=2 accesses — i.e. it satisfies every v1 promotion predicate EXCEPT the
+;; LEAF-ONLY gate, which declines it because the function contains a `call`.
+;;
+;; Purpose: the artifact the leaf-only LIFT will need. Today (leaf-only ON)
+;; promotion declines this function, so flag-on == flag-off == the frame path —
+;; `acc` lives in a frame slot and survives the call trivially. When the gate is
+;; lifted, `acc` is promoted to a callee-saved register (r4..r8) which survives
+;; the `bl` by AAPCS; the range-reallocator pins it across the call boundary
+;; (proven in isolation by reallocate_function_preserves_callee_saved_value_across_call,
+;; PR #459). This fixture is what closes that proof end-to-end.
+;;
+;; `acc` is read AFTER the call result is combined, so a promotion that placed it
+;; in a caller-saved register (the bug the leaf-only gate guards against) would see
+;; it clobbered by the `bl` and produce a wrong result.
+(module
+  (func $helper (param i32) (result i32)
+    ;; AAPCS-clobbers caller-saved r0..r3 per the call; doubles its arg.
+    (i32.mul (local.get 0) (i32.const 2)))
+
+  (func (export "cross_call") (param i32) (result i32)
+    (local i32) ;; local 1 = acc
+    ;; acc = p0 + 100  (write before any read; depth 0)
+    (local.set 1 (i32.add (local.get 0) (i32.const 100)))
+    ;; acc = acc + helper(p0)  — acc is LIVE ACROSS the call to $helper
+    (local.set 1 (i32.add (local.get 1) (call $helper (local.get 0))))
+    ;; result = acc ^ p0
+    (i32.xor (local.get 1) (local.get 0))))


### PR DESCRIPTION
## What

Fast-follow #1 (cont.) to local-promotion v1 (#458). PR #459 proved the range-reallocator preserves a cross-call callee-saved value **in isolation** but left an honest gap: the full `selector-seed + preserve_caller_saved + realloc` pipeline was untested with a real call. This closes it — **frozen-safe** (fixture + roadmap finding, no codegen change).

## The fixture

`scripts/repro/local_promote_cross_call.wat` — exported `cross_call` holds an i32 local `acc` **live across a `bl`** to `$helper`. `acc` satisfies every v1 promotion predicate *except* leaf-only.

- **Leaf-only ON (committed state):** compiles **byte-identical** flag-on vs flag-off — promotion declines, the gate holds end-to-end. Frozen-safe.

## End-to-end finding (throwaway lift, reverted, not committed)

Under a throwaway removal of the leaf-only early-return, objdump confirms the **full pipeline is correct**:

```
add.w r3, r1, #100   ; acc = p0 + 100
mov   r4, r3         ; acc promoted to r4 (callee-saved)
...
bl    func_0         ; acc (r4) live across the call
adds  r6, r4, r0     ; read acc from r4 AFTER the call  ← survived
```

`acc` lands in **r4** (callee-saved, survives the `bl` by AAPCS) and is read back from r4 after the call — **not** remapped to a caller-saved reg, exactly as the #459 reallocator-isolation proof predicted. End-to-end with-call promotion is **correctness-ready**.

## What still gates the lift (a SEPARATE step, not this PR)

Removing the leaf-only restriction is byte-changing flag-on codegen. The lift PR must: (a) drop the early-return, (b) add a with-call **execution** differential (resolve the internal BL, run flag-on vs wasmtime) as the gate, (c) re-freeze + G474RE silicon. This PR lands only the frozen-safe fixture + finding.

Frozen byte gates bit-identical; rivet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)