### PR TITLE
fix(bridge): every return path deallocates the spill frame — close #499

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,44 @@ jobs:
           SYNTH: ./target/debug/synth
         run: python scripts/repro/block_brif_483_differential.py
 
+  spill-frame-499-oracle:
+    name: optimized-path spill-frame teardown oracle
+    # #499: EXECUTE optimized-path functions whose register pressure fires the
+    # flag-off Const-eviction spill (`sub sp,#N` frame) under unicorn
+    # (UC_ARCH_ARM / Thumb) and diff linear MEMORY + SP balance vs wasmtime.
+    # Guards the #499 fix: the bridge appended fall-off-the-end returns WITHOUT
+    # the `add sp,#N` teardown, so post-#490 the `pop {…,pc}` epilogue read PC
+    # from a spill slot — a shipped crash on straight-line AND control-flow
+    # shapes. Compiles with SYNTH_BASE_CSE=0 (the #592 default relieves the
+    # pressure on these fixtures; the teardown path must stay covered) and
+    # trips loudly if a fixture stops spilling (vacuity guard). Isolated job:
+    # emulation deps pip-installed here ONLY.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Run spill-frame teardown oracle
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/repro/spill_frame_499_differential.py
+
   r12-spill-496-oracle:
     name: optimized-path register-exhaustion oracle
     # VCR-ORACLE-001 (#242, #496): EXECUTE the two silicon fixtures

--- a/crates/synth-cli/tests/base_cse_flip_468.rs
+++ b/crates/synth-cli/tests/base_cse_flip_468.rs
@@ -116,13 +116,23 @@ fn func_sizes(elf: &[u8]) -> HashMap<String, usize> {
 /// — the two corpus fixtures the planner fires on. Default goldens pinned
 /// AFTER the execution differentials passed on the new default bytes;
 /// opt-out goldens captured from the parent (pre-flip) commit's default.
+///
+/// CORRECTNESS RE-PIN (#499): the redundant_base_materialization opt-out
+/// golden originally pinned MISCOMPILED bytes — the flag-off spill frame
+/// (`sub sp,#24`) was never deallocated before `pop {…,pc}` (PC read from a
+/// spill slot; base_cse_differential.py tolerated it as "known #499"). The
+/// fix adds the `add sp,#24` teardown (+4 B) and, with a balanced epilogue,
+/// frame-slot DCE now removes the dead spill stores the mis-paired `pop`
+/// previously appeared to read (−20 B): 342 → 326 B. New opt-out bytes
+/// execution-validated (spill_frame_499_differential.py +
+/// base_cse_differential.py, unicorn vs wasmtime) before re-pinning.
 const GOLDENS: [(&str, &str, usize, &str, usize); 2] = [
     (
         "scripts/repro/redundant_base_materialization.wat",
         "a0f684bcfaaece182b55fdb2e98b94d54bbeab72243764ff354ed67b79a56aef",
         224,
-        "130ef8c690cc65619395b7cdd30ad57e7c8adbfc7476a8cc255bedbe07272876",
-        342,
+        "b44084bebcc57701b39510d365a7e066d62f9bfae5a6f93a7860fe6e87f90a05",
+        326,
     ),
     (
         "scripts/repro/volatile_segment_543.wat",

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -6158,13 +6158,18 @@ impl OptimizerBridge {
 
         // Add return if not present
         if arm_instrs.is_empty() || !matches!(arm_instrs.last(), Some(ArmOp::Bx { .. })) {
-            // VCR-RA-001 (#242): the spill-frame block above only inserts the
-            // `ADD SP` epilogue before returns that ALREADY exist; a return
-            // appended here would leave SP off by the frame size (the latent
-            // shape was unreachable flag-off: any spill implied scratch-pool
-            // exhaustion, which declined the function). Flag-gated so flag-off
-            // bytes are untouched.
-            if spill_on_exhaust && next_spill_offset > 4 {
+            // #499: the spill-frame block above only inserts the `ADD SP`
+            // epilogue before returns that ALREADY exist; a return appended
+            // here must also deallocate the frame, or SP returns off by the
+            // frame size and the `pop {…, pc}` epilogue (#490) reads PC from
+            // a spill slot. This was previously gated on `spill_on_exhaust`
+            // under the belief that a flag-off spill implied scratch-pool
+            // exhaustion (which declines the function) — false: the
+            // `Opcode::Const` allocator has its own oldest-vreg eviction
+            // spill on R4-R11/R3 pool exhaustion that never sets
+            // `r12_exhausted`, so functions that fall off the end (the common
+            // wasm shape: no explicit `return`) shipped with an imbalanced SP.
+            if next_spill_offset > 4 {
                 let frame_size = ((next_spill_offset as u32 + 7) & !7) as i32;
                 arm_instrs.push(ArmOp::Add {
                     rd: Reg::SP,
@@ -6173,6 +6178,36 @@ impl OptimizerBridge {
                 });
             }
             arm_instrs.push(ArmOp::Bx { rm: Reg::LR });
+        }
+
+        // #499 defensive post-condition (internal-bug panic pattern): if a
+        // spill frame was allocated, EVERY return must be immediately preceded
+        // by the exact `ADD SP, SP, #frame_size` teardown. The prologue is the
+        // only `SUB SP` and the epilogue inserts the only `ADD SP`s, so the
+        // "immediately preceding instruction" check is precise — any return
+        // this scan flags would ship an SP-imbalanced function.
+        if next_spill_offset > 4 {
+            let frame_size = ((next_spill_offset as u32 + 7) & !7) as i32;
+            for (i, op) in arm_instrs.iter().enumerate() {
+                if matches!(op, ArmOp::Bx { rm: Reg::LR }) {
+                    let deallocated = i > 0
+                        && matches!(
+                            &arm_instrs[i - 1],
+                            ArmOp::Add {
+                                rd: Reg::SP,
+                                rn: Reg::SP,
+                                op2: Operand2::Imm(n),
+                            } if *n == frame_size
+                        );
+                    assert!(
+                        deallocated,
+                        "internal error (#499): return at instruction {i} does not \
+                         deallocate the {frame_size}-byte spill frame — SP would \
+                         return imbalanced and `pop {{…, pc}}` would read PC from \
+                         a spill slot. This is an optimizer_bridge epilogue bug."
+                    );
+                }
+            }
         }
 
         // #490: the callee-saved prologue/epilogue the optimized path needs to

--- a/scripts/repro/spill_frame_499.wat
+++ b/scripts/repro/spill_frame_499.wat
@@ -1,0 +1,37 @@
+;; #499 — optimized-path spill frame must be deallocated on EVERY return.
+;;
+;; Two shapes that drive the flag-off `Opcode::Const` oldest-vreg eviction
+;; spill (optimizer_bridge.rs) so the bridge emits a `sub sp,#N` spill frame:
+;;
+;;  * `min_fields` — the MINIMAL straight-line shape: five i32.stores keep
+;;    10 const vregs live past the R4-R11/R3 pool, forcing at least one
+;;    spill slot. No control flow, no explicit `return` — the function falls
+;;    off the end, so its return is APPENDED by the bridge. Before the fix
+;;    the appended return had no `add sp,#N`, so the `pop {…,pc}` epilogue
+;;    (#490) read PC from a spill slot.
+;;  * `nested` — the original #499 reproducer: same spill pressure UNDER
+;;    control flow (block/br_if/br), both branch directions.
+;;
+;; Compiled with SYNTH_BASE_CSE=0 by spill_frame_499_differential.py: the
+;; #592 default-on base-CSE relieves the register pressure on these shapes
+;; (each store's address const folds away), which would make the oracle
+;; vacuous — the bug is in the frame teardown, not in base-CSE.
+(module
+  (memory 1)
+  (export "memory" (memory 0))
+  (func (export "min_fields")
+    (i32.store (i32.const 0)  (i32.const 11))
+    (i32.store (i32.const 4)  (i32.const 22))
+    (i32.store (i32.const 8)  (i32.const 33))
+    (i32.store (i32.const 12) (i32.const 44))
+    (i32.store (i32.const 16) (i32.const 55)))
+  (func (export "nested") (param $sel i32)
+    (i32.store (i32.const 20) (i32.const 55))
+    (block $outer
+      (block $inner
+        (br_if $inner (i32.eqz (local.get $sel)))
+        (br $outer))
+      (i32.store8  (i32.const 24) (i32.const 66))
+      (i32.store16 (i32.const 26) (i32.const 77))
+      (i32.store8  (i32.const 28) (i32.const 88)))
+    (i32.store (i32.const 32) (i32.const 99))))

--- a/scripts/repro/spill_frame_499_differential.py
+++ b/scripts/repro/spill_frame_499_differential.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""#499 — EXECUTION-validate optimized-path spill-frame teardown on return.
+
+The optimized (non-`--relocatable`) ARM path allocates a spill frame
+(`sub sp,#N`) when the flag-off `Opcode::Const` oldest-vreg eviction spill
+fires under register pressure, but the frame teardown (`add sp,#N`) was only
+inserted before returns that ALREADY existed in the body. The common wasm
+shape — a function that falls off its end, whose return is APPENDED by the
+bridge — got a bare return: SP came back off by N. Post-#490 the epilogue is
+`pop {r4-r8,pc}`, which READS the return address through SP → PC is popped
+from a spill slot → crash (unicorn: UC_ERR_FETCH_UNMAPPED). Reachable
+straight-line AND under control flow (the original #499 shape).
+
+This harness compiles `spill_frame_499.wat` (minimal straight-line
+`min_fields` + control-flow `nested`, both branch directions) and
+`redundant_base_materialization.wat::init_fields` (the #592 flip-wave
+reproducer) via the optimized path with `SYNTH_BASE_CSE=0` (default-on
+base-CSE post-#592 relieves the pressure and would make the oracle vacuous),
+then runs each function under unicorn (UC_ARCH_ARM / Thumb) and asserts:
+
+  1. the function actually carries a spill frame (`sub.w sp,sp,#imm` present
+     in its body) — non-vacuity tripwire: if a future lever removes the
+     pressure, refresh the fixture instead of green-washing;
+  2. execution reaches the return trampoline (no fault, PC == ret);
+  3. SP is balanced on return (== its entry value);
+  4. linear MEMORY is bit-identical to wasmtime ground truth.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/spill_frame_499_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_PC,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_SP,
+)
+
+REPRO = Path(__file__).parent
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+# Absolute linear-memory base the optimized (non-relocatable) path materializes
+# for a const address: `movw ip,#0x100; movt ip,#0x2000` → 0x20000100 (see #197).
+LINMEM = 0x20000100
+MEM_WINDOW = 64  # bytes of memory compared against ground truth
+SP_INIT = 0x98000
+
+# (wat file, function, [arg lists — empty tuple = no args])
+CASES = [
+    ("spill_frame_499.wat", "min_fields", [()]),
+    ("spill_frame_499.wat", "nested", [(0,), (1,)]),
+    ("redundant_base_materialization.wat", "init_fields", [()]),
+]
+
+
+def compile_optimized(wat, out):
+    env = {"PATH": "/usr/bin:/bin", "SYNTH_BASE_CSE": "0"}
+    r = subprocess.run(
+        [SYNTH, "compile", str(wat), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env=env,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed: {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+    return data, base, syms
+
+
+def func_body(code, base, syms, func):
+    """Bytes of `func` from its symbol to the next symbol (or .text end).
+    Thumb function symbols carry bit 0 set — mask it off."""
+    start = (syms[func] & ~1) - base
+    ends = sorted((v & ~1) - base for v in syms.values() if (v & ~1) - base > start)
+    end = ends[0] if ends else len(code)
+    return code[start:end]
+
+
+def has_spill_frame(body):
+    """True if the body contains `sub.w sp,sp,#imm` (T32: f1ad 0dxx,
+    little-endian bytes: ad f1 xx 0d)."""
+    for i in range(len(body) - 3):
+        if body[i] == 0xAD and body[i + 1] == 0xF1 and body[i + 3] == 0x0D:
+            return True
+    return False
+
+
+def wasm_mem(wat, func, args):
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, wat.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    inst.exports(st)[func](st, *args)
+    return bytes(inst.exports(st)["memory"].read(st, 0, MEM_WINDOW))
+
+
+def run_arm(code, base, addr, args):
+    """Returns (mem, err): err is a failure string or None."""
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(base & ~0xFFFF, 0x20000)
+    mu.mem_write(base, code)
+    mu.mem_map(LINMEM & ~0xFFFF, 0x20000)  # page-aligned region covering LINMEM
+    mu.mem_map(0x90000, 0x10000)
+    ret = 0x90100
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    if args:
+        mu.reg_write(UC_ARM_REG_R0, args[0] & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_SP, SP_INIT)
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    try:
+        mu.emu_start(addr | 1, ret, timeout=5_000_000)
+    except UcError as e:
+        return None, f"execution fault: {e} (PC=0x{mu.reg_read(UC_ARM_REG_PC):x})"
+    pc = mu.reg_read(UC_ARM_REG_PC)
+    if pc != ret:
+        return None, f"never returned: stopped at PC=0x{pc:x} (want 0x{ret:x})"
+    sp = mu.reg_read(UC_ARM_REG_SP)
+    if sp != SP_INIT:
+        return None, (
+            f"SP imbalanced on return: 0x{sp:x} (entry 0x{SP_INIT:x}, "
+            f"leak {SP_INIT - sp:+d} bytes) — the #499 missing `add sp`"
+        )
+    return bytes(mu.mem_read(LINMEM, MEM_WINDOW)), None
+
+
+def main():
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth first")
+
+    fails = 0
+    for wat_name, func, arg_lists in CASES:
+        wat = REPRO / wat_name
+        elf = f"/tmp/spill_frame_499_{wat.stem}.elf"
+        compile_optimized(wat, elf)
+        code, base, syms = load(elf)
+
+        if func not in syms:
+            print(f"FAIL {func}: symbol missing from {elf}")
+            fails += 1
+            continue
+        if not has_spill_frame(func_body(code, base, syms, func)):
+            print(
+                f"FAIL {func}: no `sub.w sp,sp,#imm` spill frame in body — "
+                "the fixture no longer exercises the #499 teardown path; "
+                "refresh the shape instead of shipping a vacuous oracle"
+            )
+            fails += 1
+            continue
+
+        for args in arg_lists:
+            label = f"{func}{args if args else '()'}"
+            gt = wasm_mem(wat, func, args)
+            got, err = run_arm(code, base, syms[func], args)
+            if err is not None:
+                print(f"FAIL {label}: {err}")
+                fails += 1
+                continue
+            if got != gt:
+                diff = [(i, gt[i], got[i]) for i in range(MEM_WINDOW) if gt[i] != got[i]]
+                print(f"FAIL {label}: mem diffs (off, wasmtime, synth): {diff}")
+                fails += 1
+                continue
+            print(f"OK   {label}")
+
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The bug (shipped miscompile)

The optimized (non-`--relocatable`) ARM path allocates a spill frame (`sub sp,#N`) under register pressure, but the `add sp,#N` teardown was only inserted before returns that **already existed** in the body. A return **appended** for a function that falls off its end — the common wasm shape — only got the teardown under `SYNTH_SPILL_ON_EXHAUST`.

**The named accounting defect:** the appended-return dealloc was gated on `spill_on_exhaust` under the belief that any flag-off spill implied scratch-pool exhaustion (which declines the function to the direct selector). That belief is false: the flag-off `Opcode::Const` allocator has its **own oldest-vreg eviction spill** on R4-R11/R3 pool exhaustion (`optimizer_bridge.rs` ~3649) that never sets `r12_exhausted` — so the function compiled, spilled, and returned with SP off by the frame size. Post-#490 the epilogue is `pop {…,pc}`, which **reads PC through SP** → PC popped from a spill slot → crash.

Reachable **straight-line** (the #592 flip-lane reproducer, `redundant_base_materialization.wat::init_fields` with `SYNTH_BASE_CSE=0`) **and under the original #499 control-flow shape** (`nested`, block/br_if/br — its return is also the appended fall-off-the-end return, same single root cause).

## Broken → fixed epilogue (`init_fields`, `SYNTH_BASE_CSE=0`)

Broken (main):
```
  a4: sub.w  sp, sp, #24
 ...  str.w  r4, [sp, #4]   ; spills #4..#20
 152: ldmia.w sp!, {r4-r8, pc}   ; NO add sp — PC read from [sp+20] spill garbage
```
Fixed:
```
  a4: sub.w  sp, sp, #24
 13e: add.w  sp, sp, #24
 142: ldmia.w sp!, {r4-r8, pc}
```
(unicorn on main: `UC_ERR_INSN_INVALID`/`UC_ERR_FETCH_UNMAPPED`, PC popped from a spill slot)

## Fix

- `ir_to_arm`: the appended return deallocates the frame unconditionally (`next_spill_offset > 4`, no flag gate).
- Defensive post-condition (internal-bug panic pattern): with a frame allocated, **every** `bx lr` must be immediately preceded by the exact `add sp,#frame_size` — any violation is an epilogue bug and panics instead of shipping an SP-imbalanced function.

## Gate — red → green

New `scripts/repro/spill_frame_499_differential.py` (+ CI job): compiles `min_fields` (minimal straight-line spill), `nested` (original #499 CF shape, **both branch directions**), and `init_fields` with `SYNTH_BASE_CSE=0` (the #592 default relieves the pressure — pinned so the teardown path stays covered, with a loud non-vacuity tripwire if a fixture stops spilling); runs under unicorn and asserts return reached + **SP balanced** + memory bit-identical to wasmtime.

- main: **FAIL 4/4** (execution faults, exit 1)
- this PR: **PASS 4/4** (exit 0)

`base_cse_differential.py`'s "known #499" tolerance arm now passes clean (`off=ok`), as its comment predicted.

## Correctness re-pin (real finding, as anticipated)

`base_cse_flip_468.rs`'s **opt-out** golden for `redundant_base_materialization.wat` had pinned the miscompiled bytes (342 B). Fixed opt-out bytes are 326 B: +4 (`add sp`) − 20 (frame-slot DCE now removes the five dead spill stores that the mis-paired `pop` previously appeared to *read*, which forced a conservative keep). Re-pinned only after execution validation (both differentials green). The shipped-default golden (224 B) is untouched.

All other anchors bit-identical: `frozen_codegen_bytes` (--relocatable/direct ARM + RV32, escape hatches) green unchanged.

## Verification

- `spill_frame_499_differential.py`: red on main → green here
- `base_cse_differential.py`: PASS, #499 warning gone
- `cargo test -p synth-synthesis -p synth-cli`: green
- `cargo clippy -p synth-synthesis -p synth-cli --all-targets -- -D warnings`, `cargo fmt --check`: clean

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)