### PR TITLE
feat(vcr-ra): whole-function slot liveness — dead frame stores drop (#242, VCR-RA-001)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -732,14 +732,22 @@ fn compile_wasm_to_arm(
     // flag. Per-segment commit gates: executable same-value-flow trace
     // equality, strict shrink, pool-pressure fit, sub-word/unknown-slot
     // conservatism (see `apply_spill_realloc` / `spill_rechoice_segment`).
+    // Stage 3 (whole-function slot liveness): the segment-local DCE keeps a
+    // store whose slot reaches function end ("reach-end ≠ dead" — it cannot
+    // see other segments); `eliminate_unread_frame_stores` walks the whole
+    // function (labels/branches/loops, SP-displacement tracked) and drops a
+    // store whose slot NO reachable instruction can read — flat_flight's two
+    // surviving stores (#576), completing Belady's 0-load side with a 0-store
+    // side. Same flag: the three stages are one lever for the v0.24.0 flip.
     // Flag-off (`SYNTH_SPILL_REALLOC=1`) while differential-validated;
     // off ⇒ byte-identical.
     let arm_instrs = if std::env::var("SYNTH_SPILL_REALLOC").is_ok() {
         let (out, n) = synth_synthesis::liveness::apply_spill_realloc(&arm_instrs);
         let (out, d) = synth_synthesis::liveness::eliminate_dead_frame_stores(&out);
+        let (out, u) = synth_synthesis::liveness::eliminate_unread_frame_stores(&out);
         if std::env::var("SYNTH_FUSE_STATS").is_ok() {
             eprintln!(
-                "[spill-realloc] {n} reload(s) forwarded/eliminated, {d} newly-dead frame store(s) removed"
+                "[spill-realloc] {n} reload(s) forwarded/eliminated, {d} newly-dead frame store(s) removed, {u} unread-slot store(s) removed"
             );
         }
         out

--- a/crates/synth-cli/tests/spill_realloc_242.rs
+++ b/crates/synth-cli/tests/spill_realloc_242.rs
@@ -12,9 +12,13 @@
 //!     store's source; stage 2: the Belady spill-plan RE-CHOICE
 //!     (`spill_rechoice_segment`) — where no register still holds the slot's
 //!     value, the clobbering def(s) are renamed onto a provably-dead register
-//!     so the value stays resident and the reload dissolves. Guards: same
+//!     so the value stays resident and the reload dissolves; stage 3:
+//!     WHOLE-FUNCTION frame-slot liveness (`eliminate_unread_frame_stores`) —
+//!     a store whose slot no reachable instruction can read (may-reach walk
+//!     over labels/branches with SP-displacement tracking) is dropped, the
+//!     reach-end case segment-local DCE deliberately keeps. Guards: same
 //!     value flow (executable trace equality), strict per-segment shrink,
-//!     pool-pressure fit, sub-word/unknown-slot conservatism.
+//!     pool-pressure fit, sub-word/unknown-slot/escape conservatism.
 //!   - `SYNTH_SPILL_REPORT=1` — measure-only greedy-vs-Belady (farthest next
 //!     use) frame-traffic report per segment.
 //!
@@ -31,11 +35,14 @@
 //!   3. RE-CHOICE RECOVERS flat_flight (the #569 spike's CI-locked target):
 //!      its 3 surviving reloads have no register-resident holder, so stage 1
 //!      honestly declines — stage 2 dissolves all three by renaming the
-//!      clobbering defs, and the store feeding pair #1 goes dead. Measured
-//!      2026-07-02: 412→396 B, frame traffic 3ld+3st → 0ld+2st. The two
-//!      surviving stores are blocked by the frame-slot reach-end conservatism
-//!      (a slot live to function end is not provably dead — the #483-class
-//!      stance), not by the re-choice: Belady's 0-load side is fully met.
+//!      clobbering defs, and the store feeding pair #1 goes dead. The two
+//!      then-surviving stores were blocked by the SEGMENT-LOCAL reach-end
+//!      conservatism (a slot live to segment end is not provably dead without
+//!      whole-function reasoning — the #515 stance); stage 3
+//!      (`eliminate_unread_frame_stores`, whole-function slot liveness) proves
+//!      their slots are never read anywhere in the function and drops them.
+//!      Measured 2026-07-02: 412→388 B, frame traffic 3ld+3st → 0ld+0st — the
+//!      full Belady contract (belady(k=9)=0ld+0st) is met.
 //!   4. HEADROOM IS REAL: the flag-off Belady report on flat_flight's
 //!      pressure-11 segment shows the ideal allocation needs strictly less
 //!      frame traffic than the greedy lowering emitted.
@@ -200,7 +207,9 @@ fn spill_realloc_no_grow_and_fires_on_flight_seam_242() {
     // flat_flight — the Belady re-choice target. Stage 1 has nothing to
     // forward (every holder is clobbered — the #569 spike's honest decline);
     // stage 2 renames the clobbering defs onto provably-dead registers, so
-    // all 3 reloads dissolve and the store feeding pair #1 goes dead.
+    // all 3 reloads dissolve and the store feeding pair #1 goes dead; stage 3
+    // (whole-function slot liveness) drops the two reach-end stores whose
+    // slots are never read anywhere in the function.
     let (ff_off_elf, ff_off_err) = compile(
         "scripts/repro/flat_flight/flat_flight.loom.wasm",
         "/tmp/sr242_ff_off.elf",
@@ -214,14 +223,15 @@ fn spill_realloc_no_grow_and_fires_on_flight_seam_242() {
     let (ff_off, ff_on) = (func_sizes(&ff_off_elf), func_sizes(&ff_on_elf));
     assert!(
         ff_on["flat_flight"] < ff_off["flat_flight"],
-        "the Belady re-choice must shrink flat_flight (measured 412→396 B): \
+        "the Belady re-choice must shrink flat_flight (measured 412→388 B): \
          off={}B on={}B",
         ff_off["flat_flight"],
         ff_on["flat_flight"]
     );
     assert!(
-        ff_off["flat_flight"] - ff_on["flat_flight"] >= 12,
-        "at least the three dissolved 4-byte reloads must be gone: off={}B on={}B",
+        ff_off["flat_flight"] - ff_on["flat_flight"] >= 20,
+        "the three dissolved 4-byte reloads AND the two whole-function-dead \
+         4-byte stores must be gone: off={}B on={}B",
         ff_off["flat_flight"],
         ff_on["flat_flight"]
     );
@@ -230,9 +240,10 @@ fn spill_realloc_no_grow_and_fires_on_flight_seam_242() {
         ff_fired >= 3,
         "all 3 flat_flight reloads must dissolve via re-choice; got {ff_fired}"
     );
-    // Frame traffic, from the post-pass spill report: 3ld+3st → 0ld+2st. The
-    // two surviving stores are the frame-slot reach-end conservatism (#483
-    // class), not a re-choice miss — the Belady 0-load side is fully met.
+    // Frame traffic, from the post-pass spill report: 3ld+3st → 0ld+0st —
+    // the full Belady contract (belady(k=9)=0ld+0st). Stage 3's
+    // whole-function slot liveness proves the two reach-end stores' slots are
+    // never read anywhere in the function and drops them.
     let traffic = |stderr: &str| {
         parse_reports(stderr).iter().fold((0, 0), |acc, r| {
             (acc.0 + r.actual_reloads, acc.1 + r.actual_stores)
@@ -245,9 +256,9 @@ fn spill_realloc_no_grow_and_fires_on_flight_seam_242() {
     );
     assert_eq!(
         traffic(&ff_on_err),
-        (0, 2),
+        (0, 0),
         "flag-on flat_flight frame traffic: every reload must dissolve and \
-         only the two reach-end stores may survive"
+         every provably-unread store must drop (full Belady contract)"
     );
     eprintln!(
         "[spill-rechoice-242] flat_flight off={}B on={}B, traffic {:?} -> {:?}, \

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -634,6 +634,251 @@ pub fn eliminate_dead_frame_stores(instrs: &[ArmInstruction]) -> (Vec<ArmInstruc
     (kept, dead.len())
 }
 
+/// VCR-RA whole-function frame-slot liveness (#242, VCR-RA-001): remove a
+/// `str rX, [sp, #N]` whose slot is provably never READ anywhere the store can
+/// reach — including the reach-end case [`eliminate_dead_frame_stores`]
+/// deliberately keeps. That pass proves deadness only via a later same-slot
+/// overwrite on a straight line ("reach-end ≠ dead" — the #515 stance, because
+/// segment-local reasoning cannot see past its scope). This pass supplies the
+/// missing whole-function view: it walks every path the store can reach
+/// (fall-through + label/branch edges, loops included) and drops the store only
+/// when NO reachable instruction can observe the slot's bytes. flat_flight's
+/// two surviving spill stores (#576) are exactly this shape — their slots are
+/// never loaded again anywhere in the function.
+///
+/// ADMISSION (whole function declines — returns the input unchanged — on the
+/// first violation; per-slot precision is never traded for soundness):
+///  - any sp-relative access with a REGISTER offset (`[sp, rM]`): the touched
+///    slot is unresolvable, so every slot would have to be assumed live;
+///  - SP used as a general operand (`add rD, sp, #x`, `mov rD, sp`,
+///    `[rN, sp]`, …): the frame address ESCAPES into a register, and a later
+///    plain `ldr [rD]` could read any slot invisibly;
+///  - SP redefined by anything other than the tracked shapes (`add/sub
+///    sp, sp, #imm`, `Push`, `Pop`): the frame geometry becomes untrackable;
+///  - a call (`Bl`/`Blx`/`Call`/`CallIndirect`): a callee may read an outgoing
+///    stack-argument slot through its own view of SP;
+///  - a branch whose target cannot be resolved (numeric `BOffset`/
+///    `BCondOffset` — this pass runs BEFORE `resolve_label_branches` — a
+///    `BrTable`, a missing/duplicate label, or an indirect `Bx` that is not the
+///    `bx lr` return);
+///  - any op [`reg_effect`] does not model (i64-pair pseudo-ops, FP, memory
+///    builtins, …): its memory behavior is unknown.
+///
+/// THE WALK — per candidate store, a may-reach traversal over states
+/// `(index, sp_delta)` where `sp_delta` is SP's displacement from its value at
+/// the store (so slot `N` occupies bytes `[N, N+4)` in store-time coordinates,
+/// and an access `[sp, #M]` under displacement `d` touches `[d+M, d+M+w)`):
+///  - a load (`ldr`/`ldrb`/`ldrsb`/`ldrh`/`ldrsh [sp, #M]`) whose byte
+///    interval OVERLAPS the slot ⇒ the store is LIVE (sub-word reads thus count
+///    as reads of their containing word — the #483-class lesson);
+///  - a whole-word `str [sp, #M]` with `d+M == N` COVERS the slot ⇒ the path
+///    dies (classic overwrite-kill); any partial overlap is neither a read nor
+///    a kill and the walk continues;
+///  - `add/sub sp, sp, #imm` adjusts `d` and is NOT a read (frame teardown);
+///  - `Push {regs}` writes strictly below SP (no read), `d -= 4·|regs|`;
+///  - `Pop {regs}` READS `[d, d+4·|regs|)` — if that overlaps the slot the
+///    store is LIVE (a mis-paired epilogue is caught, not assumed away);
+///    otherwise it is teardown, `d += 4·|regs|`, and a `pop {…, pc}` ends the
+///    path (return);
+///  - `bx lr` ends the path; conditional branches fork; unconditional `b`
+///    follows its label; falling off the end of the function ends the path
+///    (reach-end without a read — the case this pass exists to catch);
+///  - a state budget (`16·len + 64` visited states) bounds loops whose SP
+///    displacement diverges; exceeding it conservatively keeps the store.
+///
+/// Removal-only ⇒ the output never grows (asserted) and, run before
+/// `resolve_label_branches` like every pass here, is branch-offset neutral.
+/// The frame `sub sp, #K` is untouched (the slot goes unused; frame SHRINKING
+/// is [`elide_dead_frame`]'s job). Pure function; callers opt in
+/// (`SYNTH_SPILL_REALLOC=1` wiring in `arm_backend.rs`, same lever as the
+/// spill re-choice it completes).
+pub fn eliminate_unread_frame_stores(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
+    use ArmOp::*;
+
+    // ---- Admission: label map + whole-function soundness scan. ----
+    let mut labels: BTreeMap<&str, usize> = BTreeMap::new();
+    for (i, ins) in instrs.iter().enumerate() {
+        if let Label { name } = &ins.op
+            && labels.insert(name.as_str(), i).is_some()
+        {
+            return (instrs.to_vec(), 0); // duplicate label: ambiguous CFG
+        }
+    }
+    for ins in instrs {
+        let admissible = match &ins.op {
+            Label { .. } => true,
+            B { label } | Bhs { label } | Blo { label } | Bcc { label, .. } => {
+                labels.contains_key(label.as_str())
+            }
+            // Only the `bx lr` return form: any other indirect jump could land
+            // anywhere, so "no successors" would be a wrong CFG.
+            Bx { rm } => *rm == Reg::LR,
+            Push { .. } | Pop { .. } => true,
+            // Tracked frame adjust: add/sub sp, sp, #imm.
+            Add {
+                rd: Reg::SP,
+                rn: Reg::SP,
+                op2: Operand2::Imm(_),
+            }
+            | Sub {
+                rd: Reg::SP,
+                rn: Reg::SP,
+                op2: Operand2::Imm(_),
+            } => true,
+            // sp-relative memory access: must be a pinnable immediate slot.
+            Ldr { addr, .. }
+            | Ldrb { addr, .. }
+            | Ldrsb { addr, .. }
+            | Ldrh { addr, .. }
+            | Ldrsh { addr, .. }
+            | Str { addr, .. }
+            | Strb { addr, .. }
+            | Strh { addr, .. }
+                if addr.base == Reg::SP =>
+            {
+                addr.offset_reg.is_none()
+            }
+            // Everything else: must be fully modeled AND not touch SP at all
+            // (an SP use here is an address-of-frame ESCAPE; an SP def is an
+            // untracked frame move). Calls, BrTable, numeric branch offsets and
+            // unmodeled pseudo-ops all land in the `None` arm.
+            op => match reg_effect(op) {
+                Some(eff) => !eff.uses.contains(&Reg::SP) && !eff.defs.contains(&Reg::SP),
+                None => false,
+            },
+        };
+        if !admissible {
+            return (instrs.to_vec(), 0);
+        }
+    }
+
+    // ---- Per-store may-reach walk. ----
+    let dead: std::collections::BTreeSet<usize> = instrs
+        .iter()
+        .enumerate()
+        .filter(|(i, ins)| match &ins.op {
+            Str { addr, .. } => {
+                sp_slot(addr).is_some_and(|slot| frame_slot_unread_from(instrs, &labels, *i, slot))
+            }
+            _ => false,
+        })
+        .map(|(i, _)| i)
+        .collect();
+
+    if dead.is_empty() {
+        return (instrs.to_vec(), 0);
+    }
+    let kept: Vec<ArmInstruction> = instrs
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !dead.contains(i))
+        .map(|(_, ins)| ins.clone())
+        .collect();
+    // Guard: removal-only — the function can only shrink.
+    assert!(
+        kept.len() + dead.len() == instrs.len(),
+        "eliminate_unread_frame_stores must be removal-only"
+    );
+    (kept, dead.len())
+}
+
+/// The may-reach walk of [`eliminate_unread_frame_stores`]: `true` iff no
+/// instruction reachable from the store at `start` can read slot
+/// `[slot, slot+4)` (byte interval in store-time SP coordinates). The stream
+/// has already passed the admission scan, so every op encountered is one of
+/// the tracked shapes.
+fn frame_slot_unread_from(
+    instrs: &[ArmInstruction],
+    labels: &BTreeMap<&str, usize>,
+    start: usize,
+    slot: i32,
+) -> bool {
+    use ArmOp::*;
+    let n = instrs.len();
+    let max_states = 16 * n + 64;
+    let slot = i64::from(slot);
+    // An access at [sp, #M] of width w under displacement d overlaps the slot?
+    let reads_slot = |d: i64, m: i32, w: i64| {
+        let lo = d + i64::from(m);
+        lo < slot + 4 && slot < lo + w
+    };
+
+    let mut visited: std::collections::BTreeSet<(usize, i64)> = std::collections::BTreeSet::new();
+    // Work list of (index, sp_delta) states still to examine.
+    let mut work: Vec<(usize, i64)> = vec![(start + 1, 0)];
+    while let Some((i, d)) = work.pop() {
+        if i >= n || !visited.insert((i, d)) {
+            continue; // fell off the end (reach-end ≠ read) or already seen
+        }
+        if visited.len() > max_states {
+            return false; // budget exceeded: conservatively live
+        }
+        match &instrs[i].op {
+            // sp-relative loads: any byte overlap with the slot is a read.
+            Ldr { addr, .. } if addr.base == Reg::SP => {
+                if reads_slot(d, addr.offset, 4) {
+                    return false;
+                }
+                work.push((i + 1, d));
+            }
+            Ldrb { addr, .. } | Ldrsb { addr, .. } if addr.base == Reg::SP => {
+                if reads_slot(d, addr.offset, 1) {
+                    return false;
+                }
+                work.push((i + 1, d));
+            }
+            Ldrh { addr, .. } | Ldrsh { addr, .. } if addr.base == Reg::SP => {
+                if reads_slot(d, addr.offset, 2) {
+                    return false;
+                }
+                work.push((i + 1, d));
+            }
+            // Whole-word store covering the slot exactly: overwrite-kill — the
+            // path dies. Anything else (partial overlap, other slot, sub-word
+            // store) is neither a read nor a kill.
+            Str { addr, .. } if addr.base == Reg::SP => {
+                if d + i64::from(addr.offset) != slot {
+                    work.push((i + 1, d));
+                }
+            }
+            // Tracked frame adjusts — teardown, not a read.
+            Add {
+                rd: Reg::SP,
+                op2: Operand2::Imm(k),
+                ..
+            } => work.push((i + 1, d + i64::from(*k))),
+            Sub {
+                rd: Reg::SP,
+                op2: Operand2::Imm(k),
+                ..
+            } => work.push((i + 1, d - i64::from(*k))),
+            // Push writes strictly below SP: no read; SP drops.
+            Push { regs } => work.push((i + 1, d - 4 * regs.len() as i64)),
+            // Pop READS [d, d+4·|regs|): a mis-paired epilogue that would read
+            // the slot keeps the store; the normal `add sp,#K; pop` epilogue
+            // has d ≥ K > slot and is teardown. `pop {…, pc}` returns.
+            Pop { regs } => {
+                if slot >= d && slot < d + 4 * regs.len() as i64 {
+                    return false;
+                }
+                if !regs.contains(&Reg::PC) {
+                    work.push((i + 1, d + 4 * regs.len() as i64));
+                }
+            }
+            // Control flow (targets exist — admission checked).
+            B { label } => work.push((labels[label.as_str()], d)),
+            Bhs { label } | Blo { label } | Bcc { label, .. } => {
+                work.push((i + 1, d));
+                work.push((labels[label.as_str()], d));
+            }
+            Bx { .. } => {} // `bx lr` return: path ends
+            // Every other admitted op neither touches the frame nor moves SP.
+            _ => work.push((i + 1, d)),
+        }
+    }
+    true
+}
+
 /// VCR-RA immediate-shift folding (#390, epic #242): fold a register-materialized
 /// constant shift amount into an immediate shift, dropping the `movw`.
 ///
@@ -7080,6 +7325,229 @@ mod tests {
         ];
         let (_out, n) = eliminate_dead_frame_stores(&seq);
         assert_eq!(n, 0, "an unresolvable sp-relative access blocks removal");
+    }
+
+    // ---- whole-function frame-slot liveness (eliminate_unread_frame_stores) ----
+
+    /// The flat_flight epilogue shape: `add sp,#K; pop {…, pc}`.
+    fn teardown(k: i32) -> [ArmInstruction; 2] {
+        [
+            ins(ArmOp::Add {
+                rd: Reg::SP,
+                rn: Reg::SP,
+                op2: Operand2::Imm(k),
+            }),
+            ins(ArmOp::Pop {
+                regs: vec![Reg::R4, Reg::PC],
+            }),
+        ]
+    }
+
+    #[test]
+    fn unread_store_reaching_function_end_is_dropped() {
+        // str r0,[sp,#8] ; add r1,… ; add sp,#88 ; pop {r4,pc} — slot #8 is never
+        // read anywhere; the teardown does not count as a read. This is exactly
+        // the reach-end case the segment-local pass keeps (flat_flight's 2 stores).
+        let mut seq = vec![
+            str_sp(Reg::R0, 8),
+            ins(ArmOp::Add {
+                rd: Reg::R1,
+                rn: Reg::R2,
+                op2: Operand2::Imm(1),
+            }),
+        ];
+        seq.extend(teardown(88));
+        // The segment-local pass proves nothing here (no overwrite).
+        assert_eq!(eliminate_dead_frame_stores(&seq).1, 0);
+        let (out, n) = eliminate_unread_frame_stores(&seq);
+        assert_eq!(n, 1, "an unread reach-end store is provably dead");
+        assert_eq!(out.len(), seq.len() - 1);
+        assert!(!out.iter().any(|i| matches!(&i.op, ArmOp::Str { .. })));
+    }
+
+    #[test]
+    fn unread_store_read_via_back_edge_is_kept() {
+        // L: ldr r1,[sp,#8] ; … ; str r0,[sp,#8] ; bcc L ; teardown — the ONLY
+        // read of slot #8 is BEFORE the store in program order, reachable only
+        // through the loop back-edge. A linear scan would call the store dead;
+        // the may-reach walk must not.
+        let mut seq = vec![
+            ins(ArmOp::Label { name: "L".into() }),
+            ldr_sp(Reg::R1, 8),
+            str_sp(Reg::R0, 8),
+            ins(ArmOp::Bcc {
+                cond: Condition::NE,
+                label: "L".into(),
+            }),
+        ];
+        seq.extend(teardown(16));
+        let (out, n) = eliminate_unread_frame_stores(&seq);
+        assert_eq!(n, 0, "a slot read via a loop back-edge is live");
+        assert_eq!(out, seq);
+    }
+
+    #[test]
+    fn unread_store_subword_read_blocks() {
+        // str r0,[sp,#8] ; ldrb r1,[sp,#10] ; teardown — the byte load reads a
+        // byte INSIDE slot #8's word ⇒ live (sub-word reads count as reads of
+        // their containing word, the #483-class rule).
+        let mut seq = vec![
+            str_sp(Reg::R0, 8),
+            ins(ArmOp::Ldrb {
+                rd: Reg::R1,
+                addr: MemAddr::imm(Reg::SP, 10),
+            }),
+        ];
+        seq.extend(teardown(16));
+        let (_out, n) = eliminate_unread_frame_stores(&seq);
+        assert_eq!(
+            n, 0,
+            "a sub-word read inside the slot's word keeps the store"
+        );
+        // A byte read OUTSIDE the slot's word does not alias it.
+        let mut seq2 = vec![
+            str_sp(Reg::R0, 8),
+            ins(ArmOp::Ldrb {
+                rd: Reg::R1,
+                addr: MemAddr::imm(Reg::SP, 12),
+            }),
+        ];
+        seq2.extend(teardown(16));
+        let (_out, n2) = eliminate_unread_frame_stores(&seq2);
+        assert_eq!(n2, 1, "a byte read of a DIFFERENT word does not alias");
+    }
+
+    #[test]
+    fn unread_store_unknown_index_declines_function() {
+        // str r0,[sp,#8] ; ldr r1,[sp,r2] ; teardown — a register-offset sp
+        // access could touch any slot: the whole function declines.
+        let mut seq = vec![
+            str_sp(Reg::R0, 8),
+            ins(ArmOp::Ldr {
+                rd: Reg::R1,
+                addr: MemAddr::reg(Reg::SP, Reg::R2),
+            }),
+        ];
+        seq.extend(teardown(16));
+        let (out, n) = eliminate_unread_frame_stores(&seq);
+        assert_eq!(
+            n, 0,
+            "an unresolvable sp access declines the whole function"
+        );
+        assert_eq!(out, seq);
+    }
+
+    #[test]
+    fn unread_store_frame_escape_declines_function() {
+        // str r0,[sp,#8] ; add r2,sp,#8 ; teardown — the slot's ADDRESS escapes
+        // into r2; a later plain `ldr [r2]` could read it invisibly. Decline.
+        let mut seq = vec![
+            str_sp(Reg::R0, 8),
+            ins(ArmOp::Add {
+                rd: Reg::R2,
+                rn: Reg::SP,
+                op2: Operand2::Imm(8),
+            }),
+        ];
+        seq.extend(teardown(16));
+        let (out, n) = eliminate_unread_frame_stores(&seq);
+        assert_eq!(n, 0, "a frame-address escape declines the whole function");
+        assert_eq!(out, seq);
+
+        // mov r2, sp is the same escape.
+        let mut seq2 = vec![
+            str_sp(Reg::R0, 8),
+            ins(ArmOp::Mov {
+                rd: Reg::R2,
+                op2: Operand2::Reg(Reg::SP),
+            }),
+        ];
+        seq2.extend(teardown(16));
+        assert_eq!(eliminate_unread_frame_stores(&seq2).1, 0);
+    }
+
+    #[test]
+    fn unread_store_call_declines_function() {
+        // str r0,[sp,#0] ; bl f ; teardown — a callee may read an outgoing
+        // stack-argument slot through its own view of SP. Decline.
+        let mut seq = vec![str_sp(Reg::R0, 0), ins(ArmOp::Bl { label: "f".into() })];
+        seq.extend(teardown(16));
+        let (out, n) = eliminate_unread_frame_stores(&seq);
+        assert_eq!(n, 0, "a call declines the whole function");
+        assert_eq!(out, seq);
+    }
+
+    #[test]
+    fn unread_store_mispaired_pop_reads_slot() {
+        // str r0,[sp,#4] ; pop {r4,r5,pc} — NO `add sp` first: the pop reads
+        // [sp,#0..#12), which OVERLAPS slot #4 ⇒ live. The Pop-is-teardown rule
+        // is displacement-checked, not assumed.
+        let seq = vec![
+            str_sp(Reg::R0, 4),
+            ins(ArmOp::Pop {
+                regs: vec![Reg::R4, Reg::R5, Reg::PC],
+            }),
+        ];
+        let (_out, n) = eliminate_unread_frame_stores(&seq);
+        assert_eq!(n, 0, "a pop that reads the slot's bytes keeps the store");
+    }
+
+    #[test]
+    fn unread_store_read_on_one_branch_arm_is_kept() {
+        // str r0,[sp,#8] ; bcc T ; teardown ; T: ldr r1,[sp,#8] ; teardown —
+        // one successor reads the slot, the other returns: may-reach must keep.
+        let mut seq = vec![
+            str_sp(Reg::R0, 8),
+            ins(ArmOp::Bcc {
+                cond: Condition::EQ,
+                label: "T".into(),
+            }),
+        ];
+        seq.extend(teardown(16));
+        seq.push(ins(ArmOp::Label { name: "T".into() }));
+        seq.push(ldr_sp(Reg::R1, 8));
+        seq.extend(teardown(16));
+        let (_out, n) = eliminate_unread_frame_stores(&seq);
+        assert_eq!(n, 0, "a read on ANY reachable path keeps the store");
+    }
+
+    #[test]
+    fn unread_store_overwrite_kills_path_and_later_read_is_of_new_value() {
+        // str r0,[sp,#8] ; str r1,[sp,#8] ; ldr r2,[sp,#8] ; teardown — the
+        // second store covers the slot before any read: store #1 is dead (the
+        // read observes r1's value); store #2 is live.
+        let mut seq = vec![str_sp(Reg::R0, 8), str_sp(Reg::R1, 8), ldr_sp(Reg::R2, 8)];
+        seq.extend(teardown(16));
+        let (out, n) = eliminate_unread_frame_stores(&seq);
+        assert_eq!(
+            n, 1,
+            "overwritten-before-read store is dead; the live one stays"
+        );
+        assert!(matches!(out[0].op, ArmOp::Str { rd: Reg::R1, .. }));
+    }
+
+    #[test]
+    fn unread_store_sp_tracking_across_frame_adjust() {
+        // str r0,[sp,#8] ; sub sp,#4 ; ldr r1,[sp,#12] ; add sp,#4 ; teardown —
+        // after `sub sp,#4` the SAME bytes are named [sp,#12]: the walk tracks
+        // the displacement and sees the read.
+        let mut seq = vec![
+            str_sp(Reg::R0, 8),
+            ins(ArmOp::Sub {
+                rd: Reg::SP,
+                rn: Reg::SP,
+                op2: Operand2::Imm(4),
+            }),
+            ldr_sp(Reg::R1, 12),
+            ins(ArmOp::Add {
+                rd: Reg::SP,
+                rn: Reg::SP,
+                op2: Operand2::Imm(4),
+            }),
+        ];
+        seq.extend(teardown(16));
+        let (_out, n) = eliminate_unread_frame_stores(&seq);
+        assert_eq!(n, 0, "a renamed read after an SP adjust is still a read");
     }
 
     #[test]


### PR DESCRIPTION
## The reach-end blocker (#242, VCR-RA-001)

The Belady spill-plan re-choice (#576) dissolved flat_flight's 3 reloads, but 2 spill stores survived: their slots are **never read again anywhere in the function**, yet the segment-local frame-slot DCE (#515) can only prove deadness via a later same-slot overwrite — a slot that reaches segment end is kept ("reach-end ≠ dead", no epilogue guessing). `spill_realloc_242.rs` pinned flat_flight at (0 ld, 2 st) and named this conservatism as the blocker. This PR lands the missing whole-function view.

## The analysis — `eliminate_unread_frame_stores` (liveness.rs)

Per candidate `str rX,[sp,#N]`, a **may-reach walk** over states `(index, sp_displacement)` — fall-through + label/branch edges, loops included — proves no reachable instruction can read the slot's bytes:

- **byte-interval aliasing**: any sp-relative load whose interval overlaps `[N, N+4)` ⇒ live; sub-word reads (`ldrb`/`ldrh`/…) thereby count as reads of their containing word (the #483-class rule);
- a whole-word store **covering** the slot kills the path (overwrite); partial overlap is neither read nor kill;
- `add/sub sp,#imm` / `Push` / `Pop` are **displacement-tracked teardown**, not reads — and a mis-paired `pop` whose read interval `[d, d+4·|regs|)` would actually touch the slot keeps the store (checked, not assumed);
- a state budget (16·len+64) bounds SP-divergent loops — exceeding it keeps the store.

## Soundness rules (whole function declines honestly on the first violation)

- any `[sp, rM]` register-offset access — slot unresolvable ⇒ ALL-LIVE (decline);
- SP as a general operand (`add rD,sp,#x`, `mov rD,sp`, …) — the frame address **escapes** ⇒ decline;
- SP redefined by anything but the tracked shapes ⇒ decline;
- calls (`Bl`/`Blx`/`Call`/`CallIndirect`) — a callee may read an outgoing stack-arg slot ⇒ decline;
- unresolvable control flow (numeric `BOffset`/`BCondOffset`, `BrTable`, non-`bx lr` indirect, missing/duplicate labels) ⇒ decline;
- any op `reg_effect` does not model ⇒ decline.

Removal-only, asserted: no function can grow. Full control flow **is** handled (may-reach, not just structural Labels); no soundness rule was weakened to hit the target.

## Flag: same `SYNTH_SPILL_REALLOC` lever

Wired as stage 3 behind the SAME flag as the forwarding + Belady re-choice: it completes the same Belady contract (the 0-load side gains its 0-store side), the differential suite for that flag covers it, and one lever keeps the v0.24.0 flip atomic. Flag-off is byte-identical by construction (the pass only runs inside the flag block).

## Gate results

| check | result |
|---|---|
| flat_flight frame traffic (flag-on) | 3ld+3st → **0ld+0st** (was 0ld+2st) — `belady(k=9)=0ld+0st` fully met |
| flat_flight `.text` (flag-on) | 412 → **388 B** (was 396 B) |
| CI pin red→green | `spill_realloc_242.rs` flipped (0,2)→(0,0) + shrink ≥20 B; pre-change binary measured (0,2)/396 B ⇒ new pin fails on main, passes here |
| flag-OFF byte-identical | `frozen_codegen_bytes` 3/3 green; `const_cse_reduction_242` golden green |
| flag-ON differentials vs wasmtime | `const_cse_differential.py` PASS, `frame_slot_dce_differential.py` PASS, `flight_seam_differential.py` PASS (0x07FDF307 match), all with `SYNTH_SPILL_REALLOC=1` |
| ad-hoc unicorn run of rewritten flat_flight | 10/10 (5 input vectors × flag-off/flag-on): result **and full flight_state writeback** bit-identical to wasmtime |
| corpus no-grow | flight_seam per-function no-grow green flag-on; no flag-on compile failures anywhere in the suites |
| unit tests | 9 new (reach-end dropped; back-edge read kept; sub-word blocks; unknown-index declines; escape declines ×2; call declines; mis-paired pop kept; branch-arm read kept; overwrite-kill; SP-adjust renamed read kept) — synth-synthesis 504/504 |
| suites / hygiene | `cargo test -p synth-synthesis -p synth-cli` all green; `cargo fmt --check` clean; `clippy -D warnings` clean (synthesis, cli, backend) |

Refs #242 (VCR-RA-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)