### PR TITLE
chore(ci): pin rivet v0.23.0 + scope VCR-RA-001 to v0.21.0 (release tracking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,18 +187,18 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/rivet
-          key: ${{ runner.os }}-rivet-cli-v0.22.0
+          key: ${{ runner.os }}-rivet-cli-v0.23.0
       # PIN rivet to a release tag (was `--branch main`, unpinned). Unpinned, an
       # upstream schema/behaviour bump silently reddened the gate on unchanged
-      # artifacts (rivet 0.15.0 promoted a WARN→ERROR, #229). v0.22.0 (adds the
-      # `rivet release` planning command, #516) is validated clean on this repo's
+      # artifacts (rivet 0.15.0 promoted a WARN→ERROR, #229). v0.23.0 (adds configurable
+      # release-readiness ready-when/coverage, check verification-evidence, trace-results) is validated clean on this repo's
       # artifacts before pinning — the exact CI gate below run locally under
-      # v0.22.0 gives non-xref ERROR 0 and coverage exit 0, same as v0.19.0. Skip
+      # v0.23.0 gives non-xref ERROR 0, same as v0.22.0. Skip
       # the (expensive) build entirely on a cache hit.
-      - name: Install rivet (pinned v0.22.0)
+      - name: Install rivet (pinned v0.23.0)
         run: |
-          if ! rivet --version 2>/dev/null | grep -q "0.22.0"; then
-            cargo install --force --git https://github.com/pulseengine/rivet --tag v0.22.0 rivet-cli
+          if ! rivet --version 2>/dev/null | grep -q "0.23.0"; then
+            cargo install --force --git https://github.com/pulseengine/rivet --tag v0.23.0 rivet-cli
           fi
       - name: Validate artifacts
         run: |

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -46,7 +46,7 @@ jobs:
         uses: pulseengine/rivet/.github/actions/compliance@v0.22.1
         with:
           theme: dark
-          rivet-version: v0.15.0
+          rivet-version: v0.23.0
           include-data-formats: true
           report-label: ${{ steps.tag.outputs.tag }}
           archive: 'true'

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -252,6 +252,7 @@ artifacts:
       alias-eviction remains the sole open prerequisite. (Not empirically reproduced on
       gale's exact `gust_mix` — fixture requested to pin the trigger.)
     status: implemented
+    release: v0.21.0
     tags: [codegen, register-allocation, ssa, regalloc2, track-a, release-v0.11.40]
     links:
       - type: derives-from


### PR DESCRIPTION
Adopts **rivet v0.23.0** for release planning + tracking (user directive).

## What v0.23.0 brings to the loop
- **Configurable release-status readiness** (ready-when + coverage) — `rivet release status vX.Y.Z` is now the release burn-down gate.
- **`check verification-evidence`** — named-test-exists oracle (green on this repo).
- **`trace-results`** — forward req→test-result trace.

## Drift-validated before pinning (the #229 lesson)
The exact CI gate formula run locally under v0.23.0: **non-xref ERROR = 0** on unchanged artifacts — no WARN→ERROR promotion vs v0.22.0.

## Changes
- `ci.yml`: install pin + binary cache key `v0.22.0 → v0.23.0`.
- `compliance.yml`: `rivet-version` `v0.15.0 → v0.23.0` (was stale).
- `artifacts/verified-codegen-roadmap.yaml`: `VCR-RA-001` scoped to **v0.21.0** — the SSA-allocator spike is the active North-Star lane, so the v0.21.0 burn-down is live: `1 artifact (implemented) — NOT cuttable until verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)