### PR TITLE
chore(release): v0.20.0 — i64 large-offset fix + --volatile-segment + VCR-RA levers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-02
+
+**i64 large-offset completeness fix, the `--volatile-segment` DMA surface, and two
+flag-off VCR-RA levers.**
+
+### Added
+
+- **`--volatile-segment <base>:<len>` CLI flag (#543, Phase 1).** Marks an address
+  range of the linear memory as externally-mutable (a DMA transfer window). Phase 1
+  is the flag + config plumbing + traceability (rivet `VCR-DMA-001`); the codegen
+  consumption — the const-CSE / base-CSE (#468) load-caching passes backing off
+  inside a marked range — is the gated Phase 2. Inert today (no emitted-byte
+  change), so downstream (meld/gale) can begin wiring the surface.
+
+### Fixed
+
+- **ARM direct selector materializes large i64 load/store offsets (#382).** A
+  `--relocatable` function with an `i64.load`/`i64.store` at an immediate offset
+  `> 0xFFF` was **skipped** (Thumb-2 `LDR/STR` encodes only a 12-bit offset). The
+  i64 encoder path now materializes the offset against the read-only index register
+  (`ADD ip, index, #off; ADD.W ip, ip, base; LDR/STR [ip,#0/#4]`), so the function
+  lowers instead of being dropped. (The optimized-path and i32 cases were already
+  handled by #384/#372.) Differential vs wasmtime; frozen anchors byte-identical.
+
+### Internal (VCR-RA / #242 — flag-off, no default behavior change)
+
+- **RV32 i32 local-promotion lever ported (#472), behind `SYNTH_RV_LOCAL_PROMO`.**
+  Promotes non-param i32 locals in leaf functions to callee-saved `s8`/`s9`/`s10`,
+  matching the ARM lever (#390). Flag-off ⇒ RV32 codegen byte-identical; flag-on
+  measured −12 % `.text` on the port fixture, differential-clean vs wasmtime.
+- **const-CSE PR2 win-recovery (#242), behind `SYNTH_CONST_CSE`.** Reconstructs
+  32-bit `movw+movt` constants and adds a pressure-guarded same-register extending
+  hoist (commits only if post-transform peak pressure ≤ the R0–R8 pool). Flag-off
+  byte-identical; flag-on shrinks e.g. `spill12` 236→148 B with no function
+  growing. Notably, `flat_flight` does **not** shrink — its hot segment already
+  runs at pressure 11 > pool 9, so the guard correctly declines every hoist:
+  recovering that win needs the separate **liveness-based spilling** lever (the
+  VCR-RA SSA allocator), not more CSE.
+
 ## [0.19.0] - 2026-07-01
 
 **AArch64 host-native backend + source-level DWARF, plus a sweep of codegen

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,14 +2030,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2095,11 +2095,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.19.0"
+version = "0.20.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2154,14 +2154,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2169,11 +2169,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.19.0"
+version = "0.20.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.19.0"
+version = "0.20.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.19.0",
+    version = "0.20.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.19.0" }
+synth-core = { path = "../synth-core", version = "0.20.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.19.0" }
+synth-core = { path = "../synth-core", version = "0.20.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.19.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.19.0" }
+synth-core = { path = "../synth-core", version = "0.20.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.20.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.19.0" }
+synth-core = { path = "../synth-core", version = "0.20.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.19.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.19.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.20.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.20.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,21 +27,21 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.19.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.19.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.19.0" }
-synth-backend = { path = "../synth-backend", version = "0.19.0" }
+synth-core = { path = "../synth-core", version = "0.20.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.20.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.20.0" }
+synth-backend = { path = "../synth-backend", version = "0.20.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.19.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.20.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.19.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.19.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.19.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.20.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.20.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.20.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.19.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.20.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.19.0" }
+synth-core = { path = "../synth-core", version = "0.20.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.19.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.20.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.19.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.19.0" }
-synth-opt = { path = "../synth-opt", version = "0.19.0" }
+synth-core = { path = "../synth-core", version = "0.20.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.20.0" }
+synth-opt = { path = "../synth-opt", version = "0.20.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.19.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.19.0" }
-synth-opt = { path = "../synth-opt", version = "0.19.0" }
+synth-core = { path = "../synth-core", version = "0.20.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.20.0" }
+synth-opt = { path = "../synth-opt", version = "0.20.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.19.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.20.0", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Release **v0.20.0**. Accumulated since v0.19.0 (4 PRs merged to main):

### Added
- **`--volatile-segment <base>:<len>`** DMA-window flag (#543 Phase 1) — flag + config + rivet `VCR-DMA-001`; inert (Phase 2 = codegen suppression). New CLI surface for meld/gale to wire against.

### Fixed
- **ARM i64 large load/store offset materialization (#382)** — `--relocatable` functions with an i64 load/store at offset >0xFFF are no longer skipped; the offset is materialized against the read-only index reg. Differential vs wasmtime; frozen byte-identical.

### Internal (VCR-RA #242, flag-off — no default behavior change)
- RV32 i32 local-promotion lever (#472, `SYNTH_RV_LOCAL_PROMO`) — flag-off byte-identical, flag-on −12% .text.
- const-CSE PR2 win-recovery (#242, `SYNTH_CONST_CSE`) — 32-bit movw+movt + pressure-guarded hoist; flag-off byte-identical, flag-on shrinks spill12 236→148B. flat_flight needs the separate spilling lever (pressure 11 > pool 9) — documented, guard not loosened.

### Mechanics
- Pin sweep workspace + path-deps + MODULE.bazel `0.19.0 → 0.20.0`; Cargo.lock regenerated; CHANGELOG `[0.20.0]`.
- Frozen anchors 3/3 unchanged across all four (i64-offset adds a previously-skipped path; the two levers are flag-off).

Tag `v0.20.0` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)