### PR TITLE
feat(vcr-ra): optimized-path const-CSE behind SYNTH_CONST_CSE (flag-off) (#242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,3 +536,41 @@ jobs:
         env:
           SYNTH: ./target/debug/synth
         run: python scripts/repro/br_table_507_differential.py
+
+  const-cse-242-oracle:
+    name: const-CSE flag-on execution oracle
+    # VCR-RA const-CSE (#242): EXECUTE the optimized path compiled with
+    # SYNTH_CONST_CSE=1 under unicorn (UC_ARCH_ARM / Thumb) and diff the returned
+    # value vs wasmtime across redundant-const shapes (large/small/negative/mixed
+    # consts, reuse ACROSS an if/else where the cache must reset, and a
+    # 12-live-local function that forces real spills). The const cache aliases a
+    # repeated const to the register already holding it; this proves the aliasing
+    # is semantics-preserving on the flag-ON path. The flag ships DEFAULT-OFF
+    # (off ⇒ byte-identical, pinned by const_cse_reduction_242.rs's golden), so
+    # nothing else exercises the optimized-path const cache. Isolated job:
+    # emulation deps pip-installed here ONLY.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Run const-CSE flag-on oracle
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/repro/const_cse_differential.py

--- a/crates/synth-cli/tests/const_cse_reduction_242.rs
+++ b/crates/synth-cli/tests/const_cse_reduction_242.rs
@@ -1,0 +1,170 @@
+//! VCR-RA const-CSE (#242) — CI-gated reduction + frozen-safety oracle.
+//!
+//! The optimized (non-`--relocatable`) ARM path re-materializes a constant at
+//! every use (`i32.const N` → a fresh `movw`/`movt` each time). gale measured
+//! this on silicon: flat_flight spends 61% of its const materializations on
+//! values already held in a register. `SYNTH_CONST_CSE=1` enables a
+//! pressure-neutral const cache (`optimizer_bridge.rs`) that aliases a repeated
+//! const to the register already holding it, emitting nothing.
+//!
+//! This is byte-CHANGING codegen, so the flag ships DEFAULT-OFF. Two claims are
+//! locked here as executable CI gates; semantic equivalence under flag-ON is the
+//! separate `const_cse_differential.py` unicorn-vs-wasmtime oracle:
+//!
+//!   1. FROZEN-SAFE (OFF ≡ pre-change baseline). With the flag OFF the optimized
+//!      path emits a SPECIFIC, pinned `.text` — the golden below was captured
+//!      against the pre-const-CSE tree (verified equal by a `git stash` compare:
+//!      post-change-OFF hash == pre-change hash, both `8c3dfcbb…`). The frozen
+//!      differential fixtures (control_step / flight_algo) compile `--relocatable`
+//!      → they exercise the DIRECT path and never touch this code, so this golden
+//!      is the ONLY gate pinning optimized-path-OFF bytes. A golden, not a
+//!      compile-twice determinism check: determinism alone would not catch the
+//!      flag-off path drifting away from the byte-identical baseline.
+//!
+//!   2. REAL REDUCTION ON HEADROOM. On `large3` — a >16-bit const reused 3× with
+//!      ample free registers — the flag-ON `.text` is STRICTLY SMALLER (the two
+//!      redundant `movw`+`movt` pairs collapse to register aliases). If a future
+//!      change makes CSE inert on headroom, this fails.
+//!
+//! WHAT THIS DOES NOT CLAIM — the named prerequisites for a default-ON flip
+//! (a separate, silicon-gated release, NOT this PR):
+//!   - reg_effect DEF-COMPLETENESS. The cache's "never stale-wrong" property
+//!     rests on `liveness::reg_effect` reporting EVERY GP-register a non-const op
+//!     writes (so the reconciliation clears a clobbered alias). That is a broader
+//!     property than the #513 reg_effect↔rewrite_op *consistency* oracle, which
+//!     only pins that the two AGREE — they could agree and both under-report. The
+//!     flip must be gated on op-coverage of reg_effect, not on #513.
+//!   - ALIAS-EVICTION. Aliasing `dest` to an existing register makes two live
+//!     vregs share one physical register, breaking the spill model's vreg↔reg
+//!     bijection. If the OLDER alias is chosen as a spill victim while the
+//!     younger keeps the alias, the freed register is reused under the younger →
+//!     stale read. Not reachable in today's fixtures (the IR optimizer dedups
+//!     two consecutive identical consts before they reach this pass), but the
+//!     flip must either prove unreachability or make the spill path alias-aware.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+use object::read::elf::ElfFile32;
+use object::{Object, ObjectSection};
+
+/// Golden FNV-1a-64 of the flag-OFF optimized-path `.text` for `const_cse.wat`.
+/// Captured against the pre-const-CSE tree (stash-compare verified). Re-bless
+/// ONLY when an intentional optimized-path lowering change is made — a surprise
+/// failure here means the supposedly-frozen flag-off path drifted.
+const GOLDEN_OFF_TEXT_FNV1A: u64 = 0xa68a_a2da_e5af_e4a7;
+const GOLDEN_OFF_TEXT_LEN: usize = 576;
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro/const_cse.wat")
+}
+
+/// Compile the const-CSE fixture via the optimized path. `cse` toggles
+/// `SYNTH_CONST_CSE`; returns the raw ELF bytes.
+fn compile(out: &str, cse: bool) -> Vec<u8> {
+    let mut cmd = Command::new(synth());
+    if cse {
+        cmd.env("SYNTH_CONST_CSE", "1");
+    }
+    let status = cmd
+        .args([
+            "compile",
+            fixture().to_str().unwrap(),
+            "-o",
+            out,
+            "-b",
+            "arm",
+            "--target",
+            "cortex-m4",
+            "--all-exports",
+        ])
+        .status()
+        .expect("run synth compile");
+    assert!(status.success(), "synth compile failed (cse={cse})");
+    std::fs::read(out).expect("read ELF")
+}
+
+/// Map every named section to its bytes.
+fn sections(elf: &[u8]) -> HashMap<String, Vec<u8>> {
+    let obj = ElfFile32::<object::Endianness>::parse(elf).expect("parse ELF");
+    let mut out = HashMap::new();
+    for sec in obj.sections() {
+        if let Ok(name) = sec.name()
+            && !name.is_empty()
+        {
+            out.insert(name.to_string(), sec.data().unwrap_or(&[]).to_vec());
+        }
+    }
+    out
+}
+
+/// `.text` bytes of one named function, by reading its symbol size.
+fn func_text_len(elf: &[u8], name: &str) -> usize {
+    use object::ObjectSymbol;
+    let obj = ElfFile32::<object::Endianness>::parse(elf).expect("parse ELF");
+    for sym in obj.symbols() {
+        if sym.name() == Ok(name) {
+            return sym.size() as usize;
+        }
+    }
+    panic!("symbol {name} not found");
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// CLAIM 1 — flag OFF emits the pinned, pre-change-identical `.text`.
+#[test]
+fn const_cse_off_matches_frozen_baseline_242() {
+    let off = compile("/tmp/const_cse_off.elf", false);
+    let text = sections(&off).remove(".text").expect(".text present");
+    assert_eq!(
+        text.len(),
+        GOLDEN_OFF_TEXT_LEN,
+        "flag-off .text length drifted from the frozen baseline"
+    );
+    assert_eq!(
+        fnv1a64(&text),
+        GOLDEN_OFF_TEXT_FNV1A,
+        "flag-off optimized-path .text drifted from the pre-const-CSE baseline \
+         — the default-off path is supposed to be byte-identical; re-bless the \
+         golden ONLY if this was an intentional optimized-path lowering change"
+    );
+}
+
+/// CLAIM 2 — flag ON strictly shrinks `large3` (a >16-bit const reused 3× with
+/// register headroom): the redundant movw+movt pairs become register aliases.
+#[test]
+fn const_cse_on_shrinks_headroom_function_242() {
+    let off = compile("/tmp/const_cse_red_off.elf", false);
+    let on = compile("/tmp/const_cse_red_on.elf", true);
+
+    let off_len = func_text_len(&off, "large3");
+    let on_len = func_text_len(&on, "large3");
+
+    assert!(
+        on_len < off_len,
+        "const-CSE must shrink large3 on headroom: off={off_len}B on={on_len}B"
+    );
+
+    // Each eliminated `i32.const 100000` removes a movw(4)+movt(4) = 8 bytes;
+    // two of the three are redundant, so expect ~16 bytes saved.
+    assert!(
+        off_len - on_len >= 8,
+        "expected ≥8B saved (≥1 movw+movt pair), got {}B",
+        off_len - on_len
+    );
+}

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -2983,8 +2983,54 @@ impl OptimizerBridge {
             });
         }
 
+        // VCR-RA const-CSE (#242): when the same constant is already
+        // materialized in a still-valid register, alias the new vreg to that
+        // register and emit NO materialization. Pressure-neutral-or-better — the
+        // value is already in a register, so aliasing never adds register
+        // pressure (it can only share one). `reg_holds_const` (keyed by the
+        // u32 bit-pattern, so a negative i32 const matches its movw/movt
+        // reconstruction) is derived from the EMITTED ARM at the top of each
+        // iteration — so it survives the many `continue` arms — and is reset at
+        // every control-flow boundary, confining CSE to straight-line segments.
+        // Opt-in `SYNTH_CONST_CSE=1`; off ⇒ byte-identical (no new state read).
+        let const_cse = std::env::var("SYNTH_CONST_CSE").is_ok();
+        let mut reg_holds_const: HashMap<Reg, u32> = HashMap::new();
+        let mut cse_seen_len = 0usize;
+
         // Second pass: generate ARM instructions
         for inst in instructions {
+            if const_cse {
+                // Reconcile the cache with everything emitted since last iteration.
+                for op in &arm_instrs[cse_seen_len..] {
+                    match op {
+                        ArmOp::Movw { rd, imm16 } => {
+                            reg_holds_const.insert(*rd, *imm16 as u32);
+                        }
+                        ArmOp::Movt { rd, imm16 } => {
+                            let lo = reg_holds_const.get(rd).copied().unwrap_or(0) & 0xFFFF;
+                            reg_holds_const.insert(*rd, lo | ((*imm16 as u32) << 16));
+                        }
+                        ArmOp::Mov {
+                            rd,
+                            op2: Operand2::Imm(v),
+                        } => {
+                            reg_holds_const.insert(*rd, *v as u32);
+                        }
+                        other => match crate::liveness::reg_effect(other) {
+                            // Any other write clobbers the const in its dest reg(s).
+                            Some(eff) => {
+                                for d in eff.defs {
+                                    reg_holds_const.remove(&d);
+                                }
+                            }
+                            // Unmodeled op (branch/bl/bx/label) = control-flow
+                            // boundary: the cache cannot be trusted across it.
+                            None => reg_holds_const.clear(),
+                        },
+                    }
+                }
+                cse_seen_len = arm_instrs.len();
+            }
             match &inst.opcode {
                 Opcode::Nop => continue,
 
@@ -3071,6 +3117,33 @@ impl OptimizerBridge {
                     if let Some(plan) = &base_cse
                         && plan.skip_const.contains(&dest.0)
                     {
+                        continue;
+                    }
+                    // const-CSE: if this exact value already lives in a register
+                    // (and `dest` isn't a pre-assigned local/param), alias `dest`
+                    // to it and emit nothing. The aliased register is protected
+                    // from reuse while `dest` is live (it's in `vreg_to_arm`).
+                    //
+                    // DEFAULT-OFF prerequisite for the flip (see
+                    // const_cse_reduction_242.rs): aliasing makes two live vregs
+                    // share one physical register, breaking the spill model's
+                    // vreg↔reg bijection (the eviction path at ~3168 spills a
+                    // SINGLE victim vreg). If the older alias is spilled while the
+                    // younger keeps the alias, the freed register is reused under
+                    // the younger → stale read. Not reachable today (the IR
+                    // optimizer dedups consecutive identical consts upstream), but
+                    // default-on must prove unreachability or make the spill path
+                    // alias-aware (spill ALL vregs sharing the victim register).
+                    let cse_want = *value as u32;
+                    if const_cse
+                        && !vreg_to_arm.contains_key(&dest.0)
+                        && !local_vregs.contains(&dest.0)
+                        && let Some(rs) = reg_holds_const
+                            .iter()
+                            .find_map(|(r, v)| if *v == cse_want { Some(*r) } else { None })
+                    {
+                        vreg_to_arm.insert(dest.0, rs);
+                        vreg_alloc_order.push(dest.0);
                         continue;
                     }
                     // Allocate a register for this constant

--- a/scripts/repro/const_cse.wat
+++ b/scripts/repro/const_cse.wat
@@ -1,0 +1,62 @@
+;; VCR-RA const-CSE (#242) execution-oracle fixture.
+;;
+;; Each export materializes the SAME constant several times in a straight-line
+;; segment — exactly the redundant-const-materialization pattern gale measured
+;; on silicon (flat_flight: 61% of materializations redundant). With
+;; SYNTH_CONST_CSE=1 the optimized path aliases the repeated const to the
+;; register that already holds it and emits no second movw/movt. This harness
+;; proves that aliasing is SEMANTICS-PRESERVING (result bit-identical to
+;; wasmtime) across:
+;;   - large3 : a >16-bit const (movw+movt) reused 3×
+;;   - small3 : a <16-bit const (single mov) reused 3×
+;;   - neg    : a negative const (sign-extended bit-pattern) reused 2×
+;;   - mixed  : the same const interleaved with other consts/ops (xor/mul)
+;;   - ctrl   : a const reused ACROSS an if/else — the cache must RESET at the
+;;              control-flow boundary, so the post-merge use re-materializes;
+;;              a stale alias here would read a register the other arm clobbered
+;;   - spill12: 12 simultaneously-live locals each = param+100000 → forces real
+;;              register spills; proves the const cache stays correct when the
+;;              aliased register is itself spilled (STR is a use, not a def, so
+;;              the cache entry survives the spill and still names the live value)
+(module
+  (func (export "large3") (param i32) (result i32)
+    local.get 0 i32.const 100000 i32.add i32.const 100000 i32.add i32.const 100000 i32.add)
+
+  (func (export "small3") (param i32) (result i32)
+    local.get 0 i32.const 200 i32.add i32.const 200 i32.add i32.const 200 i32.add)
+
+  (func (export "neg") (param i32) (result i32)
+    local.get 0 i32.const -100000 i32.add i32.const -100000 i32.add)
+
+  (func (export "mixed") (param i32) (result i32)
+    local.get 0 i32.const 70000 i32.mul i32.const 70000 i32.add
+    i32.const 12345 i32.xor i32.const 70000 i32.add)
+
+  (func (export "ctrl") (param i32) (result i32)
+    (local.get 0) (i32.const 50000) (i32.add)
+    (local.get 0)
+    (if (result i32) (then (i32.const 50000)) (else (i32.const 60000)))
+    (i32.add)
+    (i32.const 50000) (i32.add))
+
+  (func (export "spill12") (param i32) (result i32)
+    (local $v0 i32) (local $v1 i32) (local $v2 i32) (local $v3 i32)
+    (local $v4 i32) (local $v5 i32) (local $v6 i32) (local $v7 i32)
+    (local $v8 i32) (local $v9 i32) (local $v10 i32) (local $v11 i32)
+    (local.set $v0 (i32.add (local.get 0) (i32.const 100000)))
+    (local.set $v1 (i32.add (local.get 0) (i32.const 100000)))
+    (local.set $v2 (i32.add (local.get 0) (i32.const 100000)))
+    (local.set $v3 (i32.add (local.get 0) (i32.const 100000)))
+    (local.set $v4 (i32.add (local.get 0) (i32.const 100000)))
+    (local.set $v5 (i32.add (local.get 0) (i32.const 100000)))
+    (local.set $v6 (i32.add (local.get 0) (i32.const 100000)))
+    (local.set $v7 (i32.add (local.get 0) (i32.const 100000)))
+    (local.set $v8 (i32.add (local.get 0) (i32.const 100000)))
+    (local.set $v9 (i32.add (local.get 0) (i32.const 100000)))
+    (local.set $v10 (i32.add (local.get 0) (i32.const 100000)))
+    (local.set $v11 (i32.add (local.get 0) (i32.const 100000)))
+    (local.get $v0) (local.get $v1) (i32.add) (local.get $v2) (i32.add)
+    (local.get $v3) (i32.add) (local.get $v4) (i32.add) (local.get $v5) (i32.add)
+    (local.get $v6) (i32.add) (local.get $v7) (i32.add) (local.get $v8) (i32.add)
+    (local.get $v9) (i32.add) (local.get $v10) (i32.add) (local.get $v11) (i32.add)
+    (i32.const 100000) (i32.add)))

--- a/scripts/repro/const_cse_differential.py
+++ b/scripts/repro/const_cse_differential.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""VCR-RA const-CSE (#242) — EXECUTION-validate the optimized-path const cache.
+
+The optimized (non-`--relocatable`) ARM path re-materializes a constant at every
+use: the same `i32.const N` becomes a fresh `movw`/`movt` (or `mov`) each time.
+gale measured this on silicon — flat_flight spends 61% of its const
+materializations on values already sitting in a register. `SYNTH_CONST_CSE=1`
+turns on a pressure-neutral const cache (`optimizer_bridge.rs`): when the wanted
+value already lives in a still-valid register, the new vreg is ALIASED to that
+register and nothing is emitted. The cache is reconstructed from the EMITTED ARM
+at the top of each lowering step (so it survives the many `continue` arms) and
+RESET at every control-flow boundary (an unmodeled `reg_effect` op), confining
+reuse to straight-line segments.
+
+This is byte-CHANGING codegen, so the flag ships DEFAULT-OFF (off ⇒ byte-identical,
+the frozen gate proves it). This harness is the correctness oracle for the
+flag-ON path: it compiles `const_cse.wat` with `SYNTH_CONST_CSE=1` via the
+optimized path, runs each export under unicorn (UC_ARCH_ARM / Thumb), and asserts
+the returned value is bit-identical to wasmtime ground truth across a spread of
+inputs (including negatives and zero). Covered shapes (see the .wat header):
+large/small/negative/mixed consts, reuse ACROSS an if/else (cache must reset),
+and a 12-live-local function that forces real spills (proves an aliased register
+is still correct after it is itself spilled — STR is a use, not a def). It also
+reports the instruction-count delta off-vs-on as information (no gate — the win
+is real where there's register headroom and inert under pressure, never a
+regression).
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/const_cse_differential.py
+Exits nonzero on any value mismatch.
+"""
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("const_cse.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+CODE, STK, RET = 0x100000, 0x900000, 0x300000
+EXPORTS = ["large3", "small3", "neg", "mixed", "ctrl", "spill12"]
+INPUTS = [5, 0, -3, 1000, -100000, 7]
+
+
+def wasmtime_run(fn, arg):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    return inst.exports(store)[fn](store, arg)
+
+
+def compile_optimized(out, cse_on):
+    env = {"PATH": "/usr/bin:/bin"}
+    if cse_on:
+        env["SYNTH_CONST_CSE"] = "1"
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env=env,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed (cse_on={cse_on}): {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for sy in sec.iter_symbols():
+                if sy.name:
+                    syms[sy.name] = sy["st_value"]
+    return code, base, syms
+
+
+def unicorn_run(code, base, faddr, arg):
+    foff = (faddr & ~1) - base
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(STK - 0x10000, 0x20000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_ARM_REG_SP, STK)
+    mu.reg_write(UC_ARM_REG_R11, 0x20000000)
+    mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    try:
+        mu.emu_start((CODE + foff) | 1, RET, count=100000)
+    except UcError as e:
+        return f"ERR:{e}"
+    raw = mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+    return struct.unpack("<i", struct.pack("<I", raw))[0]
+
+
+def insn_count(code):
+    # Rough Thumb instruction count: a halfword whose top 5 bits are 0b11101..
+    # 0b11111 starts a 32-bit instruction; otherwise it is a 16-bit instruction.
+    n, i = 0, 0
+    while i + 2 <= len(code):
+        hw = code[i] | (code[i + 1] << 8)
+        wide = (hw >> 11) >= 0b11101
+        i += 4 if wide else 2
+        n += 1
+    return n
+
+
+def main():
+    off_elf, on_elf = "/tmp/const_cse_off.elf", "/tmp/const_cse_on.elf"
+    compile_optimized(off_elf, cse_on=False)
+    compile_optimized(on_elf, cse_on=True)
+    off_code, off_base, off_syms = load(off_elf)
+    on_code, on_base, on_syms = load(on_elf)
+
+    fails = 0
+    for fn in EXPORTS:
+        faddr = on_syms.get(fn)
+        if faddr is None:
+            print(f"FAIL {fn}: symbol missing")
+            fails += 1
+            continue
+        for arg in INPUTS:
+            exp = wasmtime_run(fn, arg)
+            got = unicorn_run(on_code, on_base, faddr, arg)
+            ok = isinstance(got, int) and got == exp
+            if not ok:
+                fails += 1
+            print(f"{'OK  ' if ok else 'FAIL'} {fn} cse-on({arg}) = {got} "
+                  f"(wasmtime {exp})")
+
+    print("\n--- instruction-count delta (information, not a gate) ---")
+    off_n, on_n = insn_count(off_code), insn_count(on_code)
+    print(f".text Thumb instructions: off={off_n}  on={on_n}  "
+          f"delta={off_n - on_n} ({'fewer with CSE' if on_n < off_n else 'no change'})")
+
+    print("\nRESULT:", "PASS" if not fails else f"FAIL ({fails} mismatches)")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds **const-CSE** to the optimized (non-`--relocatable`) ARM path: when a
constant the IR wants is already materialized in a still-valid register, alias
the new vreg to that register and emit **nothing**. This is VCR-RA's attack on
the dominant silicon redundancy class — gale measured **61%** of `flat_flight`'s
const materializations targeting a value already in a register.

Pressure-neutral by construction: aliasing reuses a register that's already
live, so it can only *share* one, never *demand* one — it wins where there's
register headroom and is **inert under pressure** (never a regression).

## How it's gated (byte-changing ⇒ DEFAULT-OFF)

`SYNTH_CONST_CSE` ships **off**. Three executable gates:

| Gate | File | Asserts |
|------|------|---------|
| **OFF ≡ baseline** | `const_cse_reduction_242.rs` (golden) | flag-off optimized-path `.text` matches a pinned FNV-1a captured against the **pre-change tree** (stash-compare verified equal, `8c3dfcbb…`). The frozen fixtures compile `--relocatable` → direct path, so this golden is the **only** gate pinning optimized-path-OFF bytes. |
| **ON ≡ wasmtime** | `const_cse_differential.py` (new CI oracle) | flag-on build executed under unicorn matches wasmtime across large/small/negative/mixed consts, reuse **across an if/else** (cache must reset), and a **12-live-local** function that forces real spills. |
| **ON shrinks** | `const_cse_reduction_242.rs` | `large3` (>16-bit const reused 3×) strictly smaller flag-on (movw+movt pairs collapse to aliases). |

Measured: module total `412 → 376 B`; `.text` `210 → 200` Thumb instructions on the fixture.

## How it works

`reg_holds_const` is rebuilt from the **emitted ARM** at the top of each lowering
step (so it survives the many `continue` arms) and **reset at every control-flow
boundary** (an unmodeled `reg_effect` op), confining reuse to straight-line
segments. Keyed by u32 bit-pattern so a negative i32 matches its movw/movt
reconstruction.

## NOT a default-on flip

The flip is a **separate, silicon-gated** step. Two prerequisites are **named in
the code and test**, not assumed handled:

- **reg_effect def-completeness** — broader than the #513 reg_effect↔rewrite_op
  *consistency* oracle (which only pins that they *agree* — they could agree and
  both under-report a def, leaving a stale alias).
- **alias-eviction** — aliasing makes two live vregs share one register, breaking
  the spill model's vreg↔reg bijection. Not reachable today (the IR optimizer
  dedups consecutive identical consts upstream — verified empirically), but the
  flip must prove unreachability or make the spill path alias-aware.

Behavior frozen on every shipped path. VCR-RA / epic #242.