### PR TITLE
docs(vcr): log the driver-class non-leaf thin-forwarder prologue frontier (#428, #242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -555,6 +555,26 @@ artifacts:
       does not exist on RV32), NOT a 1:1 port of the three ARM levers. The
       byte-changing lever implementations remain SEPARATE gated steps (each flag-off
       -> RV32 execution differential -> qemu_riscv32/ESP32-C3 cycle gate -> flip).
+      DRIVER-CLASS FRONTIER — NON-LEAF THIN-FORWARDER PROLOGUE (2026-06-25, #428):
+      a measurement pass on thin-seam driver primitives (a leaf that forwards
+      through a single imported call) surfaced a gap the arithmetic levers do not
+      reach: such a forwarder still emits the full `push {r4-r8,lr}` + frame even
+      though it touches no callee-saved register. ROOT CAUSE (verified in source):
+      the prologue-shrink levers `shrink_callee_saved_saves` (default-on) and
+      `elide_dead_frame` (VCR-RA-002 dead-frame, flag-off) both DECLINE on any
+      function containing a call — `reg_effect` returns None on `Bl`, and the pass
+      bails rather than reason past the clobber boundary, so they are effectively
+      leaf-only. A distinct lever — non-leaf thin-forwarder prologue minimization
+      (a function that calls but writes no callee-saved register and reserves no
+      live frame collapses its save-set/frame to `{lr}`, or tail-calls) — is the
+      piece that reaches I/O-bound driver code; it does not exist yet. The two
+      companion driver-class residuals are already tracked: redundant adjacent
+      `str [sp,#N]; ldr [sp,#N]` is `forward_stack_reloads` (#455, built, flag-off
+      behind `SYNTH_STACK_FWD`, awaiting the on-silicon flip), and the
+      materialized-boolean-then-branch (`setcc; cmp #0; bCC`) is the already-deferred
+      `br_if`->predicated-branch half of the cmp->select item (split candidate).
+      All three are SEPARATE gated steps (flag-off -> differential -> silicon),
+      never an idle-tick increment.
     status: approved
     tags: [oracle, differential, coverage, mcdc, validation, track-c, riscv]
     links:


### PR DESCRIPTION
## What

Trace-capture of a newly-identified north-star frontier surfaced by a driver-class measurement pass (#428). Docs-only edit to the VCR-ORACLE-001 measurement log in `artifacts/verified-codegen-roadmap.yaml`. No code, frozen-safe.

## The finding

Thin-seam driver primitives — a leaf that forwards through one imported call — still emit the full `push {r4-r8,lr}` + frame even though they touch no callee-saved register. **Root cause, verified in source:** the prologue-shrink levers `shrink_callee_saved_saves` (default-on) and `elide_dead_frame` (dead-frame, flag-off) both **decline on any function containing a call** — `reg_effect` returns `None` on `Bl` and the pass bails rather than reason past the clobber boundary. They are effectively leaf-only, so a `bl`-containing forwarder is unreached.

A distinct lever — **non-leaf thin-forwarder prologue minimization** (a function that calls but writes no callee-saved register and reserves no live frame collapses its save-set/frame to `{lr}`, or tail-calls) — is the piece that reaches I/O-bound driver code, and it does not exist yet.

The two companion driver-class residuals are already tracked and noted for completeness:
- redundant adjacent `str [sp,#N]; ldr [sp,#N]` → `forward_stack_reloads` (#455), **built, flag-off** behind `SYNTH_STACK_FWD`, awaiting the on-silicon flip;
- materialized-boolean-then-branch (`setcc; cmp #0; bCC`) → the already-deferred `br_if`→predicated-branch half of the cmp→select item (split candidate).

All three remain **separate gated steps** (flag-off → differential → silicon), never an idle-tick increment.

## Gate

`rivet validate` clean (0 non-xref errors; the cross-repo xrefs are pre-existing and filtered by the CI gate). Docs-only — no frozen-fixture impact.

Part of epic #242 (VCR-*). Responds to the measurement in #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)