### PR TITLE
docs(vcr): record landed optimized-path fixes + the optimizer_bridge control-flow frontier (#242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -596,6 +596,44 @@ artifacts:
       the differential = repro) until #490 lands. This is a "correctness from
       construction" item (the north star itself) and gates the perf lever
       downstream of it.
+      RESOLVED + BROADER OPTIMIZER-BRIDGE CONTROL-FLOW FRONTIER (2026-06-26,
+      #490/#483/#500): #490 LANDED (PR #495) — the optimized path now wraps any
+      body that genuinely touches r4-r8 in `push {r4-r8,lr}` / `pop {r4-r8,pc}`,
+      decided on the POST-realloc body (only genuinely-clobbered regs saved, so a
+      cs-free leaf never gets a spurious permanent push; >4-param functions
+      decline to the direct selector, so the inserted push cannot perturb
+      incoming stack-arg offsets — verified byte-identical to `--no-optimize`),
+      gated by `scripts/repro/callee_saved_490_differential.py` (r4-r8 sentinels +
+      result vs wasmtime, covering the 16-bit push and the 32-bit PUSH.W
+      high-register form). The non-leaf thin-forwarder prologue lever this blocked
+      is now unblocked for a deliberate flip. A companion optimized-path
+      control-flow miscompile LANDED the same arc (#483, PR #497): a forward
+      `block`+`br_if` branch landed mid-instruction — two causes, the closing
+      `End` labelled with its OWN id instead of the id of the block it closes (so
+      the `br_if` resolved against an id no label held, left as the unpatched
+      offset-0 placeholder), plus a `byte_offsets` size estimate that sized
+      `Strh`/`Strb`/`Ldrh`/`Ldrsh`/`Ldrb`/`Ldrsb` as 2 when the high-base
+      optimized path emits the 4-byte `.w` form — gated by
+      `scripts/repro/block_brif_483_differential.py` (linear-memory diff vs
+      wasmtime, both branch directions, forward + nested blocks). A multi-modal
+      control-flow SWEEP then established these are ONE CLUSTER of optimizer_bridge
+      (optimized-path) control-flow / ABI defects — the concrete measured evidence
+      for VCR-SEL-001's "(ii) collapse the two/three-selector accretion
+      (select_default / select_with_stack / optimizer_bridge) into one verified
+      source" motivation — and the next gated frontier, none of it in shipped
+      firmware (gale ships `--relocatable` / direct): #500 — `br_if` STILL
+      unresolved for if/else (nested block+br_if+`br`) and SEQUENTIAL-block shapes
+      (`seqblocks`, two non-nested blocks, is the minimal repro; the #483
+      End-label fix is necessary-not-sufficient; the Pattern-3 select matcher was
+      ruled OUT); #499 — a spill frame (`sub sp,#N`) not deallocated under control
+      flow (missing `add sp`), a latent SP leak that #490's `pop {..,pc}` epilogue
+      turned FATAL (#215-class "epilogue change exposes a latent frame bug"); #498
+      — the `byte_offsets` estimator still lacks `Cmp`/`Cmn`/`Adds`/`Subs`/`Popcnt`
+      (structural: synth-synthesis cannot depend on synth-backend, so the size
+      table is a hand-maintained mirror of the encoder that drifts); #496 —
+      register-exhausting i32 folds silently miscompiled (no spill, no decline).
+      All four are SEPARATE gated steps (flag-off / differential / silicon as
+      applicable), never idle-tick increments.
     status: approved
     tags: [oracle, differential, coverage, mcdc, validation, track-c, riscv]
     links:


### PR DESCRIPTION
## What

Behavior-frozen, doc-only update to the rivet-traced #242 roadmap (`artifacts/verified-codegen-roadmap.yaml`). VCR-ORACLE-001's running log was **stale** — it ended at "#490 blocks the non-leaf prologue lever / the lever stays unmerged until #490 lands", but both that fix and a companion control-flow fix have since landed. This records the resolution and the broader frontier the work surfaced, so the roadmap reflects reality and prioritizes the next gated step.

## Appended to VCR-ORACLE-001

- **#490 LANDED** (PR #495): optimized path now wraps a body touching r4-r8 in `push {r4-r8,lr}`/`pop {r4-r8,pc}`, decided on the post-realloc body (no spurious push; >4-param fns decline to the direct selector so incoming stack-arg offsets are untouched), CI oracle `callee_saved_490_differential.py`. The non-leaf prologue lever it blocked is now unblocked.
- **#483 LANDED** (PR #497): forward `block`+`br_if` mid-instruction landing — `End` labelled with its own id not the closed block's, plus `Strh`/`Strb`/`Ldrh`/… sized 2 vs the 4-byte `.w` the high-base optimized path emits; CI oracle `block_brif_483_differential.py`.
- The multi-modal control-flow **sweep** established these are one cluster of optimizer_bridge control-flow/ABI defects — concrete measured evidence for VCR-SEL-001's "collapse the two/three-selector accretion" motivation — and the next gated frontier: **#500** (br_if still unresolved for if/else + sequential blocks), **#499** (spill frame not deallocated under control flow; #490's pop epilogue made the SP leak fatal — #215-class), **#498** (size estimator incomplete for `Cmp`/`Cmn`/`Adds`/`Subs`/`Popcnt`), **#496** (register-exhausting folds silently miscompiled). All separate gated steps; none in shipped firmware (gale ships `--relocatable`/direct).

## Verification

- `rivet validate` profile **unchanged** vs baseline (49 errors / 75 warnings / 0 broken cross-refs — all pre-existing xref/coverage gaps; **NON_XREF = 0**, the CI gate's pass condition); `rivet coverage` exit 0.
- No code changed — frozen byte gate / differentials unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)