### PR TITLE
feat(aarch64): milestone-1b — Backend trait + EM_AARCH64 ELF + -b aarch64 CLI (#538)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "synth-backend",
+ "synth-backend-aarch64",
  "synth-backend-awsm",
  "synth-backend-riscv",
  "synth-backend-wasker",

--- a/crates/BUILD.bazel
+++ b/crates/BUILD.bazel
@@ -229,8 +229,21 @@ rust_library(
     ],
 )
 
+# AArch64 host-native backend (#538) — A64 encoder + selector + ELF emitter.
+rust_library(
+    name = "synth-backend-aarch64",
+    srcs = glob(["synth-backend-aarch64/src/**/*.rs"]),
+    crate_root = "synth-backend-aarch64/src/lib.rs",
+    edition = "2024",
+    deps = [
+        ":synth-core",
+        "@crates//:thiserror",
+        "@crates//:tracing",
+    ],
+)
+
 # Main CLI binary — `riscv` feature wires synth-backend-riscv in (matches
-# Cargo's default = ["riscv"]).
+# Cargo's default = ["riscv"]); synth-backend-aarch64 is always linked (#538).
 rust_binary(
     name = "synth",
     srcs = glob(["synth-cli/src/**/*.rs"]),
@@ -243,6 +256,7 @@ rust_binary(
         ":synth-synthesis",
         ":synth-backend",
         ":synth-backend-riscv",
+        ":synth-backend-aarch64",
         "@crates//:anyhow",
         "@crates//:clap",
         "@crates//:serde_json",

--- a/crates/synth-backend-aarch64/src/backend.rs
+++ b/crates/synth-backend-aarch64/src/backend.rs
@@ -1,0 +1,129 @@
+//! `Backend` trait implementation for the AArch64 host-native backend (#538).
+//!
+//! Milestone-1b: wires the milestone-1a encoder/selector into synth's `Backend`
+//! interface — `compile_function` lowers a leaf integer function to A64 machine
+//! code, and `compile_module` concatenates the exported functions into an
+//! `EM_AARCH64` relocatable ELF object (via [`crate::elf`]). Functions outside
+//! the integer subset are loud-skipped by the caller's compile loop (the selector
+//! returns an error), never miscompiled.
+
+use synth_core::backend::{
+    Backend, BackendCapabilities, BackendError, CompilationResult, CompileConfig, CompiledFunction,
+};
+use synth_core::wasm_decoder::DecodedModule;
+use synth_core::{TargetSpec, WasmOp};
+
+use crate::elf::{self, ElfFunction};
+use crate::selector;
+
+/// The AArch64 (A64) backend. Milestone-1b: leaf integer subset, ELF output.
+#[derive(Debug, Default)]
+pub struct AArch64Backend;
+
+impl AArch64Backend {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Count register parameters from the op stream (a local index read before it is
+/// written is a parameter). Mirrors the ARM/RISC-V backends' heuristic.
+fn count_params(ops: &[WasmOp]) -> u32 {
+    use std::collections::HashMap;
+    let mut first_access: HashMap<u32, bool> = HashMap::new();
+    for op in ops {
+        match op {
+            WasmOp::LocalGet(i) => {
+                first_access.entry(*i).or_insert(true);
+            }
+            WasmOp::LocalSet(i) | WasmOp::LocalTee(i) => {
+                first_access.entry(*i).or_insert(false);
+            }
+            _ => {}
+        }
+    }
+    first_access
+        .iter()
+        .filter_map(|(&i, &read_first)| if read_first { Some(i + 1) } else { None })
+        .max()
+        .unwrap_or(0)
+}
+
+impl Backend for AArch64Backend {
+    fn name(&self) -> &str {
+        "aarch64"
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            produces_elf: true,
+            supports_rule_verification: false,
+            supports_binary_verification: true,
+            is_external: false,
+        }
+    }
+
+    fn supported_targets(&self) -> Vec<TargetSpec> {
+        vec![TargetSpec::cortex_a53()]
+    }
+
+    fn compile_function(
+        &self,
+        name: &str,
+        ops: &[WasmOp],
+        _config: &CompileConfig,
+    ) -> Result<CompiledFunction, BackendError> {
+        let num_params = count_params(ops);
+        let words = selector::select(ops, num_params)
+            .map_err(|e| BackendError::CompilationFailed(e.to_string()))?;
+        let code: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
+        Ok(CompiledFunction {
+            name: name.to_string(),
+            code,
+            wasm_ops: ops.to_vec(),
+            relocations: Vec::new(),
+            // AArch64 DWARF `.debug_line` is a later milestone (pairs with #394).
+            line_map: Vec::new(),
+        })
+    }
+
+    fn compile_module(
+        &self,
+        module: &DecodedModule,
+        config: &CompileConfig,
+    ) -> Result<CompilationResult, BackendError> {
+        let exports: Vec<&_> = module
+            .functions
+            .iter()
+            .filter(|f| f.export_name.is_some())
+            .collect();
+        if exports.is_empty() {
+            return Err(BackendError::CompilationFailed(
+                "no exported functions found".into(),
+            ));
+        }
+
+        let mut functions = Vec::new();
+        let mut elf_funcs = Vec::new();
+        for func in &exports {
+            let name = func.export_name.clone().unwrap();
+            let compiled = self.compile_function(&name, &func.ops, config)?;
+            elf_funcs.push(ElfFunction {
+                name: compiled.name.clone(),
+                code: compiled.code.clone(),
+            });
+            functions.push(compiled);
+        }
+
+        let elf = elf::build_relocatable_object(&elf_funcs);
+        Ok(CompilationResult {
+            functions,
+            elf: Some(elf),
+            backend_name: self.name().to_string(),
+        })
+    }
+
+    fn is_available(&self) -> bool {
+        true
+    }
+}

--- a/crates/synth-backend-aarch64/src/elf.rs
+++ b/crates/synth-backend-aarch64/src/elf.rs
@@ -1,0 +1,187 @@
+//! Minimal `EM_AARCH64` ELF64 relocatable-object emitter — milestone-1b (#538).
+//!
+//! Produces an `ET_REL` object for AArch64 (`e_machine = 183`) with a single
+//! `.text` (all function bodies concatenated), a `.symtab` exposing one
+//! `STT_FUNC`/`GLOBAL` symbol per function at its `.text` offset, and the two
+//! string tables. Milestone-1b functions are leaf integer bodies with no external
+//! references, so no relocation section is needed yet (`bl`/imports arrive with
+//! calls in a later milestone). The object is host-linkable on arm64 ELF targets
+//! (arm64 Linux/CI) and its `.text` is directly runnable under a native or
+//! emulated A64 core.
+
+/// A compiled function to place in `.text`.
+pub struct ElfFunction {
+    pub name: String,
+    pub code: Vec<u8>,
+}
+
+const EHDR_SIZE: usize = 64;
+const SHDR_SIZE: usize = 64;
+const SYM_SIZE: usize = 24;
+
+fn push_u16(v: &mut Vec<u8>, x: u16) {
+    v.extend_from_slice(&x.to_le_bytes());
+}
+fn push_u32(v: &mut Vec<u8>, x: u32) {
+    v.extend_from_slice(&x.to_le_bytes());
+}
+fn push_u64(v: &mut Vec<u8>, x: u64) {
+    v.extend_from_slice(&x.to_le_bytes());
+}
+
+/// Build an `EM_AARCH64` `ET_REL` object exposing each function as a global
+/// `STT_FUNC` symbol in `.text`.
+pub fn build_relocatable_object(functions: &[ElfFunction]) -> Vec<u8> {
+    // --- .text: concatenated bodies; record each function's (offset, size). ---
+    let mut text: Vec<u8> = Vec::new();
+    let mut placement: Vec<(u64, u64)> = Vec::new();
+    for f in functions {
+        // A64 instructions are 4-byte aligned; bodies are whole words already.
+        placement.push((text.len() as u64, f.code.len() as u64));
+        text.extend_from_slice(&f.code);
+    }
+
+    // --- .strtab: symbol names (index 0 is the empty string). ---
+    let mut strtab: Vec<u8> = vec![0];
+    let mut name_off: Vec<u32> = Vec::new();
+    for f in functions {
+        name_off.push(strtab.len() as u32);
+        strtab.extend_from_slice(f.name.as_bytes());
+        strtab.push(0);
+    }
+
+    // --- .symtab: [0]=NULL, then one GLOBAL STT_FUNC per function. ---
+    // st_info = (bind << 4) | type; GLOBAL=1, FUNC=2 → 0x12. shndx = 1 (.text).
+    let mut symtab: Vec<u8> = Vec::new();
+    // null symbol
+    symtab.extend_from_slice(&[0u8; SYM_SIZE]);
+    for (i, _f) in functions.iter().enumerate() {
+        let (off, size) = placement[i];
+        push_u32(&mut symtab, name_off[i]); // st_name
+        symtab.push(0x12); // st_info: GLOBAL FUNC
+        symtab.push(0); // st_other
+        push_u16(&mut symtab, 1); // st_shndx = .text (section 1)
+        push_u64(&mut symtab, off); // st_value
+        push_u64(&mut symtab, size); // st_size
+    }
+
+    // --- .shstrtab: section header names. ---
+    let mut shstrtab: Vec<u8> = vec![0];
+    let add_shstr = |sh: &mut Vec<u8>, s: &str| -> u32 {
+        let o = sh.len() as u32;
+        sh.extend_from_slice(s.as_bytes());
+        sh.push(0);
+        o
+    };
+    let n_text = add_shstr(&mut shstrtab, ".text");
+    let n_symtab = add_shstr(&mut shstrtab, ".symtab");
+    let n_strtab = add_shstr(&mut shstrtab, ".strtab");
+    let n_shstrtab = add_shstr(&mut shstrtab, ".shstrtab");
+
+    // --- Layout: ehdr | .text | .symtab | .strtab | .shstrtab | shdrs. ---
+    let text_off = EHDR_SIZE;
+    let symtab_off = text_off + text.len();
+    let strtab_off = symtab_off + symtab.len();
+    let shstrtab_off = strtab_off + strtab.len();
+    let shdr_off = shstrtab_off + shstrtab.len();
+    let num_sections = 5u16; // NULL, .text, .symtab, .strtab, .shstrtab
+
+    let mut out: Vec<u8> = Vec::new();
+
+    // ELF header (Elf64_Ehdr).
+    out.extend_from_slice(&[0x7F, b'E', b'L', b'F']); // magic
+    out.push(2); // EI_CLASS = ELFCLASS64
+    out.push(1); // EI_DATA = ELFDATA2LSB
+    out.push(1); // EI_VERSION
+    out.push(0); // EI_OSABI = SYSV
+    out.extend_from_slice(&[0u8; 8]); // EI_ABIVERSION + pad
+    push_u16(&mut out, 1); // e_type = ET_REL
+    push_u16(&mut out, 183); // e_machine = EM_AARCH64
+    push_u32(&mut out, 1); // e_version
+    push_u64(&mut out, 0); // e_entry
+    push_u64(&mut out, 0); // e_phoff
+    push_u64(&mut out, shdr_off as u64); // e_shoff
+    push_u32(&mut out, 0); // e_flags
+    push_u16(&mut out, EHDR_SIZE as u16); // e_ehsize
+    push_u16(&mut out, 0); // e_phentsize
+    push_u16(&mut out, 0); // e_phnum
+    push_u16(&mut out, SHDR_SIZE as u16); // e_shentsize
+    push_u16(&mut out, num_sections); // e_shnum
+    push_u16(&mut out, 4); // e_shstrndx = .shstrtab (section 4)
+    debug_assert_eq!(out.len(), EHDR_SIZE);
+
+    // Section data, in the order laid out above.
+    out.extend_from_slice(&text);
+    out.extend_from_slice(&symtab);
+    out.extend_from_slice(&strtab);
+    out.extend_from_slice(&shstrtab);
+    debug_assert_eq!(out.len(), shdr_off);
+
+    // Section headers (Elf64_Shdr × 5).
+    let mut shdr =
+        |name, sh_type, flags, offset: usize, size: usize, link, info, align, entsize| {
+            push_u32(&mut out, name);
+            push_u32(&mut out, sh_type);
+            push_u64(&mut out, flags);
+            push_u64(&mut out, 0); // sh_addr
+            push_u64(&mut out, offset as u64);
+            push_u64(&mut out, size as u64);
+            push_u32(&mut out, link);
+            push_u32(&mut out, info);
+            push_u64(&mut out, align);
+            push_u64(&mut out, entsize);
+        };
+    // [0] NULL
+    shdr(0, 0, 0, 0, 0, 0, 0, 0, 0);
+    // [1] .text — PROGBITS, ALLOC|EXECINSTR (0x2|0x4), align 4
+    shdr(n_text, 1, 0x6, text_off, text.len(), 0, 0, 4, 0);
+    // [2] .symtab — SYMTAB(2), link=.strtab(3), info=first-global(1), align 8
+    shdr(
+        n_symtab,
+        2,
+        0,
+        symtab_off,
+        symtab.len(),
+        3,
+        1,
+        8,
+        SYM_SIZE as u64,
+    );
+    // [3] .strtab — STRTAB(3)
+    shdr(n_strtab, 3, 0, strtab_off, strtab.len(), 0, 0, 1, 0);
+    // [4] .shstrtab — STRTAB(3)
+    shdr(n_shstrtab, 3, 0, shstrtab_off, shstrtab.len(), 0, 0, 1, 0);
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn well_formed_header_and_symbols() {
+        let obj = build_relocatable_object(&[
+            ElfFunction {
+                name: "add".into(),
+                code: vec![0, 0, 1, 0x0B, 0xE0, 0x03, 9, 0x2A, 0xC0, 0x03, 0x5F, 0xD6],
+            },
+            ElfFunction {
+                name: "sub".into(),
+                code: vec![0x62, 0, 4, 0x4B, 0xC0, 0x03, 0x5F, 0xD6],
+            },
+        ]);
+        // ELF magic + class64 + LSB.
+        assert_eq!(&obj[0..4], &[0x7F, b'E', b'L', b'F']);
+        assert_eq!(obj[4], 2); // ELFCLASS64
+        assert_eq!(obj[5], 1); // LSB
+        // e_type = ET_REL, e_machine = EM_AARCH64.
+        assert_eq!(u16::from_le_bytes([obj[16], obj[17]]), 1);
+        assert_eq!(u16::from_le_bytes([obj[18], obj[19]]), 183);
+        // e_shnum = 5.
+        assert_eq!(u16::from_le_bytes([obj[60], obj[61]]), 5);
+        // The object must be non-trivial and contain both symbol names.
+        let s = String::from_utf8_lossy(&obj);
+        assert!(s.contains("add") && s.contains("sub"));
+    }
+}

--- a/crates/synth-backend-aarch64/src/lib.rs
+++ b/crates/synth-backend-aarch64/src/lib.rs
@@ -20,9 +20,12 @@
 //!   arm64 host, diff vs wasmtime).
 //! - **later:** spilling, i64, floats, memory, control flow, calls, DWARF.
 
+pub mod backend;
+pub mod elf;
 pub mod encoder;
 pub mod selector;
 
+pub use backend::AArch64Backend;
 pub use selector::{SelectError, select};
 
 /// Lower a single leaf integer function (wasm ops + declared param count) to A64

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -32,6 +32,9 @@ synth-frontend = { path = "../synth-frontend", version = "0.18.1" }
 synth-synthesis = { path = "../synth-synthesis", version = "0.18.1" }
 synth-backend = { path = "../synth-backend", version = "0.18.1" }
 
+# AArch64 host-native backend (#538) — small pure-Rust crate, always on.
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.18.1" }
+
 # Optional external backends
 synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.18.1", optional = true }
 synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.18.1", optional = true }

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -754,6 +754,8 @@ fn resolve_target_spec(target: Option<&str>, cortex_m: bool, backend: &str) -> R
         // No --target given: pick a backend-appropriate default so `-b riscv`
         // doesn't inherit the ARM profile and bail (#218).
         None if backend == "riscv" => Ok(TargetSpec::riscv32("imac")),
+        // #538: `-b aarch64` without --target defaults to the A64 host profile.
+        None if backend == "aarch64" => Ok(TargetSpec::cortex_a53()),
         None if cortex_m => Ok(TargetSpec::cortex_m3()),
         None => {
             // Default: Arm32 ISA (non-Cortex-M, no vector table)
@@ -771,6 +773,9 @@ fn build_backend_registry() -> BackendRegistry {
 
     // Always register the built-in ARM backend
     registry.register(Box::new(ArmBackend::new()));
+
+    // AArch64 host-native backend (#538) — always available (pure Rust).
+    registry.register(Box::new(synth_backend_aarch64::AArch64Backend::new()));
 
     // Register w2c2 backend (always available, checks tool at runtime)
     registry.register(Box::new(W2C2Backend::new()));

--- a/scripts/repro/aarch64_add_538.wat
+++ b/scripts/repro/aarch64_add_538.wat
@@ -1,0 +1,13 @@
+;; #538 milestone-1b — the aarch64 integer-subset acceptance module. Each export
+;; is a leaf i32 function the milestone-1 A64 selector lowers (params in w0..,
+;; add/sub/mul/and/or/xor + const, result to w0, ret). The differential runs each
+;; under unicorn UC_ARCH_ARM64 and diffs wasmtime.
+(module
+  (func (export "add") (param i32 i32) (result i32)
+    (i32.add (local.get 0) (local.get 1)))
+  (func (export "muladd") (param i32 i32 i32) (result i32)
+    (i32.add (i32.mul (local.get 0) (local.get 1)) (local.get 2)))
+  (func (export "const_sub") (param i32) (result i32)
+    (i32.sub (local.get 0) (i32.const 7)))
+  (func (export "xor_or") (param i32 i32) (result i32)
+    (i32.or (i32.xor (local.get 0) (local.get 1)) (local.get 0))))

--- a/scripts/repro/aarch64_add_538_differential.py
+++ b/scripts/repro/aarch64_add_538_differential.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""#538 milestone-1b — validate the aarch64 backend's codegen end-to-end.
+
+Compiles a small integer module with `synth compile -b aarch64`, then executes
+each exported function's emitted A64 `.text` under unicorn (UC_ARCH_ARM64) and
+diffs the result against wasmtime ground truth. This is the "third backend = third
+oracle" property: the same wasm lowered to A64 must compute the same values as it
+does in wasmtime (and, by the Thumb-2/RV32 differentials, as on the other
+backends).
+
+Runs on any host (unicorn emulates A64); on an arm64 host the same `.text` also
+runs natively. NOTE (milestone-1c follow-up): the CLI currently wraps the A64
+`.text` in its ARM ELF container (EM_ARM) rather than the backend's EM_AARCH64
+relocatable object — this harness reads the `.text` bytes + symbol offsets and is
+wrapper-agnostic, so it validates the *codegen*; the backend's own
+`compile_module` already emits a correct EM_AARCH64 object (unit-tested in
+`crates/synth-backend-aarch64/src/elf.rs`).
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/aarch64_add_538_differential.py
+"""
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM64, UC_MODE_ARM, Uc, UcError
+from unicorn.arm64_const import (
+    UC_ARM64_REG_LR,
+    UC_ARM64_REG_SP,
+    UC_ARM64_REG_W0,
+    UC_ARM64_REG_W1,
+    UC_ARM64_REG_W2,
+)
+
+WAT = Path(__file__).with_name("aarch64_add_538.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+CODE, STK, RET = 0x100000, 0x200000, 0x300000
+ARG_REGS = [UC_ARM64_REG_W0, UC_ARM64_REG_W1, UC_ARM64_REG_W2]
+
+CASES = [
+    ("add", (2, 3)),
+    ("add", (0xFFFFFFFF, 1)),          # wrap
+    ("add", (0x7FFFFFFF, 1)),          # signed overflow
+    ("muladd", (3, 4, 5)),
+    ("muladd", (0xFFFF, 0xFFFF, 0)),   # 32-bit mul truncation
+    ("const_sub", (20,)),
+    ("const_sub", (0,)),               # 0 - 7 = -7
+    ("xor_or", (0b1010, 0b0110)),
+]
+
+
+def wasmtime_run(fn, args):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    return wasmtime.Instance(store, module, []).exports(store)[fn](store, *args)
+
+
+def compile_aarch64(out):
+    cmd = [SYNTH, "compile", str(WAT), "-o", out, "-b", "aarch64", "--all-exports"]
+    r = subprocess.run(cmd, capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"})
+    if r.returncode != 0 or "skipping" in r.stderr:
+        sys.exit(f"aarch64 compile failed/skipped: {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for sy in sec.iter_symbols():
+                if sy.name:
+                    syms[sy.name] = sy["st_value"] & ~1  # mask any stray low bit
+    return code, base, syms
+
+
+def unicorn_run(code, base, faddr, args):
+    off = faddr - base
+    mu = Uc(UC_ARCH_ARM64, UC_MODE_ARM)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(STK - 0x10000, 0x20000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_ARM64_REG_SP, STK)
+    mu.reg_write(UC_ARM64_REG_LR, RET)
+    for r, v in zip(ARG_REGS, args):
+        mu.reg_write(r, v & 0xFFFFFFFF)
+    try:
+        mu.emu_start(CODE + off, RET, count=1000)
+    except UcError as e:
+        return f"ERR:{e}"
+    raw = mu.reg_read(UC_ARM64_REG_W0) & 0xFFFFFFFF
+    return struct.unpack("<i", struct.pack("<I", raw))[0]
+
+
+def main():
+    out = "/tmp/aarch64_add_538.o"
+    compile_aarch64(out)
+    code, base, syms = load(out)
+    fails = 0
+    for fn, args in CASES:
+        if fn not in syms:
+            print(f"FAIL {fn}: symbol missing")
+            fails += 1
+            continue
+        exp = wasmtime_run(fn, args)
+        got = unicorn_run(code, base, syms[fn], args)
+        ok = isinstance(got, int) and (got & 0xFFFFFFFF) == (exp & 0xFFFFFFFF)
+        if not ok:
+            fails += 1
+        print(f"{'OK ' if ok else 'BUG'} {fn}{args} A64={got} wasmtime={exp}")
+    print("\nRESULT:", "PASS — aarch64 codegen matches wasmtime (third oracle)"
+          if not fails else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Milestone-1b of the aarch64 backend (#538), building on the merged 1a encoder/selector. `synth compile x.wat -b aarch64` now lowers a leaf integer module to A64 machine code — **a third backend, hence a third differential oracle** (A64 vs Thumb-2 vs RV32 vs wasmtime).

## Changes

- **`backend.rs`** — `AArch64Backend` impls the `Backend` trait: `compile_function` (params + selector → A64 bytes), `compile_module` (exports → EM_AARCH64 relocatable object).
- **`elf.rs`** — self-contained `EM_AARCH64` (183) `ET_REL` emitter: `.text` + `.symtab` (one GLOBAL `STT_FUNC`/function) + string tables. Unit-tested well-formed.
- **CLI** — register the backend (always-on, pure Rust) + `-b aarch64` → `TargetSpec::cortex_a53` when no `--target`. Bazel: new `rust_library` + `synth` dep.

## Verified

`scripts/repro/aarch64_add_538{.wat,_differential.py}`: compile `-b aarch64`, run each export's `.text` under unicorn `UC_ARCH_ARM64`, diff wasmtime — **8/8** (add incl. wrap/overflow, muladd incl. 32-bit truncation, const_sub incl. negative, xor_or). **Frozen anchors 3/3 byte-identical** (new backend; ARM/RV32 codegen untouched — the CLI change only adds a registration + target default). fmt + clippy clean.

## Known follow-up (milestone-1c)

The CLI still wraps the A64 `.text` in its **ARM ELF container** (EM_ARM ET_EXEC) rather than emitting the backend's **EM_AARCH64** object — the codegen is correct (proven), but the output container isn't yet a proper host-linkable aarch64 object. Route the CLI to the backend's `compile_module` elf next, then native link+run on an arm64 ELF host. (The backend's EM_AARCH64 emitter itself is done + unit-tested.)

Refs #538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)