### PR TITLE
fix(encoder): Thumb call_indirect dispatch + i64 pair right-shift + A32 symbol Thumb bit (#597, #598, #599)

### DIFF
--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -2680,9 +2680,13 @@ impl ArmEncoder {
 
                 // LSL R12, idx_reg, #2 (multiply index by 4)
                 // Thumb-2 MOV with shift: 11101010 010 S 1111 | 0 imm3 Rd imm2 type Rm
-                // LSL: type=00, imm5=2 -> imm3=0, imm2=10
+                // LSL: type=00 (bits 5:4), imm5=2 -> imm3=000, imm2=10 (bits 7:6)
+                // #597: the shift amount was previously shifted into bits 5:4 —
+                // the TYPE field — encoding `mov.w ip, rm, ASR #32`, which
+                // destroyed the index and dispatched table entry 0 for every
+                // call. imm2 lives at bits 7:6.
                 let hw1: u16 = 0xEA4F_u16; // MOV.W R12, Rm, LSL #2
-                let hw2: u16 = ((0x0C00 | (0b10 << 4)) | idx_reg) as u16;
+                let hw2: u16 = ((0x0C00 | (0b10 << 6)) | idx_reg) as u16;
                 bytes.extend_from_slice(&hw1.to_le_bytes());
                 bytes.extend_from_slice(&hw2.to_le_bytes());
 
@@ -7707,17 +7711,23 @@ mod tests {
         assert_eq!(mov, 0xE1A0_C104, "MOV r12,r4,LSL#2: {mov:#010x}");
     }
 
-    /// #594 anchor: the Thumb-2 `CallIndirect` expansion is untouched by the
-    /// A32 fix — these are the pre-#594 bytes, frozen.
+    /// #597 anchor (justified correctness RE-PIN of the #594-era freeze): the
+    /// Thumb-2 `CallIndirect` expansion is `mov.w ip, rm, LSL #2; ldr.w ip,
+    /// [r11, ip]; blx ip`.
     ///
-    /// NOTE (found while fixing #594, deliberately NOT changed here): the
-    /// first Thumb-2 word is `mov.w ip, rm, ASR #32` — the intended `LSL #2`
-    /// put its shift amount in the type field (bits 5:4) instead of imm2
-    /// (bits 7:6). For any non-negative index it yields 0, so the Thumb path
-    /// always dispatches table entry 0. Separate latent defect on the Thumb
-    /// path; tracked in the #594 follow-up note.
+    /// The #594 PR froze the then-current bytes `4F EA 20 0C ...` whose first
+    /// word decodes as `mov.w ip, rm, ASR #32` — the intended `LSL #2` had
+    /// its shift amount in the TYPE field (bits 5:4) instead of imm2 (bits
+    /// 7:6), so the index was destroyed and every call_indirect dispatched
+    /// table entry 0 (shipped miscompile, masked by index-0 probes). #597
+    /// corrects the encoding; new bytes `4F EA 80 0C ...` were
+    /// execution-validated under unicorn against the wasmtime oracle on a
+    /// multi-entry table (indexes 0, 1, 3 —
+    /// scripts/repro/call_indirect_597_differential.py) before this pin was
+    /// replaced. Old pin: [4F EA 20 0C, 5B F8 0C C0, E0 47] (ASR #32 — must
+    /// never come back).
     #[test]
-    fn test_encode_thumb_call_indirect_unchanged_594() {
+    fn test_encode_thumb_call_indirect_lsl2_597() {
         use synth_synthesis::{ArmOp, Reg};
         let enc = ArmEncoder::new_thumb2();
         let bytes = enc
@@ -7729,8 +7739,28 @@ mod tests {
             .unwrap();
         assert_eq!(
             bytes,
-            vec![0x4F, 0xEA, 0x20, 0x0C, 0x5B, 0xF8, 0x0C, 0xC0, 0xE0, 0x47],
-            "Thumb-2 CallIndirect bytes must stay frozen in this PR: {bytes:02x?}"
+            vec![0x4F, 0xEA, 0x80, 0x0C, 0x5B, 0xF8, 0x0C, 0xC0, 0xE0, 0x47],
+            "Thumb-2 CallIndirect: mov.w ip,r0,LSL#2; ldr.w ip,[r11,ip]; blx ip: {bytes:02x?}"
+        );
+        // The #597 bug bytes (ASR #32 first word) must never come back.
+        assert_ne!(
+            &bytes[0..4],
+            &[0x4F, 0xEA, 0x20, 0x0C],
+            "mov.w ip, rm, ASR #32 — the #597 type-field bug"
+        );
+
+        // A non-R0 index register lands in the mov.w's Rm field (hw2 bits 3:0).
+        let bytes = enc
+            .encode(&ArmOp::CallIndirect {
+                rd: Reg::R0,
+                type_idx: 0,
+                table_index_reg: Reg::R4,
+            })
+            .unwrap();
+        assert_eq!(
+            &bytes[0..4],
+            &[0x4F, 0xEA, 0x84, 0x0C],
+            "mov.w ip, r4, LSL #2: {bytes:02x?}"
         );
     }
 

--- a/crates/synth-backend/src/elf_builder.rs
+++ b/crates/synth-backend/src/elf_builder.rs
@@ -394,6 +394,12 @@ pub struct ElfBuilder {
     /// layout is untouched: when this is empty the build is byte-identical to the
     /// pre-generalization output (VCR-DBG-001 PR C, #394).
     extra_relocations: Vec<(String, Vec<Relocation>)>,
+    /// #598: whether the object's functions are Thumb-encoded. Bit 0 of an
+    /// STT_FUNC `st_value` (and of `e_entry`) is the Thumb interworking bit —
+    /// it must be SET for Thumb code (Cortex-M) and CLEAR for A32 code
+    /// (cortex-r5 path). Defaults to `true` (every pre-#598 ARM object was
+    /// treated as Thumb, so Thumb outputs stay bit-identical).
+    thumb_funcs: bool,
 }
 
 impl ElfBuilder {
@@ -411,16 +417,26 @@ impl ElfBuilder {
             program_headers: Vec::new(),
             relocations: Vec::new(),
             extra_relocations: Vec::new(),
+            thumb_funcs: true,
         }
+    }
+
+    /// #598: mark the object's functions as A32-encoded (cortex-r5 path) —
+    /// suppresses the Thumb interworking bit on STT_FUNC `st_value`s and on
+    /// `e_entry`. Call BEFORE `with_entry`.
+    pub fn with_thumb_funcs(mut self, thumb: bool) -> Self {
+        self.thumb_funcs = thumb;
+        self
     }
 
     /// Set entry point
     ///
-    /// For ARM (Thumb) targets, bit 0 is automatically set to indicate Thumb mode.
+    /// For ARM Thumb targets, bit 0 is automatically set to indicate Thumb mode.
     /// Cortex-M is Thumb-only, so function addresses in ELF must have bit 0 set.
+    /// A32 objects (`with_thumb_funcs(false)`, #598) keep bit 0 clear.
     pub fn with_entry(mut self, entry: u32) -> Self {
-        self.entry = if self.machine == ElfMachine::Arm {
-            entry | 1 // Set Thumb bit for ARM targets
+        self.entry = if self.machine == ElfMachine::Arm && self.thumb_funcs {
+            entry | 1 // Set Thumb bit for ARM Thumb targets
         } else {
             entry
         };
@@ -867,8 +883,14 @@ impl ElfBuilder {
             symtab.extend_from_slice(&name_offset.to_le_bytes());
 
             // st_value (4 bytes)
-            // For ARM targets, STT_FUNC symbols must have bit 0 set (Thumb interworking)
-            let value = if self.machine == ElfMachine::Arm && symbol.symbol_type == SymbolType::Func
+            // For ARM THUMB targets, STT_FUNC symbols must have bit 0 set (Thumb
+            // interworking). #598: A32 objects (cortex-r5 path) must NOT set it —
+            // bit 0 on an A32 function address is wrong metadata (harnesses had
+            // to mask it; an interworking-aware consumer would mis-classify the
+            // function as Thumb).
+            let value = if self.machine == ElfMachine::Arm
+                && self.thumb_funcs
+                && symbol.symbol_type == SymbolType::Func
             {
                 symbol.value | 1
             } else {
@@ -1451,5 +1473,37 @@ mod tests {
         let sym_type = info & 0xf;
         assert_eq!(binding, SymbolBinding::Global as u8);
         assert_eq!(sym_type, SymbolType::Func as u8);
+    }
+
+    /// #598: an A32 object (`with_thumb_funcs(false)`, cortex-r5 path) must
+    /// NOT set the Thumb interworking bit on STT_FUNC symbols or `e_entry` —
+    /// bit 0 on an A32 code address is wrong metadata (harnesses had to mask
+    /// it). Non-func symbols never carried the bit; that stays true.
+    #[test]
+    fn test_a32_symbols_have_no_thumb_bit_598() {
+        let mut builder = ElfBuilder::new_arm32().with_thumb_funcs(false);
+
+        let func_sym = Symbol::new("a32_func")
+            .with_value(0x1000)
+            .with_size(64)
+            .with_binding(SymbolBinding::Global)
+            .with_type(SymbolType::Func)
+            .with_section(1);
+        builder.add_symbol(func_sym);
+
+        let (_strtab, offsets) = builder.build_symbol_string_table();
+        let symtab = builder.build_symbol_table(&offsets);
+        let value = u32::from_le_bytes(symtab[20..24].try_into().unwrap());
+        assert_eq!(value, 0x1000, "A32 STT_FUNC st_value must keep bit 0 clear");
+
+        // e_entry stays clear too (was `0 | 1` on the A32 relocatable path).
+        let builder = ElfBuilder::new_arm32()
+            .with_thumb_funcs(false)
+            .with_entry(0x8000);
+        assert_eq!(builder.entry, 0x8000, "A32 e_entry must keep bit 0 clear");
+
+        // The default (Thumb) behavior is unchanged: bit 0 set on both.
+        let builder = ElfBuilder::new_arm32().with_entry(0x8000);
+        assert_eq!(builder.entry, 0x8001, "Thumb e_entry keeps the bit");
     }
 }

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1131,6 +1131,17 @@ fn compile_command(
     // the module's imports. `None` for the demo path (no input module).
     let mut sbom_wasm_bytes: Option<Vec<u8>> = None;
     let mut sbom_imports: Vec<ImportEntry> = Vec::new();
+    // #599: the module's declared value-width tables, plumbed into the
+    // CompileConfig exactly as the all-exports path does. This path previously
+    // built its config from `..default()` — so a read-only i64 PARAM was never
+    // classified i64 (#518's direct-path mechanism) and the selector allocated
+    // the shift-amount constant into the param's live high register:
+    // `i64.shr_u x 32` returned 32 (the shift amount) instead of the high word.
+    // Empty for the demo path (all-i32 demos).
+    let mut current_func_params_i64: Vec<bool> = Vec::new(); // #359/#518/#599
+    let mut func_ret_i64: Vec<bool> = Vec::new(); // #311: call-result pair tagging
+    let mut type_ret_i64: Vec<bool> = Vec::new(); // #311: call_indirect results
+    let mut current_func_block_arity: Vec<(u8, u8)> = Vec::new(); // #509: value-carrying branches
     let (wasm_ops, func_name): (Vec<WasmOp>, String) = match (&input, &demo) {
         (Some(path), _) => {
             info!("Compiling WASM file: {}", path.display());
@@ -1155,12 +1166,20 @@ fn compile_command(
             // Run Loom WASM optimizer if --loom is enabled
             let wasm_bytes = maybe_run_loom(loom, wasm_bytes)?;
 
+            // #599: decode the module ONCE for its signature side-tables (the
+            // per-function declared param widths and returns-i64 tables the
+            // selector needs for i64 correctness) — previously decoded only
+            // conditionally for the SBOM, so the tables never reached the config.
+            let module = decode_wasm_module(&wasm_bytes)
+                .context("Failed to decode WASM module (signature tables)")?;
+            func_ret_i64 = module.func_ret_i64;
+            type_ret_i64 = module.type_ret_i64;
+            let module_func_params_i64 = module.func_params_i64;
+
             // Capture the WASM bytes + imports for the SBOM (the bytes synth
             // actually compiles, after WAT decode and any Loom pass).
             if sbom_path.is_some() {
-                if let Ok(module) = decode_wasm_module(&wasm_bytes) {
-                    sbom_imports = module.imports;
-                }
+                sbom_imports = module.imports;
                 sbom_wasm_bytes = Some(wasm_bytes.clone());
             }
 
@@ -1192,6 +1211,14 @@ fn compile_command(
                 .clone()
                 .unwrap_or_else(|| format!("func_{}", func.index));
             info!("Compiling function {} ({} ops)", name, func.ops.len());
+
+            // #599: THIS function's declared param widths + blocktype-arity
+            // side-table (indexed by full function index), mirroring the
+            // all-exports compile loop (#359/#509/#518).
+            if let Some(p) = module_func_params_i64.get(func.index as usize) {
+                current_func_params_i64 = p.clone();
+            }
+            current_func_block_arity = func.block_arity.clone();
 
             // #554: an op the decoder DROPPED (`_ => None`, e.g. scalar `f32.*`)
             // is recorded in `func.unsupported` but is already gone from
@@ -1259,6 +1286,14 @@ fn compile_command(
         target: target_spec.clone(),
         // #543 Phase 1: threaded but not yet consumed (inert plumbing).
         volatile_segments,
+        // #599: the module's declared value-width tables — an i64 param that is
+        // only READ is 64-bit by signature, invisible to op-stream inference.
+        // Without these the selector materialized constants into the param's
+        // live high register (i64.shr_u/shr_s returned the shift amount).
+        current_func_params_i64,
+        func_ret_i64,
+        type_ret_i64,
+        current_func_block_arity,
         ..CompileConfig::default()
     };
 
@@ -2425,6 +2460,9 @@ fn compile_all_exports(
                 None
             },
             input_dwarf.as_ref(),
+            // #598: only Thumb-encoded functions get the interworking bit on
+            // their STT_FUNC symbols; the A32 path (cortex-r5) keeps bit 0 clear.
+            !matches!(target_spec.isa, synth_core::target::IsaVariant::Arm32),
         )?
     } else if cortex_m {
         build_multi_func_cortex_m_elf(&compiled_funcs, &all_memories, target_spec)?
@@ -2584,6 +2622,10 @@ fn build_relocatable_elf(
     // code_base). `None` ⇒ `--debug-line` off OR the input carried no DWARF ⇒
     // no `.debug_line` section emitted ⇒ output byte-identical to the default.
     dwarf_line: Option<&synth_core::dwarf_line::InputDwarfLine>,
+    // #598: true for Thumb targets (STT_FUNC symbols + e_entry get bit 0, the
+    // interworking bit), false for A32 (cortex-r5) — A32 code addresses must
+    // keep bit 0 clear.
+    thumb_funcs: bool,
 ) -> Result<Vec<u8>> {
     use std::collections::HashMap;
 
@@ -2595,6 +2637,7 @@ fn build_relocatable_elf(
     // (default unset ⇒ full-page reservation ⇒ frozen fixtures bit-identical).
 
     let mut elf_builder = ElfBuilder::new_arm32()
+        .with_thumb_funcs(thumb_funcs) // #598: no Thumb bit on A32 symbols
         .with_entry(0)
         .with_type(ElfType::Rel); // ET_REL: relocatable object
 
@@ -4889,8 +4932,16 @@ mod tests {
             shadow_stack_size: None,
         };
 
-        let elf = build_relocatable_elf(&[func], &[], &[], linear_memory_bytes, Some(native), None)
-            .expect("#345: native-pointer zero-linmem object builds");
+        let elf = build_relocatable_elf(
+            &[func],
+            &[],
+            &[],
+            linear_memory_bytes,
+            Some(native),
+            None,
+            true,
+        )
+        .expect("#345: native-pointer zero-linmem object builds");
 
         // Parse the ELF and inspect sections by name + type.
         let header = object::elf::FileHeader32::<Endianness>::parse(&*elf).expect("valid ELF32");
@@ -4986,7 +5037,7 @@ mod tests {
             sp_init: 65_536,
             shadow_stack_size: None,
         };
-        let elf = build_relocatable_elf(&[func], &[], &[], 131_072, Some(native), None)
+        let elf = build_relocatable_elf(&[func], &[], &[], 131_072, Some(native), None, true)
             .expect("#345: native-pointer literal-pool object builds");
 
         let header = object::elf::FileHeader32::<Endianness>::parse(&*elf).expect("valid ELF32");
@@ -5071,8 +5122,16 @@ mod tests {
             shadow_stack_size: None,
         };
 
-        let elf = build_relocatable_elf(&[func], &[], &data_segments, 131_072, Some(native), None)
-            .expect("#354: mixed-case object builds");
+        let elf = build_relocatable_elf(
+            &[func],
+            &[],
+            &data_segments,
+            131_072,
+            Some(native),
+            None,
+            true,
+        )
+        .expect("#354: mixed-case object builds");
 
         let header = object::elf::FileHeader32::<Endianness>::parse(&*elf).expect("valid ELF32");
         let endian = header.endian().expect("endian");

--- a/scripts/repro/call_indirect_594_differential.py
+++ b/scripts/repro/call_indirect_594_differential.py
@@ -31,11 +31,15 @@ EXPECT = 42  # wasmtime --invoke run call_indirect_594.wat
 e = ELFFile(open(ELF, "rb"))
 text = bytearray(e.get_section_by_name(".text").data())
 # Symbols from the symtab, never from disasm text (host-dependent).
-# NOTE: the ELF builder currently sets the Thumb interworking bit on every
-# STT_FUNC symbol even for A32 targets (pre-existing defect, noted on #594) —
-# mask bit 0 to get the real A32 code address.
+# #598 (fixed): A32 STT_FUNC symbols carry bit 0 CLEAR — the builder no longer
+# sets the Thumb interworking bit on A32 objects, so no masking workaround.
+# An unexpected bit 0 here would be a #598 regression: fail loudly.
 st = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
-syms = {s.name: s["st_value"] & ~1 for s in st.iter_symbols() if s.name}
+syms = {s.name: s["st_value"] for s in st.iter_symbols() if s.name}
+odd = [n for n, v in syms.items() if v & 1]
+if odd:
+    print(f"A32 STT_FUNC symbol(s) with Thumb bit set (#598 regression): {odd}")
+    sys.exit(1)
 for need in ("run", "func_0"):
     if need not in syms:
         print(f"SYMBOL MISSING: {need}")

--- a/scripts/repro/call_indirect_597.wat
+++ b/scripts/repro/call_indirect_597.wat
@@ -1,0 +1,15 @@
+;; #597: the Thumb-2 CallIndirect expansion encoded its `LSL #2` shift amount
+;; into the TYPE field of the mov.w (bits 5:4, giving ASR #32) instead of
+;; imm2 (bits 7:6) — the table index was destroyed and every call_indirect
+;; dispatched entry 0. A single-entry table (the #594 probe) cannot see it;
+;; this table has distinct results at indexes 0, 1 and 3.
+;; wasmtime oracle: run(0)=10, run(1)=11, run(3)=13.
+(module
+  (type $s (func (result i32)))
+  (table 4 funcref)
+  (elem (i32.const 0) $f0 $f1 $f0 $f3)
+  (func $f0 (result i32) (i32.const 10))
+  (func $f1 (result i32) (i32.const 11))
+  (func $f3 (result i32) (i32.const 13))
+  (func (export "run") (param i32) (result i32)
+    (call_indirect (type $s) (local.get 0))))

--- a/scripts/repro/call_indirect_597_differential.py
+++ b/scripts/repro/call_indirect_597_differential.py
@@ -1,0 +1,79 @@
+# #597: the Thumb-2 CallIndirect expansion put its `LSL #2` shift amount in
+# the mov.w TYPE field (bits 5:4 → ASR #32) instead of imm2 (bits 7:6), so the
+# table index was destroyed and EVERY call_indirect dispatched entry 0. A probe
+# calling index 0 (#594's) cannot see it — this one drives indexes 0, 1 and 3
+# of a 4-entry table with distinct results.
+#
+# Differential: emulate the Thumb object under unicorn (UC_MODE_THUMB) against
+# the wasmtime oracle (run(0)=10, run(1)=11, run(3)=13).
+#
+# ArmOp::CallIndirect contract (same as the A32 path, #594): R11 holds the
+# function-pointer table base; entry i is a 4-byte code address. Thumb entries
+# carry bit 0 SET (BLX interworks on bit 0).
+#
+# Usage: python3 call_indirect_597_differential.py <elf>
+#   <elf> = synth compile call_indirect_597.wat --target cortex-m3 \
+#             --all-exports --relocatable --no-optimize -o <elf>
+import struct
+import sys
+
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_THUMB
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/ci597.o"
+CODE, TABLE, STK = 0x1000000, 0x3000000, 0x6000000
+RET = CODE + 0xFFF0
+# wasmtime --invoke run call_indirect_597.wat <idx>
+EXPECT = {0: 10, 1: 11, 3: 13}
+
+e = ELFFile(open(ELF, "rb"))
+text = bytearray(e.get_section_by_name(".text").data())
+# Symbols from the symtab, never from disasm text (host-dependent).
+# Thumb STT_FUNC symbols carry bit 0 (interworking); mask it for the flat
+# code offset (the emulation start address re-adds it via UC_MODE_THUMB).
+st = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+syms = {s.name: s["st_value"] & ~1 for s in st.iter_symbols() if s.name}
+for need in ("run", "func_0", "func_1", "func_2"):
+    if need not in syms:
+        print(f"SYMBOL MISSING: {need}")
+        sys.exit(1)
+
+# Table layout mirrors the wat's (elem): [$f0, $f1, $f0, $f3] where the
+# internal functions compile as func_0/func_1/func_2 in definition order.
+table_entries = [syms["func_0"], syms["func_1"], syms["func_0"], syms["func_2"]]
+
+fails = 0
+for idx, want in sorted(EXPECT.items()):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x100000)
+    mu.mem_map(TABLE, 0x10000)
+    mu.mem_map(STK, 0x100000)
+    mu.mem_write(CODE, bytes(text))
+    # table[i] = Thumb code address of entry i (bit 0 SET for BLX interwork)
+    for i, off in enumerate(table_entries):
+        mu.mem_write(TABLE + 4 * i, struct.pack("<I", (CODE + off) | 1))
+    # Return pad: Thumb NOPs at RET (mapped inside the CODE region).
+    mu.mem_write(RET, struct.pack("<HH", 0xBF00, 0xBF00))
+
+    mu.reg_write(UC_ARM_REG_R0, idx)
+    mu.reg_write(UC_ARM_REG_R11, TABLE)
+    mu.reg_write(UC_ARM_REG_SP, STK + 0x80000)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)  # Thumb return address
+    mu.emu_start((CODE + syms["run"]) | 1, RET, count=2000)
+    got = mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+    ok = got == want
+    fails += 0 if ok else 1
+    print(f"run({idx}) = {got} (wasmtime oracle: {want}) {'OK' if ok else 'MISMATCH'}")
+
+if fails == 0:
+    print("ORACLE: PASS")
+    sys.exit(0)
+print(f"ORACLE: FAIL — {fails} index(es) misdispatched (#597)")
+sys.exit(1)

--- a/scripts/repro/i64_shr_599.wat
+++ b/scripts/repro/i64_shr_599.wat
@@ -1,0 +1,24 @@
+;; #599: i64.shr_u / i64.shr_s miscompiled on the single-function CLI path
+;; (`-n <name>`) — that path never plumbed the module's declared param widths
+;; (func_params_i64) into the CompileConfig, so a read-only i64 param stayed
+;; classified i32 and the shift-amount constant was materialized INTO the
+;; param's live high register (r1). shr_u/shr_s by 32 returned the shift
+;; amount itself; other amounts leaked spurious high bits. The all-exports
+;; path (which plumbs the widths, #518) was already correct.
+;; wasmtime oracle per function is computed by the differential harness.
+(module
+  (func (export "shr_u_32") (param i64) (result i32)
+    (i32.wrap_i64 (i64.shr_u (local.get 0) (i64.const 32))))
+  (func (export "shr_s_32") (param i64) (result i32)
+    (i32.wrap_i64 (i64.shr_s (local.get 0) (i64.const 32))))
+  (func (export "shr_u_1") (param i64) (result i32)
+    (i32.wrap_i64 (i64.shr_u (local.get 0) (i64.const 1))))
+  (func (export "shr_u_63") (param i64) (result i32)
+    (i32.wrap_i64 (i64.shr_u (local.get 0) (i64.const 63))))
+  (func (export "shr_s_63") (param i64) (result i32)
+    (i32.wrap_i64 (i64.shr_s (local.get 0) (i64.const 63))))
+  (func (export "shr_u_var") (param i64 i64) (result i32)
+    (i32.wrap_i64 (i64.shr_u (local.get 0) (local.get 1))))
+  (func (export "shl_4") (param i64) (result i32)
+    ;; control: i64.shl was already correct (issue table)
+    (i32.wrap_i64 (i64.shl (local.get 0) (i64.const 4)))))

--- a/scripts/repro/i64_shr_599_differential.py
+++ b/scripts/repro/i64_shr_599_differential.py
@@ -1,0 +1,140 @@
+# #599: i64.shr_u / i64.shr_s register-pair right shift miscompiled on the
+# single-function CLI path (`-n <name>`): the path built its CompileConfig with
+# `..default()` and never plumbed the module's declared param widths
+# (func_params_i64), so a read-only i64 param stayed classified i32 — the
+# shift-amount constant pair was allocated INTO the param's live high register
+# (movw r1, #32 over hi(param)). shr by 32 then returned the SHIFT AMOUNT
+# (lsr rd, r1, #0 with r1=32); smaller shifts leaked `n << (32-n)` into the
+# result (256>>1 gave 0x80000080). The all-exports path plumbs the widths
+# (#518) and was already correct.
+#
+# Differential: compile EACH export with `-n <name> --no-optimize` (the broken
+# path), emulate under unicorn (UC_MODE_THUMB), and difference against the
+# wasmtime oracle (invoked per vector when wasmtime is on PATH; otherwise the
+# built-in wasm-semantics expectation, which was cross-checked against
+# wasmtime when this harness was written).
+#
+# High-bit-set vectors included per the #599 gate: hi=0x80000001 >> 1 pulls a
+# hi bit into lo bit 31; 1<<63 >> 63 exercises the n>=32 funnel path both
+# logically (=1) and arithmetically (=-1).
+#
+# Usage: python3 i64_shr_599_differential.py <synth-binary> [wat]
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_THUMB
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R3,
+    UC_ARM_REG_SP,
+)
+
+SYNTH = sys.argv[1] if len(sys.argv) > 1 else "target/debug/synth"
+WAT = sys.argv[2] if len(sys.argv) > 2 else os.path.join(os.path.dirname(__file__), "i64_shr_599.wat")
+CODE, STK = 0x1000000, 0x6000000
+RET = CODE + 0xFFF0
+M64 = (1 << 64) - 1
+M32 = (1 << 32) - 1
+
+
+def sext64(v):
+    return v - (1 << 64) if v & (1 << 63) else v
+
+
+# (function, args-as-u64 tuple, wasm-semantics expected i32-as-u32)
+VECTORS = [
+    ("shr_u_32", (0x0000006300000001,), 99),  # lo=1 hi=99 -> hi word
+    ("shr_s_32", (0x0000006300000001,), 99),
+    ("shr_u_1", (256,), 128),
+    ("shr_u_1", (0x8000000100000000,), 0x80000000),  # hi bit 0 -> lo bit 31
+    ("shr_u_63", (1 << 63,), 1),
+    ("shr_s_63", (1 << 63,), M32),  # -1 wrapped
+    ("shr_u_var", (1 << 63, 63), 1),
+    ("shr_u_var", (256, 4), 16),
+    ("shl_4", (256,), 4096),  # control: shl was already correct
+]
+
+
+def wasmtime_oracle(func, args):
+    if shutil.which("wasmtime") is None:
+        return None
+    argv = ["wasmtime", "run", "--invoke", func, WAT] + [str(sext64(a)) for a in args]
+    out = subprocess.run(argv, capture_output=True, text=True)
+    if out.returncode != 0:
+        return None
+    return int(out.stdout.strip()) & M32
+
+
+def compile_func(func, out_o):
+    argv = [
+        SYNTH, "compile", WAT,
+        "-t", "cortex-m3",
+        "-n", func,
+        "--no-optimize",
+        "-o", out_o,
+    ]
+    r = subprocess.run(argv, capture_output=True, text=True)
+    if r.returncode != 0:
+        print(f"COMPILE FAILED for {func}:\n{r.stderr}")
+        sys.exit(2)
+
+
+def emulate(elf_path, func, args):
+    e = ELFFile(open(elf_path, "rb"))
+    text = e.get_section_by_name(".text").data()
+    # Symbols from the symtab, never from disasm text (host-dependent).
+    st = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: s["st_value"] & ~1 for s in st.iter_symbols() if s.name}
+    if func not in syms:
+        print(f"SYMBOL MISSING: {func}")
+        sys.exit(2)
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x100000)
+    mu.mem_map(STK, 0x100000)
+    mu.mem_write(CODE, text)
+    mu.mem_write(RET, struct.pack("<HH", 0xBF00, 0xBF00))  # Thumb NOP pad
+
+    # AAPCS: each i64 arg is a lo:hi register pair starting at an even reg.
+    regs = [UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3]
+    ri = 0
+    for a in args:
+        mu.reg_write(regs[ri], a & M32)
+        mu.reg_write(regs[ri + 1], (a >> 32) & M32)
+        ri += 2
+    mu.reg_write(UC_ARM_REG_SP, STK + 0x80000)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    mu.emu_start((CODE + syms[func]) | 1, RET, count=5000)
+    return mu.reg_read(UC_ARM_REG_R0) & M32
+
+
+tmp = tempfile.mkdtemp(prefix="i64shr599_")
+fails = 0
+for func, args, want in VECTORS:
+    oracle = wasmtime_oracle(func, args)
+    if oracle is not None and oracle != want:
+        print(f"HARNESS BUG: builtin expect {want} != wasmtime {oracle} for {func}{args}")
+        sys.exit(2)
+    want = oracle if oracle is not None else want
+    obj = os.path.join(tmp, f"{func}.o")
+    if not os.path.exists(obj):
+        compile_func(func, obj)
+    got = emulate(obj, func, args)
+    ok = got == want
+    fails += 0 if ok else 1
+    argstr = ", ".join(hex(a) for a in args)
+    print(f"{func}({argstr}) = {got:#x} (oracle: {want:#x}) {'OK' if ok else 'MISMATCH'}")
+
+if fails == 0:
+    print("ORACLE: PASS")
+    sys.exit(0)
+print(f"ORACLE: FAIL — {fails} vector(s) wrong (#599)")
+sys.exit(1)


### PR DESCRIPTION
Fixes three filed defects in synth-backend encoder/ELF territory, each red→green under a unicorn-vs-wasmtime execution differential.

## #597 (severe) — Thumb-2 CallIndirect always dispatched table entry 0

**Root cause:** the Thumb-2 `CallIndirect` expansion built `mov.w ip, rm, LSL #2` with the shift amount shifted into **bits 5:4 — the TYPE field** (`0b10` = ASR) instead of imm2 (bits 7:6). The encoded instruction was `mov.w ip, rm, ASR #32`, which zeroes any non-negative index — every `call_indirect` dispatched entry 0. Invisible to index-0 probes (#594's).

**Fix:** `arm_encoder.rs` — `(0b10 << 4)` → `(0b10 << 6)` (hw2 `0x0C20|rm` → `0x0C80|rm`).

**Justified correctness re-pin** (the #596 PR froze the buggy bytes deliberately to stay in-scope; that pin documented this exact defect as a follow-up):

| | first word bytes | decodes as |
|---|---|---|
| old pin (`test_encode_thumb_call_indirect_unchanged_594`) | `4F EA 20 0C` | `mov.w ip, r0, ASR #32` (bug) |
| new pin (`test_encode_thumb_call_indirect_lsl2_597`) | `4F EA 80 0C` | `mov.w ip, r0, LSL #2` |

The new bytes were **execution-validated before re-pinning**: `scripts/repro/call_indirect_597_differential.py` drives a 4-entry table at indexes 0, 1 and 3 (UC_MODE_THUMB unicorn vs wasmtime).

- pre-fix (RED): `run(0)=10 OK, run(1)=10 (want 11), run(3)=10 (want 13)` — always entry 0
- post-fix (GREEN): `10 / 11 / 13`, ORACLE: PASS

The `ldr.w ip,[r11,ip]; blx ip` tail bytes are unchanged; the new pin also asserts the ASR-#32 word can never come back.

## #599 — i64.shr_u / i64.shr_s miscompiled (returns shift amount / leaks high bits)

**Root cause:** the single-function CLI path (`-n <name>`, the issue's repro) built its `CompileConfig` from `..default()` and never plumbed the module's declared value-width tables. A read-only i64 param therefore stayed classified i32 (#518's exact mechanism — `infer_i64_locals` can't see a param that's never `local.set`), so the selector materialized the shift-amount constant pair **into the param's live high register**: `movw r1, #32` clobbered hi(param) in r0:r1, and `i64_pair_hi(r0)=r1` then read the shift amount as the data high word. `shr by 32` returned 32; `256>>1` returned `0x80000080` (= `128 | 1<<31`, the amount leaking through the funnel-shift cross term). The encoder's pair-shift expansion itself is correct, as is the all-exports path (which plumbs the widths).

**Fix:** `synth-cli/src/main.rs` — the single-function path now decodes the module once and plumbs `current_func_params_i64`, `func_ret_i64`, `type_ret_i64`, and `current_func_block_arity` exactly as the all-exports loop does (#359/#311/#509/#518 family).

**Differential** `scripts/repro/i64_shr_599_differential.py` (compiles each export via `-n --no-optimize`, unicorn vs wasmtime, high-bit-set vectors included):

| vector | pre-fix (RED) | oracle | post-fix |
|---|---|---|---|
| `shr_u_32(lo=1,hi=0x63)` | `0x20` (the shift amount) | `0x63` | OK |
| `shr_s_32(lo=1,hi=0x63)` | `0x20` | `0x63` | OK |
| `shr_u_1(256)` | `0x80000080` | `0x80` | OK |
| `shr_u_1(hi=0x80000001)` | `0x80000000` | `0x80000000` | OK |
| `shr_u_63(1<<63)` | `0x0` | `0x1` | OK |
| `shr_s_63(1<<63)` | `0x0` | `0xffffffff` | OK |
| `shr_u_var(1<<63, 63)` | `0x0` | `0x1` | OK |
| `shr_u_var(256, 4)` | `0x100` | `0x10` | OK |
| `shl_4(256)` (control) | `0x1000` OK | `0x1000` | OK |

7/9 wrong pre-fix → 9/9 green.

## #598 — Thumb bit on STT_FUNC symbols of A32 objects

**Root cause:** `build_symbol_table` applied `st_value | 1` for every `machine == EM_ARM` STT_FUNC symbol; `with_entry` did the same to `e_entry` — wrong metadata for A32 (cortex-r5) objects, which harnesses had to mask.

**Fix:** `ElfBuilder::with_thumb_funcs(bool)` (default **true**, so every Thumb output stays bit-identical); the relocatable path passes `isa != Arm32`. A32 objects now carry bit-0-clear function symbols and `e_entry`. The #594 harness drops its `& ~1` masking workaround and instead **fails loudly** if an A32 STT_FUNC symbol ever carries bit 0 again. Unit test `test_a32_symbols_have_no_thumb_bit_598` pins both behaviors.

## Gates

- `scripts/repro/call_indirect_597_differential.py` — RED pre-fix, PASS post-fix
- `scripts/repro/i64_shr_599_differential.py` — RED pre-fix (7/9), PASS post-fix
- `scripts/repro/call_indirect_594_differential.py` (updated, unmasked) — PASS on cortex-r5
- `cargo test -p synth-backend -p synth-synthesis -p synth-cli` — 1292 passed, 0 failed
- `cargo fmt --check` clean; `cargo clippy --workspace --exclude synth-verify --all-targets -- -D warnings` clean (synth-verify excluded: z3-sys fetch breaks local builds, known)
- All other frozen anchors untouched — the only re-pin is the #597 Thumb CallIndirect bytes (documented old→new above)

## Residual (honest notes, out of scope here)

- The `-n` single-function path still ignores `--relocatable` for the *container* (emits a Cortex-M ET_EXEC image, not ET_REL) and still doesn't plumb `func_arg_counts`/`num_imports` (call-marshaling on `-n` of functions **with calls**). Same omission family as #599 but distinct behaviors; not filed yet.
- The optimized (default) `-n` path for the i64-param shape now correctly sees param widths; the differential gates the `--no-optimize` direct path the issue reproduced.

Closes #597, Closes #598, Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)