### PR TITLE
chore(release): v0.21.0 — DWARF internal function names + rivet 0.23 tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-02
+
+**DWARF backtraces get real internal function names; release tooling on rivet
+0.23.**
+
+### Added
+
+- **Internal functions carry their real names in DWARF (#394).** The decoder now
+  parses the wasm `name` custom section (function-names subsection) and the
+  `DW_TAG_subprogram` emit prefers name-section name > export name > `func_N` —
+  so a gdb/lldb backtrace through a synth-compiled image shows
+  `core::panicking::panic_fmt::…` / `gale::msgq::put_decide::…` instead of
+  `func_7`. Best-effort: malformed debug metadata never fails a compile. DWARF
+  is additive — `.text` byte-identical.
+
+### Changed
+
+- **Release planning/tracking pinned to rivet v0.23.0** (configurable
+  release-status readiness, `check verification-evidence`, `trace-results`);
+  CI + compliance pins bumped, drift-validated (0 non-xref errors on unchanged
+  artifacts). `VCR-RA-001` (SSA allocator) tracked for v0.22.0.
+
 ## [0.20.0] - 2026-07-02
 
 **i64 large-offset completeness fix, the `--volatile-segment` DMA surface, and two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,14 +2030,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2095,11 +2095,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.20.0"
+version = "0.21.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2154,14 +2154,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2169,11 +2169,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.20.0"
+version = "0.21.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.20.0"
+version = "0.21.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.20.0",
+    version = "0.21.0",
 )
 
 # Bazel dependencies

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -252,7 +252,7 @@ artifacts:
       alias-eviction remains the sole open prerequisite. (Not empirically reproduced on
       gale's exact `gust_mix` — fixture requested to pin the trigger.)
     status: implemented
-    release: v0.21.0
+    release: v0.22.0
     tags: [codegen, register-allocation, ssa, regalloc2, track-a, release-v0.11.40]
     links:
       - type: derives-from

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.20.0" }
+synth-core = { path = "../synth-core", version = "0.21.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.20.0" }
+synth-core = { path = "../synth-core", version = "0.21.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.20.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.20.0" }
+synth-core = { path = "../synth-core", version = "0.21.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.21.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.20.0" }
+synth-core = { path = "../synth-core", version = "0.21.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.20.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.20.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.21.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.21.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,21 +27,21 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.20.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.20.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.20.0" }
-synth-backend = { path = "../synth-backend", version = "0.20.0" }
+synth-core = { path = "../synth-core", version = "0.21.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.21.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.21.0" }
+synth-backend = { path = "../synth-backend", version = "0.21.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.20.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.21.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.20.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.20.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.20.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.21.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.21.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.21.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.20.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.21.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.20.0" }
+synth-core = { path = "../synth-core", version = "0.21.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.20.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.21.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.20.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.20.0" }
-synth-opt = { path = "../synth-opt", version = "0.20.0" }
+synth-core = { path = "../synth-core", version = "0.21.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.21.0" }
+synth-opt = { path = "../synth-opt", version = "0.21.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.20.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.20.0" }
-synth-opt = { path = "../synth-opt", version = "0.20.0" }
+synth-core = { path = "../synth-core", version = "0.21.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.21.0" }
+synth-opt = { path = "../synth-opt", version = "0.21.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.20.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.21.0", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Early cut per the release-early directive — merged downstream-facing value ships now:

### Added
- **DWARF internal function names (#394 / PR #565)** — wasm `name`-section parsing + `DW_TAG_subprogram` name priority (name-section > export > `func_N`). gdb/lldb backtraces show real symbols. `.text` byte-identical.

### Changed
- **rivet v0.23.0** pinned for release planning/tracking (#566): readiness burn-down, `check verification-evidence`, `trace-results`. Drift-validated.
- `VCR-RA-001` re-scoped to v0.22.0 — `rivet release status v0.21.0` has no blocking artifacts (cuttable).

Pin sweep + lock + CHANGELOG. Frozen anchors unchanged (DWARF additive; tooling non-code). Tag `v0.21.0` on merge. The flag-off RV32 cmp→select lever (#472, in flight) rides v0.22.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)