### PR TITLE
feat(vcr-ra): ship i32 local promotion default-on — v0.14.0 (#390, #242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-24
+
+**i32 local promotion is now DEFAULT-ON (VCR-RA-001, #390, epic #242).** The ARM
+backend no longer lowers every wasm local to a frame slot (`ldr/str [sp,#off]`);
+eligible non-param i32 locals now live in callee-saved registers (r4–r8) instead,
+reusing the #193 param-reservation machinery. This is a **byte-changing** release
+on top of v0.13.0 cmp→select: stack spill/reload traffic is eliminated on
+local-heavy leaf functions — `.text` shrinks (control_step 324→316 B, flight_seam
+902→866, flight_seam_flat 1122→1006; −154 B across the frozen fixtures).
+
+Execution results are unchanged: control_step `0x00210A55` (differential 13/13)
+and flat+inlined flight_algo `0x07FDF307` are preserved; the
+`local_promote_i32` execution oracle (7 concurrent-live locals, r4–r8 + frame
+pre-dirtied with sentinels) is clean==dirty==wasmtime.
+
+gale's G474RE silicon (DWT CYCCNT, `gust_mix` leaf fixture) cleared the flip as a
+net win: dissolved **58.0 → 50.0 cyc/call (−14%)**, all 5 stack spill/reloads
+eliminated, correctness bit-identical over [0,2047], **2.00× → 1.72× vs LLVM**.
+Cumulative on real M4: 64.0 → 58.0 (cmp→select) → 50.0 cyc/call.
+
+Scope: i32 locals only (i64 → frame), leaf functions only (call-containing
+functions decline; the lift is de-risked but a separate follow-on), ARM only
+(RV32 untouched). Escape hatch: `SYNTH_NO_LOCAL_PROMOTE=1` restores the
+frame-slot path.
+
 ## [0.13.0] - 2026-06-24
 
 **cmp→select fusion is now DEFAULT-ON (VCR-SEL-004, #428, epic #242).** The ARM

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,14 +2023,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2079,11 +2079,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.13.0"
+version = "0.14.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2136,14 +2136,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2151,11 +2151,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.13.0"
+version = "0.14.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.13.0"
+version = "0.14.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.13.0",
+    version = "0.14.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.13.0" }
+synth-core = { path = "../synth-core", version = "0.14.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.13.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.13.0" }
+synth-core = { path = "../synth-core", version = "0.14.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.14.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.13.0" }
+synth-core = { path = "../synth-core", version = "0.14.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.13.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.13.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.14.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.14.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -213,9 +213,13 @@ fn compile_wasm_to_arm(
         selector.set_param_backing_on_exhaustion(param_backing_on_exhaustion);
         // VCR-RA local promotion (#390, #242): keep eligible non-param i32 locals
         // in callee-saved registers instead of frame slots — the structural lever
-        // toward native parity. Behind SYNTH_LOCAL_PROMOTE while it earns the
-        // frozen-byte + silicon gates; default off ⇒ frame-slot path bit-identical.
-        selector.set_local_promote(std::env::var("SYNTH_LOCAL_PROMOTE").is_ok());
+        // toward native parity. DEFAULT-ON as of v0.14.0: gale's G474RE DWT gate
+        // cleared it as a net win (gust_mix dissolved 58→50 cyc/call −14%, all 5
+        // stack spill/reloads eliminated, correctness bit-identical over [0,2047],
+        // 2.00×→1.72× vs LLVM). Escape hatch: `SYNTH_NO_LOCAL_PROMOTE=1` restores
+        // the frame-slot path. Leaf-only / i32-only / ARM-only (see
+        // compute_local_promotion); the leaf-only lift + i64 locals are follow-ons.
+        selector.set_local_promote(std::env::var("SYNTH_NO_LOCAL_PROMOTE").is_err());
         selector.select_with_stack(wasm_ops, num_params)
     };
     let select_direct = || -> Result<Vec<ArmInstruction>, String> {

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.13.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.13.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.13.0" }
-synth-backend = { path = "../synth-backend", version = "0.13.0" }
+synth-core = { path = "../synth-core", version = "0.14.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.14.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.14.0" }
+synth-backend = { path = "../synth-backend", version = "0.14.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.13.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.13.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.13.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.14.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.14.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.14.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.13.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.14.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-cli/tests/frozen_codegen_bytes.rs
+++ b/crates/synth-cli/tests/frozen_codegen_bytes.rs
@@ -55,16 +55,19 @@ fn fixture(name: &str) -> std::path::PathBuf {
 
 /// Compile a frozen fixture for `(backend, target)` with the exact `--all-exports
 /// --relocatable` config the `.py` differentials use, and return the SHA-256 hex
-/// of its `.text` and the section length. `SYNTH_NO_CMP_SELECT_FUSE` (the v0.13.0
-/// cmp→select opt-out) / `SYNTH_CONST_CSE` are explicitly removed so a flag set in
-/// the environment can never silently re-freeze the gate — it locks the SHIPPED
-/// lowering, which since v0.13.0 INCLUDES cmp→select fusion (default-on). The
-/// `object` crate reads `.text` arch-agnostically (ARM Thumb-2 and RV32 alike).
+/// of its `.text` and the section length. The default-changing opt-out flags
+/// (`SYNTH_NO_CMP_SELECT_FUSE` — v0.13.0 cmp→select; `SYNTH_NO_LOCAL_PROMOTE` —
+/// v0.14.0 local promotion) and `SYNTH_CONST_CSE` are explicitly removed so a flag
+/// set in the environment can never silently re-freeze the gate — it locks the
+/// SHIPPED lowering, which since v0.14.0 INCLUDES cmp→select fusion AND local
+/// promotion (both default-on). The `object` crate reads `.text` arch-agnostically
+/// (ARM Thumb-2 and RV32 alike).
 fn text_sha256(wasm: &str, backend: &str, target: &str) -> (String, usize) {
     let path = fixture(wasm);
     let elf = format!("/tmp/frozenbytes_{backend}_{wasm}.elf");
     let out = Command::new(synth())
         .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
+        .env_remove("SYNTH_NO_LOCAL_PROMOTE")
         .env_remove("SYNTH_CONST_CSE")
         .args([
             "compile",
@@ -126,30 +129,33 @@ fn assert_frozen(cases: &[(&str, &str, usize)], backend: &str, target: &str) {
 /// the `.py` differentials cover): control_step ↔ 0x00210A55, flight_seam_flat ↔
 /// flat+inlined flight_algo 0x07FDF307, plus flight_seam and the div seam.
 ///
-/// Goldens RE-FROZEN for v0.13.0 (#428): cmp→select fusion is now default-on, so
-/// these lock the FUSED .text. The execution RESULTS are preserved — re-verified on
-/// this commit with fusion on: control_step still 0x00210A55 (control_step_differential
-/// .py 13/13), flat+inlined flight_algo still 0x07FDF307 (flight_seam_differential.py
-/// MATCH). .text shrank: control_step 354→324, flight_seam 1016→902, flight_seam_flat
-/// 1240→1122 (−262 B total); signed_div_const (0 fusion sites) unchanged. Prior
-/// flag-off goldens were on main @ ef97f86 (post-#444), 2026-06-23.
+/// Goldens RE-FROZEN for v0.14.0 (#390): local promotion is now default-on (on top
+/// of v0.13.0 cmp→select), so these lock the PROMOTED+FUSED .text. The execution
+/// RESULTS are preserved — re-verified on this commit with both default-on:
+/// control_step still 0x00210A55 (control_step_differential.py 13/13), flat+inlined
+/// flight_algo still 0x07FDF307 (flight_seam_differential.py MATCH). .text shrank
+/// again (stack spill/reloads eliminated): control_step 324→316, flight_seam
+/// 902→866, flight_seam_flat 1122→1006 (−154 B total); signed_div_const (no
+/// promotable i32 locals) unchanged. gale G474RE DWT: gust_mix 58→50 cyc/call
+/// (−14%), 5→0 [sp] traffic. Prior cmp→select-only goldens were on main @ 377b93e
+/// (v0.13.0), 2026-06-24.
 #[test]
 fn frozen_fixtures_text_is_bit_identical_oracle_001() {
     let cases = [
         (
             "control_step.wasm",
-            "b4c4c290be2c8a83055d4c9696ae4ebb16486a8fd3fc268531607eeef35325e5",
-            324usize,
+            "cd929e7d91a8f7aad93f0e1cf0c93ecf3ccc6584ee94fb32e68d591134ed1410",
+            316usize,
         ),
         (
             "flight_seam.wasm",
-            "300fdf3b92a0941da63b3215441a799d9b32ef942fd404b4803a83a6efb1bb60",
-            902,
+            "52b19365e32bcd9d5a4be74565d0fa467517eb3a07648a3e1ccd0a67556c1948",
+            866,
         ),
         (
             "flight_seam_flat.wasm",
-            "23d0b6829414a855f365d84c7c3301c256f1843fe46b2cc9b369fec30610913d",
-            1122,
+            "fa019f18cbc93869fff51630c6ab9cff6c4e052e22d783fe741b663ece49fa1e",
+            1006,
         ),
         (
             "signed_div_const.wasm",

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.13.0" }
+synth-core = { path = "../synth-core", version = "0.14.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.13.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.14.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.13.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.13.0" }
-synth-opt = { path = "../synth-opt", version = "0.13.0" }
+synth-core = { path = "../synth-core", version = "0.14.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.14.0" }
+synth-opt = { path = "../synth-opt", version = "0.14.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.13.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.13.0" }
-synth-opt = { path = "../synth-opt", version = "0.13.0" }
+synth-core = { path = "../synth-core", version = "0.14.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.14.0" }
+synth-opt = { path = "../synth-opt", version = "0.14.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.13.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.14.0", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
## What

Flips **i32 local promotion default-on** (on top of v0.13.0 cmp→select) — the structural parity lever. gale's **G474RE silicon DWT gate cleared it as a net win**, same protocol as the cmp→select flip.

## Silicon (gale, G474RE, `gust_mix` leaf)

| variant | dissolved | vs LLVM | `[sp]` traffic |
|---|---|---|---|
| v0.13.0 (cmp→select) | 58.0 cyc | 2.00× | 5 |
| **v0.14.0 (+ promote)** | **50.0 cyc** | **1.72×** | **0** |

−14% cyc/call, all stack spill/reloads eliminated, correctness bit-identical over [0,2047]. Cumulative on real M4: **64.0 → 58.0 → 50.0** cyc/call.

## The flip

- `arm_backend.rs`: `set_local_promote` now **default-on**, opt-out `SYNTH_NO_LOCAL_PROMOTE=1` (mirrors v0.13.0's `SYNTH_NO_CMP_SELECT_FUSE`).
- **Re-froze ARM goldens** to the promoted+fused `.text`: control_step 324→316, flight_seam 902→866, flight_seam_flat 1122→1006 (**−154 B**); signed_div_const unchanged (no promotable i32 locals). RV32 gate untouched (ARM-only lever).

## Validation (results preserved across the byte change)

- control_step **`0x00210A55`** differential 13/13; flat+inlined flight_algo **`0x07FDF307`** MATCH.
- `local_promote_i32` execution oracle (7 concurrent-live locals, r4–r8 + frame pre-dirtied with sentinels) clean==dirty==wasmtime.
- Opt-out restores the 324 B frame path. Full workspace suite green; fmt/clippy/pin-sweep clean.

## Scope

i32-only (i64 → frame), **leaf-only** (call-containing functions decline — the lift is de-risked via #459/#460 but a separate follow-on), ARM-only. Pin-swept 0.13.0→0.14.0; CHANGELOG added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)