### PR TITLE
fix(vcr-ra): optimized path preserves callee-saved r4-r8 — AAPCS prologue (#490, #242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,3 +343,40 @@ jobs:
         env:
           SYNTH: ./target/debug/synth
         run: python scripts/repro/const_addr_fold_riscv_differential.py
+
+  callee-saved-490-oracle:
+    name: optimized-path callee-saved preservation oracle
+    # VCR-ORACLE-001 (#242, #490): EXECUTE optimized-path functions that use
+    # r4-r8 under unicorn (UC_ARCH_ARM / Thumb) with r4-r8 set to sentinels, and
+    # assert both the result matches wasmtime AND every callee-saved register is
+    # restored at return. This is the runtime gate for the #490 fix (the
+    # optimized path now emits the `push {r4-r8,lr}` / `pop {r4-r8,pc}` it was
+    # missing); the frozen byte gate only covers the `--relocatable` direct path,
+    # so nothing else exercises the optimized path's AAPCS compliance. Covers the
+    # 16-bit push and the 32-bit PUSH.W (high-register) forms. Isolated job:
+    # emulation deps pip-installed here ONLY.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Run callee-saved preservation oracle
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/repro/callee_saved_490_differential.py

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -441,9 +441,22 @@ fn compile_wasm_to_arm(
         } else {
             out
         };
+        // #490 (epic #242): the optimized selector uses r4-r8 as scratch /
+        // promoted locals but emits no prologue, silently clobbering a caller's
+        // callee-saved registers. Add the missing `push {r4-r8,lr}` /
+        // `pop {r4-r8,pc}` HERE — on the post-realloc body, where realloc has
+        // lowered low-pressure r4-r8 scratch back to r0-r3, so a save is added
+        // only for registers genuinely clobbered. `shrink_callee_saved_saves`
+        // (next) then trims it to the used set. No-op on the direct path (it
+        // already has its own prologue) and on callee-saved-free leaves.
+        let out = synth_synthesis::liveness::ensure_callee_saved_prologue(&out);
         synth_synthesis::liveness::shrink_callee_saved_saves(&out).unwrap_or(out)
     } else {
-        arm_instrs
+        // Range-realloc off (`SYNTH_RANGE_REALLOC=0`): the optimized path still
+        // must preserve the callee-saved registers it clobbers (#490). No shrink
+        // (it is coupled to the realloc lever), so the conservative full save
+        // stays — correct, just not minimised in this debug configuration.
+        synth_synthesis::liveness::ensure_callee_saved_prologue(&arm_instrs)
     };
 
     // VCR-RA-001 SHADOW ALLOCATION (#209/#242): run the register allocator on

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -2487,6 +2487,112 @@ pub fn shrink_callee_saved_saves(instrs: &[ArmInstruction]) -> Option<Vec<ArmIns
     Some(out)
 }
 
+/// #490 (epic #242): does this body clobber/read any callee-saved register, so
+/// the optimized path must wrap it in a `push {r4-r8,lr}` / `pop {r4-r8,pc}`
+/// prologue/epilogue to honour AAPCS?
+///
+/// This is the **emit-side twin** of [`shrink_callee_saved_saves`]: it reads the
+/// exact same per-op classification (the control-flow allowlist + `reg_effect`)
+/// as *push-conditions* rather than *decline-conditions*, so the two passes
+/// always agree. [`ensure_callee_saved_prologue`] emits a conservative full
+/// `push {r4-r8,lr}` when this returns `true`; `shrink_callee_saved_saves` then
+/// trims that push to the registers actually touched (or declines, leaving the
+/// full push, on frame/call/unmodeled bodies it cannot prove safe).
+///
+/// **Conservative on `None` (fail-safe).** An op `reg_effect` cannot model
+/// (i64-pair pseudo-ops, calls, anything outside the modeled scope) *might* write
+/// a callee-saved register, so it forces the push. Under-saving is the exact
+/// AAPCS violation #490 fixes; over-saving an unused register is harmless (shrink
+/// pads it down, or — on a body shrink declines — it is a few dead bytes). The
+/// only load-bearing answer is `false`: a spurious push on a callee-saved-free
+/// leaf is permanent (shrink never *removes* a push), so the control-flow
+/// allowlist and the cs-intersection test must be exact, mirroring shrink. The
+/// decision runs on the **post-range-realloc** body, where low-pressure r4-r8
+/// scratch has already been lowered to r0-r3, so only genuine clobbers remain.
+pub fn body_uses_callee_saved(instrs: &[ArmInstruction]) -> bool {
+    use ArmOp::*;
+    const CALLEE_SAVED: [Reg; 5] = [Reg::R4, Reg::R5, Reg::R6, Reg::R7, Reg::R8];
+    for ins in instrs {
+        match &ins.op {
+            // Function-boundary markers and pure label control flow carry no
+            // callee-saved data effect (mirrors shrink's allowlist exactly).
+            Push { .. }
+            | Pop { .. }
+            | Label { .. }
+            | B { .. }
+            | BOffset { .. }
+            | BCondOffset { .. }
+            | Bhs { .. }
+            | Blo { .. }
+            | Bcc { .. } => {}
+            Bx { rm } if *rm == Reg::LR => {}
+            op => match reg_effect(op) {
+                Some(e) => {
+                    if e.defs
+                        .iter()
+                        .chain(e.uses.iter())
+                        .any(|r| CALLEE_SAVED.contains(r))
+                    {
+                        return true;
+                    }
+                }
+                // Unmodeled op → assume it may touch a callee-saved register.
+                None => return true,
+            },
+        }
+    }
+    false
+}
+
+/// #490 (epic #242): give the optimized path the callee-saved prologue/epilogue
+/// it is missing. The optimized selector uses r4-r8 as scratch / promoted locals
+/// but emits no `push`/`pop`, so a caller's r4-r8 are silently clobbered — a
+/// systemic AAPCS violation. When the (post-realloc) body genuinely touches a
+/// callee-saved register, wrap it in a conservative full `push {r4-r8,lr}` /
+/// `pop {r4-r8,pc}`; [`shrink_callee_saved_saves`] (run next) trims that to the
+/// registers actually used, or declines and leaves the full save on a
+/// frame/call/unmodeled body it cannot prove safe.
+///
+/// No-op when a prologue already exists (the direct selector emits its own
+/// `push {…,lr}`) or the body is callee-saved-free (e.g. a pure-r0-r3 leaf —
+/// left byte-identical, which is load-bearing: an added push could never be
+/// removed later). The push is inserted at index 0, landing before any
+/// `sub sp,#frame` the optimized path reserved; each `bx lr` becomes
+/// `pop {…,pc}`, landing after the matching `add sp,#frame`.
+pub fn ensure_callee_saved_prologue(instrs: &[ArmInstruction]) -> Vec<ArmInstruction> {
+    use ArmOp::*;
+    // Already has a prologue (direct path) → leave it for shrink to size.
+    if instrs
+        .iter()
+        .any(|i| matches!(&i.op, Push { regs } if regs.contains(&Reg::LR)))
+    {
+        return instrs.to_vec();
+    }
+    if !body_uses_callee_saved(instrs) {
+        return instrs.to_vec();
+    }
+    let mut out = Vec::with_capacity(instrs.len() + 1);
+    out.push(ArmInstruction {
+        op: Push {
+            regs: vec![Reg::R4, Reg::R5, Reg::R6, Reg::R7, Reg::R8, Reg::LR],
+        },
+        source_line: None,
+    });
+    for ins in instrs {
+        if matches!(&ins.op, Bx { rm } if *rm == Reg::LR) {
+            out.push(ArmInstruction {
+                op: Pop {
+                    regs: vec![Reg::R4, Reg::R5, Reg::R6, Reg::R7, Reg::R8, Reg::PC],
+                },
+                source_line: ins.source_line,
+            });
+        } else {
+            out.push(ins.clone());
+        }
+    }
+    out
+}
+
 /// VCR-RA-002 (#390, epic #242): eliminate a provably-dead stack frame.
 ///
 /// `compute_local_layout` reserves a frame slot — materialized as
@@ -5883,6 +5989,101 @@ mod tests {
         }
         assert_eq!(out[2], seq[2]);
         assert_eq!(out[4], seq[4]);
+    }
+
+    // ---- ensure_callee_saved_prologue (#490) ----
+
+    #[test]
+    fn ensure_prologue_wraps_body_that_touches_callee_saved() {
+        // Optimized-path shape: no prologue, body writes r4/r5, returns via bx lr.
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R4,
+                imm16: 100,
+            }),
+            ins(ArmOp::Add {
+                rd: Reg::R5,
+                rn: Reg::R0,
+                op2: Operand2::Reg(Reg::R4),
+            }),
+            ins(ArmOp::Mov {
+                rd: Reg::R0,
+                op2: Operand2::Reg(Reg::R5),
+            }),
+            ins(ArmOp::Bx { rm: Reg::LR }),
+        ];
+        let out = ensure_callee_saved_prologue(&seq);
+        assert_eq!(
+            out[0].op,
+            ArmOp::Push {
+                regs: vec![Reg::R4, Reg::R5, Reg::R6, Reg::R7, Reg::R8, Reg::LR]
+            }
+        );
+        assert_eq!(
+            out.last().unwrap().op,
+            ArmOp::Pop {
+                regs: vec![Reg::R4, Reg::R5, Reg::R6, Reg::R7, Reg::R8, Reg::PC]
+            }
+        );
+        // Body untouched between the new prologue and epilogue.
+        assert_eq!(out[1..=3], seq[0..=2]);
+        // And shrink then sizes it to the registers actually used ({r4,r5} → pad).
+        let shrunk = shrink_callee_saved_saves(&out).expect("shrinks");
+        assert_eq!(
+            shrunk[0].op,
+            ArmOp::Push {
+                regs: vec![Reg::R4, Reg::R5, Reg::R6, Reg::LR]
+            }
+        );
+    }
+
+    #[test]
+    fn ensure_prologue_leaves_callee_saved_free_leaf_untouched() {
+        // Pure r0-r3 leaf: no callee-saved register touched → no push added
+        // (a spurious push would be permanent — shrink never removes one).
+        let seq = vec![
+            ins(ArmOp::Add {
+                rd: Reg::R0,
+                rn: Reg::R0,
+                op2: Operand2::Imm(1),
+            }),
+            ins(ArmOp::Bx { rm: Reg::LR }),
+        ];
+        assert_eq!(ensure_callee_saved_prologue(&seq), seq);
+        assert!(!body_uses_callee_saved(&seq));
+    }
+
+    #[test]
+    fn ensure_prologue_is_conservative_on_unmodeled_ops() {
+        // An op reg_effect cannot model (here a Bl call) might clobber a
+        // callee-saved register → force the push (fail-safe). shrink then
+        // declines on the call and leaves the full save.
+        let seq = vec![
+            ins(ArmOp::Bl {
+                label: "func_1".to_string(),
+            }),
+            ins(ArmOp::Bx { rm: Reg::LR }),
+        ];
+        assert!(body_uses_callee_saved(&seq));
+        let out = ensure_callee_saved_prologue(&seq);
+        assert!(matches!(&out[0].op, ArmOp::Push { regs } if regs.contains(&Reg::LR)));
+        assert_eq!(shrink_callee_saved_saves(&out), None);
+    }
+
+    #[test]
+    fn ensure_prologue_skips_body_that_already_has_one() {
+        // Direct-path output already carries its own `push {…,lr}` → no-op
+        // (shrink owns sizing it; double-wrapping would corrupt the frame).
+        let seq = vec![
+            prologue(),
+            ins(ArmOp::Add {
+                rd: Reg::R5,
+                rn: Reg::R0,
+                op2: Operand2::Imm(1),
+            }),
+            epilogue(),
+        ];
+        assert_eq!(ensure_callee_saved_prologue(&seq), seq);
     }
 
     // ---- elide_dead_frame (VCR-RA-002, #390) ----

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -5516,6 +5516,13 @@ impl OptimizerBridge {
             arm_instrs.push(ArmOp::Bx { rm: Reg::LR });
         }
 
+        // #490: the callee-saved prologue/epilogue the optimized path needs to
+        // honour AAPCS is added AFTER range-realloc (in `arm_backend`), where the
+        // re-allocated body shows which callee-saved registers are *genuinely*
+        // live — realloc lowers low-pressure r4-r8 scratch back to r0-r3, so a
+        // decision here (pre-realloc) would over-save. See
+        // `liveness::ensure_callee_saved_prologue`.
+
         Ok(arm_instrs)
     }
 }

--- a/scripts/repro/callee_saved_490.wat
+++ b/scripts/repro/callee_saved_490.wat
@@ -1,0 +1,31 @@
+(module
+  (memory 1)
+  ;; #490 fixture (epic #242): functions the OPTIMIZED path lowers using r4-r8 as
+  ;; scratch. Before the fix the optimized path emitted no prologue and silently
+  ;; clobbered a caller's callee-saved registers; the differential sets r4-r8 to
+  ;; sentinels, runs each function, and asserts the sentinels survive AND the
+  ;; result matches wasmtime — proving the push/pop the fix adds preserves them.
+  ;;
+  ;; Pressure is tuned to exercise the callee-saved range WITHOUT exhausting the
+  ;; R0-R8 pool (the optimized path has no spill, so an exhausting fold would hit
+  ;; a separate pre-existing miscompile and conflate two issues). Each function
+  ;; below is differential-verified to compute correctly on the optimized path.
+
+  ;; low: two live temps → 16-bit `push {r4,r5,r6,lr}` (r6 is shrink's even-pad).
+  (func $low (export "low") (param i32) (result i32)
+    (i32.add (local.get 0) (i32.const 100)))
+
+  ;; mid: three live subterms → `push {r4,r5,r6,lr}`.
+  (func $mid (export "mid") (param i32 i32) (result i32)
+    (i32.add (i32.mul (local.get 0) (local.get 1))
+             (i32.sub (local.get 0) (local.get 1))))
+
+  ;; wide: enough simultaneously-live products to reach r8 → 32-bit Thumb-2
+  ;; `push.w {r4-r8,lr}`, exercising the high-register save the 16-bit form
+  ;; cannot encode.
+  (func $wide (export "wide") (param i32 i32 i32) (result i32)
+    (i32.add
+      (i32.add (i32.mul (local.get 0) (local.get 1))
+               (i32.mul (local.get 1) (local.get 2)))
+      (i32.mul (local.get 0) (local.get 2))))
+)

--- a/scripts/repro/callee_saved_490_differential.py
+++ b/scripts/repro/callee_saved_490_differential.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""#490 (epic #242) — EXECUTION-validate optimized-path callee-saved preservation.
+
+The optimized ARM path (the default, non-`--relocatable` self-contained image)
+uses r4-r8 as scratch / promoted locals but emitted NO prologue, silently
+clobbering a caller's callee-saved registers — a systemic AAPCS violation. The
+fix wraps a body that genuinely touches r4-r8 in `push {r4-r8,lr}` /
+`pop {r4-r8,pc}` (sized down by `shrink_callee_saved_saves`).
+
+This harness compiles the fixture via the OPTIMIZED path (no `--relocatable`),
+runs each exported function under unicorn (UC_ARCH_ARM / Thumb) with r4-r8 set to
+distinct SENTINELS, and asserts:
+  1. the result matches wasmtime ground truth (computation unchanged), and
+  2. every callee-saved register r4-r8 is RESTORED to its sentinel at return
+     (the actual AAPCS property #490 fixes).
+
+NON-VACUITY: each function's machine code must contain a `push {...,lr}` /
+`pop {...,pc}` pair (else there is nothing preserving the sentinels and the
+check is trivially true). A function that touches no callee-saved register is
+exempt — but both fixtures are constructed to use them.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/callee_saved_490_differential.py
+Exits nonzero on any mismatch, clobbered sentinel, or vacuity failure.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R3,
+    UC_ARM_REG_R4,
+    UC_ARM_REG_R5,
+    UC_ARM_REG_R6,
+    UC_ARM_REG_R7,
+    UC_ARM_REG_R8,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("callee_saved_490.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+CS_REGS = [
+    (UC_ARM_REG_R4, "r4", 0xCA5E0004),
+    (UC_ARM_REG_R5, "r5", 0xCA5E0005),
+    (UC_ARM_REG_R6, "r6", 0xCA5E0006),
+    (UC_ARM_REG_R7, "r7", 0xCA5E0007),
+    (UC_ARM_REG_R8, "r8", 0xCA5E0008),
+]
+ARG_REGS = [UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3]
+# (name, [argument vectors]); each vector is masked to u32 going in.
+CASES = {
+    "low": [(0,), (1,), (100,), (0x7FFFFFFF,), (0xFFFFFFFF,)],
+    "mid": [(0, 0), (1, 2), (3000, 50), (0x7FFFFFFF, 1), (0xFFFFFFFF, 0x80000000)],
+    "wide": [(0, 0, 0), (1, 2, 3), (3000, 50, 7), (0x7FFFFFFF, 1, 2),
+             (0xFFFFFFFF, 0x80000000, 5)],
+}
+
+
+def compile_optimized(out):
+    """Compile via the optimized path (NO --relocatable) — the path #490 fixes.
+
+    Forwards the range-realloc / dead-frame-elim knobs so the prologue wrap can
+    be exercised in every configuration that reaches it: default (realloc-on →
+    shrink trims), `SYNTH_RANGE_REALLOC=0` (no shrink → full save kept), and
+    `SYNTH_DEAD_FRAME_ELIM=1`."""
+    env = {"PATH": "/usr/bin:/bin"}
+    for k in ("SYNTH_RANGE_REALLOC", "SYNTH_DEAD_FRAME_ELIM"):
+        if k in os.environ:
+            env[k] = os.environ[k]
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "--target", "cortex-m4",
+         "--all-exports"],
+        capture_output=True, text=True, env=env,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed: {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+    return data, base, syms
+
+
+def has_push_pop(code, off, limit=256):
+    """Structural non-vacuity: the function at byte `off` contains a prologue
+    PUSH and an epilogue POP. Recognises both the 16-bit Thumb forms (PUSH
+    {...,lr} = 0xB5xx, POP {...,pc} = 0xBDxx) and the 32-bit Thumb-2 wide forms
+    the assembler must use when the list includes a high register such as r8
+    (PUSH.W = 0xE92D <list>, POP.W = 0xE8BD <list>)."""
+    push = pop = False
+    i = off
+    end = min(off + limit, len(code))
+    while i + 1 < end:
+        hw = code[i] | (code[i + 1] << 8)
+        if (hw & 0xFF00) == 0xB500 or hw == 0xE92D:  # PUSH / PUSH.W
+            push = True
+        if (hw & 0xFF00) == 0xBD00 or hw == 0xE8BD:  # POP {pc} / POP.W
+            pop = True
+            break
+        i += 2
+    return push and pop
+
+
+def main():
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth first")
+    elf = "/tmp/cs490.elf"
+    compile_optimized(elf)
+    code, base, syms = load(elf)
+
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+
+    CODE_LO, CODE_HI = base & ~0xFFFF, 0x20000
+    STK = 0x90000
+    RET = STK + 0x100
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE_LO, CODE_HI)
+    mu.mem_write(base, code)
+    mu.mem_map(STK, 0x10000)
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")  # nop; nop landing pad
+
+    fails = 0
+    for name, vectors in CASES.items():
+        addr = syms[name]
+        foff = (addr - base) & ~1
+        if not has_push_pop(code, foff):
+            print(f"VACUOUS: {name} has no push/pop pair — nothing preserves "
+                  "the callee-saved sentinels")
+            fails += 1
+            continue
+        export = inst.exports(st)[name]
+        for vec in vectors:
+            signed = [v - (1 << 32) if v >= 1 << 31 else v for v in vec]
+            exp = export(st, *signed) & 0xFFFFFFFF
+            for r in ARG_REGS:
+                mu.reg_write(r, 0)
+            for r, v in zip(ARG_REGS, vec):
+                mu.reg_write(r, v & 0xFFFFFFFF)
+            for reg, _, sentinel in CS_REGS:
+                mu.reg_write(reg, sentinel)
+            mu.reg_write(UC_ARM_REG_SP, STK + 0x8000)
+            mu.reg_write(UC_ARM_REG_LR, RET | 1)
+            mu.emu_start(addr | 1, RET, timeout=5_000_000)
+            got = mu.reg_read(UC_ARM_REG_R0)
+            clobbered = [
+                nm for reg, nm, sentinel in CS_REGS
+                if mu.reg_read(reg) != sentinel
+            ]
+            ok = got == exp and not clobbered
+            if not ok:
+                fails += 1
+            tag = "OK  " if ok else "FAIL"
+            detail = f"= {got:#010x} expect {exp:#010x}"
+            if clobbered:
+                detail += f"  CLOBBERED {','.join(clobbered)}"
+            print(f"{tag} {name}{vec} {detail}")
+
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

The optimized ARM selection path (the default, non-`--relocatable` self-contained image) uses **r4-r8 as scratch / promoted locals but emitted no prologue**, so a caller's callee-saved registers were silently clobbered — a systemic AAPCS violation (**#490**). Masked because non-leaf callers route through the direct selector (which over-saves) and the frozen byte gate only covers the `--relocatable` direct path. It blocks flipping the non-leaf thin-forwarder prologue lever (**#428**).

## Fix

After range-realloc, wrap a body that genuinely touches a callee-saved register in a conservative `push {r4-r8,lr}` / `pop {r4-r8,pc}`; `shrink_callee_saved_saves` then trims the save to the registers actually used. Two new `liveness` helpers:

- **`body_uses_callee_saved`** — the emit-side twin of `shrink_callee_saved_saves`, reading the *same* control-flow allowlist + `reg_effect` classification as push-conditions. **Conservative on `reg_effect` `None`** (an unmodeled op may touch a callee-saved register → force the push): under-saving is the AAPCS bug; over-saving is harmless (shrink pads it down).
- **`ensure_callee_saved_prologue`** — wraps the body; no-op when a prologue already exists (direct path) or the body is callee-saved-free (a spurious push is permanent — shrink never *removes* one).

Decided on the **post-realloc** body, where realloc has lowered low-pressure r4-r8 scratch back to r0-r3, so a save is added only for genuinely-clobbered registers. Runs in both realloc-on (shrink trims) and realloc-off (full save kept).

## Scope / honesty

- **Callee-saved (r4-r8) only.** Caller-saved (r0-r3) preservation across import calls on the optimized path is a *separate* known gap (#197) — this PR does not make the optimized path fully AAPCS-correct.
- Functions with **>4 params** (incoming stack args) decline to the direct selector, so the wrap is a no-op there and **cannot perturb stack-arg offsets** (verified byte-identical to `--no-optimize`).
- **Default-on** (a correctness fix is not flag-gated). It adds save/restore cycles to optimized-path functions that use r4-r8 — a **non-shipped** path (gale ships `--relocatable`), so no silicon cost. Frozen byte gate stays **bit-identical** (direct path untouched).

## Validation

- New unicorn **sentinel oracle** (`callee_saved_490_differential.py`, **CI-gated**): sets r4-r8 to sentinels, asserts result == wasmtime **and** sentinels restored, across 16-bit push and 32-bit PUSH.W (high-register) forms; passes in default, `SYNTH_RANGE_REALLOC=0`, and `SYNTH_DEAD_FRAME_ELIM=1`. **FAILs without the fix.**
- 4 new `liveness` unit tests; full workspace suite + bulk-memory optimized-path differential green; frozen byte gate bit-identical (control_step `0x00210A55` / flight_algo `0x07FDF307` unchanged).

## Follow-up (separate)

While building the fixture I found a **pre-existing** optimized-path miscompile on register-exhausting folds (the optimized path lacks the direct path's spill-on-exhaustion and silently produces wrong code rather than declining). Filed separately; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)