### PR TITLE
fix(deps): align the wasm-tools crate family to the 252 release (#465)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "id-arena"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -2128,10 +2128,10 @@ dependencies = [
  "synth-core",
  "thiserror",
  "tracing",
- "wasm-encoder 0.248.0",
+ "wasm-encoder 0.252.0",
  "wasmparser 0.252.0",
- "wit-component",
- "wit-parser",
+ "wit-component 0.252.0",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
@@ -2455,9 +2455,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
@@ -2635,16 +2635,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.248.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
@@ -2666,6 +2656,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-metadata"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b7e08e02a3cd55bf778009d4cd6faae50da011f293644daf78a531a32d6d142"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,17 +2686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
-dependencies = [
- "bitflags",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -3030,7 +3021,7 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -3044,9 +3035,9 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn",
- "wasm-metadata",
+ "wasm-metadata 0.244.0",
  "wit-bindgen-core",
- "wit-component",
+ "wit-component 0.244.0",
 ]
 
 [[package]]
@@ -3078,9 +3069,28 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.244.0",
- "wasm-metadata",
+ "wasm-metadata 0.244.0",
  "wasmparser 0.244.0",
- "wit-parser",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76db0662b590f45d33d0e363fa13539a5a1eecd35d5a12fe208c335461c1053d"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.252.0",
+ "wasm-metadata 0.252.0",
+ "wasmparser 0.252.0",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
@@ -3099,6 +3109,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-ident",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,10 @@ categories = ["compilers", "embedded", "wasm", "no-std"]
 [workspace.dependencies]
 # WebAssembly tooling
 wasmparser = "0.252"
-wasm-encoder = "0.248"
-wit-parser = "0.244"
-wit-component = "0.244"
-wat = "1.219"
+wasm-encoder = "0.252"
+wit-parser = "0.252"
+wit-component = "0.252"
+wat = "1.252"
 wast = "252.0"
 
 # Serialization


### PR DESCRIPTION
Closes #465.

## What

@cpetig flagged that the wasm-tools-family deps in the workspace `Cargo.toml` were pinned at **mixed** upstream releases, duplicating their shared internal deps. Dependabot had bumped `wasmparser`→0.252 (and the lock's `wat`) but left the rest behind. Aligns all to release **252**:

| crate | before | after |
|---|---|---|
| wasm-encoder | 0.248 | **0.252** |
| wit-parser | 0.244 | **0.252** |
| wit-component | 0.244 | **0.252** |
| wat | 1.219 | **1.252** |
| wasmparser | 0.252 | 0.252 ✓ |
| wast | 252.0 | 252.0 ✓ |

Collapses the 0.247 + 0.248 duplicate copies into 0.252. These are `synth-frontend`-only (Component Model parsing) plus the `wat`/`wast` test parsers — the ARM/RISC-V codegen path is untouched.

## Frozen-safe

No codegen change. Frozen byte gates **bit-identical** (control_step `0x00210A55` / flight_seam / flight_seam_flat / signed_div — `wat` 1.252 parses the fixtures to the same bytes); full frontend/core/cli/test suites green. No version bump (dep-only) — rides the next release.

## Residual (out of scope, noted)

One 0.244 wasm-tools copy remains — pulled **not** by our manifest but transitively by `wit-bindgen`'s own pinned `wit-component 0.244`, deep via the z3-sys build chain (`wasip2 → getrandom → … → z3-sys → synth-verify`). That only resolves when `wit-bindgen` updates upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)