### PR TITLE
feat: flag audit flip-wave — RV shift-fold / dead-frame / uxth (evidence-gated)

### DIFF
--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -272,13 +272,21 @@ fn select_inner(
     }
     ctx.emit_return_epilogue();
     // VCR-RA RV32 lever (#472, #242): fold constant shift amounts into the
-    // immediate-shift forms (`slli/srli/srai`), dropping the `li tmp, N`. Flag-off
-    // by default — with the env unset the output is byte-identical to the
-    // pre-lever baseline (the frozen RV32 fixtures compile without it), so this is
-    // frozen-safe. The on-target cycle win is validated under the RV32 differential
-    // before the default-on flip. (Post-pass: runs after the epilogue's `ret`
-    // terminator exists so the dead-store analysis can see live-out.)
-    if std::env::var_os("SYNTH_RV_SHIFT_FOLD").is_some() {
+    // immediate-shift forms (`slli/srli/srai`), dropping the `li tmp, N`.
+    // DEFAULT-ON (#242 flag audit flip-wave; the SYNTH_RV_CMP_SELECT template):
+    // gale re-measured the fold still off and worth −8 B toward the esp32c3
+    // 128 B floor (#242, 2026-07-03). Evidence basis: RV32 repro-corpus sweep —
+    // 0 functions grow, 20 shrink (control_step 492→484 −8, flat_flight
+    // 732→696 −36, flight_seam controller_step 452→416 −36), locked by the
+    // `rv32_shift_fold_no_grow_corpus_242` cargo gate; execution differentials
+    // re-run green on the new default bytes BEFORE the frozen RV32 anchor was
+    // re-pinned (shift_fold_riscv, control_step_riscv, the full
+    // *_riscv_differential.py set — see the flip PR). Escape hatch:
+    // `SYNTH_RV_SHIFT_FOLD=0` opts out and restores the pre-flip bytes
+    // (CI-gated in `frozen_codegen_bytes.rs`). (Post-pass: runs after the
+    // epilogue's `ret` terminator exists so the dead-store analysis can see
+    // live-out.)
+    if !std::env::var("SYNTH_RV_SHIFT_FOLD").is_ok_and(|v| v == "0") {
         fold_const_shift(&mut ctx.out);
     }
     // VCR-RA RV32 lever (#472 step 2): fold a constant memory address into the
@@ -7071,10 +7079,14 @@ mod tests {
         );
     }
 
-    /// #472 immediate-shift-fold baseline: a constant shift amount uses the
-    /// REGISTER form `sll` (preceded by an `li` of the amount), not `slli #shamt`.
+    /// #472 immediate-shift-fold DEFAULT (#242 flag-audit flip-wave): a
+    /// constant shift amount now folds to `slli #shamt` in the shipped default
+    /// — the register form `sll` and its `li amount` are gone. (Pre-flip this
+    /// test pinned the opposite, unfolded baseline; the opt-out bytes are
+    /// gated end-to-end by
+    /// `frozen_fixtures_rv32_shift_fold_escape_hatch_restores_old_bytes`.)
     #[test]
-    fn const_shift_uses_register_form_baseline_472() {
+    fn const_shift_folds_to_immediate_form_by_default_472() {
         // (i32.shl (local.get 0) (i32.const 8))
         let out = s(
             &[
@@ -7087,37 +7099,47 @@ mod tests {
             1,
         );
         assert!(
-            count(&out, |op| matches!(op, RiscVOp::Sll { .. })) >= 1,
-            "baseline: const shift uses the register form `sll`: {out:?}"
+            count(&out, |op| matches!(op, RiscVOp::Slli { shamt: 8, .. })) >= 1,
+            "default: const shift folds to `slli #8`: {out:?}"
         );
         assert_eq!(
-            count(&out, |op| matches!(op, RiscVOp::Slli { .. })),
+            count(&out, |op| matches!(op, RiscVOp::Sll { .. })),
             0,
-            "baseline: not yet folded to `slli #shamt`: {out:?}"
+            "default: the register-form `sll` is gone: {out:?}"
         );
     }
 
-    /// #472 imm-shift-fold: the post-pass folds a constant shift amount into the
-    /// immediate form `slli #shamt` and drops the `li` of the amount. Driven on
-    /// the baseline fixture output — exactly what the env flag wires in the CLI.
+    /// #472 imm-shift-fold mechanism: the post-pass folds a constant shift
+    /// amount into the immediate form `slli #shamt` and drops the dead `li` of
+    /// the amount. Driven on a hand-built UNFOLDED stream (the pre-fold
+    /// selector shape) so the mechanism stays covered independently of the
+    /// now-default-on wiring (#242 flag-audit flip-wave).
     #[test]
     fn fold_const_shift_folds_amount_into_slli_472() {
-        // (i32.shl (local.get 0) (i32.const 8)) — RESULT returned (observable).
-        let mut out = s(
-            &[
-                WasmOp::LocalGet(0),
-                WasmOp::I32Const(8),
-                WasmOp::I32Shl,
-                WasmOp::End,
-            ],
-            1,
-        );
-        let before_addi8 = count(
-            &out,
-            |op| matches!(op, RiscVOp::Addi { rs1, imm: 8, .. } if *rs1 == Reg::ZERO),
-        );
-        assert_eq!(before_addi8, 1, "baseline materializes the amount: {out:?}");
-
+        // li t1, 8; sll t2, t0, t1; mv a0, t2; ret — the pre-fold shape of
+        // (i32.shl (local.get 0) (i32.const 8)) with the result returned.
+        let mut out = vec![
+            RiscVOp::Addi {
+                rd: Reg::X6,
+                rs1: Reg::ZERO,
+                imm: 8,
+            },
+            RiscVOp::Sll {
+                rd: Reg::X7,
+                rs1: Reg::X5,
+                rs2: Reg::X6,
+            },
+            RiscVOp::Addi {
+                rd: Reg::X10,
+                rs1: Reg::X7,
+                imm: 0,
+            },
+            RiscVOp::Jalr {
+                rd: Reg::X0,
+                rs1: Reg::X1,
+                imm: 0,
+            },
+        ];
         let folds = fold_const_shift(&mut out);
         assert_eq!(folds, 1, "exactly the one const shift folds: {out:?}");
         assert_eq!(
@@ -7140,21 +7162,46 @@ mod tests {
         );
     }
 
-    /// `srl`/`sra` fold to `srli`/`srai` just like `sll` → `slli`.
+    /// `srl`/`sra` fold to `srli`/`srai` just like `sll` → `slli` — driven on
+    /// hand-built unfolded streams (see
+    /// [`fold_const_shift_folds_amount_into_slli_472`]).
     #[test]
     fn fold_const_shift_handles_srl_and_sra_472() {
         for (op, want_slli, want_srli, want_srai) in
             [(WasmOp::I32ShrU, 0, 1, 0), (WasmOp::I32ShrS, 0, 0, 1)]
         {
-            let mut out = s(
-                &[
-                    WasmOp::LocalGet(0),
-                    WasmOp::I32Const(3),
-                    op.clone(),
-                    WasmOp::End,
-                ],
-                1,
-            );
+            // li t1, 3; s{rl,ra} t2, t0, t1; mv a0, t2; ret.
+            let shift = if matches!(op, WasmOp::I32ShrU) {
+                RiscVOp::Srl {
+                    rd: Reg::X7,
+                    rs1: Reg::X5,
+                    rs2: Reg::X6,
+                }
+            } else {
+                RiscVOp::Sra {
+                    rd: Reg::X7,
+                    rs1: Reg::X5,
+                    rs2: Reg::X6,
+                }
+            };
+            let mut out = vec![
+                RiscVOp::Addi {
+                    rd: Reg::X6,
+                    rs1: Reg::ZERO,
+                    imm: 3,
+                },
+                shift,
+                RiscVOp::Addi {
+                    rd: Reg::X10,
+                    rs1: Reg::X7,
+                    imm: 0,
+                },
+                RiscVOp::Jalr {
+                    rd: Reg::X0,
+                    rs1: Reg::X1,
+                    imm: 0,
+                },
+            ];
             assert_eq!(fold_const_shift(&mut out), 1, "{op:?} folds: {out:?}");
             assert_eq!(
                 count(&out, |o| matches!(o, RiscVOp::Slli { .. })),

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -653,10 +653,18 @@ fn compile_wasm_to_arm(
         // (`sub sp,#N`/`add sp,#N` reserved by `compute_local_layout` for locals
         // that promotion homed in registers, never accessed). Removing it saves
         // the two instructions AND restores the SP-untouched precondition that
-        // `shrink_callee_saved_saves` requires — so it must run FIRST. Flag-off
-        // (opt-in `SYNTH_DEAD_FRAME_ELIM=1`); off ⇒ byte-identical. Default-on
-        // flip held for on-silicon validation, like the realloc/shrink levers.
-        let out = if std::env::var("SYNTH_DEAD_FRAME_ELIM").is_ok() {
+        // `shrink_callee_saved_saves` requires — so it must run FIRST.
+        // DEFAULT-ON (#242 flag audit flip-wave, #592 audit item): evidence
+        // basis was the 2-path × repro-corpus sweep — 0 functions grow, 58
+        // shrink (flight_seam controller_step 250→242 −8 / filter_step 180→168
+        // −12, native_pointer frame_roundtrip 46→34 −12), locked by the
+        // `dead_frame_elim_no_grow_corpus_242` cargo gate; execution
+        // differentials re-run green on the new default bytes BEFORE the
+        // frozen ARM anchors were re-pinned (leaf_dead_frame, flight_seam,
+        // frame_slot_dce — see the flip PR). Escape hatch:
+        // `SYNTH_DEAD_FRAME_ELIM=0` opts out and restores the pre-flip bytes
+        // (CI-gated in `frozen_codegen_bytes.rs`).
+        let out = if !std::env::var("SYNTH_DEAD_FRAME_ELIM").is_ok_and(|v| v == "0") {
             synth_synthesis::liveness::elide_dead_frame(&out).unwrap_or(out)
         } else {
             out
@@ -879,10 +887,16 @@ fn compile_wasm_to_arm(
     // instruction, −1 live register per 16/8-bit mask. 0xffff/0xff are not Thumb-2
     // modified immediates so the selector materializes them into a register; the
     // dedicated zero-extend expresses the same masking inline. Removal-only +
-    // rewrite-in-place (offset-neutral). FLAG-OFF by default (opt-in
-    // `SYNTH_UXTH_FOLD=1`) ⇒ bit-identical (frozen gate green); the byte-changing
-    // default-on flip is the separate on-target-gated step, like the prior levers.
-    let arm_instrs = if std::env::var("SYNTH_UXTH_FOLD").is_ok() {
+    // rewrite-in-place (offset-neutral). DEFAULT-ON (#242 flag audit flip-wave,
+    // #592 audit item): evidence basis was the 2-path × repro-corpus sweep —
+    // 0 functions grow, 13 shrink (control_step 300→294 −6, gust_mix 38→32 −6,
+    // uxth_fold pack 36→24 −12), locked by the `uxth_fold_no_grow_corpus_242`
+    // cargo gate; execution differentials re-run green on the new default
+    // bytes BEFORE the frozen ARM anchors were re-pinned (uxth_fold,
+    // control_step — see the flip PR). Escape hatch: `SYNTH_UXTH_FOLD=0` opts
+    // out and restores the pre-flip bytes (CI-gated in
+    // `frozen_codegen_bytes.rs`).
+    let arm_instrs = if !std::env::var("SYNTH_UXTH_FOLD").is_ok_and(|v| v == "0") {
         let (out, folds) = synth_synthesis::liveness::fold_uxth(&arm_instrs);
         if std::env::var("SYNTH_FUSE_STATS").is_ok() {
             eprintln!("[uxth-fold] {folds} mask-and folded to uxth/uxtb, movw dropped");

--- a/crates/synth-cli/tests/flag_flip_wave_242.rs
+++ b/crates/synth-cli/tests/flag_flip_wave_242.rs
@@ -1,0 +1,206 @@
+//! #242 flag-audit flip-wave — per-flag NO-GROW corpus gates for the three
+//! levers flipped default-on together (template: the SYNTH_RV_CMP_SELECT /
+//! SYNTH_CONST_CSE flip gates):
+//!
+//!   - `SYNTH_RV_SHIFT_FOLD` (RV32, #472/#242): constant shift amounts fold
+//!     into `slli/srli/srai`, dropping the `li tmp, N`. gale re-measured it
+//!     still flag-off and worth −8 B toward the esp32c3 128 B floor (#242,
+//!     2026-07-03) — a prior lane believed a v0.11.x fold covered this; that
+//!     was the ARM `SYNTH_NO_IMM_SHIFT_FOLD` lever, a different flag. TRUE
+//!     prior default: OFF (`is_some()` opt-in).
+//!   - `SYNTH_DEAD_FRAME_ELIM` (ARM, VCR-RA-002 #390, #592 audit): elide the
+//!     provably-dead `sub sp,#N`/`add sp,#N` frame. TRUE prior default: OFF.
+//!   - `SYNTH_UXTH_FOLD` (ARM, #428, #592 audit): `movw #0xffff; and` →
+//!     `uxth` (and the 0xff/uxtb form). TRUE prior default: OFF.
+//!
+//! Execution differentials were re-run green on the new DEFAULT bytes BEFORE
+//! any golden was pinned (shift_fold_riscv 21/21, leaf_dead_frame, uxth_fold,
+//! control_step 13/13 + control_step_riscv, flight_seam 0x07FDF307,
+//! frame_slot_dce 8/8 — the full scripts/repro sweep, 52+3/56 PASS with
+//! sret_decide a pre-existing flip-neutral harness discrepancy; see the flip
+//! PR). The default goldens + per-flag `=0` escape hatches live in
+//! `frozen_codegen_bytes.rs`. What THIS file locks, per flag:
+//!
+//!   NO-GROW + non-vacuity: across the measured repro corpus (BOTH ARM paths
+//!   for the ARM levers — optimized and `--relocatable`/direct — since the
+//!   passes are path-agnostic post-passes in `compile_wasm_to_arm`), no
+//!   function grows default-vs-opt-out, and the firing fixtures genuinely
+//!   shrink. Flip-time full-corpus numbers: shift-fold 0 grow / 20 shrink
+//!   (control_step −8, flat_flight −36); dead-frame 0 grow / 58 shrink
+//!   (controller_step −8, filter_step −12); uxth 0 grow / 13 shrink
+//!   (control_step_decide −6, pack −12). The combined sweep was exactly
+//!   additive (71 = 58 + 13): no lever interaction.
+//!
+//! The #601 local-promo precedent applies: had ANY function grown, the flag
+//! would have been HELD with the numbers documented at the flag site (as
+//! `SYNTH_RV_LOCAL_PROMO` still is).
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+use object::{Object, ObjectSymbol, SymbolKind};
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture(rel: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro")
+        .join(rel)
+}
+
+/// Compile `rel` with `flag` either at the shipped default (env removed so a
+/// stray opt-out in the test environment can't skew the gate) or the `=0`
+/// opt-out (pre-flip bytes). `backend_args` selects ARM path / RV32.
+fn compile(rel: &str, out: &str, flag: &str, default_on: bool, backend_args: &[&str]) -> Vec<u8> {
+    let mut cmd = Command::new(synth());
+    // Hold the still-unflipped RV32 lever out of both arms.
+    cmd.env_remove("SYNTH_RV_LOCAL_PROMO");
+    if default_on {
+        cmd.env_remove(flag);
+    } else {
+        cmd.env(flag, "0");
+    }
+    let out_status = cmd
+        .args(["compile", fixture(rel).to_str().unwrap(), "-o", out])
+        .args(backend_args)
+        .args(["--all-exports"])
+        .output()
+        .expect("run synth compile");
+    assert!(
+        out_status.status.success(),
+        "synth compile failed ({rel}, {flag} default_on={default_on}): {}",
+        String::from_utf8_lossy(&out_status.stderr)
+    );
+    std::fs::read(out).expect("read ELF")
+}
+
+/// Every function symbol → its `.text` byte size (ELF symtab, not disasm
+/// text — the disassembler is host-dependent).
+fn func_sizes(elf: &[u8]) -> HashMap<String, usize> {
+    let obj = object::File::parse(elf).expect("parse ELF");
+    let mut out = HashMap::new();
+    for sym in obj.symbols() {
+        if sym.kind() == SymbolKind::Text
+            && sym.size() > 0
+            && let Ok(name) = sym.name()
+        {
+            out.insert(name.to_string(), sym.size() as usize);
+        }
+    }
+    out
+}
+
+/// NO-GROW + non-vacuity for one flag over `corpus × configs`: no function may
+/// grow default-vs-opt-out, and at least `min_fired` functions must shrink.
+fn assert_no_grow(flag: &str, corpus: &[&str], configs: &[(&str, &[&str])], min_fired: usize) {
+    let mut fired = 0usize;
+    for rel in corpus {
+        let tag = Path::new(rel).file_stem().unwrap().to_str().unwrap();
+        for (mode, args) in configs {
+            let off = func_sizes(&compile(
+                rel,
+                &format!("/tmp/ffw242_{flag}_{tag}_{mode}_off.o"),
+                flag,
+                false,
+                args,
+            ));
+            let on = func_sizes(&compile(
+                rel,
+                &format!("/tmp/ffw242_{flag}_{tag}_{mode}_on.o"),
+                flag,
+                true,
+                args,
+            ));
+            for (name, &o) in &off {
+                let n = *on.get(name).unwrap_or(&o);
+                assert!(
+                    n <= o,
+                    "no function may grow under default {flag}: \
+                     {name} opt-out={o}B default={n}B ({rel} [{mode}])"
+                );
+                if n < o {
+                    fired += 1;
+                }
+            }
+        }
+    }
+    assert!(
+        fired >= min_fired,
+        "non-vacuity: {flag} must shrink its firing fixtures \
+         (expected ≥{min_fired}, saw {fired} shrinking function(s))"
+    );
+}
+
+const ARM_OPT: &[&str] = &["-b", "arm", "--target", "cortex-m4"];
+const ARM_RELOC: &[&str] = &["-b", "arm", "--target", "cortex-m4", "--relocatable"];
+const RV32: &[&str] = &["-b", "riscv", "--target", "rv32imac", "--relocatable"];
+
+/// `SYNTH_RV_SHIFT_FOLD` — RV32 corpus. At flip time: 6 fixtures here held 9
+/// shrinking functions (shift_fold.wat's five imm-shift wrappers −4 each,
+/// control_step −8 — gale's exact esp32c3 number, flight_seam_flat's
+/// controller_step/flight_algo −36 each, call_6_7args −20/−24);
+/// signed_div_const and the variable-shift `shlvar` are fold-inert — they
+/// must stay EQUAL.
+#[test]
+fn rv32_shift_fold_no_grow_corpus_242() {
+    assert_no_grow(
+        "SYNTH_RV_SHIFT_FOLD",
+        &[
+            "control_step.wasm",
+            "signed_div_const.wasm",
+            "shift_fold.wat",
+            "flight_seam_flat.wasm",
+            "call_6_7args.wat",
+            "rv32_cmp_select_472.wat",
+        ],
+        &[("rv32", RV32)],
+        2,
+    );
+}
+
+/// `SYNTH_DEAD_FRAME_ELIM` — ARM corpus, BOTH paths (the elision is a
+/// path-agnostic post-pass). At flip time: flight_seam's
+/// controller_step/filter_step (−8/−12), native_pointer frame_roundtrip
+/// (−12), leaf_caller_saved leaf3 (−8), memcopy writer (−12);
+/// control_step / signed_div_const / uxth_fold are frame-inert — EQUAL.
+#[test]
+fn dead_frame_elim_no_grow_corpus_242() {
+    assert_no_grow(
+        "SYNTH_DEAD_FRAME_ELIM",
+        &[
+            "control_step.wasm",
+            "signed_div_const.wasm",
+            "flight_seam.wat",
+            "native_pointer_shadow_stack.wat",
+            "leaf_caller_saved.wat",
+            "memcopy_dropped_359.wat",
+            "uxth_fold.wat",
+        ],
+        &[("opt", ARM_OPT), ("reloc", ARM_RELOC)],
+        2,
+    );
+}
+
+/// `SYNTH_UXTH_FOLD` — ARM corpus, BOTH paths. At flip time: uxth_fold.wat's
+/// pack (−12: two folds), control_step_decide (−6), gust_kernel's gust_mix
+/// family (−6 each); flight_seam / signed_div_const have no 0xffff/0xff mask
+/// materializations — EQUAL.
+#[test]
+fn uxth_fold_no_grow_corpus_242() {
+    assert_no_grow(
+        "SYNTH_UXTH_FOLD",
+        &[
+            "control_step.wasm",
+            "signed_div_const.wasm",
+            "uxth_fold.wat",
+            "gust_kernel.wasm",
+            "flight_seam.wat",
+        ],
+        &[("opt", ARM_OPT), ("reloc", ARM_RELOC)],
+        2,
+    );
+}

--- a/crates/synth-cli/tests/frozen_codegen_bytes.rs
+++ b/crates/synth-cli/tests/frozen_codegen_bytes.rs
@@ -79,6 +79,9 @@ fn text_sha256(wasm: &str, backend: &str, target: &str) -> (String, usize) {
         .env_remove("SYNTH_BASE_CSE")
         .env_remove("SYNTH_RV_CMP_SELECT")
         .env_remove("SYNTH_RV_LOCAL_PROMO")
+        .env_remove("SYNTH_RV_SHIFT_FOLD")
+        .env_remove("SYNTH_DEAD_FRAME_ELIM")
+        .env_remove("SYNTH_UXTH_FOLD")
         .args([
             "compile",
             path.to_str().unwrap(),
@@ -177,23 +180,41 @@ fn assert_frozen(cases: &[(&str, &str, usize)], backend: &str, target: &str) {
 /// prior goldens (asserted by
 /// `frozen_fixtures_const_cse_escape_hatch_restores_old_bytes`). Prior
 /// goldens were control_step 1a97711c…/304, flight_seam 6872d6f3…/730.
+///
+/// Goldens RE-FROZEN for the #242 FLAG-AUDIT FLIP-WAVE (SYNTH_DEAD_FRAME_ELIM
+/// and SYNTH_UXTH_FOLD, both default-on; #592 audit items): the uxth/uxtb fold
+/// drops control_step's `movw #0xffff` mask materializations (300→294, −6);
+/// dead-frame elimination removes the provably-dead `sub/add sp` frames in
+/// flight_seam's controller_step (−8) and filter_step (−12) — flight_seam
+/// 726→706, flight_seam_flat 866→846. signed_div_const is inert under both.
+/// Execution differentials re-run green on the new default bytes BEFORE this
+/// re-pin: 52/56 scripts/repro/*_differential.py PASS incl. uxth_fold,
+/// leaf_dead_frame, control_step 13/13, flight_seam flat+inlined flight_algo
+/// 0x07FDF307, frame_slot_dce 8/8 (the 4 non-PASS: 3 needed regenerated
+/// external inputs then passed; sret_decide is a pre-existing flip-neutral
+/// harness discrepancy — its fixture bytes are IDENTICAL default vs opt-out).
+/// Per-flag opt-outs restore the prior goldens (asserted by
+/// `frozen_fixtures_dead_frame_elim_escape_hatch_restores_old_bytes` and
+/// `frozen_fixtures_uxth_fold_escape_hatch_restores_old_bytes`). Prior
+/// goldens were control_step 158b036b…/300, flight_seam 1e1d2b75…/726,
+/// flight_seam_flat d11849db…/866.
 #[test]
 fn frozen_fixtures_text_is_bit_identical_oracle_001() {
     let cases = [
         (
             "control_step.wasm",
-            "158b036bc678261a6f6ee71450d0af7b23d92415d16d21679347e2a436c25bb2",
-            300usize,
+            "d0907e0206e8abd5724dec30eb261f2b9d689c6ec1a3d3b66853691fb532de82",
+            294usize,
         ),
         (
             "flight_seam.wasm",
-            "1e1d2b75fe6c4975359c8b1163a6e082a548a0ce1e23d7a360495785bf5e54c2",
-            726,
+            "92fd68638e4074024f54c7744775f44aa88d2f5b36abbd0963d27d62b95e1e97",
+            706,
         ),
         (
             "flight_seam_flat.wasm",
-            "d11849db9bef82b77280ee06fdc6f076a7df278b2e5a3213284e569cbf1eccc9",
-            866,
+            "660c3fbc3a58820b13949412e11f79d47eccfb4de7cfa737a781abe01e4e1b96",
+            846,
         ),
         (
             "signed_div_const.wasm",
@@ -212,10 +233,11 @@ fn frozen_fixtures_text_is_bit_identical_oracle_001() {
 /// they are not re-checked here; the default gate above already locks them.)
 ///
 /// COMPOSITION NOTE: rolling back to the pre-STACK_FWD bytes now also requires
-/// opting out of the LATER spill-realloc lever (`SYNTH_SPILL_REALLOC=0`) and
-/// the const-CSE lever (`SYNTH_CONST_CSE=0`, #242) — both default on since
-/// their own flips and would otherwise rewrite the traffic these goldens pin.
-/// The opt-outs compose; each is separately gated.
+/// opting out of the LATER spill-realloc lever (`SYNTH_SPILL_REALLOC=0`), the
+/// const-CSE lever (`SYNTH_CONST_CSE=0`, #242), and the flag-audit flip-wave
+/// levers (`SYNTH_DEAD_FRAME_ELIM=0` + `SYNTH_UXTH_FOLD=0`, #242) — all
+/// default on since their own flips and would otherwise rewrite the traffic
+/// these goldens pin. The opt-outs compose; each is separately gated.
 #[test]
 fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
     // (fixture, PRE-flip golden sha256, PRE-flip len) — the v0.15.0 goldens.
@@ -237,6 +259,8 @@ fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
             .env("SYNTH_NO_STACK_FWD", "1")
             .env("SYNTH_SPILL_REALLOC", "0")
             .env("SYNTH_CONST_CSE", "0")
+            .env("SYNTH_DEAD_FRAME_ELIM", "0")
+            .env("SYNTH_UXTH_FOLD", "0")
             .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
             .env_remove("SYNTH_NO_LOCAL_PROMOTE")
             .env_remove("SYNTH_NO_IMM_SHIFT_FOLD")
@@ -288,8 +312,9 @@ fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
 /// locks them for both settings.)
 ///
 /// COMPOSITION NOTE: rolling back to these bytes now also requires opting out
-/// of the LATER const-CSE lever (`SYNTH_CONST_CSE=0`, #242 flip), which would
-/// otherwise drop a redundant materialization these goldens pin.
+/// of the LATER const-CSE lever (`SYNTH_CONST_CSE=0`, #242 flip) and the
+/// flag-audit flip-wave levers (`SYNTH_DEAD_FRAME_ELIM=0` + `SYNTH_UXTH_FOLD=0`,
+/// #242), which would otherwise rewrite traffic these goldens pin.
 #[test]
 fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
     // (fixture, PRE-flip golden sha256, PRE-flip len) — the pre-spill-realloc
@@ -311,6 +336,8 @@ fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
         let out = Command::new(synth())
             .env("SYNTH_SPILL_REALLOC", "0")
             .env("SYNTH_CONST_CSE", "0")
+            .env("SYNTH_DEAD_FRAME_ELIM", "0")
+            .env("SYNTH_UXTH_FOLD", "0")
             .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
             .env_remove("SYNTH_NO_LOCAL_PROMOTE")
             .env_remove("SYNTH_NO_IMM_SHIFT_FOLD")
@@ -359,9 +386,12 @@ fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
 /// moved restore their PRE-flip goldens byte-for-byte — the rollback proof
 /// AND a tripwire against the post-hoc CSE passes leaking into the opt-out
 /// path. (flight_seam_flat / signed_div_const are byte-identical under the
-/// flip, so the default gate above locks them for both settings.) Unlike the
-/// earlier hatches this needs NO composition: const-CSE is the LAST-flipped
-/// lever, so `=0` alone lands exactly on the previous shipped default.
+/// flip, so the default gate above locks them for both settings.)
+///
+/// COMPOSITION NOTE: since the #242 flag-audit flip-wave, rolling back to
+/// these bytes also requires opting out of the LATER levers
+/// (`SYNTH_DEAD_FRAME_ELIM=0` + `SYNTH_UXTH_FOLD=0`), which fire on
+/// control_step (uxth) and flight_seam (dead-frame).
 #[test]
 fn frozen_fixtures_const_cse_escape_hatch_restores_old_bytes() {
     // (fixture, PRE-flip golden sha256, PRE-flip len) — the pre-const-CSE
@@ -382,6 +412,8 @@ fn frozen_fixtures_const_cse_escape_hatch_restores_old_bytes() {
         let elf = format!("/tmp/frozen_nocse_{wasm}.elf");
         let out = Command::new(synth())
             .env("SYNTH_CONST_CSE", "0")
+            .env("SYNTH_DEAD_FRAME_ELIM", "0")
+            .env("SYNTH_UXTH_FOLD", "0")
             .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
             .env_remove("SYNTH_NO_LOCAL_PROMOTE")
             .env_remove("SYNTH_NO_IMM_SHIFT_FOLD")
@@ -426,6 +458,148 @@ fn frozen_fixtures_const_cse_escape_hatch_restores_old_bytes() {
     }
 }
 
+/// ESCAPE-HATCH GATE for the SYNTH_DEAD_FRAME_ELIM flip (#242 flag-audit
+/// flip-wave, VCR-RA-002 #390). Proves the opt-out actually rolls back: with
+/// `SYNTH_DEAD_FRAME_ELIM=0` ALONE the two fixtures the flip moved restore
+/// their PRE-flip goldens byte-for-byte — the rollback proof AND a tripwire
+/// against `elide_dead_frame` leaking into the opt-out path. No composition
+/// needed for THESE fixtures: the sibling uxth lever is fold-inert on
+/// flight_seam/flight_seam_flat (no 0xffff/0xff mask materializations), so
+/// `=0` alone lands exactly on the previous shipped default there.
+/// (control_step / signed_div_const are dead-frame-inert — the default gate
+/// above locks them.)
+#[test]
+fn frozen_fixtures_dead_frame_elim_escape_hatch_restores_old_bytes() {
+    // (fixture, PRE-flip golden sha256, PRE-flip len) — the const-CSE-flip-era
+    // defaults.
+    let old = [
+        (
+            "flight_seam.wasm",
+            "1e1d2b75fe6c4975359c8b1163a6e082a548a0ce1e23d7a360495785bf5e54c2",
+            726usize,
+        ),
+        (
+            "flight_seam_flat.wasm",
+            "d11849db9bef82b77280ee06fdc6f076a7df278b2e5a3213284e569cbf1eccc9",
+            866,
+        ),
+    ];
+    for &(wasm, golden, golden_len) in &old {
+        let elf = format!("/tmp/frozen_nodfe_{wasm}.elf");
+        let out = Command::new(synth())
+            .env("SYNTH_DEAD_FRAME_ELIM", "0")
+            .env_remove("SYNTH_UXTH_FOLD")
+            .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
+            .env_remove("SYNTH_NO_LOCAL_PROMOTE")
+            .env_remove("SYNTH_NO_IMM_SHIFT_FOLD")
+            .env_remove("SYNTH_NO_STACK_FWD")
+            .env_remove("SYNTH_SPILL_REALLOC")
+            .env_remove("SYNTH_CONST_CSE")
+            .env_remove("SYNTH_BASE_CSE")
+            .args([
+                "compile",
+                fixture(wasm).to_str().unwrap(),
+                "-o",
+                &elf,
+                "-b",
+                "arm",
+                "--target",
+                "cortex-m4",
+                "--all-exports",
+                "--relocatable",
+            ])
+            .output()
+            .expect("run synth");
+        assert!(out.status.success(), "compile failed for {wasm}");
+        let bytes = std::fs::read(&elf).expect("read elf");
+        let obj = object::File::parse(&*bytes).expect("parse elf");
+        let data = obj
+            .section_by_name(".text")
+            .expect(".text")
+            .data()
+            .expect("read .text");
+        assert_eq!(
+            data.len(),
+            golden_len,
+            "{wasm}: SYNTH_DEAD_FRAME_ELIM=0 must restore the pre-flip length"
+        );
+        let hex: String = Sha256::digest(data)
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        assert_eq!(
+            hex, golden,
+            "{wasm}: SYNTH_DEAD_FRAME_ELIM=0 must restore the pre-flip bytes (rollback broken)"
+        );
+    }
+}
+
+/// ESCAPE-HATCH GATE for the SYNTH_UXTH_FOLD flip (#242 flag-audit flip-wave,
+/// #428). Proves the opt-out actually rolls back: with `SYNTH_UXTH_FOLD=0`
+/// ALONE the fixture the flip moved restores its PRE-flip golden
+/// byte-for-byte — the rollback proof AND a tripwire against `fold_uxth`
+/// leaking into the opt-out path. No composition needed: the sibling
+/// dead-frame lever is inert on control_step (no dead frame survives), so
+/// `=0` alone lands exactly on the previous shipped default.
+#[test]
+fn frozen_fixtures_uxth_fold_escape_hatch_restores_old_bytes() {
+    // (fixture, PRE-flip golden sha256, PRE-flip len) — the const-CSE-flip-era
+    // default.
+    let old = [(
+        "control_step.wasm",
+        "158b036bc678261a6f6ee71450d0af7b23d92415d16d21679347e2a436c25bb2",
+        300usize,
+    )];
+    for &(wasm, golden, golden_len) in &old {
+        let elf = format!("/tmp/frozen_nouxth_{wasm}.elf");
+        let out = Command::new(synth())
+            .env("SYNTH_UXTH_FOLD", "0")
+            .env_remove("SYNTH_DEAD_FRAME_ELIM")
+            .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
+            .env_remove("SYNTH_NO_LOCAL_PROMOTE")
+            .env_remove("SYNTH_NO_IMM_SHIFT_FOLD")
+            .env_remove("SYNTH_NO_STACK_FWD")
+            .env_remove("SYNTH_SPILL_REALLOC")
+            .env_remove("SYNTH_CONST_CSE")
+            .env_remove("SYNTH_BASE_CSE")
+            .args([
+                "compile",
+                fixture(wasm).to_str().unwrap(),
+                "-o",
+                &elf,
+                "-b",
+                "arm",
+                "--target",
+                "cortex-m4",
+                "--all-exports",
+                "--relocatable",
+            ])
+            .output()
+            .expect("run synth");
+        assert!(out.status.success(), "compile failed for {wasm}");
+        let bytes = std::fs::read(&elf).expect("read elf");
+        let obj = object::File::parse(&*bytes).expect("parse elf");
+        let data = obj
+            .section_by_name(".text")
+            .expect(".text")
+            .data()
+            .expect("read .text");
+        assert_eq!(
+            data.len(),
+            golden_len,
+            "{wasm}: SYNTH_UXTH_FOLD=0 must restore the pre-flip length"
+        );
+        let hex: String = Sha256::digest(data)
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        assert_eq!(
+            hex, golden,
+            "{wasm}: SYNTH_UXTH_FOLD=0 must restore the pre-flip bytes (rollback broken)"
+        );
+    }
+}
+
 /// THE RV32 GATE. The RISC-V backend (`synth-backend-riscv`) is an INDEPENDENT
 /// codegen path with its own miscompile history (#220/#223/#226) — the ARM gate
 /// gives it zero protection, and its frozen RV32 result-identity invariants
@@ -454,8 +628,44 @@ fn frozen_fixtures_const_cse_escape_hatch_restores_old_bytes() {
 /// per-function no-grow blocker (its own WAR fixtures grow; see the env read
 /// in `synth-backend-riscv/src/selector.rs`) — so these goldens are the
 /// promo-UNSET bytes and `text_sha256` env-removes it for hygiene.
+///
+/// Goldens RE-FROZEN for the SYNTH_RV_SHIFT_FOLD flip (#242 flag-audit
+/// flip-wave; gale re-measured the fold still off and worth −8 B toward the
+/// esp32c3 128 B floor, #242 2026-07-03): constant shift amounts fold into
+/// the immediate forms (`slli/srli/srai`), dropping the `li tmp, N` —
+/// control_step 492→484 (−8, exactly gale's number). signed_div_const has no
+/// constant shifts surviving selection — byte-identical, hash unchanged.
+/// Execution differentials re-run green on the new default bytes BEFORE this
+/// re-pin (shift_fold_riscv 21/21, control_step_riscv 0x00210A55, plus the
+/// full *_riscv_differential.py set — see the flip PR).
+/// `SYNTH_RV_SHIFT_FOLD=0` restores the prior goldens (asserted by
+/// `frozen_fixtures_rv32_shift_fold_escape_hatch_restores_old_bytes`). Prior
+/// goldens were control_step 780e427a…/492, signed_div_const 15fa429d…/88.
 #[test]
 fn frozen_fixtures_rv32_text_is_bit_identical_oracle_001() {
+    let cases = [
+        (
+            "control_step.wasm",
+            "6ac5d7f94f3e17b0314aa2549e24b172b50dc0df110130c80a94e19d62c7b75b",
+            484usize,
+        ),
+        (
+            "signed_div_const.wasm",
+            "15fa429d5ef5474f8b65fdd9c81b3da4c70176fb077df25131e2ec3988eb999e",
+            88,
+        ),
+    ];
+    assert_frozen(&cases, "riscv", "rv32imac");
+}
+
+/// ESCAPE-HATCH GATE for the SYNTH_RV_SHIFT_FOLD flip (#242 flag-audit
+/// flip-wave): `SYNTH_RV_SHIFT_FOLD=0` ALONE must restore the pre-flip RV32
+/// goldens byte-for-byte — the rollback proof, and a tripwire against
+/// `fold_const_shift` leaking into the opt-out lowering. signed_div_const is
+/// fold-inert, so its pin is identical in both configurations — it guards
+/// that the opt-out stays a no-op there.
+#[test]
+fn frozen_fixtures_rv32_shift_fold_escape_hatch_restores_old_bytes() {
     let cases = [
         (
             "control_step.wasm",
@@ -468,7 +678,49 @@ fn frozen_fixtures_rv32_text_is_bit_identical_oracle_001() {
             88,
         ),
     ];
-    assert_frozen(&cases, "riscv", "rv32imac");
+    for &(wasm, golden, golden_len) in &cases {
+        let path = fixture(wasm);
+        let elf = format!("/tmp/frozenbytes_rv32_shiftfold_off_{wasm}.elf");
+        let out = Command::new(synth())
+            .env_remove("SYNTH_RV_LOCAL_PROMO")
+            .env_remove("SYNTH_RV_CMP_SELECT")
+            .env("SYNTH_RV_SHIFT_FOLD", "0")
+            .args([
+                "compile",
+                path.to_str().unwrap(),
+                "-o",
+                &elf,
+                "-b",
+                "riscv",
+                "--target",
+                "rv32imac",
+                "--all-exports",
+                "--relocatable",
+            ])
+            .output()
+            .expect("run synth");
+        assert!(out.status.success(), "compile failed for {wasm}");
+        let bytes = std::fs::read(&elf).expect("read elf");
+        let obj = object::File::parse(&*bytes).expect("parse elf");
+        let data = obj
+            .section_by_name(".text")
+            .expect(".text")
+            .data()
+            .expect("read .text");
+        assert_eq!(
+            data.len(),
+            golden_len,
+            "{wasm}: SYNTH_RV_SHIFT_FOLD=0 must restore the pre-flip length"
+        );
+        let hex: String = Sha256::digest(data)
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        assert_eq!(
+            hex, golden,
+            "{wasm}: SYNTH_RV_SHIFT_FOLD=0 must restore the pre-flip bytes (rollback broken)"
+        );
+    }
 }
 
 /// The RV32 flip-wave ESCAPE HATCH (#472): `SYNTH_RV_CMP_SELECT=0` must
@@ -476,6 +728,10 @@ fn frozen_fixtures_rv32_text_is_bit_identical_oracle_001() {
 /// a tripwire against the fusion path leaking into the opt-out lowering.
 /// signed_div_const is fusion-inert (no selects), so its pin is identical in
 /// both configurations — it guards that the opt-out stays a no-op there.
+///
+/// COMPOSITION NOTE: since the #242 flag-audit flip-wave, rolling back to
+/// these bytes also requires opting out of the LATER shift-fold lever
+/// (`SYNTH_RV_SHIFT_FOLD=0`), which fires on control_step.
 #[test]
 fn frozen_fixtures_rv32_cmp_select_escape_hatch_restores_old_bytes() {
     let cases = [
@@ -496,6 +752,7 @@ fn frozen_fixtures_rv32_cmp_select_escape_hatch_restores_old_bytes() {
         let out = Command::new(synth())
             .env_remove("SYNTH_RV_LOCAL_PROMO")
             .env("SYNTH_RV_CMP_SELECT", "0")
+            .env("SYNTH_RV_SHIFT_FOLD", "0")
             .args([
                 "compile",
                 path.to_str().unwrap(),

--- a/crates/synth-cli/tests/rv32_cmp_select_flip_472.rs
+++ b/crates/synth-cli/tests/rv32_cmp_select_flip_472.rs
@@ -50,6 +50,9 @@ fn fixture(rel: &str) -> std::path::PathBuf {
 fn compile(rel: &str, out: &str, default_on: bool) -> Vec<u8> {
     let mut cmd = Command::new(synth());
     cmd.env_remove("SYNTH_RV_LOCAL_PROMO");
+    // #242 flag-audit flip-wave: shift-fold is default-on; remove it so a
+    // stray opt-out can't skew the cmp-select isolation (both arms fold).
+    cmd.env_remove("SYNTH_RV_SHIFT_FOLD");
     if default_on {
         cmd.env_remove("SYNTH_RV_CMP_SELECT");
     } else {

--- a/scripts/repro/leaf_dead_frame_differential.py
+++ b/scripts/repro/leaf_dead_frame_differential.py
@@ -53,9 +53,10 @@ def to_s32(x):
 
 
 def compile_elf(out, elide):
+    # DEFAULT-ON since the #242 flag-audit flip-wave: "elide" is the shipped
+    # default, else the `SYNTH_DEAD_FRAME_ELIM=0` opt-out (pre-flip lowering).
     env = {"PATH": "/usr/bin:/bin"}
-    if elide:
-        env["SYNTH_DEAD_FRAME_ELIM"] = "1"
+    env["SYNTH_DEAD_FRAME_ELIM"] = "1" if elide else "0"
     r = subprocess.run(
         [SYNTH, "compile", WASM, "-o", out, "--target", "cortex-m4",
          "--all-exports", "--relocatable", "--native-pointer-abi"],

--- a/scripts/repro/shift_fold_riscv_differential.py
+++ b/scripts/repro/shift_fold_riscv_differential.py
@@ -55,9 +55,10 @@ CASES = {
 
 
 def compile_elf(out, fold):
+    # DEFAULT-ON since the #242 flag-audit flip-wave: "fold" is the shipped
+    # default, else the `SYNTH_RV_SHIFT_FOLD=0` opt-out (pre-flip lowering).
     env = {"PATH": "/usr/bin:/bin"}
-    if fold:
-        env["SYNTH_RV_SHIFT_FOLD"] = "1"
+    env["SYNTH_RV_SHIFT_FOLD"] = "1" if fold else "0"
     r = subprocess.run(
         [SYNTH, "compile", WAT, "-o", out, "-b", "riscv", "-t", "rv32imac",
          "--all-exports", "--relocatable"],

--- a/scripts/repro/uxth_fold_differential.py
+++ b/scripts/repro/uxth_fold_differential.py
@@ -49,9 +49,10 @@ VECTORS = [
 
 def compile_variant(fold_on):
     elf = f"/tmp/uxth_{'on' if fold_on else 'off'}.elf"
+    # DEFAULT-ON since the #242 flag-audit flip-wave: "on" is the shipped
+    # default, "off" is the `SYNTH_UXTH_FOLD=0` opt-out (pre-flip lowering).
     env = {"PATH": "/usr/bin:/bin"}
-    if fold_on:
-        env["SYNTH_UXTH_FOLD"] = "1"
+    env["SYNTH_UXTH_FOLD"] = "1" if fold_on else "0"
     env["SYNTH_FUSE_STATS"] = "1"
     r = subprocess.run(
         [SYNTH, "compile", WAT, "-o", elf, "--target", "cortex-m4",


### PR DESCRIPTION
#242 hub lane D — three flag audits with evidence gates; all three flipped default-on.

## Per-flag verdict

### 1. `SYNTH_RV_SHIFT_FOLD` — **FLIPPED** (gale's discrepancy confirmed)
**True prior default: OFF** (`env::var_os(..).is_some()` opt-in in `synth-backend-riscv/src/selector.rs`). gale was right (#242 comment 2026-07-03) — the prior lane's "v0.11.x folds default-on" belief conflated this with the ARM `SYNTH_NO_IMM_SHIFT_FOLD` imm-shift fold (default-on since v0.15.0), a different flag on a different backend.

- Corpus sweep (RV32, `--relocatable`, 143 function comparisons): **0 grow / 20 shrink** — control_step 492→484 (**−8 B, exactly gale's esp32c3 number**), flat_flight 732→696 (−36), flight_seam controller_step 452→416 (−36), call_6_7args −20/−24.
- `shift_fold_riscv_differential.py`: 21/21 vs wasmtime, `.text` 168→148 B, 5 folds — PASS on new default bytes.
- RV32 frozen anchor re-pinned control_step `6ac5d7f9…/484` (was `780e427a…/492`); signed_div_const byte-identical (fold-inert). Escape hatch `SYNTH_RV_SHIFT_FOLD=0` CI-gated to restore the pre-flip bytes; the older `SYNTH_RV_CMP_SELECT=0` hatch gained the composing opt-out.

### 2. `SYNTH_DEAD_FRAME_ELIM` (ARM, VCR-RA-002 #390) — **FLIPPED**
**True prior default: OFF** (`is_ok()` opt-in in `arm_backend.rs`).

- Corpus sweep (both ARM paths — optimized + `--relocatable`/direct; path-agnostic post-pass): **0 grow / 58 shrink** — flight_seam controller_step 250→242 (−8), filter_step 180→168 (−12), native_pointer frame_roundtrip 46→34, leaf_caller_saved leaf3 36→28.
- `leaf_dead_frame_differential.py`: 10/10 off==on==wasmtime, frame elided 36→28 B — PASS.
- ARM anchors re-pinned: flight_seam `92fd6863…/706` (was 726), flight_seam_flat `660c3fbc…/846` (was 866). `SYNTH_DEAD_FRAME_ELIM=0` alone restores the exact prior goldens (CI-gated; the sibling uxth lever is inert on these fixtures).

### 3. `SYNTH_UXTH_FOLD` (ARM, #428) — **FLIPPED**
**True prior default: OFF** (`is_ok()` opt-in).

- Corpus sweep (both ARM paths): **0 grow / 13 shrink** — control_step_decide 300→294 (−6), uxth_fold pack 36→24 (−12, two folds), gust_mix family −6 each.
- `uxth_fold_differential.py`: 7/7 off==on==wasmtime — PASS.
- ARM anchor re-pinned: control_step `d0907e02…/294` (was 300). `SYNTH_UXTH_FOLD=0` alone restores the prior golden (CI-gated; dead-frame inert on control_step).

Combined ARM sweep is exactly additive (71 = 58 + 13): **no lever interaction**. The #601 local-promo HOLD precedent did not trigger — no function grew anywhere.

## Refreeze ritual
Execution differentials re-ran green **on the new default bytes BEFORE any golden was pinned**. Full `scripts/repro/*_differential.py` sweep (56 scripts): **55 PASS** — 3 initially failed on missing external inputs (call_indirect_594/597 ELFs regenerated per script header, wake_path gist fetched) then passed; **sret_decide is a pre-existing, flip-neutral harness discrepancy** (script needs an externally supplied ELF with an undocumented invocation; with `--native-pointer-abi` it runs but vector (3,8,8) mismatches — and the fixture's bytes are byte-identical default vs opt-out, so not this wave's doing; worth its own follow-up issue).

## Gates
- `cargo test -p synth-synthesis -p synth-backend-riscv -p synth-cli` (+ `-p synth-backend`): 1526 passed / 0 failed — includes the new `flag_flip_wave_242.rs` per-flag no-grow corpus gates, the re-pinned frozen anchors, and the three new escape-hatch gates.
- Older escape hatches (stack-fwd, spill-realloc, const-CSE, rv32-cmp-select) gained the composing new-lever opt-outs (the documented composition pattern) and still restore their exact pinned bytes.
- RV selector unit tests reworked: the default-shape test now pins the FOLDED default; the fold-mechanism tests drive `fold_const_shift` on hand-built unfolded streams (coverage independent of the wiring).
- `cargo fmt --check` clean; clippy `-D warnings` clean on all touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)