### PR TITLE
feat(dwarf): DW_TAG_subprogram DIEs — function names in backtraces (#394)

### DIFF
--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -3232,10 +3232,28 @@ fn build_relocatable_elf(
             .with_section(4); // .text is section index 4
         let text_sym_idx = elf_builder.add_symbol_indexed(text_base_sym);
 
+        // #394 Tier-1: one DW_TAG_subprogram DIE per compiled function so a
+        // debugger backtrace shows the function NAME. Each function's name and
+        // its object-relative `.text` range come straight from the layout the
+        // reloc/symbol emission already uses (`func_offsets[i]` .. + code len,
+        // the same values `func.name`/`func_N` symbols carry). Purely additive:
+        // the subprogram low_pc addresses reuse the `__synth_text_base` symbol
+        // via an addend, so no new symbol is defined.
+        let subprograms: Vec<synth_core::dwarf_line::SubprogramInfo> = funcs
+            .iter()
+            .enumerate()
+            .map(|(i, func)| synth_core::dwarf_line::SubprogramInfo {
+                name: func.name.clone(),
+                low_pc: func_offsets[i] as u64,
+                high_pc: (func_offsets[i] + func.code.len() as u32) as u64,
+            })
+            .collect();
+
         let dwarf_sections = synth_core::dwarf_line::emit_debug_sections(
             &table,
             text_sym_idx as usize,
             &input_dwarf.files,
+            &subprograms,
         );
         if !dwarf_sections.is_empty() {
             let names: Vec<&str> = dwarf_sections.iter().map(|s| s.name).collect();

--- a/crates/synth-cli/tests/dwarf_debug_line_emit_394.rs
+++ b/crates/synth-cli/tests/dwarf_debug_line_emit_394.rs
@@ -330,9 +330,12 @@ fn line_rows(secs: &HashMap<String, Vec<u8>>) -> Vec<(u64, u64)> {
 /// `.rel.debug_*`. This oracle proves the records do exactly that:
 ///
 ///   1. `.debug_line` carries EXACTLY ONE relocation — `R_ARM_ABS32` against
-///      `__synth_text_base` (the single `DW_LNE_set_address` anchor) — and
-///      `.debug_info` one (the CU `DW_AT_low_pc`). REL form ⇒ the in-place addend
-///      bytes are 0.
+///      `__synth_text_base` (the single `DW_LNE_set_address` anchor), REL form ⇒
+///      its in-place addend is 0. `.debug_info` carries `1 + N` relocations
+///      (#394): the CU `DW_AT_low_pc` (addend 0) plus one per `DW_TAG_subprogram`
+///      `DW_AT_low_pc`, each `R_ARM_ABS32` against `__synth_text_base` with its
+///      in-place addend equal to that function's object-relative `.text` offset —
+///      so on link each subprogram resolves to `text_base + low_pc`.
 ///   2. APPLY the `.debug_line` relocation at a NON-ZERO base (`S + A`, A=0 ⇒
 ///      the base itself), then re-walk the line program. EVERY row's address must
 ///      shift by exactly the base and its source LINE must be preserved — i.e. on
@@ -393,7 +396,64 @@ fn rel_debug_relocations_shift_addresses_to_correct_line_394() {
     };
 
     let line_reloc_off = check_one_text_reloc(".debug_line") as usize;
-    let _ = check_one_text_reloc(".debug_info");
+
+    // `.debug_info`: 1 CU low_pc reloc (addend 0) + one per subprogram low_pc
+    // (addend = that function's object-relative `.text` offset), all R_ARM_ABS32
+    // against `__synth_text_base`. The multiset of in-place addends must equal
+    // {0} ∪ {each subprogram low_pc}, proving every subprogram low_pc relocates
+    // by the base to `text_base + low_pc` (#394).
+    {
+        let subs = collect_subprograms(&section_data(&dbg));
+        assert!(
+            !subs.is_empty(),
+            ".debug_info reloc check needs ≥1 subprogram DIE"
+        );
+        let sec = obj
+            .section_by_name(".debug_info")
+            .expect(".debug_info present");
+        let data = sec.data().expect(".debug_info data");
+        let relocs: Vec<_> = sec.relocations().collect();
+        assert_eq!(
+            relocs.len(),
+            1 + subs.len(),
+            ".debug_info must carry 1 (CU low_pc) + {} (subprogram low_pc) `.text` \
+             relocations; got {}",
+            subs.len(),
+            relocs.len()
+        );
+        let mut got_addends: Vec<u64> = Vec::new();
+        for (offset, reloc) in &relocs {
+            match reloc.flags() {
+                object::RelocationFlags::Elf { r_type } => assert_eq!(
+                    r_type, R_ARM_ABS32,
+                    ".debug_info reloc must be R_ARM_ABS32, got r_type={r_type}"
+                ),
+                other => panic!(".debug_info reloc has non-ELF flags: {other:?}"),
+            }
+            let object::RelocationTarget::Symbol(sym_idx) = reloc.target() else {
+                panic!(".debug_info reloc target is not a symbol");
+            };
+            let sym = obj.symbol_by_index(sym_idx).expect("reloc symbol");
+            assert_eq!(
+                sym.name().expect("sym name"),
+                "__synth_text_base",
+                ".debug_info reloc must resolve against the .text base symbol"
+            );
+            let off = *offset as usize;
+            got_addends.push(u32::from_le_bytes(data[off..off + 4].try_into().unwrap()) as u64);
+        }
+        got_addends.sort_unstable();
+        // Expected: the CU (0) plus every subprogram's object-relative low_pc.
+        let mut expected: Vec<u64> = std::iter::once(0u64)
+            .chain(subs.iter().map(|s| s.low_pc))
+            .collect();
+        expected.sort_unstable();
+        assert_eq!(
+            got_addends, expected,
+            ".debug_info in-place addends must be {{0 (CU)}} ∪ subprogram low_pcs; \
+             each subprogram low_pc must relocate by the base"
+        );
+    }
 
     // (2) Un-relocated rows (object-relative, base 0) vs rows after applying the
     // `.debug_line` relocation at a non-zero base.
@@ -562,5 +622,169 @@ fn emitted_debug_line_carries_real_source_filenames_394() {
     eprintln!(
         "[dbg394-oracleE] input rows reference {expected:?}; emitted file table {emitted:?} \
          (real names propagated, synth.wasm gone)"
+    );
+}
+
+/// One emitted `DW_TAG_subprogram` DIE: its `DW_AT_name` and the object-relative
+/// `[low_pc, high_pc)` its `DW_AT_low_pc`/`DW_AT_high_pc` describe. On an ET_REL
+/// object the low_pc read here is the in-place addend (object-relative `.text`
+/// offset, base 0); `DW_AT_high_pc` is the offset form (size), so
+/// `high_pc = low_pc + size`.
+#[derive(Debug, Clone)]
+struct SubprogramDie {
+    name: Option<String>,
+    low_pc: u64,
+    high_pc: u64,
+}
+
+/// Walk an emitted DWARF map the debugger way (`dwarf.units()` → the CU tree) and
+/// collect every `DW_TAG_subprogram` child DIE's name + `[low_pc, high_pc)`.
+fn collect_subprograms(secs: &HashMap<String, Vec<u8>>) -> Vec<SubprogramDie> {
+    let empty: &[u8] = &[];
+    let load = |id: SectionId| -> Result<EndianSlice<'_, LittleEndian>, gimli::Error> {
+        let data = secs.get(id.name()).map_or(empty, |v| v.as_slice());
+        Ok(EndianSlice::new(data, LittleEndian))
+    };
+    let dwarf = gimli::Dwarf::load(load).expect("load emitted .debug_* sections");
+    let mut out = Vec::new();
+    let mut units = dwarf.units();
+    while let Some(header) = units.next().expect("unit header") {
+        let unit = dwarf.unit(header).expect("unit");
+        let mut entries = unit.entries();
+        while let Some(entry) = entries.next_dfs().expect("dfs") {
+            if entry.tag() != gimli::DW_TAG_subprogram {
+                continue;
+            }
+            let name = entry
+                .attr_value(gimli::DW_AT_name)
+                .and_then(|v| dwarf.attr_string(&unit, v).ok())
+                .map(|s| s.to_string_lossy().into_owned());
+            let low_pc = match entry.attr_value(gimli::DW_AT_low_pc) {
+                Some(gimli::AttributeValue::Addr(a)) => a,
+                other => panic!("subprogram DW_AT_low_pc must be an Addr, got {other:?}"),
+            };
+            // Tier-1 emits high_pc as the offset (size) form.
+            let size = match entry.attr_value(gimli::DW_AT_high_pc) {
+                Some(gimli::AttributeValue::Udata(n)) => n,
+                other => {
+                    panic!("subprogram DW_AT_high_pc must be Udata (offset form), got {other:?}")
+                }
+            };
+            out.push(SubprogramDie {
+                name,
+                low_pc,
+                high_pc: low_pc + size,
+            });
+        }
+    }
+    out
+}
+
+/// The exported FUNCTION names declared in the input wasm's export section —
+/// ground truth for the subprogram names, derived from the fixture at runtime
+/// (like Oracle E's filenames), NOT from synth's own symbol table. These MUST
+/// reappear as `DW_TAG_subprogram` `DW_AT_name`s.
+fn wasm_exported_func_names(wasm: &[u8]) -> BTreeSet<String> {
+    use wasmparser::{ExternalKind, Parser, Payload};
+    let mut out = BTreeSet::new();
+    for payload in Parser::new(0).parse_all(wasm) {
+        if let Ok(Payload::ExportSection(reader)) = payload {
+            for export in reader.into_iter().flatten() {
+                if export.kind == ExternalKind::Func {
+                    out.insert(export.name.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// ORACLE F — Tier-1 `DW_TAG_subprogram` DIEs (#394). A debugger backtrace shows
+/// FUNCTION NAMES (not bare addresses) only if each function has a subprogram DIE
+/// carrying its name and address range. Before this fix the emitted CU had ZERO
+/// children, so gdb/lldb resolved a `.text` address to `file:line` but printed no
+/// function frame. This oracle proves the emitter now attaches one
+/// `DW_TAG_subprogram` per compiled function under the CU:
+///
+///   (a) every EXPORTED wasm function name (derived from the input's export
+///       section at runtime — non-circular) appears as a subprogram `DW_AT_name`;
+///   (b) the subprogram COUNT equals the number of `func_N` symbols the object
+///       defines (one per compiled function);
+///   (c) every subprogram's `[low_pc, high_pc)` lies within `.text`
+///       (`low_pc < high_pc <= text_len`).
+#[test]
+fn emitted_debug_info_has_subprogram_dies_per_function_394() {
+    let wasm = repro("msgq_put_359.wasm");
+    let wasm_bytes = std::fs::read(&wasm).expect("read fixture wasm");
+    let expected_names = wasm_exported_func_names(&wasm_bytes);
+    assert!(
+        !expected_names.is_empty(),
+        "fixture must export ≥1 function to anchor the name check"
+    );
+
+    let dbg = compile(&wasm, "/tmp/dbg394_msgq_oraclef.o", true);
+    let obj = ElfFile32::<object::Endianness>::parse(&*dbg).expect("parse ELF");
+    let text_len = obj.section_by_name(".text").expect(".text present").size();
+    assert!(text_len > 0, ".text must be non-empty");
+
+    // Count `func_N` symbols — every compiled function defines exactly one, so
+    // this is a synth-independent-of-DWARF count of the functions in the object.
+    let func_sym_count = obj
+        .symbols()
+        .filter_map(|s| s.name().ok().map(str::to_string))
+        .filter(|n| {
+            n.strip_prefix("func_")
+                .is_some_and(|d| !d.is_empty() && d.bytes().all(|b| b.is_ascii_digit()))
+        })
+        .count();
+    assert!(func_sym_count > 0, "object must define ≥1 func_N symbol");
+
+    let subs = collect_subprograms(&section_data(&dbg));
+    assert!(
+        !subs.is_empty(),
+        "emitted CU has NO DW_TAG_subprogram children — a debugger backtrace \
+         would show addresses, not function names"
+    );
+
+    // (b) one subprogram per compiled function.
+    assert_eq!(
+        subs.len(),
+        func_sym_count,
+        "expected one DW_TAG_subprogram per compiled function ({func_sym_count} \
+         func_N symbols); got {} subprograms: {:?}",
+        subs.len(),
+        subs.iter().map(|s| &s.name).collect::<Vec<_>>()
+    );
+
+    // (c) every subprogram range is inside `.text`.
+    for s in &subs {
+        assert!(
+            s.low_pc < s.high_pc && s.high_pc <= text_len,
+            "subprogram {:?} range [0x{:x},0x{:x}) is not within .text (<0x{text_len:x})",
+            s.name,
+            s.low_pc,
+            s.high_pc
+        );
+    }
+
+    // (a) every exported function name is present as a subprogram DW_AT_name.
+    let got_names: BTreeSet<String> = subs.iter().filter_map(|s| s.name.clone()).collect();
+    for want in &expected_names {
+        assert!(
+            got_names.contains(want),
+            "no DW_TAG_subprogram named {want:?} (an exported function); \
+             got {got_names:?}"
+        );
+    }
+
+    eprintln!(
+        "[dbg394-oracleF] {} subprogram DIEs ({} func_N syms); exports {expected_names:?} \
+         all present. sample: {:?}",
+        subs.len(),
+        func_sym_count,
+        subs.iter()
+            .take(5)
+            .map(|s| format!("{:?} [0x{:x},0x{:x})", s.name, s.low_pc, s.high_pc))
+            .collect::<Vec<_>>()
     );
 }

--- a/crates/synth-core/src/dwarf_line.rs
+++ b/crates/synth-core/src/dwarf_line.rs
@@ -237,6 +237,22 @@ fn intern_file(files: &mut Vec<(String, String)>, entry: (String, String)) -> u3
     (files.len() - 1) as u32
 }
 
+/// One function to describe with a `DW_TAG_subprogram` child DIE (#394, Tier-1)
+/// so a debugger backtrace shows the FUNCTION NAME, not a bare address. Carries
+/// the function's name and its object-relative `[low_pc, high_pc)` `.text` range
+/// (byte offsets against the `.text` base). The emitter relocates `low_pc`
+/// against the SAME `.text` symbol as the CU (addend = `low_pc`) and writes
+/// `high_pc - low_pc` as the offset form of `DW_AT_high_pc` (no relocation).
+#[derive(Debug, Clone)]
+pub struct SubprogramInfo {
+    /// The export/function name shown in a debugger frame.
+    pub name: String,
+    /// Object-relative `.text` byte offset of the function's first instruction.
+    pub low_pc: u64,
+    /// Object-relative `.text` byte offset one past the function's last byte.
+    pub high_pc: u64,
+}
+
 /// Emit an address-ordered `(arm_addr, line)` table as a FULL minimal DWARF unit
 /// (gimli::write) and return EVERY non-empty `.debug_*` section it produces —
 /// `.debug_info`, `.debug_abbrev`, `.debug_str`, `.debug_line` (and
@@ -258,6 +274,7 @@ pub fn emit_debug_sections(
     table: &[(u64, u32, u32)],
     text_sym: usize,
     files: &[(String, String)],
+    subprograms: &[SubprogramInfo],
 ) -> Vec<EmittedDwarfSection> {
     use gimli::write::{Address, AttributeValue, DwarfUnit, LineProgram, LineString, Sections};
 
@@ -353,6 +370,37 @@ pub fn emit_debug_sections(
         root_die.set(gimli::DW_AT_high_pc, AttributeValue::Udata(high_pc));
     }
 
+    // #394 Tier-1: attach one DW_TAG_subprogram child DIE per function so a
+    // debugger backtrace shows the FUNCTION NAME, not a bare address.
+    //   - DW_AT_name    = the export/function name.
+    //   - DW_AT_low_pc  = the function's `.text` address, relocated against the
+    //     SAME `__synth_text_base` symbol as the CU low_pc but with addend =
+    //     the function's object-relative offset, so it shifts correctly when a
+    //     linker places `.text` (each is an extra `.rel.debug_info` record).
+    //   - DW_AT_high_pc = the offset (size) form `high_pc - low_pc` — a plain
+    //     constant, so it needs no relocation (matches the CU's high_pc form).
+    // No parameters/locals/frame-base yet — that is Tier-2, gated on VCR-RA.
+    {
+        let root = dwarf.unit.root();
+        for sp in subprograms {
+            let name_id = dwarf.strings.add(sp.name.clone());
+            let die_id = dwarf.unit.add(root, gimli::DW_TAG_subprogram);
+            let die = dwarf.unit.get_mut(die_id);
+            die.set(gimli::DW_AT_name, AttributeValue::StringRef(name_id));
+            die.set(
+                gimli::DW_AT_low_pc,
+                AttributeValue::Address(Address::Symbol {
+                    symbol: text_sym,
+                    addend: sp.low_pc as i64,
+                }),
+            );
+            die.set(
+                gimli::DW_AT_high_pc,
+                AttributeValue::Udata(sp.high_pc.saturating_sub(sp.low_pc)),
+            );
+        }
+    }
+
     let seed = RelocWriter {
         inner: gimli::write::EndianVec::new(LittleEndian),
         relocs: Vec::new(),
@@ -416,9 +464,10 @@ pub struct EmittedDwarfSection {
 /// overridden — `write_offset` (gimli's internal section-to-section references,
 /// e.g. `.debug_info` → `.debug_str`/`.debug_abbrev` and `DW_AT_stmt_list` →
 /// `.debug_line`) keeps the default, so those stay CONCRETE intra-file offsets
-/// and need no section symbols. The only relocations captured are the two
-/// `.text` references (the line program's `DW_LNE_set_address` and the CU's
-/// `DW_AT_low_pc`). `Clone` so `Sections::new` can seed each section writer.
+/// and need no section symbols. The relocations captured are the `.text`
+/// references: the line program's `DW_LNE_set_address`, the CU's `DW_AT_low_pc`,
+/// and one per `DW_TAG_subprogram` `DW_AT_low_pc` (#394). `Clone` so
+/// `Sections::new` can seed each section writer.
 #[derive(Clone)]
 struct RelocWriter {
     inner: gimli::write::EndianVec<LittleEndian>,


### PR DESCRIPTION
## What

VCR-DBG-001 **Tier-1** increment for #394. synth already emits a real
`.debug_line` (addr→file:line) on the ARM `--relocatable` path behind
`--debug-line`, and the CU root DIE carries name/low_pc/high_pc/stmt_list.
This PR adds the missing piece: **per-function `DW_TAG_subprogram` child
DIEs**, so a gdb/lldb backtrace shows the **function name** instead of a
bare address.

### Before → after

- **Before:** the emitted `DW_TAG_compile_unit` had a `DW_AT_stmt_list`
  line table but **zero children**. A debugger resolved a `.text` address
  to `file:line`, but printed no function frame.
- **After:** one `DW_TAG_subprogram` child DIE per compiled function:
  - `DW_AT_name`    = the export/function name (synth already holds it in
    `ElfFunction.name`).
  - `DW_AT_low_pc`  = the function's `.text` address, relocated against the
    **same** `__synth_text_base` symbol as the CU low_pc (addend = the
    function's object-relative `.text` offset) — one extra
    `.rel.debug_info` `R_ARM_ABS32` record each, so it shifts correctly
    when a linker places `.text`.
  - `DW_AT_high_pc` = offset (size) form `high_pc - low_pc` — a plain
    constant, no relocation (matches the CU's high_pc form).

No parameters/locals/frame-base yet — that is **Tier-2, gated on VCR-RA**.

## Files

- `crates/synth-core/src/dwarf_line.rs` — new `SubprogramInfo` struct;
  `emit_debug_sections` takes `&[SubprogramInfo]` and adds the child DIEs
  under the CU root.
- `crates/synth-cli/src/main.rs` (DWARF compose block) — builds the
  subprogram list from `func.name` + `func_offsets[i]..+code.len()` and
  threads it in. Reloc/symbol wiring is unchanged — the extra `.text`
  relocs flow through the existing per-section `.rel.debug_*` path.
- `crates/synth-cli/tests/dwarf_debug_line_emit_394.rs` — new Oracle F;
  Oracle C tightened.

## Purely additive (frozen-safe)

Subprogram low_pcs reuse `__synth_text_base` via an addend, so **no new
symbol** is defined. `.text`/`.data`/`.bss` stay byte-identical with vs
without `--debug-line`. **Frozen `frozen_codegen_bytes` 3/3**; Oracle A
(byte-identity) green; DWARF anchors did not shift.

## Oracle: red → green

**New Oracle F** (`emitted_debug_info_has_subprogram_dies_per_function_394`):
walks the emitted CU the debugger way (`dwarf.units()` → CU tree) and asserts
1. one `DW_TAG_subprogram` per `func_N` symbol the object defines;
2. every **exported** wasm function name — derived from the input's export
   section **at runtime** (non-circular, mirroring Oracle E's filename
   check), e.g. `z_impl_k_msgq_put`, `gale_k_msgq_put_decide` — appears as
   a `DW_AT_name`;
3. every `[low_pc, high_pc)` lies within `.text`.

- **RED on pre-feature code**, for the right reason: *"emitted CU has NO
  DW_TAG_subprogram children"*.
- **GREEN** after the emit + threading.

**Oracle C tightened, not relaxed.** `.debug_line` still carries exactly
one reloc (addend 0). `.debug_info` now carries **exactly `1 + N`**
`R_ARM_ABS32` relocs vs `__synth_text_base` (CU low_pc + one per
subprogram), and the multiset of in-place addends must equal
`{0} ∪ {each subprogram low_pc}` — proving each subprogram low_pc
relocates by the base to `text_base + low_pc`.

## Gates (exit-code verified)

- `cargo test -p synth-cli --test dwarf_debug_line_emit_394` — **7/7** (A–F).
- `cargo test -p synth-cli --test frozen_codegen_bytes` — **3/3**.
- `cargo test --workspace --exclude synth-verify` — exit 0 (synth-verify
  excluded due to the local z3-sys build issue).
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Honest scope

Internal (non-exported) functions carry **`func_N`** as `DW_AT_name`,
even though the input wasm's `name` custom section has richer names
(`core::panicking::…`, `gale::msgq::put_decide::…`). This matches the
task scope ("`func_3` / the export name") and the data `ElfFunction.name`
already holds. Propagating name-section names for internals is a natural
**Tier-1.x follow-up**. Subprograms are emitted only when the unit is
emitted at all (≥1 line row), consistent with the pre-existing additive
no-op contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)