### PR TITLE
chore(release): v0.18.0 — i64-param AAPCS homing (#518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-06-30
+
+**i64-parameter codegen correctness — closes the #518 silent miscompile.**
+
 ### Fixed
+
+- **i64 params homed per AAPCS register-pairs (#518, #242).** An i64 binary op
+  reading an i64 **parameter** silently miscompiled on **both** ARM selectors: an
+  i64 param occupies an AAPCS register *pair* (param0 = R0:R1), but both selectors
+  treated a param as a single i32-width register. Direct selector
+  (`--relocatable`/shipped): `infer_i64_locals` learned i64-ness only from
+  `local.set`/`tee`, so a read-only i64 param stayed `is_i64=false` → its hi
+  register was unreserved and a following `i64.const` was allocated *into* it
+  (`movw r1,#K` clobbered R1 = the param's high half). Fixed by (a) seeding
+  `i64_locals` from the declared param widths, (b) reserving the i64 param's hi
+  half in the live-param reservation, and (c) mapping params to registers via a
+  new AAPCS even-aligned assignment (`(i32,i64)` → R0,R2:R3, not the sequential
+  R1:R2 the old mapping used). The optimized path — which lacks per-param types —
+  declines i64-param functions to the direct selector (the honest-degradation
+  pattern). All-i32 signatures map identically, so **non-i64-param functions are
+  byte-identical** (frozen anchors unchanged). Two sub-cases are declined *loudly*
+  (Ok-or-Err, never silent wrong-code), tracked under #503: an i64 param passed
+  past R3 (on the stack), and an i64 param in a frame-backing function (with a
+  call). So no silent wrong-code remains: every i64-param function is either
+  correctly compiled or loud-skipped. Gated by
+  `scripts/repro/i64_param_518_differential.py` (11 leaf cases match wasmtime on
+  both paths across the full AAPCS matrix) + a decline-contract fixture;
+  independently clean-room verified.
+
+### Changed
+
+- **CI pins rivet v0.22.0** (adds the `rivet release` planning command, #516),
+  validated regression-free on this repo's artifacts before pinning. The release
+  readiness gate (`rivet release status`) is documented in the release process.
+- **VCR-ORACLE-001 (#242):** in-tree characterization oracles landed for the
+  #518 i64-param defect (incl. the RISC-V cross-backend loud-skip contrast) and
+  the still-open #509 value-returning-branch drop; scry consumed-surface
+  re-validated against scry-sai-core 2.5.0 (FEAT-039 open-world reachability
+  soundness pinned).
+
+### Fixed (flag-off, no shipped behavior change)
 
 - **const-CSE size-regression guard (#242).** gale's v0.17.0 burndown found
   `SYNTH_CONST_CSE=1` GREW a tiny `--relocatable` function (`gust_mix` 90→92 B): the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,14 +2030,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2086,11 +2086,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2129,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2143,14 +2143,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2158,11 +2158,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2211,7 +2211,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.17.0",
+    version = "0.18.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.17.0" }
+synth-core = { path = "../synth-core", version = "0.18.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.17.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.17.0" }
+synth-core = { path = "../synth-core", version = "0.18.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.18.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.17.0" }
+synth-core = { path = "../synth-core", version = "0.18.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.17.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.17.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.18.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.18.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.17.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.17.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.17.0" }
-synth-backend = { path = "../synth-backend", version = "0.17.0" }
+synth-core = { path = "../synth-core", version = "0.18.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.18.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.18.0" }
+synth-backend = { path = "../synth-backend", version = "0.18.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.17.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.17.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.17.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.18.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.18.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.18.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.17.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.18.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.17.0" }
+synth-core = { path = "../synth-core", version = "0.18.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.17.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.18.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.17.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.17.0" }
-synth-opt = { path = "../synth-opt", version = "0.17.0" }
+synth-core = { path = "../synth-core", version = "0.18.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.18.0" }
+synth-opt = { path = "../synth-opt", version = "0.18.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.17.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.17.0" }
-synth-opt = { path = "../synth-opt", version = "0.17.0" }
+synth-core = { path = "../synth-core", version = "0.18.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.18.0" }
+synth-opt = { path = "../synth-opt", version = "0.18.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.17.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.18.0", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Release prep for **v0.18.0** (bug-fix release; the #518 fix already landed on main via #531).

- Workspace + all path-dep version pins + `MODULE.bazel` bumped **0.17.0 → 0.18.0** (mandatory pin sweep); `Cargo.lock` updated.
- `CHANGELOG.md` rolled `[Unreleased]` → `[0.18.0] - 2026-06-30`.

**Headline:** #518 — i64 binop reading an i64 param silently miscompiled on both ARM selectors (param treated as a single i32-width register, not an AAPCS register pair). Leaf register-resident cases now lower correctly; frame-backed / past-R3 sub-cases decline loudly (#503 follow-up). Non-i64-param functions are byte-identical (frozen anchors unchanged).

Also shipped since 0.17.0: CI pinned to rivet v0.22.0 (release planning, #516); VCR-ORACLE characterization oracles (#518 incl. RISC-V cross-backend contrast, #509); scry 2.5.0 consumed-surface re-validation.

Pre-tag gates green locally: fmt, clippy (`--workspace --all-targets`), tests, frozen anchors 3/3, rivet validate. On merge, `v0.18.0` will be tagged to trigger the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)