### PR TITLE
chore(vcr-mem): re-validate + consume scry 2.6.0 gaps/FEAT-043 soundness (#383, #242)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,15 +1799,15 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-bits"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a749c9b7f213d76bcd20a00caed41c7365bb0e044f0d7e407cd0561ac4d6f8f0"
+checksum = "006b1058f05801e38a59c633534649d44a815ea7113c218d886e0560e6012c00"
 
 [[package]]
 name = "scry-sai-core"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1a9e14700890ba8812cfee5ae59e9d4c7e44434694c8617721ca35ed9b043d"
+checksum = "b02d7053b71516f1f7e35b3b35a07e804a9229933efa372bbc730879cc9b7a0d"
 dependencies = [
  "scry-sai-bits",
  "scry-sai-interval",
@@ -1820,27 +1820,27 @@ dependencies = [
 
 [[package]]
 name = "scry-sai-interval"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486d13ed454c233a42cfcf804a35c1a09a5ab2f8ad3b0169f2f601e4e3627f36"
+checksum = "0d4532b75b75570dd7092c7f18dd5ab8e0a921adbd00b83185c3855be4ddde07"
 
 [[package]]
 name = "scry-sai-octagon"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ef476091d53c8cc6ced2bbc5d302ec983b328366aa988230c6d2204f4c24b6"
+checksum = "3460128de7a67fdfd8d93ad676eeeebccf2baee3ee720edab8fe963024544d10"
 
 [[package]]
 name = "scry-sai-provenance"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19071e291644ddb6017e3926eb13c8a6188857461592b6cb732b3cbe2df5926"
+checksum = "a024c296d8ec3baf850f9bddb922df89b81fcc00efe67ff74b63e51412c4384f"
 
 [[package]]
 name = "scry-sai-taint"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b255301d93308b14f235da0b53844042d3f73f2f1433411ee29051a3530e782f"
+checksum = "4edbdc5bd261f33c1bab959c2013ad6bf2fd8ecf5771da5b5eda9b7c6e56579f"
 
 [[package]]
 name = "semver"

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -73,10 +73,14 @@ gimli = { version = "0.33", default-features = false, features = ["read", "std"]
 # but synth's consumed surface (call_graph / function_summaries / stack_usage /
 # reachable_from_exports / operand_stack) is unchanged and additive-only, so the
 # bump is transparent here. See scry#63 / scry v2.0.0. Empirically re-verified
-# against scry v2.3.0 then v2.5.0 (2026-06-27, lockfile bumped) —
-# scry_shadow_stack_budget stays GREEN, so the "transparent" claim is tested, not
-# just asserted. v2.4.0 (FEAT-038) models memory.size/grow; v2.5.0 (FEAT-039)
-# makes reachable_from_exports sound in the open world (escaped funcref) — the
-# superset synth's shadow-stack pruning relies on; pinned by
-# scry_reachable_superset_is_open_world_sound_383_feat039.
+# against scry v2.3.0, v2.5.0 (2026-06-27), then v2.6.0 (2026-06-30, lockfile
+# bumped) — scry_shadow_stack_budget stays GREEN, so the "transparent" claim is
+# tested, not just asserted. v2.4.0 (FEAT-038) models memory.size/grow; v2.5.0
+# (FEAT-039) makes reachable_from_exports sound in the open world (escaped
+# funcref) — the superset synth's shadow-stack pruning relies on; pinned by
+# scry_reachable_superset_is_open_world_sound_383_feat039. v2.6.0 adds the
+# machine-readable `gaps` field (FEAT-040) + hardens the shadow-stack bound by the
+# resolved call_indirect target set (FEAT-043); consumed surface unchanged
+# (msgq_put Bytes(32) bound unchanged), now re-verified with a gap-observability
+# assertion (value-domain gaps ⇒ the finite bound is sound).
 scry-sai-core = "2.0"

--- a/crates/synth-cli/tests/scry_shadow_stack_budget.rs
+++ b/crates/synth-cli/tests/scry_shadow_stack_budget.rs
@@ -3,12 +3,20 @@
 //! Proves, in CI against the REAL gust-family module, that synth can obtain a
 //! SOUND worst-case shadow-stack budget from scry (`scry-sai-core`, the crates.io
 //! library finalized in scry#51 / scry PR #53). First validated on v1.12, then
-//! across the SCPV v3 major bump (v2.x); re-verified GREEN on **scry v2.3.0** then
-//! **v2.5.0** (2026-06-27) — the consumed surface (`stack_usage.max_stack_bytes`,
-//! `function_summaries[].recursive`, `reachable_from_exports`) is unchanged, so
-//! the "2.x bump is transparent" claim in `Cargo.toml` is empirically backed, not
-//! just asserted. scry v2.4.0/v2.5.0 are behavioral-precision + soundness updates
-//! with no API/contract change: v2.4.0 models `memory.size`/`grow` (FEAT-038);
+//! across the SCPV v3 major bump (v2.x); re-verified GREEN on **scry v2.3.0**,
+//! **v2.5.0** (2026-06-27), then **v2.6.0** (2026-06-30) — the consumed surface
+//! (`stack_usage.max_stack_bytes`, `function_summaries[].recursive`,
+//! `reachable_from_exports`) is unchanged, so the "2.x bump is transparent" claim
+//! in `Cargo.toml` is empirically backed, not just asserted. v2.6.0 ADDS the
+//! machine-readable `gaps` field (FEAT-040) and hardens the shadow-stack bound by
+//! the *resolved* `call_indirect` target set (FEAT-043, six under-reporting
+//! soundness holes closed). msgq_put's `Bytes(32)` bound is UNCHANGED under that
+//! hardening (it has no `call_indirect`), and assertion (4) below now consumes
+//! `gaps`: msgq_put gaps only in the VALUE domain (div_u/load8/store8/block),
+//! never on call resolution, which is *why* the bound stayed a finite `Bytes` —
+//! FEAT-043 forces `Unbounded` on a bound-affecting gap. scry v2.4.0/v2.5.0 are
+//! behavioral-precision + soundness updates with no API/contract change: v2.4.0
+//! models `memory.size`/`grow` (FEAT-038);
 //! v2.5.0 (FEAT-039) makes `reachable_from_exports` sound in the OPEN world — a
 //! function reachable only via an ESCAPED funcref (exported table / exported
 //! funcref global / passed to an import) is no longer dropped. That value is
@@ -37,7 +45,7 @@
 //! proves the true worst case is 32 bytes — a 2048× over-reservation the layer-1
 //! retarget will collapse.
 
-use scry_analyze_core::{AnalysisConfig, StackBound, analyze};
+use scry_analyze_core::{AnalysisConfig, GapKind, StackBound, analyze};
 
 /// Absolute path to a repo fixture (tests run with CWD = the crate dir).
 fn fixture(rel: &str) -> std::path::PathBuf {
@@ -80,6 +88,33 @@ fn scry_proves_msgq_shadow_stack_budget_383() {
     assert!(
         !r.reachable_from_exports.is_empty(),
         "reachable_from_exports is the sound superset synth prunes against"
+    );
+
+    // (4) GAP OBSERVABILITY (v2.6.0 FEAT-040 + FEAT-043). `gaps` records every
+    //     site where a fact degraded to ⊤. msgq_put DOES gap — but only in the
+    //     VALUE domain (i32.div_u / i32.load8_u / i32.store8 unsupported, plus a
+    //     havocked block) — never on call-target resolution. That distinction is
+    //     the FEAT-043 soundness contract: a call_indirect / call_ref /
+    //     table-mutation gap forces the shadow-stack bound to Unbounded/Unknown,
+    //     NOT a finite under-report (the "cardinal error"). So the finite
+    //     `Bytes(32)` above PROVES scry resolved the call structure soundly; the
+    //     value-domain gaps scrub *data* facts, not call depth. synth's
+    //     consumption rule, now mechanically checkable: trust a finite budget, and
+    //     treat Unbounded as honest-fail. A regression that let a control-flow
+    //     gap (UnmodeledBranch) co-exist with a finite bound would trip this.
+    assert!(
+        r.gaps
+            .iter()
+            .all(|g| !matches!(g.kind, GapKind::UnmodeledBranch)),
+        "msgq_put's gaps must be value-domain (no UnmodeledBranch), so the finite \
+         Bytes(32) bound is not perturbed by an unmodelled multi-target branch; \
+         got {:?}",
+        r.gaps
+    );
+    assert!(
+        matches!(r.stack_usage.max_stack_bytes, StackBound::Bytes(_)),
+        "a finite (Bytes) bound means scry resolved the call structure with no \
+         bound-affecting gap — FEAT-043 forces Unbounded/Unknown otherwise"
     );
 }
 


### PR DESCRIPTION
## What

Issue-hunt external signal: **scry v2.6.0** released (past seen v2.5.0). It adds the machine-readable **`gaps`** field (FEAT-040) and hardens the shadow-stack bound by the *resolved* `call_indirect` target set (**FEAT-043**, six under-reporting soundness holes closed) — a soundness change to the exact `max_stack_bytes` value synth's VCR-MEM-001 consumes.

## Triaged + validated

- Bumped `scry-sai-core` 2.5.0 → 2.6.0; **consumed surface unchanged** — `msgq_put`'s `Bytes(32)` bound is unchanged under FEAT-043 (it has no `call_indirect`), existing assertions stay GREEN.
- **NEW assertion (4) consumes FEAT-040 `gaps`:** `msgq_put` *does* gap, but only in the **value domain** (`i32.div_u` / `load8_u` / `store8` unsupported, a havocked block) — never on call-target resolution. That's the FEAT-043 contract: a call-resolution gap forces the bound to `Unbounded`/`Unknown`, **not** a finite under-report — so the finite `Bytes(32)` *proves* scry resolved the call structure; value-domain gaps scrub data facts, not call depth. The assertion trips if an `UnmodeledBranch` gap ever co-exists with a finite bound.
  - Honest note: my first cut asserted *gap-free*, which FEAT-040 immediately falsified (msgq_put has value-domain gaps) — corrected to the soundness-relevant check.

## Frozen-safe

scry stays a **DEV-dependency** (no production pull, no codegen). Frozen anchors 3/3; fmt + clippy clean.

Refs #383, #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)