### PR TITLE
feat(vcr-ra): frame-slot dead-store elimination behind SYNTH_STACK_FWD (flag-off) (#242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,3 +574,41 @@ jobs:
         env:
           SYNTH: ./target/debug/synth
         run: python scripts/repro/const_cse_differential.py
+
+  frame-slot-dce-242-oracle:
+    name: frame-slot DCE flag-on execution oracle
+    # VCR-RA frame-slot DCE (#242): EXECUTE flat_flight compiled with
+    # SYNTH_STACK_FWD=1 (stack-reload forwarding + dead-frame-store elimination)
+    # under unicorn (UC_ARCH_ARM / Thumb) and diff flight_algo's return value vs
+    # wasmtime across several sensor inputs, with linear memory seeded exactly as
+    # wasmtime's. The two paired passes turn frame reloads into register moves and
+    # remove the now-dead stores (flight_algo sp-traffic 20→7, 139→135 insns).
+    # The flag ships DEFAULT-OFF (off ⇒ byte-identical; the job also asserts the
+    # flag-off .text is byte-identical across builds), so nothing else exercises
+    # this optimized-path transform. Isolated job: emulation deps pip-installed
+    # here ONLY.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Run frame-slot DCE flag-on oracle
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/repro/frame_slot_dce_differential.py

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -581,6 +581,20 @@ fn compile_wasm_to_arm(
         arm_instrs
     };
 
+    // VCR-RA frame-slot DCE (#242): once `forward_stack_reloads` has turned the
+    // reloads of a spill slot into register moves, the `str rX,[sp,#N]` that fed
+    // them is a dead store — its slot is never loaded again. Remove it. Pairs
+    // with (and only pays after) SYNTH_STACK_FWD, so it shares that flag.
+    let arm_instrs = if std::env::var("SYNTH_STACK_FWD").is_ok() {
+        let (out, n) = synth_synthesis::liveness::eliminate_dead_frame_stores(&arm_instrs);
+        if std::env::var("SYNTH_FUSE_STATS").is_ok() {
+            eprintln!("[frame-slot-dce] {n} dead frame store(s) removed");
+        }
+        out
+    } else {
+        arm_instrs
+    };
+
     // VCR-RA immediate-shift folding (#390, #242): a constant shift amount the
     // stack selector materialized into a scratch register (`movw rM,#C; lsl rD,rN,rM`)
     // folds to the immediate form (`lsl rD,rN,#C`), removing the dead `movw` — −1

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -496,6 +496,144 @@ pub fn forward_stack_reloads(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>,
     (out, rewrites)
 }
 
+/// VCR-RA frame-slot dead-store elimination (#242, epic #242): remove a
+/// `str rX, [sp, #N]` whose spill slot `N` is provably never read again before
+/// it is overwritten or the function ends. This is the natural completion of
+/// [`forward_stack_reloads`]: once the reloads of a slot have been forwarded to
+/// register moves, the store that fed them writes a value nobody loads — pure
+/// dead weight. `eliminate_dead_stores` cannot catch it (a store defines no
+/// register, so its register-def liveness is vacuous); slot liveness is what's
+/// needed.
+///
+/// SOUNDNESS — a store at `i` to `[sp, #N]` (immediate slot, no register offset)
+/// is removed only if a forward scan from `i+1` reaches either the next store to
+/// the SAME immediate slot `N`, or the end of the function, WITHOUT encountering
+/// anything that could read slot `N` or that we cannot reason past. The scan
+/// conservatively KEEPS the store (proves nothing) at the first of:
+///  - a `ldr` from `[sp, #N]` (the slot is read — live),
+///  - ANY `[sp, reg-offset]` load or store (slot unresolvable — could touch `N`),
+///  - a `Push`/`Pop` (touches the stack region — could overlap `N`),
+///  - a call (`Bl`/`Blx`/`Call`/`CallIndirect`: a callee may read an outgoing
+///    stack-argument slot),
+///  - any op that defines `SP` (frame geometry changed — `#N` no longer names
+///    the same location),
+///  - any op `reg_effect` does not model (branch / label / unmodeled): control
+///    could reach a reader, so we cannot prove deadness on a straight line.
+///
+/// Only the immediate-offset `Str`/`Ldr` forms participate; everything else is a
+/// blocker. This makes the pass effective on straight-line leaf regions (the
+/// frame-resident hot kernels) and a conservative no-op elsewhere — it never
+/// removes a store whose slot any reachable instruction might load.
+///
+/// LOAD-BEARING ASSUMPTION: spill slots are word-aligned and non-overlapping, so
+/// a `str [sp,#N]` is the ONLY writer of those 4 bytes and a different immediate
+/// `#M` provably does not alias `#N`. The sub-word-access blocker above is what
+/// enforces "no partial writers/readers"; do not widen the participating set
+/// without re-checking this.
+///
+/// **Branch-offset safety:** like [`forward_stack_reloads`] and
+/// [`eliminate_dead_stores`], intended to run on the `select_with_stack` output
+/// BEFORE `resolve_label_branches`; removing a non-branch interior instruction is
+/// offset-neutral. The frame `sub sp,#K` is untouched (the slot just goes unused),
+/// so SP balance is preserved — frame SHRINKING is [`elide_dead_frame`]'s job.
+/// Pure function; callers opt in.
+pub fn eliminate_dead_frame_stores(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
+    let n = instrs.len();
+    let mut dead: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
+
+    for i in 0..n {
+        // [i] must be `str rX, [sp, #N]` (immediate slot, no register offset).
+        let slot = match &instrs[i].op {
+            ArmOp::Str { addr, .. } if addr.base == Reg::SP && addr.offset_reg.is_none() => {
+                addr.offset
+            }
+            _ => continue,
+        };
+        // Scan forward for an OVERWRITE of slot N with no intervening read or
+        // aliasing op. A store is proven dead ONLY by a later store to the same
+        // immediate slot (classic dead-store-before-overwrite) — reaching the end
+        // of the function does NOT count (that "abandoned at frame teardown" case
+        // needs epilogue reasoning we deliberately do not do here, so the default
+        // is to KEEP). This makes the pass unconditionally sound: it never removes
+        // a store whose slot any reachable instruction might load.
+        let mut overwritten = false;
+        for scan in &instrs[i + 1..] {
+            match &scan.op {
+                // A reload of the SAME immediate slot ⇒ the value is used ⇒ live.
+                ArmOp::Ldr { addr, .. }
+                    if addr.base == Reg::SP && addr.offset_reg.is_none() && addr.offset == slot =>
+                {
+                    break;
+                }
+                // Overwrite of the SAME immediate slot with no intervening read ⇒
+                // THIS store is dead (its value never escaped the slot).
+                ArmOp::Str { addr, .. }
+                    if addr.base == Reg::SP && addr.offset_reg.is_none() && addr.offset == slot =>
+                {
+                    overwritten = true;
+                    break;
+                }
+                // Any sp-relative access we cannot pin to a single slot
+                // (register offset) could touch slot N ⇒ stop. Distinct immediate
+                // slots do not alias, so a different #M is fine and falls through
+                // to the reg_effect handling below.
+                ArmOp::Ldr { addr, .. } | ArmOp::Str { addr, .. }
+                    if addr.base == Reg::SP && addr.offset_reg.is_some() =>
+                {
+                    break;
+                }
+                // Sub-word sp-relative access: a `ldrb`/`ldrh`/… reads (or a
+                // `strb`/`strh` partially writes) bytes that may fall inside slot
+                // N. The overwrite rule below assumes the only writer/reader of
+                // slot N's word is a full-word `Str`/`Ldr [sp,#N]`; any narrower
+                // sp access breaks that, so stop. (Today's spill slots are
+                // word-aligned and accessed only full-word — linear-memory
+                // sub-word traffic goes through R11 — but this guard is what keeps
+                // the pass sound if that ever changes.)
+                ArmOp::Ldrb { addr, .. }
+                | ArmOp::Ldrsb { addr, .. }
+                | ArmOp::Ldrh { addr, .. }
+                | ArmOp::Ldrsh { addr, .. }
+                | ArmOp::Strb { addr, .. }
+                | ArmOp::Strh { addr, .. }
+                    if addr.base == Reg::SP =>
+                {
+                    break;
+                }
+                // Stack-region register lists could overlap slot N.
+                ArmOp::Push { .. } | ArmOp::Pop { .. } => break,
+                // A callee may read an outgoing stack-argument slot.
+                ArmOp::Bl { .. }
+                | ArmOp::Blx { .. }
+                | ArmOp::Call { .. }
+                | ArmOp::CallIndirect { .. } => break,
+                _ => {}
+            }
+            // SP redefinition or an unmodeled op (branch/label/...) ⇒ cannot prove
+            // the slot stays dead past here.
+            match reg_effect(&scan.op) {
+                Some(eff) if eff.defs.contains(&Reg::SP) => break,
+                Some(_) => {}
+                None => break,
+            }
+        }
+        if overwritten {
+            dead.insert(i);
+        }
+    }
+
+    if dead.is_empty() {
+        return (instrs.to_vec(), 0);
+    }
+    let kept: Vec<ArmInstruction> = instrs
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !dead.contains(i))
+        .map(|(_, ins)| ins.clone())
+        .collect();
+    (kept, dead.len())
+}
+
 /// VCR-RA immediate-shift folding (#390, epic #242): fold a register-materialized
 /// constant shift amount into an immediate shift, dropping the `movw`.
 ///
@@ -5428,6 +5566,124 @@ mod tests {
             }),
         ];
         assert_eq!(redundant_const_defs(&seq), Some(vec![]));
+    }
+
+    #[test]
+    fn frame_dce_removes_store_overwritten_before_read() {
+        // str r0,[sp,#4] ; add ... ; str r1,[sp,#4]  — slot #4 overwritten with no
+        // intervening read ⇒ the FIRST store is dead.
+        let seq = vec![
+            str_sp(Reg::R0, 4),
+            ins(ArmOp::Add {
+                rd: Reg::R2,
+                rn: Reg::R3,
+                op2: Operand2::Imm(1),
+            }),
+            str_sp(Reg::R1, 4),
+        ];
+        let (out, n) = eliminate_dead_frame_stores(&seq);
+        assert_eq!(n, 1, "overwritten-before-read store is dead");
+        assert_eq!(out.len(), 2);
+        // The surviving store is the live one (r1) into slot #4.
+        assert!(matches!(out[1].op, ArmOp::Str { rd: Reg::R1, .. }));
+    }
+
+    #[test]
+    fn frame_dce_keeps_store_that_is_read() {
+        // str r0,[sp,#4] ; ldr r1,[sp,#4]  — the slot is read ⇒ store is live.
+        let seq = vec![str_sp(Reg::R0, 4), ldr_sp(Reg::R1, 4)];
+        let (out, n) = eliminate_dead_frame_stores(&seq);
+        assert_eq!(n, 0, "a store whose slot is loaded is never removed");
+        assert_eq!(out, seq);
+    }
+
+    #[test]
+    fn frame_dce_distinct_slots_do_not_alias() {
+        // str r0,[sp,#4] ; str r1,[sp,#8] ; str r2,[sp,#4]  — #8 does not alias #4,
+        // so the first #4 store is still dead (overwritten by the second #4 store).
+        let seq = vec![str_sp(Reg::R0, 4), str_sp(Reg::R1, 8), str_sp(Reg::R2, 4)];
+        let (out, n) = eliminate_dead_frame_stores(&seq);
+        assert_eq!(n, 1, "distinct immediate slots are independent");
+        assert!(
+            !out.iter()
+                .any(|i| matches!(&i.op, ArmOp::Str { rd: Reg::R0, .. }))
+        );
+    }
+
+    #[test]
+    fn frame_dce_keeps_store_across_a_call() {
+        // str r0,[sp,#4] ; bl f ; str r1,[sp,#4]  — a callee could read the slot as
+        // an outgoing stack argument ⇒ conservatively keep the first store.
+        let seq = vec![
+            str_sp(Reg::R0, 4),
+            ins(ArmOp::Bl { label: "f".into() }),
+            str_sp(Reg::R1, 4),
+        ];
+        let (_out, n) = eliminate_dead_frame_stores(&seq);
+        assert_eq!(n, 0, "a call before the overwrite blocks the removal");
+    }
+
+    #[test]
+    fn frame_dce_keeps_store_across_sp_change() {
+        // str r0,[sp,#4] ; add sp,sp,#8 ; str r1,[sp,#4]  — sp moved, so [sp,#4] no
+        // longer names the same location ⇒ conservatively keep.
+        let seq = vec![
+            str_sp(Reg::R0, 4),
+            ins(ArmOp::Add {
+                rd: Reg::SP,
+                rn: Reg::SP,
+                op2: Operand2::Imm(8),
+            }),
+            str_sp(Reg::R1, 4),
+        ];
+        let (_out, n) = eliminate_dead_frame_stores(&seq);
+        assert_eq!(n, 0, "an SP change blocks the removal");
+    }
+
+    #[test]
+    fn frame_dce_keeps_store_before_subword_read_of_slot() {
+        // str r0,[sp,#4] ; ldrb r1,[sp,#4] ; str r2,[sp,#4]  — the byte load READS
+        // slot #4, so the first store is NOT dead even though a later store
+        // overwrites the slot. A sub-word slot access must block the removal.
+        let seq = vec![
+            str_sp(Reg::R0, 4),
+            ins(ArmOp::Ldrb {
+                rd: Reg::R1,
+                addr: MemAddr::imm(Reg::SP, 4),
+            }),
+            str_sp(Reg::R2, 4),
+        ];
+        let (_out, n) = eliminate_dead_frame_stores(&seq);
+        assert_eq!(n, 0, "a sub-word read of the slot blocks the removal");
+    }
+
+    #[test]
+    fn frame_dce_never_crosses_a_branch() {
+        // str r0,[sp,#4] ; <branch> ; str r1,[sp,#4]  — control could reach a
+        // reader on the other side of the branch ⇒ the first store is kept.
+        let seq = vec![
+            str_sp(Reg::R0, 4),
+            ins(ArmOp::BOffset { offset: 4 }),
+            str_sp(Reg::R1, 4),
+        ];
+        let (_out, n) = eliminate_dead_frame_stores(&seq);
+        assert_eq!(n, 0, "a branch between the stores blocks the removal");
+    }
+
+    #[test]
+    fn frame_dce_keeps_store_before_ambiguous_reg_offset_access() {
+        // str r0,[sp,#4] ; ldr r1,[sp,r2] ; str r3,[sp,#4]  — the register-offset
+        // load could target slot #4 ⇒ keep.
+        let seq = vec![
+            str_sp(Reg::R0, 4),
+            ins(ArmOp::Ldr {
+                rd: Reg::R1,
+                addr: MemAddr::reg(Reg::SP, Reg::R2),
+            }),
+            str_sp(Reg::R3, 4),
+        ];
+        let (_out, n) = eliminate_dead_frame_stores(&seq);
+        assert_eq!(n, 0, "an unresolvable sp-relative access blocks removal");
     }
 
     #[test]

--- a/scripts/repro/frame_slot_dce_differential.py
+++ b/scripts/repro/frame_slot_dce_differential.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""VCR-RA frame-slot DCE (#242) — EXECUTION-validate stack-reload forwarding +
+dead-frame-store elimination on the optimized path.
+
+The optimized ARM path lowers wasm locals frame-resident: `local.get`→`ldr [sp]`,
+`local.set`→`str [sp]`. On the silicon hot path most of that traffic is spurious
+(gale #209: flat_flight's spills fit in R0-R8 once value-allocated). Two paired
+passes attack it, both behind `SYNTH_STACK_FWD=1`:
+  - `forward_stack_reloads` turns `str rX,[sp,#N]; … ; ldr rY,[sp,#N]` into
+    `… ; mov rY,rX` when rX still holds the value (a load → a register move);
+  - `eliminate_dead_frame_stores` then removes the `str rX,[sp,#N]` whose slot is
+    overwritten before any read (a now-dead store) — the natural completion.
+
+On flat_flight's `flight_algo` this cuts sp-relative memory traffic 20→7 (9 loads
+forwarded, 4 dead stores removed) and 139→135 instructions.
+
+This is byte-CHANGING codegen, so the flag ships DEFAULT-OFF (off ⇒ byte-identical;
+the frozen differential hashes enforce it on the shipped --relocatable path). This
+harness is the correctness oracle for the flag-ON path: it compiles flat_flight
+with `SYNTH_STACK_FWD=1`, runs each export under unicorn (UC_ARCH_ARM / Thumb) with
+linear memory seeded exactly as wasmtime's, and asserts the returned value is
+bit-identical to wasmtime ground truth across several sensor inputs. It also
+asserts the flag-OFF `.text` is byte-identical to a flag-never-read build (the
+frozen-safety half) and reports the instruction-count reduction.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/frame_slot_dce_differential.py
+Exits nonzero on any value mismatch or a flag-off byte drift.
+"""
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("flight_seam_flat.wat")
+WASM = Path(__file__).with_name("flight_seam_flat.wasm")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+
+CODE, LIN, STK = 0x10000, 0x40000, 0x90000
+ST_OFF, S_OFF = 0x1000, 0x2000
+
+
+def st_init(pitch=1000, roll=-500, yaw=200, updates=7):
+    b = bytearray(64)
+    struct.pack_into("<i", b, 0, pitch)
+    struct.pack_into("<i", b, 4, roll)
+    struct.pack_into("<i", b, 8, yaw)
+    struct.pack_into("<i", b, 24, updates)
+    return bytes(b)
+
+
+def s_init(vals=(100, -50, 30, 300, -200)):
+    b = bytearray(32)
+    for i, v in enumerate(vals):
+        struct.pack_into("<h", b, i * 2, v)
+    return bytes(b)
+
+
+# (state-init, sensor-init) input variations exercising the hot path.
+CASES = [
+    (st_init(), s_init()),
+    (st_init(0, 0, 0, 0), s_init((0, 0, 0, 0, 0))),
+    (st_init(32000, -32000, 12345, 99), s_init((-300, 300, -200, 200, -100))),
+    (st_init(-1, 1, -2, 3), s_init((1, -1, 2, -2, 3))),
+]
+
+
+def compile_flat(out, fwd):
+    env = {"PATH": "/usr/bin:/bin"}
+    if fwd:
+        env["SYNTH_STACK_FWD"] = "1"
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env=env,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed (fwd={fwd}): {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for s in sec.iter_symbols():
+                if s.name:
+                    syms[s.name] = s["st_value"]
+    return code, base, syms
+
+
+def wasmtime_run(fn, st, s):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WASM.read_bytes())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    mem = inst.exports(store)["memory"]
+    mem.write(store, st, ST_OFF)
+    mem.write(store, s, S_OFF)
+    return inst.exports(store)[fn](store, ST_OFF, S_OFF) & 0xFFFFFFFF
+
+
+def unicorn_run(code, base, faddr, st, s):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x10000)
+    mu.mem_map(LIN, 0x10000)
+    mu.mem_map(STK - 0x8000, 0x10000)
+    mu.mem_write(CODE, code)
+    mu.mem_write(LIN + ST_OFF, st)
+    mu.mem_write(LIN + S_OFF, s)
+    mu.reg_write(UC_ARM_REG_SP, STK)
+    mu.reg_write(UC_ARM_REG_R11, LIN)
+    mu.reg_write(UC_ARM_REG_R0, ST_OFF)
+    mu.reg_write(UC_ARM_REG_R1, S_OFF)
+    ret = 0x9F00 | 1
+    mu.reg_write(UC_ARM_REG_LR, ret)
+    try:
+        mu.emu_start((CODE + (faddr & ~1) - base) | 1, ret & ~1, count=4000)
+    except UcError as e:
+        return f"ERR:{e}"
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def insn_count(code):
+    n, i = 0, 0
+    while i + 2 <= len(code):
+        hw = code[i] | (code[i + 1] << 8)
+        i += 4 if (hw >> 11) >= 0b11101 else 2
+        n += 1
+    return n
+
+
+def main():
+    off, on = "/tmp/fsdce_off.elf", "/tmp/fsdce_on.elf"
+    compile_flat(off, fwd=False)
+    compile_flat(on, fwd=True)
+    off_code, off_base, off_syms = load(off)
+    on_code, on_base, on_syms = load(on)
+
+    # Frozen-safety half: a second flag-off build must be byte-identical.
+    compile_flat("/tmp/fsdce_off2.elf", fwd=False)
+    off2_code, _, _ = load("/tmp/fsdce_off2.elf")
+    if off_code != off2_code:
+        print("FAIL: flag-off .text is not deterministic/byte-identical")
+        sys.exit(1)
+    print("OK  flag-off .text byte-identical across builds")
+
+    fails = 0
+    # flight_algo is the optimization target — the only export with frame-slot
+    # traffic the passes touch (DCE fires 4× there, 0× on the others) and the one
+    # with a clean (i32 state_ptr, i32 sensor_ptr) -> i32 ABI to drive here. The
+    # flag-off byte-identity check above covers the whole module's bytes.
+    exports = [e for e in ("flight_algo",) if e in on_syms]
+    for fn in exports:
+        for st, s in CASES:
+            gt = wasmtime_run(fn, st, s)
+            got = unicorn_run(on_code, on_base, on_syms[fn], st, s)
+            ok = isinstance(got, int) and got == gt
+            if not ok:
+                fails += 1
+            tag = f"0x{got:08X}" if isinstance(got, int) else got
+            print(f"{'OK  ' if ok else 'FAIL'} {fn:16} fwd-on = {tag} "
+                  f"(wasmtime 0x{gt:08X})")
+
+    print(f"\n.text instructions: off={insn_count(off_code)} "
+          f"on={insn_count(on_code)} "
+          f"(delta={insn_count(off_code) - insn_count(on_code)})")
+    print("\nRESULT:", "PASS" if not fails else f"FAIL ({fails} mismatches)")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Completes the **stack-reload-forwarding** lever: after `forward_stack_reloads`
(already built, behind `SYNTH_STACK_FWD`) turns a frame reload into a register
move, the original `str rX,[sp,#N]` is left behind as a dead store. This adds
`eliminate_dead_frame_stores` to remove it.

This is part of the "optimize down toward native parity" push — the frame-resident
lowering (`local.get`→`ldr [sp]`, `local.set`→`str [sp]`) is the dominant spurious
traffic gale measured on silicon (#209: flat_flight's spills fit in R0-R8 once
value-allocated).

`eliminate_dead_stores` can't catch these — a `str` defines no register, so its
register-def liveness is vacuous; **slot** liveness is what's needed.

## Soundness — overwrite-only by design

A store is proven dead **only** by a later store to the **same immediate slot**
with no intervening read or aliasing op. Reaching the function end does **not**
count (the "abandoned at frame teardown" case needs epilogue reasoning we
deliberately skip — default is KEEP). The forward scan stops and keeps the store
at the first of:

- a `ldr` from the slot,
- ANY sp-relative **register-offset** access,
- ANY sp-relative **sub-word** access (`ldrb`/`ldrh`/`strb`/… — could touch bytes inside the slot),
- `Push`/`Pop`, a call (callee may read an outgoing stack-arg slot),
- an SP redefinition, or any op `reg_effect` does not model (branch/label).

Rests on the documented load-bearing assumption that **spill slots are
word-aligned and non-overlapping**. **8 unit tests** pin each boundary; the
sub-word and overwrite-at-end guards were verified *failing before the fix*
(non-vacuous) — closing the #483/#496/#507-class hole an advisor flagged before
it could reach the flip.

## Gating — DEFAULT-OFF, shipped behaviour unchanged

Both passes sit under `SYNTH_STACK_FWD`; **off ⇒ byte-identical** (no flag-off
code path changes; frozen gate green). **The shipped behaviour of this PR is
unchanged** — the win below is the flip's payoff, a separate silicon-gated step.

New CI oracle `frame_slot_dce_differential.py` EXECUTES the flag-ON build under
unicorn and asserts `flight_algo`'s return matches wasmtime across several sensor
inputs (incl. the `0x07FDF307` frozen-anchor value), linear memory seeded as
wasmtime's; it also asserts the flag-off `.text` is byte-identical across builds.

## Flip payoff (measured via objdump — NOT moved by this PR)

| metric (flat_flight `flight_algo`) | flag-off | flag-on |
|---|---|---|
| sp-relative memory ops | 20 | **7** (9 reloads → reg moves, 4 dead stores removed) |
| instructions | 139 | **135** |

VCR-RA / epic #242. Behaviour frozen on every shipped path.