### PR TITLE
chore(release): v0.16.0 — AAPCS stack-arg path lowers >8 scalar params/args (#503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-26
+
+**AAPCS stack-argument path: functions with >8 scalar i32 params/args now lower
+(#503).** The arm direct selector (`select_with_stack`, the shipped `--relocatable`
+path) used to **skip** — emit no code for — any function whose signature needs the
+AAPCS stack-argument path beyond a conservative cap: more than 8 scalar params, or
+a call passing more than 8 args. On the falcon flight component this dropped 3
+reachable helpers (a 10-param, a 25-param, and a 64-bit case) from the ELF, a
+completeness gap on the road to self-contained firmware.
+
+The incoming-param homing (`compute_local_layout` → `incoming_params`, offset
+`frame_size+24+(k-4)*4`) and the outgoing store (`emit_stack_args`, offset
+`(k-4)*4`) were already **generic in the index** — the `> 8` refusals were
+conservative, not load-bearing. This release lifts them and leans on the existing
+12-bit `[sp,#imm]` guards as the real Ok-or-Err backstop (a genuinely
+frame-too-large function still skips cleanly, never a silent miscompile). Functions
+with ≤8 i32 params/args never reach the lifted path, so existing output is
+**bit-identical** (frozen byte gate unchanged: control_step `0x00210A55`,
+flight_algo `0x07FDF307`).
+
+Scope: the **>8-scalar-i32** case only. The 64-bit stack-param case (AAPCS
+pair-alignment + back-fill) stays refused and is tracked as the #503 follow-up;
+its diagnostic now cites #503, not the closed #359. Validated by a new
+execution differential (`stack-args-503-oracle`): sum10, sum25 (reading param 24),
+a 10-arg outgoing call, and a combined incoming+outgoing function all run
+bit-identically to wasmtime under unicorn.
+
 ## [0.15.1] - 2026-06-24
 
 **Bug-fix: local promotion must never CAUSE a compile failure (#474).** v0.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,14 +2023,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2079,11 +2079,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.15.1"
+version = "0.16.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2136,14 +2136,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2151,11 +2151,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.15.1"
+version = "0.16.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.15.1"
+version = "0.16.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.15.1",
+    version = "0.16.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.15.1" }
+synth-core = { path = "../synth-core", version = "0.16.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.15.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.15.1" }
+synth-core = { path = "../synth-core", version = "0.16.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.16.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.15.1" }
+synth-core = { path = "../synth-core", version = "0.16.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.15.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.15.1", optional = true }
+synth-core = { path = "../synth-core", version = "0.16.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.16.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.15.1" }
-synth-frontend = { path = "../synth-frontend", version = "0.15.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.15.1" }
-synth-backend = { path = "../synth-backend", version = "0.15.1" }
+synth-core = { path = "../synth-core", version = "0.16.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.16.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.16.0" }
+synth-backend = { path = "../synth-backend", version = "0.16.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.15.1", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.15.1", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.15.1", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.16.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.16.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.16.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.15.1", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.16.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.15.1" }
+synth-core = { path = "../synth-core", version = "0.16.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.15.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.16.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.15.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.15.1" }
-synth-opt = { path = "../synth-opt", version = "0.15.1" }
+synth-core = { path = "../synth-core", version = "0.16.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.16.0" }
+synth-opt = { path = "../synth-opt", version = "0.16.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.15.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.15.1" }
-synth-opt = { path = "../synth-opt", version = "0.15.1" }
+synth-core = { path = "../synth-core", version = "0.16.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.16.0" }
+synth-opt = { path = "../synth-opt", version = "0.16.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.15.1", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.16.0", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Release **v0.16.0**. Pin sweep `0.15.1 → 0.16.0` ([workspace.package] + every path-dep pin + MODULE.bazel), Cargo.lock refreshed, CHANGELOG entry.

**Minor bump** — adds lowering capability: the arm backend now compiles functions needing the AAPCS stack-argument path with >8 scalar i32 params or a call passing >8 args ([#503], merged in #504), a class it previously **skipped**. Unblocks 2 of 3 falcon helpers (func_57 10-param, func_58 25-param). The 64-bit stack-param case stays refused (#503 follow-up).

**Bit-identical for existing code** — functions with ≤8 i32 params/args never reach the lifted path; frozen byte gate unchanged (control_step `0x00210A55`, flight_algo `0x07FDF307`).

Gated by `stack-args-503-oracle` (sum10/sum25/outgoing/combined, all vs wasmtime). All oracles + frozen gate green on main at the merge commit.

[#503]: https://github.com/pulseengine/synth/issues/503

🤖 Generated with [Claude Code](https://claude.com/claude-code)