### PR TITLE
chore(release): v0.30.0 — flip trilogy + North-Star designs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-07-03
+
+**Three more levers ship default-on (RV32 shift-fold, dead-frame-elim,
+uxth-fold — all evidence-gated, exactly additive); the below-native lever and
+the verified-selector DSL get their designs.**
+
+### Changed (byte-changing, deliberate — affected anchors refrozen)
+
+- **`SYNTH_RV_SHIFT_FOLD` default-ON (#611).** Was opt-in all along (the
+  "v0.11.x default-on" belief conflated it with ARM's flag — gale's #242 datum
+  was right): control_step −8 B (gale's exact esp32c3 number), corpus 0 grow /
+  20 shrink.
+- **`SYNTH_DEAD_FRAME_ELIM` default-ON (#611):** 0 grow / 58 shrink across both
+  ARM paths.
+- **`SYNTH_UXTH_FOLD` default-ON (#611):** 0 grow / 13 shrink; the combined ARM
+  sweep is exactly additive (71 = 58 + 13). Per-flag `=0` escape hatches
+  CI-gated to the prior bytes; 55/56 differentials on the new defaults before
+  pinning.
+
+### Added
+
+- **North-Star designs traced (#609):** `VCR-PERF-002` — proof-carrying
+  specialization (#494): loom's `wsc.facts` invariants become premises for
+  per-elision obligations discharged certificate-checked by the ordeal-backed
+  validator; phased toward gale's 0.45×→0.7× floor. `VCR-SEL-001` first
+  increment scoped: the 6-op auto-discharge i32 ALU class + `rotl`, delegation
+  behind `SYNTH_SEL_DSL`, mirror-pinned byte-equality migration.
+
 ## [0.29.0] - 2026-07-03
 
 **const-CSE ships default-on (hazard retired, branch-geometry sound); i64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,14 +2039,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2104,11 +2104,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.29.0"
+version = "0.30.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2163,14 +2163,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2178,11 +2178,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.29.0"
+version = "0.30.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.29.0"
+version = "0.30.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.29.0"
+version = "0.30.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.29.0",
+    version = "0.30.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.29.0" }
+synth-core = { path = "../synth-core", version = "0.30.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.29.0" }
+synth-core = { path = "../synth-core", version = "0.30.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.29.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.29.0" }
+synth-core = { path = "../synth-core", version = "0.30.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.30.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.29.0" }
+synth-core = { path = "../synth-core", version = "0.30.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.29.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.29.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.30.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.30.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,21 +27,21 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.29.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.29.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.29.0" }
-synth-backend = { path = "../synth-backend", version = "0.29.0" }
+synth-core = { path = "../synth-core", version = "0.30.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.30.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.30.0" }
+synth-backend = { path = "../synth-backend", version = "0.30.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.29.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.30.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.29.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.29.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.29.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.30.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.30.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.30.0", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.29.0", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.30.0", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.29.0" }
+synth-core = { path = "../synth-core", version = "0.30.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.29.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.30.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.29.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.29.0" }
-synth-opt = { path = "../synth-opt", version = "0.29.0" }
+synth-core = { path = "../synth-core", version = "0.30.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.30.0" }
+synth-opt = { path = "../synth-opt", version = "0.30.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -20,12 +20,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.29.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.29.0" }
-synth-opt = { path = "../synth-opt", version = "0.29.0" }
+synth-core = { path = "../synth-core", version = "0.30.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.30.0" }
+synth-opt = { path = "../synth-opt", version = "0.30.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.29.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.30.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"


### PR DESCRIPTION
Release **v0.30.0** — hub lanes D+E: three evidence-gated default-on flips (#611: RV shift-fold with gale's exact −8B, dead-frame 58-shrink, uxth 13-shrink, additive, 0-grow) + the #494/VCR-SEL-001 designs traced (#609). Pin sweep + lock + CHANGELOG. Tag on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)