### PR TITLE
fix(ci): exclude synth-verify from the Test job to stop z3 disk exhaustion (#306)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
       - name: Run tests
-        run: cargo test --workspace
+        # Exclude synth-verify: it is the only crate that pulls in z3-sys, which
+        # compiles all of Z3 from source and intermittently exhausts the runner's
+        # disk ("No space left on device" building libz3.a) — the recurring #306
+        # instability. Z3/synth-verify is already covered by the dedicated `Z3
+        # Verification` job, and the sibling jobs already exclude it, so this drops
+        # a redundant heavyweight build without losing coverage.
+        run: cargo test --workspace --exclude synth-verify
 
   clippy:
     name: Clippy


### PR DESCRIPTION
## What

Fixes the load-bearing slice of **#306 (ci instability)**: the `Test` job intermittently fails on changes that can't affect tests.

## Root cause

The `Test` job runs `cargo test --workspace`, which builds **every** crate including `synth-verify` → `z3-sys`, compiling all of Z3 from source. That build is large (disk + memory + time), and GitHub-hosted runners intermittently run out of space:

```
/usr/bin/ar: unable to copy file '../libz3.a'; reason: No space left on device
gmake: *** [Makefile:136: all] Error 2
```

Reproduced **three times in a row** on #492 — a docs-only YAML change that cannot affect any test — confirming it's pure infra, not the change.

## Fix

```diff
- run: cargo test --workspace
+ run: cargo test --workspace --exclude synth-verify
```

- z3/synth-verify is already covered by the dedicated **`Z3 Verification`** job (`cargo test -p synth-verify --features z3-solver,arm` + `comprehensive_verification`);
- sibling jobs (pin-sweep, coverage) **already** pass `--exclude synth-verify`, so this matches existing precedent;
- it removes a **redundant** heavyweight build — z3 was being compiled in both `Test` and `Z3 Verification`.

No coverage is lost; the Test job stops dragging in z3 and the disk/memory pressure goes away. The Test job on this PR exercises the lighter command directly.

Closes #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)