### PR TITLE
fix(dwarf): emit real source filenames in .debug_line, not fabricated synth.wasm (#394)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,6 +2119,7 @@ dependencies = [
  "synth-verify",
  "tracing",
  "tracing-subscriber",
+ "wasmparser 0.252.0",
  "wast",
  "wat",
 ]

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -57,6 +57,12 @@ wast.workspace = true
 
 [dev-dependencies]
 object.workspace = true
+# VCR-DBG-001 Tier-1 (#394) — oracle E parses the INPUT wasm's `.debug_*` custom
+# sections independently (mirroring the production reader) to derive, at runtime,
+# the real source basenames its `.debug_line` rows reference — so the emitted
+# file-table check is robust vs hardcoding. Test-only; matches synth-core's pin.
+# Bazel globs src/ only, so no MODULE.bazel pin is needed for a dev-dependency.
+wasmparser.workspace = true
 # VCR-ORACLE-001 (#242) — the frozen-codegen byte gate hashes each fixture's
 # `.text` to lock it against accidental drift (e.g. a dependabot parser bump
 # shifting lowering). Already in the lock tree; test-only ⇒ no production pull,

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -3192,7 +3192,8 @@ fn build_relocatable_elf(
         && !input_dwarf.rows.is_empty()
     {
         use synth_core::dwarf_line::{SourceLoc, op_offsets_to_source};
-        let mut table: Vec<(u64, u32)> = Vec::new();
+        // (arm_addr, source line, GLOBAL file index into input_dwarf.files).
+        let mut table: Vec<(u64, u32, u32)> = Vec::new();
         for (i, func) in funcs.iter().enumerate() {
             if func.line_map.is_empty() || func.op_offsets.is_empty() {
                 continue; // RISC-V (empty line_map) or a func with no op offsets
@@ -3203,17 +3204,19 @@ fn build_relocatable_elf(
             for &(machine_off, op_idx) in &func.line_map {
                 // None entries (prologue / literal pool) carry no source.
                 let Some(op_idx) = op_idx else { continue };
-                if let Some(Some(SourceLoc { line, .. })) = locs.get(op_idx)
+                // Carry the real source FILE through (was dropped, forcing every
+                // stop to the fabricated `synth.wasm`); emit reproduces it.
+                if let Some(Some(SourceLoc { line, file })) = locs.get(op_idx)
                     && *line != 0
                 {
                     let arm_addr = (func_offsets[i] + machine_off) as u64;
-                    table.push((arm_addr, *line));
+                    table.push((arm_addr, *line, *file));
                 }
             }
         }
         // One address-ordered, de-duped sequence covering every function.
-        table.sort_by_key(|&(a, _)| a);
-        table.dedup_by_key(|&mut (a, _)| a);
+        table.sort_by_key(|&(a, _, _)| a);
+        table.dedup_by_key(|&mut (a, _, _)| a);
 
         // A dedicated GLOBAL symbol at `.text + 0` that the DWARF `.rel.debug_*`
         // records resolve against (R_ARM_ABS32, REL: S=`.text` base + in-place
@@ -3229,8 +3232,11 @@ fn build_relocatable_elf(
             .with_section(4); // .text is section index 4
         let text_sym_idx = elf_builder.add_symbol_indexed(text_base_sym);
 
-        let dwarf_sections =
-            synth_core::dwarf_line::emit_debug_sections(&table, text_sym_idx as usize);
+        let dwarf_sections = synth_core::dwarf_line::emit_debug_sections(
+            &table,
+            text_sym_idx as usize,
+            &input_dwarf.files,
+        );
         if !dwarf_sections.is_empty() {
             let names: Vec<&str> = dwarf_sections.iter().map(|s| s.name).collect();
             let mut total_relocs = 0usize;

--- a/crates/synth-cli/tests/dwarf_debug_line_emit_394.rs
+++ b/crates/synth-cli/tests/dwarf_debug_line_emit_394.rs
@@ -21,7 +21,7 @@
 //!      address (in-range) to a non-zero source line. This is the path a debugger
 //!      takes, so passing it proves a debugger can reach the line data.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -433,5 +433,134 @@ fn rel_debug_relocations_shift_addresses_to_correct_line_394() {
         "[dbg394-oracleC] applied .rel.debug_line at base 0x{LINK_BASE:x}: {} rows \
          shifted by exactly the base, all source lines preserved.",
         after.len()
+    );
+}
+
+/// The basename of a (possibly `/`- or `\`-separated) path string.
+fn basename(name: &str) -> String {
+    name.rsplit(['/', '\\']).next().unwrap_or(name).to_string()
+}
+
+/// Extract a wasm module's `.debug_*` custom sections into a name→bytes map.
+fn wasm_debug_sections(wasm: &[u8]) -> HashMap<String, Vec<u8>> {
+    use wasmparser::{Parser, Payload};
+    let mut out = HashMap::new();
+    for payload in Parser::new(0).parse_all(wasm) {
+        if let Ok(Payload::CustomSection(c)) = payload
+            && c.name().starts_with(".debug_")
+        {
+            out.insert(c.name().to_string(), c.data().to_vec());
+        }
+    }
+    out
+}
+
+/// Walk a section-name→bytes DWARF map via `dwarf.units()` and return the
+/// basenames of the source files that its `.debug_line` ROWS actually reference
+/// (resolved through each unit's own file table). This is the set the compose
+/// carries into the emitted object, so it is exactly what must reappear there —
+/// derived from the fixture AT RUNTIME rather than hardcoded.
+fn row_referenced_basenames(secs: &HashMap<String, Vec<u8>>) -> BTreeSet<String> {
+    let empty: &[u8] = &[];
+    let load = |id: SectionId| -> Result<EndianSlice<'_, LittleEndian>, gimli::Error> {
+        let data = secs.get(id.name()).map_or(empty, |v| v.as_slice());
+        Ok(EndianSlice::new(data, LittleEndian))
+    };
+    let dwarf = gimli::Dwarf::load(load).expect("load .debug_* sections");
+    let mut out = BTreeSet::new();
+    let mut units = dwarf.units();
+    while let Some(header) = units.next().expect("unit header") {
+        let unit = dwarf.unit(header).expect("unit");
+        let Some(program) = unit.line_program.clone() else {
+            continue;
+        };
+        // Clone the header (it borrows the program) before consuming `program`.
+        let h = program.header().clone();
+        let mut file_indices = Vec::new();
+        let mut state = program.rows();
+        while let Some((_, row)) = state.next_row().expect("row") {
+            if row.end_sequence() {
+                continue;
+            }
+            file_indices.push(row.file_index());
+        }
+        for fi in file_indices {
+            if let Some(file) = h.file(fi)
+                && let Ok(name) = dwarf.attr_string(&unit, file.path_name())
+            {
+                out.insert(basename(&name.to_string_lossy()));
+            }
+        }
+    }
+    out
+}
+
+/// Walk an emitted DWARF map and return the basenames present in the CU line
+/// program's FILE TABLE (`header().file_names()`), the way a debugger reads it.
+fn emitted_file_basenames(secs: &HashMap<String, Vec<u8>>) -> BTreeSet<String> {
+    let empty: &[u8] = &[];
+    let load = |id: SectionId| -> Result<EndianSlice<'_, LittleEndian>, gimli::Error> {
+        let data = secs.get(id.name()).map_or(empty, |v| v.as_slice());
+        Ok(EndianSlice::new(data, LittleEndian))
+    };
+    let dwarf = gimli::Dwarf::load(load).expect("load emitted .debug_* sections");
+    let mut out = BTreeSet::new();
+    let mut units = dwarf.units();
+    while let Some(header) = units.next().expect("unit header") {
+        let unit = dwarf.unit(header).expect("unit");
+        let Some(program) = unit.line_program.clone() else {
+            continue;
+        };
+        let h = program.header();
+        for file in h.file_names() {
+            if let Ok(name) = dwarf.attr_string(&unit, file.path_name()) {
+                out.insert(basename(&name.to_string_lossy()));
+            }
+        }
+    }
+    out
+}
+
+/// ORACLE E — Tier-1 REAL source filenames (#394). Before this fix the emitter
+/// hardcoded its only file as `synth.wasm` (dir `/synth`), a file that does not
+/// exist, so gdb resolved every stop as `synth.wasm:N` — correct line, fabricated
+/// file. This oracle proves the emitted line program's file table instead carries
+/// the input wasm's REAL row-referenced source basenames (e.g. `panicking.rs`),
+/// extracted from the fixture at runtime, and that `synth.wasm` is GONE.
+#[test]
+fn emitted_debug_line_carries_real_source_filenames_394() {
+    let wasm = repro("msgq_put_359.wasm");
+    let wasm_bytes = std::fs::read(&wasm).expect("read fixture wasm");
+
+    // (a) The real source basenames the input's `.debug_line` rows reference —
+    // exactly what the compose carries into the emitted object.
+    let expected = row_referenced_basenames(&wasm_debug_sections(&wasm_bytes));
+    assert!(
+        !expected.is_empty(),
+        "fixture must have `.debug_line` rows referencing ≥1 source file"
+    );
+
+    let dbg = compile(&wasm, "/tmp/dbg394_msgq_oraclee.o", true);
+    let emitted = emitted_file_basenames(&section_data(&dbg));
+
+    // (b) The fabricated filename must be GONE.
+    assert!(
+        !emitted.contains("synth.wasm"),
+        "emitted line-program file table must NOT contain the fabricated \
+         `synth.wasm`; got {emitted:?}"
+    );
+
+    // (a) The real row-referenced basenames must be present.
+    for want in &expected {
+        assert!(
+            emitted.contains(want),
+            "emitted file table missing real source file {want:?}; \
+             expected {expected:?}, got {emitted:?}"
+        );
+    }
+
+    eprintln!(
+        "[dbg394-oracleE] input rows reference {expected:?}; emitted file table {emitted:?} \
+         (real names propagated, synth.wasm gone)"
     );
 }

--- a/crates/synth-core/src/dwarf_line.rs
+++ b/crates/synth-core/src/dwarf_line.rs
@@ -102,6 +102,14 @@ pub struct InputDwarfLine {
     /// Module-relative byte offset of the code section payload start. Empty wasm
     /// or a wasm with no code section reports 0.
     pub code_base: u32,
+    /// GLOBAL source-file table `(directory, file name)`. `LineRow.file` indexes
+    /// into this — NOT the input's per-unit DWARF file index. The input wasm has
+    /// several compilation units each with their own file table (colliding
+    /// per-unit indices), so the reader resolves every row's file to a real
+    /// `(dir, name)` string and interns it here, giving one flat table the emit
+    /// reproduces 1:1. Empty when no row resolves to a file (emit then falls back
+    /// to its single-file default).
+    pub files: Vec<(String, String)>,
 }
 
 /// Read the input wasm's `.debug_line` into code-section-relative
@@ -127,21 +135,31 @@ pub fn read_input_dwarf_line(wasm: &[u8]) -> InputDwarfLine {
         return InputDwarfLine {
             rows: Vec::new(),
             code_base,
+            files: Vec::new(),
         };
     }
 
     // (b) parse `.debug_line` with gimli. A malformed line program degrades to
     // an empty table (the feature no-ops) rather than failing the compile.
-    let rows = parse_debug_line_rows(&sections).unwrap_or_default();
-    InputDwarfLine { rows, code_base }
+    let (rows, files) = parse_debug_line_rows(&sections).unwrap_or_default();
+    InputDwarfLine {
+        rows,
+        code_base,
+        files,
+    }
 }
 
-/// gimli read of `.debug_line` → rows. `file` is recorded as the line program's
-/// file index (kept opaque per `LineRow`'s contract; the compose carries it but
-/// only `addr`/`line` are load-bearing for the wasm-offset bridge).
-fn parse_debug_line_rows(
-    sections: &HashMap<String, Vec<u8>>,
-) -> Result<Vec<LineRow>, gimli::Error> {
+/// gimli read of `.debug_line` → `(rows, global file table)`. The input carries
+/// several compilation units, each with its own file table, so a row's per-unit
+/// `file_index` is ambiguous once rows are flattened. To keep `LineRow.file`
+/// meaningful across units, each row's file index is resolved (via that unit's
+/// own header + `dwarf.attr_string`) to a real `(directory, name)` string and
+/// interned into one flat GLOBAL table; `LineRow.file` becomes that global index.
+/// `header.file(idx)` / `header.directory(idx)` handle the DWARF version's
+/// indexing (v4 is 1-based; v5 is 0-based) so both are read correctly.
+type LineTable = (Vec<LineRow>, Vec<(String, String)>);
+
+fn parse_debug_line_rows(sections: &HashMap<String, Vec<u8>>) -> Result<LineTable, gimli::Error> {
     let empty: &[u8] = &[];
     let load = |id: SectionId| -> Result<EndianSlice<'_, LittleEndian>, gimli::Error> {
         let data = sections.get(id.name()).map_or(empty, |v| v.as_slice());
@@ -150,25 +168,73 @@ fn parse_debug_line_rows(
     let dwarf = Dwarf::load(load)?;
 
     let mut rows = Vec::new();
+    let mut files: Vec<(String, String)> = Vec::new();
     let mut units = dwarf.units();
     while let Some(header) = units.next()? {
         let unit = dwarf.unit(header)?;
         let Some(program) = unit.line_program.clone() else {
             continue;
         };
+        // The header borrows the program; clone it so we can consume `program`
+        // in `rows()` while still resolving file indices afterwards.
+        let line_header = program.header().clone();
         let mut state = program.rows();
         while let Some((_, row)) = state.next_row()? {
             if row.end_sequence() {
                 continue;
             }
+            // Resolve this row's per-unit file index to a real (dir, name) and
+            // intern it into the flat global table (dedup); store the global idx.
+            let file = resolve_file(&dwarf, &unit, &line_header, row.file_index())
+                .map(|entry| intern_file(&mut files, entry))
+                .unwrap_or(0);
             rows.push(LineRow {
                 addr: row.address() as u32,
                 line: row.line().map(|l| l.get() as u32).unwrap_or(0),
-                file: row.file_index() as u32,
+                file,
             });
         }
     }
-    Ok(rows)
+    Ok((rows, files))
+}
+
+/// Resolve a line-program `file_index` to `(directory, file name)` strings using
+/// the owning unit's header. `header.file` / `header.directory` apply the correct
+/// per-version indexing; `attr_string` resolves both inline (`.debug_line`) and
+/// `.debug_line_str`/`.debug_str` forms. `None` when the index has no file entry
+/// (e.g. DWARF v4 index 0).
+fn resolve_file(
+    dwarf: &Dwarf<EndianSlice<'_, LittleEndian>>,
+    unit: &gimli::Unit<EndianSlice<'_, LittleEndian>>,
+    header: &gimli::LineProgramHeader<EndianSlice<'_, LittleEndian>>,
+    file_index: u64,
+) -> Option<(String, String)> {
+    let file = header.file(file_index)?;
+    let name = dwarf
+        .attr_string(unit, file.path_name())
+        .ok()?
+        .to_string_lossy()
+        .into_owned();
+    let dir = match header.directory(file.directory_index()) {
+        Some(av) => dwarf
+            .attr_string(unit, av)
+            .ok()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        None => String::new(),
+    };
+    Some((dir, name))
+}
+
+/// Intern a `(dir, name)` into the global file table, returning its index
+/// (existing if already present). Keeps the table small (the fixture interns a
+/// single `panicking.rs`).
+fn intern_file(files: &mut Vec<(String, String)>, entry: (String, String)) -> u32 {
+    if let Some(i) = files.iter().position(|f| *f == entry) {
+        return i as u32;
+    }
+    files.push(entry);
+    (files.len() - 1) as u32
 }
 
 /// Emit an address-ordered `(arm_addr, line)` table as a FULL minimal DWARF unit
@@ -188,7 +254,11 @@ fn parse_debug_line_rows(
 ///
 /// Ports `tests/dwarf_emit_roundtrip_step4.rs::emit_dwarf` (which emits the same
 /// full unit and round-trips through `Dwarf::units()`).
-pub fn emit_debug_sections(table: &[(u64, u32)], text_sym: usize) -> Vec<EmittedDwarfSection> {
+pub fn emit_debug_sections(
+    table: &[(u64, u32, u32)],
+    text_sym: usize,
+    files: &[(String, String)],
+) -> Vec<EmittedDwarfSection> {
     use gimli::write::{Address, AttributeValue, DwarfUnit, LineProgram, LineString, Sections};
 
     if table.is_empty() {
@@ -204,21 +274,48 @@ pub fn emit_debug_sections(table: &[(u64, u32)], text_sym: usize) -> Vec<Emitted
 
     // The span of emitted text the unit describes: low_pc=`.text`+0 (text base),
     // high_pc one past the last mapped address.
-    let high_pc = table.iter().map(|&(a, _)| a).max().unwrap_or(0) + 1;
+    let high_pc = table.iter().map(|&(a, _, _)| a).max().unwrap_or(0) + 1;
 
-    // gimli 0.33 split the comp-dir/file args: (working_dir, source_dir,
-    // source_file, source_file_info). source_dir = None ⇒ the file sits in
-    // working_dir, matching the previous single-dir behaviour.
+    // Reproduce the input's source-file table so a debugger resolves each stop to
+    // the REAL file (e.g. `panicking.rs`), not the fabricated `synth.wasm`. The
+    // comp-dir/file passed to `LineProgram::new` become the unit's primary file;
+    // use the FIRST real interned file for it (never `synth.wasm`) so even the
+    // primary is a genuine name. Then `add_file` each interned file and map its
+    // global index → the returned `FileId`. When the input carried no resolvable
+    // file table (`files` empty) keep the historical single-file default so a
+    // DWARF-less-but-lined input still emits something rather than panicking.
+    //
+    // gimli 0.33's `LineProgram::new` args are
+    // `(working_dir, working_dir_info, source_file, source_file_info)`.
+    let (primary_dir, primary_name) = files
+        .first()
+        .map(|(d, n)| (d.clone().into_bytes(), n.clone().into_bytes()))
+        .unwrap_or_else(|| (b"/synth".to_vec(), b"synth.wasm".to_vec()));
     let mut program = LineProgram::new(
         encoding,
         gimli::LineEncoding::default(),
-        LineString::String(b"/synth".to_vec()),
+        LineString::String(primary_dir),
         None,
-        LineString::String(b"synth.wasm".to_vec()),
+        LineString::String(primary_name.clone()),
         None,
     );
-    let dir = program.default_directory();
-    let fid = program.add_file(LineString::String(b"synth.wasm".to_vec()), dir, None);
+    // Global file index → emitted `FileId`. `file_ids[0]` always exists (either
+    // the first real file or the single fallback), so an out-of-range row index
+    // clamps to it rather than panicking.
+    let mut file_ids = Vec::with_capacity(files.len().max(1));
+    if files.is_empty() {
+        let dir = program.default_directory();
+        file_ids.push(program.add_file(LineString::String(b"synth.wasm".to_vec()), dir, None));
+    } else {
+        for (dir, name) in files {
+            let dir_id = program.add_directory(LineString::String(dir.clone().into_bytes()));
+            file_ids.push(program.add_file(
+                LineString::String(name.clone().into_bytes()),
+                dir_id,
+                None,
+            ));
+        }
+    }
 
     // The sequence base is `.text + 0` as a RELOCATABLE address (one
     // `DW_LNE_set_address` against the `.text` symbol, addend 0); each row's
@@ -230,10 +327,10 @@ pub fn emit_debug_sections(table: &[(u64, u32)], text_sym: usize) -> Vec<Emitted
         addend: 0,
     };
     program.begin_sequence(Some(text_base));
-    for &(addr, line) in table {
+    for &(addr, line, file) in table {
         let row = program.row();
         row.address_offset = addr;
-        row.file = fid;
+        row.file = *file_ids.get(file as usize).unwrap_or(&file_ids[0]);
         row.line = line as u64;
         program.generate_row();
     }
@@ -242,8 +339,13 @@ pub fn emit_debug_sections(table: &[(u64, u32)], text_sym: usize) -> Vec<Emitted
 
     // Populate the root DW_TAG_compile_unit DIE: a name, the text span, and (via
     // gimli auto-wiring the attached line_program) DW_AT_stmt_list → .debug_line.
+    // Name the CU after the primary real source file (fallback `synth.wasm`).
     {
-        let name_id = dwarf.strings.add("synth.wasm");
+        let cu_name = files
+            .first()
+            .map(|(_, n)| n.clone())
+            .unwrap_or_else(|| "synth.wasm".to_string());
+        let name_id = dwarf.strings.add(cu_name);
         let root = dwarf.unit.root();
         let root_die = dwarf.unit.get_mut(root);
         root_die.set(gimli::DW_AT_name, AttributeValue::StringRef(name_id));


### PR DESCRIPTION
## Problem (#394 Tier-1 follow-through)

synth's DWARF `.debug_line` pipeline already ships (v0.12.0, `--debug-line`, ARM `--relocatable` path): the machine-addr → wasm-op-offset → source-line composition is real and emitted. But the emitted line program **hardcoded its only source file as `synth.wasm`** in dir `/synth`, and the compose in `main.rs` dropped `SourceLoc.file`. So gdb/lldb resolved every stop as `synth.wasm:N` — a file that does not exist. Line numbers were correct; the **filename was fabricated**, failing the spirit of the Tier-1 acceptance ("stops at the correct **source** file:line").

## Fix

Propagate the input wasm's real directory + file tables through the pipeline:
- `read_input_dwarf_line` / `parse_debug_line_rows` now also read the input line-program header's dir + file tables (via `header.file()`, version-correct indexing).
- `InputDwarfLine` carries the file table; `main.rs` carries `SourceLoc.file` into the composed table.
- `emit_debug_sections` reproduces the input dir/file tables with an input→output file-id remap and sets each emitted row's `file` accordingly.
- Falls back to the prior single-file behavior when the input has no file table (no panic).

Before: `synth.wasm:N` → After: `<real source>:N`.

## Oracle (non-vacuous)

New `emitted_debug_line_carries_real_source_filenames_394` derives the real source basenames **at runtime** by parsing the input wasm's own `.debug_*` custom sections (new test-only `wasmparser` dev-dep, "oracle E"), then asserts the emitted CU line-program file table contains those basenames and does **not** contain `synth.wasm`.

Verified RED without the fix — reverting just the emit change makes it fail with exactly:
```
emitted line-program file table must NOT contain the fabricated `synth.wasm`; got {"synth.wasm"}
```

## Gate
- `dwarf_debug_line_emit_394` 6/6 (oracles A/B/C/D unchanged + new E).
- **Frozen-safe:** DWARF is additive/non-loadable — `.text/.data/.bss` byte-identical (Oracle A); `frozen_codegen_bytes` 3/3.
- `cargo clippy -p synth-cli -p synth-core --all-targets -- -D warnings` exit 0; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)