### PR TITLE
chore(vcr-mem): re-validate scry consumed surface against scry-sai-core 2.3.0 (#383, #242)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,42 +1798,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "scry-sai-core"
-version = "2.0.0"
+name = "scry-sai-bits"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e882493438a4122673c1fceb1fdce01b3a733b13877846aad711ec413b23942c"
+checksum = "99220601aa017b9d725d825837f01db2b1c3044b06ebe2eb5bd150161e650b1d"
+
+[[package]]
+name = "scry-sai-core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c112b0ff57cf790e5b7c5077929c91639b4dc4a97929c0df4180d14f2a460d"
 dependencies = [
+ "scry-sai-bits",
  "scry-sai-interval",
  "scry-sai-octagon",
  "scry-sai-provenance",
  "scry-sai-taint",
  "sha2 0.10.9",
- "wasmparser 0.247.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
 name = "scry-sai-interval"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b562abdc282c200e4f6156dbce23c2584583053cae87fbb675b8849dcc598b4"
+checksum = "83eac224c75f13bb39c244ad5615a7fc1a4e25203fe8ea31450155f0a865dc46"
 
 [[package]]
 name = "scry-sai-octagon"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae25bf8d4f477f72fb677ea61f1aabdf1eee1d6d51b85c8608f97f0e3d3577d"
+checksum = "7c7b4e8221a882a18638ae9ee4b82bcea3717d2dca82150ac969f4219d4cf645"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde769346d666d8a3ddd7e61212cf31e81da54ca37efa1a20176fe3ce2072dac"
+checksum = "16b21313e6683a03b557c794d1925b0979005e298be0a0ead1e7d676b8b29ad6"
 
 [[package]]
 name = "scry-sai-taint"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfaf402dc38b06582d30db8088b16ce8db18814ce7742b2d7061e8103c197e7d"
+checksum = "7006fa9dcb6e57b90fff10a014f68bab20a294f0ed8e4a9f17d0e4160ceabf17"
 
 [[package]]
 name = "semver"
@@ -2677,15 +2684,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.247.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -72,5 +72,7 @@ gimli = { version = "0.33", default-features = false, features = ["read", "std"]
 # Tracks scry 2.x (SCPV v3): the major bump reshaped the provenance wire format,
 # but synth's consumed surface (call_graph / function_summaries / stack_usage /
 # reachable_from_exports / operand_stack) is unchanged and additive-only, so the
-# bump is transparent here. See scry#63 / scry v2.0.0.
+# bump is transparent here. See scry#63 / scry v2.0.0. Empirically re-verified
+# against scry v2.3.0 (2026-06-27, lockfile bumped) — scry_shadow_stack_budget
+# stays GREEN, so the "transparent" claim is tested, not just asserted.
 scry-sai-core = "2.0"

--- a/crates/synth-cli/tests/scry_shadow_stack_budget.rs
+++ b/crates/synth-cli/tests/scry_shadow_stack_budget.rs
@@ -1,9 +1,14 @@
 //! VCR-MEM-001 (#383) layer-2 substrate — scry shadow-stack-depth proof, in-tree.
 //!
 //! Proves, in CI against the REAL gust-family module, that synth can obtain a
-//! SOUND worst-case shadow-stack budget from scry (`scry-sai-core` v1.12, the
-//! crates.io library finalized in scry#51 / scry PR #53). This is the layer-2
-//! "proof the budget is sufficient" half of #383 — the half scry owns:
+//! SOUND worst-case shadow-stack budget from scry (`scry-sai-core`, the crates.io
+//! library finalized in scry#51 / scry PR #53). First validated on v1.12, then
+//! across the SCPV v3 major bump (v2.x); re-verified GREEN on **scry v2.3.0**
+//! (2026-06-27) — the consumed surface (`stack_usage.max_stack_bytes`,
+//! `function_summaries[].recursive`, `reachable_from_exports`) is unchanged, so
+//! the "2.x bump is transparent" claim in `Cargo.toml` is empirically backed, not
+//! just asserted. This is the layer-2 "proof the budget is sufficient" half of
+//! #383 — the half scry owns:
 //!
 //!   - layer-1 (synth-side): the ELF `.bss` retarget mechanics that consume the
 //!     budget — still silicon-gated on gale's `--stack-first` answer.


### PR DESCRIPTION
## What

scry released **v2.3.0**. synth's VCR-MEM-001 (#383) layer-2 substrate pins the
`scry-sai-core` **dev-dependency** at `"2.0"` with a comment asserting the 2.x bump is
"transparent" (consumed surface unchanged) — but that was only ever verified against
2.0.0 (the lockfile pin), untested for 2.1/2.2/2.3.

This bumps the lockfile to **scry-sai-core 2.3.0** and re-runs the in-tree integration
test (`scry_shadow_stack_budget`) that calls `scry_analyze_core::analyze()` on the real
gust-family module. **GREEN** — the consumed surface is unchanged:
- `stack_usage.max_stack_bytes` = 65536
- `function_summaries[].recursive` (honest-fail recursion gate)
- `reachable_from_exports` (dead-path pruning superset)

So the "transparent bump" claim is now **empirically backed, not just asserted**. Doc
comments updated to record the 2.3.0 re-verification.

## Gate

Behavior-frozen — `scry-sai-core` is a **dev-dependency** exercised only by this test, so
the production `synth` binary does not pull scry: **no codegen / `.text` change**. Frozen
anchors bit-identical (`frozen_codegen_bytes` 3/3, control_step `0x00210A55` / flight_algo
`0x07FDF307` untouched); `cargo fmt --check` clean.

Responds to the scry v2.3.0 release; the directive's preferred "external-analysis
dev-dependency + test" shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)