### PR TITLE
feat(fact-spec): #494 phase 2 — value-range clamp elision behind SYNTH_FACT_SPEC, per-elision ordeal UNSAT obligation (VCR-PERF-002)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,46 @@ jobs:
       - name: Run two-move execution oracle
         run: python scripts/repro/cmp_select_two_move_differential.py
 
+  fact-spec-oracle:
+    name: fact-spec clamp elision oracle (#494 phase 2)
+    # VCR-PERF-002 Phase 2 (#494): the proof-carrying-specialization lever
+    # (SYNTH_FACT_SPEC, default off; per-elision ordeal obligation). Built
+    # with the `verify` feature (the solver lives in synth-verify — pure-Rust
+    # ordeal, no C++ toolchain): (1) the end-to-end flag/fact gating matrix +
+    # certificate-evidence Rust gates; (2) the in-bounds execution
+    # differential — specialized ≡ wasmtime ≡ unspecialized over the proven
+    # bound ch ∈ [524,1524] under unicorn — plus the wrong-bound loud-decline
+    # green path. Isolated job: emulation deps pip-installed here ONLY.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Run fact-spec end-to-end gates (flag matrix + certificates)
+        run: cargo test -p synth-cli --features verify --test fact_spec_clamp_494
+      - name: Build synth (verify feature)
+        run: cargo build -p synth-cli --features verify
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Run in-bounds differential (proven bound)
+        run: python scripts/repro/fact_spec_clamp_494_differential.py
+      - name: Run wrong-bound loud-decline path
+        run: >
+          python scripts/repro/fact_spec_clamp_494_differential.py
+          --fact-lo 0 --fact-hi 4000 --expect-decline
+
   rv32-shift-fold-oracle:
     name: rv32 immediate-shift-fold execution oracle
     # VCR-ORACLE-001 (#242, #472): EXECUTE the RV32 immediate-shift-fold lever

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -1654,12 +1654,37 @@ artifacts:
       byte-identical to facts-stripped; malformed/wrong-version sections
       ignored end-to-end; non-vacuity decode guard) + parser unit tests (all
       six kinds, unknown-kind skip, truncation/version/overrun => ignored).
-      Phases 2/3 NOT implemented — no elision, no SYNTH_FACT_SPEC lever yet;
-      status stays short of implemented until the full requirement (the
-      elision + gale-measured kill-criterion) has evidence.
       Phase 2 — single-elision prototype: value-range => dead conditional-branch
       elision (the gust_mix clamp shape), flag-gated, per-elision validator
-      obligation + in-bounds differential red/green oracle.
+      obligation + in-bounds differential red/green oracle. IMPLEMENTED
+      (2026-07-08): crates/synth-verify/src/fact_spec.rs — backend-agnostic
+      WasmOp-stream rewrite; at every no-else `if` the pass discharges
+      UNSAT(P ∧ cond ≠ 0) through the ordeal-backed BvSolver BEFORE emission
+      (this implies the general/specialized equivalence obligation for a
+      no-else if, whose not-taken path is the identity by wasm blocktype
+      validation); Unsat => admit + per-function certificate log line; Sat
+      (with model counterexample) / Unknown / untracked shape / impure
+      condition slice => DECLINE LOUDLY, general lowering emitted. Driver gate
+      maybe_fact_spec in synth-cli (both compile paths; SYNTH_FACT_SPEC
+      default OFF; requires the `verify` feature — absent it the flag declines
+      loudly). div/rem deliberately untracked (a deleted condition slice must
+      be effect-free under ALL inputs, not just P-admissible ones — trap-guard
+      elision is the separate divisor-nonzero fact, out of phase-2 scope).
+      Oracles: synth-verify fact_spec unit gates (admit/decline matrix,
+      declined-region havoc soundness, tee-impurity non-erasability,
+      block-arity ordinal repair, out-of-range value_id vacuity); synth-cli
+      tests/fact_spec_clamp_494.rs (flag/fact byte-identity matrix,
+      certificate evidence trail, wrong-bound Sat loud-decline); in-bounds
+      execution differential scripts/repro/fact_spec_clamp_494_differential.py
+      (specialized ≡ wasmtime ≡ unspecialized over the proven bound
+      [524,1524] ONLY; non-vacuity: exactly 2 ADMITs + .text shrink required)
+      — all CI-gated by the fact-spec-oracle job. The gust_mix clamp fixture
+      collapses 20 -> 6 ops (both clamp comparisons + branches + bodies gone);
+      measured cortex-m4 codegen 84 B/23 insns -> 14 B/6 insns (vs the 6 B
+      add+bx measured floor: residual const-materialization + reg-shuffle +
+      callee-saved frame — allocator/peephole residue, a Phase-3 datum).
+      Phase 3 NOT started — the requirement's kill-criterion is gale-measured;
+      status stays at implemented (not verified) until Phase 3 reports.
       Phase 3 — measurement vs the 0.45x floor: gale re-measures gust_mix on
       gust_floor_bench (qemu -icount) and STM32F100 silicon (DWT CYCCNT);
       kill-criterion unchanged from #494: shipped dissolved lane <1.0x then
@@ -1667,10 +1692,11 @@ artifacts:
       floor (0.45x) gives the target 0.25x of headroom — if the productized
       elision cannot land inside it, the premise-to-selector plumbing (not the
       idea) is at fault and the phase re-plans.
-    # approved (not implemented): Phase 1 of 3 landed with its oracle; the
-    # requirement's substance (the elision + kill-criterion) is Phases 2/3 —
-    # never strengthen a traceability claim beyond the evidence.
-    status: approved
+    # implemented (not verified): Phases 1+2 of 3 landed with their oracles —
+    # the elision exists, certificate-gated and differential-tested. The
+    # requirement's kill-criterion (Phase 3, gale-measured 0.70x vs native)
+    # has NO evidence yet — never strengthen a traceability claim beyond it.
+    status: implemented
     tags: [codegen, perf, proof-carrying, specialization, wsc-facts, loom-integration, ordeal, beat-llvm, synth-494, gale-121]
     links:
       - type: derives-from

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -14,6 +14,16 @@ description = "CLI for Synth, the WebAssembly-to-ARM Cortex-M AOT compiler"
 name = "synth"
 path = "src/main.rs"
 
+# VCR-PERF-002 Phase 2 (#494): the fact-spec end-to-end gate needs the synth
+# binary built WITH the ordeal-backed solver (feature `verify`), so it is a
+# dedicated test target the fact-spec CI job runs via
+# `cargo test -p synth-cli --features verify --test fact_spec_clamp_494`.
+# Plain `cargo test --workspace` skips it (required-features unmet); the pass
+# itself is unit-tested unconditionally in synth-verify.
+[[test]]
+name = "fact_spec_clamp_494"
+required-features = ["verify"]
+
 [features]
 default = ["riscv"]
 awsm = ["synth-backend-awsm"]

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -38,6 +38,90 @@ mod sign;
 /// collide with a real path the user would pass.
 const SBOM_DEFAULT_SENTINEL: &str = "\u{0}sbom-default\u{0}";
 
+// =============================================================================
+// VCR-PERF-002 Phase 2 (#494): proof-carrying specialization (fact-spec)
+// =============================================================================
+
+/// `SYNTH_FACT_SPEC` — default OFF (silicon-gated, the design doc's Phase-3
+/// flip criterion). When set (any value but `0`) AND the module carried a
+/// parseable `wsc.facts` section, the driver runs the per-function fact-spec
+/// pass before selection. Frozen fixtures carry no facts section, so they are
+/// bit-identical trivially even with the flag on.
+fn fact_spec_enabled() -> bool {
+    std::env::var("SYNTH_FACT_SPEC").is_ok_and(|v| v != "0")
+}
+
+/// One function's rewritten stream + side-tables, when the Phase-2 pass
+/// admitted at least one certificate-backed elision.
+struct SpecializedFn {
+    ops: Vec<WasmOp>,
+    block_arity: Vec<(u8, u8)>,
+    /// Indices into the ORIGINAL op stream that survived — for filtering
+    /// parallel side-tables (`op_offsets` feeding `.debug_line`).
+    #[cfg_attr(not(feature = "verify"), allow(dead_code))]
+    kept: Vec<usize>,
+}
+
+/// Run the fact-spec pass (value-range facts ⇒ dead conditional-branch
+/// elision, `docs/design/proof-carrying-specialization.md`) for one function.
+/// Every elision was individually discharged by the ordeal-backed solver
+/// (UNSAT(P ∧ cond ≠ 0), certificate-checked) BEFORE this returns; admits and
+/// declines are logged per function. Returns `Some` only when the op stream
+/// actually changed — `None` means the general lowering proceeds untouched.
+fn maybe_fact_spec(
+    func_name: &str,
+    ops: &[WasmOp],
+    block_arity: &[(u8, u8)],
+    facts: &[WscFact],
+) -> Option<SpecializedFn> {
+    if !fact_spec_enabled() || facts.is_empty() {
+        return None;
+    }
+    #[cfg(feature = "verify")]
+    {
+        let r = synth_verify::fact_spec::specialize_function(func_name, ops, block_arity, facts);
+        // Loud by contract: every decline names its site and reason; every
+        // admit carries the certificate line (the evidence trail).
+        for line in &r.declined {
+            eprintln!("fact-spec: DECLINE {line}");
+        }
+        for line in &r.admitted {
+            eprintln!("fact-spec: ADMIT {line}");
+        }
+        if r.changed() {
+            eprintln!(
+                "fact-spec: '{func_name}' specialized — {} elision(s) admitted, \
+                 {} declined ({} → {} ops)",
+                r.admitted.len(),
+                r.declined.len(),
+                ops.len(),
+                r.ops.len()
+            );
+            return Some(SpecializedFn {
+                ops: r.ops,
+                block_arity: r.block_arity,
+                kept: r.kept,
+            });
+        }
+        None
+    }
+    #[cfg(not(feature = "verify"))]
+    {
+        let _ = (func_name, ops, block_arity, facts);
+        // Decline loudly (the design doc's rule): without the solver the
+        // obligation cannot be discharged, so no elision may fire — but the
+        // user asked for specialization, so say why nothing happens.
+        eprintln!(
+            "warning: SYNTH_FACT_SPEC is set but this synth was built without the \
+             'verify' feature — the per-elision proof obligation (#494) cannot be \
+             discharged, so every elision is DECLINED and the general lowering is \
+             emitted. Rebuild with `--features verify` to enable fact-based \
+             specialization."
+        );
+        None
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "synth")]
 #[command(about = "WebAssembly-to-ARM Cortex-M AOT compiler")]
@@ -1294,6 +1378,20 @@ fn compile_command(
         }
     };
 
+    // VCR-PERF-002 Phase 2 (#494): fact-spec — behind SYNTH_FACT_SPEC and a
+    // per-elision ordeal obligation. No-op unless the module carried facts,
+    // the flag is on, AND at least one elision was certificate-admitted.
+    let mut wasm_ops = wasm_ops;
+    if let Some(spec) = maybe_fact_spec(
+        &func_name,
+        &wasm_ops,
+        &current_func_block_arity,
+        &current_func_facts,
+    ) {
+        wasm_ops = spec.ops;
+        current_func_block_arity = spec.block_arity;
+    }
+
     info!("WASM operations: {:?}", wasm_ops);
 
     // Build compile config from CLI flags
@@ -2278,7 +2376,7 @@ fn compile_all_exports(
         // direct selector can land a value carried by br/br_if/br_table in the
         // target block's designated result register (and the optimized path can
         // detect-and-decline the shape).
-        let func_config = {
+        let mut func_config = {
             let mut fc = config.clone();
             if let Some(p) = all_func_params_i64.get(func.index as usize)
                 && !p.is_empty()
@@ -2312,7 +2410,30 @@ fn compile_all_exports(
             skipped_funcs.push((name.clone(), format!("unsupported operator: {reason}")));
             continue;
         }
-        let compiled = match backend.compile_function(&name, &func.ops, &func_config) {
+        // VCR-PERF-002 Phase 2 (#494): fact-spec — behind SYNTH_FACT_SPEC and
+        // a per-elision ordeal obligation. When an elision was admitted, the
+        // rewritten stream feeds the backend and the parallel side-tables
+        // (blocktype arity, DWARF op offsets) are filtered in lockstep.
+        let spec = maybe_fact_spec(
+            &name,
+            &func.ops,
+            &func_config.current_func_block_arity,
+            &func_config.current_func_facts,
+        );
+        let (ops_for_compile, op_offsets_for_elf): (&[WasmOp], Vec<u32>) = match &spec {
+            Some(s) => {
+                func_config.current_func_block_arity = s.block_arity.clone();
+                (
+                    &s.ops,
+                    s.kept
+                        .iter()
+                        .filter_map(|&i| func.op_offsets.get(i).copied())
+                        .collect(),
+                )
+            }
+            None => (&func.ops, func.op_offsets.clone()),
+        };
+        let compiled = match backend.compile_function(&name, ops_for_compile, &func_config) {
             Ok(c) => c,
             Err(e) => {
                 eprintln!(
@@ -2344,7 +2465,9 @@ fn compile_all_exports(
             relocations: compiled.relocations,
             // VCR-DBG-001 step 4: carry the op-offset side table + the backend's
             // line_map so `--debug-line` can compose ARM text addr → source.
-            op_offsets: func.op_offsets.clone(),
+            // (#494: filtered to surviving ops when fact-spec rewrote the stream,
+            // so the table stays index-aligned with what the backend consumed.)
+            op_offsets: op_offsets_for_elf,
             line_map: compiled.line_map,
         });
 
@@ -3970,11 +4093,11 @@ fn verify_command(wasm_input: PathBuf, elf_input: PathBuf, backend_name: &str) -
             let file_bytes = std::fs::read(&wasm_input)
                 .context(format!("Failed to read: {}", wasm_input.display()))?;
 
-            let wasm_bytes = if wasm_input.extension().map_or(false, |ext| ext == "wat") {
+            let wasm_bytes = if wasm_input.extension().is_some_and(|ext| ext == "wat") {
                 wat::parse_bytes(&file_bytes)
                     .context("Failed to parse WAT file")?
                     .into_owned()
-            } else if wasm_input.extension().map_or(false, |ext| ext == "wast") {
+            } else if wasm_input.extension().is_some_and(|ext| ext == "wast") {
                 let contents =
                     String::from_utf8(file_bytes).context("WAST file is not valid UTF-8")?;
                 extract_module_from_wast(&contents)?

--- a/crates/synth-cli/tests/fact_spec_clamp_494.rs
+++ b/crates/synth-cli/tests/fact_spec_clamp_494.rs
@@ -1,0 +1,210 @@
+//! VCR-PERF-002 Phase 2 (#494) — end-to-end gates for the fact-spec clamp
+//! elision (`SYNTH_FACT_SPEC`, default OFF; per-elision ordeal obligation).
+//!
+//! Requires the `verify` feature (the pass needs the ordeal-backed solver):
+//! run with `cargo test -p synth-cli --features verify --test fact_spec_clamp_494`
+//! (the fact-spec CI job does). The execution differential (oracle 2 —
+//! specialized ≡ wasmtime ≡ unspecialized over the proven bound) lives in
+//! `scripts/repro/fact_spec_clamp_494_differential.py`; here we lock the
+//! flag/fact gating matrix and the certificate evidence trail:
+//!
+//! - flag OFF + facts present  → byte-identical to baseline (no consumer);
+//! - flag ON  + no facts       → byte-identical (nothing to consume);
+//! - flag ON  + proven bound   → .text SHRINKS + 2 certificate ADMIT lines;
+//! - flag ON  + wrong bound    → byte-identical + loud Sat DECLINE with a
+//!   counterexample (the obligation is the gate, not the fact's say-so).
+//!
+//! Frozen anchors are untouched by construction (no fixture carries a facts
+//! section) and additionally locked by `frozen_codegen_bytes.rs`.
+
+use object::{Object, ObjectSection};
+use std::process::Command;
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture_wasm() -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro/fact_spec_clamp_494.wat");
+    let wat = std::fs::read(path).expect("read fixture wat");
+    wat::parse_bytes(&wat)
+        .expect("fixture wat must parse")
+        .into_owned()
+}
+
+// ---- schema-v1 encoders (mirror docs/design/wsc-facts-encoding.md) ----
+
+fn leb_u32(mut v: u32, out: &mut Vec<u8>) {
+    loop {
+        let mut b = (v & 0x7f) as u8;
+        v >>= 7;
+        if v != 0 {
+            b |= 0x80;
+        }
+        out.push(b);
+        if v == 0 {
+            return;
+        }
+    }
+}
+
+fn leb_s64(mut v: i64, out: &mut Vec<u8>) {
+    loop {
+        let mut b = (v & 0x7f) as u8;
+        v >>= 7;
+        let done = (v == 0 && b & 0x40 == 0) || (v == -1 && b & 0x40 != 0);
+        if !done {
+            b |= 0x80;
+        }
+        out.push(b);
+        if done {
+            return;
+        }
+    }
+}
+
+/// One value-range fact `[lo, hi]` on (func 0, value_id 0 = the `local.get`
+/// producing `ch`), wrapped as the `wsc.facts` custom section.
+fn with_range_fact(mut wasm: Vec<u8>, lo: i64, hi: i64) -> Vec<u8> {
+    let mut body = Vec::new();
+    leb_s64(lo, &mut body);
+    leb_s64(hi, &mut body);
+    let mut payload = vec![0x01]; // version
+    leb_u32(1, &mut payload); // count
+    payload.push(0x01); // kind: value-range
+    leb_u32(0, &mut payload); // func_index
+    leb_u32(0, &mut payload); // value_id
+    leb_u32(body.len() as u32, &mut payload);
+    payload.extend_from_slice(&body);
+
+    let name = b"wsc.facts";
+    let mut content = Vec::new();
+    leb_u32(name.len() as u32, &mut content);
+    content.extend_from_slice(name);
+    content.extend_from_slice(&payload);
+    wasm.push(0x00);
+    leb_u32(content.len() as u32, &mut wasm);
+    wasm.extend_from_slice(&content);
+    wasm
+}
+
+/// Compile on the shipped optimized ARM path; return (.text bytes, stderr).
+fn compile(wasm: &[u8], tag: &str, fact_spec: bool) -> (Vec<u8>, String) {
+    let dir = std::env::temp_dir().join("fact_spec_494");
+    std::fs::create_dir_all(&dir).expect("mk tempdir");
+    let input = dir.join(format!("{tag}.wasm"));
+    let elf = dir.join(format!("{tag}.elf"));
+    std::fs::write(&input, wasm).expect("write wasm");
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        input.to_str().unwrap(),
+        "-o",
+        elf.to_str().unwrap(),
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+    ]);
+    if fact_spec {
+        cmd.env("SYNTH_FACT_SPEC", "1");
+    } else {
+        cmd.env_remove("SYNTH_FACT_SPEC");
+    }
+    let out = cmd.output().expect("run synth");
+    assert!(
+        out.status.success(),
+        "compile of '{tag}' failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let bytes = std::fs::read(&elf).expect("read elf");
+    let obj = object::File::parse(&*bytes).expect("parse elf");
+    let text = obj
+        .section_by_name(".text")
+        .expect(".text")
+        .data()
+        .expect("read .text")
+        .to_vec();
+    (text, String::from_utf8_lossy(&out.stderr).into_owned())
+}
+
+/// Flag OFF is byte-identical to baseline even with facts present — the
+/// Phase-2 lever is opt-in (SYNTH_FACT_SPEC=0 ≡ baseline, rivet
+/// verification-criteria).
+#[test]
+fn flag_off_with_facts_is_byte_identical_494() {
+    let base = fixture_wasm();
+    let facts = with_range_fact(base.clone(), 524, 1524);
+    let (t_base, _) = compile(&base, "off_base", false);
+    let (t_facts, _) = compile(&facts, "off_facts", false);
+    assert_eq!(
+        t_base, t_facts,
+        "SYNTH_FACT_SPEC unset must never consume facts"
+    );
+}
+
+/// Flag ON without facts is byte-identical — the lever cannot fire without a
+/// premise (this is also why every frozen fixture is trivially safe).
+#[test]
+fn flag_on_without_facts_is_byte_identical_494() {
+    let base = fixture_wasm();
+    let (t_off, _) = compile(&base, "nofacts_off", false);
+    let (t_on, _) = compile(&base, "nofacts_on", true);
+    assert_eq!(t_off, t_on, "no facts ⇒ nothing to elide ⇒ identical bytes");
+}
+
+/// THE PHASE-2 GATE: under the proven bound ch ∈ [524, 1524] both clamp
+/// branches are certificate-elided — the .text shrinks and the stderr carries
+/// the per-elision evidence trail (UNSAT + certificate-checked, per function).
+#[test]
+fn proven_bound_elides_both_clamps_with_certificates_494() {
+    let base = fixture_wasm();
+    let facts = with_range_fact(base.clone(), 524, 1524);
+    let (t_base, _) = compile(&base, "proven_base", false);
+    let (t_spec, stderr) = compile(&facts, "proven_spec", true);
+
+    let admits = stderr.matches("fact-spec: ADMIT").count();
+    assert_eq!(
+        admits, 2,
+        "both clamp `if`s must be certificate-admitted; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("UNSAT") && stderr.contains("certificate-checked"),
+        "the admit lines are the evidence trail:\n{stderr}"
+    );
+    assert!(
+        t_spec.len() < t_base.len(),
+        "specialized .text ({} B) must shrink vs baseline ({} B)",
+        t_spec.len(),
+        t_base.len()
+    );
+}
+
+/// Wrong-bound fact (ch ∈ [0, 4000]): the branch IS reachable under the
+/// premise, so the obligation is Sat — synth declines LOUDLY (with a model
+/// counterexample) and emits the general lowering, byte-identical to
+/// baseline. The obligation is the gate; the fact alone admits nothing.
+#[test]
+fn wrong_bound_declines_loudly_and_changes_nothing_494() {
+    let base = fixture_wasm();
+    let facts = with_range_fact(base.clone(), 0, 4000);
+    let (t_base, _) = compile(&base, "wrong_base", false);
+    let (t_spec, stderr) = compile(&facts, "wrong_spec", true);
+
+    assert_eq!(
+        stderr.matches("fact-spec: ADMIT").count(),
+        0,
+        "a Sat obligation must never admit:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("fact-spec: DECLINE") && stderr.contains("counterexample"),
+        "declines must be loud and carry a model:\n{stderr}"
+    );
+    assert_eq!(
+        t_base, t_spec,
+        "declined ⇒ the general lowering, byte-identical to baseline"
+    );
+}

--- a/crates/synth-verify/src/fact_spec.rs
+++ b/crates/synth-verify/src/fact_spec.rs
@@ -1,0 +1,822 @@
+//! Proof-carrying specialization — VCR-PERF-002 / #494 **Phase 2**: the
+//! single-elision prototype (value-range facts ⇒ dead conditional-branch
+//! elision, the `gust_mix` clamp shape).
+//!
+//! Design source of truth: `docs/design/proof-carrying-specialization.md`
+//! ("How synth consumes facts: the per-elision proof obligation"). loom is the
+//! PROVER (its validator discharged the `wsc.facts` invariants upstream);
+//! synth is a CONDITIONAL optimizer: it never re-derives a fact — it proves
+//! the correctness of its OWN transformation *given* the fact, per elision
+//! site, BEFORE emission, through the ordeal-backed [`BvSolver`]
+//! (certificate-checked pure-Rust QF_BV; every `Unsat` verdict carries an
+//! LRAT proof validated by the trusted `ordeal-lrat` checker before it is
+//! reported).
+//!
+//! # The transformation
+//!
+//! Working on the decoded [`WasmOp`] stream (backend-agnostic — the rewritten
+//! stream feeds whichever selector the driver picks), the pass walks the
+//! function top-level with a symbolic state (stack + locals as QF_BV terms via
+//! the existing [`WasmSemantics`] encoder) and, at every no-`else`
+//! `if … end`, discharges the obligation
+//!
+//! ```text
+//! premise    P   (every value-range fact reached so far, asserted as a hypothesis)
+//! obligation UNSAT( P ∧ cond ≠ 0 )
+//! ```
+//!
+//! `UNSAT(P ∧ cond ≠ 0)` implies the design doc's
+//! `UNSAT(P ∧ general_lowering(x) ≠ specialized_lowering(x))`: a no-`else`
+//! `if` whose condition is 0 on every P-admissible input never executes its
+//! body, and wasm validation forces a no-`else` `if` blocktype to have
+//! identical param/result types, so the not-taken path is the identity — the
+//! general and specialized lowerings agree on every input P admits. The
+//! stronger query is deliberately used because it is decided in the pure
+//! QF_BV fragment with no control-flow encoding.
+//!
+//! - **UNSAT (certificate-checked)** → the elision is ADMITTED: the
+//!   condition-producing op slice (proven pure and contiguous) plus the whole
+//!   `if … end` region are deleted; the certificate line is logged per
+//!   function (the evidence trail).
+//! - **Sat / Unknown / conflict-budget exceeded / any shape outside the
+//!   tracked fragment** → **DECLINE LOUDLY**: the general lowering is
+//!   emitted. There is no silent wrong-code path; the conservative fallback
+//!   is today's codegen.
+//!
+//! # Soundness of the symbolic tracking (over-approximation discipline)
+//!
+//! * Values produced by ops outside the tracked i32 fragment never enter the
+//!   state: the walk STOPS at the first untracked op (no further elisions in
+//!   the function; everything already admitted was justified independently).
+//! * Locals are seeded as fresh unconstrained variables (a superset of both
+//!   parameter values and the zero-init of non-param locals — sound).
+//! * A DECLINED `if` region may or may not execute: every local it assigns
+//!   (at any nesting depth) is havocked to a fresh variable, and its block
+//!   results are pushed as fresh variables.
+//! * An ADMITTED `if` region provably never executes, so state is unchanged.
+//! * `i32.div*`/`i32.rem*` are deliberately NOT tracked: they can trap, and a
+//!   deleted condition slice must be effect-free under ALL inputs, not just
+//!   P-admissible ones (the premise only justifies the branch-direction, not
+//!   trap removal — trap-guard elision is the separate divisor-nonzero fact,
+//!   out of Phase-2 scope).
+//!
+//! # Flag gating
+//!
+//! The driver only invokes this pass when `SYNTH_FACT_SPEC` is set (default
+//! OFF) AND the module carried a parseable `wsc.facts` section. Frozen
+//! fixtures carry no facts section, so every frozen anchor is bit-identical
+//! trivially; with the flag off the pass does not run at all.
+
+use crate::solver::{CheckOutcome, new_solver};
+use crate::term::{BV, Bool};
+use crate::wasm_semantics::WasmSemantics;
+use std::collections::HashMap;
+use synth_core::WasmOp;
+use synth_core::wsc_facts::{FactKind, WscFact};
+
+/// Outcome of specializing one function. `ops`/`block_arity`/`kept` are only
+/// meaningful when [`changed`](Self::changed) — otherwise they echo the input.
+#[derive(Debug)]
+pub struct FactSpecResult {
+    /// The (possibly rewritten) op stream.
+    pub ops: Vec<WasmOp>,
+    /// The blocktype-arity side-table matching `ops` (one entry per
+    /// `Block`/`Loop`/`If` in op order — entries of deleted openers removed).
+    pub block_arity: Vec<(u8, u8)>,
+    /// Indices into the ORIGINAL op stream that were kept, in order. Lets the
+    /// driver filter parallel side-tables (e.g. `op_offsets` for DWARF).
+    pub kept: Vec<usize>,
+    /// One certificate line per ADMITTED elision (logged per function).
+    pub admitted: Vec<String>,
+    /// One line per LOUD DECLINE (the general lowering is emitted for these).
+    pub declined: Vec<String>,
+}
+
+impl FactSpecResult {
+    /// True when at least one elision was admitted (i.e. `ops` differs from
+    /// the input).
+    pub fn changed(&self) -> bool {
+        !self.admitted.is_empty()
+    }
+}
+
+/// A symbolic operand-stack slot.
+#[derive(Clone)]
+struct Val {
+    bv: BV,
+    /// Start of the contiguous, side-effect-free op range that produced this
+    /// value — `None` when the producing slice is impure (`local.tee`) or not
+    /// provably contiguous. Only a `Some` slice may be deleted.
+    start: Option<usize>,
+    /// Index of the op that (last) produced this value.
+    created: usize,
+}
+
+/// Specialize one function's op stream against its `wsc.facts` premises.
+///
+/// `block_arity` is the decoder's ordinal side-table (one `(params, results)`
+/// entry per `Block`/`Loop`/`If` in op order); `facts` is the per-function
+/// slice (`CompileConfig::current_func_facts`). Total: every input yields a
+/// result — inapplicable shapes surface as loud declines, never errors.
+pub fn specialize_function(
+    func_name: &str,
+    ops: &[WasmOp],
+    block_arity: &[(u8, u8)],
+    facts: &[WscFact],
+) -> FactSpecResult {
+    let mut pass = Pass::new(func_name, ops, block_arity, facts);
+    pass.walk();
+    pass.finish()
+}
+
+struct Pass<'a> {
+    func: &'a str,
+    ops: &'a [WasmOp],
+    block_arity: &'a [(u8, u8)],
+    /// op index → ordinal into `block_arity` (for `Block`/`Loop`/`If` ops).
+    opener_ordinal: HashMap<usize, usize>,
+    /// op index → signed i32 range fact attached to that op's result.
+    range_facts: HashMap<usize, (i32, i32)>,
+    sem: WasmSemantics,
+    stack: Vec<Val>,
+    locals: HashMap<u32, BV>,
+    /// Every fresh variable created (name order), for Sat counterexamples.
+    vars: Vec<BV>,
+    fresh: u32,
+    premises: Vec<Bool>,
+    premise_desc: Vec<String>,
+    /// Inclusive op-index ranges to delete (disjoint, ascending).
+    deletions: Vec<(usize, usize)>,
+    admitted: Vec<String>,
+    declined: Vec<String>,
+}
+
+impl<'a> Pass<'a> {
+    fn new(
+        func: &'a str,
+        ops: &'a [WasmOp],
+        block_arity: &'a [(u8, u8)],
+        facts: &'a [WscFact],
+    ) -> Self {
+        let mut opener_ordinal = HashMap::new();
+        let mut ord = 0usize;
+        for (i, op) in ops.iter().enumerate() {
+            if matches!(op, WasmOp::Block | WasmOp::Loop | WasmOp::If) {
+                opener_ordinal.insert(i, ord);
+                ord += 1;
+            }
+        }
+        let mut range_facts = HashMap::new();
+        for f in facts {
+            if let FactKind::ValueRange { lo, hi } = f.kind {
+                // i32-only prototype: clamp the s64 bound into i32; a bound
+                // wholly outside i32 (or inverted) is vacuous — ignore it
+                // (the encoding doc's rule for unusable facts).
+                let lo = lo.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32;
+                let hi = hi.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32;
+                if lo <= hi && (f.value_id as usize) < ops.len() {
+                    range_facts.insert(f.value_id as usize, (lo, hi));
+                }
+            }
+        }
+        Self {
+            func,
+            ops,
+            block_arity,
+            opener_ordinal,
+            range_facts,
+            // No memory model needed: memory ops are outside the tracked
+            // fragment (the walk stops there).
+            sem: WasmSemantics::new_with_memory(Vec::new()),
+            stack: Vec::new(),
+            locals: HashMap::new(),
+            vars: Vec::new(),
+            fresh: 0,
+            premises: Vec::new(),
+            premise_desc: Vec::new(),
+            deletions: Vec::new(),
+            admitted: Vec::new(),
+            declined: Vec::new(),
+        }
+    }
+
+    fn fresh_var(&mut self, name: String) -> BV {
+        let v = BV::new_const(name, 32);
+        self.vars.push(v.clone());
+        v
+    }
+
+    fn local_bv(&mut self, idx: u32) -> BV {
+        if let Some(bv) = self.locals.get(&idx) {
+            return bv.clone();
+        }
+        let v = self.fresh_var(format!("fs_l{idx}"));
+        self.locals.insert(idx, v.clone());
+        v
+    }
+
+    /// Attach a value-range premise if a fact names op `i`'s result.
+    fn attach_fact(&mut self, i: usize, bv: &BV) {
+        if let Some(&(lo, hi)) = self.range_facts.get(&i) {
+            let lo_bv = BV::from_i64(i64::from(lo), 32);
+            let hi_bv = BV::from_i64(i64::from(hi), 32);
+            let p = Bool::and(&[&bv.bvsge(&lo_bv), &bv.bvsle(&hi_bv)]);
+            self.premises.push(p);
+            self.premise_desc
+                .push(format!("value(op#{i}) ∈ [{lo}, {hi}] (signed)"));
+        }
+    }
+
+    fn push(&mut self, bv: BV, start: Option<usize>, created: usize) {
+        self.stack.push(Val { bv, start, created });
+    }
+
+    /// Find the matching `End` for the opener at `i`; also reports whether a
+    /// top-level `Else` occurs. `None` = malformed nesting (stop the walk).
+    fn matching_end(&self, i: usize) -> Option<(usize, bool)> {
+        let mut depth = 0usize;
+        let mut has_else = false;
+        for (j, op) in self.ops.iter().enumerate().skip(i + 1) {
+            match op {
+                WasmOp::Block | WasmOp::Loop | WasmOp::If => depth += 1,
+                WasmOp::Else if depth == 0 => has_else = true,
+                WasmOp::End => {
+                    if depth == 0 {
+                        return Some((j, has_else));
+                    }
+                    depth -= 1;
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    /// Continuation after a DECLINED `if` region `[i..=end]`: the body may or
+    /// may not run, so havoc every local it assigns (any depth) and model its
+    /// block results as fresh variables.
+    fn havoc_region(&mut self, i: usize, end: usize, arity: (u8, u8)) {
+        let ops = self.ops;
+        for op in &ops[i + 1..end] {
+            if let WasmOp::LocalSet(idx) | WasmOp::LocalTee(idx) = op {
+                let n = self.fresh;
+                self.fresh += 1;
+                let v = self.fresh_var(format!("fs_h{n}"));
+                self.locals.insert(*idx, v);
+            }
+        }
+        for _ in 0..arity.0 {
+            self.stack.pop();
+        }
+        for k in 0..arity.1 {
+            let n = self.fresh;
+            self.fresh += 1;
+            let v = self.fresh_var(format!("fs_r{n}_{k}"));
+            self.push(v, None, end);
+        }
+    }
+
+    fn decline(&mut self, msg: String) {
+        self.declined
+            .push(format!("{}: {} — general lowering emitted", self.func, msg));
+    }
+
+    /// Discharge the per-elision obligation for the no-`else` `if` at `i`
+    /// (matching `End` at `end`, condition `cond`). Returns true iff admitted.
+    fn try_elide(&mut self, i: usize, end: usize, cond: &Val) -> bool {
+        if self.premises.is_empty() {
+            self.decline(format!(
+                "op#{i} `if` — no premise reaches this site (no usable value-range fact)"
+            ));
+            return false;
+        }
+        let mut solver = new_solver();
+        for p in &self.premises {
+            solver.assert(p);
+        }
+        let taken = cond.bv.ne(BV::from_i64(0, 32));
+        solver.assert(&taken);
+        match solver.check() {
+            CheckOutcome::Unsat => {
+                let Some(start) = cond.start else {
+                    // Proven dead, but the condition slice has a side effect
+                    // (`local.tee`) or is not provably contiguous — deleting
+                    // it could drop live work. Conservative: keep everything.
+                    self.decline(format!(
+                        "op#{i} `if` proven dead (UNSAT) but its condition slice is not \
+                         erasable (impure or non-contiguous producer)"
+                    ));
+                    return false;
+                };
+                self.deletions.push((start, end));
+                self.admitted.push(format!(
+                    "{}: op#{i} `if` (+condition slice) — ops [{start}..={end}] elided \
+                     ({} ops): UNSAT(P ∧ cond ≠ 0) via {} (certificate-checked QF_BV; \
+                     every Unsat carries an LRAT proof validated by ordeal-lrat); \
+                     P = {{{}}}; cond = {}",
+                    self.func,
+                    end - start + 1,
+                    solver.name(),
+                    self.premise_desc.join(" ∧ "),
+                    cond.bv,
+                ));
+                true
+            }
+            CheckOutcome::Sat => {
+                // Read the model back for an actionable counterexample.
+                let cex: Vec<String> = self
+                    .vars
+                    .iter()
+                    .filter_map(|v| {
+                        let name = format!("{v}");
+                        solver
+                            .value(v)
+                            .map(|x| format!("{name}={}", x as u32 as i32))
+                    })
+                    .collect();
+                self.decline(format!(
+                    "op#{i} `if` — obligation Sat (branch reachable under P; \
+                     counterexample: {})",
+                    if cex.is_empty() {
+                        "<no model>".to_string()
+                    } else {
+                        cex.join(", ")
+                    }
+                ));
+                false
+            }
+            CheckOutcome::Unknown(reason) => {
+                self.decline(format!(
+                    "op#{i} `if` — obligation Unknown ({reason}); conservative decline"
+                ));
+                false
+            }
+        }
+    }
+
+    fn walk(&mut self) {
+        if self.range_facts.is_empty() {
+            self.decline("no usable value-range fact targets this function".to_string());
+            return;
+        }
+        let ops = self.ops;
+        let mut i = 0usize;
+        while i < ops.len() {
+            let op = &ops[i];
+            match op {
+                WasmOp::Nop => {}
+                WasmOp::I32Const(v) => {
+                    let bv = self.sem.encode_op(&WasmOp::I32Const(*v), &[]);
+                    self.attach_fact(i, &bv);
+                    self.push(bv, Some(i), i);
+                }
+                WasmOp::LocalGet(idx) => {
+                    let bv = self.local_bv(*idx);
+                    self.attach_fact(i, &bv);
+                    self.push(bv, Some(i), i);
+                }
+                WasmOp::LocalSet(idx) => {
+                    let Some(v) = self.stack.pop() else {
+                        self.decline(format!("op#{i} local.set on empty symbolic stack"));
+                        return;
+                    };
+                    self.locals.insert(*idx, v.bv);
+                }
+                WasmOp::LocalTee(idx) => {
+                    let Some(top) = self.stack.last_mut() else {
+                        self.decline(format!("op#{i} local.tee on empty symbolic stack"));
+                        return;
+                    };
+                    // The tee is a side effect: its slice must never be
+                    // deleted as a "pure condition producer".
+                    top.start = None;
+                    top.created = i;
+                    let bv = top.bv.clone();
+                    self.locals.insert(*idx, bv.clone());
+                    self.attach_fact(i, &bv);
+                }
+                WasmOp::Drop => {
+                    if self.stack.pop().is_none() {
+                        self.decline(format!("op#{i} drop on empty symbolic stack"));
+                        return;
+                    }
+                }
+                WasmOp::I32Eqz => {
+                    let Some(a) = self.stack.pop() else {
+                        self.decline(format!("op#{i} unary op on empty symbolic stack"));
+                        return;
+                    };
+                    let bv = self.sem.encode_op(op, &[a.bv]);
+                    self.attach_fact(i, &bv);
+                    let start = a.start.filter(|_| a.created + 1 == i);
+                    self.push(bv, start, i);
+                }
+                // Tracked, trap-free i32 binops (div/rem excluded on purpose:
+                // they can trap, and a deleted slice must be effect-free).
+                WasmOp::I32Add
+                | WasmOp::I32Sub
+                | WasmOp::I32Mul
+                | WasmOp::I32And
+                | WasmOp::I32Or
+                | WasmOp::I32Xor
+                | WasmOp::I32Shl
+                | WasmOp::I32ShrS
+                | WasmOp::I32ShrU
+                | WasmOp::I32Rotl
+                | WasmOp::I32Rotr
+                | WasmOp::I32Eq
+                | WasmOp::I32Ne
+                | WasmOp::I32LtS
+                | WasmOp::I32LtU
+                | WasmOp::I32LeS
+                | WasmOp::I32LeU
+                | WasmOp::I32GtS
+                | WasmOp::I32GtU
+                | WasmOp::I32GeS
+                | WasmOp::I32GeU => {
+                    let (Some(b), Some(a)) = (self.stack.pop(), self.stack.pop()) else {
+                        self.decline(format!("op#{i} binop on underflowing symbolic stack"));
+                        return;
+                    };
+                    let bv = self.sem.encode_op(op, &[a.bv, b.bv]);
+                    self.attach_fact(i, &bv);
+                    // Contiguity proof for the combined producer slice:
+                    // a's slice, immediately followed by b's, immediately
+                    // followed by this op. Anything else ⇒ not erasable.
+                    let start = match (a.start, b.start) {
+                        (Some(sa), Some(sb)) if a.created + 1 == sb && b.created + 1 == i => {
+                            Some(sa)
+                        }
+                        _ => None,
+                    };
+                    self.push(bv, start, i);
+                }
+                WasmOp::If => {
+                    let Some(cond) = self.stack.pop() else {
+                        self.decline(format!("op#{i} `if` on empty symbolic stack"));
+                        return;
+                    };
+                    let Some((end, has_else)) = self.matching_end(i) else {
+                        self.decline(format!("op#{i} `if` without matching `end`"));
+                        return;
+                    };
+                    let Some(&ord) = self.opener_ordinal.get(&i) else {
+                        self.decline(format!("op#{i} `if` missing from the opener ordinal map"));
+                        return;
+                    };
+                    let Some(&arity) = self.block_arity.get(ord) else {
+                        self.decline(format!(
+                            "op#{i} `if` has no block_arity entry (side-table desync)"
+                        ));
+                        return;
+                    };
+                    if has_else {
+                        self.decline(format!(
+                            "op#{i} `if`/`else` — only no-else `if` is in Phase-2 scope"
+                        ));
+                        self.havoc_region(i, end, arity);
+                    } else if self.try_elide(i, end, &cond) {
+                        // Region provably never executes: state unchanged
+                        // (params-as-results pass-through is the identity for
+                        // a no-else `if`, whose blocktype has equal
+                        // param/result types by wasm validation).
+                    } else {
+                        self.havoc_region(i, end, arity);
+                    }
+                    i = end + 1;
+                    continue;
+                }
+                // Function-final `End` (top-level): done.
+                WasmOp::End => break,
+                WasmOp::Return => break,
+                other => {
+                    // First op outside the tracked fragment: stop. Everything
+                    // already admitted was justified independently of what
+                    // follows; declining the REST loudly keeps honesty.
+                    self.decline(format!(
+                        "op#{i} {other:?} is outside the tracked i32 fragment — \
+                         fact tracking stops here (no further elisions in this function)"
+                    ));
+                    return;
+                }
+            }
+            i += 1;
+        }
+    }
+
+    fn finish(self) -> FactSpecResult {
+        let Pass {
+            ops,
+            block_arity,
+            deletions,
+            admitted,
+            declined,
+            ..
+        } = self;
+        if deletions.is_empty() {
+            return FactSpecResult {
+                ops: ops.to_vec(),
+                block_arity: block_arity.to_vec(),
+                kept: (0..ops.len()).collect(),
+                admitted,
+                declined,
+            };
+        }
+        let deleted = |i: usize| deletions.iter().any(|&(s, e)| i >= s && i <= e);
+        let mut out_ops = Vec::with_capacity(ops.len());
+        let mut out_arity = Vec::with_capacity(block_arity.len());
+        let mut kept = Vec::with_capacity(ops.len());
+        let mut ord = 0usize;
+        for (i, op) in ops.iter().enumerate() {
+            let is_opener = matches!(op, WasmOp::Block | WasmOp::Loop | WasmOp::If);
+            if !deleted(i) {
+                out_ops.push(op.clone());
+                kept.push(i);
+                if is_opener && let Some(&a) = block_arity.get(ord) {
+                    out_arity.push(a);
+                }
+            }
+            if is_opener {
+                ord += 1;
+            }
+        }
+        FactSpecResult {
+            ops: out_ops,
+            block_arity: out_arity,
+            kept,
+            admitted,
+            declined,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use WasmOp::*;
+
+    fn fact(value_id: u32, lo: i64, hi: i64) -> WscFact {
+        WscFact {
+            func_index: 0,
+            value_id,
+            kind: FactKind::ValueRange { lo, hi },
+        }
+    }
+
+    /// The gust_mix clamp shape: clamp(ch + 476, 1000, 2000) via two
+    /// no-else `if`s over a local.
+    fn clamp_ops() -> Vec<WasmOp> {
+        vec![
+            LocalGet(0),    // 0   ch          ← fact target
+            I32Const(476),  // 1
+            I32Add,         // 2   v = ch+476
+            LocalSet(1),    // 3
+            LocalGet(1),    // 4
+            I32Const(1000), // 5
+            I32LtS,         // 6
+            If,             // 7
+            I32Const(1000), // 8
+            LocalSet(1),    // 9
+            End,            // 10
+            LocalGet(1),    // 11
+            I32Const(2000), // 12
+            I32GtS,         // 13
+            If,             // 14
+            I32Const(2000), // 15
+            LocalSet(1),    // 16
+            End,            // 17
+            LocalGet(1),    // 18
+            End,            // 19
+        ]
+    }
+
+    const CLAMP_ARITY: &[(u8, u8)] = &[(0, 0), (0, 0)];
+
+    #[test]
+    fn clamp_shape_elides_both_branches_under_the_proven_bound_494() {
+        let ops = clamp_ops();
+        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 524, 1524)]);
+        assert_eq!(r.admitted.len(), 2, "declines: {:?}", r.declined);
+        assert!(r.changed());
+        assert_eq!(
+            r.ops,
+            vec![
+                LocalGet(0),
+                I32Const(476),
+                I32Add,
+                LocalSet(1),
+                LocalGet(1),
+                End
+            ],
+            "both clamp comparisons + branches + bodies must be gone"
+        );
+        assert_eq!(r.block_arity, vec![], "both If arity entries removed");
+        assert_eq!(r.kept, vec![0, 1, 2, 3, 18, 19]);
+        // The certificate evidence trail names the engine and the premise.
+        for line in &r.admitted {
+            assert!(line.contains("UNSAT"), "{line}");
+            assert!(line.contains("certificate-checked"), "{line}");
+            assert!(line.contains("[524, 1524]"), "{line}");
+        }
+    }
+
+    #[test]
+    fn wrong_wide_bound_is_sat_and_declines_loudly_494() {
+        // ch ∈ [0, 4000] does NOT make the clamp dead (ch=0 → v=476 < 1000):
+        // the obligation is Sat and BOTH sites decline with a counterexample.
+        let ops = clamp_ops();
+        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 0, 4000)]);
+        assert_eq!(r.admitted.len(), 0);
+        assert!(!r.changed());
+        assert_eq!(r.ops, ops, "declined ⇒ byte-identical op stream");
+        assert_eq!(r.block_arity, CLAMP_ARITY.to_vec());
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("Sat") && d.contains("counterexample")),
+            "declines must be loud and carry a model: {:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn partially_dead_bound_elides_only_the_proven_branch_494() {
+        // ch ∈ [524, 4000]: v ≥ 1000 so the LOW clamp is dead, but v can
+        // exceed 2000 so the HIGH clamp must survive.
+        let ops = clamp_ops();
+        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 524, 4000)]);
+        assert_eq!(r.admitted.len(), 1, "declines: {:?}", r.declined);
+        assert_eq!(r.declined.len(), 1);
+        assert_eq!(
+            r.ops,
+            vec![
+                LocalGet(0),
+                I32Const(476),
+                I32Add,
+                LocalSet(1),
+                LocalGet(1),
+                I32Const(2000),
+                I32GtS,
+                If,
+                I32Const(2000),
+                LocalSet(1),
+                End,
+                LocalGet(1),
+                End,
+            ]
+        );
+        assert_eq!(r.block_arity, vec![(0, 0)], "one If survives");
+    }
+
+    #[test]
+    fn no_facts_changes_nothing_494() {
+        let ops = clamp_ops();
+        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[]);
+        assert!(!r.changed());
+        assert_eq!(r.ops, ops);
+        assert!(!r.declined.is_empty(), "the no-fact case is a loud decline");
+    }
+
+    #[test]
+    fn declined_if_havocs_its_locals_no_false_admit_downstream_494() {
+        // The FIRST if is undecidable (condition on an unconstrained local),
+        // and its body rewrites local 1 — so the SECOND if (which would be
+        // dead under the fact alone) must NOT be admitted: local 1 is
+        // havocked by the declined region.
+        let ops = vec![
+            LocalGet(0),    // 0  ← fact ch ∈ [524, 1524]
+            I32Const(476),  // 1
+            I32Add,         // 2
+            LocalSet(1),    // 3
+            LocalGet(2),    // 4  unconstrained
+            If,             // 5
+            I32Const(-9),   // 6
+            LocalSet(1),    // 7  havocs local 1
+            End,            // 8
+            LocalGet(1),    // 9
+            I32Const(2000), // 10
+            I32GtS,         // 11
+            If,             // 12
+            I32Const(2000), // 13
+            LocalSet(1),    // 14
+            End,            // 15
+            LocalGet(1),    // 16
+            End,            // 17
+        ];
+        let r = specialize_function("f", &ops, CLAMP_ARITY, &[fact(0, 524, 1524)]);
+        assert_eq!(
+            r.admitted.len(),
+            0,
+            "havocked local must block the downstream elision: {:?}",
+            r.admitted
+        );
+        assert_eq!(r.ops, ops);
+    }
+
+    #[test]
+    fn if_with_else_declines_494() {
+        let ops = vec![
+            LocalGet(0), // 0 ← fact forces cond = 0
+            If,          // 1
+            I32Const(1), // 2
+            LocalSet(1), // 3
+            Else,        // 4
+            I32Const(2), // 5
+            LocalSet(1), // 6
+            End,         // 7
+            LocalGet(1), // 8
+            End,         // 9
+        ];
+        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 0, 0)]);
+        assert_eq!(r.admitted.len(), 0);
+        assert!(
+            r.declined.iter().any(|d| d.contains("else")),
+            "{:?}",
+            r.declined
+        );
+        assert_eq!(r.ops, ops);
+    }
+
+    #[test]
+    fn nested_opener_inside_elided_body_fixes_block_arity_ordinals_494() {
+        // A dead outer if contains a nested if: BOTH arity entries vanish and
+        // the SURVIVING later block keeps its (translated) entry.
+        let ops = vec![
+            LocalGet(0), // 0 ← fact [5,5] ⇒ eqz = 0
+            I32Eqz,      // 1
+            If,          // 2   (ordinal 0)
+            LocalGet(0), // 3
+            If,          // 4   (ordinal 1, nested)
+            I32Const(7), // 5
+            LocalSet(1), // 6
+            End,         // 7
+            End,         // 8
+            Block,       // 9   (ordinal 2, survives)
+            End,         // 10
+            End,         // 11
+        ];
+        let arity = &[(0, 0), (0, 0), (0, 1)];
+        let r = specialize_function("f", &ops, arity, &[fact(0, 5, 5)]);
+        assert_eq!(r.admitted.len(), 1, "declines: {:?}", r.declined);
+        // The condition slice starts at op 0 (LocalGet feeds the eqz), so the
+        // whole deleted range is [0..=8]; only the trailing block survives.
+        assert_eq!(r.ops, vec![Block, End, End]);
+        assert_eq!(r.kept, vec![9, 10, 11]);
+        assert_eq!(
+            r.block_arity,
+            vec![(0, 1)],
+            "only the surviving Block's entry"
+        );
+    }
+
+    #[test]
+    fn tee_condition_slice_is_not_erasable_494() {
+        // cond built through local.tee: proven dead, but deleting the slice
+        // would lose the local write ⇒ decline (loud), stream unchanged.
+        let ops = vec![
+            LocalGet(0), // 0 ← fact [1,1]
+            LocalTee(1), // 1  side effect in the slice
+            I32Eqz,      // 2  = 0 under the fact
+            If,          // 3
+            I32Const(9), // 4
+            LocalSet(2), // 5
+            End,         // 6
+            End,         // 7
+        ];
+        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 1, 1)]);
+        assert_eq!(r.admitted.len(), 0);
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("not") && d.contains("erasable")),
+            "{:?}",
+            r.declined
+        );
+        assert_eq!(r.ops, ops);
+    }
+
+    #[test]
+    fn untracked_op_stops_tracking_loudly_494() {
+        let ops = vec![
+            LocalGet(0),   // 0 ← fact
+            I64ExtendI32S, // 1  untracked ⇒ stop
+            Drop,          // 2
+            End,           // 3
+        ];
+        let r = specialize_function("f", &ops, &[], &[fact(0, 1, 2)]);
+        assert!(!r.changed());
+        assert!(
+            r.declined.iter().any(|d| d.contains("outside the tracked")),
+            "{:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn out_of_range_value_id_is_vacuous_494() {
+        let ops = clamp_ops();
+        let r = specialize_function("f", &ops, CLAMP_ARITY, &[fact(999, 524, 1524)]);
+        assert!(!r.changed());
+        assert_eq!(r.ops, ops);
+    }
+}

--- a/crates/synth-verify/src/lib.rs
+++ b/crates/synth-verify/src/lib.rs
@@ -41,6 +41,12 @@ pub mod traits;
 // WASM semantics — source language for all backends (always available)
 pub mod wasm_semantics;
 
+// Proof-carrying specialization (VCR-PERF-002 / #494 Phase 2): value-range
+// facts ⇒ dead conditional-branch elision, each site behind a per-elision
+// ordeal obligation. Backend-agnostic (rewrites the WasmOp stream), so it is
+// always available like `wasm_semantics`.
+pub mod fact_spec;
+
 // ARM semantics (behind the arm feature)
 #[cfg(feature = "arm")]
 pub mod arm_semantics;
@@ -63,6 +69,7 @@ pub use properties::CompilerProperties;
 
 #[cfg(feature = "arm")]
 pub use arm_semantics::{ArmSemantics, ArmState};
+pub use fact_spec::{FactSpecResult, specialize_function};
 pub use solver::{BvSolver, CheckOutcome, OrdealSolver, new_solver};
 pub use term::{BV, Bool};
 #[cfg(feature = "arm")]

--- a/docs/design/proof-carrying-specialization.md
+++ b/docs/design/proof-carrying-specialization.md
@@ -1,7 +1,8 @@
 # VCR-PERF-002 — Proof-carrying specialization design (#494)
 
-Status: **Phase 1 implemented** (fact ingestion, codegen-neutral — see
-"Phasing"; Phases 2/3 remain design). Tracks `VCR-PERF-002` in
+Status: **Phases 1–2 implemented** (fact ingestion + the single-elision
+prototype behind `SYNTH_FACT_SPEC` — see "Phasing"; Phase 3, the gale
+measurement vs the 0.45× floor, remains). Tracks `VCR-PERF-002` in
 `artifacts/verified-codegen-roadmap.yaml`, epic #242, GitHub #494 part (a).
 Cross-repo contract: loom#240 / loom#231 (`wsc.facts`), gale PR
 pulseengine/gale#121 (`gust_floor_bench`, the measured floor).
@@ -108,6 +109,19 @@ bounds adversarial queries to a clean conservative decline.
 2. **Single-elision prototype** — value-range ⇒ dead conditional-branch
    elision (the `gust_mix` clamp shape), behind `SYNTH_FACT_SPEC`, with the
    per-elision obligation + a red/green in-bounds differential oracle.
+   **IMPLEMENTED** — pass: `crates/synth-verify/src/fact_spec.rs`
+   (backend-agnostic `WasmOp`-stream rewrite; the discharged obligation is
+   `UNSAT(P ∧ cond ≠ 0)`, which implies the general/specialized equivalence
+   above for a no-`else` `if` — see the module docs for the
+   over-approximation discipline and why `div/rem` stay untracked). Driver
+   gate: `maybe_fact_spec` in `synth-cli/src/main.rs` (both compile paths;
+   requires the `verify` feature — without it the flag declines loudly).
+   Oracles: `crates/synth-cli/tests/fact_spec_clamp_494.rs` (flag/fact
+   matrix, certificate trail, wrong-bound Sat decline) +
+   `scripts/repro/fact_spec_clamp_494_differential.py` (in-bounds execution
+   sweep, specialized ≡ wasmtime ≡ unspecialized on [524,1524]), both CI-run
+   by the `fact-spec-oracle` job. Fixture:
+   `scripts/repro/fact_spec_clamp_494.wat`.
 3. **Measurement vs the 0.45× floor** — gale re-measures `gust_mix` on
    `gust_floor_bench` (qemu `-icount`) and STM32F100 silicon (DWT CYCCNT).
    Kill-criterion (#494, unchanged): shipped dissolved lane **<1.0× then

--- a/scripts/repro/fact_spec_clamp_494.wat
+++ b/scripts/repro/fact_spec_clamp_494.wat
@@ -1,0 +1,59 @@
+;; VCR-PERF-002 Phase 2 (#494) — the gust_mix clamp shape.
+;;
+;; gust_mix is algebraically clamp(ch + 476, 1000, 2000). Under the loom-proven
+;; premise ch ∈ [524, 1524] (forwarded as a schema-v1 `wsc.facts` value-range
+;; record on value_id 0 = the `local.get $ch` producing ch), BOTH clamp
+;; comparisons are constant-false: v = ch+476 ∈ [1000, 2000], so `v < 1000`
+;; and `v > 2000` never hold. The fact-spec pass (SYNTH_FACT_SPEC=1) elides
+;; both `if` regions AND their condition slices after discharging, per site,
+;; UNSAT(P ∧ cond ≠ 0) through the ordeal-backed certificate-checked solver —
+;; collapsing the body toward the measured floor `add r0, #476; bx lr`
+;; (gale gust_floor_bench, 0.45x of native).
+;;
+;; The facts section is appended by the harnesses (the .wat itself is
+;; facts-free): scripts/repro/fact_spec_clamp_494_differential.py and
+;; crates/synth-cli/tests/fact_spec_clamp_494.rs.
+;;
+;; Op indices (value_id space, decoded order):
+;;   0 local.get $ch   <- value-range fact target
+;;   1 i32.const 476
+;;   2 i32.add
+;;   3 local.set $v
+;;   4 local.get $v    -+
+;;   5 i32.const 1000   | low-clamp condition slice + branch + body
+;;   6 i32.lt_s         | (elided: ops 4..=10)
+;;   7 if               |
+;;   8 i32.const 1000   |
+;;   9 local.set $v     |
+;;  10 end             -+
+;;  11 local.get $v    -+
+;;  12 i32.const 2000   | high-clamp (elided: ops 11..=17)
+;;  13 i32.gt_s         |
+;;  14 if               |
+;;  15 i32.const 2000   |
+;;  16 local.set $v     |
+;;  17 end             -+
+;;  18 local.get $v
+;;  19 end
+(module
+  (func (export "gust_mix") (param $ch i32) (result i32)
+    (local $v i32)
+    local.get $ch
+    i32.const 476
+    i32.add
+    local.set $v
+    local.get $v
+    i32.const 1000
+    i32.lt_s
+    if
+      i32.const 1000
+      local.set $v
+    end
+    local.get $v
+    i32.const 2000
+    i32.gt_s
+    if
+      i32.const 2000
+      local.set $v
+    end
+    local.get $v))

--- a/scripts/repro/fact_spec_clamp_494_differential.py
+++ b/scripts/repro/fact_spec_clamp_494_differential.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""VCR-PERF-002 Phase 2 (#494) — in-bounds differential for the fact-spec
+clamp elision (oracle 2 of the design doc's three).
+
+Builds the gust_mix clamp fixture WITH a schema-v1 `wsc.facts` value-range
+premise appended (default: the proven bound ch ∈ [524, 1524]), compiles it
+twice — SPECIALIZED (SYNTH_FACT_SPEC=1) and UNSPECIALIZED (flag off) — and
+sweeps EVERY value of the premise bound under unicorn (Thumb-2), asserting the
+specialized result is identical to BOTH wasmtime ground truth and the
+unspecialized synth build. Out-of-bound divergence is EXPECTED AND CORRECT —
+the bound is the contract (mirrors gale's gust_floor_bench soundness gate
+mix_proven ≡ mix_native ≡ gust_mix on [524,1524]); this harness therefore
+only sweeps in-bounds.
+
+Non-vacuity: the run FAILS unless the specialized compile actually admitted
+2 certificate-backed elisions ("fact-spec: ADMIT" on stderr) and shrank
+gust_mix's .text — so a silently-dead lever cannot pass.
+
+Red-path knob (the wrong-bound demonstration in the #494 Phase-2 PR):
+  --fact-lo/--fact-hi set the premise loom "claims"; the sweep covers that
+  claimed bound. With a deliberately-wrong bound (e.g. --fact-lo 0 --fact-hi
+  4000) the obligation is Sat and synth DECLINES (this harness then reports
+  the decline and exits 0 with elisions=0 only if --expect-decline is given).
+  Forcing an admit under a wrong bound (temporarily bypassing the solver)
+  makes this harness FAIL on the in-bounds sweep — that red run is documented
+  in the PR body.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/fact_spec_clamp_494_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import UC_ARM_REG_LR, UC_ARM_REG_R0, UC_ARM_REG_SP
+
+WAT = Path(__file__).with_name("fact_spec_clamp_494.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+FUNC = "gust_mix"
+
+
+# ---- schema-v1 wsc.facts encoding (docs/design/wsc-facts-encoding.md) ----
+
+def leb_u32(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7F
+        v >>= 7
+        out.append(b | (0x80 if v else 0))
+        if not v:
+            return bytes(out)
+
+
+def leb_s64(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7F
+        v >>= 7
+        done = (v == 0 and not (b & 0x40)) or (v == -1 and (b & 0x40))
+        out.append(b | (0 if done else 0x80))
+        if done:
+            return bytes(out)
+
+
+def facts_payload(func_index, value_id, lo, hi):
+    body = leb_s64(lo) + leb_s64(hi)
+    return (
+        b"\x01"                      # version 1
+        + leb_u32(1)                 # count
+        + b"\x01"                    # kind: value-range
+        + leb_u32(func_index)
+        + leb_u32(value_id)
+        + leb_u32(len(body))
+        + body
+    )
+
+
+def append_custom_section(wasm, name, payload):
+    content = leb_u32(len(name)) + name + payload
+    return wasm + b"\x00" + leb_u32(len(content)) + content
+
+
+# ---- compile + load ----
+
+def compile_elf(wasm_path, out, fact_spec):
+    env = {"PATH": "/usr/bin:/bin"}
+    if fact_spec:
+        env["SYNTH_FACT_SPEC"] = "1"
+    r = subprocess.run(
+        [SYNTH, "compile", str(wasm_path), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env=env,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({out}): {r.stderr}")
+    return r.stderr
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    sizes = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+                    sizes[sym.name] = sym["st_size"]
+    return data, base, syms, sizes
+
+
+def run_arm(code, base, addr, arg):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(base & ~0xFFFF, 0x20000)
+    mu.mem_write(base, code)
+    mu.mem_map(0x90000, 0x10000)
+    ret = 0x90100
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_SP, 0x98000)
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    mu.emu_start(addr | 1, ret, timeout=5_000_000)
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fact-lo", type=int, default=524,
+                    help="value-range premise lower bound (the loom claim)")
+    ap.add_argument("--fact-hi", type=int, default=1524,
+                    help="value-range premise upper bound")
+    ap.add_argument("--expect-decline", action="store_true",
+                    help="assert the elision was DECLINED (wrong-bound green path)")
+    args = ap.parse_args()
+
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth first")
+
+    # Build the facts-carrying module: fixture wasm + value-range on
+    # (func 0, value_id 0 = the local.get producing ch).
+    base_wasm = wasmtime.wat2wasm(WAT.read_text())
+    wasm = append_custom_section(
+        bytes(base_wasm), b"wsc.facts",
+        facts_payload(0, 0, args.fact_lo, args.fact_hi))
+    wasm_path = "/tmp/fact_spec_clamp_494.wasm"
+    Path(wasm_path).write_bytes(wasm)
+
+    spec_elf, base_elf = "/tmp/fact_spec_494_spec.elf", "/tmp/fact_spec_494_base.elf"
+    stderr_spec = compile_elf(wasm_path, spec_elf, fact_spec=True)
+    compile_elf(wasm_path, base_elf, fact_spec=False)
+
+    admits = stderr_spec.count("fact-spec: ADMIT")
+    declines = stderr_spec.count("fact-spec: DECLINE")
+    print(f"specialized compile: {admits} ADMIT, {declines} DECLINE")
+
+    scode, sbase, ssyms, ssizes = load(spec_elf)
+    bcode, bbase, bsyms, bsizes = load(base_elf)
+    # Prefer symtab st_size; fall back to whole-.text length (single-function
+    # module) when the builder leaves st_size at 0.
+    ssize = ssizes.get(FUNC) or len(scode)
+    bsize = bsizes.get(FUNC) or len(bcode)
+    print(f"{FUNC} size: unspecialized {bsize} B -> specialized {ssize} B")
+
+    if args.expect_decline:
+        if admits != 0:
+            sys.exit(f"expected DECLINE under bound [{args.fact_lo},{args.fact_hi}] "
+                     f"but {admits} elisions were admitted")
+        if scode != bcode:
+            sys.exit("declined build must be byte-identical to baseline")
+        print("ORACLE: PASS (declined loudly, general lowering emitted)")
+        return
+
+    # Non-vacuity: both clamp branches must actually be gone.
+    if admits != 2:
+        sys.exit(f"expected 2 certificate-backed elisions, got {admits} — "
+                 f"stderr:\n{stderr_spec}")
+    if ssize >= bsize:
+        sys.exit("specialized gust_mix did not shrink — elision did not reach codegen")
+
+    # wasmtime ground truth.
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, wasm)
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    gm = inst.exports(st)[FUNC]
+
+    # In-bounds sweep — the proven bound, and ONLY the proven bound (the
+    # out-of-bound behavior of the specialized build is deliberately
+    # unconstrained: the bound is the contract).
+    fails = 0
+    for ch in range(args.fact_lo, args.fact_hi + 1):
+        gt = gm(st, ch) & 0xFFFFFFFF
+        got_spec = run_arm(scode, sbase, ssyms[FUNC], ch)
+        got_base = run_arm(bcode, bbase, bsyms[FUNC], ch)
+        if not (got_spec == gt == got_base):
+            fails += 1
+            if fails <= 10:
+                print(f"FAIL ch={ch}: wasmtime={gt} specialized={got_spec} "
+                      f"unspecialized={got_base}")
+    n = args.fact_hi - args.fact_lo + 1
+    print(f"swept {n} in-bounds values on [{args.fact_lo}, {args.fact_hi}]")
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails}/{n})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## VCR-PERF-002 Phase 2 (#494, epic #242) — the single-elision prototype

Value-range facts ⇒ dead conditional-branch elision (the `gust_mix` clamp shape), behind `SYNTH_FACT_SPEC` (default **OFF**). Source of truth: `docs/design/proof-carrying-specialization.md`. Builds directly on Phase 1 (#624: schema-v1 `wsc.facts` parser + `CompileConfig` plumbing).

### The obligation flow (per elision, before emission)

`crates/synth-verify/src/fact_spec.rs` walks the decoded `WasmOp` stream (backend-agnostic — the rewritten stream feeds whichever selector the driver picks) with a symbolic QF_BV state (stack + locals via the existing `WasmSemantics` encoder). At every no-`else` `if … end` it discharges, through the ordeal-backed `BvSolver` (#553/#595):

```
premise    P    (every value-range fact reached so far, as a hypothesis)
obligation UNSAT( P ∧ cond ≠ 0 )
```

`UNSAT(P ∧ cond ≠ 0)` **implies** the design doc's `UNSAT(P ∧ general_lowering(x) ≠ specialized_lowering(x))`: a no-`else` `if` whose condition is 0 on every P-admissible input never runs its body, and wasm validation forces its blocktype to have equal param/result types, so the not-taken path is the identity. The stronger query is used because it is decided in pure QF_BV with no control-flow encoding.

- **Unsat (certificate-checked — every ordeal `Unsat` carries an LRAT proof validated by `ordeal-lrat` before it is reported)** → admit: delete the `if…end` region **plus** its condition-producing op slice (only when proven pure and contiguous), log the certificate line per function.
- **Sat (with model counterexample) / Unknown / budget-exceeded / `if`-with-`else` / untracked op / impure condition slice** → **decline loudly**, emit the general lowering. No silent wrong-code path.

Soundness discipline (module docs): untracked ops stop the walk; locals seed as fresh unconstrained vars; a *declined* `if` havocs every local it assigns (unit-tested: a havocked local blocks a downstream elision that the fact alone would prove); `div/rem` are deliberately untracked (a deleted slice must be effect-free under **all** inputs — trap-guard elision is the separate divisor-nonzero fact, out of scope). Driver gate `maybe_fact_spec` (both compile paths) requires the `verify` feature; built without it the flag declines loudly.

### Certificate evidence (oracle 1)

`SYNTH_FACT_SPEC=1` on the fixture + `ch ∈ [524,1524]` fact:

```
fact-spec: ADMIT gust_mix: op#7 `if` (+condition slice) — ops [4..=10] elided (7 ops): UNSAT(P ∧ cond ≠ 0) via ordeal (certificate-checked QF_BV; every Unsat carries an LRAT proof validated by ordeal-lrat); P = {value(op#0) ∈ [524, 1524] (signed)}; cond = (ite (bvslt (bvadd (_ bv476 32) fs_l0) (_ bv1000 32)) (_ bv1 32) (_ bv0 32))
fact-spec: ADMIT gust_mix: op#14 `if` (+condition slice) — ops [11..=17] elided (7 ops): UNSAT(P ∧ cond ≠ 0) via ordeal (certificate-checked QF_BV; every Unsat carries an LRAT proof validated by ordeal-lrat); P = {value(op#0) ∈ [524, 1524] (signed)}; cond = (ite (bvsgt (bvadd (_ bv476 32) fs_l0) (_ bv2000 32)) (_ bv1 32) (_ bv0 32))
fact-spec: 'gust_mix' specialized — 2 elision(s) admitted, 0 declined (20 → 6 ops)
```

### In-bounds differential (oracle 2) — `scripts/repro/fact_spec_clamp_494_differential.py`

Specialized ≡ wasmtime ≡ unspecialized over the proven bound, and **only** over the bound (out-of-bound divergence is expected and correct — the bound is the contract, mirroring gale's `gust_floor_bench` soundness gate):

```
specialized compile: 2 ADMIT, 0 DECLINE
gust_mix size: unspecialized 84 B -> specialized 14 B
swept 1001 in-bounds values on [524, 1524]
ORACLE: PASS
```

Wrong-bound green path (`--fact-lo 0 --fact-hi 4000 --expect-decline`): the obligation is Sat (counterexample `fs_l0=0` logged), synth declines loudly, bytes identical to baseline — `ORACLE: PASS (declined loudly, general lowering emitted)`.

### Red→green demonstration (the forcing is NOT in this PR)

With the solver verdict temporarily bypassed (force-admit) and the deliberately-wrong bound `ch ∈ [0,4000]`, the in-bounds differential catches the miscompile immediately:

```
specialized compile: 2 ADMIT, 0 DECLINE
gust_mix size: unspecialized 84 B -> specialized 14 B
FAIL ch=0: wasmtime=1000 specialized=476 unspecialized=1000
FAIL ch=1: wasmtime=1000 specialized=477 unspecialized=1000
...
swept 4001 in-bounds values on [0, 4000]
ORACLE: FAIL (3000/4001)
```

3000/4001 failures = exactly the 524+2476 values outside the true bound. The forcing hack was then removed and both green paths re-run (PASS). With the solver in place the same wrong bound cannot admit at all (Sat ⇒ loud decline, unit- and e2e-tested).

### Achieved codegen vs the 3-insn ideal

Optimized path, cortex-m4 (`capstone` disasm of the emitted `.text`):

```
specialized gust_mix (14 B, 6 insns):        unspecialized (84 B, 28 insns):
  push  {r4, r5, r6, lr}                       full clamp: 2× cmp/ite/beq + frame
  movw  r5, #0x1dc        ; 476
  adds  r6, r0, r5
  mov   r4, r6            ; local $v homing
  mov   r0, r4
  pop   {r4, r5, r6, pc}
```

6 instructions vs the 3-insn ideal (`movw; add; bx lr`): the remaining overhead is 1 push/pop pair + 2 local-homing `mov`s — pure register-allocation slack on the `local.set $v; local.get $v` residue, VCR-RA territory, not fact-spec. 84 B → 14 B (–83%), 28 → 6 insns.

### Oracle 3 — frozen anchors

No frozen fixture carries a facts section ⇒ the lever cannot fire; additionally flag-gated. `frozen_codegen_bytes` passes untouched (10/10). E2E byte-identity matrix locked in `crates/synth-cli/tests/fact_spec_clamp_494.rs`: flag-off+facts ≡ baseline, flag-on+no-facts ≡ baseline, wrong-bound ≡ baseline.

### Tests / CI

- `synth-verify` unit gates (10): clamp admit ×2 with certificates, wrong-bound Sat decline, partial bound elides only the proven branch, declined-region havoc blocks downstream false admits, `if/else` decline, nested-opener `block_arity` ordinal repair, `local.tee` slice non-erasability, untracked-op stop, out-of-range `value_id` vacuity.
- `synth-cli` e2e (4, `required-features = ["verify"]`).
- New CI job **fact-spec-oracle**: e2e gates + both differential paths (unicorn/wasmtime), isolated like the other execution oracles.
- Full sweep: `cargo test --workspace` 1966 passed / 0 failed; fmt + clippy (`-D warnings`, default **and** `--features verify`) clean.

### What Phase 3 (gale re-measure vs the 0.45× floor) needs

1. loom emitting the real `wsc.facts` section on the fused `gust_mix` module (loom#231/#240) — this PR's hand-authored section is bit-compatible schema v1.
2. gale rerunning `gust_floor_bench` (qemu `-icount`) and STM32F100 DWT CYCCNT with `SYNTH_FACT_SPEC=1` on the dissolved lane; kill-criterion unchanged: <1.0× then ≤0.70× vs native, soundness gate green on [524,1524].
3. If the 6-insn body still misses ≤0.70×, the homing/prologue slack above is the next lever (VCR-RA), before widening fact kinds.

Roadmap: `VCR-PERF-002` → `implemented` (phases 1+2 of 3; verification of the kill-criterion stays with Phase 3 — claim not strengthened beyond evidence).

Refs #494, #242. Design: `docs/design/proof-carrying-specialization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
