### PR TITLE
chore(verify): drop static-link-z3 from the default build/CI path (#553 steps 3/4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,11 @@ env:
 jobs:
   test:
     name: Test
-    # NOTE: moved back to ubuntu-latest from [self-hosted, linux, x64, rust-cpu]
-    # because z3-sys's C++ build was exhausting the smithy runners' temp disk
-    # ("No space left on device" while compiling z3 AST sources). The Test job
-    # builds the entire workspace including synth-verify (which depends on z3),
-    # so the disk pressure is real. Once the smithy runners get a bigger /tmp
-    # we can move this back.
+    # NOTE: stays on ubuntu-latest for now. It originally moved here from
+    # [self-hosted, linux, x64, rust-cpu] because z3-sys's C++ build exhausted
+    # the smithy runners' temp disk — that pressure is gone (#553: synth-verify
+    # defaults to the pure-Rust ordeal engine, z3 is behind the off-by-default
+    # `z3-solver` feature), so moving back is a possible follow-up.
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -Dwarnings
@@ -35,17 +34,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
       - name: Run tests
-        # Exclude synth-verify: it is the only crate that pulls in z3-sys, which
-        # compiles all of Z3 from source and intermittently exhausts the runner's
-        # disk ("No space left on device" building libz3.a) — the recurring #306
-        # instability. Z3/synth-verify is already covered by the dedicated `Z3
-        # Verification` job, and the sibling jobs already exclude it, so this drops
-        # a redundant heavyweight build without losing coverage.
-        run: cargo test --workspace --exclude synth-verify
+        # Full workspace, synth-verify included (#553 steps 3/4): with ordeal as
+        # the default solver there is no z3-sys / C++ build on the default
+        # feature set, so the long-standing `--exclude synth-verify` (the #306
+        # disk-exhaustion workaround) is gone. The z3-solver feature path is
+        # covered by the dedicated `Z3 Verification` differential job below.
+        run: cargo test --workspace
 
   clippy:
     name: Clippy
-    # Same reasoning as Test — z3-sys build exhausts the smithy runner's /tmp.
+    # Same runner note as Test — the z3-sys disk pressure that forced
+    # ubuntu-latest is gone (#553); moving back to smithy is a follow-up.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -99,10 +98,18 @@ jobs:
 
   verify:
     name: Z3 Verification
+    # #553 steps 3/4: this is now the ONLY job that builds z3 (feature
+    # `z3-solver`) — the trusted-reference differential oracle, not the default
+    # engine. SYNTH_SOLVER_DIFF=1 routes every query through BOTH engines
+    # (ordeal + Z3); any decided-verdict disagreement is a hard error. Do not
+    # delete this job: it is the standing cross-check that keeps the pure-Rust
+    # default honest.
     # Stays on ubuntu-latest: needs `sudo apt-get install -y libz3-dev`
     # (smithy runners have no sudo). Move once libz3-dev is added to
     # the smithy toolchains role.
     runs-on: ubuntu-latest
+    env:
+      SYNTH_SOLVER_DIFF: "1"
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -118,9 +125,9 @@ jobs:
             ${{ runner.os }}-cargo-
       - name: Install Z3
         run: sudo apt-get update && sudo apt-get install -y libz3-dev
-      - name: Run verification tests
+      - name: Run verification tests (differential ordeal vs Z3)
         run: cargo test -p synth-verify --features z3-solver,arm
-      - name: Run comprehensive verification
+      - name: Run comprehensive verification (differential ordeal vs Z3)
         run: cargo test -p synth-verify --test comprehensive_verification --features z3-solver,arm
 
   coverage:
@@ -145,9 +152,11 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: Generate coverage (LCOV)
+        # synth-verify is no longer excluded (#553): the default feature set is
+        # pure Rust (ordeal), so its tests run under llvm-cov like any crate.
         run: |
           cargo llvm-cov --workspace --lcov --output-path lcov.info \
-            --exclude synth-verify --exclude synth-qemu \
+            --exclude synth-qemu \
             --exclude synth-backend-awsm --exclude synth-backend-wasker
       - name: Upload to Codecov
         uses: codecov/codecov-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,12 @@ env:
 jobs:
   # ── Cross-platform binary builds ──────────────────────────────────────
   # synth-cli builds with `--features riscv` only (the workspace default).
-  # The `verify` feature (Z3 / z3-sys) is intentionally NOT enabled here:
-  # z3-sys vendors and compiles z3 from source, needs network + a large
-  # C++ build, and the CLI degrades gracefully without it (`synth verify`
-  # prints "rebuild with --features verify"). Keeping it out makes the
-  # release build fast, hermetic, and free of the libz3-dev / temp-disk
-  # problems documented in ci.yml.
+  # The `verify` feature is intentionally NOT enabled here. Historically it
+  # pulled z3-sys (vendored C++ Z3 build — slow, network-hungry); since #553
+  # it is pure Rust (ordeal engine), so enabling it is now feasible but is a
+  # deliberate follow-up decision, not a build constraint. The CLI degrades
+  # gracefully without it (`synth verify` fails loudly with "rebuild with
+  # --features verify").
   build-binaries:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ bazel test //tests/...             # Renode ARM Cortex-M4 emulation tests
 | `synth-synthesis` | WASM→ARM instruction selection, peephole optimizer, pattern matcher |
 | `synth-cfg` | Control flow graph construction and analysis |
 | `synth-opt` | IR-level optimization passes (CSE, constant folding, DCE) |
-| `synth-verify` | Z3 SMT translation validation |
+| `synth-verify` | SMT translation validation (pure-Rust ordeal engine; optional Z3 differential oracle behind `z3-solver`) |
 | `synth-analysis` | SSA, control flow analysis, call graph |
 | `synth-abi` | WebAssembly Component Model ABI (lift/lower) |
 | `synth-memory` | Portable memory abstraction (Zephyr, Linux, bare-metal) |

--- a/crates/BUILD.bazel
+++ b/crates/BUILD.bazel
@@ -164,15 +164,16 @@ rust_library(
     ],
 )
 
-# Verification (Z3 SMT + property-based testing)
-# Features: z3-solver (SMT proofs), arm (ARM semantics via synth-synthesis)
+# Verification (SMT translation validation + property-based testing)
+# Default feature set (#553): pure-Rust ordeal QF_BV engine + arm semantics —
+# no z3-sys / C++ build in the Bazel graph. The Z3 differential oracle
+# (feature z3-solver) is cargo-only, exercised by CI's `Z3 Verification` job.
 rust_library(
     name = "synth-verify",
     srcs = glob(["synth-verify/src/**/*.rs"]),
     crate_root = "synth-verify/src/lib.rs",
     edition = "2024",
     rustc_flags = [
-        "--cfg", "feature=\"z3-solver\"",
         "--cfg", "feature=\"arm\"",
     ],
     deps = [
@@ -182,11 +183,11 @@ rust_library(
         ":synth-synthesis",
         "@crates//:anyhow",
         "@crates//:chrono",
+        "@crates//:ordeal",
         "@crates//:proptest",
         "@crates//:serde",
         "@crates//:serde_json",
         "@crates//:thiserror",
-        "@crates//:z3",
     ],
 )
 

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -40,8 +40,10 @@ synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.30.2", optio
 synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.30.2", optional = true }
 synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.30.2", optional = true }
 
-# Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.30.2", optional = true, features = ["z3-solver", "arm"] }
+# Optional translation validation — pure-Rust ordeal engine by default (#553),
+# no C++ toolchain needed. For the Z3 differential oracle build with
+# `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
+synth-verify = { path = "../synth-verify", version = "0.30.2", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1383,7 +1383,7 @@ fn compile_command(
             }
             #[cfg(not(feature = "verify"))]
             {
-                println!("\nVerification requested but z3-solver not available.");
+                println!("\nVerification requested but not compiled into this binary.");
                 println!("Rebuild with: cargo build --features verify");
             }
         } else {
@@ -1752,7 +1752,7 @@ fn run_verification(wasm_ops: &[WasmOp], func_name: &str) -> Result<()> {
 
     println!("  Verifying {} instruction selection rules...", rules.len());
 
-    let (verified, failed, unknown) = synth_verify::with_z3_context(|| {
+    let (verified, failed, unknown) = synth_verify::with_verification_context(|| {
         let validator = synth_verify::TranslationValidator::new();
         let mut verified = 0u32;
         let mut failed = 0u32;
@@ -3969,7 +3969,7 @@ fn verify_command(wasm_input: PathBuf, elf_input: PathBuf, backend_name: &str) -
 
         #[cfg(not(feature = "verify"))]
         {
-            // This binary was built without the `verify` feature, so no Z3
+            // This binary was built without the `verify` feature, so no SMT
             // translation validation can run. Returning Ok here would make
             // `synth verify` exit success-shaped while doing nothing — a
             // script or CI step gating on `synth verify` would silently
@@ -3977,7 +3977,7 @@ fn verify_command(wasm_input: PathBuf, elf_input: PathBuf, backend_name: &str) -
             // with a non-zero exit instead.
             anyhow::bail!(
                 "this `synth` binary was built without the `verify` feature — \
-                 Z3 translation validation is unavailable.\n  \
+                 SMT translation validation is unavailable.\n  \
                  Rebuild with verification support:\n    \
                  cargo build --features verify\n  \
                  (or `cargo install --path crates/synth-cli --features verify`)"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -37,11 +37,11 @@ an existing tag).
    (with `README.md` + `LICENSE`), and uploaded as a workflow artifact.
 
    The build uses only the `riscv` feature (the workspace default). The
-   `verify` feature is **not** enabled — it pulls `z3-sys`, which vendors
-   and compiles Z3 from source (slow, needs network, large C++ build). The
-   CLI degrades gracefully: `synth verify` without the feature prints
-   "rebuild with `--features verify`". This keeps the release build fast and
-   free of the `libz3-dev` / temp-disk issues documented in `ci.yml`.
+   `verify` feature is **not** enabled — historically it pulled `z3-sys`
+   (vendored C++ Z3 build); since #553 it is pure Rust (ordeal engine), so
+   enabling it in release builds is now feasible but remains a deliberate
+   follow-up decision. The CLI degrades gracefully: `synth verify` without
+   the feature fails loudly with "rebuild with `--features verify`".
 
 2. **`create-release`** — collects all archives, then:
    - Generates a CycloneDX 1.5 JSON SBOM for the synth toolchain via


### PR DESCRIPTION
Part of #553 (loom #246 ecosystem decision). Follows #595.

## What #595 already did vs this PR

**#595 (merged 2026-07-03)** did the crate-level engine swap inside `synth-verify`: ordeal 0.4 behind a thin solver trait as the **default** engine, Z3 demoted to an optional differential oracle behind the off-by-default `z3-solver` feature, `SYNTH_SOLVER_DIFF=1` runtime cross-check (decided-verdict disagreement = hard error).

**This PR** finishes steps 3/4 — nothing on the *default build/CI path* compiles z3-sys anymore:

- `synth-cli/Cargo.toml`: stop forcing `synth-verify/z3-solver` — `--features verify` now builds the pure-Rust ordeal validator (verified locally: `cargo check -p synth-cli --features verify` clean in 1m40s, no C++ build)
- `crates/BUILD.bazel`: `synth-verify` loses the `z3-solver` cfg + `@crates//:z3` dep, gains `@crates//:ordeal` (present in the from_cargo universe via Cargo.lock, ordeal 0.4.2) — no z3 in the Bazel graph
- `synth-cli/src/main.rs`: `with_z3_context` → `with_verification_context` (solver-neutral); `synth verify` without the feature still **fails loudly** non-zero
- docs (`release-process.md`, `CLAUDE.md`): wording updated; release builds still don't enable `verify` — now a deliberate follow-up decision, not a build constraint

## cargo-tree proof

```
$ cargo tree -i z3-sys                                      # default features
error: package ID specification `z3-sys` did not match any packages
$ cargo tree -i z3-sys -p synth-cli --features verify       # verify feature on
error: package ID specification `z3-sys` did not match any packages
$ cargo tree -i z3-sys -p synth-verify --features z3-solver # explicit opt-in only
z3-sys v0.10.9 └── z3 v0.19.15 └── synth-verify v0.30.1
```

## CI matrix before → after

| Job | Before | After |
|---|---|---|
| Test | `cargo test --workspace --exclude synth-verify` (#306 z3 disk-exhaustion workaround) | `cargo test --workspace` — full workspace, z3-free |
| Coverage | `--exclude synth-verify` | synth-verify included in llvm-cov |
| Z3 Verification | `cargo test -p synth-verify --features z3-solver,arm` | **KEPT**, same job name, same (advisory) status — now runs with `SYNTH_SOLVER_DIFF=1` so every query cross-checks ordeal vs Z3. The only job that builds z3, and deliberately so: it is the standing differential oracle, not a leftover. |
| Clippy / Format / Bazel / oracles | unchanged | unchanged (Bazel graph no longer contains z3) |

No named required status checks exist on `main` (branch protection has empty `contexts`), so no required gate was weakened — the differential job is preserved and strengthened.

## Local verification (no-exclusion)

- `cargo test --workspace` (full, synth-verify included, default features): completed clean, **0 failures** — the historic `--exclude synth-verify` is dead
- `cargo test -p synth-verify` (pure ordeal): **86 + 53 = 139 passed, 0 failed**
- `cargo test -p synth-cli --test frozen_codegen_bytes`: **9/9 passed** — frozen anchors untouched
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean

## What remains on #553

- LRAT/certificate checking surfaced through the solver trait (untrusted-solver + verified-checker architecture, ordeal phase 2)
- Optional follow-ups unlocked by this PR: move Test/Clippy back to smithy runners (z3 temp-disk pressure gone), enable `verify` in release binaries, and let the differential job drop `static-link-z3` in favor of system libz3 to cut its ~16-min vendored build
- Close-out once the ordeal-vs-Z3 differential has soaked in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)