### PR TITLE
docs(vcr): record that #490 blocks the non-leaf prologue lever (#428, #490, #242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -575,6 +575,27 @@ artifacts:
       `br_if`->predicated-branch half of the cmp->select item (split candidate).
       All three are SEPARATE gated steps (flag-off -> differential -> silicon),
       never an idle-tick increment.
+      LEVER IMPLEMENTED, BLOCKED ON A BASE-SELECTOR CLOBBER (2026-06-25, #490): the
+      non-leaf prologue lever was implemented flag-off (relax `elide_dead_frame` +
+      `shrink_callee_saved_saves` across DIRECT calls; 9 unit tests:
+      even-count/8-byte-aligned push, keeps callee-saved held across a call,
+      declines on indirect/non-8/live-frame). Its execution differential then
+      proved the shrink's soundness is NON-LOCAL — pruning a forwarder's save-set
+      is only correct if every callee preserves r4-r8, which the OPTIMIZED PATH
+      does not: `alloc_i32_scratch` hands out the callee-saved [R4..R8] pool to
+      every function with a scratch temp and the path emits NO callee-saved push,
+      so even the silicon-validated `control_step` clobbers r4/r6/r8 (masked only
+      because it is top-level / its callers fall back to the pushing direct
+      selector). This is a SYSTEMIC base-selector ABI bug (#490), not a small-leaf
+      special case — the scratch pool is shared, so fixing it (push-what-you-use in
+      the optimized path) re-freezes control_step/filter_step and needs gale
+      re-validation. NOT a live miscompile in shipped firmware (gale ships
+      `--relocatable`, which uses the direct selector that preserves r4-r8
+      correctly); it is a latent optimized-path violation that BLOCKS this lever's
+      flip. The lever stays unmerged (branch wip/nonleaf-prologue-blocked-on-leaf-clobber,
+      the differential = repro) until #490 lands. This is a "correctness from
+      construction" item (the north star itself) and gates the perf lever
+      downstream of it.
     status: approved
     tags: [oracle, differential, coverage, mcdc, validation, track-c, riscv]
     links:


### PR DESCRIPTION
## What

Trace hygiene + capturing a root-caused finding. The VCR roadmap's non-leaf thin-forwarder entry described the lever as the next buildable piece; implementing it this session proved that's not yet true, and that finding (#490) was only in the GitHub issue tracker, not the typed VCR trace. Docs-only edit to `artifacts/verified-codegen-roadmap.yaml`, frozen-safe.

## The finding

The non-leaf prologue lever's soundness is **non-local**: pruning a forwarder's save-set is only correct if every callee preserves r4–r8. The optimized path does **not** — `alloc_i32_scratch` hands out the callee-saved `[R4..R8]` pool to every function with a scratch temp, with **no** saving push, so even the **silicon-validated** `control_step` clobbers r4/r6/r8 (masked only because it is top-level / its callers fall back to the pushing direct selector). That's the systemic base-selector ABI bug **#490**.

Not a live miscompile in shipped firmware — gale ships `--relocatable`, which uses the register-preserving direct selector. It's a latent optimized-path violation that **blocks** this lever's flip.

## Why record it now

The skill's "land actionable items in the trace" step: #490 blocks a tracked north-star lever (#428), and the existing roadmap entry was stale (it didn't note the blocker). Recording the blocked-by relationship keeps it from resurfacing as a gate surprise. The lever stays unmerged on `wip/nonleaf-prologue-blocked-on-leaf-clobber` (its differential is the #490 repro) until the systemic fix lands — independent of the (separate, user-authorized) decision on when to do that fix.

`rivet validate` clean (0 non-xref errors; the cross-repo xrefs are pre-existing and filtered by the CI gate). Part of epic #242 (VCR-* "correctness from construction").

🤖 Generated with [Claude Code](https://claude.com/claude-code)