### PR TITLE
fix(arm): memory.grow(0) returns current size, not -1 — close #539

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -148,6 +148,33 @@ fn count_params(wasm_ops: &[WasmOp]) -> u32 {
         .unwrap_or(0)
 }
 
+/// #539: fold the `i32.const 0; memory.grow m` idiom to `memory.size m`.
+/// `memory.grow(0)` always succeeds and returns the current page count (WASM
+/// Core §4.4.7), which is exactly `memory.size`; the fixed-memory backend
+/// otherwise emits a constant `-1` for every `memory.grow`, so the legal
+/// `memory.grow(0)` "read/validate current size" idiom wrongly reported failure.
+/// Only the ADJACENT const-0 delta is folded (a non-zero delta keeps the sound
+/// `-1` — fixed memory genuinely cannot grow; a runtime-computed 0 is a
+/// documented follow-up). Backend- and path-agnostic: `memory.size` reads the
+/// runtime memory-size register on every selector, so this fixes the optimized
+/// and direct paths at once.
+fn rewrite_memory_grow_zero(wasm_ops: &[WasmOp]) -> Vec<WasmOp> {
+    let mut out = Vec::with_capacity(wasm_ops.len());
+    let mut i = 0;
+    while i < wasm_ops.len() {
+        if matches!(wasm_ops[i], WasmOp::I32Const(0))
+            && let Some(WasmOp::MemoryGrow(m)) = wasm_ops.get(i + 1)
+        {
+            out.push(WasmOp::MemorySize(*m));
+            i += 2;
+        } else {
+            out.push(wasm_ops[i].clone());
+            i += 1;
+        }
+    }
+    out
+}
+
 /// Core compilation: WASM ops → ARM machine code bytes + relocations
 ///
 /// Returns (code_bytes, relocations) where relocations record BL instructions
@@ -156,6 +183,19 @@ fn compile_wasm_to_arm(
     wasm_ops: &[WasmOp],
     config: &CompileConfig,
 ) -> Result<(Vec<u8>, Vec<CodeRelocation>, LineMap), String> {
+    // #539: `memory.grow(0)` must return the CURRENT page count, not the
+    // fixed-memory `-1` sentinel — growing by zero pages can never fail (WASM
+    // Core §4.4.7), so a guest doing `if (memory.grow(0) < 0) trap;` wrongly
+    // faulted. Every lowering path emitted a delta-agnostic `-1`. `memory.grow(0)`
+    // is semantically identical to `memory.size`, which the backend already
+    // computes from the runtime memory-size register (R10 >> 16 = pages), so fold
+    // the `i32.const 0; memory.grow` idiom to `memory.size` up front — backend-
+    // and path-agnostic. A non-zero delta keeps `-1` (fixed memory genuinely
+    // cannot grow); a runtime delta that happens to be 0 is the documented
+    // follow-up.
+    let rewritten = rewrite_memory_grow_zero(wasm_ops);
+    let wasm_ops: &[WasmOp] = &rewritten;
+
     let num_params = count_params(wasm_ops);
 
     let bounds_config = match config.effective_safety_bounds() {
@@ -907,6 +947,44 @@ fn resolve_label_branches(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #539: `i32.const 0; memory.grow m` folds to `memory.size m`; other deltas
+    /// (const non-zero, runtime) are left as `memory.grow` (→ the sound fixed-
+    /// memory -1). Non-grow ops are untouched, so functions without the idiom are
+    /// byte-identical.
+    #[test]
+    fn test_rewrite_memory_grow_zero_539() {
+        // the idiom -> memory.size
+        assert_eq!(
+            rewrite_memory_grow_zero(&[WasmOp::I32Const(0), WasmOp::MemoryGrow(0)]),
+            vec![WasmOp::MemorySize(0)]
+        );
+        // const non-zero delta: NOT folded
+        assert_eq!(
+            rewrite_memory_grow_zero(&[WasmOp::I32Const(2), WasmOp::MemoryGrow(0)]),
+            vec![WasmOp::I32Const(2), WasmOp::MemoryGrow(0)]
+        );
+        // runtime delta (no preceding const): NOT folded
+        assert_eq!(
+            rewrite_memory_grow_zero(&[WasmOp::LocalGet(0), WasmOp::MemoryGrow(0)]),
+            vec![WasmOp::LocalGet(0), WasmOp::MemoryGrow(0)]
+        );
+        // a bare const-0 not feeding a grow is untouched
+        assert_eq!(
+            rewrite_memory_grow_zero(&[WasmOp::I32Const(0), WasmOp::I32Add]),
+            vec![WasmOp::I32Const(0), WasmOp::I32Add]
+        );
+        // fold is local: surrounding ops preserved, indices past the fold intact
+        assert_eq!(
+            rewrite_memory_grow_zero(&[
+                WasmOp::LocalGet(0),
+                WasmOp::I32Const(0),
+                WasmOp::MemoryGrow(0),
+                WasmOp::I32Add,
+            ]),
+            vec![WasmOp::LocalGet(0), WasmOp::MemorySize(0), WasmOp::I32Add]
+        );
+    }
 
     #[test]
     fn test_arm_backend_name() {

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -5370,10 +5370,12 @@ impl OptimizerBridge {
                     let rd =
                         alloc_i32_scratch(&vreg_to_arm, &local_to_reg, &param_reserved_regs, &[]);
                     vreg_to_arm.insert(dest.0, rd);
-                    arm_instrs.push(ArmOp::Mov {
-                        rd,
-                        op2: Operand2::Reg(Reg::R10),
-                    });
+                    // #539: emit the dedicated MemorySize op — its encoder does
+                    // `LSR rd, R10, #16` (bytes → pages). The previous `MOV rd,
+                    // R10` returned the size in BYTES, not pages, so `memory.size`
+                    // (and the `memory.grow(0)` fold that lowers to it) was 65536×
+                    // too large on the optimized path.
+                    arm_instrs.push(ArmOp::MemorySize { rd });
                     last_result_vreg = Some(dest.0);
                 }
 

--- a/scripts/repro/mem_grow_539.wat
+++ b/scripts/repro/mem_grow_539.wat
@@ -1,0 +1,19 @@
+;; #539 — `memory.grow(0)` must return the CURRENT page count, not the
+;; fixed-memory `-1` sentinel. Growing by zero pages can never fail (WASM Core
+;; §4.4.7), so `memory.grow(0)` returns the current size; a guest doing
+;; `if (memory.grow(0) < 0) trap;` (a legal "read/validate current size" idiom)
+;; wrongly faulted because every `memory.grow` lowered to a constant -1.
+;;
+;; The fix folds the `i32.const 0; memory.grow` idiom to `memory.size`
+;; (semantically identical) up front, which also surfaced + fixed a latent
+;; optimized-path bug where `memory.size` returned BYTES (MOV R10) instead of
+;; PAGES (LSR R10,#16). A non-zero delta keeps -1 (fixed memory genuinely cannot
+;; grow).
+(module
+  (memory 3)
+  ;; current size in pages — must be 3
+  (func (export "sz") (result i32) (memory.size))
+  ;; grow by 0 -> current size (3), NOT -1
+  (func (export "grow0") (result i32) (memory.grow (i32.const 0)))
+  ;; grow by >0 on fixed memory -> -1 (acceptable: cannot grow)
+  (func (export "grow2") (result i32) (memory.grow (i32.const 2))))

--- a/scripts/repro/mem_grow_539_differential.py
+++ b/scripts/repro/mem_grow_539_differential.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""#539 — EXECUTION-validate the memory.grow(0) fix on both ARM lowering paths.
+
+Before the fix, every `memory.grow` lowered to a constant `-1`, so the legal
+`memory.grow(0)` "return current size" idiom (WASM Core §4.4.7 — growing by zero
+pages can never fail) wrongly reported failure. The fix folds `i32.const 0;
+memory.grow` → `memory.size` up front (semantically identical), which also fixed
+a latent optimized-path bug where `memory.size` returned BYTES (`MOV R10`) rather
+than PAGES (`LSR R10,#16`).
+
+This harness compiles `mem_grow_539.wat` on BOTH ARM paths (optimized = default,
+direct = `--relocatable`), runs each export under unicorn (Thumb, R10 = memory
+size in bytes as the runtime startup sets it), and checks:
+  - `sz`    == 3   (current pages; catches the MOV-vs-LSR memory.size bug)
+  - `grow0` == 3   (grow-by-0 returns current size — the #539 fix)
+  - `grow2` == -1  (grow-by->0 on FIXED memory returns -1; this is the sound,
+                    documented behavior and legitimately differs from wasmtime,
+                    whose memory can actually grow — so grow>0 is asserted
+                    directly, not against wasmtime)
+
+`sz`/`grow0` are also cross-checked against wasmtime (a FRESH instance per call —
+`memory.grow` mutates the store, so a shared instance would pollution the oracle).
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/mem_grow_539_differential.py
+"""
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R10,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("mem_grow_539.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+CODE, STK, RET = 0x100000, 0x900000, 0x300000
+PAGES = 3
+R10 = PAGES * 65536  # runtime memory size in bytes (as startup sets R10)
+
+
+def wasmtime_run(fn):
+    # FRESH instance per call: memory.grow mutates the store, so a shared
+    # instance would let grow2 inflate a later memory.size read.
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    return wasmtime.Instance(store, module, []).exports(store)[fn](store)
+
+
+def compile_arm(out, relocatable):
+    cmd = [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+           "--target", "cortex-m4", "--all-exports"]
+    if relocatable:
+        cmd.append("--relocatable")
+    r = subprocess.run(cmd, capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin"})
+    if r.returncode != 0 or "skipping" in r.stderr:
+        sys.exit(f"compile failed/skipped (reloc={relocatable}): {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for sy in sec.iter_symbols():
+                if sy.name and sy["st_info"]["type"] == "STT_FUNC":
+                    syms[sy.name] = sy["st_value"]
+    return code, base, syms
+
+
+def unicorn_run(code, base, faddr):
+    foff = (faddr & ~1) - base
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(STK - 0x10000, 0x20000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_ARM_REG_SP, STK)
+    mu.reg_write(UC_ARM_REG_R10, R10)
+    mu.reg_write(UC_ARM_REG_R11, 0x20000000)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    try:
+        mu.emu_start((CODE + foff) | 1, RET, count=100000)
+    except UcError as e:
+        return f"ERR:{e}"
+    raw = mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+    return struct.unpack("<i", struct.pack("<I", raw))[0]
+
+
+def main():
+    # (export, expected). grow2 is asserted to -1 directly (fixed memory cannot
+    # grow; that is the sound behavior and differs from wasmtime by design).
+    cases = [
+        ("sz", wasmtime_run("sz")),        # 3
+        ("grow0", wasmtime_run("grow0")),  # 3 — the #539 fix
+        ("grow2", -1),                     # fixed-memory: grow>0 -> -1
+    ]
+    fails = 0
+    for relocatable, label in ((False, "optimized"), (True, "direct   ")):
+        out = f"/tmp/mg539_{'rel' if relocatable else 'opt'}.o"
+        compile_arm(out, relocatable)
+        code, base, syms = load(out)
+        for fn, expect in cases:
+            got = unicorn_run(code, base, syms[fn])
+            ok = got == expect
+            if not ok:
+                fails += 1
+            note = "" if fn != "grow2" else "  (fixed-mem: -1 is sound; wasmtime grows)"
+            print(f"{'OK ' if ok else 'BUG'} [{label}] {fn:6} synth={got} "
+                  f"expect={expect}{note}")
+    print("\nRESULT:", "PASS — memory.grow(0) returns current size on both paths"
+          if not fails else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Closes #539 (filed by the challenge harness, confirmed vs wasmtime). `memory.grow(0)` returned `-1` instead of the current page count. Growing by zero pages **can never fail** (WASM Core §4.4.7), so it must return the current size; every ARM lowering path emitted a delta-agnostic `-1`, so a guest doing `if (memory.grow(0) < 0) trap;` wrongly faulted.

## Fix

Pre-lowering peephole (`rewrite_memory_grow_zero` in `arm_backend`): fold the adjacent `i32.const 0; memory.grow` idiom to `memory.size` — **semantically identical**, backend/path-agnostic (fixes the optimized *and* direct selectors at once), and independent of `config.linear_memory_bytes` (which is 0 on the plain `synth compile` path). A non-zero delta keeps `-1` (fixed memory genuinely cannot grow); a runtime-computed `0` is a documented follow-up.

The fold **surfaced + fixed a latent bug**: on the optimized path `memory.size` emitted `MOV rd,R10` (bytes) instead of the dedicated `ArmOp::MemorySize` (`LSR R10,#16` = pages) — it was 65536× too large. Now both paths emit the correct op.

## Verified

`scripts/repro/mem_grow_539{.wat,_differential.py}` (unicorn Thumb vs wasmtime, both paths):
- `sz = 3` (catches the MOV-vs-LSR `memory.size` bug)
- `grow0 = 3` — the #539 fix
- `grow2 = -1` — grow>0 on fixed memory is **sound** (asserted directly; differs from wasmtime, whose memory can grow)

Frozen anchors **3/3 byte-identical** (no `memory.grow/size` in them). RV32 **loud-skips** `memory.size`/`grow` (sound honest-fail — no silent bug there; parity with the #518 story). Unit test `test_rewrite_memory_grow_zero_539` pins the peephole (idiom folds; other deltas untouched; non-grow ops preserved).

Fixes #539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)