### PR TITLE
fix(selector): value-carrying br/br_if/br_table land the result in the block's designated register (#509)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -80,12 +80,20 @@ impl Backend for ArmBackend {
             // 64-bit param on the AAPCS stack-argument path. Cheap clone only when
             // a signature table is present and this function has a width entry —
             // otherwise reuse the shared config (every existing module unchanged).
-            let func_config = match config.func_params_i64.get(func.index as usize) {
-                Some(p) if !p.is_empty() => Some(CompileConfig {
-                    current_func_params_i64: p.clone(),
+            // #509: same per-function pattern for the blocktype-arity side-table
+            // (value-carrying-branch lowering).
+            let params = config
+                .func_params_i64
+                .get(func.index as usize)
+                .filter(|p| !p.is_empty());
+            let func_config = if params.is_some() || !func.block_arity.is_empty() {
+                Some(CompileConfig {
+                    current_func_params_i64: params.cloned().unwrap_or_default(),
+                    current_func_block_arity: func.block_arity.clone(),
                     ..config.clone()
-                }),
-                _ => None,
+                })
+            } else {
+                None
             };
             let cfg = func_config.as_ref().unwrap_or(config);
             let compiled = self.compile_function(&name, &func.ops, cfg)?;
@@ -175,6 +183,68 @@ fn rewrite_memory_grow_zero(wasm_ops: &[WasmOp]) -> Vec<WasmOp> {
     out
 }
 
+/// #509: does the op stream contain a `br`/`br_if`/`br_table` that CARRIES a
+/// value — i.e. one targeting a result-typed block/if (forward edge with
+/// results > 0) or a parameterized loop header (backward edge with loop
+/// params > 0)?
+///
+/// The optimized path's wasm→IR lowering drops the carried value on such
+/// edges (the taken arm returns the fall-through result — same class as the
+/// #507 `br_table` drop, observed on `pick_br`/`pick_br_fall`), so — like
+/// #507 — the shape is detected on the raw op stream and routed to the direct
+/// selector, whose #509 designated-result-register lowering lands the value
+/// correctly. `block_arity` is the decoder's ordinal blocktype-arity
+/// side-table; when it is empty (hand-built op streams) every block reads as
+/// void and this never fires, keeping the optimized path byte-identical for
+/// every existing caller. Frozen-safe for the same reason as #507: the frozen
+/// fixtures compile `--relocatable` (already direct), and no optimized-path
+/// fixture branches to a result-typed block.
+fn has_value_carrying_branch(wasm_ops: &[WasmOp], block_arity: &[(u8, u8)]) -> bool {
+    // Open control constructs: (is_loop, params, results), innermost last.
+    let mut open: Vec<(bool, u8, u8)> = Vec::new();
+    let mut ctrl_ord = 0usize;
+    // A branch edge carries a value when its target is a result-typed forward
+    // join (block/if) or a parameterized loop header.
+    let carries = |open: &[(bool, u8, u8)], depth: u32| -> bool {
+        let Some(&(is_loop, params, results)) = open
+            .len()
+            .checked_sub(1 + depth as usize)
+            .and_then(|i| open.get(i))
+        else {
+            return false; // function-level target — handled by Return lowering
+        };
+        if is_loop { params > 0 } else { results > 0 }
+    };
+    for op in wasm_ops {
+        match op {
+            WasmOp::Block | WasmOp::If => {
+                let (p, r) = block_arity.get(ctrl_ord).copied().unwrap_or((0, 0));
+                ctrl_ord += 1;
+                open.push((false, p, r));
+            }
+            WasmOp::Loop => {
+                let (p, r) = block_arity.get(ctrl_ord).copied().unwrap_or((0, 0));
+                ctrl_ord += 1;
+                open.push((true, p, r));
+            }
+            WasmOp::End => {
+                open.pop(); // None only at the function-level end — harmless
+            }
+            WasmOp::Br(d) | WasmOp::BrIf(d) if carries(&open, *d) => return true,
+            WasmOp::BrTable { targets, default }
+                if targets
+                    .iter()
+                    .chain(std::iter::once(default))
+                    .any(|d| carries(&open, *d)) =>
+            {
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
 /// Core compilation: WASM ops → ARM machine code bytes + relocations
 ///
 /// Returns (code_bytes, relocations) where relocations record BL instructions
@@ -242,6 +312,11 @@ fn compile_wasm_to_arm(
         // #359: declared param widths of THIS function, so the AAPCS stack-arg
         // path can refuse 64-bit params (Ok-or-Err). Empty ⇒ assume i32.
         selector.set_params_i64(config.current_func_params_i64.clone());
+        // #509: blocktype-arity side-table of THIS function, so value-carrying
+        // br/br_if/br_table land the carried value in the target block's
+        // designated result register instead of dropping it. Empty ⇒ legacy
+        // void-block lowering.
+        selector.set_block_arity(config.current_func_block_arity.clone());
         // Stack-pointer promotion is meaningful only under the native-pointer ABI;
         // gating here keeps every non-native compile (all frozen fixtures) on the
         // legacy R9 globals-table path, bit-identical.
@@ -370,7 +445,15 @@ fn compile_wasm_to_arm(
     let has_br_table = wasm_ops
         .iter()
         .any(|op| matches!(op, WasmOp::BrTable { .. }));
-    let arm_instrs = if config.no_optimize || config.relocatable || has_br_table {
+    // #509: the optimized path also drops the value carried by a `br`/`br_if`
+    // to a result-typed block (the taken edge returns the wrong arm's value —
+    // same silent-miscompile class as the #507 br_table drop). Route the shape
+    // to the direct selector, whose designated-result-register lowering (#509)
+    // lands the carried value at the join. Never fires for void-block control
+    // flow (all frozen/optimized fixtures), so those stay byte-identical.
+    let has_value_carry = has_value_carrying_branch(wasm_ops, &config.current_func_block_arity);
+    let arm_instrs = if config.no_optimize || config.relocatable || has_br_table || has_value_carry
+    {
         select_direct()?
     } else {
         let opt_config = if config.loom_compat {

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2207,16 +2207,19 @@ fn compile_all_exports(
         // the declared widths — an unused i64 param still shifts the layout, so
         // op-stream inference cannot reconstruct them. Cheap per-function clone
         // (`compile_function` is a shared trait method with no function index).
-        let func_config = if all_func_params_i64
-            .get(func.index as usize)
-            .is_some_and(|p| !p.is_empty())
-        {
-            CompileConfig {
-                current_func_params_i64: all_func_params_i64[func.index as usize].clone(),
-                ..config.clone()
+        // #509: also thread THIS function's blocktype-arity side-table, so the
+        // direct selector can land a value carried by br/br_if/br_table in the
+        // target block's designated result register (and the optimized path can
+        // detect-and-decline the shape).
+        let func_config = {
+            let mut fc = config.clone();
+            if let Some(p) = all_func_params_i64.get(func.index as usize)
+                && !p.is_empty()
+            {
+                fc.current_func_params_i64 = p.clone();
             }
-        } else {
-            config.clone()
+            fc.current_func_block_arity = func.block_arity.clone();
+            fc
         };
         // #369: the decoder flagged a value-affecting op it cannot lower (e.g.
         // scalar f32/f64, bulk-memory). Lowering would have SILENTLY DROPPED it
@@ -4560,6 +4563,7 @@ mod tests {
             ops,
             op_offsets: Vec::new(),
             unsupported: None,
+            block_arity: Vec::new(),
         }
     }
 

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -155,6 +155,16 @@ pub struct CompileConfig {
     /// driver loop, because `compile_function` is shared across backends and
     /// carries no function index. Empty → assume i32.
     pub current_func_params_i64: Vec<bool>,
+    /// #509: blocktype-arity side-table of the function CURRENTLY being compiled
+    /// — `(param_count, result_count)` of the k-th `Block`/`Loop`/`If` in its op
+    /// stream (ordinal-keyed; see [`FunctionOps::block_arity`]). Set per function
+    /// by the driver loop (like [`current_func_params_i64`]). The direct selector
+    /// uses it to land a value carried by `br`/`br_if`/`br_table` in the target
+    /// block's designated result register instead of dropping it. Empty → every
+    /// block treated as void (the legacy lowering; hand-built op streams).
+    ///
+    /// [`FunctionOps::block_arity`]: crate::wasm_decoder::FunctionOps::block_arity
+    pub current_func_block_arity: Vec<(u8, u8)>,
 
     /// #543 Phase 1 — integrator-marked volatile linear-memory segments (the DMA
     /// transfer window). Each range `[base, base+len)` names a region of the fused
@@ -226,6 +236,9 @@ impl Default for CompileConfig {
             type_ret_i64: Vec::new(),
             func_params_i64: Vec::new(),
             current_func_params_i64: Vec::new(),
+            // #509: empty ⇒ legacy void-block lowering (unit tests / hand-built
+            // op streams); the driver loops fill it per function.
+            current_func_block_arity: Vec::new(),
             // #543 Phase 1: no volatile segments unless the CLI flag names them.
             // Empty ⇒ inert ⇒ emitted bytes unchanged.
             volatile_segments: Vec::new(),

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -141,6 +141,8 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     // #359: declared param widths per type / per function (full index).
     let mut type_params_i64: Vec<Vec<bool>> = Vec::new();
     let mut func_params_i64: Vec<Vec<bool>> = Vec::new();
+    // #509: (param_count, result_count) per type index, for FuncType blocktypes.
+    let mut type_block_arity: Vec<(u8, u8)> = Vec::new();
     let mut elem_func_indices: Vec<u32> = Vec::new();
     // #394 Tier-1.x: function index → developer-facing name from the wasm
     // `name` custom section (function-names subsection). Applied to
@@ -159,6 +161,17 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                 for rec_group in reader {
                     let rec_group = rec_group.context("Failed to parse type")?;
                     for sub_ty in rec_group.types() {
+                        // #509: blocktype arity per type index (saturated u8 —
+                        // >255 params/results is far beyond anything the
+                        // selector supports anyway, and the selector declines
+                        // rather than trusting a saturated count).
+                        type_block_arity.push(match &sub_ty.composite_type.inner {
+                            wasmparser::CompositeInnerType::Func(f) => (
+                                u8::try_from(f.params().len()).unwrap_or(u8::MAX),
+                                u8::try_from(f.results().len()).unwrap_or(u8::MAX),
+                            ),
+                            _ => (u8::MAX, u8::MAX),
+                        });
                         let (count, ret_i64, params_i64) = match &sub_ty.composite_type.inner {
                             wasmparser::CompositeInnerType::Func(func_ty) => (
                                 func_ty.params().len() as u32,
@@ -341,7 +354,8 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                 }
             }
             Payload::CodeSectionEntry(body) => {
-                let (ops, op_offsets, unsupported) = decode_function_body(&body)?;
+                let (ops, op_offsets, block_arity, unsupported) =
+                    decode_function_body(&body, &type_block_arity)?;
                 let actual_index = num_imported_funcs + func_index;
                 let export_name = export_names.get(&actual_index).cloned();
 
@@ -352,6 +366,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                     ops,
                     op_offsets,
                     unsupported,
+                    block_arity,
                 });
                 func_index += 1;
             }
@@ -420,11 +435,31 @@ pub fn decode_wasm_functions(wasm_bytes: &[u8]) -> Result<Vec<FunctionOps>> {
     let mut num_imported_funcs = 0u32;
     let mut export_names: HashMap<u32, String> = HashMap::new();
     let mut name_section_names: HashMap<u32, String> = HashMap::new();
+    // #509: (param_count, result_count) per type index, for FuncType blocktypes.
+    let mut type_block_arity: Vec<(u8, u8)> = Vec::new();
 
     for payload in Parser::new(0).parse_all(wasm_bytes) {
         let payload = payload.context("Failed to parse WASM payload")?;
 
         match payload {
+            Payload::TypeSection(reader) => {
+                // #509: the blocktype-arity side-table needs the type section
+                // for `BlockType::FuncType(i)` lookups (the wasm binary format
+                // places types before code, so the table is complete before any
+                // `CodeSectionEntry` is decoded).
+                for rec_group in reader {
+                    let rec_group = rec_group.context("Failed to parse type")?;
+                    for sub_ty in rec_group.types() {
+                        type_block_arity.push(match &sub_ty.composite_type.inner {
+                            wasmparser::CompositeInnerType::Func(f) => (
+                                u8::try_from(f.params().len()).unwrap_or(u8::MAX),
+                                u8::try_from(f.results().len()).unwrap_or(u8::MAX),
+                            ),
+                            _ => (u8::MAX, u8::MAX),
+                        });
+                    }
+                }
+            }
             Payload::ImportSection(imports) => {
                 // wasmparser 0.221+ compact-imports grouping — flatten groups
                 // to individual imports (see the ImportSection handler above).
@@ -444,7 +479,8 @@ pub fn decode_wasm_functions(wasm_bytes: &[u8]) -> Result<Vec<FunctionOps>> {
                 }
             }
             Payload::CodeSectionEntry(body) => {
-                let (ops, op_offsets, unsupported) = decode_function_body(&body)?;
+                let (ops, op_offsets, block_arity, unsupported) =
+                    decode_function_body(&body, &type_block_arity)?;
                 let actual_index = num_imported_funcs + func_index;
                 let export_name = export_names.get(&actual_index).cloned();
 
@@ -455,6 +491,7 @@ pub fn decode_wasm_functions(wasm_bytes: &[u8]) -> Result<Vec<FunctionOps>> {
                     ops,
                     op_offsets,
                     unsupported,
+                    block_arity,
                 });
                 func_index += 1;
             }
@@ -509,7 +546,43 @@ pub struct FunctionOps {
     /// contract. `None` once every op decoded or was intentionally ignorable
     /// (Nop/Unreachable).
     pub unsupported: Option<String>,
+    /// #509: blocktype arity side-table — `(param_count, result_count)` of the
+    /// k-th `Block`/`Loop`/`If` op in `ops`, in order of appearance.
+    /// ORDINAL-keyed, not op-index-keyed, on purpose: the backend may rewrite
+    /// the op stream before selection (e.g. the #539 `i32.const 0; memory.grow`
+    /// → `memory.size` fold), which shifts op indices but never adds/removes
+    /// control ops, so the ordinal stays aligned. `BlockType::Empty → (0,0)`,
+    /// `ValType → (0,1)`, `FuncType(i) →` counts from the type section
+    /// (saturated to u8; an unresolvable type index records `(u8::MAX,
+    /// u8::MAX)` so the selector declines loudly instead of miscompiling).
+    /// This is what lets the direct selector land a value carried by
+    /// `br`/`br_if`/`br_table` in the target block's designated result
+    /// register instead of dropping it — `WasmOp::Block/Loop/If` stay bare
+    /// unit variants (zero ripple through the backends' match sites), and an
+    /// empty table (hand-built op streams in unit tests) keeps the legacy
+    /// void-block lowering.
+    pub block_arity: Vec<(u8, u8)>,
 }
+
+/// #509: `(param_count, result_count)` of a wasm blocktype, for the
+/// [`FunctionOps::block_arity`] side-table. `type_block_arity` is the type
+/// section's per-type-index counts (needed for the `FuncType` form); a missing
+/// entry saturates to `(u8::MAX, u8::MAX)` so downstream declines loudly.
+fn blocktype_arity(bt: &wasmparser::BlockType, type_block_arity: &[(u8, u8)]) -> (u8, u8) {
+    match bt {
+        wasmparser::BlockType::Empty => (0, 0),
+        wasmparser::BlockType::Type(_) => (0, 1),
+        wasmparser::BlockType::FuncType(i) => type_block_arity
+            .get(*i as usize)
+            .copied()
+            .unwrap_or((u8::MAX, u8::MAX)),
+    }
+}
+
+/// The per-function payload [`decode_function_body`] extracts: `(ops,
+/// op_offsets, block_arity, unsupported)` — see the matching
+/// [`FunctionOps`] fields for each component's contract.
+type DecodedBody = (Vec<WasmOp>, Vec<u32>, Vec<(u8, u8)>, Option<String>);
 
 /// Decode a single function body to WasmOp sequence.
 ///
@@ -518,13 +591,17 @@ pub struct FunctionOps {
 /// not silently miscompiled by dropping the op).
 fn decode_function_body(
     body: &wasmparser::FunctionBody,
-) -> Result<(Vec<WasmOp>, Vec<u32>, Option<String>)> {
+    type_block_arity: &[(u8, u8)],
+) -> Result<DecodedBody> {
     let mut ops = Vec::new();
     // VCR-DBG-001 step 1: parallel to `ops` — the module-relative wasm byte
     // offset of each emitted op (the DWARF-for-wasm address space). Captured via
     // the offset-aware reader; pushed only when an op is pushed, so indices stay
     // aligned with `ops`. Additive metadata, no codegen consumer ⇒ frozen-safe.
     let mut op_offsets = Vec::new();
+    // #509: ordinal blocktype-arity side-table — one entry per Block/Loop/If in
+    // `ops` order (see `FunctionOps::block_arity`).
+    let mut block_arity: Vec<(u8, u8)> = Vec::new();
     let mut unsupported: Option<String> = None;
 
     let ops_reader = body.get_operators_reader()?;
@@ -532,6 +609,14 @@ fn decode_function_body(
         let (op, offset) = item.context("Failed to read operator")?;
 
         if let Some(wasm_op) = convert_operator(&op) {
+            // #509: capture the blocktype arity BEFORE the enum flattens it away
+            // (`WasmOp::Block/Loop/If` are unit variants by design).
+            if let wasmparser::Operator::Block { blockty }
+            | wasmparser::Operator::Loop { blockty }
+            | wasmparser::Operator::If { blockty } = &op
+            {
+                block_arity.push(blocktype_arity(blockty, type_block_arity));
+            }
             ops.push(wasm_op);
             op_offsets.push(offset as u32);
         } else if unsupported.is_none() && !is_intentionally_ignored(&op) {
@@ -542,7 +627,7 @@ fn decode_function_body(
         }
     }
 
-    Ok((ops, op_offsets, unsupported))
+    Ok((ops, op_offsets, block_arity, unsupported))
 }
 
 /// Operators that `convert_operator` returns `None` for *on purpose* — they
@@ -1650,5 +1735,58 @@ mod tests {
         let c = &module.globals[1];
         assert_eq!(c.init_i32, Some(7));
         assert!(!c.mutable, "second global is immutable");
+    }
+
+    /// #509: the decoder records `(param_count, result_count)` for every
+    /// `Block`/`Loop`/`If`, ordinal-keyed in op order, covering all three
+    /// blocktype encodings: `Empty → (0,0)`, `ValType → (0,1)`, and
+    /// `FuncType(i) →` counts from the type section (here a multi-result
+    /// block, which wat encodes as a functype blocktype).
+    #[test]
+    fn test_decode_records_block_arity_side_table_509() {
+        let wat = r#"
+            (module
+                (func (export "f") (param i32) (result i32)
+                    (block (result i32)
+                        (block (nop))
+                        (local.get 0)
+                        (if (result i32)
+                            (then (i32.const 1))
+                            (else (i32.const 2)))))
+                (func (export "g") (result i32)
+                    (block (result i32 i32)
+                        (i32.const 1) (i32.const 2))
+                    i32.add)
+                (func (export "h") (param i32) (result i32)
+                    (local.get 0)
+                    (loop (param i32) (result i32))))
+        "#;
+        let wasm = wat::parse_str(wat).expect("parse WAT");
+
+        // Both decode entry points must produce the same side-table.
+        for functions in [
+            decode_wasm_functions(&wasm).expect("decode"),
+            decode_wasm_module(&wasm).expect("decode").functions,
+        ] {
+            // f: Block(result i32), Block(void), If(result i32) — in op order.
+            assert_eq!(
+                functions[0].block_arity,
+                vec![(0, 1), (0, 0), (0, 1)],
+                "f: ValType/Empty/ValType blocktypes"
+            );
+            // g: one multi-result block via a FuncType blocktype.
+            assert_eq!(
+                functions[1].block_arity,
+                vec![(0, 2)],
+                "g: functype blocktype result count from the type section"
+            );
+            // h: a parameterized loop — the input arity is what a br to the
+            // header would carry (the #509 loud-decline discriminator).
+            assert_eq!(
+                functions[2].block_arity,
+                vec![(1, 1)],
+                "h: loop params captured"
+            );
+        }
     }
 }

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -222,6 +222,158 @@ impl StackVal {
     }
 }
 
+/// #509: one entry per OPEN wasm control construct in `select_with_stack`
+/// (replaces the old `(label, is_loop)` tuple). `label` is the branch-target
+/// label: the end label for a block/if, the start label for a loop.
+/// `params`/`results` come from the decoder's blocktype-arity side-table
+/// ([`FunctionOps::block_arity`]) — `(0, 0)` when the table is absent (the
+/// legacy hand-built-ops path, which keeps every existing unit test
+/// byte-identical).
+///
+/// `result_reg` is the block's DESIGNATED RESULT REGISTER: every edge into the
+/// join moves the carried value into it — each value-carrying `br`/`br_if`/
+/// `br_table` emits `mov R_res, carried` before its jump, and the fall-through
+/// at `End` emits `mov R_res, top` (elided when equal) — so all predecessors
+/// agree on one register by construction (the #313 if/else two-arm
+/// reconciliation generalized to N forward edges). It is allocated LAZILY at
+/// the FIRST branch that targets the block and reserved (via the per-op
+/// `live_params` reservation) for the rest of the block's extent; a value
+/// block that is never branched to therefore keeps the pure fall-through
+/// lowering AND its exact register allocation — bit-identity for existing
+/// code is structural, not behavioural.
+///
+/// [`FunctionOps::block_arity`]: synth_core::wasm_decoder::FunctionOps::block_arity
+struct BlockLabel {
+    label: String,
+    is_loop: bool,
+    /// An `if`/`else` join (its `end_label`). A branch carrying a value here
+    /// would have to agree with the #313 then/else reconciliation registers,
+    /// which are not knowable at the branch site — declined loudly (rare from
+    /// LLVM output, which branches to blocks).
+    is_if: bool,
+    /// Blocktype input arity. For a LOOP this is what a `br` to its header
+    /// carries (loop parameters) — nonzero ⇒ the branch is declined loudly.
+    params: u8,
+    /// Blocktype result arity. `>1` (multi-value) ⇒ value-carrying branches
+    /// are declined loudly (the direct selector does not do multi-value).
+    results: u8,
+    result_reg: Option<Reg>,
+}
+
+/// #509: at a `br`/`br_if`/`br_table` edge, land the carried value in the
+/// target block's designated result register (allocating it on first use).
+///
+/// No-op for edges that carry nothing: a loop back-edge without loop params, a
+/// void target block, or an empty operand stack (dead code after a terminator,
+/// #329-class — matches the legacy lowering, which also emitted a bare branch
+/// there). Loud `Err` — never a silent drop — for the shapes the direct
+/// selector does not support: loop-parameter-carrying branches, multi-value
+/// results, a branch to a result-typed `if` join, and an i64 carried value.
+///
+/// The carried value is PEEKED, not popped: on a `br_if` fall-through the
+/// value stays live on the operand stack (wasm `br_if : [t*] i32 -> [t*]`),
+/// and for `br`/`br_table` leaving it matches the legacy stack shape for the
+/// dead code that follows. The `mov R_res, carried` is emitted before the
+/// compare/branch of the edge (never between CMP and Bcc, so flag-setting MOV
+/// encodings can never corrupt the condition); a `mov` executed on a
+/// NOT-taken path is harmless because `R_res` is reserved for the block's
+/// extent and only meaningful at its join label.
+///
+/// `reserved` must contain every register the caller still needs raw (the
+/// #193 live params + this edge's condition/index register + previously
+/// allocated result registers) so the lazy `R_res` allocation cannot clobber
+/// them.
+fn edge_value_move(
+    block_labels: &mut [BlockLabel],
+    target_idx: usize,
+    stack: &mut [StackVal],
+    next_temp: &mut u8,
+    instructions: &mut Vec<ArmInstruction>,
+    spill: &mut SpillState,
+    reserved: &[Reg],
+    line: usize,
+) -> Result<()> {
+    let (is_loop, is_if, params, results) = {
+        let bl = &block_labels[target_idx];
+        (bl.is_loop, bl.is_if, bl.params, bl.results)
+    };
+    if is_loop {
+        if params > 0 {
+            return Err(synth_core::Error::synthesis(format!(
+                "#509: br to a loop header with {params} loop parameter(s) — \
+                 value-carrying backward branches are not supported by the \
+                 direct selector (declined rather than dropping the carried \
+                 value)"
+            )));
+        }
+        return Ok(()); // plain loop back-edge — carries nothing
+    }
+    if results == 0 {
+        return Ok(()); // void target — an unwound value is legal, not carried
+    }
+    if results > 1 {
+        return Err(synth_core::Error::synthesis(format!(
+            "#509: br to a block with {results} results — multi-value blocks \
+             are not supported by the direct selector (declined rather than \
+             dropping the carried values)"
+        )));
+    }
+    if is_if {
+        return Err(synth_core::Error::synthesis(
+            "#509: br to a result-typed if/else join — the #313 reconciliation \
+             registers are not knowable at the branch site (declined rather \
+             than dropping the carried value)"
+                .to_string(),
+        ));
+    }
+    // Dead code after a terminator (#329-class) can reach a branch with an
+    // empty operand stack; the legacy lowering emitted a bare branch there, so
+    // keep that (this path is unreachable at runtime for valid wasm).
+    if stack.is_empty() {
+        return Ok(());
+    }
+    if stack.last().is_some_and(StackVal::is_i64) {
+        return Err(synth_core::Error::synthesis(
+            "#509: an i64 value carried over a br/br_if/br_table is not yet \
+             supported by the direct selector (declined rather than dropping \
+             the carried value)"
+                .to_string(),
+        ));
+    }
+    // Materialize the carried value (reloads a spilled top in place).
+    let val = peek_operand(stack, next_temp, instructions, spill, reserved, line)?;
+    let r_res = match block_labels[target_idx].result_reg {
+        Some(r) => r,
+        None => {
+            // Lazy allocation: avoid the caller's reserved set, the carried
+            // value itself (it is on the vstack, but be explicit), and every
+            // already-designated result register of an open block (a sibling
+            // `br_table` edge allocated in this same op is not yet in the
+            // per-op `live_params` snapshot).
+            let mut avoid = reserved.to_vec();
+            avoid.push(val);
+            for bl in block_labels.iter() {
+                if let Some(r) = bl.result_reg {
+                    avoid.push(r);
+                }
+            }
+            let r = alloc_temp_or_spill(next_temp, stack, instructions, spill, &avoid, line)?;
+            block_labels[target_idx].result_reg = Some(r);
+            r
+        }
+    };
+    if val != r_res {
+        instructions.push(ArmInstruction {
+            op: ArmOp::Mov {
+                rd: r_res,
+                op2: Operand2::Reg(val),
+            },
+            source_line: Some(line),
+        });
+    }
+    Ok(())
+}
+
 /// Number of i64 spill slots reserved in the frame (#171). Each is 8 bytes
 /// (lo+hi). Slots are reused (freed on reload), so this caps *simultaneous*
 /// spills, not total. 8 is generous for real i64-heavy functions; exceeding it
@@ -1581,6 +1733,15 @@ pub struct InstructionSelector {
     /// path refuses (Ok-or-Err) when any param is 64-bit. Empty ⇒ assume i32
     /// (the legacy path; every function with <=4 i32 params is byte-identical).
     params_i64: Vec<bool>,
+    /// #509: blocktype-arity side-table of the function being compiled —
+    /// `(param_count, result_count)` of the k-th `Block`/`Loop`/`If` in the op
+    /// stream (ordinal-keyed: rewrites like the #539 memory.grow fold shift op
+    /// indices but never add/remove control ops). Lets `select_with_stack` give
+    /// every result-typed block a designated result register so value-carrying
+    /// `br`/`br_if`/`br_table` edges land the value at the join instead of
+    /// dropping it. Empty ⇒ every block treated as void (the legacy lowering;
+    /// hand-built op streams in unit tests stay byte-identical).
+    block_arity: Vec<(u8, u8)>,
     /// AAPCS argument count per function, indexed by the *full* WASM function
     /// index (imports first, then locals). Plumbed from the frontend's type +
     /// function sections (issue #195). `func_arg_counts[i]` = number of integer
@@ -1658,6 +1819,7 @@ impl InstructionSelector {
             func_ret_i64: Vec::new(),
             type_ret_i64: Vec::new(),
             params_i64: Vec::new(),
+            block_arity: Vec::new(),
             func_arg_counts: Vec::new(),
             type_arg_counts: Vec::new(),
             fpu: None,
@@ -1688,6 +1850,7 @@ impl InstructionSelector {
             func_ret_i64: Vec::new(),
             type_ret_i64: Vec::new(),
             params_i64: Vec::new(),
+            block_arity: Vec::new(),
             func_arg_counts: Vec::new(),
             type_arg_counts: Vec::new(),
             fpu: None,
@@ -1785,6 +1948,14 @@ impl InstructionSelector {
     /// (Ok-or-Err). Empty ⇒ all params assumed i32 (the legacy path).
     pub fn set_params_i64(&mut self, params_i64: Vec<bool>) {
         self.params_i64 = params_i64;
+    }
+
+    /// #509: register the blocktype-arity side-table of the function about to
+    /// be compiled — `(param_count, result_count)` of the k-th
+    /// `Block`/`Loop`/`If` in its op stream (see the `block_arity` field).
+    /// Empty ⇒ every block treated as void (the legacy lowering).
+    pub fn set_block_arity(&mut self, block_arity: Vec<(u8, u8)>) {
+        self.block_arity = block_arity;
     }
 
     pub fn set_native_pointer_stack(&mut self, sp_index: u32, sp_init: i32) {
@@ -5567,9 +5738,17 @@ impl InstructionSelector {
         // Control flow tracking
         let mut cf = ControlFlowManager::new();
         cf.enter_function();
-        // Stack of (label, is_loop) for branch target resolution
-        // For blocks: label is the end label; for loops: label is the start label
-        let mut block_labels: Vec<(String, bool)> = Vec::new();
+        // Stack of open control constructs for branch target resolution.
+        // For blocks/ifs: label is the end label; for loops: the start label.
+        // #509: each entry also carries the blocktype arity (from the decoder's
+        // ordinal side-table) and the block's designated result register — see
+        // [`BlockLabel`].
+        let mut block_labels: Vec<BlockLabel> = Vec::new();
+        // #509: ordinal of the NEXT Block/Loop/If op in the stream — the key
+        // into `self.block_arity` (ordinal-keyed so op-stream rewrites that
+        // don't touch control ops, e.g. the #539 memory.grow fold, stay
+        // aligned).
+        let mut ctrl_ord: usize = 0;
         // Stack of (else_label, end_label) for if/else blocks
         let mut if_labels: Vec<(String, String)> = Vec::new();
         // #313: per-if-block operand-stack checkpoint (vstack depth captured at
@@ -5721,6 +5900,16 @@ impl InstructionSelector {
                             live_params.push(hi);
                         }
                     }
+                }
+            }
+            // #509: the designated result register of every open, branched-to
+            // value block is reserved for the block's extent — a temp/const/
+            // reload allocated into it would be clobbered by the edge moves
+            // into the join. Blocks never branched to have no `result_reg`, so
+            // existing code allocates byte-identically.
+            for bl in &block_labels {
+                if let Some(r) = bl.result_reg {
+                    live_params.push(r);
                 }
             }
             match op {
@@ -7514,16 +7703,38 @@ impl InstructionSelector {
                 // =========================================================
                 Block => {
                     let label = self.alloc_label("block_end");
+                    // #509: blocktype arity from the ordinal side-table —
+                    // (0,0) (void) when absent, preserving the legacy lowering.
+                    let (params, results) =
+                        self.block_arity.get(ctrl_ord).copied().unwrap_or((0, 0));
+                    ctrl_ord += 1;
                     // Push block info so br can find the end label
                     cf.enter_block(BlockType::Block);
-                    block_labels.push((label.clone(), false)); // (end_label, is_loop)
+                    block_labels.push(BlockLabel {
+                        label, // end label
+                        is_loop: false,
+                        is_if: false,
+                        params,
+                        results,
+                        result_reg: None, // allocated lazily at the first br edge
+                    });
                     // No ARM code emitted at block entry (label at end)
                 }
 
                 Loop => {
                     let label = self.alloc_label("loop_start");
+                    let (params, results) =
+                        self.block_arity.get(ctrl_ord).copied().unwrap_or((0, 0));
+                    ctrl_ord += 1;
                     cf.enter_block(BlockType::Loop);
-                    block_labels.push((label.clone(), true)); // (start_label, is_loop)
+                    block_labels.push(BlockLabel {
+                        label: label.clone(), // start label
+                        is_loop: true,
+                        is_if: false,
+                        params,
+                        results,
+                        result_reg: None,
+                    });
                     // Emit loop start label
                     instructions.push(ArmInstruction {
                         op: ArmOp::Label { name: label },
@@ -7545,10 +7756,23 @@ impl InstructionSelector {
                     let else_label = self.alloc_label("else");
                     let end_label = self.alloc_label("if_end");
 
+                    let (params, results) =
+                        self.block_arity.get(ctrl_ord).copied().unwrap_or((0, 0));
+                    ctrl_ord += 1;
                     cf.enter_block(BlockType::If);
                     // Store both labels: else_label for the if-branch, end_label for the end
                     if_labels.push((else_label.clone(), end_label.clone()));
-                    block_labels.push((end_label, false));
+                    // #509: `is_if` marks this join as #313-reconciled — a
+                    // value-carrying br to it is declined at the branch site
+                    // (the reconciliation registers are not knowable there).
+                    block_labels.push(BlockLabel {
+                        label: end_label,
+                        is_loop: false,
+                        is_if: true,
+                        params,
+                        results,
+                        result_reg: None,
+                    });
                     // #313: checkpoint the operand-stack depth (the condition is
                     // already popped). The then-arm runs from here; its results
                     // are whatever sits ABOVE this depth at `Else`. Reservation
@@ -7687,15 +7911,65 @@ impl InstructionSelector {
                         cf.add_instruction();
                         if_labels.pop();
                         block_labels.pop();
-                    } else if let Some((label, is_loop)) = block_labels.pop()
-                        && !is_loop
+                    } else if let Some(bl) = block_labels.pop()
+                        && !bl.is_loop
                     {
-                        // Block end: emit end label
-                        instructions.push(ArmInstruction {
-                            op: ArmOp::Label { name: label },
-                            source_line: Some(idx),
-                        });
-                        cf.add_instruction();
+                        // #509: fall-through edge into a branched-to value
+                        // block's join — land the falling-through result in the
+                        // designated result register BEFORE the end label (the
+                        // branch edges jump past this move, having already done
+                        // their own), then push R_res as the block's result.
+                        // `result_reg` is only ever Some for a branched-to
+                        // arity-1 block, so plain/void blocks keep the legacy
+                        // label-only epilogue byte-identically.
+                        if let Some(r_res) = bl.result_reg {
+                            if let Some(top) = stack.last().copied() {
+                                if top.is_i64() {
+                                    return Err(synth_core::Error::synthesis(
+                                        "#509: i64 fall-through into an \
+                                         i32-carrying block join — width \
+                                         mismatch (invalid wasm or unsupported \
+                                         shape); declined rather than \
+                                         miscompiled"
+                                            .to_string(),
+                                    ));
+                                }
+                                let val = pop_operand(
+                                    &mut stack,
+                                    &mut next_temp,
+                                    &mut instructions,
+                                    &mut spill,
+                                    &live_params,
+                                    idx,
+                                )?;
+                                if val != r_res {
+                                    instructions.push(ArmInstruction {
+                                        op: ArmOp::Mov {
+                                            rd: r_res,
+                                            op2: Operand2::Reg(val),
+                                        },
+                                        source_line: Some(idx),
+                                    });
+                                    cf.add_instruction();
+                                }
+                            }
+                            // (An empty stack here is dead code after a
+                            // terminator — the branch edges already loaded
+                            // R_res, so just publish it as the result.)
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Label { name: bl.label },
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                            stack.push(StackVal::i32(r_res));
+                        } else {
+                            // Block end: emit end label
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Label { name: bl.label },
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                        }
                         // Loop end: no label at end (label is at start)
                     }
                     // else: function-level end, nothing to emit
@@ -7706,24 +7980,26 @@ impl InstructionSelector {
                     // block_labels + if_labels are combined into the block_labels stack
                     let target_idx = block_labels.len().saturating_sub(1 + *depth as usize);
                     if target_idx < block_labels.len() {
-                        let (label, is_loop) = &block_labels[target_idx];
-                        if *is_loop {
-                            // Loop: branch back to start
-                            instructions.push(ArmInstruction {
-                                op: ArmOp::B {
-                                    label: label.clone(),
-                                },
-                                source_line: Some(idx),
-                            });
-                        } else {
-                            // Block: branch forward to end
-                            instructions.push(ArmInstruction {
-                                op: ArmOp::B {
-                                    label: label.clone(),
-                                },
-                                source_line: Some(idx),
-                            });
-                        }
+                        // #509: land a carried value in the target block's
+                        // designated result register BEFORE the jump (no-op for
+                        // void targets and plain loop back-edges).
+                        edge_value_move(
+                            &mut block_labels,
+                            target_idx,
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &live_params,
+                            idx,
+                        )?;
+                        // Loop: branch back to start; block: forward to end.
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::B {
+                                label: block_labels[target_idx].label.clone(),
+                            },
+                            source_line: Some(idx),
+                        });
                     } else {
                         // Depth exceeds stack — branch to function return
                         instructions.push(ArmInstruction {
@@ -7745,6 +8021,29 @@ impl InstructionSelector {
                         idx,
                     )?;
 
+                    // #509: land a carried value in the target block's
+                    // designated result register. Emitted BEFORE the CMP so no
+                    // instruction sits between CMP and Bcc; the value is PEEKED
+                    // (it stays on the operand stack for the fall-through path,
+                    // wasm `br_if : [t*] i32 -> [t*]`), and the mov on the
+                    // not-taken path is dead — R_res is reserved for the
+                    // block's extent and only meaningful at its join.
+                    let target_idx = block_labels.len().saturating_sub(1 + *depth as usize);
+                    if target_idx < block_labels.len() {
+                        let mut edge_reserved = live_params.clone();
+                        edge_reserved.push(cond_reg);
+                        edge_value_move(
+                            &mut block_labels,
+                            target_idx,
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &edge_reserved,
+                            idx,
+                        )?;
+                    }
+
                     // CMP cond_reg, #0
                     instructions.push(ArmInstruction {
                         op: ArmOp::Cmp {
@@ -7756,13 +8055,11 @@ impl InstructionSelector {
                     cf.add_instruction();
 
                     // BNE target_label (branch if non-zero)
-                    let target_idx = block_labels.len().saturating_sub(1 + *depth as usize);
                     if target_idx < block_labels.len() {
-                        let (label, _) = &block_labels[target_idx];
                         instructions.push(ArmInstruction {
                             op: ArmOp::Bcc {
                                 cond: Condition::NE,
-                                label: label.clone(),
+                                label: block_labels[target_idx].label.clone(),
                             },
                             source_line: Some(idx),
                         });
@@ -7781,6 +8078,35 @@ impl InstructionSelector {
                         idx,
                     )?;
 
+                    // #509: land the carried value in EVERY distinct target
+                    // block's designated result register up front, before the
+                    // dispatch cascade (never between a CMP and its Bcc — a
+                    // flag-setting MOV encoding would corrupt the condition).
+                    // Each mov is dead on the edges that don't take it: every
+                    // R_res is reserved for its block's extent and only
+                    // meaningful at that block's join. Valid wasm gives all
+                    // br_table targets the same arity, so either every edge
+                    // carries the value or none does.
+                    let mut moved: Vec<usize> = Vec::new();
+                    for t in targets.iter().chain(std::iter::once(default)) {
+                        let target_idx = block_labels.len().saturating_sub(1 + *t as usize);
+                        if target_idx < block_labels.len() && !moved.contains(&target_idx) {
+                            moved.push(target_idx);
+                            let mut edge_reserved = live_params.clone();
+                            edge_reserved.push(index_reg);
+                            edge_value_move(
+                                &mut block_labels,
+                                target_idx,
+                                &mut stack,
+                                &mut next_temp,
+                                &mut instructions,
+                                &mut spill,
+                                &edge_reserved,
+                                idx,
+                            )?;
+                        }
+                    }
+
                     // Emit cascading CMP + BEQ for each target
                     for (i, target) in targets.iter().enumerate() {
                         instructions.push(ArmInstruction {
@@ -7794,11 +8120,10 @@ impl InstructionSelector {
 
                         let target_idx = block_labels.len().saturating_sub(1 + *target as usize);
                         if target_idx < block_labels.len() {
-                            let (label, _) = &block_labels[target_idx];
                             instructions.push(ArmInstruction {
                                 op: ArmOp::Bcc {
                                     cond: Condition::EQ,
-                                    label: label.clone(),
+                                    label: block_labels[target_idx].label.clone(),
                                 },
                                 source_line: Some(idx),
                             });
@@ -7809,10 +8134,9 @@ impl InstructionSelector {
                     // Default branch
                     let default_idx = block_labels.len().saturating_sub(1 + *default as usize);
                     if default_idx < block_labels.len() {
-                        let (label, _) = &block_labels[default_idx];
                         instructions.push(ArmInstruction {
                             op: ArmOp::B {
-                                label: label.clone(),
+                                label: block_labels[default_idx].label.clone(),
                             },
                             source_line: Some(idx),
                         });

--- a/crates/synth-synthesis/tests/issue_509_br_value_carry.rs
+++ b/crates/synth-synthesis/tests/issue_509_br_value_carry.rs
@@ -1,0 +1,297 @@
+//! #509 — value-carrying `br`/`br_if`/`br_table` on the direct selector.
+//!
+//! The shipped (`--relocatable`) selector used to emit a bare branch for every
+//! `br*`, silently DROPPING the value a branch carries to a result-typed block
+//! (wasmtime: `pick(1) = 12`; synth: `2`). The fix threads the decoder's
+//! blocktype-arity side-table (`set_block_arity`, ordinal-keyed) into
+//! `select_with_stack`, which gives each branched-to arity-1 block a
+//! DESIGNATED RESULT REGISTER `R_res`: every edge into the join —
+//! `br`/`br_if`/`br_table` (a `mov R_res, carried` before the jump) and the
+//! fall-through at `End` (`mov R_res, top`, elided when equal) — agrees on it
+//! by construction (the #313 if/else reconciliation generalized to N edges).
+//!
+//! This file is the cargo-CI structural gate (the execution gate is
+//! `scripts/repro/br_table_value_509_differential.py`, red→green on this fix):
+//!   * a value-carrying `br_table` emits the per-edge `mov R_res` and `End`
+//!     publishes `R_res` as the block result (traced to the function return);
+//!   * an arity-0 (void) block emits NO extra moves — control-flow-only code
+//!     is byte-identical with and without the side-table;
+//!   * the honest declines: loop-parameter-carrying br, multi-value results,
+//!     br to a result-typed if join, i64 carried values — loud `Err`
+//!     (#180/#185 Ok-or-Err), never a silent drop.
+
+use synth_synthesis::{
+    ArmInstruction, ArmOp, InstructionSelector, Operand2, Reg, RuleDatabase, WasmOp,
+};
+
+fn select(ops: &[WasmOp], num_params: u32, arity: Vec<(u8, u8)>) -> Vec<ArmInstruction> {
+    let db = RuleDatabase::with_standard_rules();
+    let mut sel = InstructionSelector::new(db.rules().to_vec());
+    sel.set_block_arity(arity);
+    sel.select_with_stack(ops, num_params)
+        .expect("selection should succeed")
+}
+
+fn select_err(ops: &[WasmOp], num_params: u32, arity: Vec<(u8, u8)>) -> String {
+    let db = RuleDatabase::with_standard_rules();
+    let mut sel = InstructionSelector::new(db.rules().to_vec());
+    sel.set_block_arity(arity);
+    sel.select_with_stack(ops, num_params)
+        .expect_err("selection must decline loudly")
+        .to_string()
+}
+
+/// The `pick` shape from `scripts/repro/br_value_509.wat`: a value-carrying
+/// `br_table` dispatching into two nested result-typed blocks.
+///
+///   (block (result i32)                 ;; outer
+///     (block (result i32)               ;; inner
+///       (i32.const 10) (i32.const 0)    ;; carried value, selector index
+///       (br_table 0 1))
+///     (i32.const 1) (i32.add))          ;; inner fall-in arm: +1
+///
+/// Asserts the full designated-register chain: one `mov R_res` per distinct
+/// edge at the dispatch, the fall-through reconcile `mov` before each block's
+/// end label, and the outer block's `R_res` reaching the function return (R0).
+#[test]
+fn br_table_value_carry_emits_edge_moves_and_end_publishes_r_res_509() {
+    use WasmOp::*;
+    let ops = vec![
+        Block,        // outer (result i32)
+        Block,        // inner (result i32)
+        I32Const(10), // carried value
+        I32Const(0),  // br_table selector index
+        BrTable {
+            targets: vec![0],
+            default: 1,
+        },
+        End, // inner
+        I32Const(1),
+        I32Add,
+        End, // outer
+        End, // function
+    ];
+    let instrs = select(&ops, 0, vec![(0, 1), (0, 1)]);
+
+    // The br_table op is index 4 — every edge mov + the dispatch cascade
+    // carries source_line Some(4). The two distinct targets (inner, outer)
+    // get distinct designated registers, so exactly two movs precede the
+    // first CMP of the cascade.
+    let at_dispatch: Vec<&ArmOp> = instrs
+        .iter()
+        .filter(|i| i.source_line == Some(4))
+        .map(|i| &i.op)
+        .collect();
+    let first_cmp = at_dispatch
+        .iter()
+        .position(|op| matches!(op, ArmOp::Cmp { .. }))
+        .expect("br_table emits a CMP cascade");
+    let edge_movs: Vec<Reg> = at_dispatch[..first_cmp]
+        .iter()
+        .filter_map(|op| match op {
+            ArmOp::Mov { rd, .. } => Some(*rd),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        edge_movs.len(),
+        2,
+        "one `mov R_res, carried` per distinct br_table target, all before \
+         the CMP cascade (never between CMP and Bcc): {at_dispatch:?}"
+    );
+    assert_ne!(
+        edge_movs[0], edge_movs[1],
+        "inner and outer blocks get distinct designated result registers"
+    );
+    // No mov may sit between a CMP and its Bcc (flag-setting encodings).
+    for w in at_dispatch[first_cmp..].windows(2) {
+        if matches!(w[0], ArmOp::Cmp { .. }) {
+            assert!(
+                matches!(w[1], ArmOp::Bcc { .. }),
+                "CMP must be immediately followed by its Bcc: {at_dispatch:?}"
+            );
+        }
+    }
+
+    // End (inner, op idx 5; outer, op idx 8): the fall-through reconcile mov
+    // into the SAME designated register, emitted BEFORE the end label.
+    for (end_idx, r_res) in [(5usize, edge_movs[0]), (8usize, edge_movs[1])] {
+        let at_end: Vec<&ArmOp> = instrs
+            .iter()
+            .filter(|i| i.source_line == Some(end_idx))
+            .map(|i| &i.op)
+            .collect();
+        let mov_pos = at_end
+            .iter()
+            .position(|op| matches!(op, ArmOp::Mov { rd, .. } if *rd == r_res))
+            .unwrap_or_else(|| {
+                panic!("End #{end_idx} reconciles the fall-through into {r_res:?}: {at_end:?}")
+            });
+        let label_pos = at_end
+            .iter()
+            .position(|op| matches!(op, ArmOp::Label { .. }))
+            .expect("block End emits its end label");
+        assert!(
+            mov_pos < label_pos,
+            "the fall-through mov lands BEFORE the join label (branch edges \
+             jump past it): {at_end:?}"
+        );
+    }
+
+    // The outer block's R_res is the function result: the epilogue moves it
+    // (or already finds it) in R0.
+    let outer_res = edge_movs[1];
+    assert!(
+        outer_res == Reg::R0
+            || instrs.iter().any(|i| {
+                matches!(
+                    &i.op,
+                    ArmOp::Mov { rd: Reg::R0, op2: Operand2::Reg(r) } if *r == outer_res
+                )
+            }),
+        "the outer designated register {outer_res:?} must reach R0"
+    );
+}
+
+/// The `pick_brif` shape: `br_if` peeks the carried value (it stays on the
+/// stack for the fall-through path) and the mov precedes the CMP.
+#[test]
+fn br_if_value_carry_moves_before_cmp_and_keeps_fallthrough_value_509() {
+    use WasmOp::*;
+    let ops = vec![
+        Block,        // (result i32)
+        I32Const(10), // carried value
+        LocalGet(0),  // condition
+        BrIf(0),
+        Drop,
+        I32Const(20),
+        End, // block
+        End, // function
+    ];
+    let instrs = select(&ops, 1, vec![(0, 1)]);
+
+    // At the br_if (op idx 3): mov R_res BEFORE the CMP, then CMP + BNE.
+    let at_brif: Vec<&ArmOp> = instrs
+        .iter()
+        .filter(|i| i.source_line == Some(3))
+        .map(|i| &i.op)
+        .collect();
+    let mov_pos = at_brif
+        .iter()
+        .position(|op| matches!(op, ArmOp::Mov { .. }))
+        .expect("br_if to a value block emits the edge mov");
+    let cmp_pos = at_brif
+        .iter()
+        .position(|op| matches!(op, ArmOp::Cmp { .. }))
+        .expect("br_if emits CMP");
+    assert!(
+        mov_pos < cmp_pos,
+        "edge mov precedes the CMP (nothing between CMP and Bcc): {at_brif:?}"
+    );
+
+    // The value was PEEKED: the fall-through `Drop` (op idx 4) must not
+    // underflow, and the not-taken arm's 20 must reconcile into the same
+    // R_res at End — i.e. the End emits a mov into the edge-mov's register.
+    let r_res = at_brif
+        .iter()
+        .find_map(|op| match op {
+            ArmOp::Mov { rd, .. } => Some(*rd),
+            _ => None,
+        })
+        .unwrap();
+    assert!(
+        instrs
+            .iter()
+            .any(|i| i.source_line == Some(6)
+                && matches!(&i.op, ArmOp::Mov { rd, .. } if *rd == r_res)),
+        "End reconciles the fall-through 20 into the same designated register"
+    );
+}
+
+/// Void blocks are BYTE-NEUTRAL: with the side-table present-but-(0,0) the
+/// emitted sequence is identical to the legacy no-table lowering — no extra
+/// moves, no allocation shift, for br, br_if, and br_table alike.
+#[test]
+fn arity_zero_blocks_emit_no_extra_moves_byte_neutral_509() {
+    use WasmOp::*;
+    let ops = vec![
+        Block, // void
+        Block, // void
+        I32Const(1),
+        Drop,
+        LocalGet(0),
+        BrIf(0),
+        I32Const(7),
+        BrTable {
+            targets: vec![0],
+            default: 1,
+        },
+        End,
+        Br(0),
+        End,
+        End, // function
+    ];
+    let legacy = select(&ops, 1, Vec::new());
+    let with_table = select(&ops, 1, vec![(0, 0), (0, 0)]);
+    assert_eq!(
+        format!("{legacy:?}"),
+        format!("{with_table:?}"),
+        "a (0,0) side-table entry must not change a single instruction"
+    );
+}
+
+/// Honest declines (#180/#185 Ok-or-Err): the unsupported value-carry shapes
+/// produce a loud `Err` naming #509 — never a silent drop.
+#[test]
+fn unsupported_value_carry_shapes_decline_loudly_509() {
+    use WasmOp::*;
+
+    // br to a parameterized loop header (loop-param carry).
+    let loop_param = vec![
+        I32Const(1),
+        Loop, // (param i32)
+        I32Const(2),
+        Br(0),
+        End,
+        Drop,
+        End,
+    ];
+    let e = select_err(&loop_param, 0, vec![(1, 0)]);
+    assert!(
+        e.contains("#509") && e.contains("loop"),
+        "loop-param br declines loudly: {e}"
+    );
+
+    // br to a multi-value block.
+    let multi = vec![Block, I32Const(1), I32Const(2), Br(0), End, Drop, End];
+    let e = select_err(&multi, 0, vec![(0, 2)]);
+    assert!(
+        e.contains("#509") && e.contains("multi-value"),
+        "multi-value br declines loudly: {e}"
+    );
+
+    // br to a result-typed if/else join (the #313-reconciled join).
+    let if_join = vec![
+        LocalGet(0),
+        If, // (result i32)
+        I32Const(1),
+        Br(0),
+        Else,
+        I32Const(2),
+        End,
+        End,
+    ];
+    let e = select_err(&if_join, 1, vec![(0, 1)]);
+    assert!(
+        e.contains("#509") && e.contains("if"),
+        "br to a result-typed if join declines loudly: {e}"
+    );
+
+    // i64 carried value.
+    let wide = vec![Block, I64Const(1), Br(0), End, Drop, End];
+    let e = select_err(&wide, 0, vec![(0, 1)]);
+    assert!(
+        e.contains("#509") && e.contains("i64"),
+        "i64 value-carry declines loudly: {e}"
+    );
+}

--- a/scripts/repro/br_table_value_509_differential.py
+++ b/scripts/repro/br_table_value_509_differential.py
@@ -50,16 +50,24 @@ WAT = Path(__file__).with_name("br_value_509.wat")
 SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
 CODE, STK, RET = 0x100000, 0x900000, 0x300000
 
-# Flip to False in the gated fix PR; the script then enforces correctness.
-EXPECT_MISCOMPILE = True
+# Flipped to False by the #509 fix PR (blocktype-arity side-table + designated
+# result register per value block in `select_with_stack`, plus the #507-style
+# detect-and-route-to-direct for value-carrying br/br_if on the optimized
+# path): the script now enforces correctness — every edge (taken, dispatched,
+# and fall-through) on BOTH paths must match wasmtime. Pre-fix recorded wrong
+# values (direct path): pick(1/2/5)->2 vs 12, pick_brif(1/7)->0 vs 10,
+# pick_br(0/1/7)->0 vs 30/31/37, pick_br_fall(1/7)->0 vs 10.
+EXPECT_MISCOMPILE = False
 
 # (export, args) — the dispatched/taken arms are the value-carry cases.
 CASES = [
     ("pick", [0, 1, 2, 5]),       # br_table; sel>=1 dispatched arms drop the carry
     ("pick_brif", [0, 1, 7]),     # br_if; taken (arg!=0) arms drop the carry
+    ("pick_br", [0, 1, 7]),       # plain br; always-taken edge drops the carry
+    ("pick_br_fall", [0, 1, 7]),  # br (taken, arg!=0) + real fall-through (arg==0)
     ("ctrl", [0, 1, 7]),          # branchless value block — control, must stay OK
 ]
-VALUE_CARRY_FNS = {"pick", "pick_brif"}
+VALUE_CARRY_FNS = {"pick", "pick_brif", "pick_br", "pick_br_fall"}
 
 
 def wasmtime_run(fn, arg):

--- a/scripts/repro/br_value_509.wat
+++ b/scripts/repro/br_value_509.wat
@@ -1,16 +1,20 @@
-;; #509 — the DIRECT selector (so the SHIPPED `--relocatable` path) drops the
+;; #509 — the DIRECT selector (so the SHIPPED `--relocatable` path) DROPPED the
 ;; CARRIED VALUE of a value-returning branch: a `br`/`br_if`/`br_table` that
-;; targets a result-typed block and carries an operand returns 0 (the value is
-;; lost) for the dispatched/taken arm. wasmtime keeps it. The IR carries no
-;; block-result arity (`WasmOp::Block` is a unit variant, the decoder tracks
-;; none), so the selector cannot thread the carried value to the join — the real
-;; fix needs block-arity threading + a result-register convention generalizing
-;; the #313 if/else reconciliation (NOT the #507 decline-to-direct shortcut,
-;; which cannot tell a CARRIED result from an UNWOUND void-target value).
+;; targets a result-typed block and carries an operand returned the wrong value
+;; (the carry was lost) for the dispatched/taken arm. wasmtime keeps it.
 ;;
-;; This is the discriminator: a value carried OVER A BRANCH is dropped, but a
-;; branchless value-returning block (`ctrl`) is correct — so the defect is the
-;; branch value-carry, not result-typed blocks in general.
+;; FIXED by threading a blocktype-arity side-table (decoder
+;; `FunctionOps::block_arity`, ordinal-keyed — `WasmOp::Block/Loop/If` stay
+;; bare) into `select_with_stack`, which gives every branched-to result-typed
+;; block a DESIGNATED RESULT REGISTER: each `br`/`br_if`/`br_table` edge emits
+;; `mov R_res, carried` before its jump and the fall-through `End` reconciles
+;; into the same register — the #313 if/else two-arm reconciliation generalized
+;; to N forward edges. (NOT the #507 decline-to-direct shortcut, which cannot
+;; tell a CARRIED result from an UNWOUND void-target value.)
+;;
+;; This is the discriminator: a value carried OVER A BRANCH was dropped, but a
+;; branchless value-returning block (`ctrl`) was always correct — so the defect
+;; was the branch value-carry, not result-typed blocks in general.
 (module
   ;; value-returning br_table: the carried `i32.const 10` should reach whichever
   ;; result-typed block the selector dispatches to. sel 0 -> inner end (+1 then
@@ -30,6 +34,25 @@
       (i32.const 10)
       (br_if 0 (local.get 0))
       (drop)(i32.const 20)))
+
+  ;; value-carrying plain br: `br 1` carries p+30 over BOTH nested result-typed
+  ;; blocks (skipping the +1 on the inner fall-through arm). Always-taken edge:
+  ;; result must be p+30 for every p.
+  (func (export "pick_br") (param i32) (result i32)
+    (block (result i32)
+      (block (result i32)
+        (local.get 0)(i32.const 30)(i32.add)
+        (br 1))
+      (i32.const 1)(i32.add)))
+
+  ;; value-carrying br + a REAL fall-through edge into the same join: p != 0
+  ;; takes the if-arm's `br 0` (carries 10), p == 0 falls through the block end
+  ;; (carries p+40). Exercises both edge kinds into one designated join.
+  (func (export "pick_br_fall") (param i32) (result i32)
+    (block (result i32)
+      (local.get 0)
+      (if (then (i32.const 10) (br 1)))
+      (local.get 0)(i32.const 40)(i32.add)))
 
   ;; CONTROL: a value-returning block with NO branch — the value flows straight
   ;; to the block end, so it is lowered correctly. Proves the defect is the


### PR DESCRIPTION
## The miscompile

The direct (shipped `--relocatable`) selector emitted a bare branch for every `br*`, silently **dropping the value a branch carries to a result-typed block**. Recorded pre-fix on this branch's oracle (direct path, vs wasmtime):

| shape | case | synth (pre-fix) | wasmtime |
|---|---|---|---|
| `br_table` | `pick(1/2/5)` | **2** | 12 |
| `br_if` (taken) | `pick_brif(1/7)` | **0** | 10 |
| plain `br` | `pick_br(0/1/7)` | **0** | 30/31/37 |
| `br` + real fall-through | `pick_br_fall(1/7)` | **0** | 10 |

The default (optimized) path dropped the plain-`br` carry too (`pick_br → 0`, `pick_br_fall → 41/47` — the fall-through arm's value). Only fall-through edges (`pick(0)`, `pick_brif(0)`, `ctrl`) were correct.

Root cause (per the scope analysis on #509): the IR carried **no block-result arity** — `WasmOp::Block/Loop/If` are unit variants — so the branch site could not tell a *carried result* from a legally *unwound void-target value* (which is why the #507 decline shortcut was unsound and over-refused valid void code).

## The fix (the design committed on #509)

1. **Arity side-table, no enum change** — the decoder records `FunctionOps::block_arity`: `(param_count, result_count)` per `Block`/`Loop`/`If`, **ordinal-keyed** (op-stream rewrites like the #539 `memory.grow(0)` fold shift op indices but never add/remove control ops). `Empty → (0,0)`, `ValType → (0,1)`, `FuncType(i)` → counts from the type section. Zero ripple through the RISC-V/AArch64 `Block|Loop|If` match sites; plumbed as `CompileConfig::current_func_block_arity` (the `current_func_params_i64` pattern).
2. **Designated result register per value block** — `select_with_stack`'s `block_labels` grows to `BlockLabel { label, is_loop, is_if, params, results, result_reg }`. Every edge into an arity-1 block's join agrees on `R_res` **by construction** (the #313 if/else reconciliation generalized to N forward edges):
   - `br`/`br_if`/`br_table` emit `mov R_res, carried` **before the jump** — always before the CMP, never between CMP and Bcc (flag-setting MOV encodings can't corrupt the condition); `br_if` **peeks** so the fall-through keeps the value on the operand stack; a mov executed on a not-taken path is dead because `R_res` is reserved and only meaningful at its join;
   - `End` reconciles the fall-through with `mov R_res, top` (elided when equal) before the join label, then publishes `R_res` as the block result.
   - `R_res` is allocated **lazily at the first branching edge** and reserved for the block's extent — a value block never branched to, and all void-block control flow, keep the exact legacy lowering *and allocation*: bit-identity for existing code is structural, not behavioural.
3. **Honest declines** (#180/#185 Ok-or-Err, #496-style): loop-parameter-carrying `br`, multi-value results, `br` to a result-typed `if/else` join (the #313 registers aren't knowable at the branch site), and i64 carried values → loud `Err` (skip/ladder), never a silent drop. Exhaustion from the extra reserved register rides the existing recovery ladder.
4. **Optimized path** — the same drop exists in the wasm→IR lowering for `br`/`br_if`; `compile_wasm_to_arm` now detects value-carrying branches on the raw op stream (`has_value_carrying_branch`, driven by the same side-table) and routes to the direct selector — the #507 pattern, and strictly better than today's wrong code.

## Red → green

- **Red** (pre-fix build): `scripts/repro/br_table_value_509_differential.py` extended with plain-`br` + `br`-with-fall-through shapes — 10 direct-path divergences (the table above), branchless `ctrl` correct (non-vacuity).
- **Green** (this branch): flipped `EXPECT_MISCOMPILE=False` — the script is now the correctness gate: **32/32 cases match wasmtime on BOTH paths, exit 0**.
- New cargo CI gates: decoder side-table capture across both decode entry points (`synth-core`), and `crates/synth-synthesis/tests/issue_509_br_value_carry.rs` — per-edge `mov R_res` at the `br_table` dispatch (before the CMP cascade), `End` publishing `R_res` through to R0, `br_if` mov-before-CMP + fall-through reconcile, **byte-neutrality of arity-0 blocks** (legacy vs side-table output identical), and the four loud declines.

## Gates

- Frozen anchors **3/3 bit-identical** (`frozen_codegen_bytes` ARM + RV32 + escape-hatch green — control_step / flat+inlined flight_algo / div seam `.text` SHA-256 unchanged).
- `cargo test --workspace --exclude synth-verify` exit **0**; `cargo fmt --check` exit **0**; `cargo clippy --workspace --all-targets -- -D warnings` exit **0**.

## Honest scope

- Loop-parameter-carrying `br`, multi-value blocks, value-carrying `br` to an `if/else` join, and i64 carried values are **declined loudly** (v1 scope per the design; rare from LLVM output).
- The optimized path gets correctness via decline-to-direct, not its own IR fix (out of scope here; `optimizer_bridge` untouched).

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)