### PR TITLE
fix(arm): materialize large i64 load/store offset in the direct selector — close #382 (direct-path remainder)

### DIFF
--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -5352,21 +5352,17 @@ impl ArmEncoder {
             // I64Ldr: LDR rdlo, [base, offset]; LDR rdhi, [base, offset+4]
             ArmOp::I64Ldr { rdlo, rdhi, addr } => {
                 let mut bytes = Vec::new();
-                let offset = if addr.offset < 0 {
-                    0u32
-                } else {
-                    addr.offset as u32
-                };
-                // #372: a memory `i64.load` carries an index register
+                // #372/#382: a memory `i64.load` carries an index register
                 // (`reg_imm(R11, addr_reg, offset)` = R11 + addr + offset). The
                 // immediate `encode_thumb32_ldr` below uses only base+offset and
                 // would SILENTLY DROP `offset_reg` — the #206 defect, here for
-                // i64. Materialize the effective base `ip = base + index` first
-                // (ADD.W ip, base, index — byte-verified), then load with
-                // immediate offsets. Frame i64 loads (no `offset_reg`, e.g. a
-                // spilled local at `[SP, #off]`) keep the plain `[base,#off]`
+                // i64. `i64_effective_base` materializes the effective base into
+                // `ip` (and, when `offset+4 > 0xFFF`, folds the offset in too so
+                // the function is NOT skipped — #382), returning the residual
+                // imm12 for the two halves. Frame i64 loads (no `offset_reg`, e.g.
+                // a spilled local at `[SP, #off]`) keep the plain `[base,#off]`
                 // form unchanged — so existing output is byte-identical.
-                let base = self.i64_effective_base(&mut bytes, addr);
+                let (base, offset) = self.i64_effective_base(&mut bytes, addr)?;
                 bytes.extend_from_slice(&self.encode_thumb32_ldr(rdlo, &base, offset)?);
                 bytes.extend_from_slice(&self.encode_thumb32_ldr(
                     rdhi,
@@ -5379,13 +5375,9 @@ impl ArmEncoder {
             // I64Str: STR rdlo, [base, offset]; STR rdhi, [base, offset+4]
             ArmOp::I64Str { rdlo, rdhi, addr } => {
                 let mut bytes = Vec::new();
-                let offset = if addr.offset < 0 {
-                    0u32
-                } else {
-                    addr.offset as u32
-                };
-                // #372: same index-materialization as I64Ldr (see above).
-                let base = self.i64_effective_base(&mut bytes, addr);
+                // #372/#382: same index-materialization + large-offset fold as
+                // I64Ldr (see above).
+                let (base, offset) = self.i64_effective_base(&mut bytes, addr)?;
                 bytes.extend_from_slice(&self.encode_thumb32_str(rdlo, &base, offset)?);
                 bytes.extend_from_slice(&self.encode_thumb32_str(
                     rdhi,
@@ -6417,26 +6409,58 @@ impl ArmEncoder {
         Ok(bytes)
     }
 
-    /// #372: resolve the base register for an `I64Ldr`/`I64Str` whose address
-    /// may carry an index register. If `addr.offset_reg` is set (a memory
-    /// `i64.load`/`i64.store`: `R11 + addr + offset`), emit `ADD.W ip, base,
-    /// index` and return `ip` (R12) as the base for the two immediate-offset
-    /// halves. If unset (a frame access at `[base, #off]`), return `addr.base`
-    /// unchanged — emitting nothing — so non-indexed i64 access is byte-identical.
-    /// `ip = base + index` is computed BEFORE the halves load, so an `rdlo`
-    /// aliasing the index register is safe (the address is already materialized).
-    fn i64_effective_base(&self, bytes: &mut Vec<u8>, addr: &MemAddr) -> Reg {
+    /// #372/#382: resolve the base register AND residual immediate offset for an
+    /// `I64Ldr`/`I64Str` whose address may carry an index register. Returns
+    /// `(base, low_offset)`; the caller accesses the halves at `[base,
+    /// #low_offset]` and `[base, #low_offset + 4]`.
+    ///
+    /// - Frame access (no `offset_reg`, e.g. a spilled local at `[SP, #off]`):
+    ///   returns `(addr.base, off)` and emits NOTHING — byte-identical.
+    /// - Memory access (`reg_imm(R11, addr, offset)` = `R11 + addr + offset`)
+    ///   with `offset + 4 <= 0xFFF`: emits `ADD.W ip, base, index` and returns
+    ///   `(ip, offset)`, folding `offset`/`offset+4` into the halves' imm12.
+    ///   Byte-identical to the pre-#382 (#372) behavior.
+    /// - Memory access with `offset + 4 > 0xFFF`: the imm12 form cannot hold the
+    ///   high half's offset, so `encode_thumb32_ldr`'s `check_ldst_imm12` (#259)
+    ///   rightly refused it and the WHOLE function was skipped (#382). Instead
+    ///   MATERIALIZE the offset into the base: `ADD ip, index, #offset` (against
+    ///   the read-only INDEX register, so `encode_thumb32_add_imm` never trips its
+    ///   `rd==rn==R12` alias trap), then `ADD.W ip, ip, base` (+ R11), and return
+    ///   `(ip, 0)` so the halves use `[ip, #0]` / `[ip, #4]`.
+    ///
+    /// The effective address is fully materialized into `ip` BEFORE the halves
+    /// are accessed, so an `rdlo` aliasing the index register is safe.
+    fn i64_effective_base(&self, bytes: &mut Vec<u8>, addr: &MemAddr) -> Result<(Reg, u32)> {
+        let offset = if addr.offset < 0 {
+            0u32
+        } else {
+            addr.offset as u32
+        };
         match addr.offset_reg {
             Some(idx) => {
                 let ip = Reg::R12;
-                // ADD.W ip, addr.base, idx  (Thumb-2, byte-verified vs as)
-                let hw1: u16 = 0xEB00 | reg_to_bits(&addr.base) as u16;
-                let hw2: u16 = 0x0C00 | reg_to_bits(&idx) as u16;
-                bytes.extend_from_slice(&hw1.to_le_bytes());
-                bytes.extend_from_slice(&hw2.to_le_bytes());
-                ip
+                if offset.wrapping_add(4) > 0xFFF {
+                    // Large static offset (#382): fold it (and R11) into ip so the
+                    // imm12 halves stay in range instead of skipping the function.
+                    // ADD ip, index, #offset  (index != ip → no add_imm alias trap)
+                    bytes.extend_from_slice(&self.encode_thumb32_add_imm(&ip, &idx, offset)?);
+                    // ADD.W ip, ip, base  (+ R11)
+                    bytes.extend_from_slice(&self.encode_thumb32_add_reg_raw(
+                        reg_to_bits(&ip),
+                        reg_to_bits(&ip),
+                        reg_to_bits(&addr.base),
+                    )?);
+                    Ok((ip, 0))
+                } else {
+                    // ADD.W ip, addr.base, idx  (Thumb-2, byte-verified vs as)
+                    let hw1: u16 = 0xEB00 | reg_to_bits(&addr.base) as u16;
+                    let hw2: u16 = 0x0C00 | reg_to_bits(&idx) as u16;
+                    bytes.extend_from_slice(&hw1.to_le_bytes());
+                    bytes.extend_from_slice(&hw2.to_le_bytes());
+                    Ok((ip, offset))
+                }
             }
-            None => addr.base,
+            None => Ok((addr.base, offset)),
         }
     }
 
@@ -8933,6 +8957,82 @@ mod tests {
             &[0x0b, 0xeb],
             "frame (non-indexed) I64Ldr must NOT emit an ADD.W"
         );
+    }
+
+    #[test]
+    fn test_382_i64_ldst_large_offset_materializes_not_skips() {
+        // #382: an indexed i64.load/store whose static offset > 0xFFF must
+        // MATERIALIZE the offset into the base — NOT return Err (skip the fn).
+        // Sequence for reg_imm(R11, R0, 5000): MOVW ip,#5000 ; ADD ip,r0,ip ;
+        // ADD ip,ip,fp ; LDR/STR halves at [ip,#0] / [ip,#4]. Byte-verified tail
+        // vs arm-none-eabi-as.
+        let encoder = ArmEncoder::new_thumb2();
+        // 0x1388 > 0xFFF (MemAddr is not Copy, so build it per use).
+
+        let ld = encoder
+            .encode(&ArmOp::I64Ldr {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                addr: MemAddr::reg_imm(Reg::R11, Reg::R0, 5000),
+            })
+            .expect("large-offset i64.load must lower, not skip");
+        // MOVW ip,#0x1388 (4) + ADD ip,r0,ip (4) + ADD ip,ip,fp (4) + 2 LDR (8).
+        assert_eq!(ld.len(), 20, "expected MOVW + 2×ADD + 2×LDR");
+        // Must NOT be the small-offset `ADD.W ip, fp, r0` (0x0b 0xeb) prefix —
+        // that path can only reach imm12 offsets.
+        assert_ne!(
+            &ld[0..2],
+            &[0x0b, 0xeb],
+            "must materialize the large offset"
+        );
+        // Effective base built in ip, then halves at [ip,#0] / [ip,#4].
+        assert_eq!(
+            &ld[4..20],
+            &[
+                0x00, 0xeb, 0x0c, 0x0c, // ADD.W ip, r0, ip
+                0x0c, 0xeb, 0x0b, 0x0c, // ADD.W ip, ip, fp
+                0xdc, 0xf8, 0x00, 0x00, // LDR.W r0, [ip, #0]
+                0xdc, 0xf8, 0x04, 0x10, // LDR.W r1, [ip, #4]
+            ],
+            "large-offset i64.load must fold offset into ip and access [ip,#0]/[ip,#4]"
+        );
+
+        // Store: same base materialization, STR halves.
+        let st = encoder
+            .encode(&ArmOp::I64Str {
+                rdlo: Reg::R2,
+                rdhi: Reg::R3,
+                addr: MemAddr::reg_imm(Reg::R11, Reg::R0, 5000),
+            })
+            .expect("large-offset i64.store must lower, not skip");
+        assert_eq!(st.len(), 20);
+        assert_eq!(
+            &st[4..20],
+            &[
+                0x00, 0xeb, 0x0c, 0x0c, // ADD.W ip, r0, ip
+                0x0c, 0xeb, 0x0b, 0x0c, // ADD.W ip, ip, fp
+                0xcc, 0xf8, 0x00, 0x20, // STR.W r2, [ip, #0]
+                0xcc, 0xf8, 0x04, 0x30, // STR.W r3, [ip, #4]
+            ],
+            "large-offset i64.store must fold offset into ip and access [ip,#0]/[ip,#4]"
+        );
+
+        // Small-offset (imm12) indexed access stays byte-identical (#372): the
+        // effective base is a single `ADD.W ip, fp, r0` and the halves keep the
+        // folded immediates — NO extra MOVW/ADD.
+        let small = encoder
+            .encode(&ArmOp::I64Ldr {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                addr: MemAddr::reg_imm(Reg::R11, Reg::R0, 8),
+            })
+            .unwrap();
+        assert_eq!(
+            &small[0..4],
+            &[0x0b, 0xeb, 0x00, 0x0c],
+            "small-offset indexed i64 must keep the single ADD.W ip, fp, r0"
+        );
+        assert_eq!(small.len(), 12, "ADD.W + 2×LDR.W (offset folded in imm12)");
     }
 
     #[test]

--- a/scripts/repro/i64_large_offset_382.wat
+++ b/scripts/repro/i64_large_offset_382.wat
@@ -1,0 +1,35 @@
+;; #382 (direct/relocatable path) — i64 load/store with a static offset > 0xFFF
+;; (4095) must MATERIALIZE the offset, not skip the function.
+;;
+;; The direct selector (`--relocatable`, R11/fp = linear-memory base) lowers a
+;; memory `i64.load`/`i64.store` to an `I64Ldr`/`I64Str` over
+;; `reg_imm(R11, addr, offset)` = `R11 + addr + offset`. The encoder materializes
+;; the effective base into `ip` (`ADD ip, base, index`) and accesses the two
+;; halves at `[ip,#offset]` / `[ip,#offset+4]`. When `offset+4 > 0xFFF` the
+;; imm12 form can't hold it, so `check_ldst_imm12` (#259) refused and the WHOLE
+;; function was skipped. i32 (word/sub-word) already lowered via the #206/#372
+;; offset_reg materialization; only i64 remained. Fix (arm_encoder
+;; ::i64_effective_base): when `offset+4 > 0xFFF`, fold the offset into the base
+;; too — `ADD ip, index, #offset; ADD ip, ip, base` — and access at `#0`/`#4`.
+;;
+;; Addresses are param-derived (dynamic) so issue-#95 const-address folding does
+;; NOT apply — this exercises the register-offset (I64Ldr/I64Str) path. The
+;; differential cross-addresses (store via offset=5000, read back ABSOLUTE at
+;; addr+5000, and vice-versa) so a dropped offset is observable, not just a
+;; self-consistent roundtrip. i32 cases are kept as a regression guard.
+(module
+  (memory (export "mem") 1)
+  ;; --- i64 (the #382 direct-path fix) ---
+  (func (export "store64_off") (param $a i32) (param $v i64)
+    local.get $a local.get $v (i64.store offset=5000))
+  (func (export "load64_off") (param $a i32) (result i64)
+    local.get $a (i64.load offset=5000))
+  (func (export "load64_abs") (param $a i32) (result i64)
+    local.get $a (i64.load offset=0))
+  ;; --- i32 (regression guard — already lowered via #206/#372) ---
+  (func (export "store32_off") (param $a i32) (param $v i32)
+    local.get $a local.get $v (i32.store offset=5000))
+  (func (export "load32_off") (param $a i32) (result i32)
+    local.get $a (i32.load offset=5000))
+  (func (export "load32_abs") (param $a i32) (result i32)
+    local.get $a (i32.load offset=0)))

--- a/scripts/repro/i64_large_offset_382_differential.py
+++ b/scripts/repro/i64_large_offset_382_differential.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""#382 (direct/relocatable path) — i64 large static load/store offset oracle.
+
+The direct selector (`--relocatable`, R11/fp = linear-memory base) lowers a
+memory `i64.load`/`i64.store` at `offset > 0xFFF` to an `I64Ldr`/`I64Str` whose
+encoder previously accessed the high half at `[ip,#offset+4]` — an imm12 the
+`check_ldst_imm12` guard (#259) refused, skipping the WHOLE function. The fix
+(`arm_encoder::i64_effective_base`) folds the large offset into the base
+(`ADD ip, index, #offset; ADD ip, ip, base`) so the halves use `#0`/`#4`.
+
+This harness runs the SAME call program under wasmtime (ground truth) and under
+unicorn (synth's emitted Thumb-2, R11 = linear-memory base). It cross-addresses
+so a *dropped* offset is observable, not just a self-consistent roundtrip: a
+value stored via `offset=5000` is read back through an ABSOLUTE load at
+`addr+5000` (and symmetrically). i32 cases are a regression guard (they already
+lowered via #206/#372). Exits nonzero on mismatch so it can gate a release.
+
+Run (rebuild synth first):
+  SYNTH=/Volumes/devcache/wave6-382/debug/synth \
+    /tmp/synthvenv/bin/python scripts/repro/i64_large_offset_382_differential.py
+"""
+import os
+import re
+import subprocess
+import sys
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R3,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = "scripts/repro/i64_large_offset_382.wat"
+WASM = "/tmp/i64_lo382.wasm"
+ELF = "/tmp/i64_lo382_diff.o"
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+# In the direct/relocatable path R11 (fp) holds the linear-memory base, set by
+# the caller. Any mapped, non-zero base works; the offsets stay in one 64 KiB page.
+LIN_BASE = 0x20000000
+
+MASK64 = (1 << 64) - 1
+V64 = 0x1122334455667788
+V64B = 0x8877665544332211
+
+
+# Each step: (fn, arg_regs, is_i64_result). `arg_regs` is the AAPCS register map
+# {reg_index: value} — i64 value params land in R2:R3 (even-aligned, R1 skipped),
+# matching what the direct selector homes (#518).
+def i64_args(addr, val):
+    return {0: addr, 2: val & 0xFFFFFFFF, 3: (val >> 32) & 0xFFFFFFFF}
+
+
+PROGRAM = [
+    ("store64_off", {0: 0, **i64_args(0, V64)}, False),   # write 8 bytes at byte 5000
+    ("load64_abs", {0: 5000}, True),                      # absolute read -> V64
+    ("load64_off", {0: 0}, True),                         # offset read of addr 0 -> V64
+    ("store64_off", {0: 24, **i64_args(24, V64B)}, False),  # byte 5024
+    ("load64_abs", {0: 5024}, True),                      # -> V64B
+    ("store32_off", {0: 64, 1: 0xDEADBEEF}, False),       # word at byte 5064
+    ("load32_abs", {0: 5064}, False),                     # -> 0xDEADBEEF
+    ("load32_off", {0: 64}, False),                       # offset read -> 0xDEADBEEF
+]
+
+
+def run_wasmtime():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, open(WASM, "rb").read())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    exports = inst.exports(store)
+    # Reconstruct positional args from the register map.
+    results = []
+    for fn, regs, is64 in PROGRAM:
+        if fn.startswith("store64"):
+            addr = regs[0]
+            val = (regs[3] << 32) | regs[2]
+            exports[fn](store, addr, val)
+        elif fn.startswith("store32"):
+            exports[fn](store, regs[0], regs[1])
+        else:  # loads take a single addr in R0
+            r = exports[fn](store, regs[0])
+            results.append(r & (MASK64 if is64 else 0xFFFFFFFF))
+    return results
+
+
+def run_unicorn():
+    subprocess.run(
+        [SYNTH, "compile", WASM, "-t", "cortex-m4", "--relocatable",
+         "--all-exports", "-o", ELF],
+        check=True, capture_output=True,
+    )
+    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
+    syms = {m.group(2): int(m.group(1), 16)
+            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
+    text = ELFFile(open(ELF, "rb")).get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+
+    CODE, STK = 0x10000, 0x30000000
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x10000)
+    mu.mem_map(LIN_BASE, 0x10000)
+    mu.mem_map(STK - 0x8000, 0x10000)
+    mu.mem_write(CODE, code)
+    RET = 0x1F00 | 1
+
+    results = []
+    for fn, regs, is64 in PROGRAM:
+        for reg, val in regs.items():
+            mu.reg_write(UC_ARM_REG_R0 + reg, val & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R11, LIN_BASE)
+        mu.reg_write(UC_ARM_REG_SP, STK)
+        mu.reg_write(UC_ARM_REG_LR, RET)
+        try:
+            mu.emu_start((CODE + syms[fn] - base) | 1, RET & ~1, count=4000)
+        except UcError as e:
+            return f"ERR in {fn}{regs}: {e}"
+        if not fn.startswith("store"):
+            lo = mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            if is64:
+                hi = mu.reg_read(UC_ARM_REG_R1) & 0xFFFFFFFF
+                results.append((hi << 32) | lo)
+            else:
+                results.append(lo)
+    return results
+
+
+def main():
+    subprocess.run(["wat2wasm", WAT, "-o", WASM], check=True)
+    gt = run_wasmtime()
+    got = run_unicorn()
+    print(f"wasmtime (ground truth): {[hex(x) for x in gt]}")
+    if isinstance(got, str):
+        print(f"synth ARM             : {got}")
+        print("MISMATCH  <-- #382 (function skipped or wrong)")
+        sys.exit(1)
+    print(f"synth ARM             : {[hex(x) for x in got]}")
+    ok = got == gt
+    print(f"\n{len(got)}/{len(gt)} match" if ok
+          else f"\nMISMATCH  <-- #382 (got {got} vs {gt})")
+    print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Closes the remaining instance of **#382** (*"arm backend skips functions with load/store immediate offset > 0xFFF"*): an **i64** memory `load`/`store` with a static `offset > 0xFFF` in the **direct / `--relocatable`** selector.

#382 was surfaced by the gust kernel and first fixed for the **optimized (non-relocatable)** path in v0.11.50 / #384 (`optimizer_bridge::fold_mem_offset`). The direct-path i64 case was a separate, still-open instance of the same class.

## The bug

The direct selector lowers a memory `i64.load`/`i64.store` to an `I64Ldr`/`I64Str` over `reg_imm(R11, addr, offset)` (= `R11 + addr + offset`). The encoder built the effective base `ip = base + index` (`ADD.W`) and accessed the halves at `[ip,#offset]` / `[ip,#offset+4]`. When `offset+4 > 0xFFF` the Thumb-2 imm12 form can't hold the high half's offset, so `check_ldst_imm12` (#259) correctly refused it — and the **whole function was skipped** (loud warning, absent symbol).

i32 word/sub-word already lowered correctly via the #206/#372 `offset_reg` materialization; **only i64 remained**.

## The fix

In `arm_encoder::i64_effective_base`, when `offset+4 > 0xFFF`, **materialize** the offset into the base instead of skipping:

```
ADD ip, index, #offset    ; offset added against the read-only INDEX reg
ADD.W ip, ip, base        ; + R11 (linmem base)
LDR/STR rdlo, [ip, #0]
LDR/STR rdhi, [ip, #4]
```

The offset is added against the read-only **index** register (never `ip`), so `encode_thumb32_add_imm` never trips its `rd==rn==R12` alias trap. The small-offset (imm12) path is untouched and stays **byte-identical** (#372).

**Scope:** bare-metal `bounds_check=None` (the repro/gust default). The Software bounds-check i64 path has a separate pre-existing large-offset limitation in its own guard `ADD` — out of scope for #382.

## Verification (exit-code gated)

- **Differential** `scripts/repro/i64_large_offset_382_differential.py` — unicorn (`R11` = linmem base) vs wasmtime, cross-addressed so a dropped offset is observable (store via `offset=5000`, read back absolute at `addr+5000`, and vice-versa). i64 large-offset was **skipped (2 fns) → now 5/5 match wasmtime**; i32 kept as a regression guard.
- **New unit test** `test_382_i64_ldst_large_offset_materializes_not_skips` — byte-verified sequence; asserts the small-offset case stays byte-identical.
- **gust_kernel** still compiles 6/6 relocatable with **0** `offset > 0xFFF` skips (regression check; its original skip was the optimized-path case fixed in #384).
- **Frozen anchors** `frozen_codegen_bytes` **3/3 bit-identical**.
- Estimator↔encoder agreement tripwire pass; `cargo test --workspace --exclude synth-verify`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)