### PR TITLE
feat(facts): wsc.facts ingestion — schema-v1 parser + CompileConfig plumbing, zero codegen change (#494 phase 1)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -1620,7 +1620,22 @@ artifacts:
       PHASING (each phase its own oracle-gated PR):
       Phase 1 — fact ingestion: parse wsc.facts, thread premises to
       CompileConfig/selector, ZERO codegen change (byte-identical, frozen-safe);
-      schema versioned, unknown-kind-tolerant.
+      schema versioned, unknown-kind-tolerant. IMPLEMENTED (2026-07-07): binary
+      encoding schema v1 specified in docs/design/wsc-facts-encoding.md
+      (resolves loom#231 open questions 1/2: keyed by (function index, value
+      id = producing-operator index), kind bytes 1-6 value-range-first,
+      length-prefixed records); total fail-safe parser
+      crates/synth-core/src/wsc_facts.rs wired into decode_wasm_module and
+      threaded to CompileConfig::wsc_facts / current_func_facts (the
+      volatile_segments/#543-Phase-1 inert-plumbing pattern) with NO consumer;
+      phase-1 verification-criteria locked by
+      crates/synth-cli/tests/wsc_facts_ingestion_494.rs (facts-present .text
+      byte-identical to facts-stripped; malformed/wrong-version sections
+      ignored end-to-end; non-vacuity decode guard) + parser unit tests (all
+      six kinds, unknown-kind skip, truncation/version/overrun => ignored).
+      Phases 2/3 NOT implemented — no elision, no SYNTH_FACT_SPEC lever yet;
+      status stays short of implemented until the full requirement (the
+      elision + gale-measured kill-criterion) has evidence.
       Phase 2 — single-elision prototype: value-range => dead conditional-branch
       elision (the gust_mix clamp shape), flag-gated, per-elision validator
       obligation + in-bounds differential red/green oracle.
@@ -1631,7 +1646,10 @@ artifacts:
       floor (0.45x) gives the target 0.25x of headroom — if the productized
       elision cannot land inside it, the premise-to-selector plumbing (not the
       idea) is at fault and the phase re-plans.
-    status: proposed
+    # approved (not implemented): Phase 1 of 3 landed with its oracle; the
+    # requirement's substance (the elision + kill-criterion) is Phases 2/3 —
+    # never strengthen a traceability claim beyond the evidence.
+    status: approved
     tags: [codegen, perf, proof-carrying, specialization, wsc-facts, loom-integration, ordeal, beat-llvm, synth-494, gale-121]
     links:
       - type: derives-from

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -18,6 +18,7 @@ use synth_core::SafetyManifest;
 use synth_core::backend::{Backend, BackendRegistry, CompileConfig, SafetyBounds, VolatileRange};
 use synth_core::target::TargetSpec;
 use synth_core::wasm_decoder::ImportEntry;
+use synth_core::wsc_facts::WscFact;
 use synth_synthesis::{
     FunctionOps, WasmGlobal, WasmMemory, WasmOp, decode_wasm_functions, decode_wasm_module,
 };
@@ -1142,6 +1143,11 @@ fn compile_command(
     let mut func_ret_i64: Vec<bool> = Vec::new(); // #311: call-result pair tagging
     let mut type_ret_i64: Vec<bool> = Vec::new(); // #311: call_indirect results
     let mut current_func_block_arity: Vec<(u8, u8)> = Vec::new(); // #509: value-carrying branches
+    // VCR-PERF-002 Phase 1 (#494): loom `wsc.facts` premises — whole-module
+    // table + this function's slice. Threaded to the CompileConfig; NOT yet
+    // consumed by any codegen path (Phase 2 is the gated elision).
+    let mut wsc_facts: Vec<WscFact> = Vec::new();
+    let mut current_func_facts: Vec<WscFact> = Vec::new();
     let (wasm_ops, func_name): (Vec<WasmOp>, String) = match (&input, &demo) {
         (Some(path), _) => {
             info!("Compiling WASM file: {}", path.display());
@@ -1175,6 +1181,10 @@ fn compile_command(
             func_ret_i64 = module.func_ret_i64;
             type_ret_i64 = module.type_ret_i64;
             let module_func_params_i64 = module.func_params_i64;
+            // VCR-PERF-002 Phase 1 (#494): whatever facts loom forwarded
+            // (empty for a section-less module — the overwhelmingly common
+            // case — and for any malformed section, per the fail-safe rule).
+            wsc_facts = module.wsc_facts;
 
             // Capture the WASM bytes + imports for the SBOM (the bytes synth
             // actually compiles, after WAT decode and any Loom pass).
@@ -1219,6 +1229,14 @@ fn compile_command(
                 current_func_params_i64 = p.clone();
             }
             current_func_block_arity = func.block_arity.clone();
+            // VCR-PERF-002 Phase 1 (#494): THIS function's facts slice, the
+            // `current_func_params_i64` pattern (`compile_function` carries no
+            // function index, so the driver filters by `func_index` up front).
+            current_func_facts = wsc_facts
+                .iter()
+                .filter(|f| f.func_index == func.index)
+                .cloned()
+                .collect();
 
             // #554: an op the decoder DROPPED (`_ => None`, e.g. scalar `f32.*`)
             // is recorded in `func.unsupported` but is already gone from
@@ -1294,6 +1312,11 @@ fn compile_command(
         func_ret_i64,
         type_ret_i64,
         current_func_block_arity,
+        // VCR-PERF-002 Phase 1 (#494): threaded but not yet consumed (inert
+        // plumbing, like volatile_segments was in #543 Phase 1). Phase 2 reads
+        // `current_func_facts` in the selector behind SYNTH_FACT_SPEC.
+        wsc_facts,
+        current_func_facts,
         ..CompileConfig::default()
     };
 
@@ -1974,6 +1997,7 @@ fn compile_all_exports(
         all_func_ret_i64, // #311: per-function returns-i64 (pair tagging)
         all_type_ret_i64, // #311: per-type returns-i64 (call_indirect)
         all_func_params_i64, // #359: per-function declared param widths (stack-arg ABI)
+        all_wsc_facts, // VCR-PERF-002 Phase 1 (#494): loom wsc.facts premises
     ) = if path.extension().is_some_and(|ext| ext == "wast") {
         info!("Parsing WAST (extracting all modules)...");
         let contents = String::from_utf8(file_bytes).context("WAST file is not valid UTF-8")?;
@@ -2070,6 +2094,7 @@ fn compile_all_exports(
             Vec::new(), // #311: WAST runs the fixture suite; i32-only
             Vec::new(),
             Vec::new(), // #359: WAST fixture suite is i32-only — no stack params
+            Vec::new(), // #494: facts are a loom-emitted-.wasm channel; WAST fixtures carry none
         )
     } else {
         let wasm_bytes = if path.extension().is_some_and(|ext| ext == "wat") {
@@ -2133,6 +2158,7 @@ fn compile_all_exports(
             module.func_ret_i64,
             module.type_ret_i64,
             module.func_params_i64,
+            module.wsc_facts,
         )
     };
 
@@ -2210,6 +2236,12 @@ fn compile_all_exports(
         // Phase-2 back-off (const-CSE + #468 base-CSE decline inside these ranges)
         // lives on the optimized path this config feeds. See VCR-DMA-001.
         volatile_segments,
+        // VCR-PERF-002 Phase 1 (#494): the module's loom-forwarded `wsc.facts`
+        // premises — threaded but not yet consumed (inert plumbing, the #543
+        // Phase-1 pattern). The per-function slice is filtered into
+        // `current_func_facts` in the compile loop below; Phase 2 reads it in
+        // the selector behind SYNTH_FACT_SPEC.
+        wsc_facts: all_wsc_facts.clone(),
         ..CompileConfig::default()
     };
 
@@ -2254,6 +2286,14 @@ fn compile_all_exports(
                 fc.current_func_params_i64 = p.clone();
             }
             fc.current_func_block_arity = func.block_arity.clone();
+            // VCR-PERF-002 Phase 1 (#494): THIS function's wsc.facts slice
+            // (`compile_function` carries no function index — the same reason
+            // `current_func_params_i64` exists). Not yet consumed.
+            fc.current_func_facts = all_wsc_facts
+                .iter()
+                .filter(|f| f.func_index == func.index)
+                .cloned()
+                .collect();
             fc
         };
         // #369: the decoder flagged a value-affecting op it cannot lower (e.g.

--- a/crates/synth-cli/tests/wsc_facts_ingestion_494.rs
+++ b/crates/synth-cli/tests/wsc_facts_ingestion_494.rs
@@ -118,7 +118,9 @@ fn append_wsc_facts_section(mut wasm: Vec<u8>, payload: &[u8]) -> Vec<u8> {
 /// Fixture wat → wasm bytes (the exact bytes the CLI would produce from .wat).
 fn fixture_wasm() -> Vec<u8> {
     let wat = std::fs::read(fixture(FIXTURE)).expect("read fixture wat");
-    wat::parse_bytes(&wat).expect("fixture wat must parse").into_owned()
+    wat::parse_bytes(&wat)
+        .expect("fixture wat must parse")
+        .into_owned()
 }
 
 /// Compile a `.wasm` byte blob on the shipped default config (optimized ARM

--- a/crates/synth-cli/tests/wsc_facts_ingestion_494.rs
+++ b/crates/synth-cli/tests/wsc_facts_ingestion_494.rs
@@ -1,0 +1,236 @@
+//! VCR-PERF-002 Phase 1 (#494) — `wsc.facts` ingestion is CODEGEN-NEUTRAL.
+//!
+//! Phase 1 is parse + plumbing only: loom's `wsc.facts` custom section
+//! (encoding: `docs/design/wsc-facts-encoding.md`, schema v1) is decoded into
+//! `CompileConfig::wsc_facts` / `current_func_facts`, and NOTHING consumes it
+//! yet. The design doc's guarantee is that the facts-ABSENT compile is
+//! byte-identical to baseline by construction; this gate proves the
+//! facts-PRESENT compile is too — a module WITH a `wsc.facts` section must
+//! produce `.text` byte-identical to the same module with the section
+//! stripped, on the SHIPPED default configuration (no opt-out env vars — in
+//! Phase 1 there is no lever to opt out of).
+//!
+//! Also locked here: the fail-safe skew rule end-to-end (loom#231 Q4) — a
+//! MALFORMED or WRONG-VERSION section must neither fail the compile nor
+//! change a byte (facts are optional accelerators; there is no error path).
+//! Record-level parser behavior (each fact kind, unknown-kind tolerance,
+//! truncation) is unit-tested in `synth-core/src/wsc_facts.rs`.
+//!
+//! NON-VACUITY: byte-identity would also hold if the section never parsed at
+//! all, so `facts_actually_reach_the_decoded_module_494` first proves the
+//! exact bytes appended here DO decode into facts via `decode_wasm_module` —
+//! the same reader the compile paths use.
+//!
+//! Traceability: rivet `VCR-PERF-002` (epic #242), GitHub #494, loom#231.
+
+use object::{Object, ObjectSection};
+use std::process::Command;
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture(name: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro")
+        .join(name)
+}
+
+/// The frozen-suite control-flow fixture: multiple stores, a `br_if`, and a
+/// clamp-ish shape — representative of what a fact would eventually annotate.
+const FIXTURE: &str = "base_cse_branch.wat";
+
+// ---- test-side encoders (mirror docs/design/wsc-facts-encoding.md) ----
+
+fn leb_u32(mut v: u32, out: &mut Vec<u8>) {
+    loop {
+        let mut b = (v & 0x7f) as u8;
+        v >>= 7;
+        if v != 0 {
+            b |= 0x80;
+        }
+        out.push(b);
+        if v == 0 {
+            return;
+        }
+    }
+}
+
+fn leb_s64(mut v: i64, out: &mut Vec<u8>) {
+    loop {
+        let mut b = (v & 0x7f) as u8;
+        v >>= 7;
+        let done = (v == 0 && b & 0x40 == 0) || (v == -1 && b & 0x40 != 0);
+        if !done {
+            b |= 0x80;
+        }
+        out.push(b);
+        if done {
+            return;
+        }
+    }
+}
+
+/// A well-formed schema-v1 payload: the gust_mix-shaped value-range premise
+/// `v ∈ [524, 1524]` on (func 0, value 1), plus a divisor-nonzero and a
+/// from-the-future unknown kind (0x2A) that a tolerant parser must skip.
+fn well_formed_facts_payload() -> Vec<u8> {
+    let mut body = Vec::new();
+    leb_s64(524, &mut body);
+    leb_s64(1524, &mut body);
+
+    let mut p = vec![0x01]; // version
+    leb_u32(3, &mut p); // count
+    // fact 1: value-range on (func 0, value 1)
+    p.push(0x01);
+    leb_u32(0, &mut p);
+    leb_u32(1, &mut p);
+    leb_u32(body.len() as u32, &mut p);
+    p.extend_from_slice(&body);
+    // fact 2: divisor-nonzero on (func 0, value 3)
+    p.push(0x03);
+    leb_u32(0, &mut p);
+    leb_u32(3, &mut p);
+    leb_u32(0, &mut p);
+    // fact 3: unknown kind 0x2A with an opaque body (skipped via length prefix)
+    p.push(0x2a);
+    leb_u32(0, &mut p);
+    leb_u32(4, &mut p);
+    leb_u32(3, &mut p);
+    p.extend_from_slice(&[0xde, 0xad, 0xbe]);
+    p
+}
+
+/// Append a wasm custom section (id 0) named `wsc.facts` with `payload`.
+fn append_wsc_facts_section(mut wasm: Vec<u8>, payload: &[u8]) -> Vec<u8> {
+    let name = b"wsc.facts";
+    let mut content = Vec::new();
+    leb_u32(name.len() as u32, &mut content);
+    content.extend_from_slice(name);
+    content.extend_from_slice(payload);
+    wasm.push(0x00); // custom section id
+    leb_u32(content.len() as u32, &mut wasm);
+    wasm.extend_from_slice(&content);
+    wasm
+}
+
+/// Fixture wat → wasm bytes (the exact bytes the CLI would produce from .wat).
+fn fixture_wasm() -> Vec<u8> {
+    let wat = std::fs::read(fixture(FIXTURE)).expect("read fixture wat");
+    wat::parse_bytes(&wat).expect("fixture wat must parse").into_owned()
+}
+
+/// Compile a `.wasm` byte blob on the shipped default config (optimized ARM
+/// self-contained path, `--all-exports`) and return the `.text` bytes.
+fn compile_text(wasm: &[u8], tag: &str) -> Vec<u8> {
+    let dir = std::env::temp_dir().join("wsc_facts_494");
+    std::fs::create_dir_all(&dir).expect("mk tempdir");
+    let input = dir.join(format!("{tag}.wasm"));
+    let elf = dir.join(format!("{tag}.elf"));
+    std::fs::write(&input, wasm).expect("write wasm");
+    let out = Command::new(synth())
+        .args([
+            "compile",
+            input.to_str().unwrap(),
+            "-o",
+            elf.to_str().unwrap(),
+            "-b",
+            "arm",
+            "--target",
+            "cortex-m4",
+            "--all-exports",
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        out.status.success(),
+        "#494 fail-safe violated: compile of '{tag}' failed (exit={:?}) — a \
+         wsc.facts section must NEVER change a compilation outcome.\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let bytes = std::fs::read(&elf).expect("read elf");
+    let obj = object::File::parse(&*bytes).expect("parse elf");
+    obj.section_by_name(".text")
+        .expect("fixture must have a .text section")
+        .data()
+        .expect("read .text")
+        .to_vec()
+}
+
+/// NON-VACUITY GUARD: the exact section bytes the identity gates append DO
+/// decode into facts through `decode_wasm_module` (the reader every compile
+/// path uses). Without this, the byte-identity below would also pass if the
+/// section were silently unparseable.
+#[test]
+fn facts_actually_reach_the_decoded_module_494() {
+    use synth_core::wsc_facts::{FactKind, WscFact};
+    let wasm = append_wsc_facts_section(fixture_wasm(), &well_formed_facts_payload());
+    let module = synth_core::decode_wasm_module(&wasm).expect("decode");
+    assert_eq!(
+        module.wsc_facts,
+        vec![
+            WscFact {
+                func_index: 0,
+                value_id: 1,
+                kind: FactKind::ValueRange { lo: 524, hi: 1524 },
+            },
+            WscFact {
+                func_index: 0,
+                value_id: 3,
+                kind: FactKind::DivisorNonZero,
+            },
+        ],
+        "well-formed facts must survive decode (unknown kind 0x2A skipped)"
+    );
+    // And the stripped module carries none.
+    let module = synth_core::decode_wasm_module(&fixture_wasm()).expect("decode");
+    assert_eq!(module.wsc_facts, vec![]);
+}
+
+/// THE PHASE-1 GATE (rivet VCR-PERF-002 verification-criteria, phase 1): a
+/// module WITH a well-formed `wsc.facts` section compiles `.text`-byte-
+/// identical to the same module WITHOUT it. Facts are parsed and threaded
+/// (proven above) but consumed by nothing.
+#[test]
+fn facts_present_compile_is_byte_identical_494() {
+    let base = fixture_wasm();
+    let with_facts = append_wsc_facts_section(base.clone(), &well_formed_facts_payload());
+    let text_without = compile_text(&base, "without_facts");
+    let text_with = compile_text(&with_facts, "with_facts");
+    assert_eq!(
+        text_without, text_with,
+        "#494 Phase 1 is ingestion ONLY: a wsc.facts section changed the \
+         emitted .text with no consumer landed — some codegen path is reading \
+         facts ahead of the Phase-2 gate (SYNTH_FACT_SPEC + per-elision \
+         ordeal obligation)"
+    );
+}
+
+/// Fail-safe skew rule end-to-end: a MALFORMED section (truncated framing)
+/// and a WRONG-VERSION section both compile successfully AND byte-identical
+/// to baseline — ignored entirely, never an error path.
+#[test]
+fn malformed_and_wrong_version_sections_are_ignored_494() {
+    let base = fixture_wasm();
+    let text_baseline = compile_text(&base, "skew_baseline");
+
+    // Truncated: claims one record, provides only a kind byte.
+    let malformed = append_wsc_facts_section(base.clone(), &[0x01, 0x01, 0x01]);
+    let text_malformed = compile_text(&malformed, "skew_malformed");
+    assert_eq!(
+        text_baseline, text_malformed,
+        "#494: a malformed wsc.facts section must be ignored entirely"
+    );
+
+    // Version 2 with otherwise-plausible bytes after it.
+    let mut v2 = vec![0x02];
+    v2.extend_from_slice(&well_formed_facts_payload()[1..]);
+    let wrong_version = append_wsc_facts_section(base, &v2);
+    let text_wrong_version = compile_text(&wrong_version, "skew_version");
+    assert_eq!(
+        text_baseline, text_wrong_version,
+        "#494: an unknown-schema-version wsc.facts section must be ignored entirely"
+    );
+}

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -6,6 +6,7 @@
 use crate::target::TargetSpec;
 use crate::wasm_decoder::DecodedModule;
 use crate::wasm_op::WasmOp;
+use crate::wsc_facts::WscFact;
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -201,6 +202,33 @@ pub struct CompileConfig {
     /// with or without this code (the frozen-codegen gate holds). See rivet
     /// `VCR-DMA-001`.
     pub volatile_segments: Vec<VolatileRange>,
+
+    /// VCR-PERF-002 Phase 1 (#494) — proven invariants forwarded by loom in
+    /// the `wsc.facts` custom section (encoding:
+    /// `docs/design/wsc-facts-encoding.md`; program:
+    /// `docs/design/proof-carrying-specialization.md`), whole-module table
+    /// keyed by `(func_index, value_id)`. The compile driver copies the
+    /// current function's slice into [`current_func_facts`] (the
+    /// `func_params_i64` → `current_func_params_i64` pattern), because
+    /// `compile_function` carries no function index.
+    ///
+    /// PHASE-1 CONTRACT: threaded but NOT consumed — no codegen path reads
+    /// facts, so emitted bytes are unchanged whether or not the module
+    /// carries the section (locked by `wsc_facts_ingestion_494.rs`). Phase 2
+    /// turns each fact into a premise for a flag-gated (`SYNTH_FACT_SPEC`),
+    /// per-elision ordeal-validated specialization; the facts-absent compile
+    /// stays byte-identical by construction (empty ⇒ every gate vacuous).
+    ///
+    /// [`current_func_facts`]: CompileConfig::current_func_facts
+    pub wsc_facts: Vec<WscFact>,
+    /// VCR-PERF-002 Phase 1 (#494): the `wsc.facts` invariants of the function
+    /// CURRENTLY being compiled (`fact.func_index == func.index`), set per
+    /// function by the driver loops like [`current_func_params_i64`]. This is
+    /// the field a Phase-2 selector pass will read its premises from. Empty →
+    /// no facts → no specialization may ever fire (the fail-safe default).
+    ///
+    /// [`current_func_params_i64`]: CompileConfig::current_func_params_i64
+    pub current_func_facts: Vec<WscFact>,
 }
 
 /// #543 — an integrator-marked volatile linear-memory segment (the DMA transfer
@@ -255,6 +283,11 @@ impl Default for CompileConfig {
             // #543 Phase 1: no volatile segments unless the CLI flag names them.
             // Empty ⇒ inert ⇒ emitted bytes unchanged.
             volatile_segments: Vec::new(),
+            // VCR-PERF-002 Phase 1 (#494): no facts unless the module carries
+            // a parseable `wsc.facts` section. Empty ⇒ inert (and Phase 1 has
+            // no consumer anyway) ⇒ emitted bytes unchanged.
+            wsc_facts: Vec::new(),
+            current_func_facts: Vec::new(),
         }
     }
 }

--- a/crates/synth-core/src/lib.rs
+++ b/crates/synth-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod target;
 pub mod wasm_decoder;
 pub mod wasm_op;
 pub mod wasm_stack_check;
+pub mod wsc_facts;
 
 pub use backend::*;
 pub use component::*;
@@ -28,3 +29,4 @@ pub use wasm_decoder::{
     decode_wasm_module,
 };
 pub use wasm_op::WasmOp;
+pub use wsc_facts::{FactKind, WSC_FACTS_SECTION_NAME, WscFact, WscFactsParse, parse_wsc_facts};

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -120,6 +120,15 @@ pub struct DecodedModule {
     /// reachable function performs a `call_indirect`. Empty for modules with no
     /// element section (every leaf/direct-call module), keeping output identical.
     pub elem_func_indices: Vec<u32>,
+    /// VCR-PERF-002 Phase 1 (#494): proven invariants from loom's `wsc.facts`
+    /// custom section, keyed by `(function index, value id)` — see
+    /// `docs/design/wsc-facts-encoding.md` (schema v1) and
+    /// [`crate::wsc_facts::parse_wsc_facts`]. FAIL-SAFE by contract (loom#231
+    /// Q4): a missing/unparseable section or unknown version yields the empty
+    /// vec, unknown fact kinds are skipped — never a decode error. Phase 1 is
+    /// ingestion only: NO codegen path consumes these yet, so emitted bytes
+    /// are unchanged whether or not a module carries the section.
+    pub wsc_facts: Vec<crate::wsc_facts::WscFact>,
 }
 
 /// Decode a WASM binary and extract functions, memory, and data segments
@@ -150,6 +159,10 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     // conventionally trails the code section, so the entries are not yet
     // available when each `CodeSectionEntry` is decoded.
     let mut name_section_names: HashMap<u32, String> = HashMap::new();
+    // VCR-PERF-002 Phase 1 (#494): facts from loom's `wsc.facts` custom
+    // section. `None` until (and unless) the first such section is seen —
+    // duplicates are ignored (one prover, one section; encoding doc rule).
+    let mut wsc_facts: Option<Vec<crate::wsc_facts::WscFact>> = None;
 
     for payload in Parser::new(0).parse_all(wasm_bytes) {
         let payload = payload.context("Failed to parse WASM payload")?;
@@ -375,6 +388,31 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                 if let wasmparser::KnownCustom::Name(reader) = c.as_known() {
                     parse_name_section_func_names(reader, &mut name_section_names);
                 }
+                // VCR-PERF-002 Phase 1 (#494): loom's `wsc.facts` section.
+                // `parse_wsc_facts` is TOTAL (fail-safe skew, loom#231 Q4):
+                // any malformed payload decodes to the empty fact list WITH a
+                // stderr diagnostic, never an error — facts are optional
+                // accelerators and must not be able to change a compilation
+                // outcome. First section wins.
+                if c.name() == crate::wsc_facts::WSC_FACTS_SECTION_NAME && wsc_facts.is_none() {
+                    let parsed = crate::wsc_facts::parse_wsc_facts(c.data());
+                    if let Some(reason) = &parsed.section_ignored {
+                        eprintln!(
+                            "warning: ignoring unparseable `wsc.facts` custom section \
+                             ({reason}) — facts are optional accelerators, compilation \
+                             is unaffected (#494 fail-safe skew rule)"
+                        );
+                    } else if parsed.records_skipped > 0 {
+                        eprintln!(
+                            "warning: skipped {} unknown/undecodable `wsc.facts` \
+                             record(s) (likely a newer loom emitter); {} known fact(s) \
+                             kept, compilation is unaffected (#494 fail-safe skew rule)",
+                            parsed.records_skipped,
+                            parsed.facts.len()
+                        );
+                    }
+                    wsc_facts = Some(parsed.facts);
+                }
             }
             _ => {}
         }
@@ -395,6 +433,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
         func_params_i64,
         globals,
         elem_func_indices,
+        wsc_facts: wsc_facts.unwrap_or_default(),
     })
 }
 

--- a/crates/synth-core/src/wsc_facts.rs
+++ b/crates/synth-core/src/wsc_facts.rs
@@ -1,0 +1,578 @@
+//! `wsc.facts` custom-section ingestion — VCR-PERF-002 / #494 **Phase 1**.
+//!
+//! loom (the PROVER, loom#231/loom#240) forwards invariants its Z3 translation
+//! validator already discharges in a custom section named `wsc.facts` (sibling
+//! of `wsc.transformation.attestation`), keyed by `(function index, value id)`.
+//! synth is a CONDITIONAL optimizer: a later phase consumes each fact as a
+//! premise behind a per-elision ordeal obligation (see
+//! `docs/design/proof-carrying-specialization.md`). THIS module is ingestion
+//! only — parse and represent; **no codegen path reads the result yet**, so
+//! emitted bytes are unchanged by construction (frozen-safe).
+//!
+//! Binary contract: `docs/design/wsc-facts-encoding.md` (schema v1). The
+//! normative fail-safe skew rule (loom#231 Q4) is implemented here:
+//!
+//! - missing section / unknown version / structurally unparseable section →
+//!   NO facts (the whole section is ignored, never an error);
+//! - unknown fact kind → that record is skipped via its length prefix;
+//! - known kind whose body doesn't decode exactly → that record is dropped.
+//!
+//! Facts are optional accelerators: there is no error path out of this module.
+//! [`parse_wsc_facts`] is total — it returns a (possibly empty) fact list for
+//! every input.
+
+/// Name of the custom section loom emits (loom#231).
+pub const WSC_FACTS_SECTION_NAME: &str = "wsc.facts";
+
+/// Schema version this parser understands. The version byte is FIRST in the
+/// payload so any incompatible future layout is detected before a single
+/// record is read (fail-safe skew: unknown version ⇒ whole section ignored).
+pub const WSC_FACTS_SCHEMA_VERSION: u8 = 1;
+
+/// One proven invariant forwarded by loom, keyed by `(function index, value
+/// id)`. `value_id` is the 0-based index of the producing operator within the
+/// function body's operator sequence — the same index space as
+/// [`FunctionOps::ops`]/[`FunctionOps::op_offsets`] (loom#231 Q1; see the
+/// encoding doc's "Value identification"). Phase 1 stores facts verbatim; an
+/// out-of-range `value_id` is vacuous and a Phase-2 consumer must ignore it.
+///
+/// [`FunctionOps::ops`]: crate::wasm_decoder::FunctionOps::ops
+/// [`FunctionOps::op_offsets`]: crate::wasm_decoder::FunctionOps::op_offsets
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WscFact {
+    /// Full wasm function index (imported functions first, then local ones) —
+    /// the same space as [`FunctionOps::index`].
+    ///
+    /// [`FunctionOps::index`]: crate::wasm_decoder::FunctionOps::index
+    pub func_index: u32,
+    /// 0-based producing-operator index within the function body (see above).
+    pub value_id: u32,
+    /// The invariant itself.
+    pub kind: FactKind,
+}
+
+/// The fact kinds of encoding schema v1, in silicon-payoff order (the numbers
+/// are the on-wire `kind` bytes; `0x00` is deliberately unassigned so a zeroed
+/// buffer never parses as a fact).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FactKind {
+    /// `0x01` — the value is within `[lo, hi]`, signed, inclusive both ends
+    /// (drives the dead-clamp elision, the `gust_mix` shape).
+    ValueRange { lo: i64, hi: i64 },
+    /// `0x02` — the shift amount is `< bound` (bare `lsl/lsr`, no mask).
+    ShiftBound { bound: u32 },
+    /// `0x03` — the divisor is never zero (the `div/rem` trap guard is dead).
+    DivisorNonZero,
+    /// `0x04` — the address plus an `access_width`-byte access stays within
+    /// linear-memory bounds (the bounds check is dead).
+    InBoundsAccess { access_width: u32 },
+    /// `0x05` — both `select` arms are safe to evaluate: branchless `IT`
+    /// lowering is admissible (pairs with VCR-SEL-004).
+    SelectTotality,
+    /// `0x06` — this address and the one produced by `other_value_id` (same
+    /// function) never alias: values may stay in registers across the store.
+    MemoryDisjointness { other_value_id: u32 },
+}
+
+/// Result of parsing a `wsc.facts` payload: the facts plus the diagnostic
+/// counters the decoder surfaces as WARNINGS (never errors — the rivet
+/// `VCR-PERF-002` phase-1 criterion is "ignored with a diagnostic, never an
+/// error"). `Default` is the missing-section value: no facts, nothing to
+/// report.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct WscFactsParse {
+    /// The facts that decoded cleanly. Empty whenever `section_ignored` is set.
+    pub facts: Vec<WscFact>,
+    /// `Some(reason)` when the WHOLE section was ignored: unknown schema
+    /// version or structural unparseability (truncated/overrun framing,
+    /// trailing bytes). Facts already decoded are dropped too — an
+    /// unparseable section is not trusted piecemeal.
+    pub section_ignored: Option<String>,
+    /// Records dropped individually while the section itself parsed: unknown
+    /// fact kinds (a newer loom) and known kinds whose length-prefixed body
+    /// was not exactly the v1 fields (an extended body). Emitter/consumer
+    /// skew signal — worth a warning, never an error.
+    pub records_skipped: u32,
+}
+
+/// Parse a `wsc.facts` custom-section payload (schema v1). TOTAL by design —
+/// this is the fail-safe skew rule (loom#231 Q4) and there is deliberately no
+/// `Result` in the signature: facts are optional accelerators, so no input can
+/// produce an error that changes a compilation outcome.
+///
+/// Whole-section ignore (reported via [`WscFactsParse::section_ignored`]):
+/// unknown schema version, truncated/overrun framing, count mismatch, or
+/// trailing bytes after the last record. Per-record skip (counted in
+/// [`WscFactsParse::records_skipped`], parsing continues): unknown fact kinds
+/// and known kinds whose length-prefixed body doesn't decode to exactly the
+/// expected fields.
+pub fn parse_wsc_facts(payload: &[u8]) -> WscFactsParse {
+    let mut out = WscFactsParse::default();
+    if parse_wsc_facts_inner(payload, &mut out).is_none() {
+        return WscFactsParse {
+            facts: Vec::new(),
+            section_ignored: Some(
+                "unknown schema version or truncated/overrun record framing".to_string(),
+            ),
+            records_skipped: 0,
+        };
+    }
+    out
+}
+
+/// Structural parse into `out`: `None` ⇒ the whole section is unparseable and
+/// must be ignored entirely (including records already decoded into `out`).
+fn parse_wsc_facts_inner(payload: &[u8], out: &mut WscFactsParse) -> Option<()> {
+    let mut r = Reader::new(payload);
+    if r.byte()? != WSC_FACTS_SCHEMA_VERSION {
+        return None;
+    }
+    let count = r.leb_u32()?;
+    for _ in 0..count {
+        let kind = r.byte()?;
+        let func_index = r.leb_u32()?;
+        let value_id = r.leb_u32()?;
+        let body_len = r.leb_u32()?;
+        let body = r.bytes(body_len as usize)?;
+        // Per-record tolerance: an unknown kind byte, or a known kind whose
+        // body isn't exactly the expected fields (a newer emitter may have
+        // extended it), drops THIS record only — the framing above already
+        // consumed it, so the rest of the section still parses.
+        match decode_body(kind, body) {
+            Some(kind) => out.facts.push(WscFact {
+                func_index,
+                value_id,
+                kind,
+            }),
+            None => out.records_skipped += 1,
+        }
+    }
+    // Trailing bytes after the declared records ⇒ structurally unparseable.
+    if !r.is_empty() {
+        return None;
+    }
+    Some(())
+}
+
+/// Decode one record body. `None` ⇒ drop the record (unknown kind, or a body
+/// that is not exactly the v1 fields for its kind).
+fn decode_body(kind: u8, body: &[u8]) -> Option<FactKind> {
+    let mut r = Reader::new(body);
+    let fact = match kind {
+        0x01 => FactKind::ValueRange {
+            lo: r.leb_s64()?,
+            hi: r.leb_s64()?,
+        },
+        0x02 => FactKind::ShiftBound {
+            bound: r.leb_u32()?,
+        },
+        0x03 => FactKind::DivisorNonZero,
+        0x04 => FactKind::InBoundsAccess {
+            access_width: r.leb_u32()?,
+        },
+        0x05 => FactKind::SelectTotality,
+        0x06 => FactKind::MemoryDisjointness {
+            other_value_id: r.leb_u32()?,
+        },
+        _ => return None,
+    };
+    // Exact-body rule: trailing bytes mean an extended (newer) body — treat
+    // like an unknown kind rather than half-reading it.
+    if !r.is_empty() {
+        return None;
+    }
+    Some(fact)
+}
+
+/// Minimal bounds-checked cursor with wasm-spec LEB128 readers. Hand-rolled
+/// (~30 lines) rather than borrowing `wasmparser::BinaryReader` so this
+/// contract cannot drift under a wasmparser major bump — the encoding doc is
+/// the single source of truth.
+struct Reader<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pos >= self.data.len()
+    }
+
+    fn byte(&mut self) -> Option<u8> {
+        let b = *self.data.get(self.pos)?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn bytes(&mut self, n: usize) -> Option<&'a [u8]> {
+        let end = self.pos.checked_add(n)?;
+        let s = self.data.get(self.pos..end)?;
+        self.pos = end;
+        Some(s)
+    }
+
+    /// Unsigned LEB128, max 5 bytes (wasm-spec `u32`).
+    fn leb_u32(&mut self) -> Option<u32> {
+        let mut result: u32 = 0;
+        for shift in [0u32, 7, 14, 21, 28] {
+            let b = self.byte()?;
+            let low = u32::from(b & 0x7f);
+            // Bits that would fall off the top make the encoding invalid.
+            if low.checked_shl(shift)? >> shift != low {
+                return None;
+            }
+            result |= low << shift;
+            if b & 0x80 == 0 {
+                return Some(result);
+            }
+        }
+        None // continuation bit set on the 5th byte
+    }
+
+    /// Signed LEB128, max 10 bytes (wasm-spec `s64`).
+    fn leb_s64(&mut self) -> Option<i64> {
+        let mut result: i64 = 0;
+        let mut shift: u32 = 0;
+        loop {
+            let b = self.byte()?;
+            if shift >= 63 {
+                // 10th byte: only 1 payload bit left. It must terminate and
+                // must be a pure sign-extension byte (0x00 or 0x7f).
+                if b & 0x80 != 0 || (b != 0x00 && b != 0x7f) {
+                    return None;
+                }
+                if b == 0x7f {
+                    result |= -1i64 << shift;
+                }
+                return Some(result);
+            }
+            result |= i64::from(b & 0x7f) << shift;
+            shift += 7;
+            if b & 0x80 == 0 {
+                // Sign-extend from the last payload bit.
+                if shift < 64 && b & 0x40 != 0 {
+                    result |= -1i64 << shift;
+                }
+                return Some(result);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Facts-only view for the happy-path assertions; the skew tests assert
+    /// the diagnostic fields explicitly.
+    fn facts(payload: &[u8]) -> Vec<WscFact> {
+        parse_wsc_facts(payload).facts
+    }
+
+    // ---- test-side encoder (mirrors docs/design/wsc-facts-encoding.md) ----
+
+    fn leb_u32(mut v: u32, out: &mut Vec<u8>) {
+        loop {
+            let mut b = (v & 0x7f) as u8;
+            v >>= 7;
+            if v != 0 {
+                b |= 0x80;
+            }
+            out.push(b);
+            if v == 0 {
+                return;
+            }
+        }
+    }
+
+    fn leb_s64(mut v: i64, out: &mut Vec<u8>) {
+        loop {
+            let mut b = (v & 0x7f) as u8;
+            v >>= 7; // arithmetic shift
+            let done = (v == 0 && b & 0x40 == 0) || (v == -1 && b & 0x40 != 0);
+            if !done {
+                b |= 0x80;
+            }
+            out.push(b);
+            if done {
+                return;
+            }
+        }
+    }
+
+    fn record(kind: u8, func_index: u32, value_id: u32, body: &[u8]) -> Vec<u8> {
+        let mut out = vec![kind];
+        leb_u32(func_index, &mut out);
+        leb_u32(value_id, &mut out);
+        leb_u32(body.len() as u32, &mut out);
+        out.extend_from_slice(body);
+        out
+    }
+
+    fn section(version: u8, records: &[Vec<u8>]) -> Vec<u8> {
+        let mut out = vec![version];
+        leb_u32(records.len() as u32, &mut out);
+        for r in records {
+            out.extend_from_slice(r);
+        }
+        out
+    }
+
+    fn value_range_body(lo: i64, hi: i64) -> Vec<u8> {
+        let mut b = Vec::new();
+        leb_s64(lo, &mut b);
+        leb_s64(hi, &mut b);
+        b
+    }
+
+    // ---- well-formed sections: every v1 fact kind round-trips ----
+
+    #[test]
+    fn parses_value_range_494() {
+        // The gust_mix premise: v ∈ [524, 1524] on (func 3, value 7).
+        let s = section(1, &[record(0x01, 3, 7, &value_range_body(524, 1524))]);
+        assert_eq!(
+            facts(&s),
+            vec![WscFact {
+                func_index: 3,
+                value_id: 7,
+                kind: FactKind::ValueRange { lo: 524, hi: 1524 },
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_negative_and_extreme_range_bounds_494() {
+        let s = section(
+            1,
+            &[record(0x01, 0, 0, &value_range_body(i64::MIN, i64::MAX))],
+        );
+        assert_eq!(
+            facts(&s),
+            vec![WscFact {
+                func_index: 0,
+                value_id: 0,
+                kind: FactKind::ValueRange {
+                    lo: i64::MIN,
+                    hi: i64::MAX,
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_shift_bound_494() {
+        let mut body = Vec::new();
+        leb_u32(32, &mut body);
+        let s = section(1, &[record(0x02, 1, 4, &body)]);
+        assert_eq!(
+            facts(&s),
+            vec![WscFact {
+                func_index: 1,
+                value_id: 4,
+                kind: FactKind::ShiftBound { bound: 32 },
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_divisor_nonzero_494() {
+        let s = section(1, &[record(0x03, 2, 9, &[])]);
+        assert_eq!(
+            facts(&s),
+            vec![WscFact {
+                func_index: 2,
+                value_id: 9,
+                kind: FactKind::DivisorNonZero,
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_in_bounds_access_494() {
+        let mut body = Vec::new();
+        leb_u32(4, &mut body);
+        let s = section(1, &[record(0x04, 5, 11, &body)]);
+        assert_eq!(
+            facts(&s),
+            vec![WscFact {
+                func_index: 5,
+                value_id: 11,
+                kind: FactKind::InBoundsAccess { access_width: 4 },
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_select_totality_494() {
+        let s = section(1, &[record(0x05, 6, 13, &[])]);
+        assert_eq!(
+            facts(&s),
+            vec![WscFact {
+                func_index: 6,
+                value_id: 13,
+                kind: FactKind::SelectTotality,
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_memory_disjointness_494() {
+        let mut body = Vec::new();
+        leb_u32(21, &mut body);
+        let s = section(1, &[record(0x06, 7, 17, &body)]);
+        assert_eq!(
+            facts(&s),
+            vec![WscFact {
+                func_index: 7,
+                value_id: 17,
+                kind: FactKind::MemoryDisjointness { other_value_id: 21 },
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_multiple_facts_in_order_494() {
+        let s = section(
+            1,
+            &[
+                record(0x01, 0, 1, &value_range_body(-8, 8)),
+                record(0x03, 0, 2, &[]),
+            ],
+        );
+        let facts = facts(&s);
+        assert_eq!(facts.len(), 2);
+        assert_eq!(facts[0].kind, FactKind::ValueRange { lo: -8, hi: 8 });
+        assert_eq!(facts[1].kind, FactKind::DivisorNonZero);
+    }
+
+    #[test]
+    fn parses_empty_fact_list_494() {
+        // A well-formed zero-fact section is NOT a skew condition: no facts,
+        // no diagnostics.
+        let parsed = parse_wsc_facts(&section(1, &[]));
+        assert_eq!(parsed, WscFactsParse::default());
+    }
+
+    // ---- fail-safe skew rule: tolerance without any error path ----
+
+    #[test]
+    fn unknown_kind_is_skipped_others_kept_494() {
+        // kind 0x2A from a future loom, length-prefixed body — skipped via the
+        // prefix; the known records around it still parse.
+        let s = section(
+            1,
+            &[
+                record(0x03, 0, 1, &[]),
+                record(0x2a, 0, 2, &[0xde, 0xad, 0xbe]),
+                record(0x05, 0, 3, &[]),
+            ],
+        );
+        let parsed = parse_wsc_facts(&s);
+        assert_eq!(parsed.facts.len(), 2);
+        assert_eq!(parsed.facts[0].kind, FactKind::DivisorNonZero);
+        assert_eq!(parsed.facts[1].kind, FactKind::SelectTotality);
+        // The skip is DIAGNOSED (skew signal), not a whole-section ignore.
+        assert_eq!(parsed.records_skipped, 1);
+        assert_eq!(parsed.section_ignored, None);
+    }
+
+    #[test]
+    fn kind_zero_is_not_a_fact_494() {
+        // 0x00 is deliberately unassigned (zeroed buffers must not parse).
+        let s = section(1, &[record(0x00, 0, 0, &[])]);
+        assert_eq!(facts(&s), vec![]);
+    }
+
+    #[test]
+    fn extended_body_on_known_kind_drops_that_record_only_494() {
+        // divisor-nonzero with a 2-byte body: a newer emitter extended it —
+        // exact-body rule drops it, the neighbor survives.
+        let s = section(
+            1,
+            &[record(0x03, 0, 1, &[0x01, 0x02]), record(0x05, 0, 2, &[])],
+        );
+        let facts = facts(&s);
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].kind, FactKind::SelectTotality);
+    }
+
+    #[test]
+    fn short_body_on_known_kind_drops_that_record_only_494() {
+        // value-range with only `lo` present — the body under-decodes.
+        let mut body = Vec::new();
+        leb_s64(524, &mut body);
+        let s = section(1, &[record(0x01, 0, 1, &body), record(0x03, 0, 2, &[])]);
+        let facts = facts(&s);
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].kind, FactKind::DivisorNonZero);
+    }
+
+    #[test]
+    fn version_mismatch_ignores_whole_section_494() {
+        for version in [0, 2, 0xff] {
+            let parsed = parse_wsc_facts(&section(version, &[record(0x03, 0, 1, &[])]));
+            assert_eq!(parsed.facts, vec![]);
+            // Whole-section ignore is DIAGNOSED, never an error.
+            assert!(parsed.section_ignored.is_some());
+        }
+    }
+
+    #[test]
+    fn empty_and_truncated_sections_ignored_494() {
+        assert_eq!(facts(&[]), vec![]); // no version byte
+        assert_eq!(facts(&[0x01]), vec![]); // no count
+        // count says 1 record, no record bytes follow
+        assert_eq!(facts(&[0x01, 0x01]), vec![]);
+        // record framing truncated mid-header (kind present, indices missing)
+        assert_eq!(facts(&[0x01, 0x01, 0x01]), vec![]);
+    }
+
+    #[test]
+    fn body_len_overrun_ignores_whole_section_494() {
+        // body_len = 200 but only 2 body bytes present — framing overrun, and
+        // the earlier GOOD record is dropped too (unparseable ⇒ ignore whole).
+        let good = record(0x03, 0, 1, &[]);
+        let mut bad = vec![0x01];
+        leb_u32(0, &mut bad);
+        leb_u32(0, &mut bad);
+        leb_u32(200, &mut bad);
+        bad.extend_from_slice(&[0xaa, 0xbb]);
+        let s = section(1, &[good, bad]);
+        assert_eq!(facts(&s), vec![]);
+    }
+
+    #[test]
+    fn trailing_bytes_after_records_ignore_whole_section_494() {
+        let mut s = section(1, &[record(0x03, 0, 1, &[])]);
+        s.push(0xff);
+        assert_eq!(facts(&s), vec![]);
+    }
+
+    #[test]
+    fn overlong_leb_ignores_whole_section_494() {
+        // func_index as a 6-byte LEB (continuation on the 5th byte) — invalid
+        // wasm-spec u32.
+        let mut s = vec![0x01, 0x01, 0x03];
+        s.extend_from_slice(&[0x80, 0x80, 0x80, 0x80, 0x80, 0x00]); // func_index
+        s.push(0x00); // value_id
+        s.push(0x00); // body_len
+        assert_eq!(facts(&s), vec![]);
+    }
+
+    #[test]
+    fn garbage_is_ignored_never_panics_494() {
+        // A few adversarial byte soups: total function, empty result.
+        for garbage in [
+            &[0xff_u8, 0xff, 0xff, 0xff][..],
+            &[0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..],
+            &[0x00, 0x00, 0x00][..],
+        ] {
+            assert_eq!(facts(garbage), vec![]);
+        }
+    }
+}

--- a/docs/design/proof-carrying-specialization.md
+++ b/docs/design/proof-carrying-specialization.md
@@ -1,6 +1,7 @@
 # VCR-PERF-002 — Proof-carrying specialization design (#494)
 
-Status: **design** (no code yet). Tracks `VCR-PERF-002` in
+Status: **Phase 1 implemented** (fact ingestion, codegen-neutral — see
+"Phasing"; Phases 2/3 remain design). Tracks `VCR-PERF-002` in
 `artifacts/verified-codegen-roadmap.yaml`, epic #242, GitHub #494 part (a).
 Cross-repo contract: loom#240 / loom#231 (`wsc.facts`), gale PR
 pulseengine/gale#121 (`gust_floor_bench`, the measured floor).
@@ -29,8 +30,12 @@ act on it *soundly*. Target: **≤0.70× of native**, kill-criterion per #494.
 
 Per loom#231: a custom section **`wsc.facts`** (sibling of
 `wsc.transformation.attestation`), carrying invariants loom's Z3 translation
-validator already discharges, keyed by `(function index, value id)`. Fact
-kinds, in silicon-payoff order:
+validator already discharges, keyed by `(function index, value id)`. The
+concrete binary encoding (schema v1 — version byte first, LEB128 fields,
+length-prefixed unknown-kind-skippable records; resolves loom#231 open
+questions 1/2) is specified in the sibling document
+[`wsc-facts-encoding.md`](wsc-facts-encoding.md). Fact kinds, in
+silicon-payoff order:
 
 1. **value-range** — `v ∈ [lo, hi]` (drives the clamp elision above)
 2. **shift-bound** — shift amount `< 32`/`< 64` (bare `lsl/lsr`, no mask)
@@ -93,7 +98,13 @@ bounds adversarial queries to a clean conservative decline.
    `CompileConfig` / the selector. **Zero codegen change**; byte-identical,
    frozen-safe. Schema versioned, unknown-kind-tolerant. Co-designed with
    loom's emitter (loom#231 open questions 1/2 resolve here: keying + binary
-   encoding).
+   encoding). **IMPLEMENTED** — encoding: `wsc-facts-encoding.md` (schema v1);
+   parser: `crates/synth-core/src/wsc_facts.rs` (total, fail-safe), wired
+   into `decode_wasm_module` and threaded to `CompileConfig::wsc_facts` /
+   `current_func_facts`; neutrality gate:
+   `crates/synth-cli/tests/wsc_facts_ingestion_494.rs` (facts-present compile
+   byte-identical to facts-stripped, malformed/wrong-version ignored
+   end-to-end).
 2. **Single-elision prototype** — value-range ⇒ dead conditional-branch
    elision (the `gust_mix` clamp shape), behind `SYNTH_FACT_SPEC`, with the
    per-elision obligation + a red/green in-bounds differential oracle.

--- a/docs/design/wsc-facts-encoding.md
+++ b/docs/design/wsc-facts-encoding.md
@@ -1,0 +1,140 @@
+# `wsc.facts` — binary encoding, schema v1 (VCR-PERF-002 / #494 Phase 1)
+
+Status: **implemented (ingestion side)**. This is the concrete binary contract
+for the `wsc.facts` custom section described in
+`proof-carrying-specialization.md` ("The contract (what loom forwards)"). It
+resolves loom#231 open questions 1 (keying / value identification) and 2
+(binary encoding) on the consumer side; loom's emitter co-designs against this
+document.
+
+Parser: `crates/synth-core/src/wsc_facts.rs` (`parse_wsc_facts`), invoked from
+`decode_wasm_module`'s custom-section arm, threaded into
+`CompileConfig::wsc_facts` / `CompileConfig::current_func_facts`. Phase 1 has
+**no consumer**: parsed facts change zero bytes of output by construction.
+
+## Container
+
+A standard wasm custom section (id 0) named exactly `wsc.facts`, a sibling of
+`wsc.transformation.attestation`. If several `wsc.facts` sections appear, only
+the **first** is honored (later duplicates are ignored — one prover, one
+section).
+
+## Fail-safe skew rule (normative, loom#231 Q4)
+
+Facts are **optional accelerators** — there is NO error path from this section
+that changes a compilation outcome. Every ignore/skip below is surfaced as a
+stderr **warning** (the skew diagnostic; rivet VCR-PERF-002: "ignored with a
+diagnostic, never an error"):
+
+- missing section → no facts;
+- unknown schema version → the whole section is ignored;
+- structurally unparseable section (truncated framing, count overrun,
+  body-length overrun) → the whole section is ignored, **including any facts
+  already decoded** from it (an unparseable section is not trusted piecemeal);
+- unknown fact kind → that record is skipped via its length prefix, the rest
+  of the section is still consumed (forward-compatible: a newer loom may emit
+  kinds an older synth does not know);
+- known fact kind whose body does not decode to exactly the expected fields
+  (short body, trailing bytes, over-long LEB) → that record alone is dropped
+  (it is treated exactly like an unknown kind: a newer emitter may have
+  extended the body).
+
+The facts-absent compile is byte-identical to baseline by construction, and
+Phase 1 keeps the facts-present compile byte-identical too (no consumer).
+
+## Payload layout
+
+All multi-byte integers are LEB128, exactly as in the wasm core spec:
+`u32`/`u64` are unsigned LEB128 (at most 5/10 bytes), `s64` is signed LEB128
+(at most 10 bytes).
+
+```
+payload := version:byte(=0x01)
+           count:u32
+           fact[count]
+
+fact    := kind:byte
+           func_index:u32          ; full wasm function index (imports first)
+           value_id:u32            ; see "Value identification" below
+           body_len:u32            ; length prefix — enables unknown-kind skip
+           body:byte[body_len]
+```
+
+The version byte comes **first** so any future layout change is detectable
+before a single record is read. `count` is the number of `fact` records; the
+payload must contain exactly `count` well-framed records (extra trailing bytes
+after the last record make the section structurally unparseable → ignored).
+
+### Fact kinds (silicon-payoff order, per the design doc)
+
+| kind | name | body | meaning (premise `P`) |
+|---|---|---|---|
+| `0x01` | value-range | `lo:s64 hi:s64` | the i32/i64 value ∈ `[lo, hi]` (signed, inclusive both ends) |
+| `0x02` | shift-bound | `bound:u32` | the shift-amount value is `< bound` (e.g. 32 or 64 — bare `lsl/lsr`, no mask) |
+| `0x03` | divisor-nonzero | (empty) | the divisor value is never 0 (the `div/rem` trap guard is dead) |
+| `0x04` | in-bounds-access | `access_width:u32` | the address value plus an `access_width`-byte access stays within linear-memory bounds (the bounds check is dead) |
+| `0x05` | select-totality | (empty) | both `select` arms are safe to evaluate — branchless `IT` lowering admissible (pairs with VCR-SEL-004) |
+| `0x06` | memory-disjointness | `other_value_id:u32` | the address value and the address produced by `other_value_id` (same function) never alias — values may stay in registers across the store |
+| other | — | skipped via `body_len` | unknown to this synth; ignored |
+
+`0x00` is deliberately not assigned (a zeroed buffer never parses as a valid
+fact kind).
+
+### Value identification (loom#231 Q1)
+
+`value_id` is the **0-based index of the producing operator within the
+function body's code-section operator sequence** — the same index space as
+synth's decoded `FunctionOps::ops` / `FunctionOps::op_offsets` (and hence the
+`source_line` op-index the selector already tracks). "Producing operator"
+means the wasm instruction whose result the fact constrains (for
+divisor-nonzero: the instruction producing the divisor operand; for
+in-bounds-access / memory-disjointness: the instruction producing the
+address).
+
+Rationale: this is the only identification both sides can compute without a
+shared SSA numbering — loom emits post-optimization binaries, so its final
+operator order IS what synth decodes; no id map has to travel alongside the
+facts. A fact whose `value_id` is out of range for its function is vacuous
+(names nothing) and any Phase-2 consumer must ignore it — Phase 1 stores it
+as-is.
+
+`func_index` is the full function index (imported functions first, then
+locally defined), the same space as `FunctionOps::index`.
+
+## Versioning
+
+`version = 0x01` is this document. Any incompatible layout change bumps the
+version byte; an old synth then ignores the whole section (fail-safe skew),
+and a new synth may keep a v1 reader. Backward-compatible growth does **not**
+need a bump: new fact kinds get new `kind` bytes, and extending an existing
+kind's body is expressed as a NEW kind (bodies are fixed per kind — a longer
+body on an existing kind is dropped per the skew rule above).
+
+## Worked example
+
+A single value-range fact `v ∈ [524, 1524]` on function 3, value 7 (the
+`gust_mix` clamp premise):
+
+```
+01                 ; version 1
+01                 ; count = 1
+01                 ; kind = value-range
+03                 ; func_index = 3
+07                 ; value_id = 7
+04                 ; body_len = 4
+8c 04              ; lo = 524  (signed LEB128)
+f4 0b              ; hi = 1524 (signed LEB128)
+```
+
+Wrapped in the custom section: `00 <section_size:u32> 09 "wsc.facts" <payload>`.
+
+## Phasing recap
+
+- **Phase 1 (this document + parser): ingestion only.** Facts land in
+  `CompileConfig::wsc_facts` (whole-module table) and
+  `CompileConfig::current_func_facts` (the compile driver filters per
+  function, mirroring `func_params_i64`/`current_func_params_i64`). Zero
+  codegen change; the integration gate proves a facts-carrying module
+  compiles `.text`-byte-identical to the stripped module.
+- **Phase 2+**: consumption per `proof-carrying-specialization.md` — every
+  elision behind `SYNTH_FACT_SPEC` plus a per-elision ordeal obligation.


### PR DESCRIPTION
Phase 1 of VCR-PERF-002 (docs/design/proof-carrying-specialization.md): parse the `wsc.facts` custom section (versioned schema, keyed by function index + value id, fact kinds 1–6) and thread premises into CompileConfig. Fail-safe by contract: unknown kinds ignored, malformed/missing section entirely ignored — facts are optional accelerators; NO consumer yet, so compilation is byte-identical with or without the section (phase-1 gate).

PROVENANCE / GATE NOTE: implemented and committed by an agent that hit the session limit before final verification could be reported. **CI is the gate** — the byte-identity integration test, frozen anchors, full test/clippy/fmt must all pass before merge.

Refs #494, #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)