### PR TITLE
fix(selector): spill rung stores before clobber — never reload a never-stored slot (#581)

### DIFF
--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -426,6 +426,50 @@ impl SpillState {
     }
 }
 
+/// #581 defensive invariant (the internal-bug panic pattern): every reload
+/// from the spill area must be preceded — in emission order, which is how the
+/// selector always orders a spill store and its reload — by a store to the
+/// same 4-byte slot offset. The #581 miscompile deleted a spill store post-hoc
+/// (a const fold dropping the tail by `source_line`), leaving `LDR` of a
+/// never-written slot: a silent wrong value on the shipped path. That is an
+/// internal selector bug, never an input property, so it panics loudly instead
+/// of compiling wrong code.
+///
+/// Only meaningful when the spill area was actually reserved (`area_reserved`);
+/// otherwise `spill_base` aliases the #204 param home slots (#331) and the scan
+/// would see unrelated frame traffic. Slot reuse means a stale earlier store
+/// can mask a lost later one — this is defense-in-depth behind the
+/// `is_const_materialization` filters, not the primary fix.
+fn assert_spill_reloads_have_stores(instructions: &[ArmInstruction], spill_base: i32) {
+    let area = spill_base..spill_base + (I64_SPILL_SLOTS as i32) * 8;
+    let mut stored = [false; I64_SPILL_SLOTS * 2]; // 4-byte halves
+    for ins in instructions {
+        match &ins.op {
+            ArmOp::Str { addr, .. }
+                if addr.base == Reg::SP
+                    && addr.offset_reg.is_none()
+                    && area.contains(&addr.offset) =>
+            {
+                stored[((addr.offset - spill_base) / 4) as usize] = true;
+            }
+            ArmOp::Ldr { addr, .. }
+                if addr.base == Reg::SP
+                    && addr.offset_reg.is_none()
+                    && area.contains(&addr.offset) =>
+            {
+                assert!(
+                    stored[((addr.offset - spill_base) / 4) as usize],
+                    "#581 internal selector bug: reload from spill slot [sp, #{}] \
+                     with no preceding spill store — a spill store was lost \
+                     (store-before-clobber invariant violated)",
+                    addr.offset
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
 /// The physical registers currently reserved by the virtual stack (#171): every
 /// [`StackVal::Reg`]'s `r` and its conventional [`i64_pair_hi`]. Spilled entries
 /// reserve nothing. (Over-reserving the pair_hi for i32 entries is the
@@ -5049,6 +5093,23 @@ impl InstructionSelector {
         if eff <= 0xFFF { Some(eff) } else { None }
     }
 
+    /// A const-materialization instruction: what the `i32.const` handler emits
+    /// to build the value in a register — `MOVW`, `MOVW+MOVT`, or `MOVW+MVN`.
+    ///
+    /// #581: the const's temp allocation can ALSO emit a spill store
+    /// (`STR victim, [SP, slot]` via [`alloc_temp_or_spill`] under the
+    /// spill-on-exhaustion retry) tagged with the SAME `source_line`. That store
+    /// is NOT part of the materialization — deleting it leaves the victim's
+    /// stack entry marked [`StackVal::Spilled`] with no store, so its later
+    /// reload reads a never-written frame slot (silent wrong value). Every
+    /// fold that drops a materialization by `source_line` must filter on this.
+    fn is_const_materialization(op: &ArmOp) -> bool {
+        matches!(
+            op,
+            ArmOp::Movw { .. } | ArmOp::Movt { .. } | ArmOp::Mvn { .. }
+        )
+    }
+
     /// Pop the const-materialization instructions emitted for the immediately
     /// preceding `i32.const`. The const handler emits 1 instruction (Movw) for
     /// values <= 0xFFFF, 2 instructions (Movw + Mvn) for inverted patterns, and
@@ -5056,9 +5117,15 @@ impl InstructionSelector {
     /// `source_line`. Removing them from the tail is safe because no later
     /// instruction depends on the materialized value once the load/store is
     /// folded.
+    ///
+    /// #581: only genuine materialization ops are popped. A spill store emitted
+    /// while allocating the const's temp shares the const's `source_line` but
+    /// MUST survive the fold — its slot is recorded as populated on the virtual
+    /// stack (store-before-clobber invariant). The materialization ops are
+    /// emitted after any such store, so the walk stops there naturally.
     fn drop_prev_const_materialization(instructions: &mut Vec<ArmInstruction>, const_idx: usize) {
         while let Some(last) = instructions.last() {
-            if last.source_line == Some(const_idx) {
+            if last.source_line == Some(const_idx) && Self::is_const_materialization(&last.op) {
                 instructions.pop();
             } else {
                 break;
@@ -5122,9 +5189,13 @@ impl InstructionSelector {
                 break;
             }
         }
-        // Drop the addr-const chunk now exposed at the tail.
+        // Drop the addr-const chunk now exposed at the tail. #581: only the
+        // materialization ops — a spill store tagged with the addr-const's
+        // line (emitted by its temp allocation under the spill retry) must
+        // survive, or its recorded slot is never populated.
         while let Some(last) = instructions.last() {
-            if last.source_line == Some(addr_const_idx) {
+            if last.source_line == Some(addr_const_idx) && Self::is_const_materialization(&last.op)
+            {
                 instructions.pop();
             } else {
                 break;
@@ -6646,9 +6717,15 @@ impl InstructionSelector {
                             // #209 cleanup: the reciprocal-multiply reads the magic
                             // constant, never the divisor — so the divisor's eager
                             // materialization (the `i32.const` at idx-1, the only op
-                            // tagged there) is dead on this path. Drop it.
+                            // tagged there) is dead on this path. Drop it. #581:
+                            // materialization ops only — a spill store emitted while
+                            // allocating the divisor's temp shares the tag but must
+                            // survive (its slot is recorded as populated).
                             if idx >= 1 {
-                                instructions.retain(|i| i.source_line != Some(idx - 1));
+                                instructions.retain(|i| {
+                                    i.source_line != Some(idx - 1)
+                                        || !Self::is_const_materialization(&i.op)
+                                });
                             }
                             // Materialize the magic constant m into rmag.
                             instructions.push(ArmInstruction {
@@ -10783,6 +10860,12 @@ impl InstructionSelector {
             },
             source_line: None,
         });
+
+        // #581 defensive invariant: no reload of a never-stored spill slot may
+        // leave the selector (see `assert_spill_reloads_have_stores`).
+        if spill.area_reserved {
+            assert_spill_reloads_have_stores(&instructions, spill.base);
+        }
 
         Ok(instructions)
     }
@@ -17553,6 +17636,85 @@ mod tests {
             then_local.is_some() && then_local == else_local,
             "both arms write the same local register; End adds no reconciliation \
              (then={then_local:?} else={else_local:?})"
+        );
+    }
+
+    /// #581: the add/sub/bitwise immediate folds delete the const
+    /// materialization by `source_line` — which, under the spill-on-exhaustion
+    /// retry, also deleted the spill store `alloc_temp_or_spill` emitted for
+    /// the const's temp (same tag), leaving the victim's stack entry marked
+    /// `Spilled` with no store: the later reload read a never-written frame
+    /// slot (silent wrong value on the shipped direct path,
+    /// `scripts/repro/spill_on_exhaust_242.wat` returned 0xffffd1ce for
+    /// hp(1,2) where wasmtime says 0x2e37). Every spill store must survive
+    /// the fold: exactly one STR per spill-area reload, at matching offsets.
+    #[test]
+    fn fold_preserves_spill_store_581() {
+        use WasmOp::*;
+        // Seven simultaneously-live binop results (R2..R8) + p0 pushed + p1
+        // reserved to its late last-read = all 9 allocatable registers pinned
+        // when `i32.const 77` materializes → the deepest value spills. The
+        // following `i32.sub` folds the const to `SUB rd, rn, #77` and drops
+        // the materialization — the spill store must NOT go with it.
+        let mut ops = Vec::new();
+        for bin in [I32Add, I32Sub, I32Xor, I32Or, I32And, I32Mul, I32Add] {
+            ops.extend([LocalGet(0), LocalGet(1), bin]);
+        }
+        ops.extend([LocalGet(0), I32Const(77), I32Sub]);
+        ops.extend([I32Sub, I32Xor, I32Add, I32Sub, I32Xor, I32Add, I32Sub]);
+        ops.extend([LocalGet(1), I32Add]);
+
+        let mut retry = fresh_selector();
+        retry.set_spill_on_exhaustion(true);
+        retry.set_params_i64(vec![false, false]);
+        let instrs = retry
+            .select_with_stack(&ops, 2)
+            .expect("spill retry must compile");
+
+        let spill_strs: Vec<i32> = instrs
+            .iter()
+            .filter_map(|i| match &i.op {
+                ArmOp::Str { addr, .. }
+                    if addr.base == Reg::SP
+                        && addr.offset_reg.is_none()
+                        && i.source_line.is_some() =>
+                {
+                    Some(addr.offset)
+                }
+                _ => None,
+            })
+            .collect();
+        let spill_ldrs: Vec<i32> = instrs
+            .iter()
+            .filter_map(|i| match &i.op {
+                ArmOp::Ldr { addr, .. }
+                    if addr.base == Reg::SP
+                        && addr.offset_reg.is_none()
+                        && i.source_line.is_some() =>
+                {
+                    Some(addr.offset)
+                }
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !spill_ldrs.is_empty(),
+            "shape must exercise the spill rung (a reload is expected)"
+        );
+        for off in &spill_ldrs {
+            assert!(
+                spill_strs.contains(off),
+                "#581: reload from [sp, #{off}] has no spill store — the fold \
+                 deleted it (spill stores emitted at the const's source_line \
+                 must survive drop_prev_const_materialization)"
+            );
+        }
+        // The fold itself must still fire: no MOVW #77 materialization remains.
+        assert!(
+            !instrs
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Movw { imm16: 77, .. })),
+            "the #253 imm fold must still drop the const materialization"
         );
     }
 

--- a/scripts/repro/spill_rung_581.wat
+++ b/scripts/repro/spill_rung_581.wat
@@ -1,0 +1,53 @@
+;; #581 — DIRECT-selector spill-rung minimal repro: a const fold deleting a
+;; spill store.
+;;
+;; Shape: seven simultaneously-live i32 binop results (R2..R8) + p0 pushed +
+;; p1 reserved to its late last-read pin all 9 allocatable registers, so the
+;; base pass hard-fails with the exhaustion Err and the backend retries on the
+;; spill rung (VCR-RA-001 3b-lite). On the retry, materializing `i32.const 77`
+;; spills the deepest live value (v1) to a frame slot — the spill STR is tagged
+;; with the const's source_line. The following `i32.sub` then folds the const
+;; to `SUB rd, rn, #77` (#253) and drops the materialization BY SOURCE_LINE,
+;; which pre-fix also deleted the spill store: v1's stack entry stayed
+;; `Spilled` and its final reload read a never-written slot — silent wrong
+;; value on the shipped `--relocatable`/direct path.
+;;
+;; hp(1,2): wasmtime 0x4f, pre-fix synth returned frame garbage.
+;;
+;; Differential oracle:
+;;   python scripts/repro/spill_rung_581_differential.py
+(module
+  (func (export "hp") (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.add        ;; v1 = p0+p1  (the spill victim)
+    local.get 0
+    local.get 1
+    i32.sub        ;; v2
+    local.get 0
+    local.get 1
+    i32.xor        ;; v3
+    local.get 0
+    local.get 1
+    i32.or         ;; v4
+    local.get 0
+    local.get 1
+    i32.and        ;; v5
+    local.get 0
+    local.get 1
+    i32.mul        ;; v6
+    local.get 0
+    local.get 1
+    i32.add        ;; v7
+    local.get 0
+    i32.const 77
+    i32.sub        ;; v8 = p0-77 — the fold whose spill store must survive
+    i32.sub        ;; v7 - v8
+    i32.xor        ;; v6 ^ …
+    i32.add        ;; v5 + …
+    i32.sub        ;; v4 - …
+    i32.xor        ;; v3 ^ …
+    i32.add        ;; v2 + …
+    i32.sub        ;; v1 - …   <- pre-fix: reloads the never-stored slot
+    local.get 1
+    i32.add))      ;; + p1 (keeps R1 reserved through the const materialization)

--- a/scripts/repro/spill_rung_581_differential.py
+++ b/scripts/repro/spill_rung_581_differential.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""#581 — DIRECT-selector spill-rung differential: unicorn vs wasmtime.
+
+The direct selector's spill rung (the backend's exhaustion retry,
+VCR-RA-001 3b-lite) spills the deepest live vstack value when materializing a
+constant exhausts the register pool. The spill STR is tagged with the const's
+source_line — and the #253 add/sub immediate fold dropped the materialization
+BY source_line, deleting the spill store with it. The victim's stack entry
+stayed `Spilled`, so its reload read a never-written frame slot: a silent
+wrong value on the shipped `--relocatable` path (issue #581; found by the
+#580 lane on `spill_on_exhaust_242.wat`, hp(1,2) = 0xffffd1ce vs wasmtime
+0x2e37).
+
+Runs BOTH fixtures on the direct path (default env — the spill rung is the
+backend's built-in retry ladder, no flag) over several argument pairs:
+  * scripts/repro/spill_rung_581.wat        — the minimal fold-deletes-store shape
+  * scripts/repro/spill_on_exhaust_242.wat  — the original discovery fixture
+
+Exits nonzero on any mismatch so it can gate a release.
+
+Run (rebuild synth first):
+  SYNTH=/Volumes/devcache/wave15-581/debug/synth \
+    /tmp/synthvenv/bin/python scripts/repro/spill_rung_581_differential.py
+"""
+
+import os
+import subprocess
+import sys
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+FIXTURES = [
+    "scripts/repro/spill_rung_581.wat",
+    "scripts/repro/spill_on_exhaust_242.wat",
+]
+
+ARGS = [(1, 2), (0, 0), (7, 3), (0xFFFFFFFF, 1), (12345, 54321), (2, 1)]
+
+LIN_BASE = 0x20000000
+MASK32 = 0xFFFFFFFF
+
+
+def symtab(path):
+    """Function symbols from the ELF symtab (NOT disasm text — host-dependent)."""
+    with open(path, "rb") as f:
+        elf = ELFFile(f)
+        out = {}
+        for sec in elf.iter_sections():
+            if sec["sh_type"] != "SHT_SYMTAB":
+                continue
+            for s in sec.iter_symbols():
+                if s["st_info"]["type"] == "STT_FUNC" and s.name:
+                    out[s.name] = s["st_value"] & ~1
+        return out
+
+
+def run_wasmtime(wasm):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, open(wasm, "rb").read())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    hp = inst.exports(store)["hp"]
+    out = []
+    for a, b in ARGS:
+        # wasmtime takes i32 params as signed
+        sa = a - (1 << 32) if a > 0x7FFFFFFF else a
+        sb = b - (1 << 32) if b > 0x7FFFFFFF else b
+        out.append(hp(store, sa, sb) & MASK32)
+    return out
+
+
+def run_unicorn(wasm, elf):
+    subprocess.run(
+        [SYNTH, "compile", wasm, "-t", "cortex-m4", "--relocatable", "-o", elf],
+        check=True,
+        capture_output=True,
+    )
+    syms = symtab(elf)
+    fn = syms.get("hp", syms.get("func_0"))
+    if fn is None:
+        return f"ERR: no hp/func_0 symbol in {elf} (have {sorted(syms)})"
+    with open(elf, "rb") as f:
+        text = ELFFile(f).get_section_by_name(".text")
+        code, base = text.data(), text["sh_addr"]
+
+    CODE, STK = 0x10000, 0x30000000
+    RET = CODE + 0xF000
+    out = []
+    for a, b in ARGS:
+        mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+        mu.mem_map(CODE, 0x10000)
+        mu.mem_map(LIN_BASE, 0x10000)
+        mu.mem_map(STK - 0x8000, 0x10000)
+        mu.mem_write(CODE, code)
+        mu.reg_write(UC_ARM_REG_R0, a)
+        mu.reg_write(UC_ARM_REG_R1, b)
+        mu.reg_write(UC_ARM_REG_R11, LIN_BASE)
+        mu.reg_write(UC_ARM_REG_SP, STK)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        try:
+            mu.emu_start((CODE + fn - base) | 1, RET, count=10000)
+        except UcError as e:
+            return f"ERR in hp({a},{b}): {e}"
+        out.append(mu.reg_read(UC_ARM_REG_R0) & MASK32)
+    return out
+
+
+def main():
+    fail = False
+    for wat in FIXTURES:
+        name = os.path.basename(wat)
+        wasm = f"/tmp/{name}.wasm"
+        elf = f"/tmp/{name}.o"
+        subprocess.run(["wat2wasm", wat, "-o", wasm], check=True)
+        gt = run_wasmtime(wasm)
+        got = run_unicorn(wasm, elf)
+        print(f"== {name} ==")
+        print(f"  args                 : {ARGS}")
+        print(f"  wasmtime (truth)     : {[hex(x) for x in gt]}")
+        if isinstance(got, str):
+            print(f"  synth ARM (unicorn)  : {got}")
+            print("  MISMATCH  <-- #581")
+            fail = True
+            continue
+        print(f"  synth ARM (unicorn)  : {[hex(x) for x in got]}")
+        if got != gt:
+            bad = [
+                f"hp{ARGS[i]}: got {hex(got[i])} want {hex(gt[i])}"
+                for i in range(len(gt))
+                if got[i] != gt[i]
+            ]
+            print(f"  MISMATCH  <-- #581: {'; '.join(bad)}")
+            fail = True
+        else:
+            print(f"  {len(got)}/{len(gt)} match")
+    print("\nORACLE:", "FAIL" if fail else "PASS")
+    sys.exit(1 if fail else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The bug (#581 — shipped-path silent miscompile, #518 severity class)

The direct selector's spill rung (the backend's exhaustion retry, VCR-RA-001 3b-lite) emitted a reload `ldr r0, [sp,#8]` of a frame slot that was **never stored**: `scripts/repro/spill_on_exhaust_242.wat` compiled `--relocatable` returns **0xffffd1ce** for `hp(1,2)` where wasmtime says **0x2e37**.

## Named root cause

**The #253 add/sub (and bitwise/const-addr) immediate folds delete the const materialization by `source_line` — which also deleted the spill store the const's own temp allocation emitted under the spill rung (`alloc_temp_or_spill` → `spill_deepest_reg` tags the victim's `STR rX,[sp,#slot]` with the const's line), leaving the victim's vstack entry marked `Spilled` with no store.** The victim's register was then legitimately reassigned (the `mul.w`-adjacent clobber the issue observed), and its later pop reloaded garbage from the never-written slot.

Three sites shared the defect:
- `drop_prev_const_materialization` (8 fold callers: add/sub/and/or/xor + const-addr loads)
- `splice_out_addr_const_materialization` (the #95 store fold)
- the #209 reciprocal-mult dead-divisor `retain` (removed by `source_line` across the whole function)

## Fix (store-before-clobber invariant restored)

- `is_const_materialization` (`MOVW`/`MOVT`/`MVN` — the only ops the const handler emits) now filters every by-`source_line` drop, so a spill store sharing the const's tag survives any fold. The materialization ops are emitted after the store, so the tail walk stops there naturally; the fold itself still fires (asserted in the new unit test).
- Defensive `assert_spill_reloads_have_stores` at the end of `select_with_stack` (the internal-bug panic pattern): a reload from the reserved spill area with no preceding store to that slot panics loudly instead of compiling wrong code. Gated on `area_reserved` (#331 aliasing).

## Red → green

`scripts/repro/spill_rung_581_differential.py` (unicorn vs wasmtime, direct path, symbols from the ELF symtab) runs the new minimal fixture `spill_rung_581.wat` (7 live binop results + `i32.const 77; i32.sub` fold — the smallest fold-deletes-store shape) plus the original #580 discovery fixture, 6 arg pairs each:

- **main**: ORACLE FAIL — minimal `hp(1,2)` = 0x4e vs 0x51; original `hp(1,2)` = **0xffffd1ce vs 0x2e37** (the recorded values)
- **this branch**: ORACLE PASS, 12/12

## Gates

- unit `fold_preserves_spill_store_581` (every spill-area reload has a matching store; the imm fold still drops the `MOVW`)
- frozen fixtures **3/3 bit-identical** (`frozen_codegen_bytes`: ARM + RV32 + stack-fwd escape hatch) — the default pass never tags a spill store with a const's line, so shipped bytes are unchanged by construction
- `r12_spill_496_differential.py` PASS, AAPCS oracle (`audit_aapcs_repro`) 5/5
- `cargo test -p synth-synthesis -p synth-cli` green (41 test binaries, 0 failures)
- `cargo fmt --check` + `clippy --all-targets -D warnings` clean

## Scope note

The fix covers all three by-`source_line` deletion sites in the direct selector. The defensive validator is linear-scan (store-before-reload in emission order, which is how the vstack machinery always orders them) and is defense-in-depth behind the filters — slot reuse can mask a lost second-generation store from the scan, but no such deletion path remains.

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)