### PR TITLE
feat(vcr-ra)!: SYNTH_SPILL_REALLOC default-on — Belady spilling ships (#242, VCR-RA-001)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -738,10 +738,22 @@ fn compile_wasm_to_arm(
     // function (labels/branches/loops, SP-displacement tracked) and drops a
     // store whose slot NO reachable instruction can read — flat_flight's two
     // surviving stores (#576), completing Belady's 0-load side with a 0-store
-    // side. Same flag: the three stages are one lever for the v0.24.0 flip.
-    // Flag-off (`SYNTH_SPILL_REALLOC=1`) while differential-validated;
-    // off ⇒ byte-identical.
-    let arm_instrs = if std::env::var("SYNTH_SPILL_REALLOC").is_ok() {
+    // side. Same flag: the three stages are one lever, flipped together.
+    // DEFAULT-ON (#242 feature loop, the v0.14.0 local-promotion pattern):
+    // Belady spilling ships by default. Evidence basis for the flip: three
+    // landed flag-off increments (#569 forwarding, #576 Belady re-choice,
+    // #579 whole-fn slot liveness), 40+ functions shrink / 0 grow across the
+    // 68-fixture × 2-path sweep, per-segment executable value-trace equality
+    // guards, and the unicorn-vs-wasmtime execution differentials re-run
+    // green on the new default bytes (flat+inlined flight_algo 0x07FDF307,
+    // const_cse, frame_slot_dce, spill_rung_581, r12_spill_496 — which covers
+    // control_step_decide vs wasmtime; control_step's .text is byte-identical
+    // under the flip) BEFORE the frozen goldens were re-pinned. Escape hatch:
+    // `SYNTH_SPILL_REALLOC=0` is the OPT-OUT — it disables all three stages
+    // and restores the pre-flip bytes (CI-gated by
+    // `frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes`). Any
+    // other value (or unset) runs the pass.
+    let arm_instrs = if !std::env::var("SYNTH_SPILL_REALLOC").is_ok_and(|v| v == "0") {
         let (out, n) = synth_synthesis::liveness::apply_spill_realloc(&arm_instrs);
         let (out, d) = synth_synthesis::liveness::eliminate_dead_frame_stores(&out);
         let (out, u) = synth_synthesis::liveness::eliminate_unread_frame_stores(&out);

--- a/crates/synth-cli/tests/frozen_codegen_bytes.rs
+++ b/crates/synth-cli/tests/frozen_codegen_bytes.rs
@@ -70,6 +70,7 @@ fn text_sha256(wasm: &str, backend: &str, target: &str) -> (String, usize) {
         .env_remove("SYNTH_NO_LOCAL_PROMOTE")
         .env_remove("SYNTH_NO_IMM_SHIFT_FOLD")
         .env_remove("SYNTH_NO_STACK_FWD")
+        .env_remove("SYNTH_SPILL_REALLOC")
         .env_remove("SYNTH_CONST_CSE")
         .args([
             "compile",
@@ -131,20 +132,23 @@ fn assert_frozen(cases: &[(&str, &str, usize)], backend: &str, target: &str) {
 /// the `.py` differentials cover): control_step ↔ 0x00210A55, flight_seam_flat ↔
 /// flat+inlined flight_algo 0x07FDF307, plus flight_seam and the div seam.
 ///
-/// Goldens RE-FROZEN for the SYNTH_STACK_FWD flip (#242 feature loop): stack-reload
-/// forwarding + frame-slot dead-store elimination are now default-on (on top of
-/// v0.13.0 cmp→select + v0.14.0 local promotion + v0.15.0 immediate-shift folding),
-/// so these lock the forwarded+DCE'd .text. The execution RESULTS are preserved —
-/// re-verified on this commit: control_step still 0x00210A55
-/// (control_step_differential.py 13/13), flat+inlined flight_algo still 0x07FDF307
-/// (flight_seam_differential.py MATCH on BOTH flat and inlined). .text shrank again
-/// (dead frame stores removed, reloads → register moves): flight_seam 774→738,
-/// flight_seam_flat 910→878 (−68 B); control_step (no spurious slot reuse) and
-/// signed_div_const unchanged. Instruction/memory-op proxy: flight_algo sp-traffic
-/// 20→7, 139→135 insns — the measured CYCLE number is gale's G474RE (post-ship).
-/// Escape hatch `SYNTH_NO_STACK_FWD=1` restores the prior goldens (asserted by
-/// `frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes`). Prior (flag-off)
-/// goldens were flight_seam 9e73eea3…/774, flight_seam_flat 887ea546…/910.
+/// Goldens RE-FROZEN for the SYNTH_SPILL_REALLOC flip (#242, VCR-RA-001): the
+/// three-stage Belady spill lever (#569 reload forwarding, #576 spill re-choice,
+/// #579 whole-fn slot liveness) is now default-on, on top of the earlier flips
+/// (v0.13.0 cmp→select, v0.14.0 local promotion, v0.15.0 imm-shift fold,
+/// SYNTH_STACK_FWD). The execution RESULTS are preserved — re-verified on this
+/// commit BEFORE re-pinning: flat+inlined flight_algo still 0x07FDF307
+/// (flight_seam_differential.py MATCH + frame_slot_dce_differential.py 8/8),
+/// control_step semantics match wasmtime (r12_spill_496_differential.py 5/5;
+/// control_step_differential.py has a pre-existing symbol-parse harness break
+/// that fails identically with the opt-out), const_cse_differential.py PASS,
+/// spill_rung_581_differential.py 12/12, i64_param_518 + br_table_value_509
+/// PASS. .text shrank again (reloads dissolved + dead frame stores dropped):
+/// flight_seam 738→730 (−8), flight_seam_flat 878→866 (−12); control_step and
+/// signed_div_const unchanged (no surviving spill traffic there). Escape hatch
+/// `SYNTH_SPILL_REALLOC=0` restores the prior goldens (asserted by
+/// `frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes`). Prior
+/// goldens were flight_seam dce728b4…/738, flight_seam_flat 0665e623…/878.
 #[test]
 fn frozen_fixtures_text_is_bit_identical_oracle_001() {
     let cases = [
@@ -155,13 +159,13 @@ fn frozen_fixtures_text_is_bit_identical_oracle_001() {
         ),
         (
             "flight_seam.wasm",
-            "dce728b48e14aa9187774799c0b268c6ad60be6dc0fa3e7cc9458c17dc65403b",
-            738,
+            "6872d6f3f00331e9a52e176428fca375a87b9fbe0cf2b3eb0fb657c304a7372d",
+            730,
         ),
         (
             "flight_seam_flat.wasm",
-            "0665e623f33457479940046d57a4b7ec02416a61bcc6ec71ea3556ed5b3cb568",
-            878,
+            "d11849db9bef82b77280ee06fdc6f076a7df278b2e5a3213284e569cbf1eccc9",
+            866,
         ),
         (
             "signed_div_const.wasm",
@@ -178,6 +182,11 @@ fn frozen_fixtures_text_is_bit_identical_oracle_001() {
 /// a tripwire — if forwarding/DCE ever leaks into the opt-out path, the old hashes
 /// stop matching. (control_step / signed_div_const are unaffected by the flip, so
 /// they are not re-checked here; the default gate above already locks them.)
+///
+/// COMPOSITION NOTE: rolling back to the pre-STACK_FWD bytes now also requires
+/// opting out of the LATER spill-realloc lever (`SYNTH_SPILL_REALLOC=0`), which
+/// defaults on since its own flip and would otherwise rewrite the frame traffic
+/// these goldens pin. The two opt-outs compose; each is separately gated.
 #[test]
 fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
     // (fixture, PRE-flip golden sha256, PRE-flip len) — the v0.15.0 goldens.
@@ -197,6 +206,7 @@ fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
         let elf = format!("/tmp/frozen_nofwd_{wasm}.elf");
         let out = Command::new(synth())
             .env("SYNTH_NO_STACK_FWD", "1")
+            .env("SYNTH_SPILL_REALLOC", "0")
             .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
             .env_remove("SYNTH_NO_LOCAL_PROMOTE")
             .env_remove("SYNTH_NO_IMM_SHIFT_FOLD")
@@ -235,6 +245,76 @@ fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
         assert_eq!(
             hex, golden,
             "{wasm}: SYNTH_NO_STACK_FWD=1 must restore the pre-flip bytes (rollback broken)"
+        );
+    }
+}
+
+/// ESCAPE-HATCH GATE for the SYNTH_SPILL_REALLOC flip (#242, VCR-RA-001).
+/// Proves the opt-out actually rolls back: with `SYNTH_SPILL_REALLOC=0` the two
+/// fixtures the flip moved restore their PRE-flip goldens byte-for-byte — the
+/// rollback proof AND a tripwire against the spill-realloc stages leaking into
+/// the opt-out path. (control_step / signed_div_const are byte-identical under
+/// the flip — no surviving spill traffic — so the default gate above already
+/// locks them for both settings.)
+#[test]
+fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
+    // (fixture, PRE-flip golden sha256, PRE-flip len) — the pre-spill-realloc
+    // goldens (the SYNTH_STACK_FWD-era defaults).
+    let old = [
+        (
+            "flight_seam.wasm",
+            "dce728b48e14aa9187774799c0b268c6ad60be6dc0fa3e7cc9458c17dc65403b",
+            738usize,
+        ),
+        (
+            "flight_seam_flat.wasm",
+            "0665e623f33457479940046d57a4b7ec02416a61bcc6ec71ea3556ed5b3cb568",
+            878,
+        ),
+    ];
+    for &(wasm, golden, golden_len) in &old {
+        let elf = format!("/tmp/frozen_nospillrealloc_{wasm}.elf");
+        let out = Command::new(synth())
+            .env("SYNTH_SPILL_REALLOC", "0")
+            .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
+            .env_remove("SYNTH_NO_LOCAL_PROMOTE")
+            .env_remove("SYNTH_NO_IMM_SHIFT_FOLD")
+            .env_remove("SYNTH_NO_STACK_FWD")
+            .env_remove("SYNTH_CONST_CSE")
+            .args([
+                "compile",
+                fixture(wasm).to_str().unwrap(),
+                "-o",
+                &elf,
+                "-b",
+                "arm",
+                "--target",
+                "cortex-m4",
+                "--all-exports",
+                "--relocatable",
+            ])
+            .output()
+            .expect("run synth");
+        assert!(out.status.success(), "compile failed for {wasm}");
+        let bytes = std::fs::read(&elf).expect("read elf");
+        let obj = object::File::parse(&*bytes).expect("parse elf");
+        let data = obj
+            .section_by_name(".text")
+            .expect(".text")
+            .data()
+            .expect("read .text");
+        assert_eq!(
+            data.len(),
+            golden_len,
+            "{wasm}: SYNTH_SPILL_REALLOC=0 must restore the pre-flip length"
+        );
+        let hex: String = Sha256::digest(data)
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        assert_eq!(
+            hex, golden,
+            "{wasm}: SYNTH_SPILL_REALLOC=0 must restore the pre-flip bytes (rollback broken)"
         );
     }
 }

--- a/crates/synth-cli/tests/spill_realloc_242.rs
+++ b/crates/synth-cli/tests/spill_realloc_242.rs
@@ -4,9 +4,10 @@
 //! flat_flight's hot segment runs peak register pressure 11 > the R0–R8 pool
 //! of 9, so every pressure-guarded optimization declines there and the greedy
 //! lowering's spill placement is naive (gale: 17 spills + 61% redundant const
-//! materializations on silicon, #209). Behind ONE flag, flag-off:
+//! materializations on silicon, #209). Behind ONE flag, DEFAULT-ON since the
+//! SYNTH_SPILL_REALLOC flip (`SYNTH_SPILL_REALLOC=0` is the opt-out):
 //!
-//!   - `SYNTH_SPILL_REALLOC=1` — stage 1: slot-value forwarding BETWEEN
+//!   - the spill-realloc lever — stage 1: slot-value forwarding BETWEEN
 //!     reloads (`liveness::apply_spill_realloc`), the case
 //!     `forward_stack_reloads` misses when pressure clobbers the spill
 //!     store's source; stage 2: the Belady spill-plan RE-CHOICE
@@ -22,11 +23,13 @@
 //!   - `SYNTH_SPILL_REPORT=1` — measure-only greedy-vs-Belady (farthest next
 //!     use) frame-traffic report per segment.
 //!
-//! Flag-OFF byte-identity is owned by the existing gates (frozen_codegen_bytes
-//! 3/3 + the const_cse_reduction_242 golden). Flag-ON semantic equivalence is
-//! the unicorn-vs-wasmtime differentials (const_cse_differential.py,
-//! frame_slot_dce_differential.py, flight_seam_differential.py — re-run green
-//! with the flag exported). What THIS file locks:
+//! DEFAULT byte-identity is owned by the existing gates (frozen_codegen_bytes,
+//! which also CI-gates the `SYNTH_SPILL_REALLOC=0` escape hatch against the
+//! pre-flip goldens, + the const_cse_reduction_242 golden). Default-path
+//! semantic equivalence is the unicorn-vs-wasmtime differentials
+//! (const_cse_differential.py, frame_slot_dce_differential.py,
+//! flight_seam_differential.py — re-run green on the new default bytes BEFORE
+//! the flip's refreeze). What THIS file locks (as default-vs-opt-out deltas):
 //!
 //!   1. NO-GROW: with the flag ON, no function in the measured corpus grows.
 //!   2. NON-VACUOUS: the rewrite actually fires on a real fixture
@@ -61,12 +64,16 @@ fn fixture(rel: &str) -> std::path::PathBuf {
         .join(rel)
 }
 
-/// Compile `rel` on the optimized path; `flag` toggles `SYNTH_SPILL_REALLOC`.
-/// Returns (ELF bytes, stderr).
+/// Compile `rel` on the optimized path; `flag` toggles `SYNTH_SPILL_REALLOC`:
+/// `true` = the shipped DEFAULT (env var removed so a stray `=0` in the test
+/// environment can't skew the gate), `false` = the `SYNTH_SPILL_REALLOC=0`
+/// opt-out (pre-flip bytes). Returns (ELF bytes, stderr).
 fn compile(rel: &str, out: &str, flag: bool) -> (Vec<u8>, String) {
     let mut cmd = Command::new(synth());
     if flag {
-        cmd.env("SYNTH_SPILL_REALLOC", "1");
+        cmd.env_remove("SYNTH_SPILL_REALLOC");
+    } else {
+        cmd.env("SYNTH_SPILL_REALLOC", "0");
     }
     let output = cmd
         .env("SYNTH_SPILL_REPORT", "1")

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -689,9 +689,9 @@ pub fn eliminate_dead_frame_stores(instrs: &[ArmInstruction]) -> (Vec<ArmInstruc
 /// Removal-only ⇒ the output never grows (asserted) and, run before
 /// `resolve_label_branches` like every pass here, is branch-offset neutral.
 /// The frame `sub sp, #K` is untouched (the slot goes unused; frame SHRINKING
-/// is [`elide_dead_frame`]'s job). Pure function; callers opt in
-/// (`SYNTH_SPILL_REALLOC=1` wiring in `arm_backend.rs`, same lever as the
-/// spill re-choice it completes).
+/// is [`elide_dead_frame`]'s job). Pure function; DEFAULT-ON via the
+/// `arm_backend.rs` wiring (`SYNTH_SPILL_REALLOC=0` is the opt-out), same
+/// lever as the spill re-choice it completes.
 pub fn eliminate_unread_frame_stores(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
     use ArmOp::*;
 
@@ -4172,8 +4172,8 @@ fn extending_alias_hoist(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usi
 //     value trace ([`segment_value_trace`]) must be identical to the
 //     original's, including exit register and frame-slot state.
 //
-//  Both rewrite stages share one flag (`SYNTH_SPILL_REALLOC=1`, stage 2 runs
-//  on stage 1's output); off ⇒ byte-identical.
+//  Both rewrite stages share one flag (stage 2 runs on stage 1's output),
+//  DEFAULT-ON; `SYNTH_SPILL_REALLOC=0` opts out ⇒ pre-flip byte-identical.
 
 /// Registers never tracked as slot-value holders and never counted as pool
 /// values: R9 (globals) / R10 (mem-size) / R11 (mem-base) are reserved, R12 is
@@ -4234,7 +4234,8 @@ fn sp_slot(addr: &MemAddr) -> Option<i32> {
 /// forwarded/eliminated across both stages (stage 1 forwarding + stage 2
 /// Belady re-choice, see the module block above — stage 2 runs on stage 1's
 /// output, same flag).
-/// Pure; callers opt in (`SYNTH_SPILL_REALLOC=1` wiring in `arm_backend.rs`).
+/// Pure; DEFAULT-ON via the `arm_backend.rs` wiring (`SYNTH_SPILL_REALLOC=0`
+/// is the opt-out).
 pub fn apply_spill_realloc(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
     let mut out: Vec<ArmInstruction> = Vec::with_capacity(instrs.len());
     let mut total = 0usize;


### PR DESCRIPTION
## SYNTH_SPILL_REALLOC default-on — Belady spilling ships (#242, VCR-RA-001)

The deliberate byte-changing flip, executed with the refreeze ritual (the v0.14.0 local-promotion pattern). The three-stage spill-realloc lever — #569 slot-value forwarding, #576 Belady spill re-choice, #579 whole-function slot liveness — now runs **by default**; `SYNTH_SPILL_REALLOC=0` is the opt-out (any other value, or unset, runs the pass). `SYNTH_SPILL_ON_EXHAUST` is untouched (population-changing — stays off pending silicon).

### Evidence basis for the flip
- Three landed, flag-off, individually oracle-gated increments (#569 → #576 → #579), each with per-segment executable value-trace equality guards, strict-shrink commit gates, and sub-word/unknown-slot conservatism.
- 40+ functions shrink / 0 grow across the 68-fixture × 2-path sweep.
- Full Belady contract met on flat_flight: frame traffic 3ld+3st → 0ld+0st (belady(k=9)=0ld+0st), 412→388 B.

### Execution differentials — run on the NEW default bytes BEFORE re-pinning
All unicorn-vs-wasmtime, exit 0:

| harness | result |
|---|---|
| `const_cse_differential.py` | PASS (all fns match wasmtime, spill12 −88 B with CSE, direct-path gate non-vacuous) |
| `frame_slot_dce_differential.py` | PASS — flight_algo `0x07FDF307` on default AND opt-out, 4 arg sets each |
| `flight_seam_differential.py` | MATCH — `0x07FDF307` vs wasmtime |
| `spill_rung_581_differential.py` | PASS 12/12 (spill_rung_581 + spill_on_exhaust_242 fixtures) |
| `r12_spill_496_differential.py` | PASS — control_step_decide 5/5 + flight_algo vs wasmtime |
| `i64_param_518_differential.py` | PASS (full AAPCS matrix, loud-skips intact) |
| `br_table_value_509_differential.py` | PASS (both paths) |

`control_step_differential.py` has a **pre-existing** harness break (KeyError `control_step_decide` in its disasm-text symbol parse — the #489 host-dependence class); it fails **identically with `SYNTH_SPILL_REALLOC=0`**, i.e. on the pre-flip bytes, so it is not the flip. Its anchor is covered by `r12_spill_496_differential.py` vs wasmtime, and control_step's `.text` is byte-identical under the flip anyway (see table).

### Refreeze table (`frozen_codegen_bytes.rs`, ARM `--relocatable` gate)

| fixture | old sha256 / len | new sha256 / len | Δ |
|---|---|---|---|
| control_step.wasm | `1a97711c…` / 304 | **unchanged** | 0 |
| flight_seam.wasm | `dce728b4…` / 738 | `6872d6f3…` / 730 | −8 B |
| flight_seam_flat.wasm | `0665e623…` / 878 | `d11849db…` / 866 | −12 B |
| signed_div_const.wasm | `b277453b…` / 34 | **unchanged** | 0 |

**RV32 anchors: UNCHANGED** — the pass is wired only in `arm_backend.rs` (ARM path); `frozen_fixtures_rv32_text_is_bit_identical_oracle_001` passes untouched. The `const_cse_reduction_242.rs` optimized-path golden (`0xa68aa2da…`/576) is also byte-identical under the flip — verified, no re-bless needed.

### Opt-out pin (CI-gated escape hatch)
- `SYNTH_SPILL_REALLOC=0` reproduces the OLD hashes byte-for-byte (verified per fixture, and locked by the new `frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes` test — the rollback proof AND a leak tripwire).
- The older `SYNTH_NO_STACK_FWD` escape hatch now composes with `SYNTH_SPILL_REALLOC=0` to reach the pre-STACK_FWD goldens (documented in the test).
- `spill_realloc_242.rs` flag-on assertions became default assertions; flag-off became the `=0` opt-out.

### Gate (all foreground, exit 0)
- `cargo build -p synth-cli` ✓
- Execution differentials (above) BEFORE refreeze ✓
- `cargo test -p synth-cli` (43+ tests incl. re-pinned frozen gate + both escape hatches) ✓
- `cargo test -p synth-synthesis` (510+) ✓
- `cargo test --workspace --exclude synth-verify` ✓
- `cargo fmt --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
