### PR TITLE
chore(release): v0.31.0 — verified selector rules, facts ingestion, RV promo flip, z3-free default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-07-08
+
+**The first Rocq-verified selector rules land (VCR-SEL-001 increment 1); the
+proof-carrying-specialization pipeline opens (wsc.facts ingestion); RV32 local
+promotion ships default-on with a measured never-grow model (the #601 hold
+lifts); and the default build drops its last C++ dependency.**
+
+### Added
+
+- **VCR-SEL-001 increment 1 (#623, epic #242):** a verified selector rule DSL —
+  declarative rule table for i32 add/sub/mul/and/or/xor + rotl (explicit
+  scratch non-aliasing side condition), generated Rust lowerings committed to
+  the tree, one universally-quantified T1 theorem per rule
+  (`coq/Synth/Synth/VcrSelRules.v`) with a coverage check that fails the
+  `//coq` build if any rule lacks its Qed. `select_default` arms delegate
+  behind `SYNTH_SEL_DSL` (default OFF — OFF ≡ baseline byte-identical).
+- **wsc.facts ingestion, #494 phase 1 (#624, VCR-PERF-002):** schema-v1 parser
+  for loom's forthcoming facts section (keyed by function index + value id,
+  fail-safe: unknown kinds and malformed/missing sections ignored) threaded
+  into `CompileConfig`. Zero codegen change — compilation is byte-identical
+  with or without the section; the consumer is phase 2.
+
+### Changed (byte-changing on RV32, deliberate)
+
+- **`SYNTH_RV_LOCAL_PROMO` default-ON (#626/#627; closes the #601 hold).**
+  The heuristic profitability model is replaced by measurement: candidate
+  locals are lowered in every subset and a promoted lowering is kept only when
+  its emitted byte size does not exceed the unpromoted baseline — per-return
+  epilogue restores (the #601 blocker) are priced by construction.
+  `emitted_byte_size` is mirror-pinned to `assemble_function` sizing.
+  Red→green: the old model grew `control_step_decide` 484→488 B; the corpus
+  gate now shows 10 shrink / 0 grow (flight_algo −32 B, accum −68 B). All 11
+  RV32 execution differentials pass on the new default bytes; both pinned RV32
+  goldens are promo-neutral by hash; `=0` opt-out escape hatch CI-gated.
+- **static-link-z3 out of the default build/CI path (#621, #553 steps 3/4):**
+  `cargo test --workspace` now builds with no C++ toolchain (ordeal is the
+  engine, 139/139); Z3 remains as the feature-gated differential oracle
+  (`z3-solver` + `SYNTH_SOLVER_DIFF=1`), same CI job, now a true differential.
+
+### Documentation
+
+- README North-Star + CLAUDE.md refreshed to post-v0.30 reality (#625): the
+  315-cycle flat_flight table is historical motivation; shipped levers,
+  in-flight rivets, and proof counts (298 Qed) now stated with provenance.
+
 ## [0.30.2] - 2026-07-07
 
 **Every A32 (cortex-r5) i64 op computed real results — the entire family was

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,14 +2060,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2125,11 +2125,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.30.2"
+version = "0.31.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2184,14 +2184,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2199,11 +2199,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.30.2"
+version = "0.31.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.30.2"
+version = "0.31.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.30.2"
+version = "0.31.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.30.2",
+    version = "0.31.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.30.2" }
+synth-core = { path = "../synth-core", version = "0.31.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.30.2" }
+synth-core = { path = "../synth-core", version = "0.31.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.30.2" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.30.2" }
+synth-core = { path = "../synth-core", version = "0.31.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.31.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.30.2" }
+synth-core = { path = "../synth-core", version = "0.31.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.30.2" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.30.2", optional = true }
+synth-core = { path = "../synth-core", version = "0.31.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.31.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -27,23 +27,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.30.2" }
-synth-frontend = { path = "../synth-frontend", version = "0.30.2" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.30.2" }
-synth-backend = { path = "../synth-backend", version = "0.30.2" }
+synth-core = { path = "../synth-core", version = "0.31.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.31.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.31.0" }
+synth-backend = { path = "../synth-backend", version = "0.31.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.30.2" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.31.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.30.2", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.30.2", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.30.2", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.31.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.31.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.31.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.30.2", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.31.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.30.2" }
+synth-core = { path = "../synth-core", version = "0.31.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.30.2" }
+synth-cfg = { path = "../synth-cfg", version = "0.31.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.30.2" }
-synth-cfg = { path = "../synth-cfg", version = "0.30.2" }
-synth-opt = { path = "../synth-opt", version = "0.30.2" }
+synth-core = { path = "../synth-core", version = "0.31.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.31.0" }
+synth-opt = { path = "../synth-opt", version = "0.31.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -20,12 +20,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.30.2" }
-synth-cfg = { path = "../synth-cfg", version = "0.30.2" }
-synth-opt = { path = "../synth-opt", version = "0.30.2" }
+synth-core = { path = "../synth-core", version = "0.31.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.31.0" }
+synth-opt = { path = "../synth-opt", version = "0.31.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.30.2", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.31.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"


### PR DESCRIPTION
Release PR: pin sweep + CHANGELOG for v0.31.0.

Scope: VCR-SEL-001 increment 1 (#623) · wsc.facts phase 1 (#624) · SYNTH_RV_LOCAL_PROMO default-on with measured never-grow model (#626/#627, closes the #601 hold) · static-link-z3 out of the default build (#621) · docs refresh (#625).

Tag v0.31.0 on green merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)