### PR TITLE
chore(release): v0.30.2 — A32 i64 silent-NOP class ends (#615)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.2] - 2026-07-07
+
+**Every A32 (cortex-r5) i64 op computed real results — the entire family was
+silently encoding to NOP (#615). The silent-NOP class (#594 → #610 → #615)
+ends here: a 221-variant no-wildcard tripwire guarantees no arm can regrow.**
+
+### Fixed
+
+- **A32 i64 mul/shifts/rotates/all-10-comparisons/eqz/clz/ctz/popcnt/div/rem/
+  const/load/store/extends — plus i32 `SetCond`/`SelectMove`/`Popcnt` — encoded
+  as the literal NOP word on `--target cortex-r5` (#615).** Verification-era
+  "NOP for now" arms became user-reachable when cortex-r5 landed; operations
+  vanished and functions returned register garbage with no diagnostic. All now
+  expand via `encode_arm_expanded` mirroring each Thumb-2 twin's register
+  contract (A32 conditional execution replaces IT blocks; div/rem get A32
+  fixed-ABI wrappers with the zero-divisor `UDF` trap). Ops no A32 target can
+  legally reach (verification-only pseudo-ops, Thumb-only MVE) are typed `Err`
+  — loud, never NOP. Evidence: 24/24 clang bit-exact encoding cross-checks,
+  branch-offset audit, 352-case ARM-mode unicorn-vs-wasmtime differential
+  (pre-fix: 254 mismatches; post-fix: 0), frozen anchors 9/9 byte-identical
+  (Thumb path untouched).
+
+### Added
+
+- **Structural tripwire `a32_no_silent_nop_615.rs`:** exhaustive no-wildcard
+  match over all 221 `ArmOp` variants — a new variant fails compilation until
+  classified; the A32 encoding may never be the bare NOP word outside the
+  documented genuine-no-op allowlist.
+
+### Changed
+
+- deps: rivet 0.24.0, ordeal 0.4.2, scry-sai-core 3.0.0 (dependabot).
+
 ## [0.30.1] - 2026-07-03
 
 **i64 rotl/rotr/div_u/rem_u (+div_s/rem_s) computed real results — were

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,14 +2060,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2125,11 +2125,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.30.1"
+version = "0.30.2"
 
 [[package]]
 name = "synth-cli"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2184,14 +2184,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2199,11 +2199,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.30.1"
+version = "0.30.2"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.30.1"
+version = "0.30.2"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.30.1"
+version = "0.30.2"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.30.1",
+    version = "0.30.2",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.30.1" }
+synth-core = { path = "../synth-core", version = "0.30.2" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.30.1" }
+synth-core = { path = "../synth-core", version = "0.30.2" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.30.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.30.1" }
+synth-core = { path = "../synth-core", version = "0.30.2" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.30.2" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.30.1" }
+synth-core = { path = "../synth-core", version = "0.30.2" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.30.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.30.1", optional = true }
+synth-core = { path = "../synth-core", version = "0.30.2" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.30.2", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,21 +27,21 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.30.1" }
-synth-frontend = { path = "../synth-frontend", version = "0.30.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.30.1" }
-synth-backend = { path = "../synth-backend", version = "0.30.1" }
+synth-core = { path = "../synth-core", version = "0.30.2" }
+synth-frontend = { path = "../synth-frontend", version = "0.30.2" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.30.2" }
+synth-backend = { path = "../synth-backend", version = "0.30.2" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.30.1" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.30.2" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.30.1", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.30.1", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.30.1", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.30.2", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.30.2", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.30.2", optional = true }
 
 # Optional verification (requires z3)
-synth-verify = { path = "../synth-verify", version = "0.30.1", optional = true, features = ["z3-solver", "arm"] }
+synth-verify = { path = "../synth-verify", version = "0.30.2", optional = true, features = ["z3-solver", "arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.30.1" }
+synth-core = { path = "../synth-core", version = "0.30.2" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.30.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.30.2" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.30.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.30.1" }
-synth-opt = { path = "../synth-opt", version = "0.30.1" }
+synth-core = { path = "../synth-core", version = "0.30.2" }
+synth-cfg = { path = "../synth-cfg", version = "0.30.2" }
+synth-opt = { path = "../synth-opt", version = "0.30.2" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -20,12 +20,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.30.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.30.1" }
-synth-opt = { path = "../synth-opt", version = "0.30.1" }
+synth-core = { path = "../synth-core", version = "0.30.2" }
+synth-cfg = { path = "../synth-cfg", version = "0.30.2" }
+synth-opt = { path = "../synth-opt", version = "0.30.2" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.30.1", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.30.2", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"


### PR DESCRIPTION
Release PR: pin sweep (workspace + path-deps + MODULE.bazel) + CHANGELOG for v0.30.2.

Content: #620 (A32 i64 mul/shift/rotate/compare expansions + the 221-variant no-silent-NOP tripwire — the #594→#610→#615 class terminator) + three dependabot bumps (rivet 0.24.0, ordeal 0.4.2, scry-sai-core 3.0.0).

Tag v0.30.2 on green merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)