### PR TITLE
chore(release): v0.17.0 — stack-fwd + frame-slot DCE default-on (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-26
+
+**Stack-reload forwarding + frame-slot dead-store elimination now default-on
+(#242).** Two paired frame-traffic passes that shipped flag-off (#514/#515) are
+flipped to default-on, the next step toward native parity (VCR-RA / epic #242).
+synth lowers every wasm local to a frame slot, so `local.set; local.get` emits
+`str rX,[sp,#N]; … ; ldr rY,[sp,#N]`. `forward_stack_reloads` rewrites the reload
+to `mov rY,rX` when `rX` still holds the value; `eliminate_dead_frame_stores` then
+removes the `str` once its slot is overwritten-before-read (a dead store the
+register-def-based DCE cannot see).
+
+The win lands on the **shipped `--relocatable` path** (the post-passes run on the
+direct selector's output): flight_seam `774→738 B`, flight_seam_flat `910→878 B`;
+control_step and all RISC-V output **unchanged** (ARM-only, m4 and m7 identically).
+RESULTS are bit-identical — control_step `0x00210A55` (13/13), flat and inlined
+flight_algo `0x07FDF307` — re-verified against wasmtime in both the default and the
+`SYNTH_NO_STACK_FWD=1` opt-out path.
+
+Gated like the cmp→select (v0.13.0) and local-promotion (v0.14.0) flips: frozen
+goldens re-frozen, an escape-hatch gate asserts `SYNTH_NO_STACK_FWD=1` restores the
+pre-flip bytes byte-for-byte, the execution differential runs both configs, and
+`cargo test --workspace` is green under the new default. Soundness is overwrite-only
+(a store is dead only when a later store to the same immediate slot overwrites it
+with no intervening read), with sub-word `[sp]` accesses treated as blockers.
+
+This is an instruction/memory-op reduction (flight_algo sp-traffic `20→7`,
+`139→135` instructions); the measured cycle number is confirmed on G474RE silicon
+post-ship. `SYNTH_NO_STACK_FWD=1` restores the prior lowering. const-CSE
+(`SYNTH_CONST_CSE`) remains flag-off.
+
 ## [0.16.0] - 2026-06-26
 
 **AAPCS stack-argument path: functions with >8 scalar i32 params/args now lower

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,14 +2023,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2079,11 +2079,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.16.0"
+version = "0.17.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2136,14 +2136,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2151,11 +2151,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.16.0"
+version = "0.17.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.16.0"
+version = "0.17.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.16.0",
+    version = "0.17.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.16.0" }
+synth-core = { path = "../synth-core", version = "0.17.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.16.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.16.0" }
+synth-core = { path = "../synth-core", version = "0.17.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.17.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.16.0" }
+synth-core = { path = "../synth-core", version = "0.17.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.16.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.16.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.17.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.17.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.16.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.16.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.16.0" }
-synth-backend = { path = "../synth-backend", version = "0.16.0" }
+synth-core = { path = "../synth-core", version = "0.17.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.17.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.17.0" }
+synth-backend = { path = "../synth-backend", version = "0.17.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.16.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.16.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.16.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.17.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.17.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.17.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.16.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.17.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.16.0" }
+synth-core = { path = "../synth-core", version = "0.17.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.16.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.17.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.16.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.16.0" }
-synth-opt = { path = "../synth-opt", version = "0.16.0" }
+synth-core = { path = "../synth-core", version = "0.17.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.17.0" }
+synth-opt = { path = "../synth-opt", version = "0.17.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.16.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.16.0" }
-synth-opt = { path = "../synth-opt", version = "0.16.0" }
+synth-core = { path = "../synth-core", version = "0.17.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.17.0" }
+synth-opt = { path = "../synth-opt", version = "0.17.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.16.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.17.0", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Release PR for **v0.17.0** — the next perf release (precedent: cmp-select v0.13.0, local-promote v0.14.0, imm-shift-fold v0.15.0).

## Contents
- **Pin sweep:** `[workspace.package].version` + every intra-workspace path-dep `version =` + MODULE.bazel `0.16.0 → 0.17.0` (verified by `scripts/check_version_pins.py`).
- **CHANGELOG:** v0.17.0 entry for the `SYNTH_STACK_FWD` flip to default-on (already merged in #516 / b043101).

## What shipped in this version
Stack-reload forwarding + frame-slot dead-store elimination are now **default-on**, delivering the win on the shipped `--relocatable` path: flight_seam `774→738 B`, flight_seam_flat `910→878 B`; control_step + all RISC-V unchanged (ARM-only). RESULTS bit-identical — control_step `0x00210A55`, flat+inlined flight_algo `0x07FDF307` — verified in both the default and `SYNTH_NO_STACK_FWD=1` opt-out. Measured cycle win confirmed on G474RE silicon post-ship.

On green: merge, then tag `v0.17.0` (release.yml handles crates.io publish + GitHub release + signing).