### PR TITLE
fix(a32): call_indirect emits a real indirect call — never a silent NOP (#594)

### DIFF
--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -122,6 +122,34 @@ impl ArmEncoder {
         Ok(Some(bytes))
     }
 
+    /// #594: A32 expansion of `ArmOp::CallIndirect` — mirror of the Thumb-2
+    /// arm (same contract: R11 holds the function-pointer table base, entry
+    /// `i` is a 4-byte code address, R12 is the encoder-scratch register):
+    ///
+    /// ```text
+    /// MOV r12, idx, LSL #2   ; table byte offset
+    /// LDR r12, [r11, r12]    ; load function pointer
+    /// BLX r12                ; indirect call
+    /// ```
+    ///
+    /// Bounds and type-signature checks are not emitted — parity with the
+    /// Thumb-2 path (tracked separately, see #594's note).
+    fn encode_arm_call_indirect(table_index_reg: &Reg) -> Vec<u8> {
+        let idx = reg_to_bits(table_index_reg);
+        let mut bytes = Vec::with_capacity(12);
+        // MOV r12, idx, LSL #2 — data-processing MOV, register op2 with
+        // imm5=2/LSL: cond=E, opcode=1101, S=0, Rd=r12.
+        let mov: u32 = 0xE1A0C000 | (2 << 7) | idx;
+        bytes.extend_from_slice(&mov.to_le_bytes());
+        // LDR r12, [r11, r12] — register offset, P=1 U=1 B=0 W=0 L=1.
+        let ldr: u32 = 0xE79BC00C;
+        bytes.extend_from_slice(&ldr.to_le_bytes());
+        // BLX r12 — cond=E, 0001 0010 1111 1111 1111 0011, Rm=r12.
+        let blx: u32 = 0xE12FFF3C;
+        bytes.extend_from_slice(&blx.to_le_bytes());
+        bytes
+    }
+
     fn encode_arm(&self, op: &ArmOp) -> Result<Vec<u8>> {
         // #206: ARM32 register-offset loads/stores. `encode_mem_addr` only
         // returns the 12-bit immediate, so the immediate-form arms below
@@ -131,6 +159,17 @@ impl ArmEncoder {
         // against `[ip, #off]`, which is uniform for word/byte/halfword/signed.
         if let Some(bytes) = self.encode_arm_reg_offset_mem(op)? {
             return Ok(bytes);
+        }
+        // #594: call_indirect was encoded as a literal NOP on the A32 path
+        // (`--target cortex-r5`) — the call never happened and the function
+        // silently returned garbage. Emit the same three-instruction expansion
+        // as the Thumb-2 path (R11 = function-pointer table base, R12 scratch):
+        //   MOV r12, idx, LSL #2 ; LDR r12, [r11, r12] ; BLX r12
+        if let ArmOp::CallIndirect {
+            table_index_reg, ..
+        } = op
+        {
+            return Ok(Self::encode_arm_call_indirect(table_index_reg));
         }
         let instr: u32 = match op {
             // Data processing instructions
@@ -769,10 +808,11 @@ impl ArmEncoder {
                 0xE1A00000 // NOP for now
             }
 
+            // #594: CallIndirect is expanded to a real multi-instruction
+            // sequence by the early return at the top of this function —
+            // it must NEVER fall through to a silent NOP again.
             ArmOp::CallIndirect { .. } => {
-                // Indirect function call pseudo-instruction
-                // Not a real ARM instruction, would be expanded to indirect branch
-                0xE1A00000 // NOP for now
+                unreachable!("CallIndirect handled by encode_arm_call_indirect (#594)")
             }
 
             // i64 pseudo-instructions (Phase 2) - encode as NOP for now
@@ -7615,6 +7655,83 @@ mod tests {
         assert_eq!(ldr, 0xE59C_0008, "LDR r0,[ip,#8]: {ldr:#010x}");
         // A bare immediate ldr (the bug) would be 0xE59B0008 (base=r11) — reject.
         assert_ne!(ldr, 0xE59B_0008, "index must not be dropped");
+    }
+
+    /// #594 regression: `call_indirect` on the A32 path (`--target cortex-r5`)
+    /// was encoded as a literal NOP (0xE1A00000) — the call never happened and
+    /// the function silently returned the leftover table-index value. The A32
+    /// encoder must emit the same three-instruction expansion as Thumb-2:
+    /// `MOV r12, idx, LSL #2; LDR r12, [r11, r12]; BLX r12`.
+    #[test]
+    fn test_encode_arm32_call_indirect_is_real_call_594() {
+        use synth_synthesis::{ArmOp, Reg};
+        let enc = ArmEncoder::new_arm32();
+        let bytes = enc
+            .encode(&ArmOp::CallIndirect {
+                rd: Reg::R0,
+                type_idx: 0,
+                table_index_reg: Reg::R0,
+            })
+            .unwrap();
+        assert_eq!(
+            bytes.len(),
+            12,
+            "expected MOV + LDR + BLX (3 words): {bytes:02x?}"
+        );
+        let mov = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let ldr = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        let blx = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        // MOV r12, r0, LSL #2 = 0xE1A0C100
+        assert_eq!(mov, 0xE1A0_C100, "MOV r12,r0,LSL#2: {mov:#010x}");
+        // LDR r12, [r11, r12] = 0xE79BC00C
+        assert_eq!(ldr, 0xE79B_C00C, "LDR r12,[r11,r12]: {ldr:#010x}");
+        // BLX r12 = 0xE12FFF3C
+        assert_eq!(blx, 0xE12F_FF3C, "BLX r12: {blx:#010x}");
+        // The bug: a single NOP word. Must never come back.
+        assert!(
+            !bytes
+                .chunks_exact(4)
+                .any(|w| w == 0xE1A0_0000u32.to_le_bytes()),
+            "call_indirect must not contain a NOP (#594): {bytes:02x?}"
+        );
+
+        // A non-R0 index register lands in the MOV's Rm field.
+        let bytes = enc
+            .encode(&ArmOp::CallIndirect {
+                rd: Reg::R0,
+                type_idx: 0,
+                table_index_reg: Reg::R4,
+            })
+            .unwrap();
+        let mov = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        assert_eq!(mov, 0xE1A0_C104, "MOV r12,r4,LSL#2: {mov:#010x}");
+    }
+
+    /// #594 anchor: the Thumb-2 `CallIndirect` expansion is untouched by the
+    /// A32 fix — these are the pre-#594 bytes, frozen.
+    ///
+    /// NOTE (found while fixing #594, deliberately NOT changed here): the
+    /// first Thumb-2 word is `mov.w ip, rm, ASR #32` — the intended `LSL #2`
+    /// put its shift amount in the type field (bits 5:4) instead of imm2
+    /// (bits 7:6). For any non-negative index it yields 0, so the Thumb path
+    /// always dispatches table entry 0. Separate latent defect on the Thumb
+    /// path; tracked in the #594 follow-up note.
+    #[test]
+    fn test_encode_thumb_call_indirect_unchanged_594() {
+        use synth_synthesis::{ArmOp, Reg};
+        let enc = ArmEncoder::new_thumb2();
+        let bytes = enc
+            .encode(&ArmOp::CallIndirect {
+                rd: Reg::R0,
+                type_idx: 0,
+                table_index_reg: Reg::R0,
+            })
+            .unwrap();
+        assert_eq!(
+            bytes,
+            vec![0x4F, 0xEA, 0x20, 0x0C, 0x5B, 0xF8, 0x0C, 0xC0, 0xE0, 0x47],
+            "Thumb-2 CallIndirect bytes must stay frozen in this PR: {bytes:02x?}"
+        );
     }
 
     /// #178/#180 regression: the Thumb `Add`/`Adds`/`Subs` reg-forms used the

--- a/scripts/repro/call_indirect_594.wat
+++ b/scripts/repro/call_indirect_594.wat
@@ -1,0 +1,11 @@
+;; #594: call_indirect on the A32 path (--target cortex-r5) compiled to a
+;; literal NOP (0xE1A00000) — the call never happened and `run` returned the
+;; leftover table-index value instead of the callee's result.
+;; wasmtime oracle: run() = 42.
+(module
+  (type $s (func (result i32)))
+  (table 1 funcref)
+  (elem (i32.const 0) $t)
+  (func $t (result i32) (i32.const 42))
+  (func (export "run") (result i32)
+    (call_indirect (type $s) (i32.const 0))))

--- a/scripts/repro/call_indirect_594_differential.py
+++ b/scripts/repro/call_indirect_594_differential.py
@@ -1,0 +1,65 @@
+# #594: call_indirect on the A32 path (--target cortex-r5) compiled to a NOP —
+# no call, wrong result (leftover table index instead of the callee's return).
+#
+# Differential: emulate the A32 object under unicorn (UC_MODE_ARM, not THUMB)
+# against the wasmtime oracle (run() = 42).
+#
+# ArmOp::CallIndirect contract (same as the Thumb-2 path): R11 holds the
+# function-pointer table base; entry i is a 4-byte code address. The harness
+# builds that table with func_0's address (bit 0 clear — A32) and sets R11.
+#
+# Usage: python3 call_indirect_594_differential.py <elf>
+#   <elf> = synth compile call_indirect_594.wat --target cortex-r5 \
+#             --all-exports --relocatable --no-optimize -o <elf>
+import struct
+import sys
+
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_ARM
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/ci594.o"
+CODE, TABLE, STK = 0x1000000, 0x3000000, 0x6000000
+RET = CODE + 0xFFF0
+EXPECT = 42  # wasmtime --invoke run call_indirect_594.wat
+
+e = ELFFile(open(ELF, "rb"))
+text = bytearray(e.get_section_by_name(".text").data())
+# Symbols from the symtab, never from disasm text (host-dependent).
+# NOTE: the ELF builder currently sets the Thumb interworking bit on every
+# STT_FUNC symbol even for A32 targets (pre-existing defect, noted on #594) —
+# mask bit 0 to get the real A32 code address.
+st = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+syms = {s.name: s["st_value"] & ~1 for s in st.iter_symbols() if s.name}
+for need in ("run", "func_0"):
+    if need not in syms:
+        print(f"SYMBOL MISSING: {need}")
+        sys.exit(1)
+
+mu = Uc(UC_ARCH_ARM, UC_MODE_ARM)
+mu.mem_map(CODE, 0x100000)
+mu.mem_map(TABLE, 0x10000)
+mu.mem_map(STK, 0x100000)
+mu.mem_write(CODE, bytes(text))
+# table[0] = address of func_0 (A32: bit 0 clear)
+mu.mem_write(TABLE, struct.pack("<I", CODE + syms["func_0"]))
+# Return pad: A32 NOPs at RET (mapped inside the CODE region).
+mu.mem_write(RET, struct.pack("<II", 0xE1A00000, 0xE1A00000))
+
+mu.reg_write(UC_ARM_REG_R11, TABLE)
+mu.reg_write(UC_ARM_REG_SP, STK + 0x80000)
+mu.reg_write(UC_ARM_REG_LR, RET)  # A32 return address: bit 0 clear
+mu.emu_start(CODE + syms["run"], RET, count=2000)
+got = mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+print(f"run() = {got} (wasmtime oracle: {EXPECT})")
+if got == EXPECT:
+    print("ORACLE: PASS")
+    sys.exit(0)
+print("ORACLE: FAIL — call_indirect did not reach the callee (#594)")
+sys.exit(1)


### PR DESCRIPTION
## Defect (#594)

On the A32 path (`--target cortex-r5`, `IsaVariant::Arm32`) the encoder emitted `ArmOp::CallIndirect` as a literal NOP (`0xE1A00000`) — the call never happened and the function silently returned the leftover table-index value. Same silent-miscompile class as #554.

## Root cause

`encode_arm` (crates/synth-backend/src/arm_encoder.rs) still had the "pseudo-instruction → NOP for now" placeholder arm for `CallIndirect`, while the Thumb-2 path had long since grown a real three-instruction expansion. The selector lowering is shared and correct — the A32 encoder was the only gap.

## Fix (real fix, not honest-fail)

`encode_arm` now expands `CallIndirect` to the exact A32 mirror of the Thumb-2 sequence (same contract: R11 = function-pointer table base, R12 encoder scratch):

```
MOV r12, idx, LSL #2    ; 0xE1A0C100 | rm
LDR r12, [r11, r12]     ; 0xE79BC00C
BLX r12                 ; 0xE12FFF3C   (BLX register — valid on ARMv7-R)
```

The multi-word emission is safe on this path: the `arm_backend` emission loop accumulates real encoded lengths (relocation offsets use `code.len()` before each encode), and `resolve_label_branches` is Thumb-only. The old NOP arm is now `unreachable!()` so this class cannot silently return.

Bounds + type-signature checks are not emitted — deliberate parity with the Thumb-2 path, which the issue itself tracks as a separate concern.

## Red → green

`scripts/repro/call_indirect_594_differential.py` (unicorn **UC_MODE_ARM**, wasmtime oracle `run() = 42`), on the issue's reproducer compiled `--target cortex-r5 --all-exports --relocatable --no-optimize`:

| build | disasm at the call site | run() | oracle |
|---|---|---|---|
| pre-fix | `e1a00000  nop` | **0** (exit 1) | 42 |
| post-fix | `lsl ip, r0, #2; ldr ip, [fp, ip]; blx ip` | **42** (exit 0) | 42 |

Unit gates: `test_encode_arm32_call_indirect_is_real_call_594` pins the A32 bytes and rejects any NOP word; `test_encode_thumb_call_indirect_unchanged_594` freezes the Thumb-2 bytes (untouched).

`cargo test -p synth-backend -p synth-synthesis -p synth-cli` all green (62 suites, 0 failures); `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.

## Found while fixing — deliberately NOT changed here (follow-ups for #594's note)

1. **Thumb-2 CallIndirect shift-encoding bug**: the first Thumb word is `mov.w ip, rm, ASR #32`, not `LSL #2` — the shift amount was OR'd into the type field (bits 5:4) instead of imm2 (bits 7:6). For any non-negative index it yields 0, so the Thumb path always dispatches **table entry 0**. The issue's probe (index 0) can't see it. Frozen in this PR by the anchor test; needs its own red→green.
2. **A32 symbols carry the Thumb bit**: the ELF builder sets bit 0 on every `STT_FUNC` symbol whenever `machine == ARM`, including A32 objects (`elf_builder.rs` `build_symbol_table` / `with_entry`). A linker will treat A32 entry points as Thumb. The differential harness masks bit 0 as a documented workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)