### PR TITLE
fix(vcr-ra): const-CSE size-regression guard — CSE-last + per-segment size guard (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **const-CSE size-regression guard (#242).** gale's v0.17.0 burndown found
+  `SYNTH_CONST_CSE=1` GREW a tiny `--relocatable` function (`gust_mix` 90→92 B): the
+  post-hoc `apply_const_cse` retargeted a use, kept a constant resident longer, and
+  defeated a downstream immediate-fold that would otherwise have absorbed it. Two
+  fixes: (1) `apply_const_cse` now runs **last** in the pass pipeline, after every
+  immediate-fold (so foldable consts are already gone before CSE looks), which
+  structurally eliminates that mechanism; (2) a per-segment **size guard** commits a
+  segment's removals/retargets only when they do not grow its *estimated* bytes (the
+  #511 encoder mirror) — e.g. a retarget that flips a 16-bit `ldr` to its 32-bit form
+  is declined. The guard's decline path is unit-tested non-vacuously;
+  `const_cse_differential.py` gains per-function no-regression gates on both the
+  optimized and `--relocatable` paths. Verified on the test corpus; gale's exact
+  `gust_mix` case is not yet reproduced in-tree (fixture requested to pin it).
+  const-CSE remains flag-off (`SYNTH_CONST_CSE`); flag-off output is byte-identical
+  (frozen gate green).
+
 ## [0.17.0] - 2026-06-26
 
 **Stack-reload forwarding + frame-slot dead-store elimination now default-on

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -238,7 +238,19 @@ artifacts:
       `cargo test --workspace` green under the new default (wast/spec suite is
       compile-only, so gale silicon is the broad-execution check). NOT flipped:
       const-CSE (SYNTH_CONST_CSE) stays flag-off — its alias-eviction prerequisite is
-      open and it is inert on flat_flight.
+      open and it is inert on flat_flight. NO-REGRESSION FIX (#242, 2026-06-26): gale's
+      v0.17.0 burndown found const-CSE GREW a `--relocatable` `gust_mix` 90→92 B (the
+      post-hoc `apply_const_cse` retargeted a use, kept a constant resident longer, and
+      defeated a downstream immediate-fold). Fixed by running `apply_const_cse` LAST in
+      the pass pipeline (after every immediate-fold, so foldable consts are already
+      gone) plus a per-segment SIZE GUARD (commit a segment's removals/retargets only
+      when they do not grow its estimated bytes — e.g. a retarget flipping a 16-bit
+      `ldr` to 32-bit is declined). Guard decline path proven non-vacuously by two
+      contrasting liveness unit tests; per-function no-regression gate added to
+      `const_cse_differential.py`; flag-off byte-identical (frozen gate green). The
+      pressure/size prerequisite for the eventual default-on flip is now CLOSED;
+      alias-eviction remains the sole open prerequisite. (Not empirically reproduced on
+      gale's exact `gust_mix` — fixture requested to pin the trigger.)
     status: implemented
     tags: [codegen, register-allocation, ssa, regalloc2, track-a, release-v0.11.40]
     links:

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -382,21 +382,14 @@ fn compile_wasm_to_arm(
     // needs an on-target/allocator-aware gate, not a byte-count gate, before it
     // can default on.
 
-    // VCR-RA-001 const-CSE / rematerialization-avoidance (#209), the first
-    // allocator-analysis-driven CODEGEN change. Drops `movw` re-materializations
-    // of a constant already resident in another register and retargets the reads
-    // — every rewrite proven by the liveness analysis, and it ONLY removes
-    // materializations (pressure never rises), so unlike the mla fusion (#277) it
-    // cannot regress on-target. Runs on the selected stream before branch
-    // resolution (it removes instructions, shifting byte offsets). Behind
-    // `SYNTH_CONST_CSE=1` while it is validated against the differential oracle +
-    // gale's five on-target baselines; off by default keeps every fixture
-    // bit-identical.
-    let arm_instrs = if std::env::var("SYNTH_CONST_CSE").is_ok() {
-        synth_synthesis::liveness::apply_const_cse(&arm_instrs).0
-    } else {
-        arm_instrs
-    };
+    // VCR-RA-001 const-CSE / rematerialization-avoidance (#209): moved to run
+    // LAST, after the immediate-folds — see the apply_const_cse call below
+    // (#242). Earlier it ran here (before range-realloc and the folds), which is
+    // what let it grow gale's --relocatable `gust_mix` 90→92 B (#242 burndown,
+    // 2026-06-26): retargeting a read defeated a *downstream* immediate-fold that
+    // would otherwise have absorbed the constant. Running CSE-last makes those
+    // foldable consts already-folded-and-gone, so CSE only ever touches genuinely
+    // redundant materializations.
 
     // VCR-RA-001 RANGE RE-ALLOCATION (#209/#242, wiring step 3a) — the first
     // CONSEQUENTIAL allocator pass: re-colour each maximal straight-line
@@ -630,6 +623,29 @@ fn compile_wasm_to_arm(
         let (out, folds) = synth_synthesis::liveness::fold_uxth(&arm_instrs);
         if std::env::var("SYNTH_FUSE_STATS").is_ok() {
             eprintln!("[uxth-fold] {folds} mask-and folded to uxth/uxtb, movw dropped");
+        }
+        out
+    } else {
+        arm_instrs
+    };
+
+    // VCR-RA-001 const-CSE / rematerialization-avoidance (#209, #242). Drops a
+    // `movw`/`mov #imm` that re-materializes a constant already resident in
+    // another register and retargets the reads — every rewrite proven by the
+    // liveness analysis. Runs LAST, after every immediate-fold (shift, uxth) and
+    // range-realloc, but BEFORE branch resolution/encoding (it removes
+    // instructions, shifting byte offsets). CSE-last is the #242 no-regression
+    // fix: the folds have already absorbed every foldable constant, so CSE can no
+    // longer defeat one (the gust_mix 90→92 mechanism). The pass additionally
+    // size-guards each segment via the byte-estimator — it commits a segment's
+    // rewrites only if they do not grow its estimated size — so a retarget that
+    // would flip a 16-bit encoding to 32-bit (higher base register) is declined.
+    // Behind `SYNTH_CONST_CSE=1` while validated against the differential oracle;
+    // off by default keeps every fixture bit-identical.
+    let arm_instrs = if std::env::var("SYNTH_CONST_CSE").is_ok() {
+        let (out, removed) = synth_synthesis::liveness::apply_const_cse(&arm_instrs);
+        if std::env::var("SYNTH_FUSE_STATS").is_ok() {
+            eprintln!("[const-cse] {removed} redundant constant materialization(s) removed");
         }
         out
     } else {

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -3383,11 +3383,28 @@ fn safe_cse_uses(
 /// and `ra` provably still holds `v` through every later read of `rd` (until
 /// `rd` is redefined within the segment), drop the `movw` and retarget those
 /// reads to `ra`. This is the allocator's rematerialization-avoidance applied as
-/// a targeted transform — every rewrite is *proven* by liveness, and it only
-/// ever REMOVES a materialization (register pressure never rises), so it cannot
-/// trigger the #277-class on-target regression. Returns the rewritten stream and
-/// the count removed. Pure; callers opt in (flag-gated, differential-verified).
+/// a targeted transform — every rewrite is *proven* by liveness.
+///
+/// SIZE GUARD (#242): this pass operates on already-register-assigned
+/// instructions, so it cannot itself spill — but a removal+retarget can still
+/// *grow* a function by changing what a later pass or the encoder does. Two
+/// concrete ways: (a) the retargeted read keeps a constant resident longer,
+/// defeating a downstream immediate-fold that would have absorbed it (the
+/// `gust_mix` 90→92 B regression gale measured on `--relocatable`, 2026-06-26);
+/// and (b) retargeting a read from a low register to a high one flips a 16-bit
+/// Thumb encoding to its 32-bit form (`ldr r0,[r3,#off]` → `ldr r0,[r8,#off]`,
+/// +2 B). (a) is structurally eliminated by running this pass LAST, after every
+/// immediate-fold (so foldable consts are already gone); (b) is caught here:
+/// each maximal segment's staged removals/rewrites are committed only if they do
+/// not increase the segment's estimated byte size
+/// ([`crate::optimizer_bridge::estimate_arm_byte_size`], the #511 encoder mirror)
+/// — otherwise the whole segment's CSE is declined and every materialization is
+/// kept. Monotone-or-neutral on size by measurement, not by hand-wave.
+///
+/// Returns the rewritten stream and the count removed. Pure; callers opt in
+/// (flag-gated, differential-verified).
 pub fn apply_const_cse(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
+    use crate::optimizer_bridge::estimate_arm_byte_size;
     let n = instrs.len();
     let mut removed = vec![false; n];
     let mut rewrites: Vec<(usize, Reg, Reg)> = Vec::new(); // (use_index, from, to)
@@ -3395,6 +3412,10 @@ pub fn apply_const_cse(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize
     // Process each maximal straight-line, fully-modeled segment independently.
     let mut seg_start = 0;
     let mut process_segment = |start: usize, end: usize| {
+        // Stage this segment's candidate changes locally; commit only if they do
+        // not grow the segment's estimated byte size (#242 size guard below).
+        let mut seg_removed: Vec<usize> = Vec::new();
+        let mut seg_rewrites: Vec<(usize, Reg, Reg)> = Vec::new();
         let mut held: Vec<(Reg, i32)> = Vec::new(); // reg → resident constant
         for i in start..end {
             if let Some((rd, v)) = const_materialization(&instrs[i].op) {
@@ -3402,9 +3423,9 @@ pub fn apply_const_cse(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize
                     && ra != rd
                     && let Some(use_indices) = safe_cse_uses(instrs, i, rd, ra, end)
                 {
-                    removed[i] = true;
+                    seg_removed.push(i);
                     for j in use_indices {
-                        rewrites.push((j, rd, ra));
+                        seg_rewrites.push((j, rd, ra));
                     }
                     continue; // movw dropped; rd not added to `held`
                 }
@@ -3416,6 +3437,37 @@ pub fn apply_const_cse(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize
                 }
             }
         }
+        if seg_removed.is_empty() {
+            return;
+        }
+        // Per-index rename map for this segment, so we can estimate the rewritten
+        // bytes (a retarget can change an op's encoding width).
+        let mut renames_seg: BTreeMap<usize, Vec<(Reg, Reg)>> = BTreeMap::new();
+        for &(j, from, to) in &seg_rewrites {
+            renames_seg.entry(j).or_default().push((from, to));
+        }
+        let orig_bytes: usize = (start..end)
+            .map(|i| estimate_arm_byte_size(&instrs[i].op))
+            .sum();
+        let new_bytes: usize = (start..end)
+            .filter(|i| !seg_removed.contains(i))
+            .map(|i| {
+                let mut op = instrs[i].op.clone();
+                if let Some(rs) = renames_seg.get(&i) {
+                    for &(from, to) in rs {
+                        op = rename_use(&op, from, to).unwrap_or(op);
+                    }
+                }
+                estimate_arm_byte_size(&op)
+            })
+            .sum();
+        if new_bytes <= orig_bytes {
+            for i in seg_removed {
+                removed[i] = true;
+            }
+            rewrites.extend(seg_rewrites);
+        }
+        // else: declining this segment's CSE keeps every materialization in place.
     };
     for (i, ins) in instrs.iter().enumerate() {
         if !is_straight_line(&ins.op) || reg_effect(&ins.op).is_none() {
@@ -7516,6 +7568,109 @@ mod tests {
         assert_eq!(
             removed, 0,
             "rd not redefined in segment → may be live-out → no fold"
+        );
+    }
+
+    #[test]
+    fn const_cse_size_guard_declines_when_retarget_flips_16bit_to_32bit() {
+        // #242 size guard (non-vacuity proof, half 1 of 2). A const resident in a
+        // HIGH register (r8) is re-materialized in a LOW register (r3) and used as
+        // the base of three 16-bit `ldr`s. Retargeting r3→r8 flips each `ldr` to
+        // its 32-bit form (low base <8 ⇒ 2 B, base r8 ⇒ 4 B): +2 B × 3 = +6 B,
+        // versus the −4 B saved by dropping the redundant `movw r3`. Net +2 B, so
+        // the guard must DECLINE the whole segment and keep every materialization.
+        let mem = |b: Reg, o: i32| crate::rules::MemAddr {
+            base: b,
+            offset: o,
+            offset_reg: None,
+        };
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R8,
+                imm16: 100,
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R3,
+                imm16: 100,
+            }),
+            ins(ArmOp::Ldr {
+                rd: Reg::R0,
+                addr: mem(Reg::R3, 0),
+            }),
+            ins(ArmOp::Ldr {
+                rd: Reg::R1,
+                addr: mem(Reg::R3, 4),
+            }),
+            ins(ArmOp::Ldr {
+                rd: Reg::R2,
+                addr: mem(Reg::R3, 8),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R3,
+                imm16: 5,
+            }),
+        ];
+        let (out, removed) = apply_const_cse(&seq);
+        assert_eq!(
+            removed, 0,
+            "guard declines: retarget would grow the segment"
+        );
+        assert_eq!(
+            out, seq,
+            "declined segment is returned byte-for-byte unchanged"
+        );
+    }
+
+    #[test]
+    fn const_cse_size_guard_commits_when_retarget_keeps_16bit_encoding() {
+        // #242 size guard (non-vacuity proof, half 2 of 2). IDENTICAL structure to
+        // the decline test, except the resident register is LOW (r2): retargeting
+        // r3→r2 keeps every `ldr` 16-bit (base still <8), so the segment shrinks by
+        // the dropped `movw` (−4 B) and the guard COMMITS. This isolates the guard
+        // to the encoding-width effect — the only difference is the register class.
+        let mem = |b: Reg, o: i32| crate::rules::MemAddr {
+            base: b,
+            offset: o,
+            offset_reg: None,
+        };
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R2,
+                imm16: 100,
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R3,
+                imm16: 100,
+            }),
+            ins(ArmOp::Ldr {
+                rd: Reg::R0,
+                addr: mem(Reg::R3, 0),
+            }),
+            ins(ArmOp::Ldr {
+                rd: Reg::R1,
+                addr: mem(Reg::R3, 4),
+            }),
+            ins(ArmOp::Ldr {
+                rd: Reg::R4,
+                addr: mem(Reg::R3, 8),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R3,
+                imm16: 5,
+            }),
+        ];
+        let (out, removed) = apply_const_cse(&seq);
+        assert_eq!(
+            removed, 1,
+            "guard commits: retarget keeps the segment smaller"
+        );
+        // The three loads now read the resident r2.
+        assert_eq!(
+            out.iter()
+                .filter(|i| matches!(&i.op, ArmOp::Ldr { addr, .. } if addr.base == Reg::R2))
+                .count(),
+            3,
+            "all three loads retargeted to the low resident register r2"
         );
     }
 

--- a/scripts/repro/const_cse_differential.py
+++ b/scripts/repro/const_cse_differential.py
@@ -1,33 +1,36 @@
 #!/usr/bin/env python3
 """VCR-RA const-CSE (#242) — EXECUTION-validate the optimized-path const cache.
 
-The optimized (non-`--relocatable`) ARM path re-materializes a constant at every
-use: the same `i32.const N` becomes a fresh `movw`/`movt` (or `mov`) each time.
-gale measured this on silicon — flat_flight spends 61% of its const
-materializations on values already sitting in a register. `SYNTH_CONST_CSE=1`
-turns on a pressure-neutral const cache (`optimizer_bridge.rs`): when the wanted
-value already lives in a still-valid register, the new vreg is ALIASED to that
-register and nothing is emitted. The cache is reconstructed from the EMITTED ARM
-at the top of each lowering step (so it survives the many `continue` arms) and
-RESET at every control-flow boundary (an unmodeled `reg_effect` op), confining
-reuse to straight-line segments.
+The ARM path re-materializes a constant at every use: the same `i32.const N`
+becomes a fresh `movw`/`movt` (or `mov`) each time. gale measured this on silicon
+— flat_flight spends 61% of its const materializations on values already sitting
+in a register. `SYNTH_CONST_CSE=1` removes the redundant materializations via the
+post-hoc `liveness::apply_const_cse` pass (it also enables an inline const cache
+on the optimized path; this harness, run without `--relocatable`, exercises both).
+
+CSE-LAST + SIZE GUARD (#242). gale's v0.17.0 burndown found const-CSE GREW a tiny
+`--relocatable` function (`gust_mix` 90→92 B): retargeting a use kept a constant
+resident longer and defeated a *downstream* immediate-fold that would otherwise
+have absorbed it. Two fixes, both validated here: (1) `apply_const_cse` now runs
+LAST in the pass pipeline, after every immediate-fold, so foldable consts are
+already gone before CSE looks; (2) it size-guards each segment — committing a
+removal/retarget only when it does not grow the segment's estimated bytes (e.g. a
+retarget that flips a 16-bit `ldr` to its 32-bit form is declined). The guard's
+decline path is unit-tested non-vacuously in `liveness.rs`; the per-function gate
+below is the end-to-end enforcement over real compiled functions.
 
 This is byte-CHANGING codegen, so the flag ships DEFAULT-OFF (off ⇒ byte-identical,
-the frozen gate proves it). This harness is the correctness oracle for the
-flag-ON path: it compiles `const_cse.wat` with `SYNTH_CONST_CSE=1` via the
-optimized path, runs each export under unicorn (UC_ARCH_ARM / Thumb), and asserts
-the returned value is bit-identical to wasmtime ground truth across a spread of
-inputs (including negatives and zero). Covered shapes (see the .wat header):
-large/small/negative/mixed consts, reuse ACROSS an if/else (cache must reset),
-and a 12-live-local function that forces real spills (proves an aliased register
-is still correct after it is itself spilled — STR is a use, not a def). It also
-reports the instruction-count delta off-vs-on as information (no gate — the win
-is real where there's register headroom and inert under pressure, never a
-regression).
+the frozen gate proves it). This harness is the correctness + no-regression oracle
+for the flag-ON path: it compiles `const_cse.wat` with `SYNTH_CONST_CSE=1`, runs
+each export under unicorn (UC_ARCH_ARM / Thumb), and asserts the returned value is
+bit-identical to wasmtime ground truth across a spread of inputs (including
+negatives and zero), THEN asserts no function grew flag-on vs flag-off. Covered
+shapes (see the .wat header): large/small/negative/mixed consts, reuse ACROSS an
+if/else (cache must reset), and a 12-live-local function that forces real spills.
 
 Run (needs wasmtime + unicorn + pyelftools):
   SYNTH=./target/debug/synth python scripts/repro/const_cse_differential.py
-Exits nonzero on any value mismatch.
+Exits nonzero on any value mismatch OR any function that grew under const-CSE.
 """
 import os
 import struct
@@ -60,30 +63,32 @@ def wasmtime_run(fn, arg):
     return inst.exports(store)[fn](store, arg)
 
 
-def compile_optimized(out, cse_on):
+def compile_optimized(out, cse_on, relocatable=False):
     env = {"PATH": "/usr/bin:/bin"}
     if cse_on:
         env["SYNTH_CONST_CSE"] = "1"
-    r = subprocess.run(
-        [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
-         "--target", "cortex-m4", "--all-exports"],
-        capture_output=True, text=True, env=env,
-    )
+    cmd = [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+           "--target", "cortex-m4", "--all-exports"]
+    if relocatable:
+        cmd.append("--relocatable")
+    r = subprocess.run(cmd, capture_output=True, text=True, env=env)
     if r.returncode != 0:
-        sys.exit(f"compile failed (cse_on={cse_on}): {r.stderr}")
+        sys.exit(f"compile failed (cse_on={cse_on}, reloc={relocatable}): {r.stderr}")
 
 
 def load(elf):
     f = ELFFile(open(elf, "rb"))
     text = f.get_section_by_name(".text")
     code, base = text.data(), text["sh_addr"]
-    syms = {}
+    syms, fsizes = {}, {}
     for sec in f.iter_sections():
         if sec.header.sh_type == "SHT_SYMTAB":
             for sy in sec.iter_symbols():
                 if sy.name:
                     syms[sy.name] = sy["st_value"]
-    return code, base, syms
+                    if sy["st_info"]["type"] == "STT_FUNC":
+                        fsizes[sy.name] = sy["st_size"]
+    return code, base, syms, fsizes
 
 
 def unicorn_run(code, base, faddr, arg):
@@ -121,8 +126,8 @@ def main():
     off_elf, on_elf = "/tmp/const_cse_off.elf", "/tmp/const_cse_on.elf"
     compile_optimized(off_elf, cse_on=False)
     compile_optimized(on_elf, cse_on=True)
-    off_code, off_base, off_syms = load(off_elf)
-    on_code, on_base, on_syms = load(on_elf)
+    off_code, off_base, off_syms, off_sizes = load(off_elf)
+    on_code, on_base, on_syms, on_sizes = load(on_elf)
 
     fails = 0
     for fn in EXPORTS:
@@ -140,12 +145,62 @@ def main():
             print(f"{'OK  ' if ok else 'FAIL'} {fn} cse-on({arg}) = {got} "
                   f"(wasmtime {exp})")
 
-    print("\n--- instruction-count delta (information, not a gate) ---")
+    # NO-REGRESSION GATE (#242): const-CSE must never GROW any function. This is
+    # gale's explicit ask after the gust_mix 90→92 B regression — enforced by the
+    # CSE-last reorder (foldable consts are already folded) plus the per-segment
+    # size guard in apply_const_cse. The guard's decline path is proven
+    # non-vacuously by the liveness unit tests; this is the end-to-end gate over
+    # real compiled functions.
+    print("\n--- per-function no-regression gate (#242) ---")
+    grew = 0
+    for fn in EXPORTS:
+        o, n = off_sizes.get(fn), on_sizes.get(fn)
+        if o is None or n is None:
+            continue
+        if n > o:
+            grew += 1
+            print(f"REGRESS {fn}: {o} -> {n} B (+{n - o}) — const-CSE grew a function")
+        else:
+            tag = f"-{o - n}" if n < o else "0"
+            print(f"OK      {fn}: {o} -> {n} B ({tag})")
+    fails += grew
+
+    # --relocatable NO-REGRESSION GATE (#242). gale's gust_mix 90→92 B regression
+    # was on `--relocatable`, which routes through `select_direct()` — there the
+    # INLINE const cache never runs, so the post-hoc `apply_const_cse` acts ALONE.
+    # This is the precise path of the bug; the optimized-path gate above does not
+    # exercise it (inline aliasing dominates there). We compile the corpus on the
+    # direct path flag-on vs flag-off and assert no function grows. NOTE: post-hoc
+    # CSE is currently INERT on this corpus (the direct selector does not emit the
+    # redundant same-value-in-two-registers shape these arithmetic fixtures would
+    # need) — so this gate is, for now, a tripwire that will light up the moment a
+    # fixture that DOES trigger it (e.g. gale's gust_mix Q8 clamp mixer) is added.
+    print("\n--- per-function no-regression gate, --relocatable / direct path (#242) ---")
+    roff, ron = "/tmp/const_cse_reloc_off.o", "/tmp/const_cse_reloc_on.o"
+    compile_optimized(roff, cse_on=False, relocatable=True)
+    compile_optimized(ron, cse_on=True, relocatable=True)
+    _, _, _, roff_sizes = load(roff)
+    _, _, _, ron_sizes = load(ron)
+    rgrew, rfired = 0, 0
+    for fn in sorted(set(roff_sizes) & set(ron_sizes)):
+        o, n = roff_sizes[fn], ron_sizes[fn]
+        if n > o:
+            rgrew += 1
+            print(f"REGRESS {fn}: {o} -> {n} B (+{n - o}) — const-CSE grew a function")
+        elif n < o:
+            rfired += 1
+            print(f"OK      {fn}: {o} -> {n} B (-{o - n}) — CSE fired")
+    if rfired == 0:
+        print(f"(post-hoc CSE inert on this corpus — {len(roff_sizes)} fns, none changed)")
+    fails += rgrew
+
+    print("\n--- instruction-count delta, optimized path (information) ---")
     off_n, on_n = insn_count(off_code), insn_count(on_code)
     print(f".text Thumb instructions: off={off_n}  on={on_n}  "
           f"delta={off_n - on_n} ({'fewer with CSE' if on_n < off_n else 'no change'})")
 
-    print("\nRESULT:", "PASS" if not fails else f"FAIL ({fails} mismatches)")
+    print("\nRESULT:", "PASS" if not fails
+          else f"FAIL ({fails} issue(s): mismatches and/or function growth)")
     sys.exit(1 if fails else 0)
 
 


### PR DESCRIPTION
## What

Fixes the const-CSE size regression gale found in the v0.17.0 burndown (#242):
`SYNTH_CONST_CSE=1` **grew** a tiny `--relocatable` function (`gust_mix` 90→92 B).

**Root cause.** On `--relocatable`, the optimized path's inline const cache never
runs (`select_direct()`), so the post-hoc `liveness::apply_const_cse` acts alone.
A remove-`movw` + rename-use post-pass on already-register-assigned instructions
cannot itself spill — it grows code only by changing what a *later* pass does. Here
it retargeted a use, kept a constant resident longer, and **defeated a downstream
immediate-fold** that would otherwise have absorbed the constant.

## Fix

1. **CSE-last** — move the `apply_const_cse` call to run *after* every immediate-fold
   (`fold_immediate_shifts` / `fold_uxth`), before branch resolution. Foldable consts
   are already folded-and-gone, so CSE can no longer defeat a fold. Structurally
   eliminates gale's mechanism.
2. **Per-segment size guard** in `apply_const_cse` — stage each segment's removals/
   retargets, estimate the rewritten segment via `estimate_arm_byte_size` (the #511
   encoder mirror), commit only if it does not grow. A retarget that flips a 16-bit
   `ldr` to its 32-bit form (low→high base register) is declined.

## Verification

- **Non-vacuous guard tests** — two contrasting `liveness` unit tests: identical
  segments differing only in the resident register's class (high R8 → encoding flips
  → declines; low R2 → no flip → commits).
- **Differential** (`const_cse_differential.py`) — flag-on values bit-identical to
  wasmtime across the corpus; new per-function no-regression gates on **both** the
  optimized and `--relocatable` paths.
- **Flag-off byte-identical** — frozen gate 3/3, const_cse golden 2/2.
- `cargo test --workspace` green (85 suites); fmt + clippy clean.

## Honesty / scope

const-CSE stays **flag-off** (`SYNTH_CONST_CSE`). The pressure/size prerequisite for
the eventual default-on flip is now closed; alias-eviction remains the sole open
prerequisite. **gale's exact `gust_mix` case is not yet reproduced in-tree** — the
post-hoc pass is currently inert on the arithmetic `--relocatable` corpus, so that
gate is a tripwire that lights up when a triggering fixture (gust_mix.wat, requested
on #242) lands. The fix is structurally sound; this PR does not claim an empirical
fix-on-gale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)