### PR TITLE
chore(release): v0.29.0 — const-CSE default-on + i64 completeness + geometry hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-07-03
+
+**const-CSE ships default-on (hazard retired, branch-geometry sound); i64
+direct-path completeness (#503 closed); five passes hardened against the
+resolved-offset branch class (#606).**
+
+### Changed (byte-changing, deliberate — affected anchors refrozen)
+
+- **`SYNTH_CONST_CSE` default-ON (#604/#242).** The inline aliasing (and its
+  alias-eviction hazard) is *deleted* — the flag gates only the post-hoc
+  passes. Corpus: 0 grow / 38 shrink / −488 B (48 B of unsound branched "wins"
+  honestly given back by the soundness fix). Opt-out `=0` CI-gated. The flip's
+  own gate caught a real CF miscompile pre-merge (`nested(1,)` stored 55 over
+  99): segments spanned **resolved-offset** branch joins, and deleting bytes
+  inside a branch→target span made the pre-resolved offset overshoot. Fixed
+  with `resolved_branch_geometry` (targets = barriers + span byte-freeze).
+
+### Added
+
+- **i64 stack params + pair spill-slot growth on the direct path
+  (#605 — closes #503, advances #587).** Full NCRN/NSAA AAPCS layout walk;
+  wide stack params lower (with calls); the i64 spill pool grows instead of
+  skipping (falcon func_60/func_73 class). Bonus fix: AAPCS C.5 no-back-fill —
+  `p3` of `(i64 i32 i32 i32)` was silently read from R3 on both paths.
+
+### Fixed
+
+- **Five passes now honor resolved branch geometry (#607 — closes #606).**
+  The audit's adversarial fixtures proved current defaults SAFE — but by five
+  accidents, only one designed. Stages 1–2 of spill-realloc, dead-frame-store
+  elimination, stack-reload forwarding, and range-realloc (a fifth exposure
+  found during the audit) all adopt barriers + span byte-freeze; zero give-back
+  (229/231 corpus combos byte-identical, 2 neutral validator-proven recolours).
+
 ## [0.28.0] - 2026-07-03
 
 **RV32 cmp→select ships default-on; three encoder miscompiles fixed (Thumb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,14 +2039,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2104,11 +2104,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.28.0"
+version = "0.29.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2163,14 +2163,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2178,11 +2178,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.28.0"
+version = "0.29.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.28.0"
+version = "0.29.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.28.0"
+version = "0.29.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.28.0",
+    version = "0.29.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.28.0" }
+synth-core = { path = "../synth-core", version = "0.29.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.28.0" }
+synth-core = { path = "../synth-core", version = "0.29.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.28.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.28.0" }
+synth-core = { path = "../synth-core", version = "0.29.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.29.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.28.0" }
+synth-core = { path = "../synth-core", version = "0.29.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.28.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.28.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.29.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.29.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,21 +27,21 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.28.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.28.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.28.0" }
-synth-backend = { path = "../synth-backend", version = "0.28.0" }
+synth-core = { path = "../synth-core", version = "0.29.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.29.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.29.0" }
+synth-backend = { path = "../synth-backend", version = "0.29.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.28.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.29.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.28.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.28.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.28.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.29.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.29.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.29.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.28.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.29.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.28.0" }
+synth-core = { path = "../synth-core", version = "0.29.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.28.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.29.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.28.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.28.0" }
-synth-opt = { path = "../synth-opt", version = "0.28.0" }
+synth-core = { path = "../synth-core", version = "0.29.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.29.0" }
+synth-opt = { path = "../synth-opt", version = "0.29.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -20,12 +20,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.28.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.28.0" }
-synth-opt = { path = "../synth-opt", version = "0.28.0" }
+synth-core = { path = "../synth-core", version = "0.29.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.29.0" }
+synth-opt = { path = "../synth-opt", version = "0.29.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.28.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.29.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"


### PR DESCRIPTION
Release **v0.29.0** — hub wave 2 (3 PRs): const-CSE default-ON with the alias hazard deleted and the CF-soundness fix its own gate caught (#604); i64 direct-path completeness closing #503 (#605); five passes hardened against the resolved-offset branch class, closing #606 with zero give-back (#607). Pin sweep + lock + CHANGELOG. Tag on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)