### PR TITLE
feat(aarch64): milestone-1a — clang-verified A64 encoder + minimal selector (#538)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2055,6 +2055,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "synth-backend-aarch64"
+version = "0.18.1"
+dependencies = [
+ "synth-core",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "synth-backend-awsm"
 version = "0.18.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/synth-backend-awsm",
     "crates/synth-backend-wasker",
     "crates/synth-backend-riscv",
+    "crates/synth-backend-aarch64",
 ]
 resolver = "2"
 

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "synth-backend-aarch64"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
+
+[dependencies]
+synth-core = { path = "../synth-core", version = "0.18.1" }
+thiserror.workspace = true
+tracing.workspace = true

--- a/crates/synth-backend-aarch64/src/encoder.rs
+++ b/crates/synth-backend-aarch64/src/encoder.rs
@@ -1,0 +1,115 @@
+//! Minimal AArch64 (A64) instruction encoder — milestone-1 integer subset (#538).
+//!
+//! Every A64 instruction is a fixed 32-bit little-endian word. This module
+//! encodes only the subset milestone-1 needs (32-bit `w` register
+//! data-processing, `movz`/`movk`, and `ret`); float, SIMD, 64-bit, and
+//! control-flow are later milestones. Each encoding is cross-checked in tests
+//! against ground truth produced by `clang -target aarch64` (see `tests`), so the
+//! bit-twiddling is verified, not asserted.
+//!
+//! Register numbering is the A64 architectural number 0..=30 (`w0..w30`); 31 is
+//! `wzr`/`wsp` depending on context.
+
+/// A 32-bit general register operand (`w0..w30`; 31 = `wzr`).
+pub type Reg = u8;
+
+pub const WZR: Reg = 31;
+
+/// A binary `Wd = Wn OP Wm` data-processing op over the shifted-register form
+/// (shift = 0). The `base` is the opcode with all operand fields zero.
+fn dp3(base: u32, rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    base | ((rm as u32) << 16) | ((rn as u32) << 5) | (rd as u32)
+}
+
+/// `add wd, wn, wm`
+pub fn add(rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    dp3(0x0B00_0000, rd, rn, rm)
+}
+/// `sub wd, wn, wm`
+pub fn sub(rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    dp3(0x4B00_0000, rd, rn, rm)
+}
+/// `and wd, wn, wm`
+pub fn and(rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    dp3(0x0A00_0000, rd, rn, rm)
+}
+/// `orr wd, wn, wm`
+pub fn orr(rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    dp3(0x2A00_0000, rd, rn, rm)
+}
+/// `eor wd, wn, wm`
+pub fn eor(rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    dp3(0x4A00_0000, rd, rn, rm)
+}
+
+/// `mul wd, wn, wm` — `madd wd, wn, wm, wzr` (Ra = 31).
+pub fn mul(rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    0x1B00_0000 | ((rm as u32) << 16) | (0x1F << 10) | ((rn as u32) << 5) | (rd as u32)
+}
+
+/// `mov wd, wn` — architectural alias `orr wd, wzr, wn`.
+pub fn mov_reg(rd: Reg, rn: Reg) -> u32 {
+    orr(rd, WZR, rn)
+}
+
+/// `movz wd, #imm16` — zero the register and set bits [15:0].
+pub fn movz(rd: Reg, imm16: u16) -> u32 {
+    0x5280_0000 | ((imm16 as u32) << 5) | (rd as u32)
+}
+
+/// `movk wd, #imm16, lsl #(16*hw)` — keep other bits, set the `hw`-th halfword.
+pub fn movk(rd: Reg, imm16: u16, hw: u8) -> u32 {
+    0x7280_0000 | ((hw as u32) << 21) | ((imm16 as u32) << 5) | (rd as u32)
+}
+
+/// `ret` (`ret x30`).
+pub fn ret() -> u32 {
+    0xD65F_03C0
+}
+
+/// Materialize a 32-bit constant into `wd` with `movz` + optional `movk`.
+/// Returns 1 or 2 words.
+pub fn mov_imm32(rd: Reg, value: u32) -> Vec<u32> {
+    let lo = (value & 0xFFFF) as u16;
+    let hi = ((value >> 16) & 0xFFFF) as u16;
+    let mut out = vec![movz(rd, lo)];
+    if hi != 0 {
+        out.push(movk(rd, hi, 1));
+    }
+    out
+}
+
+/// Append a 32-bit instruction word to a little-endian byte buffer.
+pub fn emit(buf: &mut Vec<u8>, word: u32) {
+    buf.extend_from_slice(&word.to_le_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Ground truth from `clang -target aarch64-linux-gnu` (see the #538 build log).
+    #[test]
+    fn encodings_match_clang() {
+        assert_eq!(add(0, 0, 1), 0x0B01_0000);
+        assert_eq!(sub(2, 3, 4), 0x4B04_0062);
+        assert_eq!(mul(5, 6, 7), 0x1B07_7CC5);
+        assert_eq!(and(0, 1, 2), 0x0A02_0020);
+        assert_eq!(orr(3, 4, 5), 0x2A05_0083);
+        assert_eq!(eor(6, 7, 0), 0x4A00_00E6);
+        assert_eq!(movz(9, 5), 0x5280_00A9);
+        assert_eq!(movk(9, 1, 1), 0x72A0_0029);
+        assert_eq!(mov_reg(0, 9), 0x2A09_03E0);
+        assert_eq!(ret(), 0xD65F_03C0);
+    }
+
+    #[test]
+    fn mov_imm32_uses_movz_then_movk() {
+        assert_eq!(mov_imm32(0, 5), vec![movz(0, 5)]);
+        assert_eq!(mov_imm32(0, 0x1234), vec![movz(0, 0x1234)]);
+        assert_eq!(
+            mov_imm32(3, 0x0001_2345),
+            vec![movz(3, 0x2345), movk(3, 1, 1)]
+        );
+    }
+}

--- a/crates/synth-backend-aarch64/src/lib.rs
+++ b/crates/synth-backend-aarch64/src/lib.rs
@@ -1,0 +1,54 @@
+//! AArch64 (A64) host-native backend for synth — **milestone 1** (#538).
+//!
+//! Goal (from #538): a minimal A64 integer-subset backend reachable via
+//! `-b aarch64`, so synth output runs and debugs natively on arm64 dev hosts
+//! (Apple Silicon, arm64 Linux/CI) instead of only under QEMU/Renode — and so a
+//! third backend becomes a third differential oracle against the Thumb-2 and RV32
+//! lowerings.
+//!
+//! ## Milestone status
+//!
+//! - **1a (this crate, now):** the verified A64 *encoder* (integer
+//!   data-processing + `movz`/`movk` + `ret`, cross-checked against `clang`) and
+//!   a minimal straight-line *selector* (params in `w0..w7`, i32
+//!   add/sub/mul/and/or/xor + const, result to `w0`, `ret`). `compile_bytes`
+//!   turns a leaf integer function's wasm ops into A64 machine code. Ops outside
+//!   the subset return `Unsupported` — an honest loud-skip, never wrong code.
+//! - **1b (next):** an `EM_AARCH64` relocatable-ELF emitter, the `Backend` trait
+//!   impl, `-b aarch64` CLI wiring, and the native differential-execution
+//!   acceptance probe (`synth compile add.wat -b aarch64` → link + run on the
+//!   arm64 host, diff vs wasmtime).
+//! - **later:** spilling, i64, floats, memory, control flow, calls, DWARF.
+
+pub mod encoder;
+pub mod selector;
+
+pub use selector::{SelectError, select};
+
+/// Lower a single leaf integer function (wasm ops + declared param count) to A64
+/// machine-code bytes (little-endian 32-bit words). Convenience over
+/// [`selector::select`] for callers that want raw `.text` bytes.
+pub fn compile_bytes(ops: &[synth_core::WasmOp], num_params: u32) -> Result<Vec<u8>, SelectError> {
+    let words = select(ops, num_params)?;
+    Ok(words.iter().flat_map(|w| w.to_le_bytes()).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use synth_core::WasmOp;
+
+    #[test]
+    fn compile_bytes_add_is_three_instructions() {
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32Add,
+            WasmOp::End,
+        ];
+        let code = compile_bytes(&ops, 2).unwrap();
+        assert_eq!(code.len(), 12); // add, mov, ret
+        // last instruction is RET (0xD65F03C0, little-endian)
+        assert_eq!(&code[8..12], &0xD65F_03C0u32.to_le_bytes());
+    }
+}

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -1,0 +1,178 @@
+//! Minimal AArch64 instruction selector — milestone-1 integer subset (#538).
+//!
+//! A straight-line stack-machine lowering for the leaf integer core: parameters
+//! arrive in `w0..w7` (AAPCS64), values live in a small register value-stack, and
+//! the function result is moved to `w0` before `ret`. Anything outside the subset
+//! returns `Unsupported` — an honest loud-skip (the RISC-V-skeleton contract),
+//! never silent wrong code. Spilling, i64, floats, calls, memory and control flow
+//! are later milestones.
+
+use crate::encoder as enc;
+use crate::encoder::Reg;
+use synth_core::WasmOp;
+
+/// The value-stack temp registers: caller-saved `w9..w15` (8 slots). `w0..w7`
+/// hold incoming params; results funnel back through `w0`.
+const TEMPS: [Reg; 7] = [9, 10, 11, 12, 13, 14, 15];
+
+#[derive(Debug)]
+pub struct SelectError(pub String);
+
+impl std::fmt::Display for SelectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "aarch64 selector: {}", self.0)
+    }
+}
+
+/// Lower a single function body (its wasm op stream + declared param count) to a
+/// vector of A64 instruction words. `num_params` params are assumed resident in
+/// `w0..w{num_params-1}` on entry (milestone-1 supports up to 8 i32 params).
+pub fn select(ops: &[WasmOp], num_params: u32) -> Result<Vec<u32>, SelectError> {
+    if num_params > 8 {
+        return Err(SelectError(format!(
+            "{num_params} params — milestone-1 supports at most 8 register params"
+        )));
+    }
+    let mut words: Vec<u32> = Vec::new();
+    let mut stack: Vec<Reg> = Vec::new();
+
+    // Pick a temp register not currently holding a live value-stack entry.
+    let alloc_temp = |stack: &[Reg]| -> Result<Reg, SelectError> {
+        TEMPS
+            .iter()
+            .copied()
+            .find(|t| !stack.contains(t))
+            .ok_or_else(|| SelectError("value-stack too deep (temp regs exhausted)".into()))
+    };
+
+    let binop = |words: &mut Vec<u32>,
+                 stack: &mut Vec<Reg>,
+                 f: fn(Reg, Reg, Reg) -> u32|
+     -> Result<(), SelectError> {
+        let b = stack
+            .pop()
+            .ok_or_else(|| SelectError("binop underflow".into()))?;
+        let a = stack
+            .pop()
+            .ok_or_else(|| SelectError("binop underflow".into()))?;
+        let dst = alloc_temp(stack)?;
+        words.push(f(dst, a, b));
+        stack.push(dst);
+        Ok(())
+    };
+
+    for op in ops {
+        match op {
+            WasmOp::LocalGet(i) => {
+                if *i >= num_params {
+                    return Err(SelectError(format!(
+                        "local.get {i}: non-param locals not yet supported (milestone-1)"
+                    )));
+                }
+                // params are in w0..w7
+                stack.push(*i as Reg);
+            }
+            WasmOp::I32Const(c) => {
+                let dst = alloc_temp(&stack)?;
+                for w in enc::mov_imm32(dst, *c as u32) {
+                    words.push(w);
+                }
+                stack.push(dst);
+            }
+            WasmOp::I32Add => binop(&mut words, &mut stack, enc::add)?,
+            WasmOp::I32Sub => binop(&mut words, &mut stack, enc::sub)?,
+            WasmOp::I32Mul => binop(&mut words, &mut stack, enc::mul)?,
+            WasmOp::I32And => binop(&mut words, &mut stack, enc::and)?,
+            WasmOp::I32Or => binop(&mut words, &mut stack, enc::orr)?,
+            WasmOp::I32Xor => binop(&mut words, &mut stack, enc::eor)?,
+            // End of the function body: move the result to w0 and return.
+            WasmOp::End => {
+                if let Some(top) = stack.last().copied()
+                    && top != 0
+                {
+                    words.push(enc::mov_reg(0, top));
+                }
+                words.push(enc::ret());
+            }
+            other => {
+                return Err(SelectError(format!(
+                    "unsupported wasm op for aarch64 milestone-1: {other:?}"
+                )));
+            }
+        }
+    }
+
+    // A body without a trailing `End` still needs an epilogue.
+    if !matches!(ops.last(), Some(WasmOp::End)) {
+        if let Some(top) = stack.last().copied()
+            && top != 0
+        {
+            words.push(enc::mov_reg(0, top));
+        }
+        words.push(enc::ret());
+    }
+    Ok(words)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bytes(words: &[u32]) -> Vec<u8> {
+        words.iter().flat_map(|w| w.to_le_bytes()).collect()
+    }
+
+    #[test]
+    fn add_two_params() {
+        // (param i32 i32) (result i32) local.get 0; local.get 1; i32.add
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32Add,
+            WasmOp::End,
+        ];
+        let w = select(&ops, 2).unwrap();
+        // add w9,w0,w1 ; mov w0,w9 ; ret
+        assert_eq!(w, vec![enc::add(9, 0, 1), enc::mov_reg(0, 9), enc::ret()]);
+        // sanity: three 32-bit instructions
+        assert_eq!(bytes(&w).len(), 12);
+    }
+
+    #[test]
+    fn const_add_uses_movz() {
+        // (param i32)(result i32) local.get 0; i32.const 5; i32.add
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32Const(5),
+            WasmOp::I32Add,
+            WasmOp::End,
+        ];
+        let w = select(&ops, 1).unwrap();
+        // movz w9,#5 ; add w9,w0,w9 ; mov w0,w9 ; ret — the temp w9 is freed by
+        // the pops before the result is allocated, so the selector reuses it
+        // (clang-verified: 0x528000A9, 0x0B090009, 0x2A0903E0, 0xD65F03C0).
+        assert_eq!(
+            w,
+            vec![
+                enc::movz(9, 5),
+                enc::add(9, 0, 9),
+                enc::mov_reg(0, 9),
+                enc::ret()
+            ]
+        );
+    }
+
+    #[test]
+    fn result_already_in_w0_skips_mov() {
+        // a single param returned directly: local.get 0
+        let ops = vec![WasmOp::LocalGet(0), WasmOp::End];
+        let w = select(&ops, 1).unwrap();
+        assert_eq!(w, vec![enc::ret()]); // top is w0 already, no mov
+    }
+
+    #[test]
+    fn unsupported_op_is_loud() {
+        let ops = vec![WasmOp::LocalGet(0), WasmOp::I32DivU, WasmOp::End];
+        assert!(select(&ops, 2).is_err());
+    }
+}


### PR DESCRIPTION
## What

First increment of the **aarch64 host-native backend** (#538). A new self-contained `synth-backend-aarch64` crate with the verified integer core, so later milestones wire it into `-b aarch64` for native execution + source-level debugging on arm64 dev hosts — and so a third backend becomes a third differential oracle against the Thumb-2 and RV32 lowerings.

## Milestone 1a (this PR)

- **`encoder.rs`** — A64 encoder for the integer subset (add/sub/mul/and/orr/eor 32-bit `w` data-processing, `movz`/`movk`, `mov` reg, `ret`, and a `movz`+`movk` 32-bit const materializer). **Every encoding is cross-checked in a unit test against ground truth from `clang -target aarch64`** — verified bit-twiddling, not asserted.
- **`selector.rs`** — a minimal straight-line stack-machine lowering: params in `w0..w7` (AAPCS64), i32 add/sub/mul/and/or/xor + const, result → `w0`, `ret`; a temp value-stack over `w9..w15` that reuses freed regs. Ops outside the subset return a loud `SelectError` (the RISC-V-skeleton honest-fail contract), never wrong code. Tests cover the add-two-params acceptance shape (clang-verified), const-add temp reuse (clang-verified), the result-already-in-`w0` fast path, and the loud-skip.
- **`lib.rs`** — `compile_bytes(ops, num_params)` (wasm ops → A64 `.text`).

Self-contained new crate — **no existing behavior touched** (not yet CLI-wired), so it's frozen-safe by construction. 7/7 tests, clippy + fmt clean.

## Next (milestone 1b)

`EM_AARCH64` relocatable-ELF emitter + `Backend` trait impl + `-b aarch64` CLI wiring + the **native differential acceptance probe** (`synth compile add.wat -b aarch64` → link + run on the arm64 host, diff vs wasmtime). Then: spilling, i64, floats, memory, control flow, calls, DWARF.

Refs #538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)