### PR TITLE
chore(release): v0.22.1 — DWARF CU high_pc containment regression fix (#564)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-07-02
+
+**DWARF containment regression fix (#564).**
+
+### Fixed
+
+- **CU `DW_AT_high_pc` covers child subprogram code extents (#564).** Since the
+  #557 subprogram DIEs (v0.19.0), the compile unit's `high_pc` was the
+  `.debug_line` extent, which can be smaller than the code extent — so the last
+  function's DIE fell outside its parent's range, `llvm-dwarfdump --verify`
+  failed post-link, and PC-range CU walks could miss that function. The CU
+  `high_pc` is now the max subprogram end (line-table extent as fallback).
+  Verified with real `llvm-dwarfdump --verify` ("No errors") on the issue's
+  linked repro, and CI-gated by a new gimli containment oracle (CU range ⊇
+  every subprogram range). `.debug_line` and `.text` bytes unchanged.
+
 ## [0.22.0] - 2026-07-02
 
 **Two flag-off VCR levers (RV32 cmp→select; liveness-based spill re-choice) +

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,14 +2024,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2089,11 +2089,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.22.0"
+version = "0.22.1"
 
 [[package]]
 name = "synth-cli"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2148,14 +2148,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2163,11 +2163,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.22.0"
+version = "0.22.1"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.22.0"
+version = "0.22.1"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.22.0"
+version = "0.22.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.22.0",
+    version = "0.22.1",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.22.0" }
+synth-core = { path = "../synth-core", version = "0.22.1" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.22.0" }
+synth-core = { path = "../synth-core", version = "0.22.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.22.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.22.0" }
+synth-core = { path = "../synth-core", version = "0.22.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.22.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.22.0" }
+synth-core = { path = "../synth-core", version = "0.22.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.22.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.22.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.22.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.22.1", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,21 +27,21 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.22.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.22.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.22.0" }
-synth-backend = { path = "../synth-backend", version = "0.22.0" }
+synth-core = { path = "../synth-core", version = "0.22.1" }
+synth-frontend = { path = "../synth-frontend", version = "0.22.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.22.1" }
+synth-backend = { path = "../synth-backend", version = "0.22.1" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.22.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.22.1" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.22.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.22.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.22.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.22.1", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.22.1", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.22.1", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.22.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.22.1", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.22.0" }
+synth-core = { path = "../synth-core", version = "0.22.1" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.22.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.22.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.22.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.22.0" }
-synth-opt = { path = "../synth-opt", version = "0.22.0" }
+synth-core = { path = "../synth-core", version = "0.22.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.22.1" }
+synth-opt = { path = "../synth-opt", version = "0.22.1" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -17,12 +17,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.22.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.22.0" }
-synth-opt = { path = "../synth-opt", version = "0.22.0" }
+synth-core = { path = "../synth-core", version = "0.22.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.22.1" }
+synth-opt = { path = "../synth-opt", version = "0.22.1" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.22.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.22.1", optional = true }
 
 # SMT solver for formal verification
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }


### PR DESCRIPTION
Patch release, cut immediately per the release-early policy — #573 fixes a regression in **released** DWARF output (v0.19.0+):

### Fixed
- CU `DW_AT_high_pc` now covers child subprogram code extents (#564) — `llvm-dwarfdump --verify` clean post-link; new CI-gated gimli containment oracle (CU range ⊇ every subprogram range). `.debug_line`/`.text` bytes unchanged.

Pin sweep + lock + CHANGELOG; frozen anchors unaffected. Tag `v0.22.1` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)