### PR TITLE
fix(thumb2): i64.popcnt epilogue clobber + i64.div_s INT64_MIN/-1 overflow trap (#632, #633)

### DIFF
--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -974,6 +974,9 @@ impl ArmEncoder {
             } => {
                 emit_a32_i64_fixed_abi_entry(&mut b, &[rnlo, rnhi, rmlo, rmhi]);
                 emit_a32_i64_divisor_zero_trap(&mut b);
+                // #633: INT64_MIN / -1 overflows — trap like the i32 path
+                // (rem_s stays guard-free: rem_s(INT64_MIN, -1) == 0).
+                emit_a32_i64_divs_overflow_trap(&mut b);
                 w(&mut b, 0xE92D_0FF0); // PUSH {R4-R11}
                 w(&mut b, 0xE021_9003); // EOR R9, R1, R3 (result sign in MSB)
                 skip_negate_if_positive(&mut b, 1);
@@ -1084,12 +1087,21 @@ impl ArmEncoder {
             ArmOp::I64Popcnt { rd, rnlo, rnhi } => {
                 let hi = reg_to_bits(rnhi);
                 w(&mut b, 0xE92D_0038); // PUSH {R3, R4, R5}
-                w(&mut b, 0xE1A0_4000 | reg_to_bits(rnlo)); // MOV R4, rnlo
+                // #632 audit: route rnlo through R12 so a pair living at
+                // (R3,R4) cannot read a clobbered R4 (sources read before any
+                // scratch register they could occupy is written).
+                w(&mut b, 0xE1A0_C000 | reg_to_bits(rnlo)); // MOV R12, rnlo
                 w(&mut b, 0xE1A0_5000 | hi); //                MOV R5, rnhi
+                w(&mut b, 0xE1A0_400C); //                     MOV R4, R12
                 popcnt_word(&mut b, 4, 3);
                 popcnt_word(&mut b, 5, 3);
-                dp_reg(&mut b, 0xE080_0000, reg_to_bits(rd), 4, 5); // ADD rd, R4, R5
+                // #632: carry the count across the scratch restore in R12 —
+                // rd is allocator-assigned and can land inside {R3,R4,R5};
+                // the old `ADD rd, R4, R5` before the POP was destroyed by
+                // the restore. R12 is never allocatable and never restored.
+                dp_reg(&mut b, 0xE080_0000, 12, 4, 5); // ADD R12, R4, R5
                 w(&mut b, 0xE8BD_0038); // POP {R3, R4, R5}
+                w(&mut b, 0xE1A0_0000 | (reg_to_bits(rd) << 12) | 12); // MOV rd, R12
                 w(&mut b, 0xE3A0_0000 | (hi << 12)); // MOV rnhi, #0 (i64 hi word)
             }
 
@@ -4756,15 +4768,18 @@ impl ArmEncoder {
                 // For simplicity and correctness, use the efficient parallel algorithm
                 // but implement it as a series of inline operations
 
-                // MOV R4, rnlo
-                let d_bit: u32 = 0; // R4 < 8, so high bit is 0
-                let mov: u16 = (0x4600 | (d_bit << 7) | (rn_lo_bits << 3) | (4 & 0x7)) as u16;
+                // Marshal the operand pair into the fixed scratch regs, routing
+                // rnlo through R12 (#632 audit): writing R4 first corrupted the
+                // rnhi read for a pair living at (R3,R4) — every source is read
+                // before any scratch register it could occupy is written.
+                // MOV R12, rnlo
+                let mov: u16 = (0x4600 | (1 << 7) | (rn_lo_bits << 3) | 4) as u16;
                 bytes.extend_from_slice(&mov.to_le_bytes());
-
-                // MOV R5, rnhi
-                let d_bit: u32 = 0; // R5 < 8, so high bit is 0
-                let mov: u16 = (0x4600 | (d_bit << 7) | (rn_hi_bits << 3) | (5 & 0x7)) as u16;
+                // MOV R5, rnhi (R4 untouched so far; rnhi == R5 is a no-op)
+                let mov: u16 = (0x4600 | (rn_hi_bits << 3) | 5) as u16;
                 bytes.extend_from_slice(&mov.to_le_bytes());
+                // MOV R4, R12
+                bytes.extend_from_slice(&0x4664u16.to_le_bytes());
 
                 // --- POPCNT for R4 (lo word) ---
                 // Step 1: x = x - ((x >> 1) & 0x55555555)
@@ -4973,18 +4988,32 @@ impl ArmEncoder {
                 bytes.extend_from_slice(&hw1.to_le_bytes());
                 bytes.extend_from_slice(&hw2.to_le_bytes());
 
-                // ADD rd, R4, R5 (combine lo and hi counts)
-                // ADDS Rd, Rn, Rm (T1): 0001 100 Rm Rn Rd = 0x1800 | (Rm<<6) | (Rn<<3) | Rd
-                let rd_bits_u16 = rd_bits as u16;
-                let instr: u16 = 0x1800 | (5 << 6) | (4 << 3) | rd_bits_u16;
-                bytes.extend_from_slice(&instr.to_le_bytes());
+                // #632: the count must be carried ACROSS the scratch restore
+                // in a register the POP cannot touch. rd is allocator-assigned
+                // (any of R0-R8) and can land inside the {R3,R4,R5} restore set
+                // — the old `ADDS rd, R4, R5; POP {R3,R4,R5}` destroyed the
+                // result one instruction after computing it (0 for every input
+                // under qemu). R12 is encoder scratch: never allocatable (#212)
+                // and never in a restore set, so no choice of rd can collide.
+                // ADD.W R12, R4, R5
+                bytes.extend_from_slice(&0xEB04u16.to_le_bytes());
+                bytes.extend_from_slice(&0x0C05u16.to_le_bytes());
 
                 // POP {R3, R4, R5}
                 bytes.extend_from_slice(&0xBC38u16.to_le_bytes());
 
-                // i64.popcnt returns i64, so clear high word: MOV rnhi, #0 (2 bytes)
-                let mov0: u16 = (0x2000 | (rn_hi_bits << 8)) as u16;
-                bytes.extend_from_slice(&mov0.to_le_bytes());
+                // MOV rd, R12 — after the restore. The 4-bit Rd (D:rd) form is
+                // also total over rd = R8, where the old ADDS T1 3-bit field
+                // silently corrupted the encoding (#178/#180 class).
+                let mov: u16 =
+                    (0x4600 | (((rd_bits >> 3) & 1) << 7) | (12 << 3) | (rd_bits & 7)) as u16;
+                bytes.extend_from_slice(&mov.to_le_bytes());
+
+                // i64.popcnt returns i64, so clear high word: MOV.W rnhi, #0
+                // (T2, 4 bytes — total over rnhi = R8, where the old 16-bit
+                // MOVS encoding overflowed its 3-bit field into CMP R0, #0).
+                bytes.extend_from_slice(&0xF04Fu16.to_le_bytes());
+                bytes.extend_from_slice(&(((rn_hi_bits & 0xF) << 8) as u16).to_le_bytes());
 
                 Ok(bytes)
             }
@@ -5387,6 +5416,9 @@ impl ArmEncoder {
                 let mut bytes = Vec::new();
                 emit_i64_fixed_abi_entry(&mut bytes, &[rnlo, rnhi, rmlo, rmhi]);
                 emit_i64_divisor_zero_trap(&mut bytes);
+                // #633: INT64_MIN / -1 overflows — trap like the i32 path
+                // (rem_s stays guard-free: rem_s(INT64_MIN, -1) == 0).
+                emit_i64_divs_overflow_trap(&mut bytes);
 
                 // PUSH {R4-R11} - save scratch registers (NO LR — inline code)
                 bytes.extend_from_slice(&0xE92Du16.to_le_bytes());
@@ -7894,6 +7926,38 @@ fn emit_i64_divisor_zero_trap(bytes: &mut Vec<u8>) {
     bytes.extend_from_slice(&0xDE00u16.to_le_bytes()); // UDF #0 — divide by zero
 }
 
+/// WASM `i64.div_s(INT64_MIN, -1)` must trap (Core §4.3.2 `idiv_s`: the
+/// quotient +2^63 is unrepresentable), matching the i32 path's overflow
+/// guard — #633: without it the core negated INT64_MIN onto itself and
+/// silently returned INT64_MIN. Emitted after marshaling, when the dividend
+/// pair is in R0:R1 and the divisor pair in R2:R3; R12 is encoder scratch.
+///
+/// div_s ONLY — `i64.rem_s(INT64_MIN, -1)` is defined as 0 and must NOT
+/// trap (`irem_s`), so the I64RemS arm never calls this. 22 bytes,
+/// register-independent (estimator contract, #498/#511).
+fn emit_i64_divs_overflow_trap(bytes: &mut Vec<u8>) {
+    // AND.W R12, R2, R3 — R12 == 0xFFFFFFFF iff divisor == -1
+    bytes.extend_from_slice(&0xEA02u16.to_le_bytes());
+    bytes.extend_from_slice(&0x0C03u16.to_le_bytes());
+    // CMN.W R12, #1 — EQ iff both divisor words are all-ones
+    bytes.extend_from_slice(&0xF11Cu16.to_le_bytes());
+    bytes.extend_from_slice(&0x0F01u16.to_le_bytes());
+    // BNE .no_trap
+    bytes.extend_from_slice(&0xD105u16.to_le_bytes());
+    // CMP R0, #0 — dividend lo word of INT64_MIN
+    bytes.extend_from_slice(&0x2800u16.to_le_bytes());
+    // BNE .no_trap
+    bytes.extend_from_slice(&0xD103u16.to_le_bytes());
+    // CMP.W R1, #0x80000000 — dividend hi word of INT64_MIN
+    bytes.extend_from_slice(&0xF1B1u16.to_le_bytes());
+    bytes.extend_from_slice(&0x4F00u16.to_le_bytes());
+    // BNE .no_trap
+    bytes.extend_from_slice(&0xD100u16.to_le_bytes());
+    // UDF #0 — signed-division overflow
+    bytes.extend_from_slice(&0xDE00u16.to_le_bytes());
+    // .no_trap:
+}
+
 // ======================================================================
 // #615 — A32 (ARM-mode) twins of the #610 i64 fixed-ABI wrappers above.
 // Identical register contract, A32 encodings: the multi-instruction i64
@@ -7965,6 +8029,20 @@ fn emit_a32_i64_divisor_zero_trap(bytes: &mut Vec<u8>) {
     w(bytes, 0xE192_C003); // ORRS R12, R2, R3
     w(bytes, 0x1A00_0000); // BNE +1 insn (skip the UDF)
     w(bytes, 0xE7F0_00F0); // UDF #0 — divide by zero
+}
+
+/// A32 twin of [`emit_i64_divs_overflow_trap`] (#633): trap on
+/// `i64.div_s(INT64_MIN, -1)`. Conditional execution replaces the Thumb
+/// branches — the CMPEQ chain leaves EQ set only when divisor == -1 AND
+/// dividend == INT64_MIN. div_s only; rem_s must keep returning 0.
+fn emit_a32_i64_divs_overflow_trap(bytes: &mut Vec<u8>) {
+    let w = |bytes: &mut Vec<u8>, word: u32| bytes.extend_from_slice(&word.to_le_bytes());
+    w(bytes, 0xE002_C003); // AND   R12, R2, R3 (== 0xFFFFFFFF iff divisor == -1)
+    w(bytes, 0xE37C_0001); // CMN   R12, #1     (EQ iff divisor == -1)
+    w(bytes, 0x0350_0000); // CMPEQ R0, #0      (EQ iff also dividend lo == 0)
+    w(bytes, 0x0351_0102); // CMPEQ R1, #0x80000000 (EQ iff dividend == INT64_MIN)
+    w(bytes, 0x1A00_0000); // BNE +1 insn (skip the UDF)
+    w(bytes, 0xE7F0_00F0); // UDF #0 — signed-division overflow
 }
 
 /// Fallible form of the `verify_reg_bits` contract. PC (R15) is not a valid
@@ -9899,6 +9977,258 @@ mod tests {
             rmhi: Reg::R5,
         });
         assert!(result.is_err(), "swapped rd pair must be rejected loudly");
+    }
+
+    /// #632: the I64Popcnt expansion's own scratch restore (`POP {R3,R4,R5}`)
+    /// must not clobber the result. Pre-fix the total was materialized with
+    /// `ADDS rd, R4, R5` BEFORE the pop, so any allocator-assigned
+    /// rd ∈ {R3,R4,R5} received stale stack garbage. Post-fix the count is
+    /// carried across the restore in R12 (never allocatable, never restored)
+    /// and moved into rd only after the pop — structurally rd-independent.
+    #[test]
+    fn test_632_i64_popcnt_result_survives_scratch_restore() {
+        let encoder = ArmEncoder::new_thumb2();
+        // Every allocatable rd, including the restore set {R3,R4,R5} and R8.
+        for rd in [
+            Reg::R0,
+            Reg::R2,
+            Reg::R3,
+            Reg::R4,
+            Reg::R5,
+            Reg::R6,
+            Reg::R8,
+        ] {
+            let code = encoder
+                .encode(&ArmOp::I64Popcnt {
+                    rd,
+                    rnlo: Reg::R6,
+                    rnhi: Reg::R7,
+                })
+                .unwrap();
+            assert_eq!(code.len(), 180, "register-independent size (estimator pin)");
+            let hw: Vec<u16> = code
+                .chunks(2)
+                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                .collect();
+            let pop = hw
+                .iter()
+                .position(|&h| h == 0xBC38)
+                .expect("POP {R3,R4,R5} present");
+            // Immediately before the POP: ADD.W R12, R4, R5 (the total lives
+            // in R12, which the POP cannot touch).
+            assert_eq!(
+                &hw[pop - 2..pop],
+                &[0xEB04, 0x0C05],
+                "total must be carried in R12 across the restore"
+            );
+            // Immediately after the POP: MOV rd, R12.
+            let rd_bits = match rd {
+                Reg::R8 => 8u16,
+                Reg::R6 => 6,
+                Reg::R5 => 5,
+                Reg::R4 => 4,
+                Reg::R3 => 3,
+                Reg::R2 => 2,
+                _ => 0,
+            };
+            let expect_mov = 0x4600 | (((rd_bits >> 3) & 1) << 7) | (12 << 3) | (rd_bits & 7);
+            assert_eq!(hw[pop + 1], expect_mov, "MOV rd, R12 after the restore");
+            // No write into rd between the PUSH and the POP (the old
+            // pre-restore ADDS is gone).
+            assert!(
+                !hw[..pop].contains(&(0x1800 | (5 << 6) | (4 << 3) | rd_bits)),
+                "no ADDS rd, R4, R5 before the restore pop"
+            );
+        }
+    }
+
+    /// #632 audit: the entry marshal must be permutation-safe. Pre-fix
+    /// `MOV R4, rnlo; MOV R5, rnhi` read a clobbered R4 when the operand
+    /// pair lived at (R3, R4). Post-fix rnlo routes through R12.
+    #[test]
+    fn test_632_i64_popcnt_marshal_pair_at_r3_r4() {
+        let encoder = ArmEncoder::new_thumb2();
+        let code = encoder
+            .encode(&ArmOp::I64Popcnt {
+                rd: Reg::R0,
+                rnlo: Reg::R3,
+                rnhi: Reg::R4,
+            })
+            .unwrap();
+        let hw: Vec<u16> = code
+            .chunks(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        // PUSH {R3,R4,R5}; MOV R12, R3; MOV R5, R4 (rnhi read BEFORE any
+        // write to R4); MOV R4, R12.
+        assert_eq!(hw[0], 0xB438);
+        assert_eq!(hw[1], 0x4600 | (1 << 7) | (3 << 3) | 4, "MOV R12, rnlo");
+        assert_eq!(hw[2], 0x4600 | (4 << 3) | 5, "MOV R5, rnhi");
+        assert_eq!(hw[3], 0x4664, "MOV R4, R12");
+    }
+
+    /// #632: A32 twin — same structural fix on the ARM-mode path
+    /// (`--target cortex-r5`): total carried in R12 across the restore.
+    #[test]
+    fn test_632_a32_i64_popcnt_result_survives_scratch_restore() {
+        let encoder = ArmEncoder::new_arm32();
+        for rd in [Reg::R0, Reg::R3, Reg::R4, Reg::R5, Reg::R8] {
+            let code = encoder
+                .encode(&ArmOp::I64Popcnt {
+                    rd,
+                    rnlo: Reg::R6,
+                    rnhi: Reg::R7,
+                })
+                .unwrap();
+            let words: Vec<u32> = code
+                .chunks(4)
+                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect();
+            let pop = words
+                .iter()
+                .position(|&w| w == 0xE8BD_0038)
+                .expect("POP {R3,R4,R5} present");
+            assert_eq!(words[pop - 1], 0xE084_C005, "ADD R12, R4, R5 before POP");
+            let rd_bits = match rd {
+                Reg::R8 => 8u32,
+                Reg::R5 => 5,
+                Reg::R4 => 4,
+                Reg::R3 => 3,
+                _ => 0,
+            };
+            assert_eq!(
+                words[pop + 1],
+                0xE1A0_0000 | (rd_bits << 12) | 12,
+                "MOV rd, R12 after the restore"
+            );
+        }
+    }
+
+    /// #633: I64DivS must carry the INT64_MIN/-1 overflow guard (mirroring
+    /// the i32 path) right after the zero-divisor guard — dividend in R0:R1,
+    /// divisor in R2:R3 on the #610/#613 fixed-ABI wrapper path.
+    #[test]
+    fn test_633_i64_divs_overflow_guard_emitted() {
+        let encoder = ArmEncoder::new_thumb2();
+        let code = encoder
+            .encode(&ArmOp::I64DivS {
+                rdlo: Reg::R4,
+                rdhi: Reg::R5,
+                rnlo: Reg::R0,
+                rnhi: Reg::R1,
+                rmlo: Reg::R2,
+                rmhi: Reg::R3,
+            })
+            .unwrap();
+        // 26-byte marshal + 8-byte zero-trap, then the 22-byte overflow guard.
+        let guard: Vec<u16> = code[34..56]
+            .chunks(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        assert_eq!(
+            guard,
+            vec![
+                0xEA02, 0x0C03, // AND.W R12, R2, R3
+                0xF11C, 0x0F01, // CMN.W R12, #1
+                0xD105, // BNE .no_trap
+                0x2800, // CMP R0, #0
+                0xD103, // BNE .no_trap
+                0xF1B1, 0x4F00, // CMP.W R1, #0x80000000
+                0xD100, // BNE .no_trap
+                0xDE00, // UDF #0 — signed-division overflow
+            ],
+            "INT64_MIN/-1 overflow guard after the zero-divisor guard"
+        );
+    }
+
+    /// #633 fix-guard twin: I64RemS must NOT carry the overflow guard —
+    /// rem_s(INT64_MIN, -1) is defined as 0 and must not trap. Exactly one
+    /// UDF (the zero-divisor trap) in the whole expansion.
+    #[test]
+    fn test_633_i64_rems_has_no_overflow_guard() {
+        let encoder = ArmEncoder::new_thumb2();
+        for (is_rem_s, op) in [
+            (
+                true,
+                ArmOp::I64RemS {
+                    rdlo: Reg::R4,
+                    rdhi: Reg::R5,
+                    rnlo: Reg::R0,
+                    rnhi: Reg::R1,
+                    rmlo: Reg::R2,
+                    rmhi: Reg::R3,
+                },
+            ),
+            (
+                false,
+                ArmOp::I64DivS {
+                    rdlo: Reg::R4,
+                    rdhi: Reg::R5,
+                    rnlo: Reg::R0,
+                    rnhi: Reg::R1,
+                    rmlo: Reg::R2,
+                    rmhi: Reg::R3,
+                },
+            ),
+        ] {
+            let code = encoder.encode(&op).unwrap();
+            let udfs = code
+                .chunks(2)
+                .filter(|c| u16::from_le_bytes([c[0], c[1]]) == 0xDE00)
+                .count();
+            let want = if is_rem_s { 1 } else { 2 };
+            assert_eq!(
+                udfs, want,
+                "rem_s: zero-trap only; div_s: zero-trap + overflow trap"
+            );
+        }
+    }
+
+    /// #633: A32 twin — the conditional-execution overflow guard on the
+    /// ARM-mode I64DivS, and its absence from I64RemS.
+    #[test]
+    fn test_633_a32_i64_divs_overflow_guard() {
+        let encoder = ArmEncoder::new_arm32();
+        let mk_divs = ArmOp::I64DivS {
+            rdlo: Reg::R4,
+            rdhi: Reg::R5,
+            rnlo: Reg::R0,
+            rnhi: Reg::R1,
+            rmlo: Reg::R2,
+            rmhi: Reg::R3,
+        };
+        let code = encoder.encode(&mk_divs).unwrap();
+        let words: Vec<u32> = code
+            .chunks(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        let guard = [
+            0xE002_C003u32, // AND   R12, R2, R3
+            0xE37C_0001,    // CMN   R12, #1
+            0x0350_0000,    // CMPEQ R0, #0
+            0x0351_0102,    // CMPEQ R1, #0x80000000
+            0x1A00_0000,    // BNE +1 insn
+            0xE7F0_00F0,    // UDF #0
+        ];
+        assert!(
+            words.windows(6).any(|w| w == guard),
+            "A32 I64DivS carries the INT64_MIN/-1 overflow guard"
+        );
+        let rems = encoder
+            .encode(&ArmOp::I64RemS {
+                rdlo: Reg::R4,
+                rdhi: Reg::R5,
+                rnlo: Reg::R0,
+                rnhi: Reg::R1,
+                rmlo: Reg::R2,
+                rmhi: Reg::R3,
+            })
+            .unwrap();
+        let rems_udfs = rems
+            .chunks(4)
+            .filter(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]) == 0xE7F0_00F0)
+            .count();
+        assert_eq!(rems_udfs, 1, "A32 I64RemS keeps only the zero-divisor trap");
     }
 
     #[test]

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -463,8 +463,9 @@ pub fn estimate_arm_byte_size(op: &ArmOp) -> usize {
         // I64Ctz: CMP.W(4) + BEQ(2) + RBIT.W(4) + CLZ.W(4) + B(2) + NOP(2) + RBIT.W(4) + CLZ.W(4) + ADD.W(4) + MOV(2) = 32 bytes
         ArmOp::I64Ctz { .. } => 32,
         // I64Popcnt: PUSH/POP + duplicate popcount for lo and hi word (#498:
-        // measured 172, was a ~180-guess 200 over-estimate).
-        ArmOp::I64Popcnt { .. } => 172,
+        // measured 172; #632 result-carry through R12 across the restore pop
+        // + R12-routed marshal + MOV.W hi-clear = +8).
+        ArmOp::I64Popcnt { .. } => 180,
         // I64 sign extension: SXTB/SXTH/ASR + ASR.
         ArmOp::I64Extend8S { .. } => 8,
         ArmOp::I64Extend16S { .. } => 8,
@@ -476,8 +477,10 @@ pub fn estimate_arm_byte_size(op: &ArmOp) -> usize {
         // pre-#610 cores (74/78/126/124, the #498 exact measurements).
         ArmOp::I64DivU { .. } => 120,
         ArmOp::I64RemU { .. } => 124,
-        // Signed versions have additional negation logic.
-        ArmOp::I64DivS { .. } => 172,
+        // Signed versions have additional negation logic. div_s also carries
+        // the #633 INT64_MIN/-1 overflow guard (+22 bytes); rem_s deliberately
+        // does NOT (rem_s(INT64_MIN, -1) == 0, no trap).
+        ArmOp::I64DivS { .. } => 194,
         ArmOp::I64RemS { .. } => 170,
         // AND/OR/XOR: encoder always uses 32-bit Thumb-2 (.W) encoding
         ArmOp::And { .. } | ArmOp::Orr { .. } | ArmOp::Eor { .. } => 4,

--- a/scripts/repro/i64_divs_overflow_633.wat
+++ b/scripts/repro/i64_divs_overflow_633.wat
@@ -1,0 +1,30 @@
+(module
+  ;; #633: i64.div_s(INT64_MIN, -1) must trap (WASM Core 4.3.2 idiv_s —
+  ;; +2^63 is unrepresentable). The i64 signed-div expansion emitted only
+  ;; the divide-by-zero guard, negated INT64_MIN onto itself, and returned
+  ;; INT64_MIN silently. Dividend assembled from two u32 halves (lo, hi),
+  ;; divisor the constant -1 — the issue's exact shape.
+  (func (export "div_s_m1") (param i32 i32) (result i32)
+    (i32.wrap_i64
+      (i64.div_s
+        (i64.or (i64.shl (i64.extend_i32_u (local.get 1)) (i64.const 32))
+                (i64.extend_i32_u (local.get 0)))
+        (i64.const -1))))
+  ;; Fix-guard twin (#633): rem_s(INT64_MIN, -1) is DEFINED as 0 and must
+  ;; NOT trap — the overflow guard belongs to div_s only.
+  (func (export "rem_s_m1") (param i32 i32) (result i32)
+    (i32.wrap_i64
+      (i64.rem_s
+        (i64.or (i64.shl (i64.extend_i32_u (local.get 1)) (i64.const 32))
+                (i64.extend_i32_u (local.get 0)))
+        (i64.const -1))))
+  ;; General two-i64-param forms (both operands runtime values).
+  (func (export "div_s") (param i64 i64) (result i32)
+    (i32.wrap_i64 (i64.div_s (local.get 0) (local.get 1))))
+  (func (export "rem_s") (param i64 i64) (result i32)
+    (i32.wrap_i64 (i64.rem_s (local.get 0) (local.get 1))))
+  ;; hi-word twin so both halves of the quotient are checked through the
+  ;; i32 return register.
+  (func (export "div_s_hi") (param i64 i64) (result i32)
+    (i32.wrap_i64 (i64.shr_u (i64.div_s (local.get 0) (local.get 1))
+                             (i64.const 32)))))

--- a/scripts/repro/i64_divs_overflow_633_differential.py
+++ b/scripts/repro/i64_divs_overflow_633_differential.py
@@ -1,0 +1,184 @@
+# #633: i64.div_s(INT64_MIN, -1) must trap (WASM Core 4.3.2 idiv_s — the
+# quotient +2^63 is unrepresentable). The Thumb-2 I64DivS expansion emitted
+# only the divide-by-zero guard: it negated the dividend (INT64_MIN wraps to
+# itself), negated the divisor (-1 -> 1), ran the unsigned core, and silently
+# returned 0x8000000000000000. The i32 signed-div path HAS the overflow guard
+# — this pins the i64 mirror (dividend==INT64_MIN && divisor==-1 -> UDF #0,
+# emitted on the #610/#613 fixed-ABI wrapper path where the dividend is in
+# R0:R1 and the divisor in R2:R3).
+#
+# Fix-guard twin: i64.rem_s(INT64_MIN, -1) is DEFINED as 0 and must NOT trap
+# (irem_s) — vectors below pin that the guard is div_s-only.
+#
+# Differential: compile each export with the issue's exact config
+# (`-t cortex-m3 -n <name> --relocatable`), emulate under unicorn
+# (UC_MODE_THUMB), difference against the wasmtime oracle. Trap vectors
+# assert BOTH sides trap (unicorn: UDF hit / no return-pad; wasmtime:
+# "integer overflow" / "divide by zero").
+#
+# Usage: python3 i64_divs_overflow_633_differential.py <synth-binary> [wat]
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UcError, UC_ARCH_ARM, UC_MODE_THUMB
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R3,
+    UC_ARM_REG_PC,
+    UC_ARM_REG_SP,
+)
+
+SYNTH = sys.argv[1] if len(sys.argv) > 1 else "target/debug/synth"
+WAT = (
+    sys.argv[2]
+    if len(sys.argv) > 2
+    else os.path.join(os.path.dirname(__file__), "i64_divs_overflow_633.wat")
+)
+CODE, STK = 0x1000000, 0x6000000
+RET = CODE + 0xFFF0
+M64 = (1 << 64) - 1
+M32 = (1 << 32) - 1
+TRAP = "TRAP"
+IMIN = 1 << 63  # INT64_MIN as u64
+NEG1 = M64
+
+SIG = {
+    "div_s_m1": ("i32", "i32"),
+    "rem_s_m1": ("i32", "i32"),
+    "div_s": ("i64", "i64"),
+    "rem_s": ("i64", "i64"),
+    "div_s_hi": ("i64", "i64"),
+}
+
+# (function, args tuple (unsigned), expected u32 or TRAP)
+VECTORS = [
+    # --- the issue's exact shape: dividend from halves, divisor const -1 ---
+    ("div_s_m1", (0, 0x80000000), TRAP),  # INT64_MIN / -1 -> overflow trap
+    ("div_s_m1", (100, 0), (-100) & M32),  # issue row 2: normal path intact
+    ("div_s_m1", ((-100) & M32, M32), 100),  # -100 / -1 = 100
+    # --- fix-guard twin: rem_s(INT64_MIN, -1) == 0, NO trap ---
+    ("rem_s_m1", (0, 0x80000000), 0),
+    ("rem_s_m1", (100, 0), 0),  # 100 rem -1 = 0
+    # --- general two-i64-param forms ---
+    ("div_s", (IMIN, NEG1), TRAP),  # overflow trap, runtime divisor
+    ("div_s", (100, NEG1), (-100) & M32),
+    ("div_s", (IMIN, 1), 0),  # INT64_MIN / 1: lo word 0, NO trap
+    ("div_s_hi", (IMIN, 1), 0x80000000),  # ... hi word intact, NO trap
+    ("div_s", (IMIN, 2), 0),  # INT64_MIN / 2: defined, NO trap
+    ("div_s_hi", (IMIN, 2), 0xC0000000),
+    ("div_s", ((-100) & M64, 7), (-14) & M32),
+    ("rem_s", (IMIN, NEG1), 0),  # twin again through the i64-param form
+    ("rem_s", ((-100) & M64, 7), (-2) & M32),
+    # --- divide by zero must still trap (guard ordering unchanged) ---
+    ("div_s", (100, 0), TRAP),
+    ("rem_s", (100, 0), TRAP),
+]
+
+
+def sext(kind, v):
+    bits = 32 if kind == "i32" else 64
+    return v - (1 << bits) if v & (1 << (bits - 1)) else v
+
+
+def wasmtime_oracle(func, args):
+    if shutil.which("wasmtime") is None:
+        return None
+    sig = SIG[func]
+    argv = ["wasmtime", "run", "--invoke", func, WAT] + [
+        str(sext(k, a)) for k, a in zip(sig, args)
+    ]
+    out = subprocess.run(argv, capture_output=True, text=True)
+    if out.returncode != 0:
+        if "divide by zero" in out.stderr or "integer overflow" in out.stderr:
+            return TRAP
+        return None
+    return int(out.stdout.strip()) & M32
+
+
+def compile_func(func, out_o):
+    argv = [
+        SYNTH, "compile", WAT,
+        "-t", "cortex-m3",
+        "-n", func,
+        "--relocatable",
+        "-o", out_o,
+    ]
+    r = subprocess.run(argv, capture_output=True, text=True)
+    if r.returncode != 0:
+        print(f"COMPILE FAILED for {func}:\n{r.stderr}")
+        sys.exit(2)
+
+
+def emulate(elf_path, func, args):
+    """Returns the u32 result, or TRAP if execution hit a UDF/fault."""
+    e = ELFFile(open(elf_path, "rb"))
+    text = e.get_section_by_name(".text").data()
+    # Symbols from the symtab, never from disasm text (host-dependent).
+    st = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: s["st_value"] & ~1 for s in st.iter_symbols() if s.name}
+    if func not in syms:
+        print(f"SYMBOL MISSING: {func}")
+        sys.exit(2)
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x100000)
+    mu.mem_map(STK, 0x100000)
+    mu.mem_write(CODE, text)
+    mu.mem_write(RET, struct.pack("<HH", 0xBF00, 0xBF00))  # Thumb NOP pad
+
+    # AAPCS: i32 args take one register; i64 args a lo:hi pair at an even reg.
+    regs = [UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3]
+    ri = 0
+    for kind, a in zip(SIG[func], args):
+        if kind == "i32":
+            mu.reg_write(regs[ri], a & M32)
+            ri += 1
+        else:
+            ri += ri & 1  # even-align the pair
+            mu.reg_write(regs[ri], a & M32)
+            mu.reg_write(regs[ri + 1], (a >> 32) & M32)
+            ri += 2
+    mu.reg_write(UC_ARM_REG_SP, STK + 0x80000)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    try:
+        # div expansions loop 64 times (~1.1k insns) — generous budget.
+        mu.emu_start((CODE + syms[func]) | 1, RET, count=50000)
+    except UcError:
+        return TRAP  # UDF #0 (zero-divisor or overflow guard) or genuine fault
+    if mu.reg_read(UC_ARM_REG_PC) != RET & ~1:
+        return TRAP  # never reached the return pad
+    return mu.reg_read(UC_ARM_REG_R0) & M32
+
+
+tmp = tempfile.mkdtemp(prefix="i64divs633_")
+fails = 0
+for func, args, want in VECTORS:
+    oracle = wasmtime_oracle(func, args)
+    if oracle is not None and oracle != want:
+        print(f"HARNESS BUG: builtin expect {want} != wasmtime {oracle} for {func}{args}")
+        sys.exit(2)
+    want = oracle if oracle is not None else want
+    obj = os.path.join(tmp, f"{func}.o")
+    if not os.path.exists(obj):
+        compile_func(func, obj)
+    got = emulate(obj, func, args)
+    ok = got == want
+    fails += 0 if ok else 1
+    argstr = ", ".join(hex(a) for a in args)
+    gots = got if got == TRAP else hex(got)
+    wants = want if want == TRAP else hex(want)
+    print(f"{func}({argstr}) = {gots} (oracle: {wants}) {'OK' if ok else 'MISMATCH'}")
+
+if fails == 0:
+    print("ORACLE: PASS")
+    sys.exit(0)
+print(f"ORACLE: FAIL — {fails} vector(s) wrong (#633)")
+sys.exit(1)

--- a/scripts/repro/i64_popcnt_632.wat
+++ b/scripts/repro/i64_popcnt_632.wat
@@ -1,0 +1,26 @@
+(module
+  ;; #632: assemble a u64 from two u32 halves, popcnt, wrap. The i64.or/shl/
+  ;; extend construction adds enough register pressure that the allocator
+  ;; hands the I64Popcnt expansion a result register (rd) inside its own
+  ;; scratch set {R3,R4,R5} — the expansion's restore `POP {R3,R4,R5}`
+  ;; then clobbered the freshly computed count (0 for every input on qemu).
+  (func (export "popcnt64") (param i32 i32) (result i32)
+    (i32.wrap_i64
+      (i64.popcnt
+        (i64.or
+          (i64.shl (i64.extend_i32_u (local.get 1)) (i64.const 32))
+          (i64.extend_i32_u (local.get 0))))))
+  ;; Direct form — control, correct before the fix (rd landed outside
+  ;; the expansion's scratch set).
+  (func (export "popcnt_direct") (param i64) (result i32)
+    (i32.wrap_i64 (i64.popcnt (local.get 0))))
+  ;; hi-word probe: the count is an i64 (lo = count, hi = 0); shift the pair
+  ;; right 32 so the wrapped result exposes the HI word of the popcnt pair.
+  (func (export "popcnt64_hi") (param i32 i32) (result i32)
+    (i32.wrap_i64
+      (i64.shr_u
+        (i64.popcnt
+          (i64.or
+            (i64.shl (i64.extend_i32_u (local.get 1)) (i64.const 32))
+            (i64.extend_i32_u (local.get 0))))
+        (i64.const 32)))))

--- a/scripts/repro/i64_popcnt_632_differential.py
+++ b/scripts/repro/i64_popcnt_632_differential.py
@@ -1,0 +1,173 @@
+# #632: i64.popcnt result clobbered by the expansion's own scratch-restore pop.
+#
+# The Thumb-2 I64Popcnt expansion saves scratch with `PUSH {R3,R4,R5}`,
+# computes popcnt(lo) -> R4 and popcnt(hi) -> R5, materializes the total with
+# `ADDS rd, R4, R5`, and then restores scratch with `POP {R3,R4,R5}`. The
+# selector-assigned rd is any allocatable register (R0-R8): whenever the
+# surrounding pressure (the u64-from-two-u32-halves construction below) lands
+# rd inside {R3,R4,R5}, the restore pop overwrites the count one instruction
+# after it is produced — the caller receives stale stack garbage (0 under a
+# zero-initialized emulator) for EVERY input.
+#
+# Post-fix the expansion carries the total across the restore in R12 (encoder
+# scratch, never allocatable #212, never in any restore set) and only then
+# moves it into rd — structural: no choice of rd can collide with the pop.
+#
+# Differential: compile each export with the issue's exact config
+# (`-t cortex-m3 -n <name> --relocatable`), emulate under unicorn
+# (UC_MODE_THUMB), difference against the wasmtime oracle.
+#
+# Usage: python3 i64_popcnt_632_differential.py <synth-binary> [wat]
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UcError, UC_ARCH_ARM, UC_MODE_THUMB
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R3,
+    UC_ARM_REG_PC,
+    UC_ARM_REG_SP,
+)
+
+SYNTH = sys.argv[1] if len(sys.argv) > 1 else "target/debug/synth"
+WAT = (
+    sys.argv[2]
+    if len(sys.argv) > 2
+    else os.path.join(os.path.dirname(__file__), "i64_popcnt_632.wat")
+)
+CODE, STK = 0x1000000, 0x6000000
+RET = CODE + 0xFFF0
+M64 = (1 << 64) - 1
+M32 = (1 << 32) - 1
+TRAP = "TRAP"
+
+# Signatures: arg kinds drive both register marshaling and the wasmtime CLI.
+SIG = {
+    "popcnt64": ("i32", "i32"),
+    "popcnt64_hi": ("i32", "i32"),
+    "popcnt_direct": ("i64",),
+}
+
+# (function, args tuple (unsigned), expected u32) — the #632 issue table plus
+# hi-word and direct-form controls.
+VECTORS = [
+    ("popcnt64", (7, 0), 3),  # issue row 1
+    ("popcnt64", (1, 1), 2),  # issue row 2
+    ("popcnt64", (M32, 0), 32),  # issue row 3: (-1, 0)
+    ("popcnt64", (M32, M32), 64),  # issue row 4: (-1, -1)
+    ("popcnt64", (0, 0), 0),
+    ("popcnt64", (0, M32), 32),  # all bits in the hi half
+    ("popcnt64", (0x12345678, 0x9ABCDEF0), 32),
+    ("popcnt64_hi", (M32, M32), 0),  # count is a proper i64: hi word must be 0
+    ("popcnt64_hi", (7, 0), 0),
+    ("popcnt_direct", (255,), 8),  # control: correct pre-fix
+    ("popcnt_direct", (M64,), 64),  # control: correct pre-fix
+]
+
+
+def sext(kind, v):
+    bits = 32 if kind == "i32" else 64
+    return v - (1 << bits) if v & (1 << (bits - 1)) else v
+
+
+def wasmtime_oracle(func, args):
+    if shutil.which("wasmtime") is None:
+        return None
+    sig = SIG[func]
+    argv = ["wasmtime", "run", "--invoke", func, WAT] + [
+        str(sext(k, a)) for k, a in zip(sig, args)
+    ]
+    out = subprocess.run(argv, capture_output=True, text=True)
+    if out.returncode != 0:
+        if "divide by zero" in out.stderr or "integer overflow" in out.stderr:
+            return TRAP
+        return None
+    return int(out.stdout.strip()) & M32
+
+
+def compile_func(func, out_o):
+    argv = [
+        SYNTH, "compile", WAT,
+        "-t", "cortex-m3",
+        "-n", func,
+        "--relocatable",
+        "-o", out_o,
+    ]
+    r = subprocess.run(argv, capture_output=True, text=True)
+    if r.returncode != 0:
+        print(f"COMPILE FAILED for {func}:\n{r.stderr}")
+        sys.exit(2)
+
+
+def emulate(elf_path, func, args):
+    """Returns the u32 result, or TRAP if execution hit a UDF/fault."""
+    e = ELFFile(open(elf_path, "rb"))
+    text = e.get_section_by_name(".text").data()
+    # Symbols from the symtab, never from disasm text (host-dependent).
+    st = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: s["st_value"] & ~1 for s in st.iter_symbols() if s.name}
+    if func not in syms:
+        print(f"SYMBOL MISSING: {func}")
+        sys.exit(2)
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x100000)
+    mu.mem_map(STK, 0x100000)
+    mu.mem_write(CODE, text)
+    mu.mem_write(RET, struct.pack("<HH", 0xBF00, 0xBF00))  # Thumb NOP pad
+
+    # AAPCS: i32 args take one register; i64 args a lo:hi pair at an even reg.
+    regs = [UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3]
+    ri = 0
+    for kind, a in zip(SIG[func], args):
+        if kind == "i32":
+            mu.reg_write(regs[ri], a & M32)
+            ri += 1
+        else:
+            ri += ri & 1  # even-align the pair
+            mu.reg_write(regs[ri], a & M32)
+            mu.reg_write(regs[ri + 1], (a >> 32) & M32)
+            ri += 2
+    mu.reg_write(UC_ARM_REG_SP, STK + 0x80000)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    try:
+        mu.emu_start((CODE + syms[func]) | 1, RET, count=50000)
+    except UcError:
+        return TRAP
+    if mu.reg_read(UC_ARM_REG_PC) != RET & ~1:
+        return TRAP  # never reached the return pad
+    return mu.reg_read(UC_ARM_REG_R0) & M32
+
+
+tmp = tempfile.mkdtemp(prefix="i64popcnt632_")
+fails = 0
+for func, args, want in VECTORS:
+    oracle = wasmtime_oracle(func, args)
+    if oracle is not None and oracle != want:
+        print(f"HARNESS BUG: builtin expect {want} != wasmtime {oracle} for {func}{args}")
+        sys.exit(2)
+    want = oracle if oracle is not None else want
+    obj = os.path.join(tmp, f"{func}.o")
+    if not os.path.exists(obj):
+        compile_func(func, obj)
+    got = emulate(obj, func, args)
+    ok = got == want
+    fails += 0 if ok else 1
+    argstr = ", ".join(hex(a) for a in args)
+    gots = got if got == TRAP else hex(got)
+    wants = want if want == TRAP else hex(want)
+    print(f"{func}({argstr}) = {gots} (oracle: {wants}) {'OK' if ok else 'MISMATCH'}")
+
+if fails == 0:
+    print("ORACLE: PASS")
+    sys.exit(0)
+print(f"ORACLE: FAIL — {fails} vector(s) wrong (#632)")
+sys.exit(1)


### PR DESCRIPTION
Fixes #632, fixes #633 — two shipped thumb-2 i64 miscompiles filed by gale, fixed structurally on both the Thumb-2 (cortex-m) and A32 (cortex-r5) paths.

## #632 — i64.popcnt result clobbered by the expansion's own scratch-restore pop

**Root cause (confirmed):** it is neither the allocator choosing a "wrong" register nor the *function* epilogue — the `I64Popcnt` expansion itself saves scratch with `PUSH {R3,R4,R5}`, computes `popcnt(lo)→R4`, `popcnt(hi)→R5`, materializes the total with `ADDS rd, R4, R5`, and then restores scratch with `POP {R3,R4,R5}`. `rd` is allocator-assigned (any of R0–R8); whenever pressure lands it inside the expansion's own restore set {R3,R4,R5} (the issue's case: rd=R5), the restore destroys the result one instruction after it is produced.

**Structural fix:** the count is carried ACROSS the restore in **R12** — encoder scratch, never allocatable (#212), never in any restore set — and moved into `rd` only after the pop (`ADD.W R12,R4,R5; POP {R3,R4,R5}; MOV rd,R12`). No choice of `rd` can collide, by construction. Two latent hazards in the same arm fixed alongside: the entry marshal now routes `rnlo` through R12 (an operand pair living at (R3,R4) previously read a clobbered R4), and the new MOV/MOV.W forms are total over `rd`/`rnhi` = R8 (the old `ADDS` T1 / `MOVS` T1 3-bit fields silently corrupted the encoding for R8 — #178/#180 class).

**Expansion-family audit (pop-restore clobber class), per the #615-style sweep:**

| expansion | Thumb-2 | A32 | verdict |
|---|---|---|---|
| `I64Popcnt` | `ADDS rd,R4,R5` before `POP {R3,R4,R5}` | same | **AFFECTED — fixed (both ISAs)** |
| `I64DivS/DivU/RemS/RemU` | result staged in R0:R1 *before* `POP {R4-R11}`/`{R4-R8}`/`{R4-R7}`; #610 fixed-ABI exit skips restored regs | same | safe |
| `I64Rotl/Rotr` | #610 fixed-ABI wrapper, no extra scratch pop | same | safe |
| `I64Clz/I64Ctz` | no scratch push/pop | same | safe |
| i32 `Popcnt` | no scratch push/pop (R11/R12 scratch) | same | safe (class-wise) |

`I64Popcnt` was the only member of the class, on both ISAs; both are fixed here.

## #633 — i64.div_s(INT64_MIN, -1) silently returned INT64_MIN instead of trapping

**Root cause (confirmed):** the I64DivS expansion emitted only the divide-by-zero guard. It negated the dividend (INT64_MIN wraps to itself), negated the divisor (−1→1), ran the unsigned core, and returned `0x8000000000000000` — no trap, violating WASM Core §4.3.2 `idiv_s`. The i32 path has the guard; the i64 path did not.

**Fix:** mirror the i32 overflow guard on the #610/#613 fixed-ABI wrapper path, right after the zero-divisor guard, where the dividend is in R0:R1 and the divisor in R2:R3: `divisor == -1 && dividend == INT64_MIN → UDF #0` (22 bytes Thumb-2, register-independent; conditional-execution twin on A32). Emitted for **div_s only**.

**Fix-guard twin:** `i64.rem_s(INT64_MIN, -1)` keeps returning **0 without trapping** — pinned by differential vectors (`rem_s_m1(0, 0x80000000) = 0 OK`, `rem_s(IMIN, -1) = 0 OK`) and by unit tests asserting I64RemS contains exactly one UDF (the zero-divisor trap) on both ISAs.

## Oracles — red → green

`scripts/repro/i64_popcnt_632_differential.py` (unicorn-vs-wasmtime, symtab-based, `-t cortex-m3 --relocatable`), **on origin/main**:

```
popcnt64(0x7, 0x0) = 0x0 (oracle: 0x3) MISMATCH
popcnt64(0x1, 0x1) = 0x0 (oracle: 0x2) MISMATCH
popcnt64(0xffffffff, 0x0) = 0x0 (oracle: 0x20) MISMATCH
popcnt64(0xffffffff, 0xffffffff) = 0x0 (oracle: 0x40) MISMATCH
popcnt64(0x0, 0xffffffff) = 0x0 (oracle: 0x20) MISMATCH
popcnt64(0x12345678, 0x9abcdef0) = 0x0 (oracle: 0x20) MISMATCH
popcnt_direct(0xff) = 0x8 (oracle: 0x8) OK          <- issue's direct-form control
ORACLE: FAIL — 6 vector(s) wrong (#632)
```

**post-fix:** all 11 vectors OK, `ORACLE: PASS` (issue table (7,0)→3, (1,1)→2, (−1,0)→32, (−1,−1)→64 all exact).

`scripts/repro/i64_divs_overflow_633_differential.py`, **on origin/main**:

```
div_s_m1(0x0, 0x80000000) = 0x0 (oracle: TRAP) MISMATCH
div_s(0x8000000000000000, 0xffffffffffffffff) = 0x0 (oracle: TRAP) MISMATCH
rem_s_m1(0x0, 0x80000000) = 0x0 (oracle: 0x0) OK    <- twin already correct pre-fix
ORACLE: FAIL — 2 vector(s) wrong (#633)
```

**post-fix:** all 16 vectors OK, `ORACLE: PASS` — including `100/-1 = -100`, `INT64_MIN/1` and `/2` (defined, no trap, both halves checked), `rem_s(INT64_MIN,-1) = 0` no-trap, and div/rem-by-zero still trapping on both sides.

## Gates

- Unit tests: `test_632_i64_popcnt_result_survives_scratch_restore` (all rd incl. {R3,R4,R5}, R8), `test_632_i64_popcnt_marshal_pair_at_r3_r4`, `test_632_a32_i64_popcnt_result_survives_scratch_restore`, `test_633_i64_divs_overflow_guard_emitted`, `test_633_i64_rems_has_no_overflow_guard`, `test_633_a32_i64_divs_overflow_guard`
- `estimator_encoder_agreement` (#511 pin): green — `I64Popcnt` 172→180, `I64DivS` 172→194, register-independent; `I64RemS` unchanged at 170
- `cargo test -p synth-cli --test frozen_codegen_bytes`: **all anchors untouched** (no i64 popcnt / div_s-overflow shapes in the frozen fixtures)
- `cargo test --workspace`: 105 suites, 0 failures
- `cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)