### PR TITLE
feat(verify): ordeal 0.4 solver backend behind a thin trait — Z3 demoted to differential oracle (#553)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,6 +1342,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "ordeal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc06ff17705108d56b0e8972d57c352dea633b2286fa1b14e11ee8ace15d5a5"
+dependencies = [
+ "ordeal-lrat",
+]
+
+[[package]]
+name = "ordeal-lrat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce6215e4c9708f43f5244f6f9d2edd893ea30ea30cc4ea0ffc7e301d58107a5"
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2203,6 +2218,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "criterion",
+ "ordeal",
  "proptest",
  "serde",
  "serde_json",

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -8,10 +8,13 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "Z3 SMT translation validation for the Synth compiler"
+description = "SMT translation validation for the Synth compiler (ordeal QF_BV engine; optional Z3 differential oracle)"
 
 [features]
-default = ["z3-solver", "arm"]
+default = ["arm"]
+# Optional Z3 backend: differential oracle against the default ordeal engine
+# (enable + set SYNTH_SOLVER_DIFF=1 to cross-check every query). Pulls in
+# z3-sys (C++ build) — no longer on the default build path.
 z3-solver = ["z3"]
 arm = ["synth-synthesis"]
 
@@ -24,7 +27,10 @@ synth-opt = { path = "../synth-opt", version = "0.26.0" }
 # ARM synthesis (optional, behind 'arm' feature)
 synth-synthesis = { path = "../synth-synthesis", version = "0.26.0", optional = true }
 
-# SMT solver for formal verification
+# Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
+ordeal = "0.4"
+
+# Z3: optional differential oracle (feature `z3-solver`) — no longer default
 z3 = { version = "0.19", features = ["static-link-z3"], optional = true }
 
 # Error handling
@@ -46,4 +52,4 @@ criterion = "0.8"
 
 [[example]]
 name = "verification_report"
-required-features = ["z3-solver", "arm"]
+required-features = ["arm"]

--- a/crates/synth-verify/examples/verification_report.rs
+++ b/crates/synth-verify/examples/verification_report.rs
@@ -2,10 +2,10 @@
 //!
 //! This example generates a comprehensive report of all verified synthesis rules,
 //! showing which WASM->ARM transformations have been formally proven correct.
-//! Requires both `z3-solver` and `arm` features.
+//! Requires the `arm` feature (default ordeal solver; optional Z3 differential oracle).
 
 use synth_synthesis::{ArmOp, Operand2, Pattern, Reg, Replacement, SynthesisRule, WasmOp};
-use synth_verify::{TranslationValidator, ValidationResult, with_z3_context};
+use synth_verify::{TranslationValidator, ValidationResult, with_verification_context};
 
 fn create_rule(name: &str, wasm_op: WasmOp, arm_op: ArmOp) -> SynthesisRule {
     SynthesisRule {
@@ -27,7 +27,7 @@ fn main() {
     println!("                    Synth Compiler - Phase 1");
     println!("======================================================================\n");
 
-    with_z3_context(|| {
+    with_verification_context(|| {
         let mut validator = TranslationValidator::new();
         validator.set_timeout(10000); // 10 second timeout per rule
 

--- a/crates/synth-verify/src/arm_semantics.rs
+++ b/crates/synth-verify/src/arm_semantics.rs
@@ -4,8 +4,8 @@
 //! Each ARM operation is translated to a mathematical formula that precisely
 //! captures its behavior, including register updates and condition flags.
 
+use crate::term::{BV, Bool};
 use synth_synthesis::rules::{ArmOp, Operand2, Reg, VfpReg};
-use z3::ast::{BV, Bool};
 
 /// ARM processor state representation in SMT
 ///
@@ -523,7 +523,7 @@ impl ArmSemantics {
                 // Detect carry: overflow occurred if result < either operand
                 // For unsigned: carry = (result_low < n_low)
                 let carry = result_low.bvult(&n_low);
-                let carry_bv = carry.ite(&BV::from_i64(1, 32), &BV::from_i64(0, 32));
+                let carry_bv = carry.ite(BV::from_i64(1, 32), BV::from_i64(0, 32));
 
                 // High part: add with carry
                 let high_sum = n_high.bvadd(&m_high);
@@ -593,7 +593,7 @@ impl ArmSemantics {
 
                 // Detect borrow: borrow occurred if n_low < m_low (unsigned)
                 let borrow = n_low.bvult(&m_low);
-                let borrow_bv = borrow.ite(&BV::from_i64(1, 32), &BV::from_i64(0, 32));
+                let borrow_bv = borrow.ite(BV::from_i64(1, 32), BV::from_i64(0, 32));
 
                 // High part: subtract with borrow
                 let high_diff = n_high.bvsub(&m_high);
@@ -1226,8 +1226,8 @@ impl ArmSemantics {
                 let thirty_two = BV::from_i64(32, 32);
                 let hi_is_zero = hi_clz.eq(&thirty_two);
                 let result = hi_is_zero.ite(
-                    &thirty_two.bvadd(&lo_clz), // High is zero: 32 + clz(low)
-                    &hi_clz,                    // High has bits: clz(high)
+                    thirty_two.bvadd(&lo_clz), // High is zero: 32 + clz(low)
+                    &hi_clz,                   // High has bits: clz(high)
                 );
                 state.set_reg(rd, result);
             }
@@ -1246,8 +1246,8 @@ impl ArmSemantics {
                 let thirty_two = BV::from_i64(32, 32);
                 let lo_is_zero = lo_ctz.eq(&thirty_two);
                 let result = lo_is_zero.ite(
-                    &thirty_two.bvadd(&hi_ctz), // Low is zero: 32 + ctz(high)
-                    &lo_ctz,                    // Low has bits: ctz(low)
+                    thirty_two.bvadd(&hi_ctz), // Low is zero: 32 + ctz(high)
+                    &lo_ctz,                   // Low has bits: ctz(low)
                 );
                 state.set_reg(rd, result);
             }
@@ -1857,39 +1857,39 @@ impl ArmSemantics {
         let top_16 = remaining.bvand(&mask_16);
         let top_16_zero = top_16.eq(&zero);
 
-        count = top_16_zero.ite(&count.bvadd(BV::from_i64(16, 32)), &count);
-        remaining = top_16_zero.ite(&remaining.bvshl(BV::from_i64(16, 32)), &remaining);
+        count = top_16_zero.ite(count.bvadd(BV::from_i64(16, 32)), &count);
+        remaining = top_16_zero.ite(remaining.bvshl(BV::from_i64(16, 32)), &remaining);
 
         // Check top 8 bits
         let mask_8 = BV::from_u64(0xFF000000, 32);
         let top_8 = remaining.bvand(&mask_8);
         let top_8_zero = top_8.eq(&zero);
 
-        count = top_8_zero.ite(&count.bvadd(BV::from_i64(8, 32)), &count);
-        remaining = top_8_zero.ite(&remaining.bvshl(BV::from_i64(8, 32)), &remaining);
+        count = top_8_zero.ite(count.bvadd(BV::from_i64(8, 32)), &count);
+        remaining = top_8_zero.ite(remaining.bvshl(BV::from_i64(8, 32)), &remaining);
 
         // Check top 4 bits
         let mask_4 = BV::from_u64(0xF0000000, 32);
         let top_4 = remaining.bvand(&mask_4);
         let top_4_zero = top_4.eq(&zero);
 
-        count = top_4_zero.ite(&count.bvadd(BV::from_i64(4, 32)), &count);
-        remaining = top_4_zero.ite(&remaining.bvshl(BV::from_i64(4, 32)), &remaining);
+        count = top_4_zero.ite(count.bvadd(BV::from_i64(4, 32)), &count);
+        remaining = top_4_zero.ite(remaining.bvshl(BV::from_i64(4, 32)), &remaining);
 
         // Check top 2 bits
         let mask_2 = BV::from_u64(0xC0000000, 32);
         let top_2 = remaining.bvand(&mask_2);
         let top_2_zero = top_2.eq(&zero);
 
-        count = top_2_zero.ite(&count.bvadd(BV::from_i64(2, 32)), &count);
-        remaining = top_2_zero.ite(&remaining.bvshl(BV::from_i64(2, 32)), &remaining);
+        count = top_2_zero.ite(count.bvadd(BV::from_i64(2, 32)), &count);
+        remaining = top_2_zero.ite(remaining.bvshl(BV::from_i64(2, 32)), &remaining);
 
         // Check top bit
         let mask_1 = BV::from_u64(0x80000000, 32);
         let top_1 = remaining.bvand(&mask_1);
         let top_1_zero = top_1.eq(&zero);
 
-        count = top_1_zero.ite(&count.bvadd(BV::from_i64(1, 32)), &count);
+        count = top_1_zero.ite(count.bvadd(BV::from_i64(1, 32)), &count);
 
         // Return 32 if all zeros, otherwise return count
         all_zero.ite(&result_if_zero, &count)
@@ -2138,12 +2138,11 @@ impl ArmSemantics {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::with_z3_context;
-    use z3::ast::Ast; // needed for .simplify()
+    use crate::with_verification_context;
 
     #[test]
     fn test_arm_add_semantics() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2168,7 +2167,7 @@ mod tests {
 
     #[test]
     fn test_arm_sub_semantics() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2190,7 +2189,7 @@ mod tests {
 
     #[test]
     fn test_arm_mov_immediate() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2208,7 +2207,7 @@ mod tests {
 
     #[test]
     fn test_arm_bitwise_ops() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2248,7 +2247,7 @@ mod tests {
     fn test_arm_mls() {
         // Test MLS (Multiply and Subtract): Rd = Ra - Rn * Rm
         // This is used for remainder: a % b = a - (a/b) * b
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2310,7 +2309,7 @@ mod tests {
 
     #[test]
     fn test_arm_shift_ops() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2338,7 +2337,7 @@ mod tests {
 
     #[test]
     fn test_arm_ror_comprehensive() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2434,7 +2433,7 @@ mod tests {
 
     #[test]
     fn test_arm_clz_comprehensive() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2500,7 +2499,7 @@ mod tests {
 
     #[test]
     fn test_arm_rbit_comprehensive() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2569,9 +2568,8 @@ mod tests {
     #[test]
     fn test_arm_cmp_flags() {
         // Test CMP instruction and condition flag updates
-        use z3::ast::Ast;
 
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2722,9 +2720,8 @@ mod tests {
     #[test]
     fn test_arm_flags_all_combinations() {
         // Test that flags correctly distinguish all comparison outcomes
-        use z3::ast::Ast;
 
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2767,7 +2764,7 @@ mod tests {
 
     #[test]
     fn test_arm_setcond_eq() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2817,7 +2814,7 @@ mod tests {
 
     #[test]
     fn test_arm_setcond_signed() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 
@@ -2901,7 +2898,7 @@ mod tests {
 
     #[test]
     fn test_arm_setcond_unsigned() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = ArmSemantics::new();
             let mut state = ArmState::new_symbolic();
 

--- a/crates/synth-verify/src/lib.rs
+++ b/crates/synth-verify/src/lib.rs
@@ -5,13 +5,24 @@
 //!
 //! # Architecture
 //!
-//! The verification system uses Z3 SMT solver to prove that synthesized native code
-//! has semantically equivalent behavior to the input WASM code.
+//! The verification system proves that synthesized native code has
+//! semantically equivalent behavior to the input WASM code, discharging the
+//! QF_BV queries through a thin solver trait ([`solver::BvSolver`], #553):
+//!
+//! - **Default engine:** [`ordeal`] — pure Rust, certificate-checked
+//!   (every `Unsat` verdict carries an LRAT proof validated by the trusted
+//!   `ordeal-lrat` checker). No C++ toolchain required.
+//! - **Differential oracle** (feature `z3-solver`): Z3, the former engine.
+//!   With both backends compiled in and `SYNTH_SOLVER_DIFF=1`, every query
+//!   runs through both — a verdict disagreement is a hard error; an ordeal
+//!   `Unknown` falls through to Z3's verdict.
 //!
 //! ## Backend-Agnostic Traits
 //!
 //! `SourceSemantics` and `TargetSemantics` traits allow any backend to provide
-//! SMT semantics. The ARM semantics are one implementation, behind the `arm` feature.
+//! SMT semantics. The ARM semantics are one implementation, behind the `arm`
+//! feature. All semantics encode into the solver-agnostic [`term::BV`] /
+//! [`term::Bool`] terms.
 //!
 //! ## Translation Validation
 //!
@@ -20,46 +31,69 @@
 //! - φ_target: Semantics of generated target operations
 //! - Prove: ∀inputs. φ_wasm(inputs) ⟺ φ_target(inputs)
 
+// Solver-agnostic terms + the thin solver trait (always available)
+pub mod solver;
+pub mod term;
+
 // Verification traits (always available)
-#[cfg(feature = "z3-solver")]
 pub mod traits;
 
-// ARM semantics (behind arm + z3-solver features)
-#[cfg(all(feature = "z3-solver", feature = "arm"))]
-pub mod arm_semantics;
-
-// WASM semantics (z3-solver only — source language for all backends)
-#[cfg(feature = "z3-solver")]
+// WASM semantics — source language for all backends (always available)
 pub mod wasm_semantics;
 
+// ARM semantics (behind the arm feature)
+#[cfg(feature = "arm")]
+pub mod arm_semantics;
+
 // Translation validator (requires arm for the existing concrete implementation)
-#[cfg(all(feature = "z3-solver", feature = "arm"))]
+#[cfg(feature = "arm")]
 pub mod translation_validator;
 
 // Validator-pattern prototype (issue #76 — CompCert-style certifying
 // validator scaffolding; see docs/validator-pattern.md).
-#[cfg(all(feature = "z3-solver", feature = "arm"))]
+#[cfg(feature = "arm")]
 pub mod validator_pattern;
 
-// Property-based testing (always available)
+// Property-based testing (requires arm: exercises the ARM synthesis rules)
+#[cfg(feature = "arm")]
 pub mod properties;
 
+#[cfg(feature = "arm")]
 pub use properties::CompilerProperties;
 
-#[cfg(all(feature = "z3-solver", feature = "arm"))]
+#[cfg(feature = "arm")]
 pub use arm_semantics::{ArmSemantics, ArmState};
-#[cfg(all(feature = "z3-solver", feature = "arm"))]
+pub use solver::{BvSolver, CheckOutcome, OrdealSolver, new_solver};
+pub use term::{BV, Bool};
+#[cfg(feature = "arm")]
 pub use translation_validator::{TranslationValidator, ValidationResult, VerificationError};
-#[cfg(all(feature = "z3-solver", feature = "arm"))]
+#[cfg(feature = "arm")]
 pub use validator_pattern::{
     CertifiedSelection, SolverResultKind, ValidationError as PatternValidationError, Validator,
     Witness, Z3ArmValidator,
 };
-#[cfg(feature = "z3-solver")]
 pub use wasm_semantics::WasmSemantics;
 
-#[cfg(feature = "z3-solver")]
-use z3::{Config, Solver};
+/// Run verification operations in a configured context.
+///
+/// With the default (ordeal) engine this is a plain call — the pure-Rust
+/// solver needs no global context. With the `z3-solver` feature compiled in,
+/// it additionally configures the Z3 thread-local context (30-second timeout,
+/// model generation) so the differential oracle is ready.
+pub fn with_verification_context<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R + Send + Sync,
+    R: Send + Sync,
+{
+    #[cfg(feature = "z3-solver")]
+    {
+        with_z3_context(f)
+    }
+    #[cfg(not(feature = "z3-solver"))]
+    {
+        f()
+    }
+}
 
 /// Run verification operations with a configured Z3 context.
 ///
@@ -71,22 +105,33 @@ where
     F: FnOnce() -> R + Send + Sync,
     R: Send + Sync,
 {
-    let mut cfg = Config::new();
+    let mut cfg = z3::Config::new();
     cfg.set_timeout_msec(30000); // 30 second timeout
     cfg.set_model_generation(true);
     z3::with_z3_config(&cfg, f)
 }
 
-/// Create a Z3 solver with default configuration
+/// Create a Z3 solver with default configuration (differential-oracle use)
 #[cfg(feature = "z3-solver")]
-pub fn create_solver() -> Solver {
-    Solver::new()
+pub fn create_solver() -> z3::Solver {
+    z3::Solver::new()
 }
 
-#[cfg(all(test, feature = "z3-solver"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_default_solver_decides() {
+        with_verification_context(|| {
+            let mut solver = new_solver();
+            let x = BV::new_const("x", 32);
+            solver.assert(&x.eq(&x).not());
+            assert_eq!(solver.check(), CheckOutcome::Unsat);
+        });
+    }
+
+    #[cfg(feature = "z3-solver")]
     #[test]
     fn test_z3_context_creation() {
         with_z3_context(|| {

--- a/crates/synth-verify/src/solver.rs
+++ b/crates/synth-verify/src/solver.rs
@@ -1,0 +1,496 @@
+//! The thin solver trait behind which the SMT engines sit (#553).
+//!
+//! Queries are built once as solver-agnostic terms ([`crate::term`]) and
+//! discharged through [`BvSolver`]:
+//!
+//! - [`OrdealSolver`] — the **default engine**: `ordeal`, the pure-Rust,
+//!   certificate-checked QF_BV solver (every `Unsat` carries an LRAT proof
+//!   the trusted `ordeal-lrat` checker validated before it is reported).
+//!   No C++ toolchain, no `z3-sys` build.
+//! - `Z3Solver` (feature `z3-solver`) — the former engine, retained as the
+//!   **differential oracle**.
+//! - `DifferentialSolver` — used when both backends are compiled in and
+//!   `SYNTH_SOLVER_DIFF=1`: every query runs through both engines. A verdict
+//!   disagreement (`Sat` vs `Unsat`) is a **hard error** (panic — one of the
+//!   solvers is wrong, and nothing downstream may proceed on either answer).
+//!   An ordeal `Unknown` falls through to Z3's verdict (logged, not fatal —
+//!   `Unknown` is the conservative non-answer, not a verdict).
+//!
+//! Budget: ordeal decides under a conflict budget (`check_with_limit`) so an
+//! adversarial query degrades to a clean conservative `Unknown` instead of
+//! hanging. Override with `SYNTH_ORDEAL_MAX_CONFLICTS` (0 = unbounded).
+
+use crate::term::{BV, Bool};
+use ordeal::{BoolTerm, CheckResult};
+
+/// Default conflict budget for the ordeal CDCL core. The synth burn-in corpus
+/// (pulseengine/ordeal#29) decides at a median of ~1 ms and well under this;
+/// the budget exists to bound adversarial shapes (e.g. non-canonicalized
+/// commuted multiplies) to a conservative `Unknown`.
+const DEFAULT_MAX_CONFLICTS: u64 = 1_000_000;
+
+/// Outcome of a one-shot `check` of the asserted conjunction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckOutcome {
+    /// The assertions are unsatisfiable (for a negated equivalence query:
+    /// the equivalence is proven).
+    Unsat,
+    /// The assertions are satisfiable; a model is available via
+    /// [`BvSolver::value`].
+    Sat,
+    /// The solver could not decide (budget/timeout). Callers must treat this
+    /// conservatively.
+    Unknown(String),
+}
+
+/// The thin solver interface: assert boolean terms, check once, read the
+/// model back on `Sat`. One instance = one query (no incremental solving —
+/// synth's translation-validation fragment is one-shot by design).
+pub trait BvSolver {
+    /// Engine name (diagnostics).
+    fn name(&self) -> &'static str;
+
+    /// Add `cond` to the asserted conjunction.
+    fn assert(&mut self, cond: &Bool);
+
+    /// Decide satisfiability of the asserted conjunction.
+    fn check(&mut self) -> CheckOutcome;
+
+    /// After [`CheckOutcome::Sat`]: the model value of a free variable
+    /// (with model completion — unconstrained variables read as 0, matching
+    /// z3's `eval(_, true)`). `None` if there is no model or `var` is not a
+    /// free variable.
+    fn value(&self, var: &BV) -> Option<u128>;
+}
+
+/// Construct the configured solver:
+///
+/// - default: [`OrdealSolver`];
+/// - with the `z3-solver` feature compiled in **and** `SYNTH_SOLVER_DIFF=1`:
+///   the differential solver (ordeal checked against Z3 on every query).
+pub fn new_solver() -> Box<dyn BvSolver> {
+    #[cfg(feature = "z3-solver")]
+    if std::env::var("SYNTH_SOLVER_DIFF").as_deref() == Ok("1") {
+        return Box::new(z3_backend::DifferentialSolver::new());
+    }
+    Box::new(OrdealSolver::new())
+}
+
+// ---------------------------------------------------------------------------
+// ordeal backend (default)
+// ---------------------------------------------------------------------------
+
+/// The default engine: pure-Rust `ordeal` with a conflict budget.
+pub struct OrdealSolver {
+    assertions: Vec<BoolTerm>,
+    max_conflicts: u64,
+    model: Option<ordeal::Model>,
+}
+
+impl OrdealSolver {
+    /// New solver with the budget from `SYNTH_ORDEAL_MAX_CONFLICTS`
+    /// (default [`DEFAULT_MAX_CONFLICTS`]; 0 = unbounded).
+    pub fn new() -> Self {
+        let max_conflicts = std::env::var("SYNTH_ORDEAL_MAX_CONFLICTS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_MAX_CONFLICTS);
+        Self {
+            assertions: Vec::new(),
+            max_conflicts,
+            model: None,
+        }
+    }
+}
+
+impl Default for OrdealSolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BvSolver for OrdealSolver {
+    fn name(&self) -> &'static str {
+        "ordeal"
+    }
+
+    fn assert(&mut self, cond: &Bool) {
+        self.assertions.push(cond.term().clone());
+    }
+
+    fn check(&mut self) -> CheckOutcome {
+        let mut solver = ordeal::Solver::new();
+        for a in &self.assertions {
+            solver.assert(a.clone());
+        }
+        let result = if self.max_conflicts == 0 {
+            solver.check()
+        } else {
+            solver.check_with_limit(self.max_conflicts)
+        };
+        match result {
+            CheckResult::Unsat(_certificate) => CheckOutcome::Unsat,
+            CheckResult::Sat(model) => {
+                self.model = Some(model);
+                CheckOutcome::Sat
+            }
+            CheckResult::Unknown => CheckOutcome::Unknown(format!(
+                "ordeal returned unknown (conflict budget {})",
+                self.max_conflicts
+            )),
+        }
+    }
+
+    fn value(&self, var: &BV) -> Option<u128> {
+        let model = self.model.as_ref()?;
+        let name = var.var_name()?;
+        Some(
+            model
+                .assignments
+                .iter()
+                .find(|(n, _)| n == name)
+                .map(|(_, v)| *v)
+                // Model completion: a variable the SAT core never saw is
+                // unconstrained; any value witnesses — use 0 (z3 does too).
+                .unwrap_or(0),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Z3 backend (feature-gated differential oracle)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "z3-solver")]
+mod z3_backend {
+    use super::*;
+    use ordeal::BvTerm;
+    use z3::SatResult;
+    use z3::ast::Ast;
+
+    /// Translate an ordeal `BvTerm` into a Z3 AST (the two backends consume
+    /// the identical canonicalized query).
+    fn bv_to_z3(t: &BvTerm) -> z3::ast::BV {
+        match t {
+            BvTerm::Const { value, sort } => {
+                if sort.width <= 64 {
+                    z3::ast::BV::from_u64(*value as u64, sort.width)
+                } else {
+                    // Split a wide constant into two 64-bit halves.
+                    let hi = z3::ast::BV::from_u64((value >> 64) as u64, sort.width - 64);
+                    let lo = z3::ast::BV::from_u64(*value as u64, 64);
+                    hi.concat(&lo)
+                }
+            }
+            BvTerm::Var { name, sort } => z3::ast::BV::new_const(name.clone(), sort.width),
+            BvTerm::Add(a, b) => bv_to_z3(a).bvadd(&bv_to_z3(b)),
+            BvTerm::Sub(a, b) => bv_to_z3(a).bvsub(&bv_to_z3(b)),
+            BvTerm::Mul(a, b) => bv_to_z3(a).bvmul(&bv_to_z3(b)),
+            BvTerm::Udiv(a, b) => bv_to_z3(a).bvudiv(&bv_to_z3(b)),
+            BvTerm::And(a, b) => bv_to_z3(a).bvand(&bv_to_z3(b)),
+            BvTerm::Or(a, b) => bv_to_z3(a).bvor(&bv_to_z3(b)),
+            BvTerm::Xor(a, b) => bv_to_z3(a).bvxor(&bv_to_z3(b)),
+            BvTerm::Shl(a, b) => bv_to_z3(a).bvshl(&bv_to_z3(b)),
+            BvTerm::Lshr(a, b) => bv_to_z3(a).bvlshr(&bv_to_z3(b)),
+            BvTerm::Ashr(a, b) => bv_to_z3(a).bvashr(&bv_to_z3(b)),
+            BvTerm::Rotr(a, b) => bv_to_z3(a).bvrotr(&bv_to_z3(b)),
+            BvTerm::Extract { hi, lo, arg } => bv_to_z3(arg).extract(*hi, *lo),
+            BvTerm::Concat(a, b) => bv_to_z3(a).concat(&bv_to_z3(b)),
+            BvTerm::ZeroExt { by, arg } => bv_to_z3(arg).zero_ext(*by),
+            BvTerm::SignExt { by, arg } => bv_to_z3(arg).sign_ext(*by),
+            BvTerm::Ite { cond, then_, else_ } => {
+                bool_to_z3(cond).ite(&bv_to_z3(then_), &bv_to_z3(else_))
+            }
+        }
+    }
+
+    fn bool_to_z3(t: &BoolTerm) -> z3::ast::Bool {
+        match t {
+            BoolTerm::Eq(a, b) => bv_to_z3(a).eq(&bv_to_z3(b)),
+            BoolTerm::Ne(a, b) => bv_to_z3(a).eq(&bv_to_z3(b)).not(),
+            BoolTerm::Ult(a, b) => bv_to_z3(a).bvult(&bv_to_z3(b)),
+            BoolTerm::Ule(a, b) => bv_to_z3(a).bvule(&bv_to_z3(b)),
+            BoolTerm::Ugt(a, b) => bv_to_z3(a).bvugt(&bv_to_z3(b)),
+            BoolTerm::Uge(a, b) => bv_to_z3(a).bvuge(&bv_to_z3(b)),
+            BoolTerm::Slt(a, b) => bv_to_z3(a).bvslt(&bv_to_z3(b)),
+            BoolTerm::Sle(a, b) => bv_to_z3(a).bvsle(&bv_to_z3(b)),
+            BoolTerm::Sgt(a, b) => bv_to_z3(a).bvsgt(&bv_to_z3(b)),
+            BoolTerm::Sge(a, b) => bv_to_z3(a).bvsge(&bv_to_z3(b)),
+            BoolTerm::Not(a) => bool_to_z3(a).not(),
+            BoolTerm::And(a, b) => z3::ast::Bool::and(&[&bool_to_z3(a), &bool_to_z3(b)]),
+            BoolTerm::Or(a, b) => z3::ast::Bool::or(&[&bool_to_z3(a), &bool_to_z3(b)]),
+        }
+    }
+
+    /// The former engine, now the differential oracle.
+    pub struct Z3Solver {
+        assertions: Vec<BoolTerm>,
+        model: Option<z3::Model>,
+    }
+
+    impl Z3Solver {
+        pub fn new() -> Self {
+            Self {
+                assertions: Vec::new(),
+                model: None,
+            }
+        }
+    }
+
+    impl BvSolver for Z3Solver {
+        fn name(&self) -> &'static str {
+            "z3"
+        }
+
+        fn assert(&mut self, cond: &Bool) {
+            self.assertions.push(cond.term().clone());
+        }
+
+        fn check(&mut self) -> CheckOutcome {
+            let solver = z3::Solver::new();
+            for a in &self.assertions {
+                solver.assert(bool_to_z3(a));
+            }
+            match solver.check() {
+                SatResult::Unsat => CheckOutcome::Unsat,
+                SatResult::Sat => {
+                    self.model = solver.get_model();
+                    if self.model.is_some() {
+                        CheckOutcome::Sat
+                    } else {
+                        CheckOutcome::Unknown("z3: SAT but no model available".to_string())
+                    }
+                }
+                SatResult::Unknown => CheckOutcome::Unknown("z3 returned unknown".to_string()),
+            }
+        }
+
+        fn value(&self, var: &BV) -> Option<u128> {
+            let model = self.model.as_ref()?;
+            let z3_var = bv_to_z3(var.term());
+            // z3::Model::eval is SMT model-value lookup (with completion),
+            // not code evaluation.
+            model
+                .eval(&z3_var, true)
+                .and_then(|v| v.as_u64())
+                .map(u128::from)
+        }
+    }
+
+    /// Which backend produced the authoritative model for the last `Sat`.
+    #[derive(Clone, Copy, PartialEq)]
+    enum ModelSource {
+        Ordeal,
+        Z3,
+    }
+
+    /// Runs every query through **both** engines (`SYNTH_SOLVER_DIFF=1`).
+    ///
+    /// Disagreement on a decided verdict is a hard error: it means one of
+    /// the solvers is unsound on this query, and no downstream use of either
+    /// answer is safe. ordeal `Unknown` falls through to Z3's verdict.
+    pub struct DifferentialSolver {
+        ordeal: OrdealSolver,
+        z3: Z3Solver,
+        model_source: ModelSource,
+    }
+
+    impl DifferentialSolver {
+        pub fn new() -> Self {
+            Self {
+                ordeal: OrdealSolver::new(),
+                z3: Z3Solver::new(),
+                model_source: ModelSource::Ordeal,
+            }
+        }
+    }
+
+    impl BvSolver for DifferentialSolver {
+        fn name(&self) -> &'static str {
+            "ordeal+z3-differential"
+        }
+
+        fn assert(&mut self, cond: &Bool) {
+            self.ordeal.assert(cond);
+            self.z3.assert(cond);
+        }
+
+        fn check(&mut self) -> CheckOutcome {
+            let ordeal_verdict = self.ordeal.check();
+            let z3_verdict = self.z3.check();
+            match (&ordeal_verdict, &z3_verdict) {
+                // ordeal could not decide: conservative fall-through to the
+                // oracle's verdict (logged — this is the measurable residue
+                // the ordeal budget/normalization roadmap tracks).
+                (CheckOutcome::Unknown(reason), _) => {
+                    eprintln!(
+                        "[synth-verify differential] ordeal unknown ({reason}); \
+                         falling through to z3 verdict: {z3_verdict:?}"
+                    );
+                    self.model_source = ModelSource::Z3;
+                    z3_verdict
+                }
+                // Oracle could not decide but ordeal did: verdicts do not
+                // disagree; keep ordeal's decided answer.
+                (_, CheckOutcome::Unknown(reason)) => {
+                    eprintln!(
+                        "[synth-verify differential] z3 unknown ({reason}); \
+                         keeping ordeal verdict: {ordeal_verdict:?}"
+                    );
+                    self.model_source = ModelSource::Ordeal;
+                    ordeal_verdict
+                }
+                (CheckOutcome::Unsat, CheckOutcome::Unsat) => CheckOutcome::Unsat,
+                (CheckOutcome::Sat, CheckOutcome::Sat) => {
+                    self.model_source = ModelSource::Ordeal;
+                    CheckOutcome::Sat
+                }
+                // Decided disagreement: one solver is wrong. Hard error.
+                (o, z) => panic!(
+                    "SOLVER DISAGREEMENT (#553 differential oracle): \
+                     ordeal={o:?} z3={z:?} on the same query — one engine is \
+                     unsound on this fragment; refusing to proceed"
+                ),
+            }
+        }
+
+        fn value(&self, var: &BV) -> Option<u128> {
+            match self.model_source {
+                ModelSource::Ordeal => self.ordeal.value(var),
+                ModelSource::Z3 => self.z3.value(var),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "z3-solver")]
+pub use z3_backend::{DifferentialSolver, Z3Solver};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn x32() -> BV {
+        BV::new_const("x", 32)
+    }
+    fn y32() -> BV {
+        BV::new_const("y", 32)
+    }
+
+    /// Small equivalence corpus: (label, query, expect_unsat).
+    /// Every query is a negated equivalence, exactly the validator's shape.
+    fn corpus() -> Vec<(&'static str, Bool, bool)> {
+        let x = x32();
+        let y = y32();
+        let one = BV::from_i64(1, 32);
+        vec![
+            ("add-comm", x.bvadd(&y).eq(y.bvadd(&x)).not(), true),
+            ("mul-comm", x.bvmul(&y).eq(y.bvmul(&x)).not(), true),
+            ("and-comm", x.bvand(&y).eq(y.bvand(&x)).not(), true),
+            (
+                "shl1-vs-mul2",
+                x.bvshl(&one).eq(x.bvmul(BV::from_i64(2, 32))).not(),
+                true,
+            ),
+            (
+                "sub-not-comm",
+                x.bvsub(&y).eq(y.bvsub(&x)).not(),
+                false, // SAT: x-y != y-x has witnesses
+            ),
+            (
+                "ite-select",
+                {
+                    let c = x.eq(BV::from_i64(0, 32)).not();
+                    c.ite(&y, &one).eq(c.ite(&y, &one)).not()
+                },
+                true,
+            ),
+            (
+                "add-vs-sub-bug",
+                x.bvadd(&y).eq(x.bvsub(&y)).not(),
+                false, // SAT: differs whenever y != 0
+            ),
+        ]
+    }
+
+    #[test]
+    fn ordeal_decides_the_corpus() {
+        for (label, query, expect_unsat) in corpus() {
+            let mut solver = OrdealSolver::new();
+            solver.assert(&query);
+            let outcome = solver.check();
+            if expect_unsat {
+                assert_eq!(outcome, CheckOutcome::Unsat, "{label}");
+            } else {
+                assert_eq!(outcome, CheckOutcome::Sat, "{label}");
+                // Model readback must produce usable witness values.
+                assert!(solver.value(&x32()).is_some(), "{label}: no model value");
+            }
+        }
+    }
+
+    #[test]
+    fn ordeal_finds_counterexample_with_model() {
+        // x + 1 == x - 1 is UNSAT-free: always differs -> negation is... the
+        // direct assertion x+1 == x-1 is unsatisfiable; assert the EQUALITY
+        // and expect Unsat, then assert a satisfiable disequality and read
+        // the model back.
+        let x = x32();
+        let mut solver = OrdealSolver::new();
+        solver.assert(
+            &x.bvadd(BV::from_i64(1, 32))
+                .eq(x.bvsub(BV::from_i64(1, 32))),
+        );
+        assert_eq!(solver.check(), CheckOutcome::Unsat);
+
+        let mut solver = OrdealSolver::new();
+        solver.assert(&x.eq(BV::from_i64(7, 32)));
+        assert_eq!(solver.check(), CheckOutcome::Sat);
+        assert_eq!(solver.value(&x), Some(7));
+    }
+
+    #[test]
+    fn bool_var_bridge_is_symbolic() {
+        // Bool::new_const must be genuinely free: both polarities satisfiable.
+        let flag = Bool::new_const("flag");
+        let one = BV::from_i64(1, 32);
+        let zero = BV::from_i64(0, 32);
+        // `out` selects on the flag; constraining the flag's polarity must
+        // force the selected value — in both directions.
+        for (cond, expected) in [(flag.clone(), 1u128), (flag.not(), 0u128)] {
+            let mut solver = OrdealSolver::new();
+            let out = flag.ite(&one, &zero);
+            let probe = BV::new_const("probe", 32);
+            solver.assert(&probe.eq(&out));
+            solver.assert(&cond);
+            assert_eq!(solver.check(), CheckOutcome::Sat);
+            assert_eq!(solver.value(&probe), Some(expected));
+        }
+    }
+
+    /// The differential oracle itself: run the corpus through BOTH engines.
+    /// Any decided disagreement panics inside `DifferentialSolver::check`.
+    /// This runs in the CI Z3 job (`--features z3-solver,arm`) regardless of
+    /// the SYNTH_SOLVER_DIFF env, so the cross-check is always exercised
+    /// where Z3 is available.
+    #[cfg(feature = "z3-solver")]
+    #[test]
+    fn differential_zero_disagreements_on_corpus() {
+        crate::with_z3_context(|| {
+            for (label, query, expect_unsat) in corpus() {
+                let mut solver = DifferentialSolver::new();
+                solver.assert(&query);
+                let outcome = solver.check();
+                if expect_unsat {
+                    assert_eq!(outcome, CheckOutcome::Unsat, "{label}");
+                } else {
+                    assert_eq!(outcome, CheckOutcome::Sat, "{label}");
+                }
+            }
+        });
+    }
+}

--- a/crates/synth-verify/src/term.rs
+++ b/crates/synth-verify/src/term.rs
@@ -1,0 +1,952 @@
+//! Solver-agnostic bitvector / boolean term types (#553).
+//!
+//! `BV` and `Bool` wrap [`ordeal::BvTerm`] / [`ordeal::BoolTerm`] behind the
+//! exact method surface the semantics encoders (`wasm_semantics.rs`,
+//! `arm_semantics.rs`) previously used from `z3::ast::{BV, Bool}` — so the
+//! encoders stay in their native idiom while becoming solver-independent.
+//! Both backends (the default pure-Rust `ordeal` engine and the optional
+//! feature-gated Z3 differential oracle) consume these terms; see
+//! `solver.rs`.
+//!
+//! # Commutative-operand canonicalization (interim shim)
+//!
+//! ordeal 0.4 has no term normalization yet (scoped upstream for ordeal
+//! v0.8.0, pulseengine/ordeal#29): syntactically commuted operands of a
+//! commutative op (`a*b` vs `b*a`) can blast to structurally distinct AIGs
+//! and, for `Mul`, hit a CDCL cliff. Until v0.8.0 lands, the constructors for
+//! the commutative ops (`bvadd`, `bvmul`, `bvand`, `bvor`, `bvxor`, and the
+//! `Eq`/`Ne` predicates) order their operands by a deterministic structural
+//! key, so both sides of an equivalence query build the *same* term for the
+//! same commuted expression. This is a pure reordering of arguments to
+//! commutative SMT-LIB operations — semantics are untouched (the Z3 oracle
+//! sees the identical canonicalized query).
+
+use ordeal::{BoolTerm, BvTerm, Sort};
+use std::borrow::Borrow;
+use std::cmp::Ordering;
+use std::fmt;
+
+/// Bit-mask of `width` low bits (saturating at 128).
+fn mask(width: u32) -> u128 {
+    if width >= 128 {
+        u128::MAX
+    } else {
+        (1u128 << width) - 1
+    }
+}
+
+/// A bitvector term of a known width.
+///
+/// Mirrors the `z3::ast::BV` call surface used by the semantics encoders.
+#[derive(Clone, Debug)]
+pub struct BV {
+    term: BvTerm,
+    width: u32,
+}
+
+/// A boolean term (predicate).
+///
+/// Mirrors the `z3::ast::Bool` call surface used by the semantics encoders.
+#[derive(Clone, Debug)]
+pub struct Bool {
+    term: BoolTerm,
+}
+
+// ---------------------------------------------------------------------------
+// Structural ordering for canonicalization
+// ---------------------------------------------------------------------------
+
+fn bv_rank(t: &BvTerm) -> u8 {
+    match t {
+        BvTerm::Const { .. } => 0,
+        BvTerm::Var { .. } => 1,
+        BvTerm::Add(..) => 2,
+        BvTerm::Sub(..) => 3,
+        BvTerm::Mul(..) => 4,
+        BvTerm::Udiv(..) => 5,
+        BvTerm::And(..) => 6,
+        BvTerm::Or(..) => 7,
+        BvTerm::Xor(..) => 8,
+        BvTerm::Shl(..) => 9,
+        BvTerm::Lshr(..) => 10,
+        BvTerm::Ashr(..) => 11,
+        BvTerm::Rotr(..) => 12,
+        BvTerm::Extract { .. } => 13,
+        BvTerm::Concat(..) => 14,
+        BvTerm::ZeroExt { .. } => 15,
+        BvTerm::SignExt { .. } => 16,
+        BvTerm::Ite { .. } => 17,
+    }
+}
+
+fn bool_rank(t: &BoolTerm) -> u8 {
+    match t {
+        BoolTerm::Eq(..) => 0,
+        BoolTerm::Ne(..) => 1,
+        BoolTerm::Ult(..) => 2,
+        BoolTerm::Ule(..) => 3,
+        BoolTerm::Ugt(..) => 4,
+        BoolTerm::Uge(..) => 5,
+        BoolTerm::Slt(..) => 6,
+        BoolTerm::Sle(..) => 7,
+        BoolTerm::Sgt(..) => 8,
+        BoolTerm::Sge(..) => 9,
+        BoolTerm::Not(..) => 10,
+        BoolTerm::And(..) => 11,
+        BoolTerm::Or(..) => 12,
+    }
+}
+
+/// Total, deterministic structural order over `BvTerm` (canonicalization key).
+fn ord_bv(a: &BvTerm, b: &BvTerm) -> Ordering {
+    bv_rank(a).cmp(&bv_rank(b)).then_with(|| match (a, b) {
+        (
+            BvTerm::Const {
+                value: va,
+                sort: sa,
+            },
+            BvTerm::Const {
+                value: vb,
+                sort: sb,
+            },
+        ) => sa.width.cmp(&sb.width).then(va.cmp(vb)),
+        (BvTerm::Var { name: na, sort: sa }, BvTerm::Var { name: nb, sort: sb }) => {
+            sa.width.cmp(&sb.width).then_with(|| na.cmp(nb))
+        }
+        (BvTerm::Add(a1, a2), BvTerm::Add(b1, b2))
+        | (BvTerm::Sub(a1, a2), BvTerm::Sub(b1, b2))
+        | (BvTerm::Mul(a1, a2), BvTerm::Mul(b1, b2))
+        | (BvTerm::Udiv(a1, a2), BvTerm::Udiv(b1, b2))
+        | (BvTerm::And(a1, a2), BvTerm::And(b1, b2))
+        | (BvTerm::Or(a1, a2), BvTerm::Or(b1, b2))
+        | (BvTerm::Xor(a1, a2), BvTerm::Xor(b1, b2))
+        | (BvTerm::Shl(a1, a2), BvTerm::Shl(b1, b2))
+        | (BvTerm::Lshr(a1, a2), BvTerm::Lshr(b1, b2))
+        | (BvTerm::Ashr(a1, a2), BvTerm::Ashr(b1, b2))
+        | (BvTerm::Rotr(a1, a2), BvTerm::Rotr(b1, b2))
+        | (BvTerm::Concat(a1, a2), BvTerm::Concat(b1, b2)) => {
+            ord_bv(a1, b1).then_with(|| ord_bv(a2, b2))
+        }
+        (
+            BvTerm::Extract {
+                hi: ha,
+                lo: la,
+                arg: aa,
+            },
+            BvTerm::Extract {
+                hi: hb,
+                lo: lb,
+                arg: ab,
+            },
+        ) => ha.cmp(hb).then(la.cmp(lb)).then_with(|| ord_bv(aa, ab)),
+        (BvTerm::ZeroExt { by: ba, arg: aa }, BvTerm::ZeroExt { by: bb, arg: ab })
+        | (BvTerm::SignExt { by: ba, arg: aa }, BvTerm::SignExt { by: bb, arg: ab }) => {
+            ba.cmp(bb).then_with(|| ord_bv(aa, ab))
+        }
+        (
+            BvTerm::Ite {
+                cond: ca,
+                then_: ta,
+                else_: ea,
+            },
+            BvTerm::Ite {
+                cond: cb,
+                then_: tb,
+                else_: eb,
+            },
+        ) => ord_bool(ca, cb)
+            .then_with(|| ord_bv(ta, tb))
+            .then_with(|| ord_bv(ea, eb)),
+        // Different ranks were handled above; same-rank pairs are all matched.
+        _ => unreachable!("ord_bv: rank-equal variants are exhaustively matched"),
+    })
+}
+
+/// Total, deterministic structural order over `BoolTerm`.
+fn ord_bool(a: &BoolTerm, b: &BoolTerm) -> Ordering {
+    bool_rank(a).cmp(&bool_rank(b)).then_with(|| match (a, b) {
+        (BoolTerm::Eq(a1, a2), BoolTerm::Eq(b1, b2))
+        | (BoolTerm::Ne(a1, a2), BoolTerm::Ne(b1, b2))
+        | (BoolTerm::Ult(a1, a2), BoolTerm::Ult(b1, b2))
+        | (BoolTerm::Ule(a1, a2), BoolTerm::Ule(b1, b2))
+        | (BoolTerm::Ugt(a1, a2), BoolTerm::Ugt(b1, b2))
+        | (BoolTerm::Uge(a1, a2), BoolTerm::Uge(b1, b2))
+        | (BoolTerm::Slt(a1, a2), BoolTerm::Slt(b1, b2))
+        | (BoolTerm::Sle(a1, a2), BoolTerm::Sle(b1, b2))
+        | (BoolTerm::Sgt(a1, a2), BoolTerm::Sgt(b1, b2))
+        | (BoolTerm::Sge(a1, a2), BoolTerm::Sge(b1, b2)) => {
+            ord_bv(a1, b1).then_with(|| ord_bv(a2, b2))
+        }
+        (BoolTerm::Not(a1), BoolTerm::Not(b1)) => ord_bool(a1, b1),
+        (BoolTerm::And(a1, a2), BoolTerm::And(b1, b2))
+        | (BoolTerm::Or(a1, a2), BoolTerm::Or(b1, b2)) => {
+            ord_bool(a1, b1).then_with(|| ord_bool(a2, b2))
+        }
+        _ => unreachable!("ord_bool: rank-equal variants are exhaustively matched"),
+    })
+}
+
+/// Order two operands of a commutative op deterministically (the interim
+/// canonicalization shim — see the module docs).
+fn canonical_pair(a: BvTerm, b: BvTerm) -> (Box<BvTerm>, Box<BvTerm>) {
+    if ord_bv(&a, &b) == Ordering::Greater {
+        (Box::new(b), Box::new(a))
+    } else {
+        (Box::new(a), Box::new(b))
+    }
+}
+
+/// Recursively canonicalize a term built *outside* the shim constructors
+/// (`ordeal::lowering` helpers build e.g. `Mul(q, b)` verbatim): reorder
+/// every commutative node bottom-up so shim-built and lowering-built
+/// expressions of the same value share one structure. Without this, the two
+/// sides of an equivalence query can differ by a commuted `Mul` — precisely
+/// the CDCL cliff the canonicalization exists to avoid.
+fn canonicalize_bv(t: &BvTerm) -> BvTerm {
+    let bin = |a: &BvTerm, b: &BvTerm| (Box::new(canonicalize_bv(a)), Box::new(canonicalize_bv(b)));
+    let comm = |a: &BvTerm, b: &BvTerm| canonical_pair(canonicalize_bv(a), canonicalize_bv(b));
+    match t {
+        BvTerm::Const { .. } | BvTerm::Var { .. } => t.clone(),
+        BvTerm::Add(a, b) => {
+            let (a, b) = comm(a, b);
+            BvTerm::Add(a, b)
+        }
+        BvTerm::Mul(a, b) => {
+            let (a, b) = comm(a, b);
+            BvTerm::Mul(a, b)
+        }
+        BvTerm::And(a, b) => {
+            let (a, b) = comm(a, b);
+            BvTerm::And(a, b)
+        }
+        BvTerm::Or(a, b) => {
+            let (a, b) = comm(a, b);
+            BvTerm::Or(a, b)
+        }
+        BvTerm::Xor(a, b) => {
+            let (a, b) = comm(a, b);
+            BvTerm::Xor(a, b)
+        }
+        BvTerm::Sub(a, b) => {
+            let (a, b) = bin(a, b);
+            BvTerm::Sub(a, b)
+        }
+        BvTerm::Udiv(a, b) => {
+            let (a, b) = bin(a, b);
+            BvTerm::Udiv(a, b)
+        }
+        BvTerm::Shl(a, b) => {
+            let (a, b) = bin(a, b);
+            BvTerm::Shl(a, b)
+        }
+        BvTerm::Lshr(a, b) => {
+            let (a, b) = bin(a, b);
+            BvTerm::Lshr(a, b)
+        }
+        BvTerm::Ashr(a, b) => {
+            let (a, b) = bin(a, b);
+            BvTerm::Ashr(a, b)
+        }
+        BvTerm::Rotr(a, b) => {
+            let (a, b) = bin(a, b);
+            BvTerm::Rotr(a, b)
+        }
+        BvTerm::Concat(a, b) => {
+            let (a, b) = bin(a, b);
+            BvTerm::Concat(a, b)
+        }
+        BvTerm::Extract { hi, lo, arg } => BvTerm::Extract {
+            hi: *hi,
+            lo: *lo,
+            arg: Box::new(canonicalize_bv(arg)),
+        },
+        BvTerm::ZeroExt { by, arg } => BvTerm::ZeroExt {
+            by: *by,
+            arg: Box::new(canonicalize_bv(arg)),
+        },
+        BvTerm::SignExt { by, arg } => BvTerm::SignExt {
+            by: *by,
+            arg: Box::new(canonicalize_bv(arg)),
+        },
+        BvTerm::Ite { cond, then_, else_ } => BvTerm::Ite {
+            cond: Box::new(canonicalize_bool(cond)),
+            then_: Box::new(canonicalize_bv(then_)),
+            else_: Box::new(canonicalize_bv(else_)),
+        },
+    }
+}
+
+fn canonicalize_bool(t: &BoolTerm) -> BoolTerm {
+    let bin = |a: &BvTerm, b: &BvTerm| (Box::new(canonicalize_bv(a)), Box::new(canonicalize_bv(b)));
+    let comm = |a: &BvTerm, b: &BvTerm| canonical_pair(canonicalize_bv(a), canonicalize_bv(b));
+    match t {
+        BoolTerm::Eq(a, b) => {
+            let (a, b) = comm(a, b);
+            BoolTerm::Eq(a, b)
+        }
+        BoolTerm::Ne(a, b) => {
+            let (a, b) = comm(a, b);
+            BoolTerm::Ne(a, b)
+        }
+        BoolTerm::Ult(a, b) => {
+            let (a, b) = bin(a, b);
+            BoolTerm::Ult(a, b)
+        }
+        BoolTerm::Ule(a, b) => {
+            let (a, b) = bin(a, b);
+            BoolTerm::Ule(a, b)
+        }
+        BoolTerm::Ugt(a, b) => {
+            let (a, b) = bin(a, b);
+            BoolTerm::Ugt(a, b)
+        }
+        BoolTerm::Uge(a, b) => {
+            let (a, b) = bin(a, b);
+            BoolTerm::Uge(a, b)
+        }
+        BoolTerm::Slt(a, b) => {
+            let (a, b) = bin(a, b);
+            BoolTerm::Slt(a, b)
+        }
+        BoolTerm::Sle(a, b) => {
+            let (a, b) = bin(a, b);
+            BoolTerm::Sle(a, b)
+        }
+        BoolTerm::Sgt(a, b) => {
+            let (a, b) = bin(a, b);
+            BoolTerm::Sgt(a, b)
+        }
+        BoolTerm::Sge(a, b) => {
+            let (a, b) = bin(a, b);
+            BoolTerm::Sge(a, b)
+        }
+        BoolTerm::Not(a) => BoolTerm::Not(Box::new(canonicalize_bool(a))),
+        BoolTerm::And(a, b) => BoolTerm::And(
+            Box::new(canonicalize_bool(a)),
+            Box::new(canonicalize_bool(b)),
+        ),
+        BoolTerm::Or(a, b) => BoolTerm::Or(
+            Box::new(canonicalize_bool(a)),
+            Box::new(canonicalize_bool(b)),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BV
+// ---------------------------------------------------------------------------
+
+impl BV {
+    /// The underlying ordeal term (consumed by the Z3 oracle translation).
+    #[cfg_attr(not(feature = "z3-solver"), allow(dead_code))]
+    pub(crate) fn term(&self) -> &BvTerm {
+        &self.term
+    }
+
+    /// If this is a free variable, its name.
+    pub(crate) fn var_name(&self) -> Option<&str> {
+        match &self.term {
+            BvTerm::Var { name, .. } => Some(name),
+            _ => None,
+        }
+    }
+
+    /// A fresh free (symbolic) bitvector variable.
+    pub fn new_const(name: impl Into<String>, width: u32) -> Self {
+        Self {
+            term: BvTerm::Var {
+                name: name.into(),
+                sort: Sort::new(width),
+            },
+            width,
+        }
+    }
+
+    /// A concrete constant from a signed value (two's-complement, masked).
+    pub fn from_i64(value: i64, width: u32) -> Self {
+        Self {
+            term: BvTerm::Const {
+                value: (value as u64 as u128) & mask(width),
+                sort: Sort::new(width),
+            },
+            width,
+        }
+    }
+
+    /// A concrete constant from an unsigned value (masked to width).
+    pub fn from_u64(value: u64, width: u32) -> Self {
+        Self {
+            term: BvTerm::Const {
+                value: (value as u128) & mask(width),
+                sort: Sort::new(width),
+            },
+            width,
+        }
+    }
+
+    /// Bit width of this term.
+    pub fn get_size(&self) -> u32 {
+        self.width
+    }
+
+    fn binop(
+        &self,
+        other: impl Borrow<BV>,
+        f: impl FnOnce(Box<BvTerm>, Box<BvTerm>) -> BvTerm,
+    ) -> BV {
+        let other = other.borrow();
+        BV {
+            term: f(Box::new(self.term.clone()), Box::new(other.term.clone())),
+            width: self.width,
+        }
+    }
+
+    fn commutative(
+        &self,
+        other: impl Borrow<BV>,
+        f: impl FnOnce(Box<BvTerm>, Box<BvTerm>) -> BvTerm,
+    ) -> BV {
+        let other = other.borrow();
+        let (a, b) = canonical_pair(self.term.clone(), other.term.clone());
+        BV {
+            term: f(a, b),
+            width: self.width,
+        }
+    }
+
+    // --- Arithmetic ---
+
+    /// Modular addition.
+    pub fn bvadd(&self, other: impl Borrow<BV>) -> BV {
+        self.commutative(other, BvTerm::Add)
+    }
+
+    /// Modular subtraction.
+    pub fn bvsub(&self, other: impl Borrow<BV>) -> BV {
+        self.binop(other, BvTerm::Sub)
+    }
+
+    /// Modular multiplication.
+    pub fn bvmul(&self, other: impl Borrow<BV>) -> BV {
+        self.commutative(other, BvTerm::Mul)
+    }
+
+    /// Unsigned division (SMT-LIB: division by zero yields all-ones).
+    pub fn bvudiv(&self, other: impl Borrow<BV>) -> BV {
+        self.binop(other, BvTerm::Udiv)
+    }
+
+    /// Signed division (SMT-LIB semantics, via `ordeal::lowering`).
+    pub fn bvsdiv(&self, other: impl Borrow<BV>) -> BV {
+        BV {
+            term: canonicalize_bv(&ordeal::lowering::bvsdiv(
+                self.term.clone(),
+                other.borrow().term.clone(),
+                self.width,
+            )),
+            width: self.width,
+        }
+    }
+
+    /// Unsigned remainder (via `ordeal::lowering`).
+    pub fn bvurem(&self, other: impl Borrow<BV>) -> BV {
+        BV {
+            term: canonicalize_bv(&ordeal::lowering::bvurem(
+                self.term.clone(),
+                other.borrow().term.clone(),
+                self.width,
+            )),
+            width: self.width,
+        }
+    }
+
+    /// Signed remainder (via `ordeal::lowering`).
+    pub fn bvsrem(&self, other: impl Borrow<BV>) -> BV {
+        BV {
+            term: canonicalize_bv(&ordeal::lowering::bvsrem(
+                self.term.clone(),
+                other.borrow().term.clone(),
+                self.width,
+            )),
+            width: self.width,
+        }
+    }
+
+    /// Two's-complement negation (via `ordeal::lowering`).
+    pub fn bvneg(&self) -> BV {
+        BV {
+            term: canonicalize_bv(&ordeal::lowering::bvneg(self.term.clone(), self.width)),
+            width: self.width,
+        }
+    }
+
+    // --- Bitwise ---
+
+    /// Bitwise AND.
+    pub fn bvand(&self, other: impl Borrow<BV>) -> BV {
+        self.commutative(other, BvTerm::And)
+    }
+
+    /// Bitwise OR.
+    pub fn bvor(&self, other: impl Borrow<BV>) -> BV {
+        self.commutative(other, BvTerm::Or)
+    }
+
+    /// Bitwise XOR.
+    pub fn bvxor(&self, other: impl Borrow<BV>) -> BV {
+        self.commutative(other, BvTerm::Xor)
+    }
+
+    /// Bitwise NOT (via `ordeal::lowering`).
+    pub fn bvnot(&self) -> BV {
+        BV {
+            term: canonicalize_bv(&ordeal::lowering::bvnot(self.term.clone(), self.width)),
+            width: self.width,
+        }
+    }
+
+    // --- Shifts / rotates ---
+
+    /// Logical shift left (SMT-LIB oversize semantics: amount >= width → 0).
+    pub fn bvshl(&self, other: impl Borrow<BV>) -> BV {
+        self.binop(other, BvTerm::Shl)
+    }
+
+    /// Logical shift right.
+    pub fn bvlshr(&self, other: impl Borrow<BV>) -> BV {
+        self.binop(other, BvTerm::Lshr)
+    }
+
+    /// Arithmetic shift right.
+    pub fn bvashr(&self, other: impl Borrow<BV>) -> BV {
+        self.binop(other, BvTerm::Ashr)
+    }
+
+    /// Rotate left by a term amount (via `ordeal::lowering`).
+    pub fn bvrotl(&self, other: impl Borrow<BV>) -> BV {
+        BV {
+            term: canonicalize_bv(&ordeal::lowering::bvrotl(
+                self.term.clone(),
+                other.borrow().term.clone(),
+                self.width,
+            )),
+            width: self.width,
+        }
+    }
+
+    /// Rotate right by a term amount.
+    pub fn bvrotr(&self, other: impl Borrow<BV>) -> BV {
+        self.binop(other, BvTerm::Rotr)
+    }
+
+    // --- Structural ---
+
+    /// Bit extraction `[hi:lo]` (inclusive).
+    pub fn extract(&self, hi: u32, lo: u32) -> BV {
+        BV {
+            term: BvTerm::Extract {
+                hi,
+                lo,
+                arg: Box::new(self.term.clone()),
+            },
+            width: hi - lo + 1,
+        }
+    }
+
+    /// Concatenation: `self` becomes the high bits.
+    pub fn concat(&self, other: impl Borrow<BV>) -> BV {
+        let other = other.borrow();
+        BV {
+            term: BvTerm::Concat(Box::new(self.term.clone()), Box::new(other.term.clone())),
+            width: self.width + other.width,
+        }
+    }
+
+    /// Zero-extension by `by` bits.
+    pub fn zero_ext(&self, by: u32) -> BV {
+        BV {
+            term: BvTerm::ZeroExt {
+                by,
+                arg: Box::new(self.term.clone()),
+            },
+            width: self.width + by,
+        }
+    }
+
+    /// Sign-extension by `by` bits.
+    pub fn sign_ext(&self, by: u32) -> BV {
+        BV {
+            term: BvTerm::SignExt {
+                by,
+                arg: Box::new(self.term.clone()),
+            },
+            width: self.width + by,
+        }
+    }
+
+    // --- Predicates ---
+
+    fn cmp_op(
+        &self,
+        other: impl Borrow<BV>,
+        f: impl FnOnce(Box<BvTerm>, Box<BvTerm>) -> BoolTerm,
+    ) -> Bool {
+        Bool {
+            term: f(
+                Box::new(self.term.clone()),
+                Box::new(other.borrow().term.clone()),
+            ),
+        }
+    }
+
+    /// Equality predicate (canonicalized — `=` is commutative).
+    pub fn eq(&self, other: impl Borrow<BV>) -> Bool {
+        let (a, b) = canonical_pair(self.term.clone(), other.borrow().term.clone());
+        Bool {
+            term: BoolTerm::Eq(a, b),
+        }
+    }
+
+    /// Disequality predicate (canonicalized — `distinct` is commutative).
+    pub fn ne(&self, other: impl Borrow<BV>) -> Bool {
+        let (a, b) = canonical_pair(self.term.clone(), other.borrow().term.clone());
+        Bool {
+            term: BoolTerm::Ne(a, b),
+        }
+    }
+
+    /// Unsigned less-than.
+    pub fn bvult(&self, other: impl Borrow<BV>) -> Bool {
+        self.cmp_op(other, BoolTerm::Ult)
+    }
+
+    /// Unsigned less-or-equal.
+    pub fn bvule(&self, other: impl Borrow<BV>) -> Bool {
+        self.cmp_op(other, BoolTerm::Ule)
+    }
+
+    /// Unsigned greater-than.
+    pub fn bvugt(&self, other: impl Borrow<BV>) -> Bool {
+        self.cmp_op(other, BoolTerm::Ugt)
+    }
+
+    /// Unsigned greater-or-equal.
+    pub fn bvuge(&self, other: impl Borrow<BV>) -> Bool {
+        self.cmp_op(other, BoolTerm::Uge)
+    }
+
+    /// Signed less-than.
+    pub fn bvslt(&self, other: impl Borrow<BV>) -> Bool {
+        self.cmp_op(other, BoolTerm::Slt)
+    }
+
+    /// Signed less-or-equal.
+    pub fn bvsle(&self, other: impl Borrow<BV>) -> Bool {
+        self.cmp_op(other, BoolTerm::Sle)
+    }
+
+    /// Signed greater-than.
+    pub fn bvsgt(&self, other: impl Borrow<BV>) -> Bool {
+        self.cmp_op(other, BoolTerm::Sgt)
+    }
+
+    /// Signed greater-or-equal.
+    pub fn bvsge(&self, other: impl Borrow<BV>) -> Bool {
+        self.cmp_op(other, BoolTerm::Sge)
+    }
+
+    // --- Constant folding (test convenience; mirrors z3's simplify()) ---
+
+    /// Return `self` unchanged; pair with [`BV::as_i64`] / [`BV::as_u64`],
+    /// which concretely evaluate closed terms (the z3 idiom
+    /// `x.simplify().as_i64()` keeps working).
+    pub fn simplify(&self) -> BV {
+        self.clone()
+    }
+
+    /// Concrete value of a closed (variable-free) term, as z3's `as_i64`
+    /// reports it: the *unsigned* value when it fits in `i64`.
+    pub fn as_i64(&self) -> Option<i64> {
+        self.eval_closed().and_then(|v| i64::try_from(v).ok())
+    }
+
+    /// Concrete value of a closed (variable-free) term as `u64`.
+    pub fn as_u64(&self) -> Option<u64> {
+        self.eval_closed().and_then(|v| u64::try_from(v).ok())
+    }
+
+    fn eval_closed(&self) -> Option<u128> {
+        ordeal::eval::eval_bv(&self.term, &ordeal::eval::Env::new()).ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bool
+// ---------------------------------------------------------------------------
+
+impl Bool {
+    /// The underlying ordeal term.
+    pub(crate) fn term(&self) -> &BoolTerm {
+        &self.term
+    }
+
+    /// A fresh free (symbolic) boolean variable.
+    ///
+    /// ordeal's fragment has no boolean variables, so this is encoded as
+    /// `var != 0` over a fresh 1-bit bitvector variable — an exact bridge.
+    pub fn new_const(name: impl Into<String>) -> Self {
+        let var = BvTerm::Var {
+            name: name.into(),
+            sort: Sort::new(1),
+        };
+        Self {
+            term: BoolTerm::Ne(
+                Box::new(var),
+                Box::new(BvTerm::Const {
+                    value: 0,
+                    sort: Sort::new(1),
+                }),
+            ),
+        }
+    }
+
+    /// The boolean literal `true` / `false`.
+    pub fn from_bool(value: bool) -> Self {
+        Self::literal(value)
+    }
+
+    /// Boolean equality (iff), encoded as `(a ∧ b) ∨ (¬a ∧ ¬b)` — the
+    /// fragment has no native boolean `=`.
+    pub fn eq(&self, other: impl Borrow<Bool>) -> Bool {
+        let a = self.term.clone();
+        let b = other.borrow().term.clone();
+        Bool {
+            term: BoolTerm::Or(
+                Box::new(BoolTerm::And(Box::new(a.clone()), Box::new(b.clone()))),
+                Box::new(BoolTerm::And(
+                    Box::new(BoolTerm::Not(Box::new(a))),
+                    Box::new(BoolTerm::Not(Box::new(b))),
+                )),
+            ),
+        }
+    }
+
+    /// Logical negation.
+    pub fn not(&self) -> Bool {
+        Bool {
+            term: BoolTerm::Not(Box::new(self.term.clone())),
+        }
+    }
+
+    /// N-ary conjunction (empty slice is `true`).
+    pub fn and(values: &[&Bool]) -> Bool {
+        Self::fold(values, BoolTerm::And, true)
+    }
+
+    /// N-ary disjunction (empty slice is `false`).
+    pub fn or(values: &[&Bool]) -> Bool {
+        Self::fold(values, BoolTerm::Or, false)
+    }
+
+    fn fold(
+        values: &[&Bool],
+        f: impl Fn(Box<BoolTerm>, Box<BoolTerm>) -> BoolTerm,
+        empty: bool,
+    ) -> Bool {
+        let mut iter = values.iter();
+        let Some(first) = iter.next() else {
+            return Self::literal(empty);
+        };
+        let mut acc = first.term.clone();
+        for v in iter {
+            acc = f(Box::new(acc), Box::new(v.term.clone()));
+        }
+        Bool { term: acc }
+    }
+
+    /// The boolean literal `true` / `false` (as a trivially decided
+    /// comparison — the fragment has no boolean constants).
+    fn literal(value: bool) -> Bool {
+        let zero = || {
+            Box::new(BvTerm::Const {
+                value: 0,
+                sort: Sort::new(1),
+            })
+        };
+        Bool {
+            term: if value {
+                BoolTerm::Eq(zero(), zero())
+            } else {
+                BoolTerm::Ne(zero(), zero())
+            },
+        }
+    }
+
+    /// If-then-else over bitvector branches (the bool→BV bridge;
+    /// `BvTerm::Ite` is native in ordeal 0.4).
+    pub fn ite(&self, then_: impl Borrow<BV>, else_: impl Borrow<BV>) -> BV {
+        let then_ = then_.borrow();
+        let else_ = else_.borrow();
+        BV {
+            term: BvTerm::Ite {
+                cond: Box::new(self.term.clone()),
+                then_: Box::new(then_.term.clone()),
+                else_: Box::new(else_.term.clone()),
+            },
+            width: then_.width,
+        }
+    }
+
+    /// Return `self` unchanged; pair with [`Bool::as_bool`], which concretely
+    /// evaluates closed predicates (the z3 `simplify().as_bool()` idiom).
+    pub fn simplify(&self) -> Bool {
+        self.clone()
+    }
+
+    /// Concrete value of a closed (variable-free) predicate.
+    pub fn as_bool(&self) -> Option<bool> {
+        ordeal::eval::eval_bool(&self.term, &ordeal::eval::Env::new()).ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Display (SMT-LIB-style mnemonics; used by tests and diagnostics)
+// ---------------------------------------------------------------------------
+
+fn fmt_bv(t: &BvTerm, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match t {
+        BvTerm::Const { value, sort } => write!(f, "(_ bv{} {})", value, sort.width),
+        BvTerm::Var { name, .. } => write!(f, "{}", name),
+        BvTerm::Add(a, b) => fmt_bin(f, "bvadd", a, b),
+        BvTerm::Sub(a, b) => fmt_bin(f, "bvsub", a, b),
+        BvTerm::Mul(a, b) => fmt_bin(f, "bvmul", a, b),
+        BvTerm::Udiv(a, b) => fmt_bin(f, "bvudiv", a, b),
+        BvTerm::And(a, b) => fmt_bin(f, "bvand", a, b),
+        BvTerm::Or(a, b) => fmt_bin(f, "bvor", a, b),
+        BvTerm::Xor(a, b) => fmt_bin(f, "bvxor", a, b),
+        BvTerm::Shl(a, b) => fmt_bin(f, "bvshl", a, b),
+        BvTerm::Lshr(a, b) => fmt_bin(f, "bvlshr", a, b),
+        BvTerm::Ashr(a, b) => fmt_bin(f, "bvashr", a, b),
+        BvTerm::Rotr(a, b) => fmt_bin(f, "bvrotr", a, b),
+        BvTerm::Extract { hi, lo, arg } => {
+            write!(f, "((_ extract {} {}) ", hi, lo)?;
+            fmt_bv(arg, f)?;
+            write!(f, ")")
+        }
+        BvTerm::Concat(a, b) => fmt_bin(f, "concat", a, b),
+        BvTerm::ZeroExt { by, arg } => {
+            write!(f, "((_ zero_extend {}) ", by)?;
+            fmt_bv(arg, f)?;
+            write!(f, ")")
+        }
+        BvTerm::SignExt { by, arg } => {
+            write!(f, "((_ sign_extend {}) ", by)?;
+            fmt_bv(arg, f)?;
+            write!(f, ")")
+        }
+        BvTerm::Ite { cond, then_, else_ } => {
+            write!(f, "(ite ")?;
+            fmt_bool(cond, f)?;
+            write!(f, " ")?;
+            fmt_bv(then_, f)?;
+            write!(f, " ")?;
+            fmt_bv(else_, f)?;
+            write!(f, ")")
+        }
+    }
+}
+
+fn fmt_bin(f: &mut fmt::Formatter<'_>, op: &str, a: &BvTerm, b: &BvTerm) -> fmt::Result {
+    write!(f, "({} ", op)?;
+    fmt_bv(a, f)?;
+    write!(f, " ")?;
+    fmt_bv(b, f)?;
+    write!(f, ")")
+}
+
+fn fmt_bool(t: &BoolTerm, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let bin = |f: &mut fmt::Formatter<'_>, op: &str, a: &BvTerm, b: &BvTerm| -> fmt::Result {
+        write!(f, "({} ", op)?;
+        fmt_bv(a, f)?;
+        write!(f, " ")?;
+        fmt_bv(b, f)?;
+        write!(f, ")")
+    };
+    match t {
+        BoolTerm::Eq(a, b) => bin(f, "=", a, b),
+        BoolTerm::Ne(a, b) => bin(f, "distinct", a, b),
+        BoolTerm::Ult(a, b) => bin(f, "bvult", a, b),
+        BoolTerm::Ule(a, b) => bin(f, "bvule", a, b),
+        BoolTerm::Ugt(a, b) => bin(f, "bvugt", a, b),
+        BoolTerm::Uge(a, b) => bin(f, "bvuge", a, b),
+        BoolTerm::Slt(a, b) => bin(f, "bvslt", a, b),
+        BoolTerm::Sle(a, b) => bin(f, "bvsle", a, b),
+        BoolTerm::Sgt(a, b) => bin(f, "bvsgt", a, b),
+        BoolTerm::Sge(a, b) => bin(f, "bvsge", a, b),
+        BoolTerm::Not(a) => {
+            write!(f, "(not ")?;
+            fmt_bool(a, f)?;
+            write!(f, ")")
+        }
+        BoolTerm::And(a, b) => {
+            write!(f, "(and ")?;
+            fmt_bool(a, f)?;
+            write!(f, " ")?;
+            fmt_bool(b, f)?;
+            write!(f, ")")
+        }
+        BoolTerm::Or(a, b) => {
+            write!(f, "(or ")?;
+            fmt_bool(a, f)?;
+            write!(f, " ")?;
+            fmt_bool(b, f)?;
+            write!(f, ")")
+        }
+    }
+}
+
+impl fmt::Display for BV {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_bv(&self.term, f)
+    }
+}
+
+impl fmt::Display for Bool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_bool(&self.term, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn const_folding_matches_z3_idiom() {
+        let a = BV::from_i64(40, 32);
+        let b = BV::from_i64(2, 32);
+        assert_eq!(a.bvadd(&b).simplify().as_i64(), Some(42));
+        assert_eq!(a.bvsub(&b).simplify().as_i64(), Some(38));
+        // as_i64 reports the unsigned value (z3 behavior the tests rely on).
+        assert_eq!(BV::from_i64(-1, 32).as_i64(), Some(0xFFFF_FFFF));
+    }
+
+    #[test]
+    fn commutative_construction_is_canonical() {
+        let x = BV::new_const("x", 32);
+        let y = BV::new_const("y", 32);
+        // a*b and b*a must build the identical term (the v0.8.0 interim shim).
+        assert_eq!(x.bvmul(&y).to_string(), y.bvmul(&x).to_string());
+        assert_eq!(x.bvadd(&y).to_string(), y.bvadd(&x).to_string());
+        assert_eq!(x.eq(&y).to_string(), y.eq(&x).to_string());
+        // Non-commutative ops must NOT be reordered.
+        assert_ne!(x.bvsub(&y).to_string(), y.bvsub(&x).to_string());
+    }
+
+    #[test]
+    fn display_uses_smtlib_mnemonics() {
+        let x = BV::new_const("x", 32);
+        let s = x.bvadd(BV::from_i64(1, 32)).to_string();
+        assert!(s.contains("bvadd"), "{s}");
+    }
+}

--- a/crates/synth-verify/src/traits.rs
+++ b/crates/synth-verify/src/traits.rs
@@ -4,9 +4,11 @@
 //! instruction set. The translation validator is generic over source and
 //! target semantics.
 //!
-//! Z3 0.19 uses thread-local context — no lifetime parameters needed.
+//! Semantics encode into the solver-agnostic [`crate::term::BV`] terms, so
+//! implementations are independent of the SMT engine behind
+//! [`crate::solver::BvSolver`].
 
-use z3::ast::BV;
+use crate::term::BV;
 
 /// Encodes source (WASM) operation semantics as SMT formulas
 pub trait SourceSemantics {

--- a/crates/synth-verify/src/translation_validator.rs
+++ b/crates/synth-verify/src/translation_validator.rs
@@ -19,12 +19,12 @@
 //! We prove: forall a,b. i32.add(a, b) == ADD(a, b)
 
 use crate::arm_semantics::{ArmSemantics, ArmState};
+use crate::solver::{CheckOutcome, new_solver};
+use crate::term::BV;
 use crate::wasm_semantics::WasmSemantics;
 use synth_core::WasmOp;
 use synth_synthesis::{ArmOp, Reg, SynthesisRule};
 use thiserror::Error;
-use z3::ast::BV;
-use z3::{SatResult, Solver};
 
 /// Verification error types
 #[derive(Debug, Error)]
@@ -62,9 +62,9 @@ pub enum ValidationResult {
     Unknown { reason: String },
 }
 
-/// Translation validator using Z3 SMT solver.
-///
-/// Z3 0.19 uses thread-local context -- no lifetime parameters needed.
+/// Translation validator over the configured SMT engine (see
+/// [`crate::solver::new_solver`]: ordeal by default, optionally
+/// cross-checked against Z3 when `SYNTH_SOLVER_DIFF=1`).
 pub struct TranslationValidator {
     wasm_encoder: WasmSemantics,
     arm_encoder: ArmSemantics,
@@ -137,7 +137,7 @@ impl TranslationValidator {
         arm_ops: &[ArmOp],
         concrete_params: &[(usize, i64)],
     ) -> Result<ValidationResult, VerificationError> {
-        let solver = Solver::new();
+        let mut solver = new_solver();
 
         // Create inputs - some symbolic, some concrete
         let num_inputs = self.get_num_inputs(wasm_op);
@@ -164,24 +164,22 @@ impl TranslationValidator {
         // Assert that results are NOT equal
         // If this is UNSAT, then the results are always equal (proven correct)
         // If this is SAT, we found a counterexample
-        solver.assert(wasm_result.eq(&arm_result).not());
+        solver.assert(&wasm_result.eq(&arm_result).not());
 
         match solver.check() {
-            SatResult::Unsat => {
+            CheckOutcome::Unsat => {
                 // Proven correct - no inputs exist where results differ
                 Ok(ValidationResult::Verified)
             }
 
-            SatResult::Sat => {
-                // Found counterexample
-                let model = solver.get_model().ok_or_else(|| {
-                    VerificationError::SolverError("SAT but no model available".to_string())
-                })?;
-
+            CheckOutcome::Sat => {
+                // Found counterexample: read the differing inputs back from
+                // the model (symbolic inputs only — concrete params have no
+                // model entry). Values are reported unsigned, as before.
                 let mut counterexample = Vec::new();
                 for (i, input) in inputs.iter().enumerate() {
-                    if let Some(value) = model.eval(input, true)
-                        && let Some(int_val) = value.as_i64()
+                    if let Some(value) = solver.value(input)
+                        && let Ok(int_val) = i64::try_from(value)
                     {
                         counterexample.push((format!("input_{}", i), int_val));
                     }
@@ -190,10 +188,10 @@ impl TranslationValidator {
                 Ok(ValidationResult::Invalid { counterexample })
             }
 
-            SatResult::Unknown => {
+            CheckOutcome::Unknown(reason) => {
                 // Verification inconclusive
                 Ok(ValidationResult::Unknown {
-                    reason: "SMT solver returned unknown".to_string(),
+                    reason: format!("SMT solver returned unknown: {reason}"),
                 })
             }
         }
@@ -321,7 +319,7 @@ impl TranslationValidator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::with_z3_context;
+    use crate::with_verification_context;
     use synth_synthesis::{Cost, Operand2, Pattern, Replacement};
 
     fn create_test_rule(wasm_op: WasmOp, arm_op: ArmOp) -> SynthesisRule {
@@ -340,7 +338,7 @@ mod tests {
 
     #[test]
     fn test_verify_add_correct() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = TranslationValidator::new();
 
             let rule = create_test_rule(
@@ -359,7 +357,7 @@ mod tests {
 
     #[test]
     fn test_verify_sub_correct() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = TranslationValidator::new();
 
             let rule = create_test_rule(
@@ -378,7 +376,7 @@ mod tests {
 
     #[test]
     fn test_verify_mul_correct() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = TranslationValidator::new();
 
             let rule = create_test_rule(
@@ -397,7 +395,7 @@ mod tests {
 
     #[test]
     fn test_verify_and_correct() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = TranslationValidator::new();
 
             let rule = create_test_rule(
@@ -416,7 +414,7 @@ mod tests {
 
     #[test]
     fn test_verify_incorrect_rule() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = TranslationValidator::new();
 
             // INCORRECT rule: WASM i32.add -> ARM SUB (should find counterexample)
@@ -442,7 +440,7 @@ mod tests {
 
     #[test]
     fn test_verify_bitwise_ops() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = TranslationValidator::new();
 
             // Test OR

--- a/crates/synth-verify/src/validator_pattern.rs
+++ b/crates/synth-verify/src/validator_pattern.rs
@@ -108,14 +108,14 @@
 //!   bit-counting ops, sits outside the #76 binary-op core and is deferred to
 //!   keep this change focused and reviewable.
 
-#![cfg(all(feature = "z3-solver", feature = "arm"))]
+#![cfg(feature = "arm")]
 
+use crate::solver::{CheckOutcome, new_solver};
+use crate::term::{BV, Bool};
 use synth_core::WasmOp;
 use synth_synthesis::rules::Condition;
 use synth_synthesis::{ArmOp, Operand2, Reg};
 use thiserror::Error;
-use z3::ast::{BV, Bool};
-use z3::{SatResult, Solver};
 
 /// A concrete selection produced by the instruction selector.
 ///
@@ -172,7 +172,7 @@ pub struct Witness {
     pub solver_result: SolverResultKind,
 }
 
-/// Solver result kind (mirrors `z3::SatResult` but without the lifetime).
+/// Solver result kind (mirrors [`crate::solver::CheckOutcome`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SolverResultKind {
     /// `Unsat` of the negated equivalence — selection is correct.
@@ -237,7 +237,7 @@ fn k32(v: i64) -> BV {
 
 /// Boolean → 32-bit `0`/`1` bitvector (WASM comparison result encoding).
 fn bool_to_i32(b: &Bool) -> BV {
-    b.ite(&k32(1), &k32(0))
+    b.ite(k32(1), k32(0))
 }
 
 /// 64-bit value as a pair of 32-bit limbs: `lo` is bits 0..=31, `hi` is
@@ -288,7 +288,7 @@ impl I64Pair {
 /// then folded into the high limb: `hi = a_hi + b_hi + carry`.
 fn i64_add(a: &I64Pair, b: &I64Pair) -> I64Pair {
     let lo = a.lo.bvadd(&b.lo);
-    let carry = lo.bvult(&a.lo).ite(&k32(1), &k32(0));
+    let carry = lo.bvult(&a.lo).ite(k32(1), k32(0));
     let hi = a.hi.bvadd(&b.hi).bvadd(&carry);
     I64Pair { lo, hi }
 }
@@ -300,7 +300,7 @@ fn i64_add(a: &I64Pair, b: &I64Pair) -> I64Pair {
 /// subtracted from the high limb: `hi = a_hi - b_hi - borrow`.
 fn i64_sub(a: &I64Pair, b: &I64Pair) -> I64Pair {
     let lo = a.lo.bvsub(&b.lo);
-    let borrow = a.lo.bvult(&b.lo).ite(&k32(1), &k32(0));
+    let borrow = a.lo.bvult(&b.lo).ite(k32(1), k32(0));
     let hi = a.hi.bvsub(&b.hi).bvsub(&borrow);
     I64Pair { lo, hi }
 }
@@ -346,8 +346,8 @@ fn i64_shl(a: &I64Pair, s: &BV) -> I64Pair {
     let lo_big = k32(0);
     let hi_big = a.lo.bvshl(s.bvsub(k32(32)));
 
-    let lo = s_is_zero.ite(&a.lo, &s_lt_32.ite(&lo_small, &lo_big));
-    let hi = s_is_zero.ite(&a.hi, &s_lt_32.ite(&hi_small, &hi_big));
+    let lo = s_is_zero.ite(&a.lo, s_lt_32.ite(&lo_small, &lo_big));
+    let hi = s_is_zero.ite(&a.hi, s_lt_32.ite(&hi_small, &hi_big));
     I64Pair { lo, hi }
 }
 
@@ -366,8 +366,8 @@ fn i64_shr_u(a: &I64Pair, s: &BV) -> I64Pair {
     let lo_big = a.hi.bvlshr(s.bvsub(k32(32)));
     let hi_big = k32(0);
 
-    let lo = s_is_zero.ite(&a.lo, &s_lt_32.ite(&lo_small, &lo_big));
-    let hi = s_is_zero.ite(&a.hi, &s_lt_32.ite(&hi_small, &hi_big));
+    let lo = s_is_zero.ite(&a.lo, s_lt_32.ite(&lo_small, &lo_big));
+    let hi = s_is_zero.ite(&a.hi, s_lt_32.ite(&hi_small, &hi_big));
     I64Pair { lo, hi }
 }
 
@@ -391,8 +391,8 @@ fn i64_shr_s(a: &I64Pair, s: &BV) -> I64Pair {
     let lo_big = a.hi.bvashr(s.bvsub(k32(32)));
     let hi_big = sign.clone();
 
-    let lo = s_is_zero.ite(&a.lo, &s_lt_32.ite(&lo_small, &lo_big));
-    let hi = s_is_zero.ite(&a.hi, &s_lt_32.ite(&hi_small, &hi_big));
+    let lo = s_is_zero.ite(&a.lo, s_lt_32.ite(&lo_small, &lo_big));
+    let hi = s_is_zero.ite(&a.hi, s_lt_32.ite(&hi_small, &hi_big));
     I64Pair { lo, hi }
 }
 
@@ -550,9 +550,10 @@ impl Default for Z3ArmValidator {
 }
 
 impl Z3ArmValidator {
-    /// Construct a fresh validator. Z3 0.19 uses thread-local contexts, so
-    /// callers should wrap any sequence of `validate` calls in
-    /// [`crate::with_z3_context`].
+    /// Construct a fresh validator. Callers should wrap any sequence of
+    /// `validate` calls in [`crate::with_verification_context`] (a no-op for
+    /// the default ordeal engine; configures Z3's thread-local context when
+    /// the differential oracle is compiled in).
     pub fn new() -> Self {
         Self
     }
@@ -820,7 +821,7 @@ impl Z3ArmValidator {
                 }
                 // ADC: add with the carry flag (i64 high limb).
                 ArmOp::Adc { rd, rn, op2 } => {
-                    let c = flags.c.ite(&k32(1), &k32(0));
+                    let c = flags.c.ite(k32(1), k32(0));
                     regs[idx(rd)] = regs[idx(rn)].bvadd(&eval_op2(&regs, op2)?).bvadd(&c);
                 }
                 // SUBS: subtract and set carry. ARM convention: C = 1 means
@@ -833,7 +834,7 @@ impl Z3ArmValidator {
                 }
                 // SBC: subtract with borrow. Rd = Rn - op2 - (1 - C).
                 ArmOp::Sbc { rd, rn, op2 } => {
-                    let borrow = flags.c.ite(&k32(0), &k32(1));
+                    let borrow = flags.c.ite(k32(0), k32(1));
                     regs[idx(rd)] = regs[idx(rn)].bvsub(&eval_op2(&regs, op2)?).bvsub(&borrow);
                 }
                 ArmOp::Mul { rd, rn, rm } => {
@@ -1126,7 +1127,7 @@ impl Validator<WasmOp, ArmOp> for Z3ArmValidator {
         self.arity(&sel.wasm)
             .ok_or_else(|| ValidationError::UnsupportedOp(sel.wasm.clone()))?;
 
-        let solver = Solver::new();
+        let mut solver = new_solver();
 
         // Symbolic operands. Each operand is a limb pair; for i32 ops only the
         // `.lo` limb is meaningful and the `.hi` limb is left unconstrained
@@ -1143,7 +1144,7 @@ impl Validator<WasmOp, ArmOp> for Z3ArmValidator {
         // For division / remainder, restrict to non-trapping inputs so the
         // value-domain equivalence is the property actually being proved.
         if Self::is_div_rem(&sel.wasm) {
-            solver.assert(self.div_rem_precondition(&sel.wasm, &a, &b));
+            solver.assert(&self.div_rem_precondition(&sel.wasm, &a, &b));
         }
 
         let wasm_result = self
@@ -1164,35 +1165,35 @@ impl Validator<WasmOp, ArmOp> for Z3ArmValidator {
         solver.assert(&differ);
 
         match solver.check() {
-            SatResult::Unsat => Ok(Witness {
+            CheckOutcome::Unsat => Ok(Witness {
                 wasm_op_label: label,
                 arm_op_count: sel.arm.len(),
                 solver_result: SolverResultKind::Unsat,
             }),
-            SatResult::Sat => {
-                let description = match solver.get_model() {
-                    Some(model) => {
-                        let mut parts = Vec::new();
-                        for (name, bv) in [
-                            ("a_lo", &a.lo),
-                            ("a_hi", &a.hi),
-                            ("b_lo", &b.lo),
-                            ("b_hi", &b.hi),
-                        ] {
-                            if let Some(v) = model.eval(bv, true).and_then(|v| v.as_i64()) {
-                                parts.push(format!("{name}={v}"));
-                            }
-                        }
-                        parts.join(", ")
+            CheckOutcome::Sat => {
+                // Model readback: report the differing inputs.
+                let mut parts = Vec::new();
+                for (name, bv) in [
+                    ("a_lo", &a.lo),
+                    ("a_hi", &a.hi),
+                    ("b_lo", &b.lo),
+                    ("b_hi", &b.hi),
+                ] {
+                    if let Some(v) = solver.value(bv) {
+                        parts.push(format!("{name}={v}"));
                     }
-                    None => "no model available".to_string(),
+                }
+                let description = if parts.is_empty() {
+                    "no model available".to_string()
+                } else {
+                    parts.join(", ")
                 };
                 Err(ValidationError::Counterexample {
                     wasm_op_label: label,
                     description,
                 })
             }
-            SatResult::Unknown => Err(ValidationError::SolverUnknown(label)),
+            CheckOutcome::Unknown(_) => Err(ValidationError::SolverUnknown(label)),
         }
     }
 }
@@ -1200,7 +1201,7 @@ impl Validator<WasmOp, ArmOp> for Z3ArmValidator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::with_z3_context;
+    use crate::with_verification_context;
 
     // ---- helpers ----------------------------------------------------------
 
@@ -1264,7 +1265,7 @@ mod tests {
     /// certifies; a wrong selector picking `SUB` is rejected.
     #[test]
     fn i32_add_certifies() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = Z3ArmValidator::new();
 
             let correct = CertifiedSelection::new(
@@ -1302,7 +1303,7 @@ mod tests {
     /// Unsupported ops return a structured error, not a panic.
     #[test]
     fn unsupported_op_returns_structured_error() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = Z3ArmValidator::new();
             // `Drop` is not in the i32/i64 arithmetic surface.
             let sel = CertifiedSelection::<WasmOp, ArmOp>::new(WasmOp::Drop, vec![]);
@@ -1340,7 +1341,7 @@ mod tests {
 
     #[test]
     fn i32_arith_logic_certifies() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             assert_certifies(
                 WasmOp::I32Add,
                 dp_r0_r0_r1(|rd, rn, op2| ArmOp::Add { rd, rn, op2 }),
@@ -1376,7 +1377,7 @@ mod tests {
 
     #[test]
     fn i32_shifts_certify() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             // WASM masks the shift count mod 32. The faithful lowering masks
             // R1 with #31 first, then does the register shift.
             let mask_then = |shift: ArmOp| {
@@ -1447,7 +1448,7 @@ mod tests {
 
     #[test]
     fn i32_comparisons_certify() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             // Each comparison lowers to CMP + SetCond with the matching ARM
             // condition code. Signed: LT/LE/GT/GE; unsigned: LO/LS/HI/HS.
             assert_certifies(WasmOp::I32Eq, i32_cmp(Condition::EQ));
@@ -1465,7 +1466,7 @@ mod tests {
 
     #[test]
     fn i32_eqz_certifies() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             // i32.eqz: (a == 0). CMP R0, #0 then SetCond EQ.
             assert_certifies(
                 WasmOp::I32Eqz,
@@ -1487,7 +1488,7 @@ mod tests {
 
     #[test]
     fn i32_div_certify() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             // div_s / div_u map directly onto SDIV / UDIV (bvsdiv / bvudiv);
             // no symbolic multiply, so the equivalence is solver-tractable.
             // The non-trapping precondition excludes divisor 0 (and, for
@@ -1518,7 +1519,7 @@ mod tests {
     /// silently certifying or hanging.
     #[test]
     fn i32_rem_is_scoped_out() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = Z3ArmValidator::new();
             for op in [WasmOp::I32RemS, WasmOp::I32RemU] {
                 let sel = CertifiedSelection::<WasmOp, ArmOp>::new(op.clone(), vec![]);
@@ -1534,7 +1535,7 @@ mod tests {
 
     #[test]
     fn i64_add_certifies() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             // i64.add register-pair lowering:
             //   ADDS R0, R0, R2   ; lo = a_lo + b_lo, sets carry
             //   ADC  R1, R1, R3   ; hi = a_hi + b_hi + carry
@@ -1558,7 +1559,7 @@ mod tests {
 
     #[test]
     fn i64_sub_certifies() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             // i64.sub register-pair lowering:
             //   SUBS R0, R0, R2   ; lo = a_lo - b_lo, sets borrow (C)
             //   SBC  R1, R1, R3   ; hi = a_hi - b_hi - borrow
@@ -1590,7 +1591,7 @@ mod tests {
     /// `ArmOp` level the validator inspects.
     #[test]
     fn i64_mul_certifies() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             assert_certifies(
                 WasmOp::I64Mul,
                 vec![ArmOp::I64Mul {
@@ -1607,7 +1608,7 @@ mod tests {
 
     #[test]
     fn i64_logic_certifies() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             assert_certifies(
                 WasmOp::I64And,
                 i64_logic(|rd, rn, op2| ArmOp::And { rd, rn, op2 }),
@@ -1640,14 +1641,14 @@ mod tests {
         native: fn(&BV, &BV) -> BV,
         label: &str,
     ) {
-        let solver = Solver::new();
+        let mut solver = new_solver();
         let a = I64Pair {
             lo: sym32("sa_lo"),
             hi: sym32("sa_hi"),
         };
         // Symbolic amount, already reduced mod 64 (the masked count).
         let amt = sym32("samt");
-        solver.assert(amt.bvult(k32(64)));
+        solver.assert(&amt.bvult(k32(64)));
 
         let limb = limb_fn(&a, &amt);
         let limb64 = limb.hi.concat(&limb.lo);
@@ -1657,17 +1658,17 @@ mod tests {
         let amt64 = k32(0).concat(&amt);
         let truth = native(&a64, &amt64);
 
-        solver.assert(limb64.eq(&truth).not());
+        solver.assert(&limb64.eq(&truth).not());
         assert_eq!(
             solver.check(),
-            SatResult::Unsat,
+            CheckOutcome::Unsat,
             "{label} limb reference must equal the native 64-bit shift for all inputs"
         );
     }
 
     #[test]
     fn i64_shift_references_match_native() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             prove_shift_reference(i64_shl, |x, s| x.bvshl(s), "i64.shl");
             prove_shift_reference(i64_shr_u, |x, s| x.bvlshr(s), "i64.shr_u");
             prove_shift_reference(i64_shr_s, |x, s| x.bvashr(s), "i64.shr_s");
@@ -1676,7 +1677,7 @@ mod tests {
 
     #[test]
     fn i64_shifts_certify() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             // Composite pseudo-op lowering: shift the (R0:R1) pair by R2.
             assert_certifies(
                 WasmOp::I64Shl,
@@ -1716,7 +1717,7 @@ mod tests {
 
     #[test]
     fn i64_rotates_certify() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             assert_certifies(
                 WasmOp::I64Rotl,
                 vec![ArmOp::I64Rotl {
@@ -1748,8 +1749,8 @@ mod tests {
     /// closes the loop: it shows the *helper itself* is the right relation.
     #[test]
     fn i64_compare_references_match_native() {
-        with_z3_context(|| {
-            let solver = Solver::new();
+        with_verification_context(|| {
+            let mut solver = new_solver();
             let a = I64Pair {
                 lo: sym32("ca_lo"),
                 hi: sym32("ca_hi"),
@@ -1765,10 +1766,10 @@ mod tests {
             let lt_u_wrong = i64_lt_u(&a, &b).eq(a64.bvult(&b64)).not();
             // i64_lt_s must equal native signed 64-bit less-than.
             let lt_s_wrong = i64_lt_s(&a, &b).eq(a64.bvslt(&b64)).not();
-            solver.assert(Bool::or(&[&lt_u_wrong, &lt_s_wrong]));
+            solver.assert(&Bool::or(&[&lt_u_wrong, &lt_s_wrong]));
             assert_eq!(
                 solver.check(),
-                SatResult::Unsat,
+                CheckOutcome::Unsat,
                 "i64 lexicographic compare references must match native 64-bit comparisons"
             );
         });
@@ -1776,7 +1777,7 @@ mod tests {
 
     #[test]
     fn i64_comparisons_certify() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             // Each i64 comparison lowers to a single I64SetCond pseudo-op
             // over the register pairs (R0:R1) and (R2:R3).
             assert_certifies(WasmOp::I64Eq, i64_cmp(Condition::EQ));
@@ -1794,7 +1795,7 @@ mod tests {
 
     #[test]
     fn i64_eqz_certifies() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             // i64.eqz: 1 iff the whole register pair is zero.
             assert_certifies(
                 WasmOp::I64Eqz,
@@ -1815,7 +1816,7 @@ mod tests {
     /// produce a carry, e.g. `a_lo = b_lo = 0x8000_0000`).
     #[test]
     fn wrong_i64_add_lowering_rejected() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = Z3ArmValidator::new();
             let wrong = CertifiedSelection::new(
                 WasmOp::I64Add,
@@ -1850,7 +1851,7 @@ mod tests {
     /// validator must reject it.
     #[test]
     fn wrong_i32_lt_s_lowering_rejected() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = Z3ArmValidator::new();
             let wrong = CertifiedSelection::new(
                 WasmOp::I32LtS,
@@ -1882,7 +1883,7 @@ mod tests {
     /// low-limb shift.
     #[test]
     fn wrong_i64_shl_lowering_rejected() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = Z3ArmValidator::new();
             let wrong = CertifiedSelection::new(
                 WasmOp::I64Shl,
@@ -1909,7 +1910,7 @@ mod tests {
     /// rather than silently certifying.
     #[test]
     fn i64_div_is_scoped_out() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let validator = Z3ArmValidator::new();
             for op in [
                 WasmOp::I64DivS,

--- a/crates/synth-verify/src/wasm_semantics.rs
+++ b/crates/synth-verify/src/wasm_semantics.rs
@@ -4,8 +4,8 @@
 //! Each WASM operation is translated to a mathematical formula that precisely
 //! captures its behavior.
 
+use crate::term::{BV, Bool};
 use synth_core::WasmOp;
-use z3::ast::{BV, Bool};
 
 /// WASM semantics encoder
 ///
@@ -984,39 +984,39 @@ impl WasmSemantics {
         let top_16_zero = top_16.eq(&zero);
 
         // If top 16 are zero, add 16 to count and shift focus to bottom 16
-        count = top_16_zero.ite(&count.bvadd(BV::from_i64(16, 32)), &count);
-        remaining = top_16_zero.ite(&remaining.bvshl(BV::from_i64(16, 32)), &remaining);
+        count = top_16_zero.ite(count.bvadd(BV::from_i64(16, 32)), &count);
+        remaining = top_16_zero.ite(remaining.bvshl(BV::from_i64(16, 32)), &remaining);
 
         // Check top 8 bits (of the 16 we're examining)
         let mask_8 = BV::from_u64(0xFF000000, 32);
         let top_8 = remaining.bvand(&mask_8);
         let top_8_zero = top_8.eq(&zero);
 
-        count = top_8_zero.ite(&count.bvadd(BV::from_i64(8, 32)), &count);
-        remaining = top_8_zero.ite(&remaining.bvshl(BV::from_i64(8, 32)), &remaining);
+        count = top_8_zero.ite(count.bvadd(BV::from_i64(8, 32)), &count);
+        remaining = top_8_zero.ite(remaining.bvshl(BV::from_i64(8, 32)), &remaining);
 
         // Check top 4 bits
         let mask_4 = BV::from_u64(0xF0000000, 32);
         let top_4 = remaining.bvand(&mask_4);
         let top_4_zero = top_4.eq(&zero);
 
-        count = top_4_zero.ite(&count.bvadd(BV::from_i64(4, 32)), &count);
-        remaining = top_4_zero.ite(&remaining.bvshl(BV::from_i64(4, 32)), &remaining);
+        count = top_4_zero.ite(count.bvadd(BV::from_i64(4, 32)), &count);
+        remaining = top_4_zero.ite(remaining.bvshl(BV::from_i64(4, 32)), &remaining);
 
         // Check top 2 bits
         let mask_2 = BV::from_u64(0xC0000000, 32);
         let top_2 = remaining.bvand(&mask_2);
         let top_2_zero = top_2.eq(&zero);
 
-        count = top_2_zero.ite(&count.bvadd(BV::from_i64(2, 32)), &count);
-        remaining = top_2_zero.ite(&remaining.bvshl(BV::from_i64(2, 32)), &remaining);
+        count = top_2_zero.ite(count.bvadd(BV::from_i64(2, 32)), &count);
+        remaining = top_2_zero.ite(remaining.bvshl(BV::from_i64(2, 32)), &remaining);
 
         // Check top bit
         let mask_1 = BV::from_u64(0x80000000, 32);
         let top_1 = remaining.bvand(&mask_1);
         let top_1_zero = top_1.eq(&zero);
 
-        count = top_1_zero.ite(&count.bvadd(BV::from_i64(1, 32)), &count);
+        count = top_1_zero.ite(count.bvadd(BV::from_i64(1, 32)), &count);
 
         // Return 32 if all zeros, otherwise return count
         all_zero.ite(&result_if_zero, &count)
@@ -1042,39 +1042,39 @@ impl WasmSemantics {
         let bottom_16 = remaining.bvand(&mask_16);
         let bottom_16_zero = bottom_16.eq(&zero);
 
-        count = bottom_16_zero.ite(&count.bvadd(BV::from_i64(16, 32)), &count);
-        remaining = bottom_16_zero.ite(&remaining.bvlshr(BV::from_i64(16, 32)), &remaining);
+        count = bottom_16_zero.ite(count.bvadd(BV::from_i64(16, 32)), &count);
+        remaining = bottom_16_zero.ite(remaining.bvlshr(BV::from_i64(16, 32)), &remaining);
 
         // Check bottom 8 bits
         let mask_8 = BV::from_u64(0x000000FF, 32);
         let bottom_8 = remaining.bvand(&mask_8);
         let bottom_8_zero = bottom_8.eq(&zero);
 
-        count = bottom_8_zero.ite(&count.bvadd(BV::from_i64(8, 32)), &count);
-        remaining = bottom_8_zero.ite(&remaining.bvlshr(BV::from_i64(8, 32)), &remaining);
+        count = bottom_8_zero.ite(count.bvadd(BV::from_i64(8, 32)), &count);
+        remaining = bottom_8_zero.ite(remaining.bvlshr(BV::from_i64(8, 32)), &remaining);
 
         // Check bottom 4 bits
         let mask_4 = BV::from_u64(0x0000000F, 32);
         let bottom_4 = remaining.bvand(&mask_4);
         let bottom_4_zero = bottom_4.eq(&zero);
 
-        count = bottom_4_zero.ite(&count.bvadd(BV::from_i64(4, 32)), &count);
-        remaining = bottom_4_zero.ite(&remaining.bvlshr(BV::from_i64(4, 32)), &remaining);
+        count = bottom_4_zero.ite(count.bvadd(BV::from_i64(4, 32)), &count);
+        remaining = bottom_4_zero.ite(remaining.bvlshr(BV::from_i64(4, 32)), &remaining);
 
         // Check bottom 2 bits
         let mask_2 = BV::from_u64(0x00000003, 32);
         let bottom_2 = remaining.bvand(&mask_2);
         let bottom_2_zero = bottom_2.eq(&zero);
 
-        count = bottom_2_zero.ite(&count.bvadd(BV::from_i64(2, 32)), &count);
-        remaining = bottom_2_zero.ite(&remaining.bvlshr(BV::from_i64(2, 32)), &remaining);
+        count = bottom_2_zero.ite(count.bvadd(BV::from_i64(2, 32)), &count);
+        remaining = bottom_2_zero.ite(remaining.bvlshr(BV::from_i64(2, 32)), &remaining);
 
         // Check bottom bit
         let mask_1 = BV::from_u64(0x00000001, 32);
         let bottom_1 = remaining.bvand(&mask_1);
         let bottom_1_zero = bottom_1.eq(&zero);
 
-        count = bottom_1_zero.ite(&count.bvadd(BV::from_i64(1, 32)), &count);
+        count = bottom_1_zero.ite(count.bvadd(BV::from_i64(1, 32)), &count);
 
         // Return 32 if all zeros, otherwise return count
         all_zero.ite(&result_if_zero, &count)
@@ -1134,12 +1134,11 @@ impl WasmSemantics {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::with_z3_context;
-    use z3::ast::Ast; // needed for .simplify()
+    use crate::with_verification_context;
 
     #[test]
     fn test_wasm_add_encoding() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
             let a = BV::new_const("a", 32);
             let b = BV::new_const("b", 32);
@@ -1150,7 +1149,7 @@ mod tests {
 
     #[test]
     fn test_wasm_sub_encoding() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
             let a = BV::new_const("a", 32);
             let b = BV::new_const("b", 32);
@@ -1161,7 +1160,7 @@ mod tests {
 
     #[test]
     fn test_wasm_const_encoding() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
             let result = encoder.encode_op(&WasmOp::I32Const(42), &[]);
             assert_eq!(result.simplify().as_i64(), Some(42));
@@ -1170,7 +1169,7 @@ mod tests {
 
     #[test]
     fn test_wasm_comparison() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
             let a = BV::from_i64(5, 32);
             let b = BV::from_i64(10, 32);
@@ -1181,7 +1180,7 @@ mod tests {
 
     #[test]
     fn test_wasm_bitwise_ops() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
             let a = BV::from_i64(0b1010, 32);
             let b = BV::from_i64(0b1100, 32);
@@ -1199,7 +1198,7 @@ mod tests {
 
     #[test]
     fn test_wasm_shift_ops() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
             let value = BV::from_i64(8, 32);
             let shift = BV::from_i64(2, 32);
@@ -1214,7 +1213,7 @@ mod tests {
 
     #[test]
     fn test_wasm_shift_modulo() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
             let value = BV::from_i64(0xFF, 32);
             let shift = BV::from_i64(33, 32);
@@ -1225,7 +1224,7 @@ mod tests {
 
     #[test]
     fn test_wasm_rem_ops() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
             let a = BV::from_i64(17, 32);
             let b = BV::from_i64(5, 32);
@@ -1240,7 +1239,7 @@ mod tests {
 
     #[test]
     fn test_wasm_rotation_ops() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
             let value = BV::from_i64(0x12345678, 32);
             let rotate = BV::from_i64(8, 32);
@@ -1255,7 +1254,7 @@ mod tests {
 
     #[test]
     fn test_wasm_clz_comprehensive() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
 
             let zero = BV::from_i64(0, 32);
@@ -1325,7 +1324,7 @@ mod tests {
 
     #[test]
     fn test_wasm_ctz_comprehensive() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
 
             assert_eq!(
@@ -1396,7 +1395,7 @@ mod tests {
 
     #[test]
     fn test_wasm_popcnt() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
 
             assert_eq!(
@@ -1446,7 +1445,7 @@ mod tests {
 
     #[test]
     fn test_wasm_select() {
-        with_z3_context(|| {
+        with_verification_context(|| {
             let encoder = WasmSemantics::new();
 
             let val1 = BV::from_i64(10, 32);

--- a/crates/synth-verify/tests/comprehensive_verification.rs
+++ b/crates/synth-verify/tests/comprehensive_verification.rs
@@ -1,14 +1,16 @@
 //! Comprehensive Verification Test Suite for All Synthesis Rules
 //!
 //! This module systematically verifies all WASM→ARM synthesis rules.
-//! Requires both `z3-solver` and `arm` features.
-#![cfg(all(feature = "z3-solver", feature = "arm"))]
+//! Requires the `arm` feature; runs on the default (ordeal) solver, and adds
+//! the Z3 differential oracle when built with `--features z3-solver` and
+//! `SYNTH_SOLVER_DIFF=1`.
+#![cfg(feature = "arm")]
 
 use synth_synthesis::{ArmOp, Operand2, Pattern, Reg, Replacement, SynthesisRule, WasmOp};
 use synth_verify::{
-    ArmSemantics, ArmState, TranslationValidator, ValidationResult, WasmSemantics, with_z3_context,
+    ArmSemantics, ArmState, BV, TranslationValidator, ValidationResult, WasmSemantics,
+    with_verification_context,
 };
-use z3::ast::{Ast, BV};
 
 /// Helper to create a test synthesis rule
 fn create_rule(name: &str, wasm_op: WasmOp, arm_op: ArmOp) -> SynthesisRule {
@@ -31,7 +33,7 @@ fn create_rule(name: &str, wasm_op: WasmOp, arm_op: ArmOp) -> SynthesisRule {
 
 #[test]
 fn verify_i32_add() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = create_rule(
@@ -53,7 +55,7 @@ fn verify_i32_add() {
 
 #[test]
 fn verify_i32_sub() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = create_rule(
@@ -75,7 +77,7 @@ fn verify_i32_sub() {
 
 #[test]
 fn verify_i32_mul() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = create_rule(
@@ -97,7 +99,7 @@ fn verify_i32_mul() {
 
 #[test]
 fn verify_i32_div_s() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = create_rule(
@@ -119,7 +121,7 @@ fn verify_i32_div_s() {
 
 #[test]
 fn verify_i32_div_u() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = create_rule(
@@ -142,7 +144,7 @@ fn verify_i32_div_u() {
 #[test]
 fn test_remainder_sequences_concrete() {
     // Test remainder sequences with concrete values before formal verification
-    with_z3_context(|| {
+    with_verification_context(|| {
         let wasm_encoder = WasmSemantics::new();
         let arm_encoder = ArmSemantics::new();
 
@@ -254,7 +256,7 @@ fn verify_i32_rem_s() {
     //
     // This proves ∀a,b. WASM_REM_S(a, b) = a - (a/b) * b
 
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = SynthesisRule {
@@ -313,7 +315,7 @@ fn verify_i32_rem_u() {
     //
     // This proves ∀a,b. WASM_REM_U(a, b) = a - (a/b) * b
 
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = SynthesisRule {
@@ -367,7 +369,7 @@ fn verify_i32_rem_u() {
 
 #[test]
 fn verify_i32_and() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = create_rule(
@@ -389,7 +391,7 @@ fn verify_i32_and() {
 
 #[test]
 fn verify_i32_or() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = create_rule(
@@ -411,7 +413,7 @@ fn verify_i32_or() {
 
 #[test]
 fn verify_i32_xor() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = create_rule(
@@ -440,7 +442,7 @@ fn verify_i32_shl_parameterized() {
     // Verify WASM I32Shl with all constant shift amounts (0-31)
     // For each n in 0..32: ∀x. WASM_SHL(x, n) ≡ ARM_LSL(x, n)
 
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let result = validator.verify_parameterized_range(
@@ -473,7 +475,7 @@ fn verify_i32_shr_u_parameterized() {
     // Verify WASM I32ShrU (logical shift right) with all constant shift amounts
     // For each n in 0..32: ∀x. WASM_SHR_U(x, n) ≡ ARM_LSR(x, n)
 
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let result = validator.verify_parameterized_range(
@@ -506,7 +508,7 @@ fn verify_i32_shr_s_parameterized() {
     // Verify WASM I32ShrS (arithmetic shift right) with all constant shift amounts
     // For each n in 0..32: ∀x. WASM_SHR_S(x, n) ≡ ARM_ASR(x, n)
 
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let result = validator.verify_parameterized_range(
@@ -559,7 +561,7 @@ fn test_arm_ror_semantics() {
     // by testing concrete values. Full symbolic verification requires
     // parameterized testing framework (Phase 1A).
 
-    with_z3_context(|| {
+    with_verification_context(|| {
         let encoder = ArmSemantics::new();
         let mut state = ArmState::new_symbolic();
 
@@ -599,7 +601,7 @@ fn verify_i32_rotr_parameterized() {
     // Verify WASM I32Rotr with all constant shift amounts (0-31)
     // For each n in 0..32: ∀x. WASM_ROTR(x, n) ≡ ARM_ROR(x, n)
 
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let result = validator.verify_parameterized_range(
@@ -632,7 +634,7 @@ fn verify_i32_rotl_transformation() {
     // Verify WASM I32Rotl(x, n) ≡ ARM ROR(x, 32-n) for all n in 0..32
     // This proves the transformation is correct
 
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let result = validator.verify_parameterized_range(
@@ -665,7 +667,7 @@ fn verify_i32_rotl_transformation() {
 
 #[test]
 fn verify_i32_clz() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // ARM has CLZ instruction - direct mapping!
@@ -688,7 +690,7 @@ fn verify_i32_clz() {
 fn test_ctz_sequence_concrete() {
     // First, test that the CTZ sequence works correctly with concrete values
     // This builds confidence before formal verification
-    with_z3_context(|| {
+    with_verification_context(|| {
         let wasm_encoder = WasmSemantics::new();
         let arm_encoder = ArmSemantics::new();
 
@@ -781,7 +783,7 @@ fn verify_i32_ctz() {
     // This proves that the two-instruction sequence is semantically equivalent
     // to WASM's I32Ctz operation for ALL possible inputs.
 
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = SynthesisRule {
@@ -820,7 +822,7 @@ fn verify_i32_ctz() {
 
 #[test]
 fn verify_i32_eq() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // i32.eq uses CMP + SetCond EQ
@@ -857,7 +859,7 @@ fn verify_i32_eq() {
 
 #[test]
 fn verify_i32_ne() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = SynthesisRule {
@@ -892,7 +894,7 @@ fn verify_i32_ne() {
 
 #[test]
 fn verify_i32_lt_s() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = SynthesisRule {
@@ -927,7 +929,7 @@ fn verify_i32_lt_s() {
 
 #[test]
 fn verify_i32_le_s() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = SynthesisRule {
@@ -962,7 +964,7 @@ fn verify_i32_le_s() {
 
 #[test]
 fn verify_i32_gt_s() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = SynthesisRule {
@@ -997,7 +999,7 @@ fn verify_i32_gt_s() {
 
 #[test]
 fn verify_i32_ge_s() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = SynthesisRule {
@@ -1032,7 +1034,7 @@ fn verify_i32_ge_s() {
 
 #[test]
 fn verify_i32_lt_u() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = SynthesisRule {
@@ -1067,7 +1069,7 @@ fn verify_i32_lt_u() {
 
 #[test]
 fn verify_i32_le_u() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = SynthesisRule {
@@ -1102,7 +1104,7 @@ fn verify_i32_le_u() {
 
 #[test]
 fn verify_i32_gt_u() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = SynthesisRule {
@@ -1137,7 +1139,7 @@ fn verify_i32_gt_u() {
 
 #[test]
 fn verify_i32_ge_u() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rule = SynthesisRule {
@@ -1172,7 +1174,7 @@ fn verify_i32_ge_u() {
 
 #[test]
 fn verify_i32_eqz() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // i32.eqz uses CMP with immediate #0 + SetCond EQ
@@ -1209,7 +1211,7 @@ fn verify_i32_eqz() {
 
 #[test]
 fn verify_i32_popcnt() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // i32.popcnt uses ARM Popcnt pseudo-instruction
@@ -1234,7 +1236,7 @@ fn verify_i32_popcnt() {
 
 #[test]
 fn verify_select() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // Select operation: select(val1, val2, cond) = cond ? val1 : val2
@@ -1271,7 +1273,7 @@ fn verify_select() {
 
 #[test]
 fn verify_local_get() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // LocalGet loads a local variable
@@ -1301,7 +1303,7 @@ fn verify_local_get() {
 
 #[test]
 fn verify_local_set() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // LocalSet stores to a local variable
@@ -1331,7 +1333,7 @@ fn verify_local_set() {
 
 #[test]
 fn verify_local_tee() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // LocalTee stores and returns the value
@@ -1362,7 +1364,7 @@ fn verify_local_tee() {
 
 #[test]
 fn verify_global_get() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // GlobalGet loads a global variable
@@ -1392,7 +1394,7 @@ fn verify_global_get() {
 
 #[test]
 fn verify_global_set() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // GlobalSet stores to a global variable
@@ -1422,7 +1424,7 @@ fn verify_global_set() {
 
 #[test]
 fn verify_nop() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // Nop does nothing
@@ -1448,7 +1450,7 @@ fn verify_nop() {
 
 #[test]
 fn verify_block() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // Block is a structure marker
@@ -1469,7 +1471,7 @@ fn verify_block() {
 
 #[test]
 fn verify_loop() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // Loop is a structure marker
@@ -1490,7 +1492,7 @@ fn verify_loop() {
 
 #[test]
 fn verify_end() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // End is a structure marker
@@ -1511,7 +1513,7 @@ fn verify_end() {
 
 #[test]
 fn verify_if() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // If is a structure marker with condition
@@ -1546,7 +1548,7 @@ fn verify_if() {
 
 #[test]
 fn verify_else() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // Else is a structure marker
@@ -1571,7 +1573,7 @@ fn verify_else() {
 
 #[test]
 fn batch_verify_all_arithmetic() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rules = vec![
@@ -1638,7 +1640,7 @@ fn batch_verify_all_arithmetic() {
 
 #[test]
 fn batch_verify_all_bitwise() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         let rules = vec![
@@ -1688,7 +1690,7 @@ fn batch_verify_all_bitwise() {
 
 #[test]
 fn generate_verification_report() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // Test all directly mappable operations
@@ -1820,7 +1822,7 @@ fn generate_verification_report() {
 
 #[test]
 fn verify_i32_const() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // Test various constant values
@@ -1864,7 +1866,7 @@ fn verify_i32_const() {
 
 #[test]
 fn verify_br_table() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // Test various br_table configurations
@@ -1915,7 +1917,7 @@ fn verify_br_table() {
 
 #[test]
 fn verify_br_table_empty() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // Empty targets list - all indices go to default
@@ -1951,7 +1953,7 @@ fn verify_br_table_empty() {
 
 #[test]
 fn verify_call() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // Test various function indices
@@ -1979,7 +1981,7 @@ fn verify_call() {
 
 #[test]
 fn verify_call_indirect() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // Test various type indices
@@ -2021,7 +2023,7 @@ fn verify_call_indirect() {
 
 #[test]
 fn verify_unreachable() {
-    with_z3_context(|| {
+    with_verification_context(|| {
         let validator = TranslationValidator::new();
 
         // Unreachable instruction - should trap


### PR DESCRIPTION
Implements **step 2 of #553**: `synth-verify`'s translation validator now runs on **ordeal 0.4** (pure-Rust, certificate-checked QF_BV) behind a thin solver trait, with Z3 demoted from engine to **feature-gated differential oracle**.

## The headline

`synth-verify` builds and passes its full validator suite **without a C++ toolchain** for the first time:

```
cargo build -p synth-verify --no-default-features --features arm   # no z3-sys
cargo test  -p synth-verify                                        # 139/139 on ordeal, ~2 s
```

The 30+-minute local `z3-sys` from-source build (and its `build.rs` breakage class) is off the default path. The `--exclude synth-verify` in workspace test invocations can likely be dropped in a follow-up (deliberately not changed here).

## Design (per the ADOPT-NOW verdict on #553)

- **`term.rs`** — solver-agnostic `BV`/`Bool` wrapping `ordeal::BvTerm`/`BoolTerm` behind the exact `z3::ast` method surface the semantics encoders already used. The encoders (`wasm_semantics.rs`, `arm_semantics.rs`, `validator_pattern.rs`) keep their native idiom — the 49 `.ite()` uses translate directly onto ordeal 0.4's native `BvTerm::Ite`; derived ops (`bvsdiv`/`bvsrem`/`bvurem`/`bvnot`/`bvneg`/`bvrotl`) come from the upstream-blessed `ordeal::lowering`.
- **`solver.rs`** — the thin trait `BvSolver { assert, check, value }` with three impls:
  - `OrdealSolver` (default): `check_with_limit` under a conflict budget (`SYNTH_ORDEAL_MAX_CONFLICTS`, default 1M, 0 = unbounded) — adversarial queries degrade to a clean conservative `Unknown`, never a hang or an unchecked verdict.
  - `Z3Solver` (feature `z3-solver`): translates the identical canonicalized term to Z3.
  - `DifferentialSolver` (both compiled in + `SYNTH_SOLVER_DIFF=1`): every query through both engines — **decided disagreement (Sat vs Unsat) = hard error (panic)**; ordeal `Unknown` → logged fall-through to Z3's verdict.
- **Commuted-operand canonicalization (interim until ordeal v0.8.0 normalization):** commutative constructors (`bvadd/bvmul/bvand/bvor/bvxor`, `Eq`/`Ne`) order operands by a deterministic structural key, and terms returned from `ordeal::lowering` are recursively re-canonicalized. This matters in practice: `i32.rem_s/rem_u` equivalence (`bvsrem(a,b)` vs `SDIV+MLS`) differs exactly by a commuted `Mul` without it — >60 s DNF before, instant UNSAT after. Pure argument reordering of commutative SMT-LIB ops; the Z3 oracle receives the identical canonicalized query.

## Feature/CI semantics preserved

- `default = ["arm"]` (was `["z3-solver", "arm"]`); `z3-solver` unchanged as an optional feature.
- synth-cli's `verify` feature already requests `features = ["z3-solver", "arm"]` explicitly and `with_z3_context` is retained under `z3-solver` — the CLI verify path and the CI "Z3 Verification" job (`cargo test -p synth-verify --features z3-solver,arm`) work unchanged. That job now additionally runs the in-tree differential test (`differential_zero_disagreements_on_corpus`), which cross-checks ordeal vs Z3 regardless of env.
- `with_verification_context` is the solver-agnostic wrapper (no-op on ordeal; configures Z3's thread-local context when compiled in).

## Verification

- `cargo build -p synth-verify --no-default-features --features arm` → exit 0, **no z3-sys in the graph**.
- `cargo test -p synth-verify` (ordeal only) → **139/139** (86 lib + 53 comprehensive), ~2 s wall. Every previously-Z3-proven verdict reproduces on ordeal — zero wrong verdicts, zero Unknowns on the corpus.
- `SYNTH_SOLVER_DIFF=1 cargo test -p synth-verify --features z3-solver` (local, z3 built from source on APFS): **141/141 pass with every query running through both engines — zero verdict disagreements, zero ordeal-`Unknown` fall-throughs** across the full validator corpus (the disagreement path panics; the fall-through path logs — neither fired).
- Frozen codegen anchors: untouched by construction (synth-verify is not in the codegen path); `cargo test -p synth-cli --test frozen_codegen_bytes` → 4/4.
- `cargo fmt --check` + `cargo clippy -p synth-verify --all-targets -- -D warnings` → clean.

## Honest scope

- **`Z3ArmValidator` keeps its name** (public API); it is no longer Z3-specific — rename to `SmtArmValidator` is cosmetic follow-up.
- **Step 3/4 of #553 (drop `static-link-z3` from CI entirely) is not this PR** — Z3 stays available and the CI Z3 job keeps running as the standing differential gate.
- The canonicalization shim retires when ordeal v0.8.0 ships term normalization (pulseengine/ordeal#29 ask 4).
- LRAT certificates are validated inside ordeal before any `Unsat` is reported, but are not yet surfaced through the trait (`Certificate` is dropped at the boundary) — surfacing them for the #76 witness story is follow-up.

Closes nothing yet; tracks #553 (step 2 of 4). Refs #76, #242, loom#246, pulseengine/ordeal#29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
