### PR TITLE
feat(dwarf): internal functions get their real names from the wasm name section (#394)

### DIFF
--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -749,6 +749,12 @@ fn print_hardware_info(caps: &HardwareCapabilities) {
 /// Compiled function for ELF building (name + code bytes + relocations)
 struct ElfFunction {
     name: String,
+    /// #394 Tier-1.x: the developer-facing name from the wasm `name` custom
+    /// section (present for internal functions too, unlike the export name).
+    /// Consumed ONLY by the `--debug-line` `DW_TAG_subprogram` emit — symbol
+    /// names and relocation labels keep using `name` (export name or `func_N`),
+    /// so linkability and emitted bytes are unchanged.
+    debug_name: Option<String>,
     /// WASM function index — used to define a `func_{index}` symbol so that
     /// internal calls (`BL func_N`, emitted by the selector against the WASM
     /// index) resolve to this function's address (#167).
@@ -2252,6 +2258,9 @@ fn compile_all_exports(
 
         compiled_funcs.push(ElfFunction {
             name: name.clone(),
+            // #394 Tier-1.x: thread the `name`-section name through for the
+            // DWARF subprogram DIE (internal functions get their REAL name).
+            debug_name: func.debug_name.clone(),
             wasm_index: func.index,
             code: compiled.code,
             relocations: compiled.relocations,
@@ -3346,7 +3355,13 @@ fn build_relocatable_elf(
             .iter()
             .enumerate()
             .map(|(i, func)| synth_core::dwarf_line::SubprogramInfo {
-                name: func.name.clone(),
+                // #394 Tier-1.x: name priority `name`-section > export name >
+                // `func_N`. `func.name` already is export-name-or-`func_N`, so
+                // internal functions stop showing the synthetic `func_N` in a
+                // backtrace whenever the input carried a `name` section (e.g.
+                // `core::panicking::panic_fmt::h...`). DWARF-only: the symbol
+                // table and relocations keep using `func.name`.
+                name: func.debug_name.clone().unwrap_or_else(|| func.name.clone()),
                 low_pc: func_offsets[i] as u64,
                 high_pc: (func_offsets[i] + func.code.len() as u32) as u64,
             })
@@ -4541,6 +4556,7 @@ mod tests {
         FunctionOps {
             index,
             export_name: export.map(String::from),
+            debug_name: None,
             ops,
             op_offsets: Vec::new(),
             unsupported: None,
@@ -4842,6 +4858,7 @@ mod tests {
         let code = vec![0u8; 8]; // MOVW + MOVT placeholders
         let func = ElfFunction {
             name: "decide".to_string(),
+            debug_name: None,
             wasm_index: 0,
             code,
             relocations: vec![
@@ -4942,6 +4959,7 @@ mod tests {
         code[4..8].copy_from_slice(&0u32.to_le_bytes()); // __synth_globals + 0
         let func = ElfFunction {
             name: "decide".to_string(),
+            debug_name: None,
             wasm_index: 0,
             code,
             relocations: vec![
@@ -5029,6 +5047,7 @@ mod tests {
         code[0..4].copy_from_slice(&C.to_le_bytes());
         let func = ElfFunction {
             name: "stack_push_decide".to_string(),
+            debug_name: None,
             wasm_index: 0,
             code,
             relocations: vec![synth_core::backend::CodeRelocation {

--- a/crates/synth-cli/tests/dwarf_debug_line_emit_394.rs
+++ b/crates/synth-cli/tests/dwarf_debug_line_emit_394.rs
@@ -788,3 +788,106 @@ fn emitted_debug_info_has_subprogram_dies_per_function_394() {
             .collect::<Vec<_>>()
     );
 }
+
+/// The function-names subsection of the input wasm's `name` custom section —
+/// full function index (imports first) → developer-facing name. Ground truth
+/// for Oracle G, derived from the fixture at runtime (non-circular: read with
+/// wasmparser directly, not through synth's decoder).
+fn wasm_name_section_func_names(wasm: &[u8]) -> HashMap<u32, String> {
+    use wasmparser::{KnownCustom, Parser, Payload};
+    let mut out = HashMap::new();
+    for payload in Parser::new(0).parse_all(wasm) {
+        if let Ok(Payload::CustomSection(c)) = payload
+            && let KnownCustom::Name(reader) = c.as_known()
+        {
+            for subsection in reader.into_iter().flatten() {
+                if let wasmparser::Name::Function(map) = subsection {
+                    for naming in map.into_iter().flatten() {
+                        out.insert(naming.index, naming.name.to_string());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// ORACLE G — Tier-1.x REAL names for INTERNAL functions (#394 follow-up).
+/// Oracle F proves exported functions get their export name; but an internal
+/// (non-exported) callee — a panic helper, an outlined kernel routine — fell
+/// back to the synthetic `func_N`, even when the input's `name` custom section
+/// carried its real developer-facing name. A backtrace through a panic then
+/// showed `func_7` instead of `core::panicking::panic_const::...`. This oracle
+/// proves the `name`-section names are threaded through to the
+/// `DW_TAG_subprogram` `DW_AT_name`s:
+///
+///   (a) ≥1 compiled function is INTERNAL (not exported) AND named by the
+///       fixture's `name` section — otherwise the oracle would be vacuous;
+///   (b) every such internal function's subprogram DIE carries its REAL
+///       `name`-section name (e.g. `gale::msgq::put_decide::h...`);
+///   (c) since the fixture's `name` section names EVERY function, NO
+///       subprogram is left with a synthetic `func_N` name.
+///
+/// Ground truth (name section + export section) is parsed from the fixture at
+/// runtime with wasmparser directly — independent of synth's decoder.
+#[test]
+fn emitted_subprogram_names_use_name_section_for_internal_functions_394() {
+    let wasm = repro("msgq_put_359.wasm");
+    let wasm_bytes = std::fs::read(&wasm).expect("read fixture wasm");
+    let name_map = wasm_name_section_func_names(&wasm_bytes);
+    assert!(
+        !name_map.is_empty(),
+        "fixture must carry a `name` custom section with function names \
+         (otherwise this oracle tests nothing — pick a different fixture)"
+    );
+    let exported = wasm_exported_func_names(&wasm_bytes);
+
+    // The real names of the fixture's INTERNAL (non-exported) functions.
+    let internal_names: BTreeSet<String> = name_map
+        .values()
+        .filter(|n| !exported.contains(*n))
+        .cloned()
+        .collect();
+    assert!(
+        !internal_names.is_empty(),
+        "fixture must have ≥1 internal function named by its `name` section"
+    );
+
+    let dbg = compile(&wasm, "/tmp/dbg394_msgq_oracleg.o", true);
+    let subs = collect_subprograms(&section_data(&dbg));
+    let got_names: BTreeSet<String> = subs.iter().filter_map(|s| s.name.clone()).collect();
+
+    // (a)+(b): ≥1 compiled subprogram is an internal function carrying its
+    // REAL `name`-section name. (Not every internal function need be compiled
+    // — reachability/skips can drop some — but the fixture's export calls an
+    // internal helper, so at least one must be present under its real name.)
+    let internal_present: Vec<&String> = internal_names.intersection(&got_names).collect();
+    assert!(
+        !internal_present.is_empty(),
+        "no DW_TAG_subprogram carries an internal function's `name`-section \
+         name; internal names in fixture: {internal_names:?}, subprogram names: \
+         {got_names:?} — internal functions are still falling back to `func_N`"
+    );
+
+    // (c) the fixture's `name` section names EVERY function, so no compiled
+    // function may be left with the synthetic `func_N` fallback.
+    let synthetic: Vec<&String> = got_names
+        .iter()
+        .filter(|n| {
+            n.strip_prefix("func_")
+                .is_some_and(|d| !d.is_empty() && d.bytes().all(|b| b.is_ascii_digit()))
+        })
+        .collect();
+    assert!(
+        synthetic.is_empty(),
+        "the fixture's `name` section names every function, yet {} subprogram \
+         DIE(s) still carry the synthetic fallback: {synthetic:?}",
+        synthetic.len()
+    );
+
+    eprintln!(
+        "[dbg394-oracleG] {} subprogram DIEs; internal `name`-section names \
+         present: {internal_present:?}; zero synthetic func_N names remain.",
+        subs.len()
+    );
+}

--- a/crates/synth-core/src/dwarf_line.rs
+++ b/crates/synth-core/src/dwarf_line.rs
@@ -245,7 +245,11 @@ fn intern_file(files: &mut Vec<(String, String)>, entry: (String, String)) -> u3
 /// `high_pc - low_pc` as the offset form of `DW_AT_high_pc` (no relocation).
 #[derive(Debug, Clone)]
 pub struct SubprogramInfo {
-    /// The export/function name shown in a debugger frame.
+    /// The function name shown in a debugger frame. The caller composes it
+    /// with priority `name`-section name > export name > synthetic `func_N`
+    /// (#394 Tier-1.x), so internal functions carry their real developer-facing
+    /// name (e.g. `core::panicking::panic_fmt::h...`) whenever the input wasm
+    /// has a `name` custom section.
     pub name: String,
     /// Object-relative `.text` byte offset of the function's first instruction.
     pub low_pc: u64,

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -142,6 +142,12 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     let mut type_params_i64: Vec<Vec<bool>> = Vec::new();
     let mut func_params_i64: Vec<Vec<bool>> = Vec::new();
     let mut elem_func_indices: Vec<u32> = Vec::new();
+    // #394 Tier-1.x: function index → developer-facing name from the wasm
+    // `name` custom section (function-names subsection). Applied to
+    // `FunctionOps.debug_name` after the parse loop — the custom section
+    // conventionally trails the code section, so the entries are not yet
+    // available when each `CodeSectionEntry` is decoded.
+    let mut name_section_names: HashMap<u32, String> = HashMap::new();
 
     for payload in Parser::new(0).parse_all(wasm_bytes) {
         let payload = payload.context("Failed to parse WASM payload")?;
@@ -342,15 +348,24 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                 functions.push(FunctionOps {
                     index: actual_index,
                     export_name,
+                    debug_name: None, // filled from the `name` section after the loop
                     ops,
                     op_offsets,
                     unsupported,
                 });
                 func_index += 1;
             }
+            Payload::CustomSection(c) => {
+                // #394 Tier-1.x: the wasm `name` custom section.
+                if let wasmparser::KnownCustom::Name(reader) = c.as_known() {
+                    parse_name_section_func_names(reader, &mut name_section_names);
+                }
+            }
             _ => {}
         }
     }
+
+    apply_name_section(&mut functions, &name_section_names);
 
     Ok(DecodedModule {
         functions,
@@ -368,12 +383,43 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     })
 }
 
+/// Parse the function-names subsection of a wasm `name` custom section into
+/// `out` (function index → developer-facing name, e.g.
+/// `core::panicking::panic_fmt::h...`). Best-effort by design: the section is
+/// DEBUG METADATA only, so a malformed entry is skipped rather than failing the
+/// compile — no codegen path depends on it (#394 Tier-1.x).
+fn parse_name_section_func_names(
+    reader: wasmparser::NameSectionReader<'_>,
+    out: &mut HashMap<u32, String>,
+) {
+    for subsection in reader.into_iter().flatten() {
+        if let wasmparser::Name::Function(map) = subsection {
+            for naming in map.into_iter().flatten() {
+                out.insert(naming.index, naming.name.to_string());
+            }
+        }
+    }
+}
+
+/// Fill each function's `debug_name` from the `name`-section map (keyed by the
+/// FULL function index, imports first — the same index space `FunctionOps.index`
+/// uses). A function without an entry keeps `None` (⇒ `func_N` downstream).
+fn apply_name_section(functions: &mut [FunctionOps], names: &HashMap<u32, String>) {
+    if names.is_empty() {
+        return;
+    }
+    for f in functions {
+        f.debug_name = names.get(&f.index).cloned();
+    }
+}
+
 /// Decode a WASM binary and extract all function bodies as WasmOp sequences
 pub fn decode_wasm_functions(wasm_bytes: &[u8]) -> Result<Vec<FunctionOps>> {
     let mut functions = Vec::new();
     let mut func_index = 0u32;
     let mut num_imported_funcs = 0u32;
     let mut export_names: HashMap<u32, String> = HashMap::new();
+    let mut name_section_names: HashMap<u32, String> = HashMap::new();
 
     for payload in Parser::new(0).parse_all(wasm_bytes) {
         let payload = payload.context("Failed to parse WASM payload")?;
@@ -405,15 +451,24 @@ pub fn decode_wasm_functions(wasm_bytes: &[u8]) -> Result<Vec<FunctionOps>> {
                 functions.push(FunctionOps {
                     index: actual_index,
                     export_name,
+                    debug_name: None, // filled from the `name` section after the loop
                     ops,
                     op_offsets,
                     unsupported,
                 });
                 func_index += 1;
             }
+            Payload::CustomSection(c) => {
+                // #394 Tier-1.x: the wasm `name` custom section.
+                if let wasmparser::KnownCustom::Name(reader) = c.as_known() {
+                    parse_name_section_func_names(reader, &mut name_section_names);
+                }
+            }
             _ => {}
         }
     }
+
+    apply_name_section(&mut functions, &name_section_names);
 
     Ok(functions)
 }
@@ -425,6 +480,15 @@ pub struct FunctionOps {
     pub index: u32,
     /// Export name if this function is exported
     pub export_name: Option<String>,
+    /// #394 Tier-1.x: the function's developer-facing name from the wasm `name`
+    /// custom section (function-names subsection), e.g.
+    /// `core::panicking::panic_fmt::h6651313c3e2c6c2f` — present for INTERNAL
+    /// (non-exported) functions too, unlike `export_name`. DEBUG METADATA only:
+    /// consumed by the `--debug-line` `DW_TAG_subprogram` emit (name priority:
+    /// name-section > export name > `func_N`); no codegen or symbol-table path
+    /// reads it, so emitted `.text`/`.symtab` are unchanged (frozen-safe).
+    /// `None` when the module has no `name` section or no entry for this index.
+    pub debug_name: Option<String>,
     /// The WASM operations in this function body
     pub ops: Vec<WasmOp>,
     /// VCR-DBG-001 step 1 (#394): module-relative wasm byte offset of each op in


### PR DESCRIPTION
## What

Tier-1.x follow-up to #557 (#394): `DW_TAG_subprogram` `DW_AT_name` for **internal (non-exported) functions** was the synthetic `func_N`, because the wasm `name` custom section (function-names subsection) was never parsed. A backtrace through a panic helper showed `func_7` instead of the real developer-facing name.

**Before → after** (`msgq_put_359.wasm`, `--relocatable --debug-line`, subprogram `DW_AT_name`s):

| func idx | before | after |
|---|---|---|
| 6 (exported) | `z_impl_k_msgq_put` | `z_impl_k_msgq_put` |
| 7 (internal) | `func_7` | `core::panicking::panic_const::panic_const_add_overflow::hacec966df230a78f` |
| 8 (internal) | `func_8` | `gale::msgq::put_decide::h36409b4bbfd25a9a` |
| 9 (exported) | `gale_k_msgq_put_decide` | `gale_k_msgq_put_decide` |
| 10 (internal) | `func_10` | `core::panicking::panic_fmt::h6651313c3e2c6c2f` |

## How

- **`wasm_decoder.rs`**: parse the `name` custom section (`KnownCustom::Name` → `Name::Function` map) into a new `FunctionOps.debug_name`, applied after the parse loop (the custom section trails the code section). Best-effort by design — debug metadata must never fail a compile. Both `decode_wasm_module` and `decode_wasm_functions`.
- **`synth-cli/main.rs`**: thread `debug_name` through `ElfFunction` into the subprogram compose. Name priority: **name-section > export name > `func_N`**. DWARF-only — the symbol table and relocation labels keep using the export-name-or-`func_N` `name`, so linkability is untouched.
- **`dwarf_line.rs`**: doc-only (the priority contract on `SubprogramInfo.name`).

## Oracle (RED → GREEN)

New **Oracle G** in `dwarf_debug_line_emit_394.rs` (`emitted_subprogram_names_use_name_section_for_internal_functions_394`): ground truth (name section + export section) parsed from the fixture at runtime with wasmparser directly (non-circular). Asserts (a) ≥1 compiled internal function's DIE carries its real name-section name, and (b) zero synthetic `func_N` names remain (the fixture names every function). **RED before** — the pre-change binary emits `func_7`/`func_8`/`func_10` and none of the internal real names appear anywhere in the object; **GREEN after**.

## Gates (exit-code-verified)

- DWARF oracles A–G: 8/8 pass
- `frozen_codegen_bytes`: **3/3** — `.text` byte-identical (purely additive DWARF metadata; `.symtab` unchanged)
- `cargo test --workspace --exclude synth-verify`: 90 suites, 1677 passed, 0 failed (exit 0)
- `cargo fmt --check`: exit 0
- `cargo clippy --workspace --all-targets -- -D warnings`: exit 0 (full workspace incl. synth-verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)