### PR TITLE
ci: pin rivet-cli to v0.19.0 + version-key its cache (#242 release cadence)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,19 +171,27 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      - name: Cache Cargo dependencies
+      # Cache the rivet-cli BINARY keyed on its pinned version, NOT on Cargo.lock.
+      # The old key (hashFiles Cargo.lock) invalidated on every release version
+      # bump, forcing a full rebuild of rivet-cli's HiGHS C++ dependency — which
+      # filled a self-hosted runner's disk and red-failed the v0.14.0 release
+      # (No space left on device). Version-keying means a Cargo.lock change no
+      # longer triggers the rebuild; the cached binary is reused.
+      - name: Cache rivet-cli binary
         uses: actions/cache@v5
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-            target/
-          key: ${{ runner.os }}-rivet-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-rivet-
-      - name: Install rivet
-        run: cargo install --force --git https://github.com/pulseengine/rivet --branch main rivet-cli
+          path: ~/.cargo/bin/rivet
+          key: ${{ runner.os }}-rivet-cli-v0.19.0
+      # PIN rivet to a release tag (was `--branch main`, unpinned). Unpinned, an
+      # upstream schema/behaviour bump silently reddened the gate on unchanged
+      # artifacts (rivet 0.15.0 promoted a WARN→ERROR, #229). v0.19.0 is validated
+      # clean on this repo's artifacts (non-xref ERROR 0, coverage exit 0). Skip
+      # the (expensive) build entirely on a cache hit.
+      - name: Install rivet (pinned v0.19.0)
+        run: |
+          if ! rivet --version 2>/dev/null | grep -q "0.19.0"; then
+            cargo install --force --git https://github.com/pulseengine/rivet --tag v0.19.0 rivet-cli
+          fi
       - name: Validate artifacts
         run: |
           sed -i '/^externals:/,$d' rivet.yaml


### PR DESCRIPTION
## What

Pin the `Rivet Validation` job's `rivet-cli` install, and stop its binary cache from invalidating on every release. **CI-only / frozen-safe** — zero codegen change, frozen fixtures bit-identical by construction.

## Why

Unpinned `rivet --branch main` has now red-failed a release **twice**, both on *unchanged* artifacts:
- **#229:** rivet 0.15.0 promoted a status-enum check WARN→ERROR (schema drift).
- **v0.14.0:** rivet 0.19.0's HiGHS C++ dependency filled a self-hosted runner's disk on a full rebuild (`No space left on device`). The rebuild fired because the bin cache was keyed on `Cargo.lock`, which a release version bump invalidates.

Both cost diagnosis + re-run time, and the next release (the queued imm-shift-fold flip) would hit the same trap.

## Fix (two parts)

1. **Pin** the install to release tag **v0.19.0** — validated clean on this repo's artifacts (non-xref ERROR 0, coverage exit 0). Upstream bumps become deliberate.
2. **Version-key** the `~/.cargo/bin/rivet` cache (not `Cargo.lock`) and **skip the build** when that exact version is already present. A release's `Cargo.lock` change no longer forces the HiGHS rebuild.

Self-healing on persistent self-hosted runners: a stale binary fails the version grep → `cargo install --force --tag v0.19.0` pins it back.

The PR's own Rivet Validation run is the gate — it must stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)