### PR TITLE
feat(cli): --volatile-segment DMA-window flag + config + rivet req (#543 Phase 1, no codegen yet)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -2228,3 +2228,63 @@ artifacts:
         MC/DC or a recorded faithful-implementation argument. No object branch is
         untraceable to a source decision. Frozen fixtures bit-identical (the map
         is emitted metadata, not a codegen change).
+
+  - id: VCR-DMA-001
+    type: sw-req
+    title: Volatile DMA segment — loads/stores in a marked range not cached or reordered
+    description: >
+      An integrator can mark a segment of the fused linear memory as VOLATILE —
+      the DMA transfer window. During a DMA-owned window an external agent (the
+      DMA engine, which gale models as a Component-Model `own<buffer>` handoff,
+      gale#124) rewrites the segment out-of-band, so synth must treat that byte
+      range `[base, base+len)` as volatile: a load or store whose address falls
+      inside a marked range must NOT be cached, hoisted, common-subexpression-
+      eliminated, or reordered across the transfer boundary — each access
+      re-materializes its address and re-issues the memory operation. gale's
+      decision DD-DMA-REGION-001 places the DMA buffer in a dedicated shared
+      segment precisely so the range is concrete and verifier-visible.
+
+      PHASE 1 (this artifact, LANDED — flag + plumbing + traceability only, no
+      codegen change): synth accepts `--volatile-segment <base>:<len>` (hex or
+      decimal, repeatable), parses it into `CompileConfig.volatile_segments`
+      (crates/synth-core/src/backend.rs), and threads it to codegen. The ranges
+      are NOT yet consumed by any pass, so the emitted `.text` is byte-identical
+      whether or not the flag is passed (the frozen-codegen byte gate holds). This
+      is why the status is `proposed`, not `implemented`: the requirement's actual
+      guarantee (no caching/reordering across the boundary) is not yet realized.
+
+      PHASE 2 (deferred, gated — the codegen back-off): the optimizer's
+      address-caching passes must DECLINE for any access overlapping a volatile
+      range — specifically const-CSE (`SYNTH_CONST_CSE`, aliasing repeated address
+      constants — see VCR-RA-001) and the #468 base-CSE / const-address-fold
+      (hoisting the linmem base into R11 and folding `[R11,#imm]` loads — also
+      VCR-RA-001), plus any load-reuse / instruction reordering that would move a
+      marked access across the boundary. That step CHANGES emitted bytes, so it is
+      oracle-gated: a differential proving the volatile access pattern (re-load
+      after an external write) and a deliberate re-freeze of any affected fixture.
+
+      Alternative surface deferred with Phase 2: honoring a wasm custom-section
+      convention meld emits (so the range travels with the module) in addition to
+      the explicit CLI flag (#543 option 2).
+    status: proposed
+    tags: [dma, volatile, memory, codegen, const-cse, base-cse, gale-integration, synth-543, phase-1]
+    links:
+      - type: derives-from
+        target: VCR-001
+      - type: constrained-by
+        target: VCR-RA-001
+    fields:
+      req-type: functional
+      priority: should
+      verification-criteria: >
+        Tracks GitHub issue #543 (see description + `synth-543` tag).
+        Phase 1 (met): `--volatile-segment 0x20001000:4096` parses into
+        `CompileConfig.volatile_segments` with base=0x20001000 and len=4096;
+        malformed input (`--volatile-segment garbage`) is rejected with a
+        non-zero exit and a descriptive error; a compile WITH the flag is
+        `.text`-byte-identical to one WITHOUT it (the flag is inert plumbing).
+        Phase 2 (deferred, gated): a differential in which an external agent
+        rewrites the marked range between two loads observes the SECOND value,
+        proving synth did not cache/reorder across the boundary; const-CSE and
+        the #468 base-CSE decline for accesses overlapping a marked range; any
+        affected frozen fixture is deliberately re-frozen alongside the change.

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -15,7 +15,7 @@ use synth_backend::{
 };
 use synth_core::HardwareCapabilities;
 use synth_core::SafetyManifest;
-use synth_core::backend::{Backend, BackendRegistry, CompileConfig, SafetyBounds};
+use synth_core::backend::{Backend, BackendRegistry, CompileConfig, SafetyBounds, VolatileRange};
 use synth_core::target::TargetSpec;
 use synth_core::wasm_decoder::ImportEntry;
 use synth_synthesis::{
@@ -269,6 +269,21 @@ enum Commands {
         /// separately until the local-section-symbol follow-up lands.
         #[arg(long)]
         debug_line: bool,
+
+        /// #543 (Phase 1): mark a linear-memory segment as VOLATILE — the DMA
+        /// transfer window. Format `<base>:<len>`; both accept hex (`0x…`) or
+        /// decimal, e.g. `--volatile-segment 0x20001000:4096`. Repeatable to mark
+        /// more than one range. Names a region `[base, base+len)` of the fused
+        /// linear memory that an external agent (the DMA engine, gale's
+        /// `own<buffer>` handoff / decision DD-DMA-REGION-001) rewrites out-of-band,
+        /// so loads/stores inside it must eventually not be cached or reordered
+        /// across the transfer boundary. PHASE 1 = plumbing only: the ranges are
+        /// parsed and threaded to codegen but NOT yet consumed — the emitted bytes
+        /// are unchanged whether or not the flag is passed. The codegen back-off
+        /// (const-CSE + #468 base-CSE decline inside these ranges) is the gated
+        /// Phase 2. See rivet VCR-DMA-001.
+        #[arg(long, value_name = "BASE:LEN")]
+        volatile_segment: Vec<String>,
     },
 
     /// Disassemble an ARM ELF file (e.g., synth disasm output.elf)
@@ -387,6 +402,7 @@ fn main() -> Result<()> {
             sign_output,
             shadow_stack_size,
             debug_line,
+            volatile_segment,
         } => {
             // Resolve target spec: --target overrides, --cortex-m is backwards compat
             let target_spec = resolve_target_spec(target.as_deref(), cortex_m, &backend)?;
@@ -406,6 +422,10 @@ fn main() -> Result<()> {
             // means "next to the ELF" (`<output>.cdx.json`); `--sbom PATH`
             // writes there; absent means no SBOM.
             let sbom_path = resolve_sbom_path(sbom, &output);
+
+            // #543 Phase 1: parse the volatile DMA-window ranges. Inert plumbing —
+            // threaded to codegen but not yet consumed (Phase 2 is gated).
+            let volatile_segments = parse_volatile_segments(&volatile_segment)?;
 
             compile_command(
                 input,
@@ -428,6 +448,7 @@ fn main() -> Result<()> {
                 sign_output,
                 shadow_stack_size,
                 debug_line,
+                volatile_segments,
             )?;
 
             // If --link requested, invoke the cross-linker
@@ -931,6 +952,55 @@ fn resolve_sbom_path(sbom: Option<PathBuf>, output: &std::path::Path) -> Option<
     }
 }
 
+/// #543 (Phase 1): parse the repeated `--volatile-segment <base>:<len>` flag
+/// values into [`VolatileRange`]s. Both fields accept a `0x`-prefixed hex or a
+/// plain decimal `u32`. A range must be `base:len` with exactly one colon; a
+/// zero-length range and a range whose `base + len` overflows `u32` are rejected.
+///
+/// Phase 1 only PARSES and validates — the ranges are threaded onto
+/// [`CompileConfig::volatile_segments`] but not yet consumed by any pass, so the
+/// flag is inert on the emitted bytes. Returns a descriptive error for malformed
+/// input (the flag surface must reject `garbage` loudly, not silently drop it).
+fn parse_volatile_segments(raw: &[String]) -> Result<Vec<VolatileRange>> {
+    fn parse_u32(field: &str, whole: &str) -> Result<u32> {
+        let t = field.trim();
+        let parsed = if let Some(hex) = t.strip_prefix("0x").or_else(|| t.strip_prefix("0X")) {
+            u32::from_str_radix(hex, 16)
+        } else {
+            t.parse::<u32>()
+        };
+        parsed.map_err(|_| {
+            anyhow::anyhow!(
+                "invalid --volatile-segment '{whole}': '{field}' is not a u32 \
+                 (expected hex like 0x20001000 or decimal)"
+            )
+        })
+    }
+
+    let mut ranges = Vec::with_capacity(raw.len());
+    for spec in raw {
+        let (base_s, len_s) = spec.split_once(':').ok_or_else(|| {
+            anyhow::anyhow!(
+                "invalid --volatile-segment '{spec}': expected '<base>:<len>' \
+                 (e.g. 0x20001000:4096)"
+            )
+        })?;
+        let base = parse_u32(base_s, spec)?;
+        let len = parse_u32(len_s, spec)?;
+        if len == 0 {
+            anyhow::bail!("invalid --volatile-segment '{spec}': length must be non-zero");
+        }
+        if base.checked_add(len).is_none() {
+            anyhow::bail!(
+                "invalid --volatile-segment '{spec}': base + len overflows the 32-bit \
+                 linear-memory address space"
+            );
+        }
+        ranges.push(VolatileRange { base, len });
+    }
+    Ok(ranges)
+}
+
 /// Emit a CycloneDX 1.5 SBOM next to the compiled ELF when `--sbom` was
 /// requested. The SBOM documents the synth compiler, the input WASM module
 /// (hash + size), the output ELF (hash + size + target + backend), and the
@@ -994,6 +1064,9 @@ fn compile_command(
     shadow_stack_size: Option<u32>,
     // VCR-DBG-001 step 4 (#394): `--debug-line` — emit `.debug_line` DWARF.
     debug_line: bool,
+    // #543 Phase 1: integrator-marked volatile DMA-window ranges. Threaded to the
+    // CompileConfig; not yet consumed (Phase 2 is the gated codegen back-off).
+    volatile_segments: Vec<VolatileRange>,
 ) -> Result<()> {
     // Validate backend exists
     let registry = build_backend_registry();
@@ -1042,6 +1115,7 @@ fn compile_command(
             sign_output,
             shadow_stack_size,
             debug_line,
+            volatile_segments,
         );
     }
 
@@ -1177,6 +1251,8 @@ fn compile_command(
         loom_compat,
         safety_bounds,
         target: target_spec.clone(),
+        // #543 Phase 1: threaded but not yet consumed (inert plumbing).
+        volatile_segments,
         ..CompileConfig::default()
     };
 
@@ -1827,6 +1903,9 @@ fn compile_all_exports(
     // VCR-DBG-001 step 4 (#394): emit a `.debug_line` section from the input
     // wasm's DWARF + the ARM line_maps. Default off ⇒ output byte-identical.
     debug_line: bool,
+    // #543 Phase 1: integrator-marked volatile DMA-window ranges. Threaded to the
+    // CompileConfig; not yet consumed (Phase 2 is the gated codegen back-off).
+    volatile_segments: Vec<VolatileRange>,
 ) -> Result<()> {
     let path = input.context("--all-exports requires an input file")?;
 
@@ -2086,6 +2165,10 @@ fn compile_all_exports(
         // source of truth for the AAPCS stack-argument refusal. The per-function
         // `current_func_params_i64` is derived from this in the compile loop.
         func_params_i64: all_func_params_i64.clone(),
+        // #543 Phase 1: threaded but not yet consumed (inert plumbing). The
+        // Phase-2 back-off (const-CSE + #468 base-CSE decline inside these ranges)
+        // lives on the optimized path this config feeds. See VCR-DMA-001.
+        volatile_segments,
         ..CompileConfig::default()
     };
 
@@ -4402,6 +4485,57 @@ fn link_firmware(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- #543 Phase 1: `--volatile-segment` parsing ---------------------------
+
+    /// The canonical example from the flag docs parses into a `VolatileRange`
+    /// with the right base/len. Hex base + decimal len is the documented form.
+    #[test]
+    fn volatile_segment_parses_hex_base_decimal_len_543() {
+        let ranges = parse_volatile_segments(&["0x20001000:4096".to_string()]).unwrap();
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].base, 0x2000_1000);
+        assert_eq!(ranges[0].len, 4096);
+    }
+
+    /// Both fields accept decimal or hex interchangeably, and the flag is
+    /// repeatable (>1 range).
+    #[test]
+    fn volatile_segment_accepts_decimal_and_is_repeatable_543() {
+        let ranges = parse_volatile_segments(&[
+            "536875008:0x1000".to_string(), // decimal base, hex len
+            "0x20002000:256".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0].base, 536_875_008);
+        assert_eq!(ranges[0].len, 0x1000);
+        assert_eq!(ranges[1].base, 0x2000_2000);
+        assert_eq!(ranges[1].len, 256);
+    }
+
+    /// Malformed input must be rejected loudly (not silently dropped): missing
+    /// colon, non-numeric fields, zero length, and base+len overflow all error.
+    #[test]
+    fn volatile_segment_rejects_malformed_543() {
+        assert!(parse_volatile_segments(&["garbage".to_string()]).is_err());
+        assert!(parse_volatile_segments(&["0x20001000".to_string()]).is_err());
+        assert!(parse_volatile_segments(&["nothex:4096".to_string()]).is_err());
+        assert!(parse_volatile_segments(&["0x1000:notlen".to_string()]).is_err());
+        assert!(parse_volatile_segments(&["0x1000:0".to_string()]).is_err());
+        assert!(parse_volatile_segments(&["0xFFFFFFFF:0x10".to_string()]).is_err());
+        // Too many colons is malformed (base:len only).
+        assert!(parse_volatile_segments(&["0x1000:0x10:0x20".to_string()]).is_err());
+    }
+
+    /// No `--volatile-segment` flags → empty ranges (the inert default). This is
+    /// what keeps the config's `volatile_segments` empty on a normal compile, so
+    /// Phase 1 changes no emitted bytes.
+    #[test]
+    fn volatile_segment_empty_by_default_543() {
+        assert!(parse_volatile_segments(&[]).unwrap().is_empty());
+        assert!(CompileConfig::default().volatile_segments.is_empty());
+    }
 
     fn fop(index: u32, export: Option<&str>, ops: Vec<WasmOp>) -> FunctionOps {
         FunctionOps {

--- a/crates/synth-cli/tests/volatile_segment_flag_543.rs
+++ b/crates/synth-cli/tests/volatile_segment_flag_543.rs
@@ -1,0 +1,129 @@
+//! #543 Phase 1 — `--volatile-segment <base>:<len>` CLI flag: acceptance,
+//! rejection, and INERTNESS.
+//!
+//! Phase 1 is FLAG + PLUMBING + TRACEABILITY only — the marked DMA-window ranges
+//! are parsed into `CompileConfig.volatile_segments` and threaded to codegen, but
+//! NOT yet consumed by any pass. The codegen back-off (const-CSE + the #468
+//! base-CSE declining inside a marked range) is the gated Phase 2.
+//!
+//! The load-bearing Phase-1 claim is therefore INERTNESS *even when the flag is
+//! set*: compiling WITH `--volatile-segment` must produce byte-identical `.text`
+//! to compiling WITHOUT it. `frozen_codegen_bytes.rs` only proves the flag-OFF
+//! bytes are unchanged (trivially true for an empty default); this test proves
+//! the stronger promise. Value-level parsing correctness (base/len, malformed →
+//! error) is unit-tested in `main.rs::tests` (`volatile_segment_*_543`).
+//!
+//! Traceability: rivet `VCR-DMA-001` (status `proposed`), gale decision
+//! `DD-DMA-REGION-001`.
+
+use object::{Object, ObjectSection};
+use std::process::Command;
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture(name: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro")
+        .join(name)
+}
+
+/// Compile a fixture on the optimized ARM path (self-contained image — the path
+/// where const-CSE and the #468 base-CSE live, so the Phase-2 back-off will
+/// eventually change these bytes). `extra` supplies any additional CLI args
+/// (e.g. `--volatile-segment ...`). Returns the `.text` bytes on success or the
+/// process exit/stderr on failure.
+fn compile_text(fixture_name: &str, out_tag: &str, extra: &[&str]) -> Result<Vec<u8>, String> {
+    let path = fixture(fixture_name);
+    let elf = format!("/tmp/volseg543_{out_tag}.elf");
+    let mut args = vec![
+        "compile",
+        path.to_str().unwrap(),
+        "-o",
+        &elf,
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+    ];
+    args.extend_from_slice(extra);
+    let out = Command::new(synth())
+        .args(&args)
+        .output()
+        .expect("run synth");
+    if !out.status.success() {
+        return Err(format!(
+            "exit={:?} stderr={}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr)
+        ));
+    }
+    let bytes = std::fs::read(&elf).expect("read elf");
+    let obj = object::File::parse(&*bytes).expect("parse elf");
+    let text = obj
+        .section_by_name(".text")
+        .expect("fixture must have a .text section")
+        .data()
+        .expect("read .text")
+        .to_vec();
+    Ok(text)
+}
+
+const FIXTURE: &str = "base_cse_branch.wat";
+
+/// The flag is ACCEPTED end-to-end, singly and repeatably (>1 range), on both
+/// hex and decimal forms.
+#[test]
+fn volatile_segment_flag_accepted_543() {
+    compile_text(
+        FIXTURE,
+        "accept_single",
+        &["--volatile-segment", "0x20001000:4096"],
+    )
+    .expect("single --volatile-segment must be accepted");
+    compile_text(
+        FIXTURE,
+        "accept_repeat",
+        &[
+            "--volatile-segment",
+            "0x20001000:4096",
+            "--volatile-segment",
+            "536875008:256",
+        ],
+    )
+    .expect("repeated --volatile-segment must be accepted");
+}
+
+/// Malformed input is REJECTED with a non-zero exit (not silently dropped).
+#[test]
+fn volatile_segment_flag_rejects_garbage_543() {
+    let err = compile_text(FIXTURE, "reject", &["--volatile-segment", "garbage"])
+        .expect_err("`--volatile-segment garbage` must fail");
+    assert!(
+        err.contains("volatile-segment"),
+        "error should name the offending flag, got: {err}"
+    );
+}
+
+/// INERTNESS: compiling WITH the flag is `.text`-byte-identical to compiling
+/// WITHOUT it. This is the Phase-1 frozen-safe contract — the ranges are parsed
+/// and threaded but no pass consumes them yet, so no emitted byte moves.
+#[test]
+fn volatile_segment_flag_is_byte_inert_543() {
+    let without = compile_text(FIXTURE, "inert_without", &[])
+        .expect("baseline compile (no flag) must succeed");
+    let with = compile_text(
+        FIXTURE,
+        "inert_with",
+        &["--volatile-segment", "0x20001000:4096"],
+    )
+    .expect("compile with flag must succeed");
+    assert_eq!(
+        without, with,
+        "#543 Phase 1 must be inert: --volatile-segment changed the emitted .text \
+         (that back-off is the GATED Phase 2, not Phase 1)"
+    );
+}

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -155,6 +155,42 @@ pub struct CompileConfig {
     /// driver loop, because `compile_function` is shared across backends and
     /// carries no function index. Empty → assume i32.
     pub current_func_params_i64: Vec<bool>,
+
+    /// #543 Phase 1 — integrator-marked volatile linear-memory segments (the DMA
+    /// transfer window). Each range `[base, base+len)` names a region of the fused
+    /// linear memory that an EXTERNAL agent (the DMA engine, modelled by gale as a
+    /// Component-Model `own<buffer>` handoff — gale decision `DD-DMA-REGION-001`,
+    /// gale#124) rewrites out-of-band. Loads and stores whose address falls inside
+    /// a marked range must eventually be treated as VOLATILE: not cached, hoisted,
+    /// or reordered across the transfer boundary.
+    ///
+    /// PHASE-1 CONTRACT (this field is plumbing only): it is populated by the CLI
+    /// `--volatile-segment <base>:<len>` flag and threaded to codegen, but is NOT
+    /// yet consumed by any pass. Empty by default, so the emitted `.text` is
+    /// byte-identical with or without the flag (the frozen-codegen gate holds).
+    ///
+    /// PHASE-2 CONSUMPTION POINT (deferred, gated — issue #543): the optimizer's
+    /// address-caching passes must BACK OFF for any access inside these ranges —
+    /// specifically const-CSE (`SYNTH_CONST_CSE`, aliasing repeated address
+    /// constants) and the #468 base-CSE / const-address-fold (hoisting the linmem
+    /// base into R11 and folding `[R11,#imm]` loads), plus any load-reuse /
+    /// reorder. A load or store overlapping a volatile range must re-materialize
+    /// its address and re-issue the memory access at each occurrence, and no such
+    /// access may move across a marked boundary. See rivet `VCR-DMA-001`.
+    pub volatile_segments: Vec<VolatileRange>,
+}
+
+/// #543 — an integrator-marked volatile linear-memory segment (the DMA transfer
+/// window): the half-open byte range `[base, base + len)` of the fused linear
+/// memory that an external agent rewrites out-of-band. Parsed from the CLI
+/// `--volatile-segment <base>:<len>` flag. See [`CompileConfig::volatile_segments`]
+/// for the Phase-1/Phase-2 split.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VolatileRange {
+    /// Start address of the volatile region, in linear-memory bytes.
+    pub base: u32,
+    /// Length of the volatile region, in bytes. The region is `[base, base+len)`.
+    pub len: u32,
 }
 
 impl CompileConfig {
@@ -190,6 +226,9 @@ impl Default for CompileConfig {
             type_ret_i64: Vec::new(),
             func_params_i64: Vec::new(),
             current_func_params_i64: Vec::new(),
+            // #543 Phase 1: no volatile segments unless the CLI flag names them.
+            // Empty ⇒ inert ⇒ emitted bytes unchanged.
+            volatile_segments: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Phase 1 of #543 — volatile DMA segment (flag + plumbing + traceability only)

gale models a DMA transfer as a Component-Model `own<buffer>` handoff (gale#124): during a DMA-owned window an external agent (the DMA engine) rewrites a dedicated segment of the fused linear memory, so synth must eventually treat that address range as **volatile** — no caching/reordering of loads or stores across the transfer boundary. gale decision `DD-DMA-REGION-001` puts the DMA buffer in a dedicated shared segment precisely so the range is concrete and verifier-visible.

This PR delivers **option (1)** of the issue — the `--volatile-segment <base>:<len>` flag — as **plumbing only**. It is **frozen-safe: no emitted byte changes.** The codegen suppression is the gated **Phase 2**.

### What Phase 1 delivers
- **CLI flag** (`crates/synth-cli/src/main.rs`): `--volatile-segment <base>:<len>`, base and len each hex (`0x…`) or decimal, **repeatable** (>1 range). `parse_volatile_segments()` parses into `Vec<VolatileRange>` and rejects malformed input (missing colon, non-numeric, zero length, `base+len` overflow) with a descriptive non-zero-exit error.
- **Config plumbing** (`crates/synth-core/src/backend.rs`): new `VolatileRange { base: u32, len: u32 }` and `CompileConfig.volatile_segments: Vec<VolatileRange>` (empty by default). Threaded onto both config build sites in the CLI (single-function + `--all-exports`). **Available at codegen time but not consumed.**
- **Traceability**: rivet `VCR-DMA-001` (`sw-req`, status `proposed`) under `artifacts/verified-codegen-roadmap.yaml`, linked `derives-from VCR-001` + `constrained-by VCR-RA-001`, citing `DD-DMA-REGION-001` and the const-CSE / #468 base-CSE passes it gates in Phase 2.
- **Tests**: unit tests in `main.rs::tests` (`volatile_segment_*_543`) for base/len parsing, malformed→Err, empty-by-default; integration test `crates/synth-cli/tests/volatile_segment_flag_543.rs` proving the flag is accepted (single + repeated), `garbage` is rejected, and the emitted `.text` is **byte-identical with vs without** the flag.

### Phase-2 consumption point (deferred, gated — NOT in this PR)
Documented on the `CompileConfig.volatile_segments` doc comment (`crates/synth-core/src/backend.rs`): the optimizer's address-caching passes must **back off** for any access overlapping a marked range — specifically **const-CSE** (`SYNTH_CONST_CSE`, aliasing repeated address constants) and the **#468 base-CSE / const-address-fold** (hoisting the linmem base into R11 and folding `[R11,#imm]` loads), plus any load-reuse / reorder. That step changes emitted bytes → oracle-gated (volatile-access differential + deliberate re-freeze).

### Gate (exit-code verified)
- `cargo test --workspace --exclude synth-verify` — pass (exit 0)
- `cargo test -p synth-cli --test frozen_codegen_bytes` — **3/3** green (flag inert)
- `rivet validate` — this repo's baseline exits FAIL (51 pre-existing coverage/xref ERRORs); the **CI gate formula** (`^  ERROR:` minus cross-repo xref lines) = **0**, unchanged by this PR. `VCR-DMA-001` adds only the standard "should be verified" WARN shared by every sibling `proposed` req.
- `rivet check bidirectional` — reports a repo-wide baseline of ~1992 missing-inverse entries (exit 1 on `main` too; the repo does not register link inverses, and this check is not part of the CI gate). `VCR-DMA-001` contributes 2 entries (`derives-from → VCR-001`, `constrained-by → VCR-RA-001`) **identical in shape to every existing VCR sibling** (e.g. VCR-SEL-001, VCR-DBG-001); no new anomaly is introduced.
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
