### PR TITLE
fix(repro): control_step_differential resolves symbols from symtab (#584)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,6 +504,46 @@ jobs:
           python scripts/repro/flight_seam_differential.py /tmp/fsf.elf \
             scripts/repro/flight_seam_flat.wasm
 
+  control-step-584-oracle:
+    name: control-step relocatable-path execution oracle
+    # VCR-ORACLE-001 (#242, #209, #584): EXECUTE the control_step silicon fixture
+    # (4x unsigned constant div_u — the reciprocal-multiply cost-gate repro)
+    # compiled via the SHIPPED direct path (--relocatable) under unicorn
+    # (UC_ARCH_ARM / Thumb) and diff control_step_decide's result vs wasmtime
+    # (anchor 0x00210A55, 13 vectors). Previously a dev-only script: its `synth
+    # disasm` text parse drifted into a KeyError on current main (#584, same
+    # class as #570/#489) — symbols now come from the ELF symtab, and CI-gating
+    # it here (flight-seam-570-oracle pattern) so harness drift reddens instead
+    # of rotting. The r12_spill_496 oracle covers control_step on the DEFAULT
+    # optimized path; this covers the --relocatable direct path. Isolated job:
+    # emulation deps pip-installed here ONLY.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Run control-step oracle
+        run: |
+          ./target/debug/synth compile scripts/repro/control_step.wasm \
+            -o /tmp/cs.elf --target cortex-m4 --all-exports --relocatable
+          python scripts/repro/control_step_differential.py /tmp/cs.elf
+
   stack-args-503-oracle:
     name: AAPCS stack-argument path oracle
     # VCR-ORACLE-001 (#242, #503): EXECUTE functions that need the AAPCS

--- a/scripts/repro/control_step_differential.py
+++ b/scripts/repro/control_step_differential.py
@@ -14,15 +14,19 @@ correct**: wasmtime is ground truth; unicorn runs synth's ARM (the `--relocatabl
 path) with the `.rodata` table loaded into linear memory. gale's reference vector
 `control_step_decide(3000,50,40,0)` must give `0x00210A55`.
 
-Run:
+Symbols are resolved from the ELF symtab (SHT_SYMTAB, located by section type —
+synth's relocatable objects leave the section name empty), matching the export
+name first with a positional `func_N` fallback for older objects. `synth disasm`
+text is NOT parsed: it is host-dependent (PR #489) and this script's regex parse
+drifted into a KeyError on current main (#584, same class as #570).
+
+Run (deps: wasmtime unicorn pyelftools):
   synth compile scripts/repro/control_step.wasm -o /tmp/cs.elf \
         --target cortex-m4 --all-exports --relocatable
-  /tmp/armv/bin/python scripts/repro/control_step_differential.py /tmp/cs.elf
+  python scripts/repro/control_step_differential.py /tmp/cs.elf
 
 Exits nonzero on any mismatch.
 """
-import re
-import subprocess
 import sys
 
 import wasmtime
@@ -40,11 +44,34 @@ from unicorn.arm_const import (
 
 WASM = "scripts/repro/control_step.wasm"
 ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/cs.elf"
-SYNTH = "./target/debug/synth"
 
 # The `.rodata` data segment lives at linear-memory offset 0x10000 (2 pages).
 RODATA_BASE, RODATA_END = 0x10000, 0x20000
 CODE, LIN, STK, RET = 0x200000, 0x40000, 0x90000, 0x300000
+
+def elf_func_symbols(path):
+    """(func symbols, .text bytes, .text base) read from the ELF itself.
+
+    The symtab is found by section TYPE — synth's ET_REL objects emit it with
+    an empty section name, so get_section_by_name('.symtab') returns None.
+    st_value carries the Thumb bit on STT_FUNC symbols; clear it so the
+    addresses index .text directly.
+    """
+    with open(path, "rb") as fh:
+        elf = ELFFile(fh)
+        symtab = next(
+            (s for s in elf.iter_sections() if s["sh_type"] == "SHT_SYMTAB"), None
+        )
+        if symtab is None:
+            sys.exit(f"no SHT_SYMTAB section in {path}")
+        syms = {
+            s.name: s["st_value"] & ~1
+            for s in symtab.iter_symbols()
+            if s.name and s["st_info"]["type"] == "STT_FUNC"
+        }
+        text = elf.get_section_by_name(".text")
+        return syms, text.data(), text["sh_addr"]
+
 
 VECTORS = [
     (3000, 50, 40, 0),   # gale's reference -> 0x00210A55
@@ -66,12 +93,13 @@ def main():
         rodata = bytes(inst.exports(store)["memory"].read(store, RODATA_BASE, RODATA_END))
         return r, rodata
 
-    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
-    syms = {m.group(2): int(m.group(1), 16)
-            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
-    fa = syms["func_0"] if "func_0" in syms else syms["control_step_decide"]
-    text = ELFFile(open(ELF, "rb")).get_section_by_name(".text")
-    code, base = text.data(), text["sh_addr"]
+    syms, code, base = elf_func_symbols(ELF)
+    # Export/name-section name first (post-#394); positional func_N alias
+    # as a fallback for older objects (#570 — never hardcode func_N).
+    fa = next((syms[c] for c in ("control_step_decide", "func_0") if c in syms), None)
+    if fa is None:
+        sys.exit(f"SYMBOL MISSING: control_step_decide (or func_0); "
+                 f"symtab has {sorted(syms)}")
 
     def arm(args, rodata):
         mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)


### PR DESCRIPTION
## Summary

`scripts/repro/control_step_differential.py` (the #209 reciprocal-multiply pressure oracle) parsed `synth disasm` text with a regex to find the `control_step_decide` entry point — the #489 host-dependence class — and drifted into a KeyError on current main (found by the #583 flip lane; identical with `SYNTH_SPILL_REALLOC=0`, so pre-existing harness drift, not a codegen change).

This PR replaces the disasm-text parse with ELF symtab resolution via pyelftools, mirroring the merged #575 `flight_seam_differential.py` pattern:

- **SHT_SYMTAB located by section TYPE** — synth's ET_REL objects emit the symtab with an empty section name, so `get_section_by_name('.symtab')` returns `None`
- **Thumb bit masked** on `STT_FUNC` `st_value` so addresses index `.text` directly
- **Export name first** (`control_step_decide`, post-#394), positional `func_0` fallback for older objects, loud `SYMBOL MISSING` exit listing the symtab otherwise (#570 — never hardcode `func_N`)
- Vectors and semantics unchanged (13 vectors incl. gale's reference anchor `control_step_decide(3000,50,40,0) = 0x00210A55`); the script no longer needs a synth binary at runtime at all

Also **CI-gates it** as `control-step-584-oracle` (exact `flight-seam-570-oracle` job pattern, isolated pip deps) so this class of harness drift reddens instead of rotting. The `r12_spill_496` oracle covers control_step on the DEFAULT optimized path; this job covers the `--relocatable` direct path the script was written for.

## Before / after

Before (main): the `synth disasm` text parse fails (KeyError on the flip lane; on a host without `./target/debug/synth` it dies even earlier in the disasm subprocess — same host-dependence class).

After:

```
control_step_decide(3000, 50, 40, 0) = 0x00210A55  (wasmtime 0x00210A55)
...
13/13 match
ORACLE: PASS
```

## Verification

- `cargo build -p synth-cli`; fixture compiled per the script header (`--target cortex-m4 --all-exports --relocatable`); script PASSES 13/13 vs wasmtime incl. the frozen 0x00210A55 anchor
- No Rust changed, so the frozen byte anchors are trivially unaffected
- ci.yml parses (YAML validated); new job uses only static commands, no event-payload interpolation

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)