### PR TITLE
feat(vcr-ra): liveness-based spill re-choice spike, flag-off (#242, VCR-RA-001)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -632,6 +632,32 @@ fn compile_wasm_to_arm(
         arm_instrs
     };
 
+    // VCR-RA-001 spill re-choice spike (#242): slot-value forwarding BETWEEN
+    // reloads. `forward_stack_reloads` (above) forwards only from a spill
+    // store's SOURCE register, so when register pressure clobbers that source
+    // — the genuine-spill case, flat_flight's peak-11 hot segment — its
+    // reloads survive. This pass tracks which registers provably still hold a
+    // frame slot's value (through earlier reloads and reg-reg moves) and turns
+    // reload #2..#n into a 1-cycle `mov` (or deletes it when the target
+    // already holds the value). A forwarded reload can leave the feeding
+    // store dead, so the frame-slot DCE sweep runs once more behind the same
+    // flag. Per-segment commit gates: never grows, and post-transform peak
+    // value pressure must fit the R0–R8 pool or not exceed the pre-transform
+    // peak (see `apply_spill_realloc`). Flag-off (`SYNTH_SPILL_REALLOC=1`)
+    // while differential-validated; off ⇒ byte-identical.
+    let arm_instrs = if std::env::var("SYNTH_SPILL_REALLOC").is_ok() {
+        let (out, n) = synth_synthesis::liveness::apply_spill_realloc(&arm_instrs);
+        let (out, d) = synth_synthesis::liveness::eliminate_dead_frame_stores(&out);
+        if std::env::var("SYNTH_FUSE_STATS").is_ok() {
+            eprintln!(
+                "[spill-realloc] {n} reload(s) forwarded/eliminated, {d} newly-dead frame store(s) removed"
+            );
+        }
+        out
+    } else {
+        arm_instrs
+    };
+
     // VCR-RA immediate-shift folding (#390, #242): a constant shift amount the
     // stack selector materialized into a scratch register (`movw rM,#C; lsl rD,rN,rM`)
     // folds to the immediate form (`lsl rD,rN,#C`), removing the dead `movw` — −1
@@ -691,6 +717,29 @@ fn compile_wasm_to_arm(
     } else {
         arm_instrs
     };
+
+    // VCR-RA-001 spill-choice REPORT (#242): measure-only, like SYNTH_SHADOW_ALLOC.
+    // Per straight-line segment, the frame-slot traffic actually emitted vs the
+    // reload/store count a farthest-next-use (Belady) allocation over the R0-R8
+    // pool would need — the measured headroom for the full spill-choice rewrite.
+    // Printed on the FINAL stream (post all rewrite passes), so a flag-off run
+    // reports the greedy baseline and a flag-on run reports what remains.
+    if std::env::var("SYNTH_SPILL_REPORT").is_ok() {
+        for seg in synth_synthesis::liveness::spill_choice_report(&arm_instrs, 9) {
+            if seg.actual_reloads + seg.actual_spill_stores > 0 || seg.peak_pressure > 9 {
+                eprintln!(
+                    "[spill-report] seg@{} len={} peak={} actual={}ld+{}st belady(k=9)={}ld+{}st",
+                    seg.start,
+                    seg.len,
+                    seg.peak_pressure,
+                    seg.actual_reloads,
+                    seg.actual_spill_stores,
+                    seg.belady_reloads,
+                    seg.belady_spill_stores
+                );
+            }
+        }
+    }
 
     // ISA feature gate: validate that all generated instructions are supported
     // by the target. This catches FPU instructions on no-FPU targets, double-precision

--- a/crates/synth-cli/tests/spill_realloc_242.rs
+++ b/crates/synth-cli/tests/spill_realloc_242.rs
@@ -1,0 +1,242 @@
+//! VCR-RA-001 spill re-choice spike (#242) — CI-gated no-grow + firing +
+//! headroom-report oracles.
+//!
+//! flat_flight's hot segment runs peak register pressure 11 > the R0–R8 pool
+//! of 9, so every pressure-guarded optimization declines there and the greedy
+//! lowering's spill placement is naive (gale: 17 spills + 61% redundant const
+//! materializations on silicon, #209). This spike ships, flag-off:
+//!
+//!   - `SYNTH_SPILL_REALLOC=1` — slot-value forwarding BETWEEN reloads
+//!     (`liveness::apply_spill_realloc`): the case `forward_stack_reloads`
+//!     misses when pressure clobbers the spill store's source. 1-for-1 or
+//!     deletion ⇒ never grows; per-segment pressure gate.
+//!   - `SYNTH_SPILL_REPORT=1` — measure-only greedy-vs-Belady (farthest next
+//!     use) frame-traffic report per segment: the recovery headroom the full
+//!     VCR-RA-001 spill-choice rewrite targets.
+//!
+//! Flag-OFF byte-identity is owned by the existing gates (frozen_codegen_bytes
+//! 3/3 + the const_cse_reduction_242 golden). Flag-ON semantic equivalence is
+//! the unicorn-vs-wasmtime differentials (const_cse_differential.py,
+//! frame_slot_dce_differential.py — both re-run green with the flag exported).
+//! What THIS file locks:
+//!
+//!   1. NO-GROW: with the flag ON, no function in the measured corpus grows.
+//!   2. NON-VACUOUS: the rewrite actually fires on a real fixture
+//!      (flight_seam::flight_algo — 3 reloads forwarded, 306→300 B when
+//!      measured 2026-07-02) — an inert pass cannot pass this.
+//!   3. HONESTY: flat_flight stays byte-equal (its 3 surviving reloads have no
+//!      register-resident holder — spill RE-CHOICE, not forwarding, is what
+//!      recovers those; that is the next VCR-RA-001 step, not this one).
+//!   4. HEADROOM IS REAL: the Belady report on flat_flight's pressure-11
+//!      segment shows the ideal allocation needs strictly less frame traffic
+//!      than the greedy lowering emitted.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture(rel: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+/// Compile `rel` on the optimized path; `flag` toggles `SYNTH_SPILL_REALLOC`.
+/// Returns (ELF bytes, stderr).
+fn compile(rel: &str, out: &str, flag: bool) -> (Vec<u8>, String) {
+    let mut cmd = Command::new(synth());
+    if flag {
+        cmd.env("SYNTH_SPILL_REALLOC", "1");
+    }
+    let output = cmd
+        .env("SYNTH_SPILL_REPORT", "1")
+        .env("SYNTH_FUSE_STATS", "1")
+        .args([
+            "compile",
+            fixture(rel).to_str().unwrap(),
+            "-o",
+            out,
+            "-b",
+            "arm",
+            "--target",
+            "cortex-m4",
+            "--all-exports",
+        ])
+        .output()
+        .expect("run synth compile");
+    assert!(output.status.success(), "synth compile failed ({rel})");
+    (
+        std::fs::read(out).expect("read ELF"),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// Every function symbol → its `.text` byte size.
+fn func_sizes(elf: &[u8]) -> HashMap<String, usize> {
+    use object::{Object, ObjectSymbol, SymbolKind};
+    let obj = object::read::elf::ElfFile32::<object::Endianness>::parse(elf).expect("parse ELF");
+    let mut out = HashMap::new();
+    for sym in obj.symbols() {
+        if sym.kind() == SymbolKind::Text
+            && sym.size() > 0
+            && let Ok(name) = sym.name()
+        {
+            out.insert(name.to_string(), sym.size() as usize);
+        }
+    }
+    out
+}
+
+/// One parsed `[spill-report]` line.
+#[derive(Debug)]
+struct SegReport {
+    peak: usize,
+    actual_reloads: usize,
+    actual_stores: usize,
+    belady_reloads: usize,
+    belady_stores: usize,
+}
+
+/// Parse `[spill-report] seg@S len=L peak=P actual=Ald+Bst belady(k=9)=Cld+Dst`.
+fn parse_reports(stderr: &str) -> Vec<SegReport> {
+    fn lead_digits(s: &str) -> usize {
+        let d: String = s.chars().take_while(|c| c.is_ascii_digit()).collect();
+        d.parse().expect("leading digits")
+    }
+    fn after<'a>(line: &'a str, field: &str) -> &'a str {
+        line.split(field)
+            .nth(1)
+            .unwrap_or_else(|| panic!("cannot parse `{field}` from: {line}"))
+    }
+    stderr
+        .lines()
+        .filter(|l| l.contains("[spill-report]"))
+        .map(|l| {
+            let actual = after(l, "actual=");
+            let belady = after(l, "belady(k=9)=");
+            SegReport {
+                peak: lead_digits(after(l, "peak=")),
+                actual_reloads: lead_digits(actual),
+                actual_stores: lead_digits(after(actual, "ld+")),
+                belady_reloads: lead_digits(belady),
+                belady_stores: lead_digits(after(belady, "ld+")),
+            }
+        })
+        .collect()
+}
+
+/// Sum of `[spill-realloc] N reload(s) forwarded/eliminated…` counts.
+fn forwarded_total(stderr: &str) -> usize {
+    stderr
+        .lines()
+        .filter(|l| l.contains("[spill-realloc]"))
+        .map(|l| {
+            l.split("[spill-realloc] ")
+                .nth(1)
+                .and_then(|r| {
+                    let d: String = r.chars().take_while(|c| c.is_ascii_digit()).collect();
+                    d.parse::<usize>().ok()
+                })
+                .unwrap_or_else(|| panic!("cannot parse [spill-realloc] line: {l}"))
+        })
+        .sum()
+}
+
+/// CLAIMS 1–3: no function grows flag-on; the rewrite fires on flight_seam's
+/// flight_algo (which shrinks); pressure-saturated flat_flight honestly stays
+/// byte-equal (nothing forwardable — re-choice, not forwarding, owns it).
+#[test]
+fn spill_realloc_no_grow_and_fires_on_flight_seam_242() {
+    // flight_seam — the firing fixture.
+    let (off_elf, _) = compile(
+        "scripts/repro/flight_seam.wat",
+        "/tmp/sr242_fs_off.elf",
+        false,
+    );
+    let (on_elf, on_err) = compile(
+        "scripts/repro/flight_seam.wat",
+        "/tmp/sr242_fs_on.elf",
+        true,
+    );
+    let (off, on) = (func_sizes(&off_elf), func_sizes(&on_elf));
+    for (name, &o) in &off {
+        let n = *on.get(name).unwrap_or(&o);
+        assert!(
+            n <= o,
+            "no function may grow flag-on: {name} off={o}B on={n}B"
+        );
+    }
+    assert!(
+        on["flight_algo"] < off["flight_algo"],
+        "the spike must shrink flight_seam::flight_algo (measured 306→300 B): off={}B on={}B",
+        off["flight_algo"],
+        on["flight_algo"]
+    );
+    let fired = forwarded_total(&on_err);
+    assert!(
+        fired >= 3,
+        "expected ≥3 reloads forwarded on flight_seam (measured 3); got {fired} — the pass went inert"
+    );
+    eprintln!(
+        "[spill-realloc-242] flight_seam::flight_algo off={}B on={}B, {} reload(s) forwarded",
+        off["flight_algo"], on["flight_algo"], fired
+    );
+
+    // flat_flight — the honest non-firing fixture (holders all clobbered).
+    let (ff_off_elf, _) = compile(
+        "scripts/repro/flat_flight/flat_flight.loom.wasm",
+        "/tmp/sr242_ff_off.elf",
+        false,
+    );
+    let (ff_on_elf, _) = compile(
+        "scripts/repro/flat_flight/flat_flight.loom.wasm",
+        "/tmp/sr242_ff_on.elf",
+        true,
+    );
+    assert_eq!(
+        func_sizes(&ff_on_elf)["flat_flight"],
+        func_sizes(&ff_off_elf)["flat_flight"],
+        "flat_flight's surviving reloads have no register-resident holder; \
+         forwarding must decline — recovering them is the spill RE-CHOICE step"
+    );
+}
+
+/// CLAIM 4: the greedy-vs-Belady report is alive on flat_flight and shows real
+/// recovery headroom on its pressure-saturated hot segment.
+#[test]
+fn spill_report_shows_flat_flight_headroom_242() {
+    let (_, stderr) = compile(
+        "scripts/repro/flat_flight/flat_flight.loom.wasm",
+        "/tmp/sr242_ff_rep.elf",
+        false,
+    );
+    let reports = parse_reports(&stderr);
+    assert!(
+        !reports.is_empty(),
+        "no [spill-report] lines — the measure-only instrumentation went dead"
+    );
+    // The hot segment: peak pressure 11 > pool 9, with real frame traffic the
+    // ideal (Belady, k=9) allocation would not need (measured 2026-07-02:
+    // actual 3ld+3st vs belady 0ld+0st).
+    let hot = reports
+        .iter()
+        .find(|r| r.peak > 9)
+        .expect("flat_flight must report a peak>9 (pressure-saturated) segment");
+    let (actual, ideal) = (
+        hot.actual_reloads + hot.actual_stores,
+        hot.belady_reloads + hot.belady_stores,
+    );
+    assert!(
+        ideal < actual,
+        "the pressure-11 segment must show recovery headroom: actual {actual} vs belady {ideal}"
+    );
+    eprintln!(
+        "[spill-report-242] flat_flight hot segment: peak={} actual={}ld+{}st \
+         belady(k=9)={}ld+{}st — the VCR-RA-001 recovery target",
+        hot.peak, hot.actual_reloads, hot.actual_stores, hot.belady_reloads, hot.belady_stores
+    );
+}

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -3880,6 +3880,553 @@ fn extending_alias_hoist(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usi
     (out, count)
 }
 
+// ─── VCR-RA-001 spill re-choice spike (#242) ────────────────────────────────
+//
+// MOTIVATION. flat_flight's hot segment runs peak register pressure 11 > the
+// R0–R8 pool of 9, so every pressure-guarded optimization (const-CSE PR2, the
+// extending-alias hoist) correctly declines there, and the greedy selector's
+// spill placement is naive — gale measured 17 spills + 61% redundant const
+// materializations on silicon (G474RE, #209). The only lever that wins on a
+// genuinely-saturated segment is smarter SPILL placement: keep the value with
+// the NEAREST next use in a register and send the FURTHEST-next-use value to
+// memory (Belady / farthest-first). This spike ships two bounded pieces:
+//
+//  1. REPORT: [`spill_choice_report`] — per straight-line segment, the actual
+//     frame-slot traffic the greedy lowering emitted (`ldr`/`str [sp,#N]`)
+//     vs. the reload/store count a farthest-next-use (Belady MIN) allocation
+//     of the same value trace would need with a k-register pool. The delta is
+//     the measured headroom the full VCR-RA-001 spill-choice rewrite can
+//     recover. Pure analysis; wired behind `SYNTH_SPILL_REPORT=1`.
+//
+//  2. REWRITE (the simplest strictly-profitable case): [`apply_spill_realloc`]
+//     — slot-value forwarding *between reloads*. Where a `ldr rZ,[sp,#N]`
+//     reloads a value PROVABLY still register-resident (an earlier reload /
+//     store / reg-reg move of the same slot value survives unclobbered), the
+//     reload is replaced by `mov rZ,rY` — or DELETED outright when `rZ`
+//     itself still holds it. Every rewritten reload is one fewer load
+//     executed. This is exactly the case [`forward_stack_reloads`] misses:
+//     that pass forwards only from the STORE's source register, so when
+//     pressure clobbers the source (the real-spill case this spike targets),
+//     its reloads survive — but reload #2..#n can still forward from reload
+//     #1. Flag-off (`SYNTH_SPILL_REALLOC=1`); off ⇒ byte-identical.
+
+/// Registers never tracked as slot-value holders and never counted as pool
+/// values: R9 (globals) / R10 (mem-size) / R11 (mem-base) are reserved, R12 is
+/// the ENCODER's scratch (encode-time expansions may clobber it without any
+/// `ArmOp`-level def — #212), and SP/LR/PC are never value homes.
+fn is_reserved_reg(r: Reg) -> bool {
+    matches!(
+        r,
+        Reg::R9 | Reg::R10 | Reg::R11 | Reg::R12 | Reg::SP | Reg::LR | Reg::PC
+    )
+}
+
+/// True for the word-sized `[sp, #imm]` address form — the only frame-slot
+/// shape the spill passes reason about (spill slots are word-aligned,
+/// non-overlapping, and accessed full-word; see
+/// [`eliminate_dead_frame_stores`]'s load-bearing-assumption note).
+fn sp_slot(addr: &MemAddr) -> Option<i32> {
+    (addr.base == Reg::SP && addr.offset_reg.is_none()).then_some(addr.offset)
+}
+
+/// VCR-RA-001 spill-reload forwarding (#242, spike step): replace or delete a
+/// frame-slot reload whose value is provably already in a register.
+///
+/// Per maximal straight-line, fully-modeled segment (same segmentation as
+/// [`reallocate_function`]), tracks — per slot `#N` — the set of R0–R8
+/// registers currently holding slot `N`'s value. Sources: the feeding
+/// `str rY,[sp,#N]` (holder `rY`), a reload `ldr rY,[sp,#N]` (holder `rY`),
+/// and value copies (`mov rZ,rY` extends every set containing `rY`). Kills: a
+/// redefinition of the register (any modeled def, including `Movt`'s RMW), a
+/// store to the slot (set reset to the new source), ANY `[sp]` access that
+/// cannot be pinned to a single whole word slot (register-offset or sub-word),
+/// `Push`/`Pop` (SP moves + stack memory touched), and any SP def. A reload
+/// `ldr rZ,[sp,#N]` with a surviving holder `rY` becomes `mov rZ,rY` (1-for-1,
+/// count-neutral, load→1-cycle move), or is DELETED when `rZ == rY`
+/// (offset-safe: runs before `resolve_label_branches`, like every pass here).
+///
+/// SOUNDNESS is by construction: the replacement writes `rZ` with the exact
+/// value the load would have fetched (the holder tracking proves memory and
+/// register agree), and a deletion leaves `rZ` already holding that value —
+/// every downstream register state is bit-identical. Non-SP stores are assumed
+/// not to alias the frame (wasm linear memory via R11 is disjoint from the
+/// machine stack — the same assumption [`forward_stack_reloads`] ships with).
+///
+/// COMMIT GATES, per segment (the whole segment keeps its original bytes if
+/// any gate fails):
+///  (a) semantics — by construction, above;
+///  (b) instruction count must not grow — structural (replacements are 1-for-1,
+///      deletions shrink), asserted;
+///  (c) register-pressure guard: a `mov` extends the holder value's live
+///      range, so the segment's post-transform peak VALUE pressure
+///      ([`straight_line_peak_pressure`]) must not exceed the pre-transform
+///      peak unless it still fits the R0–R8 pool ([`ALLOCATABLE_POOL`]) — the
+///      rewrite never turns a fitting segment into a spilling one, and on an
+///      already-saturated segment (flat_flight's peak 11) it never makes the
+///      saturation worse.
+///
+/// Returns the rewritten stream and the number of reloads forwarded/deleted.
+/// Pure; callers opt in (`SYNTH_SPILL_REALLOC=1` wiring in `arm_backend.rs`).
+pub fn apply_spill_realloc(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
+    let mut out: Vec<ArmInstruction> = Vec::with_capacity(instrs.len());
+    let mut total = 0usize;
+    let mut seg: Vec<ArmInstruction> = Vec::new();
+    let flush =
+        |seg: &mut Vec<ArmInstruction>, out: &mut Vec<ArmInstruction>, total: &mut usize| {
+            if seg.is_empty() {
+                return;
+            }
+            match spill_forward_segment(seg) {
+                Some((rewritten, n)) => {
+                    *total += n;
+                    out.extend(rewritten);
+                }
+                None => out.append(seg),
+            }
+            seg.clear();
+        };
+    for ins in instrs {
+        if is_straight_line(&ins.op) && reg_effect(&ins.op).is_some() {
+            seg.push(ins.clone());
+        } else {
+            flush(&mut seg, &mut out, &mut total);
+            out.push(ins.clone());
+        }
+    }
+    flush(&mut seg, &mut out, &mut total);
+    (out, total)
+}
+
+/// One segment of [`apply_spill_realloc`]: `Some((rewritten, count))` iff at
+/// least one reload was forwarded/deleted AND every commit gate holds;
+/// `None` ⇒ caller keeps the original segment bytes.
+fn spill_forward_segment(seg: &[ArmInstruction]) -> Option<(Vec<ArmInstruction>, usize)> {
+    // slot #N → set of R0–R8 registers currently holding slot N's value.
+    let mut holders: BTreeMap<i32, BTreeSet<Reg>> = BTreeMap::new();
+    // Staged edits: index → Some(op) = replace, None = delete.
+    let mut staged: BTreeMap<usize, Option<ArmOp>> = BTreeMap::new();
+
+    for (i, ins) in seg.iter().enumerate() {
+        match &ins.op {
+            // Full-word reload of a pinnable slot — the forwarding candidate.
+            ArmOp::Ldr { rd, addr } if sp_slot(addr).is_some() => {
+                let slot = sp_slot(addr).unwrap();
+                let rd = *rd;
+                let known = holders.get(&slot).cloned().unwrap_or_default();
+                if !is_reserved_reg(rd) && known.contains(&rd) {
+                    // rd already holds the slot's value — the reload is a no-op.
+                    staged.insert(i, None);
+                    // State unchanged: rd keeps the (identical) value.
+                } else if !is_reserved_reg(rd) && !known.is_empty() {
+                    let ry = *known.iter().next().unwrap(); // lowest reg: deterministic
+                    staged.insert(
+                        i,
+                        Some(ArmOp::Mov {
+                            rd,
+                            op2: Operand2::Reg(ry),
+                        }),
+                    );
+                    // rd is redefined with the slot's value (same as the ldr):
+                    for set in holders.values_mut() {
+                        set.remove(&rd);
+                    }
+                    // rd now equals ry — it joins every slot set ry belongs to
+                    // (which includes `slot`).
+                    for set in holders.values_mut() {
+                        if set.contains(&ry) {
+                            set.insert(rd);
+                        }
+                    }
+                } else {
+                    // Ordinary reload: rd is redefined and now holds slot's value.
+                    for set in holders.values_mut() {
+                        set.remove(&rd);
+                    }
+                    if !is_reserved_reg(rd) {
+                        holders.entry(slot).or_default().insert(rd);
+                    }
+                }
+            }
+            // Full-word store to a pinnable slot: the slot now holds rd's value.
+            ArmOp::Str { rd, addr } if sp_slot(addr).is_some() => {
+                let mut set = BTreeSet::new();
+                if !is_reserved_reg(*rd) {
+                    set.insert(*rd);
+                }
+                holders.insert(sp_slot(addr).unwrap(), set);
+            }
+            // Any [sp] access we cannot pin to a single whole word slot:
+            // register offset (unresolvable) or sub-word (partial overlap).
+            ArmOp::Ldr { addr, .. } | ArmOp::Str { addr, .. } if addr.base == Reg::SP => {
+                holders.clear();
+            }
+            ArmOp::Ldrb { addr, .. }
+            | ArmOp::Ldrsb { addr, .. }
+            | ArmOp::Ldrh { addr, .. }
+            | ArmOp::Ldrsh { addr, .. }
+            | ArmOp::Strb { addr, .. }
+            | ArmOp::Strh { addr, .. }
+                if addr.base == Reg::SP =>
+            {
+                holders.clear();
+            }
+            // SP moves + stack memory touched — every slot name is invalidated.
+            ArmOp::Push { .. } | ArmOp::Pop { .. } => holders.clear(),
+            // Register-to-register copy propagates value identity.
+            ArmOp::Mov {
+                rd,
+                op2: Operand2::Reg(rm),
+            } if rd != rm => {
+                let (rd, rm) = (*rd, *rm);
+                let member: Vec<i32> = holders
+                    .iter()
+                    .filter(|(_, s)| s.contains(&rm))
+                    .map(|(k, _)| *k)
+                    .collect();
+                for set in holders.values_mut() {
+                    set.remove(&rd);
+                }
+                if !is_reserved_reg(rd) {
+                    for k in member {
+                        if let Some(s) = holders.get_mut(&k) {
+                            s.insert(rd);
+                        }
+                    }
+                }
+            }
+            op => {
+                // Segment precondition guarantees Some; `?` stays sound if the
+                // segmentation ever drifts.
+                let eff = reg_effect(op)?;
+                if eff.defs.contains(&Reg::SP) {
+                    holders.clear();
+                } else {
+                    for d in &eff.defs {
+                        for set in holders.values_mut() {
+                            set.remove(d);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if staged.is_empty() {
+        return None;
+    }
+
+    let mut rewritten: Vec<ArmInstruction> = Vec::with_capacity(seg.len());
+    for (i, ins) in seg.iter().enumerate() {
+        match staged.get(&i) {
+            None => rewritten.push(ins.clone()),
+            Some(None) => {} // deleted redundant reload
+            Some(Some(op)) => rewritten.push(ArmInstruction {
+                op: op.clone(),
+                source_line: ins.source_line,
+            }),
+        }
+    }
+    // Gate (b): never grow — structural, but asserted so a future edit that
+    // breaks the 1-for-1/deletion property fails loudly.
+    assert!(
+        rewritten.len() <= seg.len(),
+        "spill_forward_segment must never grow a segment"
+    );
+    // Gate (c): pressure guard — a forwarding `mov` extends the holder's live
+    // range; commit only if the segment still fits the pool or did not get
+    // more saturated than it already was.
+    let pre = straight_line_peak_pressure(seg)?;
+    let post = straight_line_peak_pressure(&rewritten)?;
+    if post > pre && post > ALLOCATABLE_POOL {
+        return None;
+    }
+    Some((rewritten, staged.len()))
+}
+
+/// Per-segment greedy-vs-Belady spill-choice report — the REPORT half of the
+/// VCR-RA-001 spike (#242). See [`spill_choice_report`].
+#[derive(Debug, Clone)]
+pub struct SegmentSpillChoice {
+    /// Function-stream index of the segment's first instruction.
+    pub start: usize,
+    /// Segment length in instructions.
+    pub len: usize,
+    /// Peak VALUE pressure of the segment ([`straight_line_peak_pressure`]).
+    pub peak_pressure: usize,
+    /// Frame-slot reloads the greedy lowering actually emitted
+    /// (word `ldr [sp,#imm]` count).
+    pub actual_reloads: usize,
+    /// Frame-slot stores the greedy lowering actually emitted
+    /// (word `str [sp,#imm]` count).
+    pub actual_spill_stores: usize,
+    /// Reloads a farthest-next-use (Belady MIN) allocation of the segment's
+    /// value trace would execute with a k-register pool.
+    pub belady_reloads: usize,
+    /// Spill stores the Belady allocation would execute.
+    pub belady_spill_stores: usize,
+}
+
+/// The greedy-vs-farthest-next-use spill-choice delta, per straight-line
+/// segment: how much of the emitted frame-slot traffic a Belady (evict the
+/// value with the FURTHEST next use) allocation over `k` registers would
+/// avoid. `actual_* − belady_*` is the measured recovery headroom for the full
+/// VCR-RA-001 spill-choice rewrite.
+///
+/// METHOD. The segment's frame traffic is first dissolved back into an
+/// abstract VALUE trace: a `str [sp,#N]` binds slot `N` to its source's value
+/// and a `ldr [sp,#N]` re-binds the target register to that same value — so a
+/// value's uses after a reload are uses of the ORIGINAL value, and the spill
+/// instructions themselves vanish from the ideal trace (a reload from a slot
+/// whose value is unknown — written outside the segment — stays a genuine,
+/// unavoidable load and is charged to Belady too). Values homed in reserved
+/// registers (R9–R12/SP/LR/PC) are excluded: they do not compete for the pool.
+/// Belady MIN then replays the trace with `k` register slots, evicting the
+/// resident value with the farthest next use (a first eviction of a value that
+/// is still needed and has no memory copy costs one store; re-touching an
+/// evicted value costs one reload).
+///
+/// CAVEAT (stated, not hidden): the actual counts include the frame-resident
+/// lowering's LOCAL-variable traffic, so the delta is the ceiling recoverable
+/// by full value-based allocation (locals promoted + Belady spill choice), not
+/// by spill re-choice alone. Pure analysis — changes no bytes; wired behind
+/// `SYNTH_SPILL_REPORT=1`.
+pub fn spill_choice_report(instrs: &[ArmInstruction], k: usize) -> Vec<SegmentSpillChoice> {
+    let mut out = Vec::new();
+    let mut seg_start = 0usize;
+    let flush = |start: usize, end: usize, out: &mut Vec<SegmentSpillChoice>| {
+        if end > start
+            && let Some(r) = segment_spill_choice(&instrs[start..end], k, start)
+        {
+            out.push(r);
+        }
+    };
+    for (i, ins) in instrs.iter().enumerate() {
+        if !is_straight_line(&ins.op) || reg_effect(&ins.op).is_none() {
+            flush(seg_start, i, &mut out);
+            seg_start = i + 1;
+        }
+    }
+    flush(seg_start, instrs.len(), &mut out);
+    out
+}
+
+/// Value-trace reconstruction + Belady MIN simulation for one straight-line,
+/// fully-modeled segment. `None` iff the segment cannot be modeled (should not
+/// happen under [`spill_choice_report`]'s segmentation).
+fn segment_spill_choice(
+    seg: &[ArmInstruction],
+    k: usize,
+    start: usize,
+) -> Option<SegmentSpillChoice> {
+    // ── 1. Reconstruct the abstract value trace. ──────────────────────────
+    let mut current: BTreeMap<Reg, usize> = BTreeMap::new(); // reg → value id
+    let mut slot_value: BTreeMap<i32, usize> = BTreeMap::new(); // slot → value id
+    let mut n_values = 0usize;
+    let mut mem_origin: Vec<bool> = Vec::new(); // value born memory-resident?
+    // Per position: values that must be register-resident (reads), values born
+    // into a register (writes), values entering from unknown memory (charged
+    // as unavoidable reloads on both sides).
+    struct PosTouch {
+        required: Vec<usize>,
+        born: Vec<usize>,
+        mem_born: Vec<usize>,
+    }
+    let mut touches: Vec<PosTouch> = Vec::with_capacity(seg.len());
+    let mut required_at: Vec<Vec<usize>> = Vec::new(); // value → positions
+    let mut actual_reloads = 0usize;
+    let mut actual_spill_stores = 0usize;
+
+    let mut new_value = |mem: bool, mem_origin: &mut Vec<bool>| -> usize {
+        let v = n_values;
+        n_values += 1;
+        mem_origin.push(mem);
+        v
+    };
+
+    for (p, ins) in seg.iter().enumerate() {
+        let mut t = PosTouch {
+            required: Vec::new(),
+            born: Vec::new(),
+            mem_born: Vec::new(),
+        };
+        match &ins.op {
+            // Spill store: binds the slot to the source's value; not part of
+            // the ideal trace (the value is already in a register here).
+            ArmOp::Str { rd, addr } if sp_slot(addr).is_some() => {
+                actual_spill_stores += 1;
+                match current.get(rd).copied() {
+                    Some(v) if !is_reserved_reg(*rd) => {
+                        slot_value.insert(sp_slot(addr).unwrap(), v);
+                    }
+                    _ => {
+                        slot_value.remove(&sp_slot(addr).unwrap());
+                    }
+                }
+            }
+            // Spill reload: re-binds the register to the slot's value. A known
+            // slot value vanishes from the ideal trace; an unknown one is a
+            // genuine memory-resident value entering registers.
+            ArmOp::Ldr { rd, addr } if sp_slot(addr).is_some() => {
+                actual_reloads += 1;
+                let slot = sp_slot(addr).unwrap();
+                if is_reserved_reg(*rd) {
+                    current.remove(rd);
+                } else {
+                    match slot_value.get(&slot).copied() {
+                        Some(v) => {
+                            current.insert(*rd, v);
+                        }
+                        None => {
+                            let v = new_value(true, &mut mem_origin);
+                            required_at.push(Vec::new());
+                            slot_value.insert(slot, v);
+                            current.insert(*rd, v);
+                            t.mem_born.push(v);
+                        }
+                    }
+                }
+            }
+            op => {
+                // Any other [sp] access invalidates the slot map (unpinnable),
+                // but still has its ordinary register effect.
+                let sp_touch = match op {
+                    ArmOp::Ldr { addr, .. }
+                    | ArmOp::Str { addr, .. }
+                    | ArmOp::Ldrb { addr, .. }
+                    | ArmOp::Ldrsb { addr, .. }
+                    | ArmOp::Ldrh { addr, .. }
+                    | ArmOp::Ldrsh { addr, .. }
+                    | ArmOp::Strb { addr, .. }
+                    | ArmOp::Strh { addr, .. } => addr.base == Reg::SP,
+                    ArmOp::Push { .. } | ArmOp::Pop { .. } => true,
+                    _ => false,
+                };
+                if sp_touch {
+                    slot_value.clear();
+                }
+                let eff = reg_effect(op)?;
+                for u in &eff.uses {
+                    if is_reserved_reg(*u) {
+                        continue;
+                    }
+                    let v = match current.get(u).copied() {
+                        Some(v) => v,
+                        None => {
+                            // Segment input: arrives register-resident.
+                            let v = new_value(false, &mut mem_origin);
+                            required_at.push(Vec::new());
+                            current.insert(*u, v);
+                            v
+                        }
+                    };
+                    t.required.push(v);
+                    required_at[v].push(p);
+                }
+                if eff.defs.contains(&Reg::SP) {
+                    slot_value.clear();
+                }
+                for d in &eff.defs {
+                    if is_reserved_reg(*d) {
+                        current.remove(d);
+                        continue;
+                    }
+                    let v = new_value(false, &mut mem_origin);
+                    required_at.push(Vec::new());
+                    current.insert(*d, v);
+                    t.born.push(v);
+                }
+            }
+        }
+        touches.push(t);
+    }
+
+    // ── 2. Belady MIN replay with k register slots. ───────────────────────
+    let next_required = |v: usize, p: usize| -> Option<usize> {
+        let reqs = &required_at[v];
+        let idx = reqs.partition_point(|&q| q <= p);
+        reqs.get(idx).copied()
+    };
+    let mut resident: BTreeSet<usize> = BTreeSet::new();
+    let mut stored: BTreeSet<usize> = BTreeSet::new(); // has a memory copy
+    let mut belady_reloads = 0usize;
+    let mut belady_spill_stores = 0usize;
+
+    for (p, t) in touches.iter().enumerate() {
+        let make_room = |resident: &mut BTreeSet<usize>,
+                         stored: &mut BTreeSet<usize>,
+                         protect: &BTreeSet<usize>,
+                         stores: &mut usize| {
+            while resident.len() >= k {
+                // Farthest next requirement; a value never needed again (None)
+                // is the ideal victim and costs nothing.
+                let victim = resident
+                    .iter()
+                    .filter(|v| !protect.contains(v))
+                    .max_by_key(|&&v| next_required(v, p).unwrap_or(usize::MAX))
+                    .copied();
+                let Some(v) = victim else { break }; // over-wide instruction
+                if next_required(v, p).is_some() && !stored.contains(&v) {
+                    *stores += 1;
+                    stored.insert(v);
+                }
+                resident.remove(&v);
+            }
+        };
+        // Reads: every required value must be resident (protect all reads).
+        let protect: BTreeSet<usize> = t.required.iter().copied().collect();
+        for &v in &t.required {
+            if resident.contains(&v) {
+                continue;
+            }
+            // First touch of an input value is free (it arrives in a register);
+            // re-touching an evicted (memory-backed) value is a reload.
+            if stored.contains(&v) || mem_origin[v] {
+                belady_reloads += 1;
+            }
+            make_room(
+                &mut resident,
+                &mut stored,
+                &protect,
+                &mut belady_spill_stores,
+            );
+            resident.insert(v);
+        }
+        // Writes: reads are done (operands consumed before the write), so only
+        // the values born at this instruction are protected.
+        let born_protect: BTreeSet<usize> =
+            t.born.iter().chain(t.mem_born.iter()).copied().collect();
+        for &v in &t.born {
+            make_room(
+                &mut resident,
+                &mut stored,
+                &born_protect,
+                &mut belady_spill_stores,
+            );
+            resident.insert(v);
+        }
+        for &v in &t.mem_born {
+            belady_reloads += 1; // unavoidable: the slot was written elsewhere
+            make_room(
+                &mut resident,
+                &mut stored,
+                &born_protect,
+                &mut belady_spill_stores,
+            );
+            resident.insert(v);
+            stored.insert(v); // its memory copy exists by construction
+        }
+    }
+
+    Some(SegmentSpillChoice {
+        start,
+        len: seg.len(),
+        peak_pressure: straight_line_peak_pressure(seg)?,
+        actual_reloads,
+        actual_spill_stores,
+        belady_reloads,
+        belady_spill_stores,
+    })
+}
+
 /// Per-register def+use occurrence counts over an instruction stream — the
 /// numerator of Chaitin's spill cost (each spill inserts a store per def and a
 /// reload per use, so spill cost scales with occurrences). Unmodeled ops are
@@ -9154,6 +9701,332 @@ mod tests {
              (criterion: <5% of {} segments; current truth and the pinned \
              value: 0)",
             total.segments
+        );
+    }
+
+    // ---- VCR-RA-001 spill re-choice spike (#242) ----------------------------
+
+    fn sp_str(rd: Reg, off: i32) -> ArmInstruction {
+        ins(ArmOp::Str {
+            rd,
+            addr: crate::rules::MemAddr {
+                base: Reg::SP,
+                offset: off,
+                offset_reg: None,
+            },
+        })
+    }
+    fn sp_ldr(rd: Reg, off: i32) -> ArmInstruction {
+        ins(ArmOp::Ldr {
+            rd,
+            addr: crate::rules::MemAddr {
+                base: Reg::SP,
+                offset: off,
+                offset_reg: None,
+            },
+        })
+    }
+    fn movw(rd: Reg, imm16: u16) -> ArmInstruction {
+        ins(ArmOp::Movw { rd, imm16 })
+    }
+    fn add3(rd: Reg, rn: Reg, rm: Reg) -> ArmInstruction {
+        ins(ArmOp::Add {
+            rd,
+            rn,
+            op2: Operand2::Reg(rm),
+        })
+    }
+    fn mov_rr(rd: Reg, rm: Reg) -> ArmInstruction {
+        ins(ArmOp::Mov {
+            rd,
+            op2: Operand2::Reg(rm),
+        })
+    }
+
+    /// The target case forward_stack_reloads misses: the spill store's SOURCE
+    /// is clobbered (genuine pressure spill), but reload #2 can forward from
+    /// reload #1.
+    #[test]
+    fn spill_realloc_forwards_reload_to_reload_242() {
+        let seq = vec![
+            sp_str(Reg::R0, 8), // spill A
+            movw(Reg::R0, 7),   // A's register clobbered → store-source dead
+            sp_ldr(Reg::R1, 8), // reload #1 (stays: no holder survives)
+            add3(Reg::R2, Reg::R1, Reg::R0),
+            sp_ldr(Reg::R3, 8), // reload #2 → mov r3, r1
+            add3(Reg::R4, Reg::R3, Reg::R2),
+        ];
+        let (out, n) = apply_spill_realloc(&seq);
+        assert_eq!(n, 1, "exactly the second reload forwards");
+        assert_eq!(out.len(), seq.len(), "1-for-1 replacement, no growth");
+        assert_eq!(out[2].op, seq[2].op, "reload #1 must remain a load");
+        assert_eq!(
+            out[4].op,
+            ArmOp::Mov {
+                rd: Reg::R3,
+                op2: Operand2::Reg(Reg::R1)
+            },
+            "reload #2 forwards from reload #1's register"
+        );
+    }
+
+    /// A reload into a register that already holds the slot's value is deleted.
+    #[test]
+    fn spill_realloc_deletes_redundant_same_reg_reload_242() {
+        let seq = vec![
+            sp_str(Reg::R0, 4),
+            movw(Reg::R0, 1), // clobber the store source
+            sp_ldr(Reg::R1, 4),
+            ins(ArmOp::Cmp {
+                rn: Reg::R1,
+                op2: Operand2::Imm(0),
+            }),
+            sp_ldr(Reg::R1, 4), // r1 still holds slot #4's value → delete
+            add3(Reg::R2, Reg::R1, Reg::R0),
+        ];
+        let (out, n) = apply_spill_realloc(&seq);
+        assert_eq!(n, 1);
+        assert_eq!(out.len(), seq.len() - 1, "the redundant reload is deleted");
+        assert!(
+            !out.iter()
+                .skip(3)
+                .any(|i| matches!(&i.op, ArmOp::Ldr { addr, .. } if addr.base == Reg::SP)),
+            "no second frame reload remains"
+        );
+    }
+
+    /// Clobbering the only holder kills forwarding — the reload must stay.
+    #[test]
+    fn spill_realloc_holder_clobber_blocks_forwarding_242() {
+        let seq = vec![
+            sp_str(Reg::R0, 4),
+            movw(Reg::R0, 1),
+            sp_ldr(Reg::R1, 4),
+            movw(Reg::R1, 2), // holder clobbered
+            sp_ldr(Reg::R2, 4),
+        ];
+        let (out, n) = apply_spill_realloc(&seq);
+        assert_eq!(n, 0, "no provable holder at reload #2");
+        assert_eq!(out, seq, "stream unchanged");
+    }
+
+    /// Push/Pop moves SP and touches stack memory — every slot name dies.
+    #[test]
+    fn spill_realloc_push_pop_clears_slot_tracking_242() {
+        let seq = vec![
+            sp_str(Reg::R0, 4),
+            ins(ArmOp::Push {
+                regs: vec![Reg::R4],
+            }),
+            sp_ldr(Reg::R1, 4), // #4 no longer names the same slot
+        ];
+        let (out, n) = apply_spill_realloc(&seq);
+        assert_eq!(n, 0);
+        assert_eq!(out, seq);
+    }
+
+    /// A reg-reg move propagates value identity: the copy becomes a holder.
+    #[test]
+    fn spill_realloc_mov_propagates_holder_242() {
+        let seq = vec![
+            sp_str(Reg::R0, 0),
+            mov_rr(Reg::R3, Reg::R0), // r3 := A (copy)
+            movw(Reg::R0, 9),         // original holder clobbered
+            sp_ldr(Reg::R1, 0),       // → mov r1, r3
+        ];
+        let (out, n) = apply_spill_realloc(&seq);
+        assert_eq!(n, 1);
+        assert_eq!(
+            out[3].op,
+            ArmOp::Mov {
+                rd: Reg::R1,
+                op2: Operand2::Reg(Reg::R3)
+            }
+        );
+    }
+
+    /// A slot overwrite retargets forwarding to the NEW value's holder.
+    #[test]
+    fn spill_realloc_slot_overwrite_retargets_242() {
+        let seq = vec![
+            sp_str(Reg::R0, 4),
+            movw(Reg::R0, 1),
+            sp_str(Reg::R5, 4), // slot now holds r5's value
+            sp_ldr(Reg::R2, 4), // → mov r2, r5 (NOT r0)
+        ];
+        let (out, n) = apply_spill_realloc(&seq);
+        assert_eq!(n, 1);
+        assert_eq!(
+            out[3].op,
+            ArmOp::Mov {
+                rd: Reg::R2,
+                op2: Operand2::Reg(Reg::R5)
+            }
+        );
+    }
+
+    /// Pressure gate (c): the forwarding `mov` extends the holder's live range;
+    /// if that pushes the segment's peak value pressure past the pool AND past
+    /// the pre-transform peak, the whole segment is declined. Identical stream
+    /// minus the extra long-lived value commits (post ≤ pool headroom rule).
+    #[test]
+    fn spill_realloc_pressure_gate_declines_when_saturated_242() {
+        // Common skeleton: A := r1 (from a load); spill A; A's last real use;
+        // 8 long-lived values fill r0,r2..r8; then a reload of A that forwards
+        // from r1, extending A across the fat window.
+        let build = |with_extra: bool| {
+            let mut s = vec![
+                ins(ArmOp::Ldr {
+                    rd: Reg::R1,
+                    addr: crate::rules::MemAddr {
+                        base: Reg::R11,
+                        offset: 0,
+                        offset_reg: None,
+                    },
+                }),
+                sp_str(Reg::R1, 0), // holders = {r1}
+                ins(ArmOp::Cmp {
+                    rn: Reg::R1,
+                    op2: Operand2::Imm(0),
+                }), // A's last pre-transform use
+            ];
+            if with_extra {
+                // Two more values live across the window (homed OUTSIDE the
+                // pool, in R9/R10 — value pressure counts every register, so
+                // these saturate the window without freeing a pool reg).
+                s.push(movw(Reg::R9, 98));
+                s.push(movw(Reg::R10, 99));
+            }
+            for (k, rd) in [Reg::R3, Reg::R4, Reg::R5, Reg::R6, Reg::R7, Reg::R8]
+                .iter()
+                .enumerate()
+            {
+                s.push(movw(*rd, k as u16));
+            }
+            s.push(movw(Reg::R0, 40)); // v0, last use just before the reload
+            s.push(ins(ArmOp::Cmp {
+                rn: Reg::R0,
+                op2: Operand2::Imm(0),
+            }));
+            s.push(sp_ldr(Reg::R0, 0)); // reload A → mov r0, r1 (candidate)
+            // Keep SP's value live past the reload (real segments always have
+            // later frame traffic), so the forwarding genuinely ADDS pressure.
+            s.push(sp_str(Reg::R4, 20));
+            let mut used = vec![
+                Reg::R0,
+                Reg::R3,
+                Reg::R4,
+                Reg::R5,
+                Reg::R6,
+                Reg::R7,
+                Reg::R8,
+            ];
+            if with_extra {
+                used.push(Reg::R9);
+                used.push(Reg::R10);
+            }
+            s.push(ins(ArmOp::Push { regs: used }));
+            s
+        };
+
+        // Without the extra value: post-transform peak fits the pool → commit.
+        let lean = build(false);
+        let (out, n) = apply_spill_realloc(&lean);
+        assert_eq!(
+            n, 1,
+            "lean segment: forwarding commits within pool headroom"
+        );
+        assert!(
+            out.iter().any(|i| i.op
+                == ArmOp::Mov {
+                    rd: Reg::R0,
+                    op2: Operand2::Reg(Reg::R1)
+                }),
+            "the reload became a mov"
+        );
+
+        // With them: post > pre AND post > pool → the segment is declined whole.
+        let fat = build(true);
+        let pre = straight_line_peak_pressure(&fat).unwrap();
+        let (out, n) = apply_spill_realloc(&fat);
+        assert_eq!(
+            n, 0,
+            "saturated segment (pre-peak {pre}) must be declined by the pressure gate"
+        );
+        assert_eq!(out, fat, "declined segment keeps its original bytes");
+    }
+
+    /// Belady report: the double-reload trace needs ZERO frame traffic with the
+    /// full pool — the emitted 1 store + 2 reloads are all recoverable headroom.
+    #[test]
+    fn spill_report_belady_beats_greedy_on_double_reload_242() {
+        let seq = vec![
+            movw(Reg::R0, 5), // A
+            sp_str(Reg::R0, 8),
+            movw(Reg::R0, 7), // B clobbers A's register
+            sp_ldr(Reg::R1, 8),
+            add3(Reg::R2, Reg::R1, Reg::R0),
+            sp_ldr(Reg::R3, 8),
+            add3(Reg::R4, Reg::R3, Reg::R2),
+        ];
+        let report = spill_choice_report(&seq, 9);
+        assert_eq!(report.len(), 1);
+        let s = &report[0];
+        assert_eq!((s.actual_reloads, s.actual_spill_stores), (2, 1));
+        assert_eq!(
+            (s.belady_reloads, s.belady_spill_stores),
+            (0, 0),
+            "≤9 concurrent values → the ideal allocation needs no frame traffic"
+        );
+        assert!(s.peak_pressure <= 9);
+    }
+
+    /// Belady mechanics under an artificially tiny pool (k=2): one eviction
+    /// (store) of the farthest-next-use value and one reload when it returns.
+    #[test]
+    fn spill_report_belady_counts_eviction_and_reload_k2_242() {
+        let seq = vec![
+            movw(Reg::R0, 1),                // A
+            movw(Reg::R1, 2),                // B
+            add3(Reg::R2, Reg::R0, Reg::R1), // C := A+B; k=2 → evict B (farther)
+            ins(ArmOp::Cmp {
+                rn: Reg::R0,
+                op2: Operand2::Imm(0),
+            }), // use A (near)
+            ins(ArmOp::Cmp {
+                rn: Reg::R1,
+                op2: Operand2::Imm(0),
+            }), // use B (far) → reload
+        ];
+        let report = spill_choice_report(&seq, 2);
+        assert_eq!(report.len(), 1);
+        let s = &report[0];
+        assert_eq!((s.actual_reloads, s.actual_spill_stores), (0, 0));
+        assert_eq!(
+            (s.belady_reloads, s.belady_spill_stores),
+            (1, 1),
+            "farthest-first evicts B once (1 store) and reloads it once"
+        );
+    }
+
+    /// A reload from a slot written OUTSIDE the segment is unavoidable: it is
+    /// charged to Belady too (no phantom headroom).
+    #[test]
+    fn spill_report_unknown_slot_reload_charged_to_belady_242() {
+        let seq = vec![
+            sp_ldr(Reg::R0, 12), // slot written before the segment
+            ins(ArmOp::Cmp {
+                rn: Reg::R0,
+                op2: Operand2::Imm(0),
+            }),
+        ];
+        let report = spill_choice_report(&seq, 9);
+        assert_eq!(report.len(), 1);
+        let s = &report[0];
+        assert_eq!(s.actual_reloads, 1);
+        assert_eq!(
+            s.belady_reloads, 1,
+            "an out-of-segment slot value must be loaded in the ideal world too"
         );
     }
 }


### PR DESCRIPTION
## Motivation (const-CSE PR2 finding, #562)

flat_flight's hot segment runs **peak register pressure 11 > the R0–R8 pool of 9**, so every pressure-guarded optimization (const-CSE PR2, the extending-alias hoist) correctly declines there, and the greedy lowering's spill placement is naive — gale measured **17 spills + 61% redundant const materializations** on silicon (G474RE, #209). The only lever that wins on a genuinely saturated segment is smarter spill placement: evict the value with the **farthest next use** (Belady). This PR is the bounded, flag-off first step of **VCR-RA-001**, shipped as a post-hoc rewrite pass like `apply_const_cse` — not a new allocator.

## What shipped (scope level 2, stated honestly)

Full greedy-spill-choice **replacement** did not fit the no-grow gate in one PR (the swap rewrite fundamentally adds a save `mov` + a counter-reload, +2 instructions). Per the scope contract, this ships the honest smaller increment:

1. **REPORT-ONLY Belady analysis** — `liveness::spill_choice_report(instrs, k)` (wired behind `SYNTH_SPILL_REPORT=1`, measure-only like `SYNTH_SHADOW_ALLOC`). Per straight-line segment it dissolves the emitted frame traffic back into an abstract value trace (`str`/`ldr [sp,#N]` bind slot↔value, so reload consumers are uses of the original value; unknown-slot reloads stay charged to Belady too) and replays it with farthest-next-use eviction over a k-register pool. The greedy−Belady delta is the measured recovery headroom for the full spill-choice rewrite.
2. **The simplest strictly-profitable rewrite** — `liveness::apply_spill_realloc` behind `SYNTH_SPILL_REALLOC=1`: **slot-value forwarding between reloads**. This is exactly the case default-on `forward_stack_reloads` misses: it forwards only from the spill store's SOURCE register, so when pressure clobbers that source (the genuine-spill case), its reloads survive — but reload #2..#n provably still have the value register-resident in reload #1's target (tracked through reg-reg copies, killed on any redefinition, slot overwrite, unpinnable `[sp]` access, `Push`/`Pop`, SP def). Each such `ldr` becomes a 1-cycle `mov` (1-for-1) or is **deleted** when the target already holds the value. Per-segment commit gates: (a) semantics identical by construction, (b) instruction count never grows (asserted), (c) post-transform peak value pressure ≤ pool or ≤ pre-transform peak — never turns a fitting segment into a spilling one, never worsens a saturated one.

## Measured (debug build, 2026-07-02, optimized path)

| fixture | function | flag-off | flag-on | reloads |
|---|---|---|---|---|
| flight_seam.wat | `flight_algo` | 306 B | **300 B** | 6 ld → **3 ld** (3 forwarded) |
| flight_seam.wat | `controller_step` / `filter_step` | 250/180 B | 250/180 B (no growth) | 0 forwarded |
| flat_flight.loom.wasm | `flat_flight` | 412 B | 412 B (**honestly unchanged**) | 0 forwarded |

`[spill-report]` on flat_flight's hot segment: `len=106 peak=11 actual=3ld+3st belady(k=9)=0ld+0st` — **all** of its surviving frame traffic is recoverable by a value-based allocation, but none of it by forwarding (the holders are all clobbered — the greedy allocator reuses them). Recovering those needs the actual spill RE-CHOICE step; that is the next VCR-RA-001 increment, and this report is its now-CI-locked baseline (`spill_realloc_242.rs` claim 4).

## Gates (all foreground, exit-code-checked)

- `cargo build -p synth-cli` ✅
- **Flag-OFF byte-identical**: `frozen_codegen_bytes` 3/3 ✅; `const_cse_reduction_242` golden (incl. the pinned flag-off `.text` FNV) unchanged ✅ — the pass is opt-in env-gated, off ⇒ zero byte change.
- **Flag-ON differentials** (`SYNTH_SPILL_REALLOC=1` exported): `scripts/repro/const_cse_differential.py` PASS ✅; `scripts/repro/frame_slot_dce_differential.py` PASS ✅ (flight_algo result anchor 0x07FDF307 preserved, results == wasmtime). Note: `flight_seam_differential.py` is broken on main independently of this PR (it looks up `func_0`/`func_1`, which #394's real-name DWARF change renamed — pre-existing, verified failing flag-off too).
- `cargo test -p synth-synthesis` 488+ ✅ (10 new unit tests: forwarding, deletion, holder-clobber/push-pop/slot-overwrite blocking, mov propagation, non-vacuous pressure-gate decline, Belady mechanics at k=2 and k=9, unknown-slot honesty)
- `cargo test -p synth-cli` all 17 binaries ✅ (new `spill_realloc_242.rs`: no-grow corpus gate + non-vacuous firing floor + flat_flight equality + headroom report oracle)
- `cargo fmt --check` ✅, `cargo clippy -p synth-synthesis -p synth-cli --all-targets -- -D warnings` ✅

Refs #242 (VCR-RA-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)