### PR TITLE
chore(release): v0.27.0 — base-CSE default-on + miscompile fixes + ordeal solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-07-03
+
+**base-CSE ships default-on; two shipped miscompiles fixed; synth-verify goes
+pure-Rust (ordeal replaces the Z3 engine).**
+
+### Changed (byte-changing, deliberate — anchors refrozen where affected)
+
+- **`SYNTH_BASE_CSE` is default-ON (#468/#592).** The linmem base-CSE +
+  const-address-fold runs by default on the optimized path (−180 B corpus, −34 %
+  on its fixture, no function grows; composes with the #543 volatile-segment
+  exclusion). Opt-out `SYNTH_BASE_CSE=0`, CI-gated. const-CSE stays off: its
+  recorded flip prerequisite (retiring the bridge inline aliasing) is genuinely
+  unmet — verified, not assumed.
+- **synth-verify runs on `ordeal` (pure-Rust QF_BV) by default (#553/#595).**
+  A thin `BvSolver` trait; ordeal 0.4 as engine (139/139 validator tests, ~2 s);
+  Z3 demoted to the feature-gated differential oracle (141/141, zero
+  disagreements) — **synth-verify builds and tests without a C++ toolchain for
+  the first time**.
+
+### Fixed
+
+- **Spill frame deallocated on every return path (#499/#593).** The appended
+  return's `add sp` was gated on a flag the flag-off Const-evictor spill never
+  sets — `pop {…,pc}` read PC from a spill slot. Straight-line and the original
+  control-flow shapes covered; defensive sp-balance assert added.
+- **A32 `call_indirect` emits a real indirect call (#594/#596).** The A32
+  encoder carried a "NOP for now" placeholder — a silent wrong result on
+  `--target cortex-r5`. Now `LSL/LDR/BLX` (mirror of the Thumb sequence);
+  follow-ups filed: #597 (Thumb-2 dispatch always hits entry 0 — shift encoded
+  into the type field) and #598 (Thumb bit on A32 symbols).
+
+## Known issues
+
+- #597 (Thumb-2 call_indirect entry-0 dispatch), #599 (i64 pair right-shift
+  miscompile) — both under fix for v0.27.1.
+
 ## [0.26.0] - 2026-07-03
 
 **i64 pair-aware Belady eviction on exhaustion (#587 partial, flag-off).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,14 +2039,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2104,11 +2104,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.26.0"
+version = "0.27.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2163,14 +2163,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2178,11 +2178,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.26.0"
+version = "0.27.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.26.0"
+version = "0.27.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.26.0",
+    version = "0.27.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.26.0" }
+synth-core = { path = "../synth-core", version = "0.27.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.26.0" }
+synth-core = { path = "../synth-core", version = "0.27.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.26.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.26.0" }
+synth-core = { path = "../synth-core", version = "0.27.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.27.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.26.0" }
+synth-core = { path = "../synth-core", version = "0.27.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.26.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.26.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.27.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.27.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,21 +27,21 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.26.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.26.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.26.0" }
-synth-backend = { path = "../synth-backend", version = "0.26.0" }
+synth-core = { path = "../synth-core", version = "0.27.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.27.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.27.0" }
+synth-backend = { path = "../synth-backend", version = "0.27.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.26.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.27.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.26.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.26.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.26.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.27.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.27.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.27.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.26.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.27.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.26.0" }
+synth-core = { path = "../synth-core", version = "0.27.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.26.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.27.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.26.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.26.0" }
-synth-opt = { path = "../synth-opt", version = "0.26.0" }
+synth-core = { path = "../synth-core", version = "0.27.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.27.0" }
+synth-opt = { path = "../synth-opt", version = "0.27.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -20,12 +20,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.26.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.26.0" }
-synth-opt = { path = "../synth-opt", version = "0.26.0" }
+synth-core = { path = "../synth-core", version = "0.27.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.27.0" }
+synth-opt = { path = "../synth-opt", version = "0.27.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.26.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.27.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"


### PR DESCRIPTION
Release **v0.27.0** — 4 PRs since v0.26.0:
- **base-CSE default-ON** (#592): −180B corpus, opt-out CI-gated; const-CSE held (prereq verified unmet).
- **#499 fixed** (#593): spill frame deallocated on every return (PC-from-spill-slot).
- **#594 fixed** (#596): A32 call_indirect real BLX (was a NOP); #597/#598 follow-ups filed.
- **ordeal adoption** (#595): synth-verify pure-Rust by default, Z3 = differential oracle (141/141, 0 disagreements).

Known issues #597/#599 → v0.27.1 lane. Pin sweep + lock + CHANGELOG. Tag on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)