### PR TITLE
test(vcr-oracle): estimator↔encoder agreement oracle for the optimized path (#498, #242)

### DIFF
--- a/crates/synth-backend/tests/estimator_encoder_agreement.rs
+++ b/crates/synth-backend/tests/estimator_encoder_agreement.rs
@@ -1,0 +1,1105 @@
+//! #498 / #242 (VCR-ORACLE-001) — estimator↔encoder agreement oracle.
+//!
+//! The optimized ARM path (`synth_synthesis::optimizer_bridge::ir_to_arm`)
+//! resolves branch displacements by summing a hand-maintained *byte-size
+//! estimator* (`estimate_arm_byte_size`) over the instruction stream. That
+//! estimator is a mirror of the Thumb-2 encoder
+//! (`synth_backend::ArmEncoder::encode`), kept by hand only because
+//! synth-synthesis cannot depend on synth-backend (the encoder lives
+//! downstream) — the structural cause behind #498. When the mirror drifts from
+//! the encoder, a forward branch spanning the drifting op lands at the wrong
+//! byte: under-estimate → short (the #483-class miscompile), over-estimate →
+//! long.
+//!
+//! This crate sits downstream of synth-synthesis and so can see BOTH the
+//! estimator and the real encoder. This oracle pins one against the other for
+//! every op the optimized path emits, at the operand shapes it emits them in.
+//!
+//! ## Scope — this is a gap-documenting REGRESSION GUARD, not a #498 fix.
+//!
+//! Several estimator entries diverge from the encoder today; this test does not
+//! correct them (that is byte-changing codegen, a separately-gated step — it
+//! shifts every branch displacement on the optimized path and must be re-frozen,
+//! execution-differentialed, and silicon-checked). Instead it freezes the
+//! divergence as a measured `KNOWN_GAP`, so:
+//!
+//! - a NEW estimator drift (an added op left at the `_ => 2` default, or a
+//!   changed encoding) fails the agreement assertion loudly, and
+//! - a future #498 fix that closes a gap fails the `assert_ne!` "still
+//!   diverges" check, forcing the gap to be removed from the list.
+//!
+//! ## Findings recorded here (correct + extend #498's original report)
+//! - #498 claimed `Cmp` high-reg drifts. It does NOT: the 16-bit CMP (T2,
+//!   `0x45xx`) encodes high registers, so `cmp r10, r8` is 2 bytes and the
+//!   estimator's default is right. The real high-reg drifts are `Cmn`/`Adds`/
+//!   `Subs` (no 16-bit high-reg form / flag-setting) → 4 bytes, est 2.
+//! - `Popcnt` is absent from the estimator entirely → `_ => 2`, but the
+//!   encoder expands it to a 21-instruction sequence = 86 bytes. An 84-byte
+//!   hole — the largest single drift.
+//! - The i64 long-sequence estimates `I64DivU/RemU/DivS/RemS`, `I64Popcnt`
+//!   and `I64Extend32S` OVER-estimate (e.g. DivU est 100 vs 74) — branch
+//!   lands long.
+//! - Far branches (`BOffset`/`BCondOffset` with a large displacement) need
+//!   the 4-byte `.w` form but the estimator (which runs BEFORE displacements
+//!   are known, with a 0-offset placeholder) sizes them 2 — a chicken-and-egg
+//!   the single-pass estimator cannot resolve.
+//! - `Mov` with a small NEGATIVE immediate: estimator sizes 4 (prudent), but
+//!   the encoder's `if *imm <= 255` is a *signed* test and emits a 2-byte
+//!   `MOVS Rd, #(imm & 0xFF)` — a wrong-value 0xFF, a latent ENCODER bug for
+//!   negative imm8, surfaced here as a side effect. Tracked separately.
+
+use synth_backend::ArmEncoder;
+use synth_synthesis::{ArmOp, Condition, MemAddr, Operand2, Reg, estimate_arm_byte_size};
+
+/// A documented divergence: the optimized-path estimator and the encoder
+/// disagree on this op's size today. Pinned to the exact measured pair so a
+/// regression (new drift) or a fix (gap closed) both trip the oracle.
+struct Gap {
+    est: usize,
+    enc: usize,
+    /// Why it diverges and which direction the branch lands.
+    _reason: &'static str,
+}
+
+fn mem(base: Reg) -> MemAddr {
+    MemAddr {
+        base,
+        offset: 0,
+        offset_reg: None,
+    }
+}
+
+/// One oracle case: a representative instruction at an operand shape the
+/// optimized path actually emits, and whether agreement is expected (`None`) or
+/// a documented `KNOWN_GAP` (`Some`).
+struct Case {
+    label: &'static str,
+    op: ArmOp,
+    gap: Option<Gap>,
+}
+
+fn agree(label: &'static str, op: ArmOp) -> Case {
+    Case {
+        label,
+        op,
+        gap: None,
+    }
+}
+
+fn gap(label: &'static str, op: ArmOp, est: usize, enc: usize, reason: &'static str) -> Case {
+    Case {
+        label,
+        op,
+        gap: Some(Gap {
+            est,
+            enc,
+            _reason: reason,
+        }),
+    }
+}
+
+/// The agreement cases. Operand shapes mirror what `ir_to_arm` emits: sub-word
+/// memory ops use a HIGH base (`r11`/`ip`, the #483 invariant), data-processing
+/// ops appear in both low- and high-reg forms, branches in near and far forms.
+fn cases() -> Vec<Case> {
+    use ArmOp::*;
+    let r0 = Reg::R0;
+    vec![
+        // --- data-processing, agreement (low-reg + always-32-bit forms) ---
+        agree(
+            "Add_lo",
+            Add {
+                rd: r0,
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            },
+        ),
+        agree(
+            "Add_hi",
+            Add {
+                rd: Reg::R10,
+                rn: Reg::R10,
+                op2: Operand2::Reg(Reg::R8),
+            },
+        ),
+        agree(
+            "Sub_lo",
+            Sub {
+                rd: r0,
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            },
+        ),
+        agree(
+            "Sub_hi",
+            Sub {
+                rd: Reg::R10,
+                rn: Reg::R10,
+                op2: Operand2::Reg(Reg::R8),
+            },
+        ),
+        agree(
+            "Adds_lo",
+            Adds {
+                rd: r0,
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            },
+        ),
+        agree(
+            "Subs_lo",
+            Subs {
+                rd: r0,
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            },
+        ),
+        agree(
+            "Adc",
+            Adc {
+                rd: r0,
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            },
+        ),
+        agree(
+            "Sbc",
+            Sbc {
+                rd: r0,
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            },
+        ),
+        agree(
+            "And",
+            And {
+                rd: r0,
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            },
+        ),
+        agree(
+            "Orr",
+            Orr {
+                rd: r0,
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            },
+        ),
+        agree(
+            "Eor",
+            Eor {
+                rd: r0,
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            },
+        ),
+        agree(
+            "Mul",
+            Mul {
+                rd: r0,
+                rn: Reg::R1,
+                rm: Reg::R2,
+            },
+        ),
+        agree(
+            "Mls",
+            Mls {
+                rd: r0,
+                rn: Reg::R1,
+                rm: Reg::R2,
+                ra: Reg::R3,
+            },
+        ),
+        agree(
+            "Sdiv",
+            Sdiv {
+                rd: r0,
+                rn: Reg::R1,
+                rm: Reg::R2,
+            },
+        ),
+        agree(
+            "Udiv",
+            Udiv {
+                rd: r0,
+                rn: Reg::R1,
+                rm: Reg::R2,
+            },
+        ),
+        agree(
+            "Rsb",
+            Rsb {
+                rd: r0,
+                rn: Reg::R1,
+                imm: 32,
+            },
+        ),
+        agree(
+            "AsrReg",
+            AsrReg {
+                rd: r0,
+                rn: Reg::R1,
+                rm: Reg::R2,
+            },
+        ),
+        agree(
+            "LslReg",
+            LslReg {
+                rd: r0,
+                rn: Reg::R1,
+                rm: Reg::R2,
+            },
+        ),
+        agree(
+            "LsrReg",
+            LsrReg {
+                rd: r0,
+                rn: Reg::R1,
+                rm: Reg::R2,
+            },
+        ),
+        agree(
+            "RorReg",
+            RorReg {
+                rd: r0,
+                rn: Reg::R1,
+                rm: Reg::R2,
+            },
+        ),
+        agree(
+            "Clz",
+            Clz {
+                rd: r0,
+                rm: Reg::R1,
+            },
+        ),
+        agree(
+            "Rbit",
+            Rbit {
+                rd: r0,
+                rm: Reg::R1,
+            },
+        ),
+        agree(
+            "Sxtb_lo",
+            Sxtb {
+                rd: r0,
+                rm: Reg::R1,
+            },
+        ),
+        agree(
+            "Sxtb_hi",
+            Sxtb {
+                rd: Reg::R9,
+                rm: Reg::R10,
+            },
+        ),
+        agree(
+            "Sxth_lo",
+            Sxth {
+                rd: r0,
+                rm: Reg::R1,
+            },
+        ),
+        agree(
+            "Uxtb_lo",
+            Uxtb {
+                rd: r0,
+                rm: Reg::R1,
+            },
+        ),
+        agree(
+            "Uxth_lo",
+            Uxth {
+                rd: r0,
+                rm: Reg::R1,
+            },
+        ),
+        // --- moves ---
+        agree(
+            "Mov_lo_imm",
+            Mov {
+                rd: r0,
+                op2: Operand2::Imm(5),
+            },
+        ),
+        agree(
+            "Mov_hi",
+            Mov {
+                rd: Reg::R10,
+                op2: Operand2::Imm(5),
+            },
+        ),
+        agree(
+            "Mov_imm_big",
+            Mov {
+                rd: r0,
+                op2: Operand2::Imm(300),
+            },
+        ),
+        agree(
+            "Mov_reg",
+            Mov {
+                rd: r0,
+                op2: Operand2::Reg(Reg::R1),
+            },
+        ),
+        agree(
+            "Movw",
+            Movw {
+                rd: r0,
+                imm16: 0x1234,
+            },
+        ),
+        agree(
+            "Movt",
+            Movt {
+                rd: r0,
+                imm16: 0x1234,
+            },
+        ),
+        // --- compares ---
+        agree(
+            "Cmp_lo",
+            Cmp {
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            },
+        ),
+        agree(
+            "Cmp_hi",
+            Cmp {
+                rn: Reg::R10,
+                op2: Operand2::Reg(Reg::R8),
+            },
+        ),
+        agree(
+            "Cmp_imm",
+            Cmp {
+                rn: Reg::R1,
+                op2: Operand2::Imm(5),
+            },
+        ),
+        agree(
+            "Cmn_lo",
+            Cmn {
+                rn: Reg::R1,
+                op2: Operand2::Reg(Reg::R2),
+            },
+        ),
+        // --- loads/stores: word (offset/base shapes) + sub-word (HIGH base) ---
+        agree(
+            "Ldr_lo",
+            Ldr {
+                rd: r0,
+                addr: mem(Reg::R1),
+            },
+        ),
+        agree(
+            "Ldr_hibase",
+            Ldr {
+                rd: r0,
+                addr: mem(Reg::R11),
+            },
+        ),
+        agree(
+            "Ldr_offbig",
+            Ldr {
+                rd: r0,
+                addr: MemAddr {
+                    base: Reg::R1,
+                    offset: 200,
+                    offset_reg: None,
+                },
+            },
+        ),
+        agree(
+            "Str_lo",
+            Str {
+                rd: r0,
+                addr: mem(Reg::R1),
+            },
+        ),
+        agree(
+            "Str_hibase",
+            Str {
+                rd: r0,
+                addr: mem(Reg::R11),
+            },
+        ),
+        agree(
+            "Ldrb_hi",
+            Ldrb {
+                rd: r0,
+                addr: mem(Reg::R11),
+            },
+        ),
+        agree(
+            "Ldrh_hi",
+            Ldrh {
+                rd: r0,
+                addr: mem(Reg::R11),
+            },
+        ),
+        agree(
+            "Ldrsb_hi",
+            Ldrsb {
+                rd: r0,
+                addr: mem(Reg::R11),
+            },
+        ),
+        agree(
+            "Ldrsh_hi",
+            Ldrsh {
+                rd: r0,
+                addr: mem(Reg::R11),
+            },
+        ),
+        agree(
+            "Strb_hi",
+            Strb {
+                rd: r0,
+                addr: mem(Reg::R11),
+            },
+        ),
+        agree(
+            "Strh_hi",
+            Strh {
+                rd: r0,
+                addr: mem(Reg::R11),
+            },
+        ),
+        // --- branches/control + select ---
+        agree("BOffset_near", BOffset { offset: 4 }),
+        agree(
+            "BCondOffset_near",
+            BCondOffset {
+                cond: Condition::EQ,
+                offset: 4,
+            },
+        ),
+        agree("Bx", Bx { rm: Reg::LR }),
+        agree(
+            "Bl",
+            Bl {
+                label: "f".to_string(),
+            },
+        ),
+        agree("Udf", Udf { imm: 0 }),
+        agree(
+            "SetCond",
+            SetCond {
+                rd: r0,
+                cond: Condition::EQ,
+            },
+        ),
+        agree(
+            "SelectMove",
+            SelectMove {
+                rd: r0,
+                rm: Reg::R1,
+                cond: Condition::EQ,
+            },
+        ),
+        // --- i64 long sequences that the estimator sizes EXACTLY ---
+        agree(
+            "I64SetCond",
+            I64SetCond {
+                rd: r0,
+                rn_lo: Reg::R1,
+                rn_hi: Reg::R2,
+                rm_lo: Reg::R3,
+                rm_hi: Reg::R4,
+                cond: Condition::EQ,
+            },
+        ),
+        agree(
+            "I64SetCondZ",
+            I64SetCondZ {
+                rd: r0,
+                rn_lo: Reg::R1,
+                rn_hi: Reg::R2,
+            },
+        ),
+        agree(
+            "I64Mul",
+            I64Mul {
+                rd_lo: r0,
+                rd_hi: Reg::R1,
+                rn_lo: Reg::R2,
+                rn_hi: Reg::R3,
+                rm_lo: Reg::R4,
+                rm_hi: Reg::R5,
+            },
+        ),
+        agree(
+            "I64Shl",
+            I64Shl {
+                rd_lo: r0,
+                rd_hi: Reg::R1,
+                rn_lo: Reg::R2,
+                rn_hi: Reg::R3,
+                rm_lo: Reg::R4,
+                rm_hi: Reg::R5,
+            },
+        ),
+        agree(
+            "I64ShrU",
+            I64ShrU {
+                rd_lo: r0,
+                rd_hi: Reg::R1,
+                rn_lo: Reg::R2,
+                rn_hi: Reg::R3,
+                rm_lo: Reg::R4,
+                rm_hi: Reg::R5,
+            },
+        ),
+        agree(
+            "I64ShrS",
+            I64ShrS {
+                rd_lo: r0,
+                rd_hi: Reg::R1,
+                rn_lo: Reg::R2,
+                rn_hi: Reg::R3,
+                rm_lo: Reg::R4,
+                rm_hi: Reg::R5,
+            },
+        ),
+        agree(
+            "I64Rotl",
+            I64Rotl {
+                rdlo: r0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+                rnhi: Reg::R3,
+                shift: Reg::R4,
+            },
+        ),
+        agree(
+            "I64Rotr",
+            I64Rotr {
+                rdlo: r0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+                rnhi: Reg::R3,
+                shift: Reg::R4,
+            },
+        ),
+        agree(
+            "I64Clz",
+            I64Clz {
+                rd: r0,
+                rnlo: Reg::R1,
+                rnhi: Reg::R2,
+            },
+        ),
+        agree(
+            "I64Ctz",
+            I64Ctz {
+                rd: r0,
+                rnlo: Reg::R1,
+                rnhi: Reg::R2,
+            },
+        ),
+        agree(
+            "I64Extend8S",
+            I64Extend8S {
+                rdlo: r0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+            },
+        ),
+        agree(
+            "I64Extend16S",
+            I64Extend16S {
+                rdlo: r0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+            },
+        ),
+        // ============================ KNOWN GAPS ============================
+        // High-reg flag-setting / no-16-bit-form ops: estimator default 2, but
+        // the encoder must use the 32-bit `.w` form (4 bytes). The #498 core.
+        gap(
+            "Cmn_hi",
+            Cmn {
+                rn: Reg::R10,
+                op2: Operand2::Reg(Reg::R8),
+            },
+            2,
+            4,
+            "CMN has no 16-bit high-reg form → CMN.W (4); estimator _=>2. Under-estimate.",
+        ),
+        gap(
+            "Adds_hi",
+            Adds {
+                rd: Reg::R10,
+                rn: Reg::R10,
+                op2: Operand2::Reg(Reg::R8),
+            },
+            2,
+            4,
+            "flag-setting ADDS high-reg → ADDS.W (4); estimator _=>2. Under-estimate.",
+        ),
+        gap(
+            "Subs_hi",
+            Subs {
+                rd: Reg::R10,
+                rn: Reg::R10,
+                op2: Operand2::Reg(Reg::R8),
+            },
+            2,
+            4,
+            "flag-setting SUBS high-reg → SUBS.W (4); estimator _=>2. Under-estimate.",
+        ),
+        // Popcnt: absent from the estimator entirely; encoder expands it.
+        gap(
+            "Popcnt",
+            Popcnt {
+                rd: Reg::R0,
+                rm: Reg::R1,
+            },
+            2,
+            86,
+            "Popcnt absent from estimator (_=>2); encoder emits a 21-insn sequence (86). 84-byte under-estimate.",
+        ),
+        // i64 long sequences whose hand-counted estimate is too large.
+        gap(
+            "I64Popcnt",
+            I64Popcnt {
+                rd: Reg::R0,
+                rnlo: Reg::R1,
+                rnhi: Reg::R2,
+            },
+            200,
+            172,
+            "estimate 200 (~180 guess) vs real 172. Over-estimate.",
+        ),
+        gap(
+            "I64Extend32S",
+            I64Extend32S {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+            },
+            8,
+            6,
+            "estimate 8 vs real 6 (MOV + ASR). Over-estimate.",
+        ),
+        gap(
+            "I64DivU",
+            I64DivU {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+                rnhi: Reg::R3,
+                rmlo: Reg::R4,
+                rmhi: Reg::R5,
+            },
+            100,
+            74,
+            "estimate 100 (~80-150 guess) vs real 74. Over-estimate.",
+        ),
+        gap(
+            "I64RemU",
+            I64RemU {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+                rnhi: Reg::R3,
+                rmlo: Reg::R4,
+                rmhi: Reg::R5,
+            },
+            100,
+            78,
+            "estimate 100 vs real 78. Over-estimate.",
+        ),
+        gap(
+            "I64DivS",
+            I64DivS {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+                rnhi: Reg::R3,
+                rmlo: Reg::R4,
+                rmhi: Reg::R5,
+            },
+            150,
+            126,
+            "estimate 150 vs real 126. Over-estimate.",
+        ),
+        gap(
+            "I64RemS",
+            I64RemS {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+                rnhi: Reg::R3,
+                rmlo: Reg::R4,
+                rmhi: Reg::R5,
+            },
+            150,
+            124,
+            "estimate 150 vs real 124. Over-estimate.",
+        ),
+        // Far branches: the estimator sizes the 0-offset placeholder (it runs
+        // before displacements are resolved) as 2, but a far target needs the
+        // 4-byte form. Chicken-and-egg in the single-pass estimator.
+        gap(
+            "BOffset_far",
+            BOffset { offset: 5000 },
+            2,
+            4,
+            "far B needs T4 (4); estimator _=>2 on the pre-resolution placeholder. Under-estimate.",
+        ),
+        gap(
+            "BCondOffset_far",
+            BCondOffset {
+                cond: Condition::EQ,
+                offset: 5000,
+            },
+            2,
+            4,
+            "far Bcc needs T3 (4); estimator _=>2 on the pre-resolution placeholder. Under-estimate.",
+        ),
+        // Negative small immediate: estimator prudently sizes 4; the encoder's
+        // signed `imm <= 255` test wrongly emits a 2-byte MOVS #(imm&0xFF).
+        // Latent ENCODER bug (wrong value), surfaced here. Tracked separately.
+        gap(
+            "Mov_imm_neg",
+            Mov {
+                rd: Reg::R0,
+                op2: Operand2::Imm(-1),
+            },
+            4,
+            2,
+            "estimator 4 (prudent); encoder emits wrong-value 2-byte MOVS #0xFF (signed imm<=255 bug).",
+        ),
+    ]
+}
+
+/// Every `ArmOp` variant, classified as emitted by the optimized path
+/// (`OnPath`) or not (`OffPath`). NO wildcard: a newly-added `ArmOp` variant
+/// will fail to compile here until it is *consciously classified* — the
+/// tripwire that puts a new op in front of a human instead of letting it default
+/// to the estimator's `_ => 2`.
+///
+/// What this guarantees and what it does NOT:
+/// - It DOES force every new `ArmOp` variant to be classified OnPath/OffPath.
+/// - It does NOT force an agreement case: a variant classified `OnPath` with
+///   nothing added to `cases()` still passes vacuously. Adding the OnPath
+///   variant's agreement case is a *manual* step this match cannot enforce
+///   (closing that would mean restructuring so the per-variant match itself
+///   returns the sample + expectation — out of scope here).
+/// - It cannot catch an existing `OffPath` op later being wired into
+///   `ir_to_arm` (the classification is a hand-asserted claim).
+///
+/// So: a compile-time prompt to classify, not a proof of coverage.
+#[derive(PartialEq, Debug)]
+enum Coverage {
+    OnPath,
+    OffPath,
+}
+
+fn coverage(op: &ArmOp) -> Coverage {
+    use ArmOp::*;
+    use Coverage::*;
+    match op {
+        // Emitted by ir_to_arm into arm_instrs (flows through byte_offsets).
+        Add { .. }
+        | Sub { .. }
+        | Adds { .. }
+        | Subs { .. }
+        | Adc { .. }
+        | Sbc { .. }
+        | Mul { .. }
+        | Mls { .. }
+        | Sdiv { .. }
+        | Udiv { .. }
+        | And { .. }
+        | Orr { .. }
+        | Eor { .. }
+        | Asr { .. }
+        | AsrReg { .. }
+        | LslReg { .. }
+        | LsrReg { .. }
+        | RorReg { .. }
+        | Rsb { .. }
+        | Clz { .. }
+        | Rbit { .. }
+        | Popcnt { .. }
+        | Sxtb { .. }
+        | Sxth { .. }
+        | Uxtb { .. }
+        | Uxth { .. }
+        | Mov { .. }
+        | Movw { .. }
+        | Movt { .. }
+        | Cmp { .. }
+        | Cmn { .. }
+        | Ldr { .. }
+        | Str { .. }
+        | Ldrb { .. }
+        | Ldrh { .. }
+        | Ldrsb { .. }
+        | Ldrsh { .. }
+        | Strb { .. }
+        | Strh { .. }
+        | BOffset { .. }
+        | BCondOffset { .. }
+        | Bx { .. }
+        | Bl { .. }
+        | Udf { .. }
+        | SetCond { .. }
+        | SelectMove { .. }
+        | I64SetCond { .. }
+        | I64SetCondZ { .. }
+        | I64Mul { .. }
+        | I64Shl { .. }
+        | I64ShrU { .. }
+        | I64ShrS { .. }
+        | I64Rotl { .. }
+        | I64Rotr { .. }
+        | I64Clz { .. }
+        | I64Ctz { .. }
+        | I64Popcnt { .. }
+        | I64Extend8S { .. }
+        | I64Extend16S { .. }
+        | I64Extend32S { .. }
+        | I64DivU { .. }
+        | I64RemU { .. }
+        | I64DivS { .. }
+        | I64RemS { .. } => OnPath,
+
+        // NOT emitted by ir_to_arm:
+        //  - imm shifts / Mvn / Umull / Mla: direct-selector-only (#209/#257) or
+        //    folded by peephole; not produced by the optimized lowering.
+        //  - sym-loads (--native-pointer-abi), Memory*, Push/Pop (inserted
+        //    post-resolution), Label/Nop/B/Bcc/Bhs/Blo/Blx (path uses the
+        //    resolved BOffset/BCondOffset forms), pseudo Local*/Global*/Select/
+        //    Call*/BrTable (lowered to primitives upstream).
+        //  - i64 BINOPS (Add/Sub/And/Or/Xor/Eq..GeU/Const/Ldr/Str/ExtendI32*/
+        //    I32WrapI64): lowered to 32-bit op pairs upstream, never appear as
+        //    I64* in arm_instrs (which is why the estimator lists only the
+        //    SURVIVING i64 ops above).
+        //  - all F32*/F64* scalar VFP (dropped at the decoder today, #369) and
+        //    all Mve* vector ops (not on the scalar integer path).
+        Lsl { .. }
+        | Lsr { .. }
+        | Ror { .. }
+        | Mvn { .. }
+        | Umull { .. }
+        | Mla { .. }
+        | MovwSym { .. }
+        | MovtSym { .. }
+        | LdrSym { .. }
+        | MemorySize { .. }
+        | MemoryGrow { .. }
+        | Label { .. }
+        | Nop
+        | Push { .. }
+        | Pop { .. }
+        | B { .. }
+        | Bcc { .. }
+        | Bhs { .. }
+        | Blo { .. }
+        | Blx { .. }
+        | Select { .. }
+        | LocalGet { .. }
+        | LocalSet { .. }
+        | LocalTee { .. }
+        | GlobalGet { .. }
+        | GlobalSet { .. }
+        | Call { .. }
+        | CallIndirect { .. }
+        | BrTable { .. }
+        | I64Add { .. }
+        | I64Sub { .. }
+        | I64And { .. }
+        | I64Or { .. }
+        | I64Xor { .. }
+        | I64Eqz { .. }
+        | I64Eq { .. }
+        | I64Ne { .. }
+        | I64LtS { .. }
+        | I64LtU { .. }
+        | I64LeS { .. }
+        | I64LeU { .. }
+        | I64GtS { .. }
+        | I64GtU { .. }
+        | I64GeS { .. }
+        | I64GeU { .. }
+        | I64Const { .. }
+        | I64Ldr { .. }
+        | I64Str { .. }
+        | I64ExtendI32S { .. }
+        | I64ExtendI32U { .. }
+        | I32WrapI64 { .. }
+        | F32Add { .. }
+        | F32Sub { .. }
+        | F32Mul { .. }
+        | F32Div { .. }
+        | F32Abs { .. }
+        | F32Neg { .. }
+        | F32Sqrt { .. }
+        | F32Ceil { .. }
+        | F32Floor { .. }
+        | F32Trunc { .. }
+        | F32Nearest { .. }
+        | F32Min { .. }
+        | F32Max { .. }
+        | F32Copysign { .. }
+        | F32Eq { .. }
+        | F32Ne { .. }
+        | F32Lt { .. }
+        | F32Le { .. }
+        | F32Gt { .. }
+        | F32Ge { .. }
+        | F32Const { .. }
+        | F32Load { .. }
+        | F32Store { .. }
+        | F32ConvertI32S { .. }
+        | F32ConvertI32U { .. }
+        | F32ConvertI64S { .. }
+        | F32ConvertI64U { .. }
+        | F32ReinterpretI32 { .. }
+        | I32ReinterpretF32 { .. }
+        | I32TruncF32S { .. }
+        | I32TruncF32U { .. }
+        | F64Add { .. }
+        | F64Sub { .. }
+        | F64Mul { .. }
+        | F64Div { .. }
+        | F64Abs { .. }
+        | F64Neg { .. }
+        | F64Sqrt { .. }
+        | F64Ceil { .. }
+        | F64Floor { .. }
+        | F64Trunc { .. }
+        | F64Nearest { .. }
+        | F64Min { .. }
+        | F64Max { .. }
+        | F64Copysign { .. }
+        | F64Eq { .. }
+        | F64Ne { .. }
+        | F64Lt { .. }
+        | F64Le { .. }
+        | F64Gt { .. }
+        | F64Ge { .. }
+        | F64Const { .. }
+        | F64Load { .. }
+        | F64Store { .. }
+        | F64ConvertI32S { .. }
+        | F64ConvertI32U { .. }
+        | F64ConvertI64S { .. }
+        | F64ConvertI64U { .. }
+        | F64PromoteF32 { .. }
+        | F64ReinterpretI64 { .. }
+        | I64ReinterpretF64 { .. }
+        | I64TruncF64S { .. }
+        | I64TruncF64U { .. }
+        | I32TruncF64S { .. }
+        | I32TruncF64U { .. }
+        | MveLoad { .. }
+        | MveStore { .. }
+        | MveConst { .. }
+        | MveAnd { .. }
+        | MveOrr { .. }
+        | MveEor { .. }
+        | MveMvn { .. }
+        | MveBic { .. }
+        | MveAddI { .. }
+        | MveSubI { .. }
+        | MveMulI { .. }
+        | MveNegI { .. }
+        | MveCmpEqI { .. }
+        | MveCmpNeI { .. }
+        | MveCmpLtS { .. }
+        | MveCmpLtU { .. }
+        | MveCmpGtS { .. }
+        | MveCmpGtU { .. }
+        | MveCmpLeS { .. }
+        | MveCmpLeU { .. }
+        | MveCmpGeS { .. }
+        | MveCmpGeU { .. }
+        | MveDup { .. }
+        | MveExtractLane { .. }
+        | MveInsertLane { .. }
+        | MveAddF32 { .. }
+        | MveSubF32 { .. }
+        | MveMulF32 { .. }
+        | MveNegF32 { .. }
+        | MveAbsF32 { .. }
+        | MveCmpEqF32 { .. }
+        | MveCmpNeF32 { .. }
+        | MveCmpLtF32 { .. }
+        | MveCmpLeF32 { .. }
+        | MveCmpGtF32 { .. }
+        | MveCmpGeF32 { .. }
+        | MveDupF32 { .. }
+        | MveExtractLaneF32 { .. }
+        | MveReplaceLaneF32 { .. }
+        | MveDivF32 { .. }
+        | MveSqrtF32 { .. } => OffPath,
+    }
+}
+
+/// The estimator must agree with the encoder for every op the optimized path
+/// emits — or the divergence must be a documented `KNOWN_GAP` pinned to its
+/// exact measured (estimate, encoder) pair.
+#[test]
+fn estimator_encoder_agreement() {
+    let enc = ArmEncoder::new_thumb2();
+    let mut surprises = Vec::new();
+
+    for case in cases() {
+        // Every case must be an op the optimized path actually emits.
+        assert_eq!(
+            coverage(&case.op),
+            Coverage::OnPath,
+            "{}: oracle case is for an OffPath op — remove it or reclassify",
+            case.label
+        );
+
+        let est = estimate_arm_byte_size(&case.op);
+        let real = enc
+            .encode(&case.op)
+            .unwrap_or_else(|e| panic!("{}: encoder rejected the op: {e:?}", case.label))
+            .len();
+
+        match case.gap {
+            None => {
+                if est != real {
+                    surprises.push(format!(
+                        "NEW DRIFT {}: estimator {est} != encoder {real} \
+                         (fix the estimator, or add a documented KNOWN_GAP)",
+                        case.label
+                    ));
+                }
+            }
+            Some(g) => {
+                if (est, real) != (g.est, g.enc) {
+                    surprises.push(format!(
+                        "KNOWN_GAP CHANGED {}: was (est {}, enc {}), now (est {est}, enc {real}) \
+                         — update or remove the gap",
+                        case.label, g.est, g.enc
+                    ));
+                }
+                if est == real {
+                    surprises.push(format!(
+                        "GAP CLOSED {}: estimator and encoder now agree ({est}) \
+                         — remove it from KNOWN_GAP",
+                        case.label
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        surprises.is_empty(),
+        "estimator↔encoder drift:\n{}",
+        surprises.join("\n")
+    );
+}

--- a/crates/synth-synthesis/src/lib.rs
+++ b/crates/synth-synthesis/src/lib.rs
@@ -19,7 +19,9 @@ pub use instruction_selector::{
     ArmInstruction, BoundsCheckConfig, InstructionSelector, RegisterState, SelectionStats,
     infer_i64_locals, validate_instructions, validate_instructions_with_helium,
 };
-pub use optimizer_bridge::{OptimizationConfig, OptimizationStats, OptimizerBridge};
+pub use optimizer_bridge::{
+    OptimizationConfig, OptimizationStats, OptimizerBridge, estimate_arm_byte_size,
+};
 pub use pattern_matcher::{
     ApplyStats, Bindings, MatchResult, MatchValue, PatternMatcher, RuleApplicator,
 };

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -290,6 +290,165 @@ pub struct OptimizationStats {
 }
 
 /// Optimizer bridge that integrates with synthesis pipeline
+/// Estimate the encoded byte size of a single optimized-path ARM instruction.
+///
+/// This MUST mirror the Thumb-2 encoder (`synth_backend::ArmEncoder::encode`)
+/// for every `ArmOp` the optimized path emits, because `ir_to_arm`'s
+/// branch-resolution pass sums these sizes to compute branch displacements: an
+/// under-estimate lands a forward branch short (the #483-class miscompile), an
+/// over-estimate lands it long. It is a *hand-maintained mirror* of the encoder
+/// only because synth-synthesis cannot depend on synth-backend (the encoder
+/// lives downstream), so the two cannot share one source of truth — the
+/// structural cause behind #498. The `estimator_encoder_agreement` oracle in
+/// synth-backend (which *can* see both) pins this mirror against the real
+/// encoder and documents every remaining divergence as a known gap.
+///
+/// Extracted verbatim from the inline `instr_byte_size` closure (#498, #242) so
+/// the agreement oracle can call it; the body is logic-identical to the
+/// pre-extraction closure.
+pub fn estimate_arm_byte_size(op: &ArmOp) -> usize {
+    use crate::rules::{Operand2, Reg};
+    // Helper to get register number
+    let reg_num = |r: &Reg| -> u8 {
+        match r {
+            Reg::R0 => 0,
+            Reg::R1 => 1,
+            Reg::R2 => 2,
+            Reg::R3 => 3,
+            Reg::R4 => 4,
+            Reg::R5 => 5,
+            Reg::R6 => 6,
+            Reg::R7 => 7,
+            Reg::R8 => 8,
+            Reg::R9 => 9,
+            Reg::R10 => 10,
+            Reg::R11 => 11,
+            Reg::R12 => 12,
+            Reg::SP => 13,
+            Reg::LR => 14,
+            Reg::PC => 15,
+        }
+    };
+
+    match op {
+        // SetCond: ITE + MOV #1 + MOV #0 = 2 + 2 + 2 = 6 bytes
+        ArmOp::SetCond { .. } => 6,
+        // SelectMove: IT + MOV = 2 + 2 = 4 bytes
+        ArmOp::SelectMove { .. } => 4,
+        // 32-bit Thumb-2 instructions (always 4 bytes)
+        ArmOp::Movw { .. } | ArmOp::Movt { .. } => 4,
+        // Register shifts and RSB are always 32-bit Thumb-2
+        ArmOp::LslReg { .. }
+        | ArmOp::LsrReg { .. }
+        | ArmOp::AsrReg { .. }
+        | ArmOp::RorReg { .. }
+        | ArmOp::Rsb { .. } => 4,
+        // MUL, MLS, SDIV, UDIV are always 32-bit Thumb-2
+        ArmOp::Mul { .. } | ArmOp::Mls { .. } | ArmOp::Sdiv { .. } | ArmOp::Udiv { .. } => 4,
+        // ADC, SBC are always 32-bit Thumb-2
+        ArmOp::Adc { .. } | ArmOp::Sbc { .. } => 4,
+        // CLZ, RBIT are always 32-bit Thumb-2
+        ArmOp::Clz { .. } | ArmOp::Rbit { .. } => 4,
+        // SXTB, SXTH, UXTB, UXTH can be 16-bit for low registers
+        ArmOp::Sxtb { rd, rm }
+        | ArmOp::Sxth { rd, rm }
+        | ArmOp::Uxtb { rd, rm }
+        | ArmOp::Uxth { rd, rm } => {
+            let rd_bits = reg_num(rd);
+            let rm_bits = reg_num(rm);
+            if rd_bits < 8 && rm_bits < 8 { 2 } else { 4 }
+        }
+        // I64SetCond: multi-instruction sequence (12 bytes for all conditions)
+        // EQ/NE: CMP(2) + IT EQ(2) + CMP(2) + ITE(2) + MOV(2) + MOV(2)
+        // LT/GT: CMP(2) + SBCS(4) + ITE(2) + MOV(2) + MOV(2)
+        ArmOp::I64SetCond { .. } => 12,
+        // I64SetCondZ: ORR.W(4) + CMP(2) + ITE(2) + MOV(2) + MOV(2)
+        ArmOp::I64SetCondZ { .. } => 12,
+        // I64Mul: MUL(4) + MLA(4) + UMULL(4) + ADD(2) = 14 bytes
+        ArmOp::I64Mul { .. } => 14,
+        // I64Shl/ShrU: AND.W(4) + SUBS.W(4) + BPL(2) + small_block(22) + B(2) + large_block(6) - but byte_size = total = 38
+        ArmOp::I64Shl { .. } | ArmOp::I64ShrU { .. } => 38,
+        // I64ShrS: same as ShrU but large block is 8 bytes (ASR+ASR vs LSR+MOV) = 40
+        ArmOp::I64ShrS { .. } => 40,
+        // I64Rotl/Rotr: PUSH(2) + AND(4) + SUBS(4) + BPL(2) + small_block(30) + B(2) + large_block(30) + POP(2) = 74 bytes
+        ArmOp::I64Rotl { .. } | ArmOp::I64Rotr { .. } => 74,
+        // I64Clz: CMP.W(4) + BEQ(2) + CLZ.W(4) + B(2) + NOP(2) + CLZ.W(4) + ADD.W(4) + MOV(2) = 24 bytes
+        ArmOp::I64Clz { .. } => 24,
+        // I64Ctz: CMP.W(4) + BEQ(2) + RBIT.W(4) + CLZ.W(4) + B(2) + NOP(2) + RBIT.W(4) + CLZ.W(4) + ADD.W(4) + MOV(2) = 32 bytes
+        ArmOp::I64Ctz { .. } => 32,
+        // I64Popcnt: large implementation with PUSH/POP and duplicate algorithm for lo and hi = ~180 bytes
+        ArmOp::I64Popcnt { .. } => 200,
+        // I64 sign extension: SXTB/SXTH/ASR + ASR = 4-8 bytes
+        ArmOp::I64Extend8S { .. } => 8,
+        ArmOp::I64Extend16S { .. } => 8,
+        ArmOp::I64Extend32S { .. } => 8,
+        // I64 division: PUSH + init + loop body + MOV + POP = ~80-150 bytes
+        ArmOp::I64DivU { .. } => 100,
+        ArmOp::I64RemU { .. } => 100,
+        // Signed versions have additional negation logic
+        ArmOp::I64DivS { .. } => 150,
+        ArmOp::I64RemS { .. } => 150,
+        // AND/OR/XOR: encoder always uses 32-bit Thumb-2 (.W) encoding
+        ArmOp::And { .. } | ArmOp::Orr { .. } | ArmOp::Eor { .. } => 4,
+        // LDR/STR with high base register or large offset need 32-bit
+        ArmOp::Ldr { rd, addr } => {
+            let rd_bits = reg_num(rd);
+            let base_bits = reg_num(&addr.base);
+            let offset = addr.offset as u32;
+            if rd_bits < 8 && base_bits < 8 && (offset & 0x3) == 0 && offset <= 124 {
+                2
+            } else {
+                4
+            }
+        }
+        ArmOp::Str { rd, addr } => {
+            let rd_bits = reg_num(rd);
+            let base_bits = reg_num(&addr.base);
+            let offset = addr.offset as u32;
+            if rd_bits < 8 && base_bits < 8 && (offset & 0x3) == 0 && offset <= 124 {
+                2
+            } else {
+                4
+            }
+        }
+        // #483: half/byte loads and stores. The optimized path always
+        // materializes a memory access against a HIGH base register
+        // (`ip`/r12 for a const address, r11 for the base-CSE linmem
+        // anchor), so the encoder always emits the 32-bit `.w` form — the
+        // 16-bit Thumb T1 encoding (low base + small aligned offset) is
+        // never produced here. Sizing these as the default 2 (the bug)
+        // drifts `byte_offsets` and miscompiles any branch that spans the
+        // access (the i32.store16 in the #483 `block`/`br_if` repro).
+        ArmOp::Strh { .. }
+        | ArmOp::Strb { .. }
+        | ArmOp::Ldrh { .. }
+        | ArmOp::Ldrsh { .. }
+        | ArmOp::Ldrb { .. }
+        | ArmOp::Ldrsb { .. } => 4,
+        // BL is always 32-bit
+        ArmOp::Bl { .. } => 4,
+        // MOV with high register (R8-R15) or large immediate needs MOVW (4 bytes)
+        ArmOp::Mov {
+            rd,
+            op2: Operand2::Imm(v),
+        } if reg_num(rd) > 7 || *v > 255 || *v < 0 => 4,
+        ArmOp::Mov { .. } => 2,
+        // SUB/ADD with high registers need 32-bit encoding
+        ArmOp::Sub {
+            rd,
+            rn,
+            op2: Operand2::Reg(rm),
+        } if reg_num(rd) > 7 || reg_num(rn) > 7 || reg_num(rm) > 7 => 4,
+        ArmOp::Add {
+            rd,
+            rn,
+            op2: Operand2::Reg(rm),
+        } if reg_num(rd) > 7 || reg_num(rn) > 7 || reg_num(rm) > 7 => 4,
+        // Most 16-bit Thumb instructions (MOV low, CMP low, B, etc.)
+        _ => 2,
+    }
+}
+
 pub struct OptimizerBridge {
     config: OptimizationConfig,
     /// Number of imported functions (wasm function indices `< num_imports` are
@@ -5263,158 +5422,17 @@ impl OptimizerBridge {
         // Calculate byte offsets for each instruction to handle variable-length
         // Thumb-2 encoding (SetCond = 6 bytes, most others = 2 bytes).
 
-        // Helper to estimate instruction byte size
-        // Must match the encoder's behavior for correct branch offset calculation
-        // Helper to get register number
-        let reg_num = |r: &Reg| -> u8 {
-            match r {
-                Reg::R0 => 0,
-                Reg::R1 => 1,
-                Reg::R2 => 2,
-                Reg::R3 => 3,
-                Reg::R4 => 4,
-                Reg::R5 => 5,
-                Reg::R6 => 6,
-                Reg::R7 => 7,
-                Reg::R8 => 8,
-                Reg::R9 => 9,
-                Reg::R10 => 10,
-                Reg::R11 => 11,
-                Reg::R12 => 12,
-                Reg::SP => 13,
-                Reg::LR => 14,
-                Reg::PC => 15,
-            }
-        };
-
-        let instr_byte_size = |op: &ArmOp| -> usize {
-            match op {
-                // SetCond: ITE + MOV #1 + MOV #0 = 2 + 2 + 2 = 6 bytes
-                ArmOp::SetCond { .. } => 6,
-                // SelectMove: IT + MOV = 2 + 2 = 4 bytes
-                ArmOp::SelectMove { .. } => 4,
-                // 32-bit Thumb-2 instructions (always 4 bytes)
-                ArmOp::Movw { .. } | ArmOp::Movt { .. } => 4,
-                // Register shifts and RSB are always 32-bit Thumb-2
-                ArmOp::LslReg { .. }
-                | ArmOp::LsrReg { .. }
-                | ArmOp::AsrReg { .. }
-                | ArmOp::RorReg { .. }
-                | ArmOp::Rsb { .. } => 4,
-                // MUL, MLS, SDIV, UDIV are always 32-bit Thumb-2
-                ArmOp::Mul { .. } | ArmOp::Mls { .. } | ArmOp::Sdiv { .. } | ArmOp::Udiv { .. } => {
-                    4
-                }
-                // ADC, SBC are always 32-bit Thumb-2
-                ArmOp::Adc { .. } | ArmOp::Sbc { .. } => 4,
-                // CLZ, RBIT are always 32-bit Thumb-2
-                ArmOp::Clz { .. } | ArmOp::Rbit { .. } => 4,
-                // SXTB, SXTH, UXTB, UXTH can be 16-bit for low registers
-                ArmOp::Sxtb { rd, rm }
-                | ArmOp::Sxth { rd, rm }
-                | ArmOp::Uxtb { rd, rm }
-                | ArmOp::Uxth { rd, rm } => {
-                    let rd_bits = reg_num(rd);
-                    let rm_bits = reg_num(rm);
-                    if rd_bits < 8 && rm_bits < 8 { 2 } else { 4 }
-                }
-                // I64SetCond: multi-instruction sequence (12 bytes for all conditions)
-                // EQ/NE: CMP(2) + IT EQ(2) + CMP(2) + ITE(2) + MOV(2) + MOV(2)
-                // LT/GT: CMP(2) + SBCS(4) + ITE(2) + MOV(2) + MOV(2)
-                ArmOp::I64SetCond { .. } => 12,
-                // I64SetCondZ: ORR.W(4) + CMP(2) + ITE(2) + MOV(2) + MOV(2)
-                ArmOp::I64SetCondZ { .. } => 12,
-                // I64Mul: MUL(4) + MLA(4) + UMULL(4) + ADD(2) = 14 bytes
-                ArmOp::I64Mul { .. } => 14,
-                // I64Shl/ShrU: AND.W(4) + SUBS.W(4) + BPL(2) + small_block(22) + B(2) + large_block(6) - but byte_size = total = 38
-                ArmOp::I64Shl { .. } | ArmOp::I64ShrU { .. } => 38,
-                // I64ShrS: same as ShrU but large block is 8 bytes (ASR+ASR vs LSR+MOV) = 40
-                ArmOp::I64ShrS { .. } => 40,
-                // I64Rotl/Rotr: PUSH(2) + AND(4) + SUBS(4) + BPL(2) + small_block(30) + B(2) + large_block(30) + POP(2) = 74 bytes
-                ArmOp::I64Rotl { .. } | ArmOp::I64Rotr { .. } => 74,
-                // I64Clz: CMP.W(4) + BEQ(2) + CLZ.W(4) + B(2) + NOP(2) + CLZ.W(4) + ADD.W(4) + MOV(2) = 24 bytes
-                ArmOp::I64Clz { .. } => 24,
-                // I64Ctz: CMP.W(4) + BEQ(2) + RBIT.W(4) + CLZ.W(4) + B(2) + NOP(2) + RBIT.W(4) + CLZ.W(4) + ADD.W(4) + MOV(2) = 32 bytes
-                ArmOp::I64Ctz { .. } => 32,
-                // I64Popcnt: large implementation with PUSH/POP and duplicate algorithm for lo and hi = ~180 bytes
-                ArmOp::I64Popcnt { .. } => 200,
-                // I64 sign extension: SXTB/SXTH/ASR + ASR = 4-8 bytes
-                ArmOp::I64Extend8S { .. } => 8,
-                ArmOp::I64Extend16S { .. } => 8,
-                ArmOp::I64Extend32S { .. } => 8,
-                // I64 division: PUSH + init + loop body + MOV + POP = ~80-150 bytes
-                ArmOp::I64DivU { .. } => 100,
-                ArmOp::I64RemU { .. } => 100,
-                // Signed versions have additional negation logic
-                ArmOp::I64DivS { .. } => 150,
-                ArmOp::I64RemS { .. } => 150,
-                // AND/OR/XOR: encoder always uses 32-bit Thumb-2 (.W) encoding
-                ArmOp::And { .. } | ArmOp::Orr { .. } | ArmOp::Eor { .. } => 4,
-                // LDR/STR with high base register or large offset need 32-bit
-                ArmOp::Ldr { rd, addr } => {
-                    let rd_bits = reg_num(rd);
-                    let base_bits = reg_num(&addr.base);
-                    let offset = addr.offset as u32;
-                    if rd_bits < 8 && base_bits < 8 && (offset & 0x3) == 0 && offset <= 124 {
-                        2
-                    } else {
-                        4
-                    }
-                }
-                ArmOp::Str { rd, addr } => {
-                    let rd_bits = reg_num(rd);
-                    let base_bits = reg_num(&addr.base);
-                    let offset = addr.offset as u32;
-                    if rd_bits < 8 && base_bits < 8 && (offset & 0x3) == 0 && offset <= 124 {
-                        2
-                    } else {
-                        4
-                    }
-                }
-                // #483: half/byte loads and stores. The optimized path always
-                // materializes a memory access against a HIGH base register
-                // (`ip`/r12 for a const address, r11 for the base-CSE linmem
-                // anchor), so the encoder always emits the 32-bit `.w` form — the
-                // 16-bit Thumb T1 encoding (low base + small aligned offset) is
-                // never produced here. Sizing these as the default 2 (the bug)
-                // drifts `byte_offsets` and miscompiles any branch that spans the
-                // access (the i32.store16 in the #483 `block`/`br_if` repro).
-                ArmOp::Strh { .. }
-                | ArmOp::Strb { .. }
-                | ArmOp::Ldrh { .. }
-                | ArmOp::Ldrsh { .. }
-                | ArmOp::Ldrb { .. }
-                | ArmOp::Ldrsb { .. } => 4,
-                // BL is always 32-bit
-                ArmOp::Bl { .. } => 4,
-                // MOV with high register (R8-R15) or large immediate needs MOVW (4 bytes)
-                ArmOp::Mov {
-                    rd,
-                    op2: Operand2::Imm(v),
-                } if reg_num(rd) > 7 || *v > 255 || *v < 0 => 4,
-                ArmOp::Mov { .. } => 2,
-                // SUB/ADD with high registers need 32-bit encoding
-                ArmOp::Sub {
-                    rd,
-                    rn,
-                    op2: Operand2::Reg(rm),
-                } if reg_num(rd) > 7 || reg_num(rn) > 7 || reg_num(rm) > 7 => 4,
-                ArmOp::Add {
-                    rd,
-                    rn,
-                    op2: Operand2::Reg(rm),
-                } if reg_num(rd) > 7 || reg_num(rn) > 7 || reg_num(rm) > 7 => 4,
-                // Most 16-bit Thumb instructions (MOV low, CMP low, B, etc.)
-                _ => 2,
-            }
-        };
+        // Estimate instruction byte sizes via the shared `estimate_arm_byte_size`
+        // (extracted from the former inline closure, #498/#242). Must match the
+        // encoder's behavior for correct branch offset calculation; the
+        // `estimator_encoder_agreement` oracle in synth-backend pins it.
 
         // Build byte offset table: byte_offsets[i] = byte position of instruction i
         let mut byte_offsets: Vec<usize> = Vec::with_capacity(arm_instrs.len() + 1);
         let mut current_offset = 0usize;
         for op in &arm_instrs {
             byte_offsets.push(current_offset);
-            current_offset += instr_byte_size(op);
+            current_offset += estimate_arm_byte_size(op);
         }
         byte_offsets.push(current_offset); // End marker for target lookups
 


### PR DESCRIPTION
## What

VCR-ORACLE-001 (epic #242). A CI-gated oracle that pins the optimized ARM path's hand-maintained byte-size **estimator** against the real Thumb-2 **encoder**, for every op the path emits.

### Why this matters

`ir_to_arm` resolves branch displacements by summing `estimate_arm_byte_size` over the instruction stream. That estimator is a hand-maintained mirror of `ArmEncoder::encode`, kept by hand only because `synth-synthesis` cannot depend on `synth-backend` (the encoder lives downstream) — the **structural cause behind #498**. When the mirror drifts, a forward branch spanning the drifting op lands at the wrong byte: under-estimate → short (the #483-class miscompile), over-estimate → long. `synth-backend` sits downstream and *can* see both, so the oracle lives there.

## How

1. **Extract** the inline `instr_byte_size`/`reg_num` closures from `ir_to_arm` to a module-level `pub fn estimate_arm_byte_size(op: &ArmOp) -> usize`. Logic-identical — the whitespace-normalized diff of the match body is empty; frozen byte gate + 59 synthesis tests confirm the optimized path is **bit-identical**.
2. **Oracle** (`crates/synth-backend/tests/estimator_encoder_agreement.rs`): for each op the optimized path emits, at the operand shapes it emits them in, assert `estimate == encode().len()` **OR** a documented `KNOWN_GAP` pinned to its exact measured `(est, enc)` pair. A no-wildcard `coverage()` match over all 220 `ArmOp` variants is a compile-time tripwire — a new variant won't compile until consciously classified OnPath/OffPath. (It forces *classification*, not an agreement case; that remains a documented manual step.)

Both failure paths verified non-vacuous: a perturbed gap value trips `KNOWN_GAP CHANGED`; an `agree` case pointed at a drift op trips `NEW DRIFT`.

## Scope

A **gap-documenting regression guard, NOT a #498 fix.** Correcting the estimator is byte-changing codegen (shifts every optimized-path branch displacement) and stays a separately-gated step (re-freeze + execution differential + silicon). No release — pure refactor + test.

## Findings (correct + extend #498's original report)

- **#498's claim that `Cmp` high-reg drifts is FALSE** — 16-bit CMP (T2, `0x45xx`) encodes high regs → 2 bytes; the estimator default is right. The real high-reg drifts are `Cmn`/`Adds`/`Subs` (no 16-bit high-reg / flag-setting form) → 4, est 2.
- **`Popcnt` is absent from the estimator entirely** (`_ => 2`) but the encoder expands it to 86 bytes — an 84-byte hole, the largest single drift.
- `I64DivU/RemU/DivS/RemS`, `I64Popcnt`, `I64Extend32S` **over-estimate** (e.g. DivU est 100 vs 74).
- far `BOffset`/`BCondOffset` need the 4-byte form but the estimator sizes the pre-resolution 0-offset placeholder as 2 (single-pass chicken-and-egg).
- `Mov` small-negative imm: the encoder's signed `imm <= 255` test emits a wrong-value 2-byte `MOVS #(imm&0xFF)` — a **latent encoder bug**, surfaced here as a side effect.

Refs #498, #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)