### PR TITLE
feat(rv32-promo)!: SYNTH_RV_LOCAL_PROMO default-on — measured local promotion ships (#472, #601, epic #242)

### DIFF
--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -193,20 +193,27 @@ pub fn select_with_result_types(
     type_ret_i64: &[bool],
 ) -> Result<RiscVSelection, SelectorError> {
     // #472: read the local-promotion flag exactly once, here, so the rest of the
-    // selector (and its unit tests) work off a plain bool. Flag off by default →
-    // `compute_local_promotion` is never consulted → byte-identical baseline.
+    // selector (and its unit tests) work off a plain bool.
     //
-    // Still opt-in, but the #601 no-grow blocker is FIXED: profitability is now
-    // MEASURED, not modeled — `select_inner` lowers the function with and
-    // without promotion (and over every candidate subset) and keeps a promoted
-    // lowering only when its emitted byte size is <= the unpromoted baseline.
-    // The v1 "≥2 accesses repay save/restore" estimate under-charged (it priced
-    // neither the per-RETURN `lw s_i` restore `preserve_callee_saved` duplicates
-    // into every epilogue nor the WAR-snapshot `mv`s), growing war_set 56→64 B,
-    // war_tee 60→68 B and control_step_decide +4 B. The measured decision prices
-    // every cost by construction (#511 lesson: emitted bytes, not a side table).
-    // Corpus gate: `rv32_local_promo_no_grow_corpus_472` (synth-cli tests).
-    let promote_locals = std::env::var_os("SYNTH_RV_LOCAL_PROMO").is_some();
+    // DEFAULT-ON (#601 closes; the SYNTH_RV_CMP_SELECT flip template): the
+    // no-grow blocker that HELD this lever out of the RV32 flip-wave is fixed —
+    // profitability is now MEASURED, not modeled. `select_inner` lowers the
+    // function with and without promotion (and over every candidate subset)
+    // and keeps a promoted lowering only when its emitted byte size is <= the
+    // unpromoted baseline. The v1 "≥2 accesses repay save/restore" estimate
+    // under-charged (it priced neither the per-RETURN `lw s_i` restore
+    // `preserve_callee_saved` duplicates into every epilogue nor the
+    // WAR-snapshot `mv`s), growing war_set 56→64 B, war_tee 60→68 B and
+    // control_step_decide +4 B. The measured decision prices every cost by
+    // construction (#511 lesson: emitted bytes, not a side table). Flip-time
+    // full-corpus numbers: 10 functions shrink / 0 grow across the 67
+    // RV32-compiling repro fixtures (accum −68 B, flight_algo −32 B,
+    // controller_step_decide −24 B); the frozen RV32 goldens are byte-neutral
+    // (the measured gate declines everywhere in them). Corpus gate:
+    // `rv32_local_promo_no_grow_corpus_472`; `SYNTH_RV_LOCAL_PROMO=0` opts out
+    // → `compute_local_promotion` is never consulted → the pre-flip baseline
+    // (CI-gated escape hatch in frozen_codegen_bytes.rs).
+    let promote_locals = !std::env::var("SYNTH_RV_LOCAL_PROMO").is_ok_and(|v| v == "0");
     // #472: cmp→select fusion (the VCR-SEL-004 lever, ported from ARM). Same
     // read-once discipline; DEFAULT-ON since the RV32 flip-wave (no function
     // grows across the RV32 corpus, control_step −12 B, execution
@@ -1114,9 +1121,9 @@ struct Selector {
     /// `Unsupported` in this selector.
     type_ret_i64: Vec<bool>,
     /// #472 (VCR-RA RV32 local promotion): non-parameter i32 locals promoted
-    /// into callee-saved s-registers (`s8`/`s9`/`s10`). Empty unless
-    /// `SYNTH_RV_LOCAL_PROMO` is set — with the flag off the frame path is
-    /// taken for every local and codegen is byte-identical to the baseline.
+    /// into callee-saved s-registers (`s8`/`s9`/`s10`). Empty under the
+    /// `SYNTH_RV_LOCAL_PROMO=0` opt-out — the frame path is then taken for
+    /// every local and codegen is byte-identical to the pre-flip baseline.
     /// See [`compute_local_promotion`].
     promoted: std::collections::HashMap<u32, Reg>,
     /// #472: promoted locals whose FIRST access is a read — they rely on the
@@ -1127,9 +1134,9 @@ struct Selector {
     /// find the smallest lowering. `None` = every mapped candidate promotes.
     promo_allow: Option<std::collections::HashSet<u32>>,
     /// #472: whether local promotion is enabled for this function. Set by the
-    /// public entry point from `SYNTH_RV_LOCAL_PROMO` (still opt-in — held
-    /// from the flip-wave on the no-grow blocker documented there); the env is
-    /// read exactly once so the decision function stays pure and unit-testable.
+    /// public entry point from `SYNTH_RV_LOCAL_PROMO` (default-on since the
+    /// #601 measured-profitability fix, `=0` opts out); the env is read
+    /// exactly once so the decision function stays pure and unit-testable.
     promote_locals: bool,
     /// #472 (VCR-SEL-004 port): whether cmp→select fusion is enabled. Set by
     /// the public entry point from `SYNTH_RV_CMP_SELECT` (default-on, `=0`
@@ -1200,12 +1207,14 @@ impl Selector {
         use std::collections::BTreeSet;
         self.i64_locals =
             synth_synthesis::infer_i64_locals(wasm_ops, &self.func_ret_i64, &self.type_ret_i64);
-        // #472: VCR-RA local promotion — flag-gated (SYNTH_RV_LOCAL_PROMO). With
-        // the flag unset the map is empty, every local falls to the frame path
-        // below, and codegen is byte-identical to the pre-lever baseline (the
-        // frozen RV32 fixtures compile without it). The promoted set is the ONE
-        // source of truth: the layout skips exactly the promoted locals, so a
-        // frame slot is reserved iff the local is NOT register-resident.
+        // #472: VCR-RA local promotion — default-on (SYNTH_RV_LOCAL_PROMO=0
+        // opts out). Under the opt-out the map is empty, every local falls to
+        // the frame path below, and codegen is byte-identical to the pre-lever
+        // baseline (the frozen RV32 goldens are promo-byte-neutral anyway —
+        // the measured gate declines everywhere in them). The promoted set is
+        // the ONE source of truth: the layout skips exactly the promoted
+        // locals, so a frame slot is reserved iff the local is NOT
+        // register-resident.
         if self.promote_locals {
             let (mut map, mut zero_init) =
                 compute_local_promotion(wasm_ops, num_params, &self.i64_locals);
@@ -7913,30 +7922,32 @@ mod tests {
         ]
     }
 
-    /// Flag OFF must be byte-identical to the default `select()` path, and must
-    /// keep the local on the frame (frame `lw`s, no promoted s-register).
-    /// (Local promotion is still OPT-IN — HELD from the RV32 flip-wave on the
-    /// no-grow blocker documented at the env read in
-    /// [`select_with_result_types`].)
+    /// The env-unset default `select()` path must equal the flag-ON lowering
+    /// (local promotion is DEFAULT-ON since the #601 measured-profitability
+    /// flip — on this shape promotion measures no larger than the baseline
+    /// and ties prefer the promoted lowering), while the explicit opt-out arm
+    /// must keep the local on the frame (frame `lw`s, no promoted
+    /// s-register) — the `SYNTH_RV_LOCAL_PROMO=0` rollback contract.
     #[test]
-    fn local_promotion_flag_off_is_identical_and_frame_backed_472() {
+    fn local_promotion_default_is_promoted_and_opt_out_frame_backed_472() {
         let ops = promotable_ops();
-        // select() reads the env; promotion is opt-in, cmp→select is
-        // default-on (flip-wave) — promotable_ops has no select, so fusion is
-        // a no-op here and the env-unset default is the unpromoted lowering.
+        // select() reads the env; promotion and cmp→select fusion are both
+        // default-on — promotable_ops has no select, so fusion is a no-op
+        // here and the env-unset default is the PROMOTED lowering.
         let default = s(&ops, 1);
-        let off = s_promo(&ops, 1, false);
+        let on = s_promo(&ops, 1, true);
         assert_eq!(
-            default, off,
-            "flag-off must equal the default select() path"
+            default, on,
+            "the default select() path must equal the flag-on lowering"
         );
+        let off = s_promo(&ops, 1, false);
         assert!(
             count_lw_any_sp(&off) >= 3,
-            "local must stay frame-backed (>=3 lw): {off:?}"
+            "opt-out must stay frame-backed (>=3 lw): {off:?}"
         );
         assert!(
             !writes_reg(&off, Reg::S8),
-            "no promotion register may be written with the flag off: {off:?}"
+            "no promotion register may be written under the opt-out: {off:?}"
         );
     }
 

--- a/crates/synth-cli/tests/flag_flip_wave_242.rs
+++ b/crates/synth-cli/tests/flag_flip_wave_242.rs
@@ -33,7 +33,8 @@
 //!
 //! The #601 local-promo precedent applies: had ANY function grown, the flag
 //! would have been HELD with the numbers documented at the flag site (as
-//! `SYNTH_RV_LOCAL_PROMO` still is).
+//! `SYNTH_RV_LOCAL_PROMO` was, until its measured-profitability fix flipped
+//! it default-on — see `rv32_local_promo_flip_472.rs`).
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -57,8 +58,11 @@ fn fixture(rel: &str) -> std::path::PathBuf {
 /// opt-out (pre-flip bytes). `backend_args` selects ARM path / RV32.
 fn compile(rel: &str, out: &str, flag: &str, default_on: bool, backend_args: &[&str]) -> Vec<u8> {
     let mut cmd = Command::new(synth());
-    // Hold the still-unflipped RV32 lever out of both arms.
-    cmd.env_remove("SYNTH_RV_LOCAL_PROMO");
+    // #601 promo flip: local promotion is default-on now; pin it OFF in both
+    // arms so this gate keeps isolating its own lever against the same
+    // pre-promo baseline it was frozen on (the flip has its own gate in
+    // `rv32_local_promo_flip_472.rs`).
+    cmd.env("SYNTH_RV_LOCAL_PROMO", "0");
     if default_on {
         cmd.env_remove(flag);
     } else {

--- a/crates/synth-cli/tests/frozen_codegen_bytes.rs
+++ b/crates/synth-cli/tests/frozen_codegen_bytes.rs
@@ -58,14 +58,17 @@ fn fixture(name: &str) -> std::path::PathBuf {
 /// of its `.text` and the section length. The default-changing opt-out flags
 /// (`SYNTH_NO_CMP_SELECT_FUSE` — v0.13.0 cmp→select; `SYNTH_NO_LOCAL_PROMOTE` —
 /// v0.14.0 local promotion; `SYNTH_RV_CMP_SELECT` — #472 RV32 cmp→select,
-/// `=0` opts out; `SYNTH_CONST_CSE` — #242 const-CSE, `=0` opts out) and the
-/// still-opt-in lever (`SYNTH_RV_LOCAL_PROMO`) are explicitly removed so a
-/// flag set in the environment can never silently re-freeze the gate — it
-/// locks the SHIPPED lowering, which since v0.14.0 INCLUDES cmp→select fusion
-/// AND local promotion on ARM (both default-on), since the #472 flip-wave
-/// includes RV32 cmp→select fusion, and since the #242 const-CSE flip includes
-/// the post-hoc `apply_const_cse` passes on ARM (both paths). The `object`
-/// crate reads `.text` arch-agnostically (ARM Thumb-2 and RV32 alike).
+/// `=0` opts out; `SYNTH_CONST_CSE` — #242 const-CSE, `=0` opts out;
+/// `SYNTH_RV_LOCAL_PROMO` — #472/#601 RV32 local promotion, `=0` opts out)
+/// are explicitly removed so a flag set in the environment can never silently
+/// re-freeze the gate — it locks the SHIPPED lowering, which since v0.14.0
+/// INCLUDES cmp→select fusion AND local promotion on ARM (both default-on),
+/// since the #472 flip-wave includes RV32 cmp→select fusion, since the #601
+/// measured-profitability flip includes RV32 local promotion (byte-neutral on
+/// these goldens — the measured gate declines everywhere in them, verified at
+/// flip time), and since the #242 const-CSE flip includes the post-hoc
+/// `apply_const_cse` passes on ARM (both paths). The `object` crate reads
+/// `.text` arch-agnostically (ARM Thumb-2 and RV32 alike).
 fn text_sha256(wasm: &str, backend: &str, target: &str) -> (String, usize) {
     let path = fixture(wasm);
     let elf = format!("/tmp/frozenbytes_{backend}_{wasm}.elf");
@@ -624,10 +627,17 @@ fn frozen_fixtures_uxth_fold_escape_hatch_restores_old_bytes() {
 /// goldens (main @ 57206a1, 2026-06-23) were control_step 6e734c4c…/504,
 /// signed_div_const 15fa429d…/88.
 ///
-/// `SYNTH_RV_LOCAL_PROMO` (#472's second lever) did NOT flip — HELD on a
-/// per-function no-grow blocker (its own WAR fixtures grow; see the env read
-/// in `synth-backend-riscv/src/selector.rs`) — so these goldens are the
-/// promo-UNSET bytes and `text_sha256` env-removes it for hygiene.
+/// `SYNTH_RV_LOCAL_PROMO` (#472's second lever) flipped DEFAULT-ON with the
+/// #601 measured-profitability fix (profitability is measured per candidate
+/// subset against the unpromoted baseline — strict no-grow by construction).
+/// These goldens are UNCHANGED by that flip: the measured gate declines
+/// promotion everywhere in control_step and signed_div_const, so the promo-ON
+/// bytes are bit-identical to the promo-UNSET bytes pinned here (verified by
+/// hash at flip time; `frozen_fixtures_rv32_local_promo_escape_hatch_is_noop`
+/// locks the opt-out side). Execution differentials were re-run green on the
+/// flag-ON bytes BEFORE the flip (all 11 `*_riscv_differential.py`; corpus
+/// no-grow gate `rv32_local_promo_no_grow_corpus_472`: 10 shrink / 0 grow
+/// across 67 fixtures — see the flip PR).
 ///
 /// Goldens RE-FROZEN for the SYNTH_RV_SHIFT_FOLD flip (#242 flag-audit
 /// flip-wave; gale re-measured the fold still off and worth −8 B toward the
@@ -681,8 +691,11 @@ fn frozen_fixtures_rv32_shift_fold_escape_hatch_restores_old_bytes() {
     for &(wasm, golden, golden_len) in &cases {
         let path = fixture(wasm);
         let elf = format!("/tmp/frozenbytes_rv32_shiftfold_off_{wasm}.elf");
+        // COMPOSITION (#601 promo flip): local promotion is default-on but
+        // byte-neutral on these fixtures; pin it off anyway so the rollback
+        // stays an exact pre-flip composition, not a byte-neutrality bet.
         let out = Command::new(synth())
-            .env_remove("SYNTH_RV_LOCAL_PROMO")
+            .env("SYNTH_RV_LOCAL_PROMO", "0")
             .env_remove("SYNTH_RV_CMP_SELECT")
             .env("SYNTH_RV_SHIFT_FOLD", "0")
             .args([
@@ -731,7 +744,9 @@ fn frozen_fixtures_rv32_shift_fold_escape_hatch_restores_old_bytes() {
 ///
 /// COMPOSITION NOTE: since the #242 flag-audit flip-wave, rolling back to
 /// these bytes also requires opting out of the LATER shift-fold lever
-/// (`SYNTH_RV_SHIFT_FOLD=0`), which fires on control_step.
+/// (`SYNTH_RV_SHIFT_FOLD=0`), which fires on control_step; since the #601
+/// promo flip, `SYNTH_RV_LOCAL_PROMO=0` is pinned too (byte-neutral here,
+/// pinned for exactness).
 #[test]
 fn frozen_fixtures_rv32_cmp_select_escape_hatch_restores_old_bytes() {
     let cases = [
@@ -749,8 +764,10 @@ fn frozen_fixtures_rv32_cmp_select_escape_hatch_restores_old_bytes() {
     for &(wasm, golden, golden_len) in &cases {
         let path = fixture(wasm);
         let elf = format!("/tmp/frozenbytes_rv32_cmpsel_off_{wasm}.elf");
+        // COMPOSITION (#601 promo flip): see the shift-fold hatch — promo is
+        // pinned off so the rollback composition stays exact.
         let out = Command::new(synth())
-            .env_remove("SYNTH_RV_LOCAL_PROMO")
+            .env("SYNTH_RV_LOCAL_PROMO", "0")
             .env("SYNTH_RV_CMP_SELECT", "0")
             .env("SYNTH_RV_SHIFT_FOLD", "0")
             .args([
@@ -787,6 +804,74 @@ fn frozen_fixtures_rv32_cmp_select_escape_hatch_restores_old_bytes() {
         assert_eq!(
             hex, golden,
             "{wasm}: SYNTH_RV_CMP_SELECT=0 must restore the pre-flip bytes (rollback broken)"
+        );
+    }
+}
+
+/// ESCAPE-HATCH GATE for the SYNTH_RV_LOCAL_PROMO flip (#472/#601):
+/// `SYNTH_RV_LOCAL_PROMO=0` ALONE (every other lever at the shipped default)
+/// must restore the pre-flip RV32 goldens byte-for-byte. Both pinned fixtures
+/// are promo-NEUTRAL — the measured profitability gate declines promotion
+/// everywhere in them, so pre-flip bytes == the current default goldens and
+/// this doubles as the tripwire that (a) the opt-out stays a genuine no-op
+/// here and (b) no promotion machinery leaks into the `=0` lowering. The
+/// fixtures where the lever genuinely fires are locked by the corpus gate in
+/// `rv32_local_promo_flip_472.rs` (default-vs-opt-out, no-grow + non-vacuity).
+#[test]
+fn frozen_fixtures_rv32_local_promo_escape_hatch_is_noop() {
+    let cases = [
+        (
+            "control_step.wasm",
+            "6ac5d7f94f3e17b0314aa2549e24b172b50dc0df110130c80a94e19d62c7b75b",
+            484usize,
+        ),
+        (
+            "signed_div_const.wasm",
+            "15fa429d5ef5474f8b65fdd9c81b3da4c70176fb077df25131e2ec3988eb999e",
+            88,
+        ),
+    ];
+    for &(wasm, golden, golden_len) in &cases {
+        let path = fixture(wasm);
+        let elf = format!("/tmp/frozenbytes_rv32_promo_off_{wasm}.elf");
+        let out = Command::new(synth())
+            .env("SYNTH_RV_LOCAL_PROMO", "0")
+            .env_remove("SYNTH_RV_CMP_SELECT")
+            .env_remove("SYNTH_RV_SHIFT_FOLD")
+            .args([
+                "compile",
+                path.to_str().unwrap(),
+                "-o",
+                &elf,
+                "-b",
+                "riscv",
+                "--target",
+                "rv32imac",
+                "--all-exports",
+                "--relocatable",
+            ])
+            .output()
+            .expect("run synth");
+        assert!(out.status.success(), "compile failed for {wasm}");
+        let bytes = std::fs::read(&elf).expect("read elf");
+        let obj = object::File::parse(&*bytes).expect("parse elf");
+        let data = obj
+            .section_by_name(".text")
+            .expect(".text")
+            .data()
+            .expect("read .text");
+        assert_eq!(
+            data.len(),
+            golden_len,
+            "{wasm}: SYNTH_RV_LOCAL_PROMO=0 must restore the pre-flip length"
+        );
+        let hex: String = Sha256::digest(data)
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        assert_eq!(
+            hex, golden,
+            "{wasm}: SYNTH_RV_LOCAL_PROMO=0 must restore the pre-flip bytes (rollback broken)"
         );
     }
 }

--- a/crates/synth-cli/tests/rv32_cmp_select_flip_472.rs
+++ b/crates/synth-cli/tests/rv32_cmp_select_flip_472.rs
@@ -20,11 +20,13 @@
 //!   shrink (control_step −12 B, the sel_* family −4/−8 B each, clamp −8 B
 //!   at flip time).
 //!
-//! `SYNTH_RV_LOCAL_PROMO` (the wave's second lever) did NOT flip — HELD on a
-//! per-function no-grow blocker (its own WAR fixtures grow: war_set 56→64 B,
-//! war_tee 60→68 B; promo-alone grows control_step 504→508 B). The blocker is
-//! documented at the env read in `synth-backend-riscv/src/selector.rs`; this
-//! test env-removes the flag so a stray value can't skew the gate.
+//! `SYNTH_RV_LOCAL_PROMO` (the wave's second lever) was HELD out of the wave
+//! on a per-function no-grow blocker (its own WAR fixtures grew under the v1
+//! access-count model: war_set 56→64 B, war_tee 60→68 B) and later flipped
+//! default-on once profitability became MEASURED (#601; see
+//! `rv32_local_promo_flip_472.rs`). This gate pins it OFF in both arms so it
+//! keeps isolating the cmp→select lever against the same pre-promo baseline
+//! it was frozen on.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -49,7 +51,8 @@ fn fixture(rel: &str) -> std::path::PathBuf {
 /// `SYNTH_RV_CMP_SELECT=0` opt-out (pre-flip bytes).
 fn compile(rel: &str, out: &str, default_on: bool) -> Vec<u8> {
     let mut cmd = Command::new(synth());
-    cmd.env_remove("SYNTH_RV_LOCAL_PROMO");
+    // #601 promo flip: default-on now — pin OFF in both arms (see module doc).
+    cmd.env("SYNTH_RV_LOCAL_PROMO", "0");
     // #242 flag-audit flip-wave: shift-fold is default-on; remove it so a
     // stray opt-out can't skew the cmp-select isolation (both arms fold).
     cmd.env_remove("SYNTH_RV_SHIFT_FOLD");

--- a/crates/synth-cli/tests/rv32_local_promo_flip_472.rs
+++ b/crates/synth-cli/tests/rv32_local_promo_flip_472.rs
@@ -26,8 +26,11 @@
 //!   NO-GROW: for every function, text size(flag-on) <= text size(flag-off).
 //!   NON-VACUITY: the lever genuinely fires (>=1 function shrinks — accum).
 //!
-//! This gate is the flip precondition: it was verified RED on the old model
-//! (war_set/war_tee grew) before the measured decision landed.
+//! This gate was the flip precondition: it was verified RED on the old model
+//! (war_set/war_tee grew) before the measured decision landed, GREEN after,
+//! and the flip shipped — `SYNTH_RV_LOCAL_PROMO` is DEFAULT-ON, `=0` opts out
+//! (pre-flip bytes; CI-gated escape hatch in `frozen_codegen_bytes.rs`). The
+//! two arms below are now default-vs-opt-out, same invariant.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -47,18 +50,20 @@ fn fixture(rel: &str) -> std::path::PathBuf {
 }
 
 /// Compile `rel` for RV32 exactly like the `.py` differentials do.
-/// `promo_on` toggles ONLY `SYNTH_RV_LOCAL_PROMO`; every other lever env var
-/// is removed so both arms run the shipped defaults and the gate isolates the
-/// promotion lever.
+/// `promo_on` toggles ONLY `SYNTH_RV_LOCAL_PROMO` (`true` = the shipped
+/// default, env removed so a stray opt-out in the test environment can't skew
+/// the gate; `false` = the `=0` opt-out, pre-flip bytes); every other lever
+/// env var is removed so both arms run the shipped defaults and the gate
+/// isolates the promotion lever.
 fn compile(rel: &str, out: &str, promo_on: bool) -> Vec<u8> {
     let mut cmd = Command::new(synth());
     cmd.env_remove("SYNTH_RV_CMP_SELECT");
     cmd.env_remove("SYNTH_RV_SHIFT_FOLD");
     cmd.env_remove("SYNTH_RV_ADDR_FOLD");
     if promo_on {
-        cmd.env("SYNTH_RV_LOCAL_PROMO", "1");
-    } else {
         cmd.env_remove("SYNTH_RV_LOCAL_PROMO");
+    } else {
+        cmd.env("SYNTH_RV_LOCAL_PROMO", "0");
     }
     let out_status = cmd
         .args([


### PR DESCRIPTION
## SYNTH_RV_LOCAL_PROMO default-on — measured local promotion ships (#472, closes #601, epic #242)

Stacked on #626 (the measured-profitability model). The deliberate flip, executed with the refreeze ritual (PR #583 template). The RV32 local-promotion lever — leaf functions' non-parameter i32 locals into callee-saved s8/s9/s10 — now runs **by default**; `SYNTH_RV_LOCAL_PROMO=0` is the opt-out (pre-flip bytes).

### Evidence basis for the flip (all from #626, re-verified on this branch)
- Profitability is MEASURED per function: baseline + every candidate subset lowered, promoted lowering kept only at `emitted_byte_size <= baseline` — per-return epilogue restores and WAR-snapshot `mv`s (the #601 blocker) priced by construction; `emitted_byte_size` mirror-pinned to `assemble_function` (#511).
- **10 functions shrink / 0 grow, function sets unchanged, across all 67 RV32-compiling repro fixtures** (`rv32_local_promo_no_grow_corpus_472`, arms now default-vs-opt-out).

### Execution differentials — run on the NEW DEFAULT bytes BEFORE any pin
All 11 `scripts/repro/*riscv*_differential.py`, env unset (i.e. the shipped default), fresh binary: **11/11 PASS** (const_addr_fold −56 B, control_step + controller_step + filter_axis correct + ABI-compliant, i64_divs_317, if_else_result_343, rv32_cmp_select_472 182 vectors, rv32_local_promotion_472, shift_fold 21/21, signed_div_const, u64_unpack).

### Refreeze table (`frozen_fixtures_rv32_text_is_bit_identical_oracle_001`)
| fixture | old sha256 / len | new | Δ |
|---|---|---|---|
| control_step.wasm | `6ac5d7f9…` / 484 | **unchanged** | 0 |
| signed_div_const.wasm | `15fa429d…` / 88 | **unchanged** | 0 |

**No re-pin needed**: the measured gate declines promotion everywhere in both pinned fixtures — promo-ON `.text` verified bit-identical by hash. ARM gates untouched (the lever is RV32-selector-only).

### Per-function deltas at the new default (vs `=0` opt-out)
| fixture | function | opt-out | default | Δ |
|---|---|---|---|---|
| controller_step.wasm/.wat | controller_step_decide | 332 | 308 | −24 |
| flight_seam.wasm/.wat | controller_step | 416 | 412 | −4 |
| flight_seam_flat.wasm/.wat | controller_step | 416 | 412 | −4 |
| flight_seam_flat.wasm/.wat | flight_algo | 756 | 724 | −32 |
| rv32_cmp_select_472.wat | clamp | 104 | 100 | −4 |
| rv32_local_promotion_472.wat | accum | 264 | 196 | −68 |

### Opt-out pin (CI-gated escape hatch)
- New `frozen_fixtures_rv32_local_promo_escape_hatch_is_noop`: `SYNTH_RV_LOCAL_PROMO=0` alone reproduces the pinned goldens (rollback proof + leak tripwire; the pins are promo-neutral so old bytes == current goldens).
- The shift-fold and cmp-select escape hatches now pin `SYNTH_RV_LOCAL_PROMO=0` too — exact pre-flip composition, not a byte-neutrality bet (the documented COMPOSITION NOTE pattern).
- `flag_flip_wave_242` + `rv32_cmp_select_flip_472` pin promo `=0` in both arms so each gate keeps isolating its own lever on the baseline it was frozen on.
- `local_promotion_default_is_promoted_and_opt_out_frame_backed_472` (riscv unit test): env-unset default == flag-on lowering; opt-out stays frame-backed, no s8 write.

### Gate (all green on this branch)
- 11/11 execution differentials on new default bytes BEFORE pinning ✓
- `cargo test -p synth-backend-riscv` (210) ✓ · `cargo test -p synth-cli` (frozen gates + all three escape hatches + flip gates) ✓
- `cargo test --workspace` — 104 suites, 0 failures ✓
- `cargo fmt --check` ✓ · chunked + full `cargo clippy --workspace --all-targets -- -D warnings` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
