### PR TITLE
chore(release): v0.18.1 — memory.grow(0) returns current size (#539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-07-01
+
+**`memory.grow(0)` correctness — closes #539.**
+
+### Fixed
+
+- **`memory.grow(0)` returns the current page count, not `-1` (#539).** Growing
+  by zero pages can never fail (WASM Core §4.4.7), so `memory.grow(0)` must return
+  the current size; every ARM lowering path emitted a delta-agnostic `-1`, so a
+  guest doing `if (memory.grow(0) < 0) trap;` (a legal "read/validate current
+  size" idiom) wrongly faulted. Fixed by folding the `i32.const 0; memory.grow`
+  idiom to `memory.size` before lowering — semantically identical, and it fixes
+  the optimized and direct selectors at once. A non-zero delta keeps `-1` (fixed
+  memory genuinely cannot grow). The fold also surfaced and fixed a latent
+  optimized-path bug where `memory.size` returned the size in **bytes**
+  (`MOV rd, R10`) instead of **pages** (`LSR R10, #16`). Verified on both paths
+  under unicorn vs wasmtime; frozen anchors byte-identical; RISC-V continues to
+  loud-skip `memory.size`/`grow` (sound honest-fail).
+
 ## [0.18.0] - 2026-06-30
 
 **i64-parameter codegen correctness — closes the #518 silent miscompile.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,14 +2030,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2086,11 +2086,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.18.0"
+version = "0.18.1"
 
 [[package]]
 name = "synth-cli"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2129,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2143,14 +2143,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2158,11 +2158,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.18.0"
+version = "0.18.1"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2211,7 +2211,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.18.0"
+version = "0.18.1"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.18.0",
+    version = "0.18.1",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.18.0" }
+synth-core = { path = "../synth-core", version = "0.18.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.18.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.18.0" }
+synth-core = { path = "../synth-core", version = "0.18.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.18.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.18.0" }
+synth-core = { path = "../synth-core", version = "0.18.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.18.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.18.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.18.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.18.1", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,18 +27,18 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.18.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.18.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.18.0" }
-synth-backend = { path = "../synth-backend", version = "0.18.0" }
+synth-core = { path = "../synth-core", version = "0.18.1" }
+synth-frontend = { path = "../synth-frontend", version = "0.18.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.18.1" }
+synth-backend = { path = "../synth-backend", version = "0.18.1" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.18.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.18.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.18.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.18.1", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.18.1", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.18.1", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.18.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.18.1", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.18.0" }
+synth-core = { path = "../synth-core", version = "0.18.1" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.18.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.18.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.18.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.18.0" }
-synth-opt = { path = "../synth-opt", version = "0.18.0" }
+synth-core = { path = "../synth-core", version = "0.18.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.18.1" }
+synth-opt = { path = "../synth-opt", version = "0.18.1" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.18.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.18.0" }
-synth-opt = { path = "../synth-opt", version = "0.18.0" }
+synth-core = { path = "../synth-core", version = "0.18.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.18.1" }
+synth-opt = { path = "../synth-opt", version = "0.18.1" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.18.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.18.1", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Release prep for **v0.18.1** (bug-fix; the #539 fix already landed on main via #541).

- Workspace + all path-dep pins + `MODULE.bazel` bumped **0.18.0 → 0.18.1** (mandatory pin sweep); `Cargo.lock` updated.
- `CHANGELOG.md` rolled `[Unreleased]` → `[0.18.1] - 2026-07-01`.

**Headline:** #539 — `memory.grow(0)` returned `-1` instead of the current page count (grow-by-0 can't fail, WASM Core §4.4.7). Fixed by folding `i32.const 0; memory.grow` → `memory.size` on both ARM paths; also fixed a latent optimized-path `memory.size`-returns-bytes bug.

Pre-tag gates green locally: fmt, clippy (`--workspace --all-targets`), tests, frozen anchors 3/3. On merge, `v0.18.1` will be tagged to trigger the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)