### PR TITLE
feat(vcr-ra)!: retire inline const aliasing; SYNTH_CONST_CSE default-on (#242)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -821,8 +821,20 @@ fn compile_wasm_to_arm(
     // size-guards each segment via the byte-estimator — it commits a segment's
     // rewrites only if they do not grow its estimated size — so a retarget that
     // would flip a 16-bit encoding to 32-bit (higher base register) is declined.
-    // Behind `SYNTH_CONST_CSE=1` while validated against the differential oracle;
-    // off by default keeps every fixture bit-identical.
+    // DEFAULT-ON (#242 flip-wave, the SYNTH_SPILL_REALLOC/SYNTH_BASE_CSE
+    // template): const-CSE ships by default. The flip prerequisites recorded in
+    // `const_cse_reduction_242.rs` were retired first — the bridge-level INLINE
+    // aliasing (the alias-eviction spill-bijection hazard) was DELETED from
+    // `optimizer_bridge::ir_to_arm`, so this post-hoc, liveness-proven pass is
+    // the flag's ONLY effect. Evidence basis: 152 fixture×path corpus sweep — 0
+    // functions grow (size-guarded per segment), 40 shrink (const_cse::spill12
+    // 236→148 B), total −536 B — and the execution differentials re-run green
+    // on the new default bytes BEFORE the frozen goldens were re-pinned
+    // (const_cse, frame_slot_dce, flight_seam 0x07FDF307, spill_rung_581,
+    // volatile_segment_543, control_step 0x00210A55). Escape hatch:
+    // `SYNTH_CONST_CSE=0` is the OPT-OUT — it restores the pre-flip bytes
+    // (CI-gated by `const_cse_escape_hatch_restores_old_bytes_242` and the
+    // frozen-anchor escape-hatch gate). Any other value (or unset) runs the pass.
     //
     // #543 Phase 2: const-CSE declines WHOLESALE while any volatile DMA range
     // (`--volatile-segment`) is marked. At the ArmOp level a cached constant
@@ -831,17 +843,17 @@ fn compile_wasm_to_arm(
     // conservative stance for statically-unknown addressing is to decline every
     // aliasing rewrite — each constant is re-materialized at each occurrence,
     // the documented volatile contract (`CompileConfig::volatile_segments`).
-    // Mirrors the bridge-level const-CSE gate in `optimizer_bridge::ir_to_arm`.
-    let arm_instrs =
-        if std::env::var("SYNTH_CONST_CSE").is_ok() && config.volatile_segments.is_empty() {
-            let (out, removed) = synth_synthesis::liveness::apply_const_cse(&arm_instrs);
-            if std::env::var("SYNTH_FUSE_STATS").is_ok() {
-                eprintln!("[const-cse] {removed} redundant constant materialization(s) removed");
-            }
-            out
-        } else {
-            arm_instrs
-        };
+    let arm_instrs = if !std::env::var("SYNTH_CONST_CSE").is_ok_and(|v| v == "0")
+        && config.volatile_segments.is_empty()
+    {
+        let (out, removed) = synth_synthesis::liveness::apply_const_cse(&arm_instrs);
+        if std::env::var("SYNTH_FUSE_STATS").is_ok() {
+            eprintln!("[const-cse] {removed} redundant constant materialization(s) removed");
+        }
+        out
+    } else {
+        arm_instrs
+    };
 
     // VCR-RA-001 spill-choice REPORT (#242): measure-only, like SYNTH_SHADOW_ALLOC.
     // Per straight-line segment, the frame-slot traffic actually emitted vs the

--- a/crates/synth-cli/tests/base_cse_flip_468.rs
+++ b/crates/synth-cli/tests/base_cse_flip_468.rs
@@ -49,14 +49,24 @@ fn fixture(rel: &str) -> std::path::PathBuf {
 }
 
 /// Compile `rel` on the optimized ARM path. `default_on` = the shipped
-/// default (env var removed so a stray opt-out in the test environment can't
+/// default (env vars removed so a stray opt-out in the test environment can't
 /// skew the gate); `false` = the `SYNTH_BASE_CSE=0` opt-out (pre-flip bytes).
+///
+/// COMPOSITION NOTE (#242): const-CSE is default-ON since its own flip, so
+/// rolling back to the pre-BASE-CSE-flip bytes now also requires
+/// `SYNTH_CONST_CSE=0` on the opt-out arm (const-CSE would otherwise rewrite
+/// the verbatim per-access materializations these goldens pin). The DEFAULT
+/// arm leaves both env vars untouched — verified at const-CSE-flip time that
+/// the default goldens below are byte-identical under const-CSE (its
+/// size-guarded passes find nothing left on the folded shape), so this gate
+/// keeps pinning the TRUE shipped default.
 fn compile(rel: &str, out: &str, default_on: bool) -> Vec<u8> {
     let mut cmd = Command::new(synth());
-    cmd.env_remove("SYNTH_CONST_CSE");
     if default_on {
+        cmd.env_remove("SYNTH_CONST_CSE");
         cmd.env_remove("SYNTH_BASE_CSE");
     } else {
+        cmd.env("SYNTH_CONST_CSE", "0");
         cmd.env("SYNTH_BASE_CSE", "0");
     }
     let out_status = cmd
@@ -167,8 +177,11 @@ fn base_cse_escape_hatch_restores_old_bytes_468() {
 /// GATE 3 — NO-GROW + non-vacuity: across the measured corpus no function
 /// grows default-vs-opt-out, and the two firing fixtures genuinely shrink
 /// (redundant_base_materialization −118 B, volatile_segment_543 −62 B at
-/// flip time). flat_flight / flight_seam / const_cse are decline-shaped for
-/// this planner (control flow / non-const addresses) — they must stay EQUAL.
+/// flip time). Since the #242 const-CSE flip the opt-out arm disables BOTH
+/// levers (see `compile`), so this is a combined-default no-grow claim;
+/// flat_flight / flight_seam / const_cse decline for the base-CSE planner
+/// (control flow / non-const addresses) but may shrink under const-CSE —
+/// per-lever equality is pinned in each lever's own gate file.
 #[test]
 fn base_cse_no_grow_corpus_468() {
     let corpus = [

--- a/crates/synth-cli/tests/const_cse_reduction_242.rs
+++ b/crates/synth-cli/tests/const_cse_reduction_242.rs
@@ -1,46 +1,51 @@
-//! VCR-RA const-CSE (#242) — CI-gated reduction + frozen-safety oracle.
+//! VCR-RA const-CSE (#242) — flip gates: default golden, escape hatch,
+//! reduction, and no-grow corpus.
 //!
-//! The optimized (non-`--relocatable`) ARM path re-materializes a constant at
-//! every use (`i32.const N` → a fresh `movw`/`movt` each time). gale measured
-//! this on silicon: flat_flight spends 61% of its const materializations on
-//! values already held in a register. `SYNTH_CONST_CSE=1` enables a
-//! pressure-neutral const cache (`optimizer_bridge.rs`) that aliases a repeated
-//! const to the register already holding it, emitting nothing.
+//! The ARM path re-materializes a constant at every use (`i32.const N` → a
+//! fresh `movw`/`movt` each time). gale measured this on silicon: flat_flight
+//! spends 61% of its const materializations on values already held in a
+//! register. const-CSE removes the redundant materializations via the
+//! post-hoc, liveness-proven `liveness::apply_const_cse` passes (PR1 #519
+//! cross-register fold + PR2 #562 extending-alias hoist), wired LAST in
+//! `arm_backend.rs` — DEFAULT-ON since the #242 flip; `SYNTH_CONST_CSE=0` is
+//! the opt-out.
 //!
-//! This is byte-CHANGING codegen, so the flag ships DEFAULT-OFF. Two claims are
-//! locked here as executable CI gates; semantic equivalence under flag-ON is the
-//! separate `const_cse_differential.py` unicorn-vs-wasmtime oracle:
+//! FLIP PREREQUISITES — recorded here pre-flip, now RETIRED:
+//!   - ALIAS-EVICTION: the bridge-level INLINE const cache (alias a repeated
+//!     const's vreg to the register already holding it, in
+//!     `optimizer_bridge::ir_to_arm`) made two live vregs share one physical
+//!     register, breaking the spill model's vreg↔reg bijection — a spilled
+//!     shared victim would leave the surviving alias reading a reused
+//!     register. RETIRED BY DELETION (this flip's PR): the inline arm is gone;
+//!     every const materializes normally and the flag gates ONLY the post-hoc
+//!     passes, which rewrite already-register-assigned code (removal+retarget,
+//!     never two-vregs-one-reg) — the eviction paths keep a `count == 1` alias
+//!     guard as a structural tripwire.
+//!   - reg_effect DEF-COMPLETENESS: the INLINE cache's "never stale-wrong"
+//!     property rested on `liveness::reg_effect` reporting every GP-register
+//!     write. Retired WITH the inline cache: the post-hoc passes treat any
+//!     `reg_effect = None` op as an opaque segment boundary and only rewrite
+//!     within fully-modeled straight-line segments, so an unmodeled op declines
+//!     instead of going stale (per-op under-reporting remains an ordinary
+//!     modeled-op bug class, pinned by the #513 consistency oracle + the
+//!     execution differentials).
 //!
-//!   1. FROZEN-SAFE (OFF ≡ pre-change baseline). With the flag OFF the optimized
-//!      path emits a SPECIFIC, pinned `.text` — the golden below was captured
-//!      against the pre-const-CSE tree (verified equal by a `git stash` compare:
-//!      post-change-OFF hash == pre-change hash, both `8c3dfcbb…`). The frozen
-//!      differential fixtures (control_step / flight_algo) compile `--relocatable`
-//!      → they exercise the DIRECT path and never touch this code, so this golden
-//!      is the ONLY gate pinning optimized-path-OFF bytes. A golden, not a
-//!      compile-twice determinism check: determinism alone would not catch the
-//!      flag-off path drifting away from the byte-identical baseline.
+//! Claims locked here as executable CI gates; semantic equivalence on the
+//! default bytes is the separate `const_cse_differential.py`
+//! unicorn-vs-wasmtime oracle (re-run green BEFORE these goldens were pinned):
 //!
-//!   2. REAL REDUCTION ON HEADROOM. On `large3` — a >16-bit const reused 3× with
-//!      ample free registers — the flag-ON `.text` is STRICTLY SMALLER (the two
-//!      redundant `movw`+`movt` pairs collapse to register aliases). If a future
-//!      change makes CSE inert on headroom, this fails.
+//!   1. ESCAPE HATCH (`=0` ≡ pre-flip baseline). With `SYNTH_CONST_CSE=0` the
+//!      optimized path emits the SAME pinned `.text` the pre-flip default
+//!      emitted (the golden survives the flip UNCHANGED from its pre-flip
+//!      capture — the opt-out path is untouched). The rollback proof, and the
+//!      ONLY gate pinning optimized-path opt-out bytes.
 //!
-//! WHAT THIS DOES NOT CLAIM — the named prerequisites for a default-ON flip
-//! (a separate, silicon-gated release, NOT this PR):
-//!   - reg_effect DEF-COMPLETENESS. The cache's "never stale-wrong" property
-//!     rests on `liveness::reg_effect` reporting EVERY GP-register a non-const op
-//!     writes (so the reconciliation clears a clobbered alias). That is a broader
-//!     property than the #513 reg_effect↔rewrite_op *consistency* oracle, which
-//!     only pins that the two AGREE — they could agree and both under-report. The
-//!     flip must be gated on op-coverage of reg_effect, not on #513.
-//!   - ALIAS-EVICTION. Aliasing `dest` to an existing register makes two live
-//!     vregs share one physical register, breaking the spill model's vreg↔reg
-//!     bijection. If the OLDER alias is chosen as a spill victim while the
-//!     younger keeps the alias, the freed register is reused under the younger →
-//!     stale read. Not reachable in today's fixtures (the IR optimizer dedups
-//!     two consecutive identical consts before they reach this pass), but the
-//!     flip must either prove unreachability or make the spill path alias-aware.
+//!   2. DEFAULT GOLDEN. The shipped default emits the CSE'd `.text` on the
+//!      headroom fixture (pinned FNV + length), so an accidental change to the
+//!      default lowering fails loud.
+//!
+//!   3. REAL REDUCTION ON HEADROOM + NO-GROW (below): `large3` and `spill12`
+//!      strictly shrink under the default; nothing in the corpus grows.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -49,12 +54,19 @@ use std::process::Command;
 use object::read::elf::ElfFile32;
 use object::{Object, ObjectSection};
 
-/// Golden FNV-1a-64 of the flag-OFF optimized-path `.text` for `const_cse.wat`.
-/// Captured against the pre-const-CSE tree (stash-compare verified). Re-bless
-/// ONLY when an intentional optimized-path lowering change is made — a surprise
-/// failure here means the supposedly-frozen flag-off path drifted.
+/// Golden FNV-1a-64 of the OPT-OUT (`SYNTH_CONST_CSE=0`) optimized-path `.text`
+/// for `const_cse.wat`. Captured against the pre-const-CSE tree (stash-compare
+/// verified) and UNCHANGED by the default-on flip — the opt-out path is the
+/// pre-flip default. Re-bless ONLY when an intentional optimized-path lowering
+/// change is made — a surprise failure here means the opt-out rollback drifted.
 const GOLDEN_OFF_TEXT_FNV1A: u64 = 0xa68a_a2da_e5af_e4a7;
 const GOLDEN_OFF_TEXT_LEN: usize = 576;
+
+/// Golden FNV-1a-64 of the SHIPPED-DEFAULT optimized-path `.text` for
+/// `const_cse.wat` (const-CSE on). Pinned at flip time, AFTER
+/// `const_cse_differential.py` re-ran green on these exact bytes.
+const GOLDEN_DEFAULT_TEXT_FNV1A: u64 = 0x9577_c583_bc14_5a46;
+const GOLDEN_DEFAULT_TEXT_LEN: usize = 452;
 
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
@@ -66,12 +78,15 @@ fn fixture() -> std::path::PathBuf {
         .join("scripts/repro/const_cse.wat")
 }
 
-/// Compile the const-CSE fixture via the optimized path. `cse` toggles
-/// `SYNTH_CONST_CSE`; returns the raw ELF bytes.
+/// Compile the const-CSE fixture via the optimized path. `cse = true` is the
+/// SHIPPED DEFAULT (env removed so a stray opt-out can't skew a gate);
+/// `cse = false` is the `SYNTH_CONST_CSE=0` opt-out. Returns the raw ELF bytes.
 fn compile(out: &str, cse: bool) -> Vec<u8> {
     let mut cmd = Command::new(synth());
     if cse {
-        cmd.env("SYNTH_CONST_CSE", "1");
+        cmd.env_remove("SYNTH_CONST_CSE");
+    } else {
+        cmd.env("SYNTH_CONST_CSE", "0");
     }
     let status = cmd
         .args([
@@ -118,13 +133,17 @@ fn func_text_len(elf: &[u8], name: &str) -> usize {
 }
 
 /// Compile an arbitrary repo-relative fixture via the optimized path.
+/// `cse` semantics as in [`compile`]: `true` = shipped default, `false` = the
+/// `=0` opt-out.
 fn compile_fixture(rel: &str, out: &str, cse: bool) -> Vec<u8> {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
         .join(rel);
     let mut cmd = Command::new(synth());
     if cse {
-        cmd.env("SYNTH_CONST_CSE", "1");
+        cmd.env_remove("SYNTH_CONST_CSE");
+    } else {
+        cmd.env("SYNTH_CONST_CSE", "0");
     }
     let status = cmd
         .args([
@@ -160,9 +179,9 @@ fn func_sizes(elf: &[u8]) -> HashMap<String, usize> {
     out
 }
 
-/// Compile a fixture flag-off and flag-on and assert the PR2 (#242) win-recovery
-/// invariant: NO function grows, and every named function shrinks by at most the
-/// bytes accounted for. Returns `(off, on)` size maps for per-function asserts.
+/// Compile a fixture opt-out (`=0`) and default (CSE on) and assert the PR2
+/// (#242) win-recovery invariant: NO function grows under the default. Returns
+/// `(off, on)` size maps for per-function asserts.
 fn corpus_offon(rel: &str, tag: &str) -> (HashMap<String, usize>, HashMap<String, usize>) {
     let off = func_sizes(&compile_fixture(
         rel,
@@ -178,7 +197,7 @@ fn corpus_offon(rel: &str, tag: &str) -> (HashMap<String, usize>, HashMap<String
         let on_len = *on.get(name).unwrap_or(&off_len);
         assert!(
             on_len <= off_len,
-            "no function may grow flag-on: {name} off={off_len}B on={on_len}B ({rel})"
+            "no function may grow under default const-CSE: {name} opt-out={off_len}B default={on_len}B ({rel})"
         );
     }
     (off, on)
@@ -189,7 +208,7 @@ fn corpus_offon(rel: &str, tag: &str) -> (HashMap<String, usize>, HashMap<String
 ///
 ///   - `flight_seam.wat` `flight_algo`: the greedy selector re-materializes the
 ///     same constant into one register at two reuses (the register is clobbered
-///     between), so neither Pass 1 nor the inline cache can see it. The PR2
+///     between), so Pass 1's still-resident fold cannot see it. The PR2
 ///     same-register hoist pins it in a free register and drops the repeat.
 ///   - `const_cse.wat` `spill12`: a 32-bit `movw+movt` constant re-materialized
 ///     12× — recovered only because [`const_units`] reconstructs the pair (PR2
@@ -242,27 +261,48 @@ fn fnv1a64(bytes: &[u8]) -> u64 {
     h
 }
 
-/// CLAIM 1 — flag OFF emits the pinned, pre-change-identical `.text`.
+/// CLAIM 1 — ESCAPE HATCH: `SYNTH_CONST_CSE=0` emits the pinned, pre-flip
+/// `.text` byte-for-byte (the golden is the pre-const-CSE capture, unchanged
+/// by the flip). The rollback proof and a tripwire against the post-hoc CSE
+/// passes leaking into the opt-out path.
 #[test]
-fn const_cse_off_matches_frozen_baseline_242() {
+fn const_cse_escape_hatch_restores_old_bytes_242() {
     let off = compile("/tmp/const_cse_off.elf", false);
     let text = sections(&off).remove(".text").expect(".text present");
     assert_eq!(
         text.len(),
         GOLDEN_OFF_TEXT_LEN,
-        "flag-off .text length drifted from the frozen baseline"
+        "opt-out .text length drifted from the pre-flip baseline"
     );
     assert_eq!(
         fnv1a64(&text),
         GOLDEN_OFF_TEXT_FNV1A,
-        "flag-off optimized-path .text drifted from the pre-const-CSE baseline \
-         — the default-off path is supposed to be byte-identical; re-bless the \
-         golden ONLY if this was an intentional optimized-path lowering change"
+        "SYNTH_CONST_CSE=0 optimized-path .text drifted from the pre-const-CSE \
+         baseline — the opt-out is supposed to restore the pre-flip bytes; \
+         re-bless the golden ONLY if this was an intentional optimized-path \
+         lowering change"
     );
 }
 
-/// CLAIM 2 — flag ON strictly shrinks `large3` (a >16-bit const reused 3× with
-/// register headroom): the redundant movw+movt pairs become register aliases.
+/// CLAIM 2a — DEFAULT GOLDEN: the shipped default emits the pinned CSE'd
+/// `.text` (pinned AFTER const_cse_differential.py re-ran green on these
+/// bytes). An accidental change to the default lowering fails loud here.
+#[test]
+fn const_cse_default_matches_flip_golden_242() {
+    let on = compile("/tmp/const_cse_def.elf", true);
+    let text = sections(&on).remove(".text").expect(".text present");
+    assert_eq!(
+        (text.len(), fnv1a64(&text)),
+        (GOLDEN_DEFAULT_TEXT_LEN, GOLDEN_DEFAULT_TEXT_FNV1A),
+        "shipped-default optimized-path .text drifted from the flip golden — \
+         if intentional, re-run const_cse_differential.py on this commit and \
+         re-pin (they move together)"
+    );
+}
+
+/// CLAIM 2b — the default strictly shrinks `large3` (a >16-bit const reused 3×
+/// with register headroom): the redundant movw+movt pairs are dropped and the
+/// reads retargeted by the post-hoc passes.
 #[test]
 fn const_cse_on_shrinks_headroom_function_242() {
     let off = compile("/tmp/const_cse_red_off.elf", false);

--- a/crates/synth-cli/tests/frozen_codegen_bytes.rs
+++ b/crates/synth-cli/tests/frozen_codegen_bytes.rs
@@ -58,13 +58,14 @@ fn fixture(name: &str) -> std::path::PathBuf {
 /// of its `.text` and the section length. The default-changing opt-out flags
 /// (`SYNTH_NO_CMP_SELECT_FUSE` — v0.13.0 cmp→select; `SYNTH_NO_LOCAL_PROMOTE` —
 /// v0.14.0 local promotion; `SYNTH_RV_CMP_SELECT` — #472 RV32 cmp→select,
-/// `=0` opts out) and the still-opt-in levers (`SYNTH_CONST_CSE`,
-/// `SYNTH_RV_LOCAL_PROMO`) are explicitly removed so a flag set in the
-/// environment can never silently re-freeze the gate — it locks the SHIPPED
-/// lowering, which since v0.14.0 INCLUDES cmp→select fusion AND local
-/// promotion on ARM (both default-on) and since the #472 flip-wave includes
-/// RV32 cmp→select fusion. The `object` crate reads `.text` arch-agnostically
-/// (ARM Thumb-2 and RV32 alike).
+/// `=0` opts out; `SYNTH_CONST_CSE` — #242 const-CSE, `=0` opts out) and the
+/// still-opt-in lever (`SYNTH_RV_LOCAL_PROMO`) are explicitly removed so a
+/// flag set in the environment can never silently re-freeze the gate — it
+/// locks the SHIPPED lowering, which since v0.14.0 INCLUDES cmp→select fusion
+/// AND local promotion on ARM (both default-on), since the #472 flip-wave
+/// includes RV32 cmp→select fusion, and since the #242 const-CSE flip includes
+/// the post-hoc `apply_const_cse` passes on ARM (both paths). The `object`
+/// crate reads `.text` arch-agnostically (ARM Thumb-2 and RV32 alike).
 fn text_sha256(wasm: &str, backend: &str, target: &str) -> (String, usize) {
     let path = fixture(wasm);
     let elf = format!("/tmp/frozenbytes_{backend}_{wasm}.elf");
@@ -162,18 +163,32 @@ fn assert_frozen(cases: &[(&str, &str, usize)], backend: &str, target: &str) {
 /// under the flip). Its own default/opt-out goldens live in
 /// `base_cse_flip_468.rs`. `SYNTH_BASE_CSE` is still env-removed above so a
 /// stray opt-out in the environment can't skew any future coupling.
+///
+/// Goldens RE-FROZEN for the SYNTH_CONST_CSE flip (#242): the post-hoc
+/// `apply_const_cse` passes run on the direct path too (they rewrite the
+/// selected ArmOp stream in `compile_wasm_to_arm`, path-agnostic), so
+/// control_step (304→300, −4) and flight_seam (730→726, −4) each drop one
+/// redundant materialization; flight_seam_flat and signed_div_const are
+/// byte-identical (nothing redundant survives the earlier folds there).
+/// Execution differentials re-run green on the new default bytes BEFORE this
+/// re-pin: control_step 13/13 vs wasmtime, flight_seam flat+inlined
+/// flight_algo 0x07FDF307, const_cse, frame_slot_dce 8/8, spill_rung_581 6/6,
+/// volatile_segment_543 (see the flip PR). `SYNTH_CONST_CSE=0` restores the
+/// prior goldens (asserted by
+/// `frozen_fixtures_const_cse_escape_hatch_restores_old_bytes`). Prior
+/// goldens were control_step 1a97711c…/304, flight_seam 6872d6f3…/730.
 #[test]
 fn frozen_fixtures_text_is_bit_identical_oracle_001() {
     let cases = [
         (
             "control_step.wasm",
-            "1a97711cfb4754794a8577814388f08b81eff444edcba3de7d3e3d18ff435183",
-            304usize,
+            "158b036bc678261a6f6ee71450d0af7b23d92415d16d21679347e2a436c25bb2",
+            300usize,
         ),
         (
             "flight_seam.wasm",
-            "6872d6f3f00331e9a52e176428fca375a87b9fbe0cf2b3eb0fb657c304a7372d",
-            730,
+            "1e1d2b75fe6c4975359c8b1163a6e082a548a0ce1e23d7a360495785bf5e54c2",
+            726,
         ),
         (
             "flight_seam_flat.wasm",
@@ -197,9 +212,10 @@ fn frozen_fixtures_text_is_bit_identical_oracle_001() {
 /// they are not re-checked here; the default gate above already locks them.)
 ///
 /// COMPOSITION NOTE: rolling back to the pre-STACK_FWD bytes now also requires
-/// opting out of the LATER spill-realloc lever (`SYNTH_SPILL_REALLOC=0`), which
-/// defaults on since its own flip and would otherwise rewrite the frame traffic
-/// these goldens pin. The two opt-outs compose; each is separately gated.
+/// opting out of the LATER spill-realloc lever (`SYNTH_SPILL_REALLOC=0`) and
+/// the const-CSE lever (`SYNTH_CONST_CSE=0`, #242) — both default on since
+/// their own flips and would otherwise rewrite the traffic these goldens pin.
+/// The opt-outs compose; each is separately gated.
 #[test]
 fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
     // (fixture, PRE-flip golden sha256, PRE-flip len) — the v0.15.0 goldens.
@@ -220,10 +236,10 @@ fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
         let out = Command::new(synth())
             .env("SYNTH_NO_STACK_FWD", "1")
             .env("SYNTH_SPILL_REALLOC", "0")
+            .env("SYNTH_CONST_CSE", "0")
             .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
             .env_remove("SYNTH_NO_LOCAL_PROMOTE")
             .env_remove("SYNTH_NO_IMM_SHIFT_FOLD")
-            .env_remove("SYNTH_CONST_CSE")
             .env_remove("SYNTH_BASE_CSE")
             .args([
                 "compile",
@@ -270,6 +286,10 @@ fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
 /// the opt-out path. (control_step / signed_div_const are byte-identical under
 /// the flip — no surviving spill traffic — so the default gate above already
 /// locks them for both settings.)
+///
+/// COMPOSITION NOTE: rolling back to these bytes now also requires opting out
+/// of the LATER const-CSE lever (`SYNTH_CONST_CSE=0`, #242 flip), which would
+/// otherwise drop a redundant materialization these goldens pin.
 #[test]
 fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
     // (fixture, PRE-flip golden sha256, PRE-flip len) — the pre-spill-realloc
@@ -290,11 +310,11 @@ fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
         let elf = format!("/tmp/frozen_nospillrealloc_{wasm}.elf");
         let out = Command::new(synth())
             .env("SYNTH_SPILL_REALLOC", "0")
+            .env("SYNTH_CONST_CSE", "0")
             .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
             .env_remove("SYNTH_NO_LOCAL_PROMOTE")
             .env_remove("SYNTH_NO_IMM_SHIFT_FOLD")
             .env_remove("SYNTH_NO_STACK_FWD")
-            .env_remove("SYNTH_CONST_CSE")
             .env_remove("SYNTH_BASE_CSE")
             .args([
                 "compile",
@@ -330,6 +350,78 @@ fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
         assert_eq!(
             hex, golden,
             "{wasm}: SYNTH_SPILL_REALLOC=0 must restore the pre-flip bytes (rollback broken)"
+        );
+    }
+}
+
+/// ESCAPE-HATCH GATE for the SYNTH_CONST_CSE flip (#242). Proves the opt-out
+/// actually rolls back: with `SYNTH_CONST_CSE=0` the two fixtures the flip
+/// moved restore their PRE-flip goldens byte-for-byte — the rollback proof
+/// AND a tripwire against the post-hoc CSE passes leaking into the opt-out
+/// path. (flight_seam_flat / signed_div_const are byte-identical under the
+/// flip, so the default gate above locks them for both settings.) Unlike the
+/// earlier hatches this needs NO composition: const-CSE is the LAST-flipped
+/// lever, so `=0` alone lands exactly on the previous shipped default.
+#[test]
+fn frozen_fixtures_const_cse_escape_hatch_restores_old_bytes() {
+    // (fixture, PRE-flip golden sha256, PRE-flip len) — the pre-const-CSE
+    // goldens (the SYNTH_BASE_CSE-flip-era defaults).
+    let old = [
+        (
+            "control_step.wasm",
+            "1a97711cfb4754794a8577814388f08b81eff444edcba3de7d3e3d18ff435183",
+            304usize,
+        ),
+        (
+            "flight_seam.wasm",
+            "6872d6f3f00331e9a52e176428fca375a87b9fbe0cf2b3eb0fb657c304a7372d",
+            730,
+        ),
+    ];
+    for &(wasm, golden, golden_len) in &old {
+        let elf = format!("/tmp/frozen_nocse_{wasm}.elf");
+        let out = Command::new(synth())
+            .env("SYNTH_CONST_CSE", "0")
+            .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
+            .env_remove("SYNTH_NO_LOCAL_PROMOTE")
+            .env_remove("SYNTH_NO_IMM_SHIFT_FOLD")
+            .env_remove("SYNTH_NO_STACK_FWD")
+            .env_remove("SYNTH_SPILL_REALLOC")
+            .env_remove("SYNTH_BASE_CSE")
+            .args([
+                "compile",
+                fixture(wasm).to_str().unwrap(),
+                "-o",
+                &elf,
+                "-b",
+                "arm",
+                "--target",
+                "cortex-m4",
+                "--all-exports",
+                "--relocatable",
+            ])
+            .output()
+            .expect("run synth");
+        assert!(out.status.success(), "compile failed for {wasm}");
+        let bytes = std::fs::read(&elf).expect("read elf");
+        let obj = object::File::parse(&*bytes).expect("parse elf");
+        let data = obj
+            .section_by_name(".text")
+            .expect(".text")
+            .data()
+            .expect("read .text");
+        assert_eq!(
+            data.len(),
+            golden_len,
+            "{wasm}: SYNTH_CONST_CSE=0 must restore the pre-flip length"
+        );
+        let hex: String = Sha256::digest(data)
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        assert_eq!(
+            hex, golden,
+            "{wasm}: SYNTH_CONST_CSE=0 must restore the pre-flip bytes (rollback broken)"
         );
     }
 }

--- a/crates/synth-cli/tests/volatile_segment_flag_543.rs
+++ b/crates/synth-cli/tests/volatile_segment_flag_543.rs
@@ -7,16 +7,15 @@
 //! the #468 base-CSE excludes accesses inside a marked range from its fold set
 //! and const-CSE declines wholesale while any range is marked.
 //!
-//! Since the base-CSE lever flip (#468, default-ON), the DEFAULT
-//! configuration genuinely CONSUMES the ranges — marking a range can change
-//! the emitted bytes (that is the Phase-2 contract working, locked in
-//! `volatile_segment_phase2_543.rs`). The inertness claim locked HERE is
-//! therefore the OPT-OUT form: with the levers disabled (`SYNTH_BASE_CSE=0`,
-//! `SYNTH_CONST_CSE` unset — const-CSE is still opt-in), compiling WITH
-//! `--volatile-segment` must produce byte-identical `.text` to compiling
-//! WITHOUT it (the ranges are consumed vacuously). Value-level parsing
-//! correctness (base/len, malformed → error) is unit-tested in
-//! `main.rs::tests` (`volatile_segment_*_543`).
+//! Since the lever flips (#468 base-CSE, #242 const-CSE — both default-ON),
+//! the DEFAULT configuration genuinely CONSUMES the ranges — marking a range
+//! can change the emitted bytes (that is the Phase-2 contract working, locked
+//! in `volatile_segment_phase2_543.rs`). The inertness claim locked HERE is
+//! therefore the OPT-OUT form: with the levers disabled (`SYNTH_BASE_CSE=0`
+//! AND `SYNTH_CONST_CSE=0`), compiling WITH `--volatile-segment` must produce
+//! byte-identical `.text` to compiling WITHOUT it (the ranges are consumed
+//! vacuously). Value-level parsing correctness (base/len, malformed → error)
+//! is unit-tested in `main.rs::tests` (`volatile_segment_*_543`).
 //!
 //! Traceability: rivet `VCR-DMA-001`, gale decision `DD-DMA-REGION-001`.
 
@@ -124,27 +123,33 @@ fn volatile_segment_flag_rejects_garbage_543() {
 }
 
 /// INERTNESS on the LEVERS-OPTED-OUT configuration: with `SYNTH_BASE_CSE=0`
-/// (base-CSE is default-ON since the lever flip) and const-CSE unset (still
-/// opt-in), compiling WITH the flag is `.text`-byte-identical to compiling
-/// WITHOUT it — the ranges are consumed vacuously when no address-caching
-/// lever is active. The byte-CHANGING behavior on the shipped default (and
-/// under `SYNTH_CONST_CSE=1`) is locked in `volatile_segment_phase2_543.rs`.
+/// and `SYNTH_CONST_CSE=0` (both levers are default-ON since their flips),
+/// compiling WITH the flag is `.text`-byte-identical to compiling WITHOUT it
+/// — the ranges are consumed vacuously when no address-caching lever is
+/// active. The byte-CHANGING behavior on the shipped default is locked in
+/// `volatile_segment_phase2_543.rs`.
 #[test]
 fn volatile_segment_flag_is_byte_inert_543() {
     const BASE_CSE_OFF: (&str, &str) = ("SYNTH_BASE_CSE", "0");
-    let without = compile_text(FIXTURE, "inert_without", &[BASE_CSE_OFF], &[])
-        .expect("baseline compile (no flag) must succeed");
+    const CONST_CSE_OFF: (&str, &str) = ("SYNTH_CONST_CSE", "0");
+    let without = compile_text(
+        FIXTURE,
+        "inert_without",
+        &[BASE_CSE_OFF, CONST_CSE_OFF],
+        &[],
+    )
+    .expect("baseline compile (no flag) must succeed");
     let with = compile_text(
         FIXTURE,
         "inert_with",
-        &[BASE_CSE_OFF],
+        &[BASE_CSE_OFF, CONST_CSE_OFF],
         &["--volatile-segment", "0x20001000:4096"],
     )
     .expect("compile with flag must succeed");
     assert_eq!(
         without, with,
         "#543: --volatile-segment changed the emitted .text with every \
-         address-caching lever disabled (SYNTH_BASE_CSE=0, const-CSE unset) \
+         address-caching lever disabled (SYNTH_BASE_CSE=0, SYNTH_CONST_CSE=0) \
          — the back-off must only fire through an active lever"
     );
 }

--- a/crates/synth-cli/tests/volatile_segment_phase2_543.rs
+++ b/crates/synth-cli/tests/volatile_segment_phase2_543.rs
@@ -16,22 +16,26 @@
 //!      (statically-unknown) addresses were never fold candidates, so they are
 //!      always left verbatim — the conservative stance.
 //!
-//!   2. const-CSE (`SYNTH_CONST_CSE=1`, still opt-in — its recorded flip
-//!      prerequisites are unmet, see `const_cse_reduction_242.rs` — both the
-//!      bridge-level cache and `liveness::apply_const_cse`): declines
-//!      WHOLESALE while any range is marked, because at that level a cached
-//!      constant cannot be classified address-vs-data — every constant is
-//!      re-materialized at each occurrence, the documented volatile contract
-//!      (conservative v1).
+//!   2. const-CSE (`liveness::apply_const_cse`, DEFAULT-ON since the #242
+//!      flip, opt-out `SYNTH_CONST_CSE=0`; the former bridge-level inline
+//!      cache is retired): declines WHOLESALE while any range is marked,
+//!      because at that level a cached constant cannot be classified
+//!      address-vs-data — every constant is re-materialized at each
+//!      occurrence, the documented volatile contract (conservative v1).
 //!
-//! Since the base-CSE flip the DEFAULT pipeline genuinely CONSUMES the ranges
+//! Since the lever flips the DEFAULT pipeline genuinely CONSUMES the ranges
 //! (marking a range can change default bytes — that is the Phase-2 contract
-//! doing its job); with the levers opted OUT (`SYNTH_BASE_CSE=0`, const-CSE
-//! unset) the ranges are consumed vacuously and `--volatile-segment` stays
-//! byte-inert (the Phase-1 test pins that opt-out form). An empty range
-//! vector changes nothing by construction (the frozen-codegen anchors still
-//! pass — they compile `--relocatable`, the direct path base-CSE never
-//! reaches).
+//! doing its job); with the levers opted OUT (`SYNTH_BASE_CSE=0`,
+//! `SYNTH_CONST_CSE=0`) the ranges are consumed vacuously and
+//! `--volatile-segment` stays byte-inert (the Phase-1 test pins that opt-out
+//! form). An empty range vector changes nothing by construction.
+//!
+//! The base-CSE lattice below pins `SYNTH_CONST_CSE=0` on ALL FOUR builds so
+//! it isolates the base-CSE lever (with const-CSE running, the range-free
+//! arms shrink for const-CSE's own reasons and the F ≡ C equality goes
+//! vacuous). No coverage is lost: with any range marked const-CSE declines
+//! wholesale, so the range-marked builds are byte-identical to the shipped
+//! default — exactly what the const-CSE gate below asserts.
 //!
 //! Semantic (results-level) equivalence in both modes is the separate
 //! `scripts/repro/volatile_segment_543_differential.py` unicorn-vs-wasmtime
@@ -103,6 +107,9 @@ fn compile_text(
 const FIXTURE: &str = "volatile_segment_543.wat";
 /// The base-CSE OPT-OUT (default-ON since the lever flip).
 const BASE_CSE_OFF: (&str, &str) = ("SYNTH_BASE_CSE", "0");
+/// The const-CSE OPT-OUT (default-ON since the #242 flip) — pinned on the
+/// base-CSE lattice builds to isolate that lever.
+const CONST_CSE_OFF: (&str, &str) = ("SYNTH_CONST_CSE", "0");
 
 /// The red→green Phase-2 oracle for base-CSE (#468).
 ///
@@ -121,13 +128,18 @@ const BASE_CSE_OFF: (&str, &str) = ("SYNTH_BASE_CSE", "0");
 ///        byte-identical to C — every store survives verbatim.
 #[test]
 fn base_cse_honors_volatile_window_543() {
-    let c = compile_text(FIXTURE, "baseline", &[BASE_CSE_OFF], &[]);
-    let a = compile_text(FIXTURE, "folded", &[], &[]);
-    let p = compile_text(FIXTURE, "window", &[], &["--volatile-segment", "0x100:16"]);
+    let c = compile_text(FIXTURE, "baseline", &[BASE_CSE_OFF, CONST_CSE_OFF], &[]);
+    let a = compile_text(FIXTURE, "folded", &[CONST_CSE_OFF], &[]);
+    let p = compile_text(
+        FIXTURE,
+        "window",
+        &[CONST_CSE_OFF],
+        &["--volatile-segment", "0x100:16"],
+    );
     let f = compile_text(
         FIXTURE,
         "fullcover",
-        &[],
+        &[CONST_CSE_OFF],
         &["--volatile-segment", "0x80:144"],
     );
 
@@ -160,10 +172,11 @@ fn base_cse_honors_volatile_window_543() {
     );
 }
 
-/// The red→green Phase-2 oracle for const-CSE: any marked range ⇒ wholesale
-/// decline (conservative v1 — constants can't be classified address-vs-data),
-/// byte-identical to never enabling `SYNTH_CONST_CSE`. Uses the existing
-/// const-CSE headroom fixture whose flag-ON reduction is already CI-pinned
+/// The red→green Phase-2 oracle for const-CSE (DEFAULT-ON since the #242
+/// flip): any marked range ⇒ wholesale decline (conservative v1 — constants
+/// can't be classified address-vs-data), byte-identical to the
+/// `SYNTH_CONST_CSE=0` opt-out. Uses the existing const-CSE headroom fixture
+/// whose default reduction is already CI-pinned
 /// (`const_cse_reduction_242.rs`). All three compiles pin `SYNTH_BASE_CSE=0`
 /// to isolate the const-CSE lever: base-CSE is default-ON and does a SURGICAL
 /// (per-access) volatile back-off, so leaving it on would make the
@@ -173,28 +186,34 @@ fn base_cse_honors_volatile_window_543() {
 /// that accident.)
 #[test]
 fn const_cse_declines_wholesale_under_volatile_543() {
-    const CSE: (&str, &str) = ("SYNTH_CONST_CSE", "1");
-    let base = compile_text("const_cse.wat", "cse_baseline", &[BASE_CSE_OFF], &[]);
-    let on = compile_text("const_cse.wat", "cse_on", &[CSE, BASE_CSE_OFF], &[]);
+    let base = compile_text(
+        "const_cse.wat",
+        "cse_baseline",
+        &[BASE_CSE_OFF, CONST_CSE_OFF],
+        &[],
+    );
+    // Shipped default (const-CSE env untouched by `compile_text`'s removal).
+    let on = compile_text("const_cse.wat", "cse_on", &[BASE_CSE_OFF], &[]);
     let on_volatile = compile_text(
         "const_cse.wat",
         "cse_on_volatile",
-        &[CSE, BASE_CSE_OFF],
+        &[BASE_CSE_OFF],
         &["--volatile-segment", "0x100:16"],
     );
 
     assert!(
         on.len() < base.len(),
-        "non-vacuity: const-CSE must fire on the headroom fixture \
+        "non-vacuity: default const-CSE must fire on the headroom fixture \
          ({} B !< {} B)",
         on.len(),
         base.len()
     );
     assert_eq!(
         on_volatile, base,
-        "#543 Phase 2 RED CHECK: with a marked volatile range const-CSE must \
-         decline wholesale — byte-identical to SYNTH_CONST_CSE unset (a \
-         difference means an aliasing rewrite still fired)"
+        "#543 Phase 2 RED CHECK: with a marked volatile range the DEFAULT \
+         const-CSE must decline wholesale — byte-identical to the \
+         SYNTH_CONST_CSE=0 opt-out (a difference means a CSE rewrite still \
+         fired inside a volatile build)"
     );
 }
 

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -182,12 +182,12 @@ pub struct CompileConfig {
     ///    intersects a marked range is EXCLUDED from the fold set — it keeps
     ///    its verbatim per-access materialize-and-access codegen, while
     ///    accesses outside the range still fold;
-    ///  - const-CSE (`SYNTH_CONST_CSE`, both the bridge-level cache in
-    ///    `optimizer_bridge::ir_to_arm` and `liveness::apply_const_cse` wired in
-    ///    `arm_backend.rs`): declines WHOLESALE while any range is marked — a
-    ///    cached constant cannot be classified address-vs-data at that level, so
-    ///    the conservative stance for statically-unknown addressing is to
-    ///    re-materialize every constant at each occurrence.
+    ///  - const-CSE (`liveness::apply_const_cse` wired in `arm_backend.rs`,
+    ///    DEFAULT-ON, opt-out `SYNTH_CONST_CSE=0`; the former bridge-level
+    ///    inline cache is retired, #242): declines WHOLESALE while any range is
+    ///    marked — a cached constant cannot be classified address-vs-data at
+    ///    that level, so the conservative stance for statically-unknown
+    ///    addressing is to re-materialize every constant at each occurrence.
     ///
     /// Passes that only touch SP-relative frame slots (stack-reload forwarding,
     /// frame-slot DCE, spill re-choice) are unaffected by design: these ranges

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -3757,8 +3757,8 @@ fn free_reg_over(
 /// — otherwise the whole segment's CSE is declined and every materialization is
 /// kept. Monotone-or-neutral on size by measurement, not by hand-wave.
 ///
-/// WIN RECOVERY (PR2, #242): the cross-register fold above (and the inline cache)
-/// only catch a constant that is *still resident* in some register. gale measured
+/// WIN RECOVERY (PR2, #242): the cross-register fold above only catches a
+/// constant that is *still resident* in some register. gale measured
 /// 61% of flat_flight's materializations as redundant, yet almost none are of that
 /// shape — the greedy selector re-materializes each clamp constant into the SAME
 /// register, which is clobbered between uses, so no register holds it at the reuse.
@@ -3894,7 +3894,7 @@ fn cross_reg_const_cse(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize
 /// Pass 2 (PR2, #242 win recovery): same-register extending-alias hoist. The
 /// greedy selector re-materializes a constant into the SAME register at each
 /// reuse (e.g. flat_flight's clamp `movw r3,#980 … movw r3,#980`, with `r3`
-/// clobbered between — so no register holds it and Pass 1 / the inline cache miss
+/// clobbered between — so no register holds it and Pass 1 misses
 /// it). For a value re-materialized into one register ≥2× in a straight-line
 /// segment, pin it in a register that is provably FREE across the reuse window
 /// ([`free_reg_over`]), delete the repeat materializations, and retarget the
@@ -9522,7 +9522,7 @@ mod tests {
     fn const_cse_hoists_a_same_register_reuse_into_a_free_register_242() {
         // #242 PR2 win recovery: `movw r2,#500` is materialized into r2, r2 is
         // clobbered (to #9) between uses, then #500 is re-materialized into r2 —
-        // the SAME register, so Pass 1 / the inline cache miss it (no register
+        // the SAME register, so Pass 1 misses it (no register
         // holds 500 at the reuse). The extending-alias hoist pins 500 in a FREE
         // register (r0), drops the repeat, and retargets both uses. r2 is redefined
         // at the end (#1) so its value is local.

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -3734,6 +3734,94 @@ fn free_reg_over(
     None
 }
 
+/// Geometry of RESOLVED numeric branches (`BOffset`/`BCondOffset`) — the #604
+/// `nested(1,)` soundness rule.
+///
+/// The optimized (non-`--relocatable`) path resolves its branch displacements
+/// to byte-accurate halfword offsets INSIDE `optimizer_bridge::ir_to_arm` —
+/// BEFORE `apply_const_cse` runs — and nothing re-resolves them afterwards
+/// (`resolve_label_branches` explicitly leaves `BOffset`/`BCondOffset`
+/// untouched). Two consequences for any rewrite performed here:
+///
+///   1. a branch TARGET (join point) is invisible in the stream — no `Label`
+///      op marks it — so a "straight-line segment" can silently span a join,
+///      and `held`/hoist state proven along the fall-through path does NOT
+///      hold on the taken edge. (`spill_frame_499.wat::nested(1)`: the join
+///      tail's base materialization was folded onto a register only defined
+///      on the fall-through arm, so the taken path stored 55 over the 99.)
+///   2. deleting or resizing an instruction BETWEEN a branch and its target
+///      changes their byte distance, silently invalidating the pre-resolved
+///      displacement. (Same miscompile: two 8-byte `movw+movt` deletions in
+///      the arm made the `b` overshoot the join by exactly 16 bytes.)
+///
+/// This helper reconstructs each numeric branch's target instruction index by
+/// mirroring the bridge's own offset table (`estimate_arm_byte_size`, the
+/// #511-pinned estimator the displacements were computed against), so the
+/// passes can (1) treat every target as a segment BARRIER and (2) FREEZE the
+/// total byte size of any segment lying between a branch and its target.
+#[derive(Default)]
+struct ResolvedBranchGeometry {
+    /// Instruction indices that are targets of resolved numeric branches —
+    /// segment barriers (the target instruction STARTS a fresh segment).
+    targets: BTreeSet<usize>,
+    /// Per-instruction: lies between some resolved branch and its target, so
+    /// the enclosing segment's total byte size is load-bearing for that
+    /// displacement and must not change.
+    frozen: Vec<bool>,
+}
+
+/// `Some(geometry)` when every resolved numeric branch's displacement maps to
+/// an exact instruction boundary (empty geometry when there are none);
+/// `None` when a target cannot be mapped — or when the stream mixes numeric
+/// branches with `Label` pseudo-ops (whose real size is 0, not the
+/// estimator's default) — in which case the caller must decline the whole
+/// function rather than guess.
+fn resolved_branch_geometry(instrs: &[ArmInstruction]) -> Option<ResolvedBranchGeometry> {
+    use crate::optimizer_bridge::estimate_arm_byte_size;
+    let n = instrs.len();
+    if !instrs
+        .iter()
+        .any(|i| matches!(i.op, ArmOp::BOffset { .. } | ArmOp::BCondOffset { .. }))
+    {
+        return Some(ResolvedBranchGeometry {
+            targets: BTreeSet::new(),
+            frozen: vec![false; n],
+        });
+    }
+    if instrs.iter().any(|i| matches!(i.op, ArmOp::Label { .. })) {
+        return None; // mixed stream: byte offsets not reconstructible
+    }
+    // Mirror of the bridge's resolution table.
+    let mut byte_offsets: Vec<i64> = Vec::with_capacity(n + 1);
+    let mut cur: i64 = 0;
+    for ins in instrs {
+        byte_offsets.push(cur);
+        cur += estimate_arm_byte_size(&ins.op) as i64;
+    }
+    byte_offsets.push(cur);
+    let mut targets = BTreeSet::new();
+    let mut frozen = vec![false; n];
+    for (i, ins) in instrs.iter().enumerate() {
+        let offset = match &ins.op {
+            ArmOp::BOffset { offset } => *offset,
+            ArmOp::BCondOffset { offset, .. } => *offset,
+            _ => continue,
+        };
+        // Displacement is halfwords from PC (branch byte + 4):
+        // target byte = branch + 4 + 2·offset — the bridge's own formula.
+        let target_byte = byte_offsets[i] + 4 + 2 * offset as i64;
+        let ti = byte_offsets.binary_search(&target_byte).ok()?;
+        targets.insert(ti); // ti == n (function end) is a vacuous barrier
+        // Freeze everything between branch and target (either direction):
+        // deleting/resizing any of it shifts exactly one endpoint.
+        let (lo, hi) = if ti > i { (i, ti) } else { (ti, i) };
+        for f in frozen.iter_mut().take(hi.min(n)).skip(lo) {
+            *f = true;
+        }
+    }
+    Some(ResolvedBranchGeometry { targets, frozen })
+}
+
 /// Const-CSE / rematerialization-avoidance driven by the value-range analysis:
 /// where a `movw rd, #v` re-materializes a constant already resident in `ra`,
 /// and `ra` provably still holds `v` through every later read of `rd` (until
@@ -3794,6 +3882,11 @@ pub fn apply_const_cse(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize
 fn cross_reg_const_cse(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
     use crate::optimizer_bridge::estimate_arm_byte_size;
     let n = instrs.len();
+    // #604: resolved numeric branches make join points invisible and byte
+    // layout load-bearing — decline the whole function if unmappable.
+    let Some(geo) = resolved_branch_geometry(instrs) else {
+        return (instrs.to_vec(), 0);
+    };
     let mut removed = vec![false; n];
     let mut rewrites: Vec<(usize, Reg, Reg)> = Vec::new(); // (use_index, from, to)
 
@@ -3844,7 +3937,16 @@ fn cross_reg_const_cse(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize
                 estimate_arm_byte_size(&op)
             })
             .sum();
-        if new_bytes <= orig_bytes {
+        // #604: a segment between a resolved branch and its target has a
+        // load-bearing byte size (the displacement was resolved against it) —
+        // its rewrite must be exactly size-neutral, not merely no-grow.
+        let frozen_seg = geo.frozen[start..end].iter().any(|&f| f);
+        let size_ok = if frozen_seg {
+            new_bytes == orig_bytes
+        } else {
+            new_bytes <= orig_bytes
+        };
+        if size_ok {
             for i in seg_removed {
                 removed[i] = true;
             }
@@ -3852,6 +3954,13 @@ fn cross_reg_const_cse(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize
         }
     };
     for (i, ins) in instrs.iter().enumerate() {
+        // #604: a resolved-branch TARGET is a join point — state proven above
+        // it holds only on the fall-through edge. Barrier; the target
+        // instruction itself starts the next segment.
+        if geo.targets.contains(&i) && i > seg_start {
+            process_segment(seg_start, i);
+            seg_start = i;
+        }
         if !is_straight_line(&ins.op) || reg_effect(&ins.op).is_none() {
             if i > seg_start {
                 process_segment(seg_start, i);
@@ -3905,6 +4014,11 @@ fn cross_reg_const_cse(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize
 fn extending_alias_hoist(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
     use crate::optimizer_bridge::estimate_arm_byte_size;
     let n = instrs.len();
+    // #604: recomputed on THIS pass's input (pass 1 preserved every resolved
+    // displacement, so the reconstruction stays exact on its output).
+    let Some(geo) = resolved_branch_geometry(instrs) else {
+        return (instrs.to_vec(), 0);
+    };
     let mut removed = vec![false; n];
     let mut rewrites: Vec<(usize, Reg, Reg)> = Vec::new(); // (use_index, from, to)
     let mut replace_at: BTreeMap<usize, ArmOp> = BTreeMap::new(); // holder materializations
@@ -4074,7 +4188,14 @@ fn extending_alias_hoist(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usi
             .sum();
         let pressure_ok =
             matches!(straight_line_peak_pressure(&rewritten), Some(p) if p <= ALLOCATABLE_POOL);
-        if new_bytes <= orig_bytes && pressure_ok {
+        // #604: size-frozen between a resolved branch and its target.
+        let frozen_seg = geo.frozen[start..end].iter().any(|&f| f);
+        let size_ok = if frozen_seg {
+            new_bytes == orig_bytes
+        } else {
+            new_bytes <= orig_bytes
+        };
+        if size_ok && pressure_ok {
             for i in seg_removed {
                 removed[i] = true;
             }
@@ -4083,6 +4204,11 @@ fn extending_alias_hoist(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usi
         }
     };
     for (i, ins) in instrs.iter().enumerate() {
+        // #604: resolved-branch target = join point = barrier (see pass 1).
+        if geo.targets.contains(&i) && i > seg_start {
+            process_segment(seg_start, i);
+            seg_start = i;
+        }
         if !is_straight_line(&ins.op) || reg_effect(&ins.op).is_none() {
             if i > seg_start {
                 process_segment(seg_start, i);
@@ -9611,6 +9737,172 @@ mod tests {
         ];
         let (_out, removed) = apply_const_cse(&seq);
         assert_eq!(removed, 0, "value live-out → hoist declines");
+    }
+
+    #[test]
+    fn const_cse_treats_resolved_branch_target_as_state_barrier_604() {
+        // The #604 nested(1,) miscompile, minimized: a resolved `BOffset`
+        // (optimized-path, already byte-resolved — target = branch + 4 + 2·off)
+        // jumps over a fall-through arm to a JOIN. Pre-fix, the join carried no
+        // barrier (no `Label` op), so the segment spanned it and the join's
+        // `movw r1,#0x63` was folded onto r0 — a register only defined on the
+        // fall-through arm. On the taken edge r0 holds something else entirely.
+        //
+        // Byte layout (estimator): BOffset=2 @0, Movw=4 @2, Cmp=2 @6, JOIN
+        // Movw=4 @8, Cmp=2 @12, Movw=4 @14. offset 2 ⇒ target byte 8 = JOIN.
+        let seq = vec![
+            ins(ArmOp::BOffset { offset: 2 }),
+            ins(ArmOp::Movw {
+                rd: Reg::R0,
+                imm16: 0x63,
+            }),
+            ins(ArmOp::Cmp {
+                rn: Reg::R4,
+                op2: Operand2::Reg(Reg::R0),
+            }),
+            // JOIN (branch target): both edges execute from here on.
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 0x63,
+            }),
+            ins(ArmOp::Cmp {
+                rn: Reg::R5,
+                op2: Operand2::Reg(Reg::R1),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 7,
+            }),
+        ];
+        let (out, removed) = apply_const_cse(&seq);
+        assert_eq!(removed, 0, "join is a barrier: fall-through-only residency");
+        assert_eq!(out.len(), seq.len(), "stream unchanged");
+    }
+
+    #[test]
+    fn const_cse_freezes_bytes_between_resolved_branch_and_target_604() {
+        // A backward resolved branch (loop shape): every byte between target
+        // and branch is load-bearing for the pre-resolved displacement, so a
+        // fold that DELETES a materialization inside the span must decline
+        // even where the residency proof itself holds.
+        //
+        // Byte layout: Movw=4 @0, Cmp=2 @4, Movw=4 @6, Cmp=2 @10, Movw=4 @12,
+        // BOffset=2 @16. offset -10 ⇒ target byte 16 + 4 − 20 = 0 (loop head).
+        let seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R0,
+                imm16: 0x7e,
+            }),
+            ins(ArmOp::Cmp {
+                rn: Reg::R5,
+                op2: Operand2::Reg(Reg::R0),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 0x7e,
+            }),
+            ins(ArmOp::Cmp {
+                rn: Reg::R6,
+                op2: Operand2::Reg(Reg::R1),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 5,
+            }),
+            ins(ArmOp::BOffset { offset: -10 }),
+        ];
+        let (out, removed) = apply_const_cse(&seq);
+        assert_eq!(removed, 0, "in-span deletion would shift the displacement");
+        assert_eq!(out.len(), seq.len(), "stream unchanged");
+    }
+
+    #[test]
+    fn const_cse_still_folds_outside_resolved_branch_spans_604() {
+        // The soundness rule is targeted, not wholesale: a straight-line block
+        // AFTER every resolved-branch span (here a 2-byte skip-the-UDF trap
+        // guard: offset 0 ⇒ target byte 0 + 4 = the Movw) still folds.
+        let seq = vec![
+            ins(ArmOp::BCondOffset {
+                cond: crate::rules::Condition::NE,
+                offset: 0,
+            }),
+            ins(ArmOp::Udf { imm: 0 }),
+            // Past the span: the redundant-clamp shape folds as before.
+            ins(ArmOp::Movw {
+                rd: Reg::R0,
+                imm16: 0x7e,
+            }),
+            ins(ArmOp::Cmp {
+                rn: Reg::R5,
+                op2: Operand2::Reg(Reg::R0),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 0x7e,
+            }),
+            ins(ArmOp::Cmp {
+                rn: Reg::R6,
+                op2: Operand2::Reg(Reg::R1),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 99,
+            }),
+        ];
+        let (out, removed) = apply_const_cse(&seq);
+        assert_eq!(removed, 1, "fold outside the frozen span still commits");
+        assert!(
+            out.iter().any(|i| matches!(
+                &i.op,
+                ArmOp::Cmp {
+                    rn: Reg::R6,
+                    op2: Operand2::Reg(Reg::R0)
+                }
+            )),
+            "the surviving read is retargeted to the resident register"
+        );
+    }
+
+    #[test]
+    fn const_cse_hoist_declines_inside_resolved_branch_span_604() {
+        // The extending-alias hoist (pass 2) obeys the same freeze: the exact
+        // profitable same-register-reuse shape it exists for, wrapped in a
+        // backward resolved branch so the whole body is displacement-frozen.
+        // Deleting the repeat would shrink the span ⇒ decline.
+        let add = |rd, rn| {
+            ins(ArmOp::Add {
+                rd,
+                rn,
+                op2: Operand2::Reg(rn),
+            })
+        };
+        let mut seq = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R2,
+                imm16: 500,
+            }),
+            add(Reg::R3, Reg::R2),
+            ins(ArmOp::Movw {
+                rd: Reg::R2,
+                imm16: 9,
+            }),
+            add(Reg::R4, Reg::R2),
+            ins(ArmOp::Movw {
+                rd: Reg::R2,
+                imm16: 500,
+            }),
+            add(Reg::R5, Reg::R2),
+            ins(ArmOp::Movw {
+                rd: Reg::R2,
+                imm16: 1,
+            }),
+        ];
+        // Bytes: Movw=4 / low-reg Add=2 → 4+2+4+2+4+2+4 = 22; branch @22 ⇒
+        // target 22 + 4 + 2·(−13) = 0 (the loop head).
+        seq.push(ins(ArmOp::BOffset { offset: -13 }));
+        let (out, removed) = apply_const_cse(&seq);
+        assert_eq!(removed, 0, "hoist deletion inside the span would shift it");
+        assert_eq!(out.len(), seq.len(), "stream unchanged");
     }
 
     #[test]

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -3147,30 +3147,18 @@ impl OptimizerBridge {
             });
         }
 
-        // VCR-RA const-CSE (#242): when the same constant is already
-        // materialized in a still-valid register, alias the new vreg to that
-        // register and emit NO materialization. Pressure-neutral-or-better — the
-        // value is already in a register, so aliasing never adds register
-        // pressure (it can only share one). `reg_holds_const` (keyed by the
-        // u32 bit-pattern, so a negative i32 const matches its movw/movt
-        // reconstruction) is derived from the EMITTED ARM at the top of each
-        // iteration — so it survives the many `continue` arms — and is reset at
-        // every control-flow boundary, confining CSE to straight-line segments.
-        // Opt-in `SYNTH_CONST_CSE=1`; off ⇒ byte-identical (no new state read).
-        //
-        // #543 Phase 2: const-CSE declines WHOLESALE while any volatile DMA
-        // range is marked. At this level a cached constant cannot be classified
-        // as address-vs-data (its uses — including memory-access bases with
-        // per-use immediate offsets — are not known at aliasing time), so the
-        // conservative stance for statically-unknown addressing is to decline
-        // every aliasing rewrite: each constant, address or not, is
-        // re-materialized at each occurrence, which is exactly the documented
-        // volatile contract (`CompileConfig::volatile_segments`). Empty ranges
-        // (the default) ⇒ unchanged behavior by construction.
-        let const_cse =
-            std::env::var("SYNTH_CONST_CSE").is_ok() && self.volatile_segments.is_empty();
-        let mut reg_holds_const: HashMap<Reg, u32> = HashMap::new();
-        let mut cse_seen_len = 0usize;
+        // VCR-RA const-CSE (#242): the bridge-level INLINE aliasing that used
+        // to live here (alias a repeated const's vreg to the register already
+        // holding the value, under `SYNTH_CONST_CSE`) is RETIRED. Inline
+        // aliasing made two live vregs share one physical register, breaking
+        // the spill model's vreg↔reg bijection — the recorded alias-eviction
+        // hazard that blocked the default-on flip (see the #592 PR body and
+        // `const_cse_reduction_242.rs`). Const materialization now always
+        // falls through to the normal allocate-and-emit below; the flag gates
+        // ONLY the post-hoc, liveness-proven `liveness::apply_const_cse`
+        // passes wired in `arm_backend.rs` (PR1 #519 cross-register fold +
+        // PR2 #562 extending-alias hoist), which are removal+retarget on
+        // already-register-assigned code and cannot alias two live vregs.
 
         // VCR-RA-001 allocation-time spill-on-exhaustion (#242, closes #496 for
         // straight-line i32 functions; #587 extends it to i64 register PAIRS).
@@ -3226,39 +3214,6 @@ impl OptimizerBridge {
 
         // Second pass: generate ARM instructions
         for (spill_idx, inst) in instructions.iter().enumerate() {
-            if const_cse {
-                // Reconcile the cache with everything emitted since last iteration.
-                for op in &arm_instrs[cse_seen_len..] {
-                    match op {
-                        ArmOp::Movw { rd, imm16 } => {
-                            reg_holds_const.insert(*rd, *imm16 as u32);
-                        }
-                        ArmOp::Movt { rd, imm16 } => {
-                            let lo = reg_holds_const.get(rd).copied().unwrap_or(0) & 0xFFFF;
-                            reg_holds_const.insert(*rd, lo | ((*imm16 as u32) << 16));
-                        }
-                        ArmOp::Mov {
-                            rd,
-                            op2: Operand2::Imm(v),
-                        } => {
-                            reg_holds_const.insert(*rd, *v as u32);
-                        }
-                        other => match crate::liveness::reg_effect(other) {
-                            // Any other write clobbers the const in its dest reg(s).
-                            Some(eff) => {
-                                for d in eff.defs {
-                                    reg_holds_const.remove(&d);
-                                }
-                            }
-                            // Unmodeled op (branch/bl/bx/label) = control-flow
-                            // boundary: the cache cannot be trusted across it.
-                            None => reg_holds_const.clear(),
-                        },
-                    }
-                }
-                cse_seen_len = arm_instrs.len();
-            }
-
             // VCR-RA-001 spill pre-step (#242, #496): with the flag on and the
             // whole function in the modeled subset, make sure the handler below
             // never hits pool exhaustion:
@@ -3591,33 +3546,14 @@ impl OptimizerBridge {
                     {
                         continue;
                     }
-                    // const-CSE: if this exact value already lives in a register
-                    // (and `dest` isn't a pre-assigned local/param), alias `dest`
-                    // to it and emit nothing. The aliased register is protected
-                    // from reuse while `dest` is live (it's in `vreg_to_arm`).
-                    //
-                    // DEFAULT-OFF prerequisite for the flip (see
-                    // const_cse_reduction_242.rs): aliasing makes two live vregs
+                    // NOTE (#242): the inline const-CSE aliasing that used to
+                    // short-circuit here (alias `dest` to a register already
+                    // holding the value) is RETIRED — it made two live vregs
                     // share one physical register, breaking the spill model's
-                    // vreg↔reg bijection (the eviction path at ~3168 spills a
-                    // SINGLE victim vreg). If the older alias is spilled while the
-                    // younger keeps the alias, the freed register is reused under
-                    // the younger → stale read. Not reachable today (the IR
-                    // optimizer dedups consecutive identical consts upstream), but
-                    // default-on must prove unreachability or make the spill path
-                    // alias-aware (spill ALL vregs sharing the victim register).
-                    let cse_want = *value as u32;
-                    if const_cse
-                        && !vreg_to_arm.contains_key(&dest.0)
-                        && !local_vregs.contains(&dest.0)
-                        && let Some(rs) = reg_holds_const
-                            .iter()
-                            .find_map(|(r, v)| if *v == cse_want { Some(*r) } else { None })
-                    {
-                        vreg_to_arm.insert(dest.0, rs);
-                        vreg_alloc_order.push(dest.0);
-                        continue;
-                    }
+                    // vreg↔reg bijection (the alias-eviction hazard). Every
+                    // const now allocates and materializes normally; redundant
+                    // materializations are recovered post-hoc by the
+                    // liveness-proven `liveness::apply_const_cse` passes.
                     // Allocate a register for this constant
                     let rd = if let Some(&r) = vreg_to_arm.get(&dest.0) {
                         r
@@ -6818,10 +6754,12 @@ fn spill_evict_farthest(
                 && !param_reserved_regs.contains(&r)
                 && !avoid.contains(&r)
                 // Alias guard: only evict a register held by exactly ONE vreg.
-                // const-CSE aliasing (SYNTH_CONST_CSE) makes two live vregs
-                // share a register; spilling a single victim would leave the
-                // other alias reading a reused register (the documented
-                // spill-bijection hazard).
+                // The inline const-CSE aliasing that could make two live vregs
+                // share a register is RETIRED (#242 — const-CSE is now only
+                // the post-hoc `liveness::apply_const_cse`), so today the
+                // vreg↔reg map is a bijection by construction; the guard stays
+                // as a cheap structural tripwire (spilling a shared victim
+                // would leave the other alias reading a reused register).
                 && vreg_to_arm.values().filter(|&&u| u == r).count() == 1
         })
         .collect();

--- a/scripts/repro/const_cse_differential.py
+++ b/scripts/repro/const_cse_differential.py
@@ -4,9 +4,11 @@
 The ARM path re-materializes a constant at every use: the same `i32.const N`
 becomes a fresh `movw`/`movt` (or `mov`) each time. gale measured this on silicon
 — flat_flight spends 61% of its const materializations on values already sitting
-in a register. `SYNTH_CONST_CSE=1` removes the redundant materializations via the
-post-hoc `liveness::apply_const_cse` pass (it also enables an inline const cache
-on the optimized path; this harness, run without `--relocatable`, exercises both).
+in a register. const-CSE removes the redundant materializations via the post-hoc
+`liveness::apply_const_cse` pass — DEFAULT-ON since the #242 flip (opt-out
+`SYNTH_CONST_CSE=0`); the former bridge-level inline const cache is RETIRED
+(alias-eviction spill-bijection hazard), so the post-hoc pass is the flag's only
+effect on both paths.
 
 CSE-LAST + SIZE GUARD (#242). gale's v0.17.0 burndown found const-CSE GREW a tiny
 `--relocatable` function (`gust_mix` 90→92 B): retargeting a use kept a constant
@@ -19,9 +21,8 @@ retarget that flips a 16-bit `ldr` to its 32-bit form is declined). The guard's
 decline path is unit-tested non-vacuously in `liveness.rs`; the per-function gate
 below is the end-to-end enforcement over real compiled functions.
 
-This is byte-CHANGING codegen, so the flag ships DEFAULT-OFF (off ⇒ byte-identical,
-the frozen gate proves it). This harness is the correctness + no-regression oracle
-for the flag-ON path: it compiles `const_cse.wat` with `SYNTH_CONST_CSE=1`, runs
+This harness is the correctness + no-regression oracle
+for the flag-ON (= shipped default) path: it compiles `const_cse.wat` with CSE on, runs
 each export under unicorn (UC_ARCH_ARM / Thumb), and asserts the returned value is
 bit-identical to wasmtime ground truth across a spread of inputs (including
 negatives and zero), THEN asserts no function grew flag-on vs flag-off. Covered
@@ -75,9 +76,10 @@ def wasmtime_run(fn, arg, wat=WAT):
 
 
 def compile_optimized(out, cse_on, relocatable=False, wat=WAT):
-    env = {"PATH": "/usr/bin:/bin"}
-    if cse_on:
-        env["SYNTH_CONST_CSE"] = "1"
+    # Post-flip (#242): const-CSE is DEFAULT-ON; "off" is the SYNTH_CONST_CSE=0
+    # opt-out (pre-flip it was the unset-env default — same bytes either way,
+    # the flag-off path is untouched by the flip).
+    env = {"PATH": "/usr/bin:/bin", "SYNTH_CONST_CSE": "1" if cse_on else "0"}
     cmd = [SYNTH, "compile", str(wat), "-o", out, "-b", "arm",
            "--target", "cortex-m4", "--all-exports"]
     if relocatable:

--- a/scripts/repro/volatile_segment_543_differential.py
+++ b/scripts/repro/volatile_segment_543_differential.py
@@ -9,11 +9,17 @@ stay bit-identical to wasmtime ground truth in EVERY mode. This harness runs
 the fixture's `dma_window(v)` under unicorn in four builds —
 
   base    : SYNTH_BASE_CSE=0 opt-out, no ranges (the pre-flip baseline)
-  folded  : shipped default, no ranges       (all 4 const-address stores fold)
-  window  : default + --volatile-segment 0x100:16
+  folded  : base-CSE default, no ranges      (all 4 const-address stores fold)
+  window  : base-CSE default + --volatile-segment 0x100:16
             (the 2 window stores stay verbatim, the 2 outside still fold)
-  cover   : default + --volatile-segment 0x80:144
+  cover   : base-CSE default + --volatile-segment 0x80:144
             (covers all 4 → base-CSE fully declines)
+
+All four pin SYNTH_CONST_CSE=0 so the lattice isolates the base-CSE lever
+(const-CSE is DEFAULT-ON since the #242 flip); a composition check then proves
+the range-marked builds are byte-identical to the shipped default (const-CSE
+declines wholesale under a marked range), so their execution covers the
+default bytes too.
 
 — and asserts the resulting LINEAR MEMORY (fields 0x80/0x84 outside, 0x100/0x104
 inside the DMA window) matches wasmtime for several input values.
@@ -54,13 +60,22 @@ BUILDS = {
 }
 
 
-def compile_elf(out, base_cse, extra):
+def compile_elf(out, base_cse, extra, const_cse_opt_out=True):
     env = {"PATH": "/usr/bin:/bin"}
     # base-CSE is DEFAULT-ON since the #468 lever flip: base_cse=True is the
     # shipped default (env untouched); base_cse=False is the SYNTH_BASE_CSE=0
     # opt-out (the pre-flip baseline codegen).
     if not base_cse:
         env["SYNTH_BASE_CSE"] = "0"
+    # const-CSE is DEFAULT-ON since the #242 flip; opt it out UNIFORMLY so the
+    # base/folded/window/cover size lattice isolates the BASE-CSE lever (with
+    # const-CSE running, the range-free `base` arm shrinks for const-CSE's own
+    # reasons and the lattice goes vacuous). NOT a coverage loss for the
+    # range-marked arms: with any range marked const-CSE declines WHOLESALE,
+    # so window/cover are byte-identical to the shipped default — asserted
+    # below in main().
+    if const_cse_opt_out:
+        env["SYNTH_CONST_CSE"] = "0"
     r = subprocess.run(
         [SYNTH, "compile", WAT, "-o", out, "-b", "arm", "--target", "cortex-m4",
          "--all-exports", *extra],
@@ -141,6 +156,22 @@ def main():
                  "(cover .text != base .text)")
     print(f".text: base={sizes['base']}B folded={sizes['folded']}B "
           f"window={sizes['window']}B cover={sizes['cover']}B (≡ base)")
+
+    # Default-on const-CSE composition check (#242): with any range marked,
+    # const-CSE must decline WHOLESALE, so the shipped default (env untouched)
+    # must be byte-identical to the SYNTH_CONST_CSE=0 opt-out on the
+    # range-marked builds — which also means executing window/cover above
+    # covers the shipped-default bytes.
+    for tag in ("window", "cover"):
+        cse, extra = BUILDS[tag]
+        default_elf = f"/tmp/volseg543_diff_{tag}_default.elf"
+        compile_elf(default_elf, cse, extra, const_cse_opt_out=False)
+        if text_bytes(default_elf) != text_bytes(elfs[tag]):
+            sys.exit(f"FAIL: {tag}: shipped-default bytes != SYNTH_CONST_CSE=0 "
+                     "bytes with a range marked — the volatile wholesale "
+                     "decline is broken under default-on const-CSE")
+    print("default-on const-CSE composition: window/cover byte-identical "
+          "to the =0 opt-out (wholesale decline holds)")
 
     fails = 0
     for v in [0, 1, 22, 0xDEADBEEF, 0x7FFFFFFF, 0xFFFFFFFF]:


### PR DESCRIPTION
## Why

PR #592 flipped `SYNTH_BASE_CSE` but held `SYNTH_CONST_CSE` on two verified blockers: the bridge-level INLINE const aliasing still lived under the flag (with its alias-eviction spill-bijection hazard), and the `reg_effect` def-completeness prerequisite it implied. This PR retires the hazard **by deletion** and completes the flip-wave: the post-hoc, liveness-proven passes (PR1 #519 + PR2 #562) become the flag's only implementation, and they ship by default.

## 1 — Hazard retirement (the inline arm is GONE)

Deleted from `optimizer_bridge::ir_to_arm` (−87 lines):

- the `reg_holds_const` cache + its per-iteration emitted-ARM reconciliation loop,
- the `Opcode::Const` alias arm that inserted `dest → rs` into `vreg_to_arm` without materializing — the exact rewrite that made **two live vregs share one physical register**, breaking the spill model's vreg↔reg bijection (spilling a shared victim leaves the surviving alias reading a reused register).

Const materialization now always falls through to normal allocate-and-emit. `grep reg_holds_const` over `src/` returns only the retirement comment. The Belady evictor keeps its `count == 1` alias guard as a structural tripwire (documented as such, no longer load-bearing). The recorded **reg_effect DEF-COMPLETENESS** prerequisite retires with the inline cache: the post-hoc passes treat any `reg_effect = None` op as an opaque segment boundary and only rewrite inside fully-modeled straight-line segments — an unmodeled op declines instead of going stale.

With the arm deleted (flag semantics unchanged at that point): flag-off golden byte-identical (pre-flip `const_cse_off` FNV `0xa68a…e4a7`/576 still matched), and every flag-on shrink claim still held — **the post-hoc passes own the win**; `const_cse_reduction_242.rs`'s "WHAT THIS DOES NOT CLAIM" section now records both prerequisites as RETIRED.

## 2 — `SYNTH_CONST_CSE` DEFAULT-ON (opt-out `=0`)

Gate: `!env(SYNTH_CONST_CSE).is_ok_and(|v| v == "0") && volatile_segments.is_empty()` — the `SYNTH_SPILL_REALLOC`/`SYNTH_BASE_CSE` template. The pass is path-agnostic (runs on the selected ArmOp stream), so unlike base-CSE it also moves two `--relocatable` frozen anchors — both shrink, and were re-pinned only after the differentials passed on the new bytes.

### Execution differentials — run on the new DEFAULT bytes BEFORE pinning any hash (all exit 0)

| oracle | result |
|---|---|
| `const_cse_differential.py` | PASS (all exports vs wasmtime; direct-path gate non-vacuous, 0 grow) |
| `frame_slot_dce_differential.py` | PASS |
| `flight_seam_differential.py` | MATCH (0x07FDF307) |
| `spill_rung_581_differential.py` | PASS (6/6) |
| `volatile_segment_543_differential.py` | PASS (base/folded/window/cover × 6 inputs) + NEW default-on composition check |
| `control_step_differential.py` | PASS (13/13) |

### Volatile exclusion keeps working default-on

With any `--volatile-segment` range marked, const-CSE declines WHOLESALE — verified two ways: the re-anchored cargo gate (`const_cse_declines_wholesale_under_volatile_543`: default + range ≡ `=0` opt-out, byte-identical) and a new assertion inside `volatile_segment_543_differential.py` (shipped-default window/cover builds ≡ `=0` builds byte-for-byte, so executing them covers the default bytes). The base-CSE lattice arms now pin `SYNTH_CONST_CSE=0` uniformly to isolate that lever (otherwise the range-free baseline shrinks for const-CSE's own reasons and the F ≡ C equality goes vacuous — the exact failure the un-updated script showed).

### Per-fixture deltas + corpus totals (opt-out → new default)

**Corpus sweep: 152 fixture×path combos (76 fixtures × optimized + `--relocatable`), 0 functions grow, 40 function entries shrink, TOTAL −536 B** (per-function symtab sizes; STOP-gate was any growth). Headline entries:

| fixture [path] | function | old | new | delta |
|---|---|---|---|---|
| const_cse.wat [opt] | spill12 | 236 | 148 | **−88** |
| const_cse.wat [opt] | large3 | 40 | 24 | −16 |
| spill_frame_499.wat [opt] | nested | 148 | 124 | −24 |
| base_cse_branch.wat [opt] | init_branch | 114 | 98 | −16 |
| add_imm_large.wat [opt] | store_load_large | 42 | 32 | −10 |
| control_step.wasm [rel] | control_step_decide | 304 | 300 | −4 |
| flight_seam.wasm [rel] | flight_algo | 300 | 296 | −4 |
| flat_flight [opt] | flat_flight | — | — | 0 (pressure-saturated; guard declines, pinned equal) |

### Refreeze ledger

- `frozen_codegen_bytes.rs` ARM gate re-pinned: control_step `158b036b…`/300, flight_seam `1e1d2b75…`/726 (flight_seam_flat + signed_div_const byte-identical). **RV32 anchors untouched** (const-CSE is wired in the ARM backend only).
- NEW `frozen_fixtures_const_cse_escape_hatch_restores_old_bytes`: `SYNTH_CONST_CSE=0` restores the prior goldens (`1a97711c…`/304, `6872d6f3…`/730) byte-for-byte — verified against the exact pre-flip pins, which this PR did not touch.
- NEW `const_cse_default_matches_flip_golden_242` (default `.text` FNV `0x9577…5a46`/452) + the claim-1 golden re-purposed as the `=0` escape hatch — its pre-flip FNV `0xa68a…e4a7`/576 **passes unchanged**, proving the opt-out path is the pre-flip default.
- Older escape hatches (`SYNTH_NO_STACK_FWD`, `SYNTH_SPILL_REALLOC=0`) gain the `SYNTH_CONST_CSE=0` composition (same pattern as the spill-realloc flip added to stack-fwd).
- `base_cse_flip_468.rs`: default arm keeps pinning the TRUE shipped default (verified byte-identical under const-CSE — its folded shapes leave nothing for the size-guarded passes); opt-out arm composes `=0`.

## Gates

`cargo test -p synth-synthesis -p synth-backend -p synth-cli` ✅ (63 suites, 0 failures, exit 0) · `cargo fmt --check` ✅ (exit 0) · `cargo clippy --workspace --exclude synth-verify --all-targets -- -D warnings` ✅ (exit 0) · corpus sweep exit 0 (no-grow enforced) · all six differentials exit 0.

Not touched: `artifacts/verified-codegen-roadmap.yaml` narrative blobs that describe the pre-flip state are historical evidence records of landed PRs; the rivet status advance for this rivet rides the release PR as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)