### PR TITLE
fix(optimizer): optimized-path block/br_if branch lands mid-instruction (#483, #242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,3 +380,41 @@ jobs:
         env:
           SYNTH: ./target/debug/synth
         run: python scripts/repro/callee_saved_490_differential.py
+
+  block-brif-483-oracle:
+    name: optimized-path block/br_if lowering oracle
+    # VCR-ORACLE-001 (#242, #483): EXECUTE optimized-path functions with forward
+    # `block`/`br_if` and nested `block`+`br` under unicorn (UC_ARCH_ARM / Thumb)
+    # and diff the resulting linear MEMORY vs wasmtime across both branch
+    # directions. Guards the #483 fix (End labels with the closed block's id, and
+    # the half/byte memory-op byte-size estimate) — before it, a forward br_if
+    # resolved against an id no label held and landed mid-instruction, silently
+    # miscompiling any non-relocatable function with that control flow. The frozen
+    # byte gate only covers the `--relocatable` direct path, so nothing else
+    # exercises the optimized path's branch resolution. Isolated job: emulation
+    # deps pip-installed here ONLY.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Run block/br_if lowering oracle
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/repro/block_brif_483_differential.py

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -1793,10 +1793,22 @@ impl OptimizerBridge {
                 }
 
                 // End: marks the end of a block/loop/function. No stack effect.
-                WasmOp::End => {
-                    block_stack.pop();
-                    Opcode::Label { id: inst_id }
-                }
+                //
+                // #483: a forward `block` is the branch target of any `br`/`br_if`
+                // that exits it — and those branches target the id pushed when the
+                // `Block` was opened (block_stack stores the Block's inst_id, and
+                // the `Block` arm emits only a `Nop`, no label). So the End that
+                // closes a block must emit its label with the BLOCK's id, not its
+                // own, or the branch resolves against an id no label carries and is
+                // left as the unpatched placeholder (offset 0 → a mid-instruction
+                // landing — the #483 miscompile). Loop ends and the function-end
+                // keep their own id: a loop's target label is already at its start
+                // (backward branch), and the function end is just the structural
+                // trailing label.
+                WasmOp::End => match block_stack.pop() {
+                    Some((0, block_id)) => Opcode::Label { id: block_id },
+                    _ => Opcode::Label { id: inst_id },
+                },
 
                 // Br: unconditional branch to label. No stack effect at IR
                 // level (the wasm validator handles unreachable stack after Br).
@@ -5342,6 +5354,20 @@ impl OptimizerBridge {
                         4
                     }
                 }
+                // #483: half/byte loads and stores. The optimized path always
+                // materializes a memory access against a HIGH base register
+                // (`ip`/r12 for a const address, r11 for the base-CSE linmem
+                // anchor), so the encoder always emits the 32-bit `.w` form — the
+                // 16-bit Thumb T1 encoding (low base + small aligned offset) is
+                // never produced here. Sizing these as the default 2 (the bug)
+                // drifts `byte_offsets` and miscompiles any branch that spans the
+                // access (the i32.store16 in the #483 `block`/`br_if` repro).
+                ArmOp::Strh { .. }
+                | ArmOp::Strb { .. }
+                | ArmOp::Ldrh { .. }
+                | ArmOp::Ldrsh { .. }
+                | ArmOp::Ldrb { .. }
+                | ArmOp::Ldrsb { .. } => 4,
                 // BL is always 32-bit
                 ArmOp::Bl { .. } => 4,
                 // MOV with high register (R8-R15) or large immediate needs MOVW (4 bytes)

--- a/scripts/repro/block_brif_483.wat
+++ b/scripts/repro/block_brif_483.wat
@@ -1,0 +1,27 @@
+(module
+  (memory 1)
+  (export "memory" (memory 0))
+
+  ;; #483 canonical repro: a forward `block` + `br_if` exit. The br_if target
+  ;; (block end) must skip the guarded stores when taken. i32.store16 inside the
+  ;; block is the size-estimator trigger (Strh encodes 4 bytes, was sized 2).
+  (func (export "init_branch") (param $sel i32)
+    (i32.store (i32.const 0) (i32.const 11))
+    (i32.store (i32.const 4) (i32.const 22))
+    (block $skip
+      (br_if $skip (i32.eqz (local.get $sel)))
+      (i32.store   (i32.const 8)  (i32.const 33))
+      (i32.store16 (i32.const 12) (i32.const 44))))
+
+  ;; Nested blocks + an unconditional `br 1` exiting the OUTER block from inside
+  ;; the inner one — exercises the `Br` path and label resolution across nested
+  ;; Ends (each End must carry the id of the block it closes). Kept light (single
+  ;; guarded word store) to isolate the branch resolution from spill/frame paths.
+  (func (export "nested") (param $sel i32)
+    (block $outer
+      (block $inner
+        (br_if $inner (local.get $sel))            ;; sel!=0 → skip to $inner end
+        (br $outer))                               ;; sel==0 → exit $outer entirely
+      (i32.store (i32.const 24) (i32.const 77)))   ;; reached only when sel!=0
+    (i32.store (i32.const 32) (i32.const 99)))     ;; always reached
+)

--- a/scripts/repro/block_brif_483_differential.py
+++ b/scripts/repro/block_brif_483_differential.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""#483 (epic #242) — EXECUTION-validate optimized-path block/br_if lowering.
+
+On the OPTIMIZED (non-`--relocatable`) ARM path, a forward `block` + `br_if`
+lowered to a conditional branch whose target landed MID-INSTRUCTION: the branch
+targeted the id pushed for the `Block` opener, but the only emitted label sat at
+the matching `End` carrying the End's *own* id — so the target resolved against
+an id no label held and was left as the unpatched offset-0 placeholder. A
+companion size-estimator gap (i32.store16 → `Strh`, a 4-byte `.w` encoding, was
+sized as 2) drifted `byte_offsets` so even a resolved branch missed by 2 bytes.
+
+This harness compiles the fixture via the optimized path, runs each function
+under unicorn (UC_ARCH_ARM / Thumb) with the linear memory mapped at the absolute
+base the optimized path materializes, and asserts the resulting MEMORY is
+bit-identical to wasmtime ground truth across both branch directions (taken /
+not-taken). The functions write memory and return nothing, so memory is the
+observable. Before the fix, `init_branch(0)` (br_if taken → block skipped) wrote
+the guarded fields anyway.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/block_brif_483_differential.py
+Exits nonzero on any mismatch.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import UC_ARM_REG_LR, UC_ARM_REG_R0, UC_ARM_REG_SP
+
+WAT = Path(__file__).with_name("block_brif_483.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+# Absolute linear-memory base the optimized (non-relocatable) path materializes
+# for a const address: `movw ip,#0x100; movt ip,#0x2000` → 0x20000100 (see #197).
+LINMEM = 0x20000100
+MEM_WINDOW = 64      # bytes of memory compared against ground truth
+# (function, [sel values exercising both branch directions])
+CASES = {"init_branch": [0, 1], "nested": [0, 1]}
+
+
+def compile_optimized(out):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"},
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed: {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+    return data, base, syms
+
+
+def wasm_mem(func, sel):
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    inst.exports(st)[func](st, sel)
+    return bytes(inst.exports(st)["memory"].read(st, 0, MEM_WINDOW))
+
+
+def run_rv(code, base, addr, sel):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(base & ~0xFFFF, 0x20000)
+    mu.mem_write(base, code)
+    mu.mem_map(LINMEM & ~0xFFFF, 0x20000)  # page-aligned region covering LINMEM
+    mu.mem_map(0x90000, 0x10000)
+    ret = 0x90100
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    mu.reg_write(UC_ARM_REG_R0, sel & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_SP, 0x98000)
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    mu.emu_start(addr | 1, ret, timeout=5_000_000)
+    return bytes(mu.mem_read(LINMEM, MEM_WINDOW))
+
+
+def main():
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth first")
+    elf = "/tmp/block_brif_483.elf"
+    compile_optimized(elf)
+    code, base, syms = load(elf)
+
+    fails = 0
+    for func, sels in CASES.items():
+        for sel in sels:
+            gt = wasm_mem(func, sel)
+            got = run_rv(code, base, syms[func], sel)
+            ok = got == gt
+            if not ok:
+                fails += 1
+            print(f"{'OK  ' if ok else 'FAIL'} {func}(sel={sel})")
+            if not ok:
+                diff = [(i, gt[i], got[i]) for i in range(MEM_WINDOW) if gt[i] != got[i]]
+                print(f"     mem diffs (off, wasmtime, synth): {diff}")
+
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

On the **optimized** (non-`--relocatable`) ARM path, a forward `block` + `br_if` lowered to a conditional branch whose target landed **mid-instruction** and did not skip the block — silently miscompiling any such function (**#483**). The `--relocatable` direct path was unaffected.

Two root causes:

1. **Label id mismatch.** A `br`/`br_if` exiting a forward `block` targets the id pushed when the `Block` opened (the `Block` arm emits only a `Nop`, no label). But the matching `End` emitted its label with the End's *own* id, so the branch resolved against an id no label carried and was left as the unpatched offset-0 placeholder. Fix: `End` labels with the id of the block it closes (loop ends / function-end keep their own id).

2. **Byte-size estimate gap.** The `byte_offsets` table driving branch displacement sized `Strh`/`Strb`/`Ldrh`/`Ldrsh`/`Ldrb`/`Ldrsb` as the default 2 bytes, but the optimized path always addresses memory off a high base register (`ip`/r11) → the encoder emits the 4-byte `.w` form. Once branches resolved (fix 1), the `i32.store16` in the repro drifted the target by 2. Fix: size these as 4.

## Validation

- New **CI-gated unicorn differential** (`block_brif_483_differential.py`): runs the forward-block repro *and* a nested-block + unconditional `br` case through the optimized path, diffing linear memory vs wasmtime across **both** branch directions. **Fails without the fix** (`init_branch(0)` wrongly executes the guarded stores, writing `{0:33, 12:44}`).
- Frozen byte gate stays **bit-identical** (direct path untouched); full workspace suite green; fmt + clippy clean.

## Scope / follow-ups

- The size estimator also lacks correct arms for other variable-width ops (`Cmp`/`Cmn`/`Adds`/`Subs`/`Popcnt`) that could drift a branch spanning them — **not** triggered by this repro; filing a table-completeness follow-up.
- A heavier nested fixture surfaced a *separate* pre-existing spill+control-flow frame bug (a `sub sp,#N` frame not deallocated before the epilogue `pop`) — independent of this fix; filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)