### PR TITLE
chore(release): v0.19.0 — AArch64 backend + source-level DWARF + codegen fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-01
+
+**AArch64 host-native backend + source-level DWARF, plus a sweep of codegen
+correctness fixes across three backends.**
+
+### Added
+
+- **AArch64 (A64) host-native backend (#538).** New `synth-backend-aarch64`
+  crate reachable via `-b aarch64`: a `clang`-verified A64 integer encoder, a
+  minimal straight-line selector (params `w0..w7`, i32 add/sub/mul/and/or/xor +
+  const, result `w0`, `ret`), an `EM_AARCH64` ELF64 relocatable-object emitter,
+  and the `Backend` trait wiring. synth output now runs and debugs natively on
+  arm64 dev hosts (Apple Silicon, arm64 Linux/CI) instead of only under
+  QEMU/Renode, and a third backend becomes a third differential oracle against
+  the Thumb-2 and RV32 lowerings. Milestone-1 is the integer subset; ops outside
+  it fail honestly (see #554 below).
+- **Source-level DWARF debug info on the ARM `--relocatable` path (#394).** The
+  emitted `.debug_line` now carries the **real** source file names from the input
+  wasm's DWARF (not a fabricated `synth.wasm`), and per-function
+  `DW_TAG_subprogram` DIEs are emitted so gdb/lldb backtraces show **function
+  names**, not bare addresses. DWARF is additive/non-loadable — `.text` stays
+  byte-identical. (Variable locations remain Tier-2, gated on the VCR-RA
+  allocator.)
+
+### Fixed
+
+- **AArch64 rejects f32 ops honestly instead of silent miscompile (#554).**
+  Scalar `f32.*` is dropped by the decoder (`_ => None`) and recorded in
+  `FunctionOps::unsupported`, but the single-function CLI path discarded that
+  marker and lowered the remaining stream into wrong code (`f32.add` → `mov
+  w0,w1`). Now the decode-boundary honors the loud-skip marker — the
+  single-function analogue of the `--all-exports` loud-skip (#369) — closing the
+  same latent silent-drop on the ARM/RISC-V single-function paths too.
+- **RV32 `if`/`else`-with-result register reconciliation (#343).** A
+  value-returning `if/else` left the two arms' results in different registers; the
+  epilogue read whichever the else-arm left, so the then-path returned a stale
+  value. The join now reconciles both arms onto one result register (i32 and the
+  i64 lo/hi pair), byte-identical when the arms already coincide.
+- **RV32 `i64.div_s`/`i64.rem_s` sign clobber (#317).** The sign-mask temporaries
+  landed in the udiv core's fixed `t4`/`t5` (`DIV_D_LO/HI`) registers and were
+  overwritten before `result_sign` was computed (wrong signs). Moved to
+  callee-saved `s4..s6`, outside the core's fixed register file.
+- **Value-stack pre-flight soundness on stack-polymorphic terminators (#329).**
+  Code after `unreachable`/`return`/`br`/`br_table` is unreachable and
+  type-checks against an infinite polymorphic stack (wasm spec); the finite depth
+  counter reported false underflows on such dead code. The check now bails
+  soundly there. (The falcon false-underflow this issue reported was already
+  resolved by #369's float loud-skip.)
+- **ARM byte-size estimator ↔ encoder alignment (#498).** Closed 10 pure-estimator
+  size gaps (`Cmn`/`Adds`/`Subs` high-reg forms, `Popcnt`/`I64Popcnt`,
+  `I64Extend32S`, i64 `div`/`rem`) so `estimate_arm_byte_size` matches the real
+  encoder length, tightening the agreement oracle. Estimator-only — no emitted
+  `.text` change. (A latent neg-imm `MOVS` *encoder* bug is documented for a
+  separate, byte-changing PR.)
+
+### Changed
+
+- **Publish verification uses `cargo package` (#146).** The release pre-flight
+  verifies each publishable crate with `cargo package` rather than `cargo publish
+  --dry-run`; restored `synth-backend-aarch64` to the publishable set.
+
 ## [0.18.1] - 2026-07-01
 
 **`memory.grow(0)` correctness — closes #539.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,14 +2030,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2095,11 +2095,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.18.1"
+version = "0.19.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2154,14 +2154,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2169,11 +2169,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.18.1"
+version = "0.19.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.18.1"
+version = "0.19.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.18.1"
+version = "0.19.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.18.1",
+    version = "0.19.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.18.1" }
+synth-core = { path = "../synth-core", version = "0.19.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.18.1" }
+synth-core = { path = "../synth-core", version = "0.19.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.18.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.18.1" }
+synth-core = { path = "../synth-core", version = "0.19.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.19.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.18.1" }
+synth-core = { path = "../synth-core", version = "0.19.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.18.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.18.1", optional = true }
+synth-core = { path = "../synth-core", version = "0.19.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.19.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,21 +27,21 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.18.1" }
-synth-frontend = { path = "../synth-frontend", version = "0.18.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.18.1" }
-synth-backend = { path = "../synth-backend", version = "0.18.1" }
+synth-core = { path = "../synth-core", version = "0.19.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.19.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.19.0" }
+synth-backend = { path = "../synth-backend", version = "0.19.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.18.1" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.19.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.18.1", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.18.1", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.18.1", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.19.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.19.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.19.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.18.1", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.19.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.18.1" }
+synth-core = { path = "../synth-core", version = "0.19.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.18.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.19.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.18.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.18.1" }
-synth-opt = { path = "../synth-opt", version = "0.18.1" }
+synth-core = { path = "../synth-core", version = "0.19.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.19.0" }
+synth-opt = { path = "../synth-opt", version = "0.19.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.18.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.18.1" }
-synth-opt = { path = "../synth-opt", version = "0.18.1" }
+synth-core = { path = "../synth-core", version = "0.19.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.19.0" }
+synth-opt = { path = "../synth-opt", version = "0.19.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.18.1", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.19.0", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Release **v0.19.0**. Wave since v0.18.1 (9 PRs, all merged to main):

### Added
- **AArch64 host-native backend (#538)** — `-b aarch64`, clang-verified A64 encoder + selector + `EM_AARCH64` ELF64 + `Backend` trait; third differential oracle (#544/#545/#547).
- **Source-level DWARF on ARM `--relocatable` (#394)** — real source filenames in `.debug_line` (#550) + `DW_TAG_subprogram` DIEs for named backtraces (#557). Additive; `.text` byte-identical.

### Fixed
- AArch64 f32 silent miscompile → honest error (#554)
- RV32 if/else-with-result register reconciliation (#343)
- RV32 i64.div_s/rem_s sign clobber (#317)
- Value-stack pre-flight soundness on terminators (#329)
- ARM estimator↔encoder byte-size alignment, 10 gaps (#498)

### Changed
- Publish verification via `cargo package` (#146)

### Release mechanics
- Pin sweep: workspace + all path-dep versions + MODULE.bazel `0.18.1 → 0.19.0`; Cargo.lock regenerated.
- CHANGELOG `[0.19.0]`.
- Frozen anchors unchanged across the wave (control_step / flight_algo / divseam 3/3); DWARF + estimator + guard changes are all `.text`-neutral.

Tag `v0.19.0` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)