### PR TITLE
fix(repro): flight_seam_differential resolves symbols from symtab, not func_N (#570)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,6 +461,49 @@ jobs:
           SYNTH: ./target/debug/synth
         run: python scripts/repro/r12_spill_496_differential.py
 
+  flight-seam-570-oracle:
+    name: flight-seam relocatable-path execution oracle
+    # VCR-ORACLE-001 (#242, #212/#215, #570): EXECUTE the two flight_seam silicon
+    # fixtures (inlined w/ internal `bl filter_step`, and flat fully-dissolved)
+    # compiled via the SHIPPED direct path (--relocatable) under unicorn
+    # (UC_ARCH_ARM / Thumb) and diff flight_algo's result vs wasmtime (anchor
+    # 0x07FDF307). Guards the #212 R12-scratch reservation and #215 exposure on
+    # the relocatable path. Previously a dev-only script: it drifted silently
+    # when the #394 name work changed symbol naming (#570) — CI-gating it here
+    # so harness drift reddens instead of rotting. Symbols come from the ELF
+    # symtab, not `synth disasm` text (host-dependent, PR #489). Isolated job:
+    # emulation deps pip-installed here ONLY.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools capstone
+      - name: Run flight-seam oracle (inlined #212 + flat #215)
+        run: |
+          ./target/debug/synth compile scripts/repro/flight_seam.wasm \
+            -o /tmp/fs.elf --target cortex-m4 --all-exports --relocatable
+          python scripts/repro/flight_seam_differential.py /tmp/fs.elf
+          ./target/debug/synth compile scripts/repro/flight_seam_flat.wasm \
+            -o /tmp/fsf.elf --target cortex-m4 --all-exports --relocatable
+          python scripts/repro/flight_seam_differential.py /tmp/fsf.elf \
+            scripts/repro/flight_seam_flat.wasm
+
   stack-args-503-oracle:
     name: AAPCS stack-argument path oracle
     # VCR-ORACLE-001 (#242, #503): EXECUTE functions that need the AAPCS

--- a/scripts/repro/flight_seam_differential.py
+++ b/scripts/repro/flight_seam_differential.py
@@ -15,16 +15,20 @@ divided fields (st[0], st[4]) used that pattern under enough pressure to reach
 R12, so aileron/elevator saturated to 127 while rudder/updates read correctly.
 Fix: reserve R12 as scratch (remove it from ALLOCATABLE_REGS).
 
-Run:
+Symbols are resolved from the ELF symtab (SHT_SYMTAB, located by section type —
+synth's relocatable objects leave the section name empty), matching the export
+name first with a positional `func_N` fallback for older objects. `synth disasm`
+text is NOT parsed: it is host-dependent (PR #489) and its naming changed with
+the #394 name work (#570 — this script used to hardcode `func_0`/`func_1`).
+
+Run (deps: wasmtime unicorn pyelftools capstone):
   synth compile scripts/repro/flight_seam.wasm -o /tmp/fs.elf \
         --target cortex-m4 --all-exports --relocatable
-  /tmp/armv/bin/python scripts/repro/flight_seam_differential.py /tmp/fs.elf
+  python scripts/repro/flight_seam_differential.py /tmp/fs.elf
 
 Exits nonzero on mismatch so it can gate a release.
 """
-import re
 import struct
-import subprocess
 import sys
 
 import wasmtime
@@ -45,9 +49,32 @@ from unicorn.arm_const import (
 # `flight_algo` contains a `bl` and only hooks filter_step when it does.
 ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/fs.elf"
 WASM = sys.argv[2] if len(sys.argv) > 2 else "scripts/repro/flight_seam.wasm"
-SYNTH = "./target/debug/synth"
 
 ST_OFF, S_OFF = 0x1000, 0x2000
+
+
+def elf_func_symbols(path):
+    """(func symbols, .text bytes, .text base) read from the ELF itself.
+
+    The symtab is found by section TYPE — synth's ET_REL objects emit it with
+    an empty section name, so get_section_by_name('.symtab') returns None.
+    st_value carries the Thumb bit on STT_FUNC symbols; clear it so the
+    addresses index .text directly.
+    """
+    with open(path, "rb") as fh:
+        elf = ELFFile(fh)
+        symtab = next(
+            (s for s in elf.iter_sections() if s["sh_type"] == "SHT_SYMTAB"), None
+        )
+        if symtab is None:
+            sys.exit(f"no SHT_SYMTAB section in {path}")
+        syms = {
+            s.name: s["st_value"] & ~1
+            for s in symtab.iter_symbols()
+            if s.name and s["st_info"]["type"] == "STT_FUNC"
+        }
+        text = elf.get_section_by_name(".text")
+        return syms, text.data(), text["sh_addr"]
 
 
 def st_init():
@@ -78,16 +105,24 @@ def main():
     gt = inst.exports(store)["flight_algo"](store, ST_OFF, S_OFF) & 0xFFFFFFFF
 
     # synth ARM under unicorn (full flight_algo incl. internal bl filter_step)
-    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
-    syms = {m.group(2): int(m.group(1), 16)
-            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
-    text = ELFFile(open(ELF, "rb")).get_section_by_name(".text")
-    code, base = text.data(), text["sh_addr"]
-    fa, fs = syms["func_0"], syms["func_1"]
+    syms, code, base = elf_func_symbols(ELF)
+
+    def resolve(name, idx):
+        # Export/name-section name first (post-#394); positional func_N alias
+        # as a fallback for older objects (#570 — never hardcode func_N).
+        for cand in (name, f"func_{idx}"):
+            if cand in syms:
+                return syms[cand]
+        sys.exit(f"SYMBOL MISSING: {name} (or func_{idx}); symtab has {sorted(syms)}")
+
+    fa = resolve("flight_algo", 0)
+    fs = resolve("filter_step", 1)
+    fa_end = min((a for a in syms.values() if a > fa), default=base + len(code))
     md = Cs(CS_ARCH_ARM, CS_MODE_THUMB)
     # Inlined (#212) variant has an internal `bl filter_step`; the flat (#215)
     # fully-dissolved variant has none. Hook the BL only when present.
-    bl_addr = next((i.address for i in md.disasm(bytes(code[fa:syms["func_1"]]), fa)
+    bl_addr = next((i.address for i in
+                    md.disasm(bytes(code[fa - base:fa_end - base]), fa)
                     if i.mnemonic == "bl"), None)
 
     CODE, LIN, STK = 0x10000, 0x40000, 0x90000


### PR DESCRIPTION
## What

`scripts/repro/flight_seam_differential.py` parsed `synth disasm` text and hardcoded `func_0`/`func_1` — harness drift since the #394 name work (functions now carry export/name-section names in the paths the script reads), and host-dependent besides (the PR #489 lesson). Emitted code was never affected; the CI-gated differentials on the same fixtures pass.

## Fix

- Symbols now come from the ELF **SHT_SYMTAB** via pyelftools, located by section **type** (synth's ET_REL objects emit the symtab with an empty section name, so `get_section_by_name('.symtab')` returns `None`).
- Thumb bit cleared from `st_value` so addresses index `.text` directly.
- Resolution priority: export name (`flight_algo`, `filter_step`) first, positional `func_N` alias as fallback for older objects — never hardcoded.
- The `bl`-scan window for the inlined-variant hook is derived from the next symbol address (falls back to end of `.text` for the flat variant).
- The `synth disasm` subprocess and its `./target/debug/synth` dependency are gone entirely. Vectors and semantics unchanged.

## Before (main)

```
  File "flight_seam_differential.py", line 86, in main
    fa, fs = syms["func_0"], syms["func_1"]
             ~~~~^^^^^^^^^^
KeyError: 'func_0'
```

## After (both fixture variants, fresh compile via `--target cortex-m4 --all-exports --relocatable`)

```
=== inlined (#212) variant ===          === flat (#215) variant ===
wasmtime (ground truth): 0x07FDF307     wasmtime (ground truth): 0x07FDF307
synth ARM             : 0x07FDF307     synth ARM             : 0x07FDF307
MATCH  (exit 0)                         MATCH  (exit 0)
```

The `flight_algo` anchor **0x07FDF307** matches wasmtime on both variants.

## CI gate

Issue #570's second point (dev script → drifted silently): added `flight-seam-570-oracle` to `ci.yml`, mirroring the existing execution-oracle jobs (`r12-spill-496-oracle` et al.) — builds `synth-cli`, compiles both flight_seam fixtures via the shipped `--relocatable` direct path, and runs the differential on each. No untrusted event inputs in the job.

No Rust code changed ⇒ frozen byte anchors trivially unaffected.

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)