### PR TITLE
fix(rv32): reconcile if/else result registers at the join (#343)

### DIFF
--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -704,6 +704,12 @@ struct ControlFrame {
     /// Snapshot of the value-stack height when this frame was pushed.
     /// Used to drop excess values on br / end.
     stack_height_at_entry: usize,
+    /// #343: for an `if (result …)` frame, the then-arm's result value(s) —
+    /// the vstack entries above `stack_height_at_entry`, captured at `else`.
+    /// They are reconciled with the else-arm's results at `end` so both arms
+    /// leave the value in the SAME register(s) at the join. Empty for
+    /// blocks/loops and for control-flow-only (arity-0) if/else.
+    then_results: Vec<VstackVal>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1198,6 +1204,7 @@ impl Selector {
                     head_label: None,
                     else_label: None,
                     stack_height_at_entry: self.vstack.len(),
+                    then_results: Vec::new(),
                 });
             }
             Loop => {
@@ -1210,6 +1217,7 @@ impl Selector {
                     head_label: Some(head),
                     else_label: None,
                     stack_height_at_entry: self.vstack.len(),
+                    then_results: Vec::new(),
                 });
             }
             If => self.lower_if(op)?,
@@ -1960,14 +1968,17 @@ impl Selector {
             head_label: None,
             else_label: Some(else_label),
             stack_height_at_entry: self.vstack.len(),
+            then_results: Vec::new(),
         });
         Ok(())
     }
 
     fn lower_else(&mut self, _op: &WasmOp) -> Result<(), SelectorError> {
+        // Read the frame's fields up front so the mutable borrow is released
+        // before touching `self.vstack` / `self.out`.
         let frame = self
             .ctrl
-            .last_mut()
+            .last()
             .ok_or(SelectorError::ControlMismatch("else without matching if"))?;
         if frame.kind != FrameKind::If {
             return Err(SelectorError::ControlMismatch(
@@ -1979,6 +1990,7 @@ impl Selector {
             .else_label
             .clone()
             .ok_or(SelectorError::ControlMismatch("if frame has no else label"))?;
+        let entry = frame.stack_height_at_entry;
         // jal zero, Lif_end  → end of then-branch jumps past the else
         self.out.push(RiscVOp::Jal {
             rd: Reg::ZERO,
@@ -1986,9 +1998,18 @@ impl Selector {
         });
         // Lelse:
         self.out.push(RiscVOp::Label { name: else_label });
-        // Reset the value-stack height to what it was at if-entry — wasm
-        // discards then-branch values when entering the else-branch.
-        self.vstack.truncate(frame.stack_height_at_entry);
+        // #343: capture the then-arm's result value(s) — the vstack entries
+        // above the if-entry checkpoint — before resetting the stack for the
+        // else-arm. wasm discards the then-branch values when entering the
+        // else-branch, but their REGISTERS must be reconciled with the
+        // else-arm's at `end` (see `lower_end`) so both arms leave the join
+        // value in the same place. `split_off` both captures and truncates.
+        let then_results = self.vstack.split_off(entry);
+        let frame = self
+            .ctrl
+            .last_mut()
+            .expect("if frame still open (checked above)");
+        frame.then_results = then_results;
         frame.kind = FrameKind::Else;
         Ok(())
     }
@@ -2002,8 +2023,36 @@ impl Selector {
                 && let Some(else_label) = frame.else_label.clone()
             {
                 // The if had no else: emit the else label here and let it
-                // join the end label so beq lands here.
+                // join the end label so beq lands here. A valid if-without-else
+                // has arity 0 (no result), so there is nothing to reconcile.
                 self.out.push(RiscVOp::Label { name: else_label });
+            } else if frame.kind == FrameKind::Else {
+                // #343: reconcile the two arms onto a single set of result
+                // registers. The then-arm's results were captured at `else`
+                // (`frame.then_results`); the else-arm's results are the vstack
+                // entries above the entry checkpoint right now. The `mv`s
+                // emitted here sit on the ELSE path — between the else-arm body
+                // and `end_label` — and the then-path's `jal end_label`
+                // (emitted at `else`) jumps over them. So on the then path the
+                // then-arm's value is already live in the merged register; on
+                // the else path each `mv rd_then, rd_else` moves the else value
+                // into the same register. When both arms already chose the same
+                // register, NO `mv` is emitted (control-flow-only / register-
+                // symmetric if/else stays byte-identical).
+                let then_results = frame.then_results;
+                let else_results = self.vstack.split_off(frame.stack_height_at_entry);
+                if then_results.len() != else_results.len() {
+                    return Err(SelectorError::ControlMismatch(
+                        "if/else arms disagree on result arity (#343)",
+                    ));
+                }
+                for (then_v, else_v) in then_results.iter().zip(else_results.iter()) {
+                    self.reconcile_if_result(*then_v, *else_v)?;
+                }
+                // The merged results live in the then-arm's registers — push
+                // them back so the surrounding code (return / outer op) reads
+                // them.
+                self.vstack.extend(then_results);
             }
             self.out.push(RiscVOp::Label {
                 name: frame.end_label,
@@ -2014,6 +2063,64 @@ impl Selector {
             self.emitted_return = true;
         }
         Ok(())
+    }
+
+    /// #343: reconcile one if-result position between the two arms — make the
+    /// else-arm's result register(s) hold the value the then-arm's do, by
+    /// emitting `mv rd_then, rd_else` (i64: lo and hi) on the ELSE path when the
+    /// two arms chose different registers. RV32 has no `mv` mnemonic; `addi rd,
+    /// rs, 0` is the canonical encoding (the same one the return epilogue uses).
+    /// Emitting NOTHING when the registers already match is what keeps register-
+    /// symmetric / control-flow-only if/else byte-identical.
+    ///
+    /// A width mismatch between arms (i32 vs i64) is invalid wasm; surface it as
+    /// a recoverable `ControlMismatch` rather than emit a half-move.
+    ///
+    /// The i64 case emits the `lo` then `hi` move sequentially, which is only
+    /// correct if the two positions do not form a register-permutation cycle
+    /// (`else.lo == then.hi && else.hi == then.lo`). That cannot arise here:
+    /// both arms begin allocation from the identical free-register set (the
+    /// else-arm resets the vstack to the if-entry checkpoint) and every i64
+    /// lowering allocates `lo` before `hi`, so `lo` occupies a lower-indexed
+    /// register than `hi` in BOTH arms — a 2-cycle would require
+    /// `else.lo == then.hi > then.lo == else.hi`, contradicting lo-before-hi.
+    fn reconcile_if_result(
+        &mut self,
+        then_v: VstackVal,
+        else_v: VstackVal,
+    ) -> Result<(), SelectorError> {
+        match (then_v, else_v) {
+            (VstackVal::I32(rt), VstackVal::I32(re)) => {
+                if rt != re {
+                    self.out.push(RiscVOp::Addi {
+                        rd: rt,
+                        rs1: re,
+                        imm: 0,
+                    });
+                }
+                Ok(())
+            }
+            (VstackVal::I64 { lo: tl, hi: th }, VstackVal::I64 { lo: el, hi: eh }) => {
+                if tl != el {
+                    self.out.push(RiscVOp::Addi {
+                        rd: tl,
+                        rs1: el,
+                        imm: 0,
+                    });
+                }
+                if th != eh {
+                    self.out.push(RiscVOp::Addi {
+                        rd: th,
+                        rs1: eh,
+                        imm: 0,
+                    });
+                }
+                Ok(())
+            }
+            _ => Err(SelectorError::ControlMismatch(
+                "if/else result width mismatch between arms (#343)",
+            )),
+        }
     }
 
     fn lower_br(&mut self, depth: u32, _op: &WasmOp) -> Result<(), SelectorError> {
@@ -4471,6 +4578,84 @@ mod tests {
         );
         // The then-branch needs to jump past the else.
         assert!(count(&out, |op| matches!(op, RiscVOp::Jal { .. })) >= 1);
+    }
+
+    /// #343: an `if (result i32)` whose arms land the result in DIFFERENT
+    /// registers must reconcile them at the join — exactly one `mv rd_then,
+    /// rd_else` (`addi rd, rs, 0`) on the else path, between the else label and
+    /// the end label. The then-path `jal` jumps over it, so both arms leave the
+    /// value in `rd_then`. Here the then-arm computes `1 + 2` (result lands in
+    /// an `add` destination, a distinct register from the else-arm's bare const).
+    #[test]
+    fn if_result_asymmetric_arms_reconcile_to_one_register_343() {
+        let out = s(
+            &[
+                WasmOp::LocalGet(0),
+                WasmOp::If,
+                WasmOp::I32Const(1),
+                WasmOp::I32Const(2),
+                WasmOp::I32Add, // then-result in the add's dest reg
+                WasmOp::Else,
+                WasmOp::I32Const(20), // else-result in a bare const reg
+                WasmOp::End,
+                WasmOp::End,
+            ],
+            1,
+        );
+        let else_pos = out
+            .iter()
+            .position(|o| matches!(o, RiscVOp::Label { name } if name.starts_with("Lelse")))
+            .expect("else label emitted");
+        let end_pos = out
+            .iter()
+            .position(|o| matches!(o, RiscVOp::Label { name } if name.starts_with("Lif_end")))
+            .expect("if-end label emitted");
+        assert!(else_pos < end_pos, "else label precedes end label");
+        // A reconciliation move is `addi rd, rs, 0` with rd != rs (register→
+        // register copy). The else-arm's const is `addi rd, zero, 20` (imm 20),
+        // so it is not mistaken for one.
+        let recon: Vec<(Reg, Reg)> = out[else_pos + 1..end_pos]
+            .iter()
+            .filter_map(|o| match o {
+                RiscVOp::Addi { rd, rs1, imm: 0 } if rd != rs1 => Some((*rd, *rs1)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            recon.len(),
+            1,
+            "exactly one reconciliation mv on the else path, got {recon:?}"
+        );
+    }
+
+    /// #343: a control-flow-only / result-less `if/else` (arity 0) carries no
+    /// value across the join, so NO reconciliation move is emitted — this is
+    /// what keeps such if/else byte-identical to the pre-#343 output.
+    #[test]
+    fn if_without_result_emits_no_reconciliation_343() {
+        let out = s(
+            &[
+                WasmOp::LocalGet(0),
+                WasmOp::If,
+                WasmOp::Else,
+                WasmOp::End,
+                WasmOp::End,
+            ],
+            1,
+        );
+        let else_pos = out
+            .iter()
+            .position(|o| matches!(o, RiscVOp::Label { name } if name.starts_with("Lelse")))
+            .expect("else label emitted");
+        let end_pos = out
+            .iter()
+            .position(|o| matches!(o, RiscVOp::Label { name } if name.starts_with("Lif_end")))
+            .expect("if-end label emitted");
+        let recon = out[else_pos + 1..end_pos]
+            .iter()
+            .filter(|o| matches!(o, RiscVOp::Addi { rd, rs1, imm: 0 } if rd != rs1))
+            .count();
+        assert_eq!(recon, 0, "no reconciliation for an arity-0 if/else");
     }
 
     #[test]

--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -4628,6 +4628,63 @@ mod tests {
         );
     }
 
+    /// #343 (i64): an `if (result i64)` whose arms land the pair in DIFFERENT
+    /// register pairs must reconcile BOTH halves — two `mv` (`addi rd, rs, 0`)
+    /// on the else path, one for `lo` and one for `hi`. This is the arm carrying
+    /// the documented no-cycle argument (`lo` allocated before `hi` in both
+    /// arms), so it gets its own gate rather than riding on the i32 test. The
+    /// then-arm's `i64.add` result occupies a distinct pair from the else-arm's
+    /// bare `i64.const`, and both halves of the two constants differ, so neither
+    /// move can collapse into a self-copy.
+    #[test]
+    fn if_result_i64_reconciles_both_halves_343() {
+        let out = s(
+            &[
+                WasmOp::LocalGet(0),
+                WasmOp::If,
+                WasmOp::I64Const(0x1_0000_0002),
+                WasmOp::I64Const(1),
+                WasmOp::I64Add, // then-result pair in the add's dest regs
+                WasmOp::Else,
+                WasmOp::I64Const(0x7_0000_0020), // else-result pair, distinct
+                WasmOp::End,
+                WasmOp::End,
+            ],
+            1,
+        );
+        let else_pos = out
+            .iter()
+            .position(|o| matches!(o, RiscVOp::Label { name } if name.starts_with("Lelse")))
+            .expect("else label emitted");
+        let end_pos = out
+            .iter()
+            .position(|o| matches!(o, RiscVOp::Label { name } if name.starts_with("Lif_end")))
+            .expect("if-end label emitted");
+        assert!(else_pos < end_pos, "else label precedes end label");
+        let recon: Vec<(Reg, Reg)> = out[else_pos + 1..end_pos]
+            .iter()
+            .filter_map(|o| match o {
+                RiscVOp::Addi { rd, rs1, imm: 0 } if rd != rs1 => Some((*rd, *rs1)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            recon.len(),
+            2,
+            "an i64 join reconciles both lo and hi, got {recon:?}"
+        );
+        // The no-cycle invariant: the two moves are not a register permutation
+        // (`mv a,b; mv b,a` would clobber `b` before its move). Distinct dests,
+        // and no dest is another move's source.
+        let (d0, s0) = recon[0];
+        let (d1, s1) = recon[1];
+        assert_ne!(d0, d1, "lo and hi move to different registers");
+        assert!(
+            d0 != s1 && d1 != s0,
+            "reconciliation moves must not form a permutation cycle: {recon:?}"
+        );
+    }
+
     /// #343: a control-flow-only / result-less `if/else` (arity 0) carries no
     /// value across the join, so NO reconciliation move is emitted — this is
     /// what keeps such if/else byte-identical to the pre-#343 output.

--- a/scripts/repro/if_else_result_343.wat
+++ b/scripts/repro/if_else_result_343.wat
@@ -1,0 +1,34 @@
+(module
+  (memory 1)
+  ;; #343 — `if (result i32)` with a value on BOTH arms. The then-arm computes
+  ;; its result into a different register (t2, via `add`) than the else-arm
+  ;; (t0, a bare const). Without result-register reconciliation at the join the
+  ;; epilogue reads one fixed register, so one arm returns a stale value.
+  ;;   pick(nonzero) = 1 + 2 = 3   (then-arm)
+  ;;   pick(0)       = 20          (else-arm)
+  (func (export "pick") (param i32) (result i32)
+    (if (result i32) (local.get 0)
+      (then (i32.add (i32.const 1) (i32.const 2)))
+      (else (i32.const 20))))
+
+  ;; A second shape: the else-arm is the one that lands in a higher register.
+  ;;   pick2(nonzero) = 7               (then-arm)
+  ;;   pick2(0)       = 100 + 200 = 300 (else-arm)
+  (func (export "pick2") (param i32) (result i32)
+    (if (result i32) (local.get 0)
+      (then (i32.const 7))
+      (else (i32.add (i32.const 100) (i32.const 200)))))
+
+  ;; A value live ACROSS the if/else: `5` is pushed before the `if` and consumed
+  ;; by `i32.add` after `end`. Guards the join split-index — the reconciliation
+  ;; must merge only the arms' result (above the checkpoint), never the carried
+  ;; value below it.
+  ;;   pick3(nonzero) = 5 + 10 = 15  (then-arm)
+  ;;   pick3(0)       = 5 + 20 = 25  (else-arm)
+  (func (export "pick3") (param i32) (result i32)
+    (i32.const 5)
+    (if (result i32) (local.get 0)
+      (then (i32.const 10))
+      (else (i32.const 20)))
+    (i32.add))
+)

--- a/scripts/repro/if_else_result_343.wat
+++ b/scripts/repro/if_else_result_343.wat
@@ -31,4 +31,17 @@
       (then (i32.const 10))
       (else (i32.const 20)))
     (i32.add))
+
+  ;; #343 i64 — exercises the I64 arm of `reconcile_if_result` (the lo/hi pair
+  ;; move and its documented no-cycle argument). Each arm lands its result in a
+  ;; DIFFERENT register pair (then via i64.add, else a bare i64 const), and BOTH
+  ;; halves are nonzero and differ between arms — so the join must emit BOTH the
+  ;; lo and the hi `mv`, and a dropped hi-move would corrupt the top 32 bits
+  ;; rather than hide behind a zero high half.
+  ;;   pick64(nonzero) = 0x1_0000_0002 + 1 = 0x0000_0001_0000_0003  (then-arm)
+  ;;   pick64(0)       =                     0x0000_0007_0000_0020  (else-arm)
+  (func (export "pick64") (param i32) (result i64)
+    (if (result i64) (local.get 0)
+      (then (i64.add (i64.const 0x100000002) (i64.const 1)))
+      (else (i64.const 0x700000020))))
 )

--- a/scripts/repro/if_else_result_343_riscv_differential.py
+++ b/scripts/repro/if_else_result_343_riscv_differential.py
@@ -30,6 +30,7 @@ from elftools.elf.elffile import ELFFile
 from unicorn import UC_ARCH_RISCV, UC_MODE_RISCV32, Uc, UcError
 from unicorn.riscv_const import (
     UC_RISCV_REG_A0,
+    UC_RISCV_REG_A1,
     UC_RISCV_REG_RA,
     UC_RISCV_REG_S11,
     UC_RISCV_REG_SP,
@@ -39,6 +40,10 @@ WAT = "scripts/repro/if_else_result_343.wat"
 ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/if343.o"
 
 CODE, LIN, RET = 0x100000, 0x40000, 0x200000
+# Functions returning i64 hand their result back in the a0:a1 pair (lo:hi),
+# per the RV32 ILP32 convention — the harness reads both halves for these and
+# masks the comparison to 64 bits.
+I64_FUNCS = {"pick64"}
 # (export, param) — exercise BOTH the then-arm (nonzero cond) and the
 # else-arm (zero cond) of each value-returning if/else.
 VECTORS = [
@@ -51,6 +56,11 @@ VECTORS = [
     ("pick3", 1),
     ("pick3", 99),
     ("pick3", 0),
+    # #343 i64 — both arms land in different register pairs with nonzero,
+    # differing high halves, so the join must emit BOTH the lo and hi `mv`.
+    ("pick64", 1),
+    ("pick64", 55),
+    ("pick64", 0),
 ]
 
 
@@ -72,7 +82,8 @@ def main():
     def wt(name, arg):
         store = wasmtime.Store(engine)
         inst = wasmtime.Instance(store, module, [])
-        return inst.exports(store)[name](store, arg) & 0xFFFFFFFF
+        mask = 0xFFFFFFFFFFFFFFFF if name in I64_FUNCS else 0xFFFFFFFF
+        return inst.exports(store)[name](store, arg) & mask
 
     syms, code = symbols(ELF)
 
@@ -92,7 +103,11 @@ def main():
             mu.emu_start(CODE + addr, RET, count=4000)
         except UcError as e:
             return None, str(e)
-        return mu.reg_read(UC_RISCV_REG_A0) & 0xFFFFFFFF, ""
+        lo = mu.reg_read(UC_RISCV_REG_A0) & 0xFFFFFFFF
+        if name in I64_FUNCS:
+            hi = mu.reg_read(UC_RISCV_REG_A1) & 0xFFFFFFFF
+            return lo | (hi << 32), ""
+        return lo, ""
 
     fails = 0
     for name, arg in VECTORS:

--- a/scripts/repro/if_else_result_343_riscv_differential.py
+++ b/scripts/repro/if_else_result_343_riscv_differential.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""#343 — RV32 `if (result i32)` result-register reconciliation.
+
+The RV32 selector lowered a value-returning `if/else` without merging the two
+arms' result registers at the join. The then-arm computed its value into one
+register (e.g. `t2`, from `add`) and jumped to the end label; the else-arm left
+its value in another (`t0`, a bare const); the epilogue then unconditionally
+read whichever register the else-arm happened to leave — so the then path
+returned a stale leftover instead of its own result.
+
+This oracle compiles the module for RV32, runs each export under unicorn
+(UC_ARCH_RISCV / UC_MODE_RISCV32, ILP32) across both arms, and compares with
+wasmtime. Pre-fix it FAILS the then-arm (and the pick2 else-arm); post-fix all
+vectors match.
+
+Symbols are read from the ELF .symtab (SHT_SYMTAB) rather than `synth disasm`
+text — the disassembler is host-dependent (it decodes RV bytes with whatever
+target it defaults to) so its text is not a reliable symbol source.
+
+Run:
+  synth compile scripts/repro/if_else_result_343.wat -b riscv \
+        --target riscv32imac --relocatable --all-exports -o /tmp/if343.o
+  /tmp/synthvenv/bin/python \
+        scripts/repro/if_else_result_343_riscv_differential.py /tmp/if343.o
+"""
+import sys
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_RISCV, UC_MODE_RISCV32, Uc, UcError
+from unicorn.riscv_const import (
+    UC_RISCV_REG_A0,
+    UC_RISCV_REG_RA,
+    UC_RISCV_REG_S11,
+    UC_RISCV_REG_SP,
+)
+
+WAT = "scripts/repro/if_else_result_343.wat"
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/if343.o"
+
+CODE, LIN, RET = 0x100000, 0x40000, 0x200000
+# (export, param) — exercise BOTH the then-arm (nonzero cond) and the
+# else-arm (zero cond) of each value-returning if/else.
+VECTORS = [
+    ("pick", 1),
+    ("pick", 7),
+    ("pick", 0),
+    ("pick2", 1),
+    ("pick2", 42),
+    ("pick2", 0),
+    ("pick3", 1),
+    ("pick3", 99),
+    ("pick3", 0),
+]
+
+
+def symbols(path):
+    f = ELFFile(open(path, "rb"))
+    st = f.get_section_by_name(".symtab")
+    syms = {}
+    for s in st.iter_symbols():
+        if s.name and s["st_info"]["type"] == "STT_FUNC":
+            syms[s.name] = s["st_value"]
+    code = f.get_section_by_name(".text").data()
+    return syms, code
+
+
+def main():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, WAT)
+
+    def wt(name, arg):
+        store = wasmtime.Store(engine)
+        inst = wasmtime.Instance(store, module, [])
+        return inst.exports(store)[name](store, arg) & 0xFFFFFFFF
+
+    syms, code = symbols(ELF)
+
+    def run(name, arg):
+        addr = syms.get(name)
+        if addr is None:
+            return None, f"symbol {name} missing (function skipped?)"
+        mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+        for base, size in [(CODE, 0x20000), (LIN, 0x20000), (0x88000, 0x10000), (RET, 0x1000)]:
+            mu.mem_map(base, size)
+        mu.mem_write(CODE, code)
+        mu.reg_write(UC_RISCV_REG_SP, 0x90000)
+        mu.reg_write(UC_RISCV_REG_S11, LIN)
+        mu.reg_write(UC_RISCV_REG_A0, arg & 0xFFFFFFFF)
+        mu.reg_write(UC_RISCV_REG_RA, RET)
+        try:
+            mu.emu_start(CODE + addr, RET, count=4000)
+        except UcError as e:
+            return None, str(e)
+        return mu.reg_read(UC_RISCV_REG_A0) & 0xFFFFFFFF, ""
+
+    fails = 0
+    for name, arg in VECTORS:
+        gt = wt(name, arg)
+        res, err = run(name, arg)
+        ok = res == gt
+        fails += 0 if ok else 1
+        shown = f"0x{res:08x}={res}" if res is not None else f"ERR({err})"
+        print(f"{name}({arg}) = {shown}  wasmtime=0x{gt:08x}={gt}  {'OK' if ok else 'FAIL'}")
+
+    print("\nRISC-V if/else-result #343 ORACLE: PASS" if not fails
+          else f"\nRISC-V if/else-result #343 ORACLE: FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem (#343)

A wasm `if (result i32) … else … end` producing a value on **both** arms was miscompiled by the RV32 selector. Each arm left its result in whatever register its own allocation chose, the then-arm jumped to the end label, and the return epilogue then read one fixed register unconditionally — so the arm whose result lived in the *other* register returned a stale leftover.

Concretely, for `(if (result i32)(local.get 0)(then (i32.add (i32.const 1)(i32.const 2)))(else (i32.const 20)))`:

```
mv   t0, a0        ; cond
beq  t0, zero, Lelse
li   t0, 1
li   t1, 2
add  t2, t0, t1    ; then-result in t2
jal  Lif_end
Lelse:
li   t0, 20        ; else-result in t0
Lif_end:
mv   a0, t0        ; epilogue reads t0 — WRONG on the then path (t2 held the result)
ret
```

`pick(nonzero)` returned `1` (stale const) instead of `3`.

## Fix

Modelled on the ARM #313 reconciliation:

- `lower_else` captures the then-arm's result value(s) — the vstack entries above the if-entry checkpoint — into the control frame before resetting the stack for the else-arm.
- `lower_end`, on closing an if/else, pops the else-arm's results and emits `mv rd_then, rd_else` (`addi rd, rs, 0`) for each position where the two arms chose different registers. The moves sit on the **else** path (between the else body and `end_label`); the then-path's `jal end_label` jumps over them. Both arms leave the join value in the then-arm's register(s), pushed back onto the vstack.

No `mv` is emitted when the arms already agree, so control-flow-only / register-symmetric if/else stays **byte-identical**. A width mismatch between arms surfaces as a recoverable `ControlMismatch` rather than a half-move. No persistent reservation of the then-arm registers is needed (unlike ARM, which reserves only for byte-identity with its own pre-fix output): overwriting `rd_then` on the else path destroys nothing live, since `rd_then` was allocated avoiding every below-checkpoint value and the only live else value at the join is `rd_else` itself.

## Evidence

`scripts/repro/if_else_result_343_riscv_differential.py` + `if_else_result_343.wat` run each export under unicorn (RV32 / ILP32) vs wasmtime across both arms, including `pick3` which carries a value **live across** the if/else (guards the join split-index). Symbols read from the ELF `.symtab` (the disassembler text is host-dependent).

Pre-fix (fix stashed, rebuilt):
```
pick(1)   = 1   wasmtime=3   FAIL
pick(7)   = 1   wasmtime=3   FAIL
pick(0)   = 20  wasmtime=20  OK
pick2(1)  = 0   wasmtime=7   FAIL
pick2(42) = 0   wasmtime=7   FAIL
pick2(0)  = 300 wasmtime=300 OK
pick3(*)  … OK  (arms coincidentally share a register)
RISC-V if/else-result #343 ORACLE: FAIL (4)
```

Post-fix:
```
pick(1)=3  pick(7)=3  pick(0)=20
pick2(1)=7 pick2(42)=7 pick2(0)=300
pick3(1)=15 pick3(99)=15 pick3(0)=25
RISC-V if/else-result #343 ORACLE: PASS  (9/9)
```

## Gates

- `cargo test -p synth-cli --test frozen_codegen_bytes` — 3/3 (RV32 anchor `frozen_fixtures_rv32_text_is_bit_identical_oracle_001` unchanged)
- `cargo test -p synth-backend-riscv` — 192 pass (incl. two new #343 unit tests: exactly-one-mv asymmetric, zero-mv arity-0)
- `cargo fmt --check` clean; `cargo clippy -p synth-backend-riscv --all-targets -- -D warnings` clean
- Only `crates/synth-backend-riscv/` touched (plus the two repro deliverables under `scripts/repro/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)