### PR TITLE
chore(deps): bump scry-sai-core dev-dep to 2.0 (SCPV v3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-core"
-version = "1.17.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d824fd34eb63f03c03a18bbee0b6ee09ac583cf59d8481b7c09d28dd101f46"
+checksum = "e882493438a4122673c1fceb1fdce01b3a733b13877846aad711ec413b23942c"
 dependencies = [
  "scry-sai-interval",
  "scry-sai-octagon",
@@ -1813,27 +1813,27 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "1.17.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baef3023bc5abc4945c913e182365c8b11f8111bafa5f4c56a111c096f1c1878"
+checksum = "8b562abdc282c200e4f6156dbce23c2584583053cae87fbb675b8849dcc598b4"
 
 [[package]]
 name = "scry-sai-octagon"
-version = "1.17.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c356dbe7e3530302b8a026792a607f22d98f65adb4e64578f4739f65e3ae313f"
+checksum = "dae25bf8d4f477f72fb677ea61f1aabdf1eee1d6d51b85c8608f97f0e3d3577d"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "1.17.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4495ebc8027410e5f7f24d39a56a6481b9c9391bfdc0dcec14b293bc2f4aec"
+checksum = "bde769346d666d8a3ddd7e61212cf31e81da54ca37efa1a20176fe3ce2072dac"
 
 [[package]]
 name = "scry-sai-taint"
-version = "1.17.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ba3e6516132a377e463421c5fa6e23e5b152bf4fad05fae12ea2b826573a93"
+checksum = "cfaf402dc38b06582d30db8088b16ce8db18814ce7742b2d7061e8103c197e7d"
 
 [[package]]
 name = "semver"

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -69,4 +69,8 @@ gimli = { version = "0.33", default-features = false, features = ["read", "std"]
 # binary does not pull scry until the gated consumption step (the .bss shrink /
 # prologue elision) lands. Test-only ⇒ Bazel (which globs src/ only) never sees
 # it, so no MODULE.bazel pin is needed yet. See scry#51.
-scry-sai-core = "1.12"
+# Tracks scry 2.x (SCPV v3): the major bump reshaped the provenance wire format,
+# but synth's consumed surface (call_graph / function_summaries / stack_usage /
+# reachable_from_exports / operand_stack) is unchanged and additive-only, so the
+# bump is transparent here. See scry#63 / scry v2.0.0.
+scry-sai-core = "2.0"


### PR DESCRIPTION
scry shipped a breaking **v2.0.0** (provenance wire format reshaped to binary-canonical SCPV v3, scry#63). synth-cli pins `scry-sai-core` **only as a dev-dependency** (the shadow-stack-budget test; the production binary doesn't link it until the gated VCR-MEM-001 consumption step, #383).

The scry release notes explicitly confirm — and this PR verifies — that synth's consumed surface (`call_graph` / `function_summaries` / `stack_usage` / `reachable_from_exports` / `operand_stack`) is **unchanged and additive-only**, so 2.0 is a transparent bump:

- `scry-sai-core` 2.0.0 + synth-cli (binary + tests) build green.
- `scry_shadow_stack_budget` test passes.
- **Frozen byte gate bit-identical** (scry is not on the codegen path).

Keeps the dev-dep aligned with the released major so the eventual provenance consumption targets SCPV v3, not the v1 binary format that never connected. No MODULE.bazel change (Bazel globs `src/` only; the dev-dep is test-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)