### PR TITLE
feat(fact-spec): #494 phase 2b — divisor-nonzero div/rem trap-guard elision (two-guard obligation split, VCR-PERF-002)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
         run: python scripts/repro/cmp_select_two_move_differential.py
 
   fact-spec-oracle:
-    name: fact-spec clamp elision oracle (#494 phase 2)
+    name: fact-spec elision oracle (#494 phases 2 + 2b)
     # VCR-PERF-002 Phase 2 (#494): the proof-carrying-specialization lever
     # (SYNTH_FACT_SPEC, default off; per-elision ordeal obligation). Built
     # with the `verify` feature (the solver lives in synth-verify — pure-Rust
@@ -295,7 +295,11 @@ jobs:
     # certificate-evidence Rust gates; (2) the in-bounds execution
     # differential — specialized ≡ wasmtime ≡ unspecialized over the proven
     # bound ch ∈ [524,1524] under unicorn — plus the wrong-bound loud-decline
-    # green path. Isolated job: emulation deps pip-installed here ONLY.
+    # green path. Phase 2b (divisor-nonzero, kind 3): the div/rem trap-guard
+    # elision byte gates + differential (incl. the two-guard distinction — the
+    # i64 INT64_MIN/-1 overflow guard is RETAINED under a nonzero-only fact —
+    # and the RED force-admit divergence demo, debug-build lever). Isolated
+    # job: emulation deps pip-installed here ONLY.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -312,6 +316,8 @@ jobs:
             ${{ runner.os }}-cargo-
       - name: Run fact-spec end-to-end gates (flag matrix + certificates)
         run: cargo test -p synth-cli --features verify --test fact_spec_clamp_494
+      - name: Run divisor-nonzero guard-elision gates (#494 phase 2b byte evidence)
+        run: cargo test -p synth-cli --features verify --test fact_spec_div_494
       - name: Build synth (verify feature)
         run: cargo build -p synth-cli --features verify
       - uses: actions/setup-python@v6
@@ -325,6 +331,18 @@ jobs:
         run: >
           python scripts/repro/fact_spec_clamp_494_differential.py
           --fact-lo 0 --fact-hi 4000 --expect-decline
+      # #494 phase 2b — divisor-nonzero: in-bounds div/rem differential
+      # (specialized ≡ wasmtime ≡ unspecialized over the proven divisor bound,
+      # incl. the RETAINED-i64-overflow-guard trap assertion), the
+      # Sat loud-decline byte-identity leg, and the RED force-admit divergence
+      # demonstration (the lever exists in debug builds only — CI's synth is
+      # a debug build).
+      - name: Run divisor-nonzero in-bounds differential (green)
+        run: python scripts/repro/fact_spec_div_494_differential.py
+      - name: Run divisor-including-zero loud-decline path
+        run: python scripts/repro/fact_spec_div_494_differential.py --expect-decline
+      - name: Run RED force-admit divergence demonstration
+        run: python scripts/repro/fact_spec_div_494_differential.py --force-admit
 
   rv32-shift-fold-oracle:
     name: rv32 immediate-shift-fold execution oracle

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -1683,6 +1683,43 @@ artifacts:
       measured cortex-m4 codegen 84 B/23 insns -> 14 B/6 insns (vs the 6 B
       add+bx measured floor: residual const-materialization + reg-shuffle +
       callee-saved frame — allocator/peephole residue, a Phase-3 datum).
+      Phase 2b — divisor-nonzero trap-guard elision (fact kind 3).
+      IMPLEMENTED (2026-07-08): the fact_spec walk now TRACKS i32/i64 div/rem
+      (upgrading the phase-2 hard stop) — never deleting them (they can trap;
+      result carries no erasable slice) but discharging up to TWO INDEPENDENT
+      per-site guard obligations: divide-by-zero = UNSAT(P AND divisor == 0)
+      (div_u/div_s/rem_u/rem_s, both widths) and INT_MIN/-1 overflow =
+      UNSAT(P AND dividend == INT_MIN AND divisor == -1) (div_s ONLY). THE
+      TWO-GUARD DISTINCTION (#633/#634 synergy): a divisor-nonzero fact
+      discharges the first but NOT the second — divisor != 0 does not exclude
+      -1, so the overflow guard is RETAINED (loud decline) unless the premises
+      independently prove it (a value-range divisor in [1,N] proves both;
+      either fact kind works). Discharged obligations become per-site elision
+      marks (FactSpecResult::elide_div_zero/elide_div_ovf, remapped through
+      any clamp-elision rewrite) threaded via
+      CompileConfig::fact_div_zero_elide/fact_div_ovf_elide to the DIRECT
+      selector only — the optimized path's IR passes renumber instructions,
+      so marked functions route to select_with_stack (the #507/#509
+      honest-degradation pattern; never fires without flag+facts+obligation).
+      i32 guards are selector-emitted and simply skipped; i64 guards live
+      inside the ArmOp::I64Div*/I64Rem* encoder expansions, which gained
+      per-guard elision flags (Thumb-2 + A32), with estimator sizes tracking
+      the flags (estimator<->encoder agreement oracle extended with the 5
+      elided variants — zero guard 8 B Thumb / 12 B A32, div_s overflow 22 B
+      / 24 B). Oracles: fact_spec unit gates (two-guard matrix, i64 width
+      discipline via current_func_params_i64, mark remapping); encoder splice
+      pins (elision removes EXACTLY the guard bytes, overflow retained under
+      zero-only); synth-cli tests/fact_spec_div_494.rs (byte evidence on the
+      qu/qs/ru/qs64 fixture: guard UDFs present without facts, absent with
+      facts+flag, qs64's INT64_MIN/-1 guard retained under kind 3 = 1 UDF
+      left; Sat-decline byte-identity; the debug-only
+      SYNTH_FACT_SPEC_FORCE_ADMIT red lever screams);
+      scripts/repro/fact_spec_div_494_differential.py (1584-case in-bounds
+      sweep specialized ≡ wasmtime ≡ unspecialized over the proven divisor
+      bound, retained-guard trap qs64(INT64_MIN,-1) fires in BOTH wasmtime
+      and the specialized build, --expect-decline byte-identity leg,
+      --force-admit RED leg demonstrating the wasmtime-traps/unsound-build-
+      returns-0 divergence) — all CI-gated by the fact-spec-oracle job.
       Phase 3 NOT started — the requirement's kill-criterion is gale-measured;
       status stays at implemented (not verified) until Phase 3 reports.
       Phase 3 — measurement vs the 0.45x floor: gale re-measures gust_mix on
@@ -1692,7 +1729,7 @@ artifacts:
       floor (0.45x) gives the target 0.25x of headroom — if the productized
       elision cannot land inside it, the premise-to-selector plumbing (not the
       idea) is at fault and the phase re-plans.
-    # implemented (not verified): Phases 1+2 of 3 landed with their oracles —
+    # implemented (not verified): Phases 1+2+2b of 3 landed with their oracles —
     # the elision exists, certificate-gated and differential-tested. The
     # requirement's kill-criterion (Phase 3, gale-measured 0.70x vs native)
     # has NO evidence yet — never strengthen a traceability claim beyond it.

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -264,6 +264,24 @@ fn compile_wasm_to_arm(
     // cannot grow); a runtime delta that happens to be 0 is the documented
     // follow-up.
     let rewritten = rewrite_memory_grow_zero(wasm_ops);
+    // #494 phase 2b: the fact-spec guard-elision marks are keyed by op index
+    // into the stream the DRIVER handed us. The memory.grow(0) fold above can
+    // only shift indices AT OR AFTER a `memory.grow` — an op the fact-spec
+    // walk never crosses (it stops at the first untracked op, so no mark can
+    // follow one). Defense in depth: if the fold fired at all, drop the marks
+    // loudly rather than risk keying a guard elision to the wrong op.
+    let (fact_div_zero_elide, fact_div_ovf_elide): (&[usize], &[usize]) = if rewritten.len()
+        == wasm_ops.len()
+    {
+        (&config.fact_div_zero_elide, &config.fact_div_ovf_elide)
+    } else {
+        if !config.fact_div_zero_elide.is_empty() || !config.fact_div_ovf_elide.is_empty() {
+            eprintln!(
+                "fact-spec: DECLINE div-guard elision marks dropped — the                      memory.grow(0) fold shifted op indices (#494 defensive gate);                      general lowering emitted"
+            );
+        }
+        (&[], &[])
+    };
     let wasm_ops: &[WasmOp] = &rewritten;
 
     let num_params = count_params(wasm_ops);
@@ -348,6 +366,10 @@ fn compile_wasm_to_arm(
         // which on a dense function leaves the spill allocator with nothing to
         // free → the frame-slot path is the escape that restores compilability).
         selector.set_local_promote(local_promote);
+        // #494 phase 2b: certificate-discharged div/rem trap-guard elision
+        // marks (empty in every compile without SYNTH_FACT_SPEC + facts).
+        selector
+            .set_fact_div_guard_elisions(fact_div_zero_elide.to_vec(), fact_div_ovf_elide.to_vec());
         selector.select_with_stack(wasm_ops, num_params)
     };
     let select_direct = || -> Result<Vec<ArmInstruction>, String> {
@@ -517,11 +539,19 @@ fn compile_wasm_to_arm(
         .iter()
         .take(num_params as usize)
         .any(|&w| w);
+    // #494 phase 2b: div/rem guard-elision marks are consumed by the DIRECT
+    // selector only — the optimized path's IR passes (const-fold/CSE/DCE)
+    // renumber instructions, so an op-index-keyed mark cannot soundly survive
+    // them. Route marked functions direct (the #507/#509 honest-degradation
+    // pattern). Never fires without SYNTH_FACT_SPEC + facts + a discharged
+    // obligation, so every existing compile keeps its path byte-identical.
+    let has_fact_div_elide = !fact_div_zero_elide.is_empty() || !fact_div_ovf_elide.is_empty();
     let arm_instrs = if config.no_optimize
         || config.relocatable
         || has_br_table
         || has_value_carry
         || has_wide_param
+        || has_fact_div_elide
     {
         if std::env::var("SYNTH_PATH_DEBUG").is_ok() {
             eprintln!("[path-debug] direct (pre-gate)");

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -948,9 +948,14 @@ impl ArmEncoder {
                 rnhi,
                 rmlo,
                 rmhi,
+                elide_zero_guard,
             } => {
                 emit_a32_i64_fixed_abi_entry(&mut b, &[rnlo, rnhi, rmlo, rmhi]);
-                emit_a32_i64_divisor_zero_trap(&mut b);
+                // #494 phase 2b: elided only under a certificate-discharged
+                // UNSAT(P ∧ divisor == 0) obligation (fact-spec pass).
+                if !elide_zero_guard {
+                    emit_a32_i64_divisor_zero_trap(&mut b);
+                }
                 w(&mut b, 0xE92D_00F0); // PUSH {R4-R7}
                 for r in 4..8u32 {
                     w(&mut b, 0xE3A0_0000 | (r << 12)); // MOV Rr, #0
@@ -971,12 +976,23 @@ impl ArmEncoder {
                 rnhi,
                 rmlo,
                 rmhi,
+                elide_zero_guard,
+                elide_overflow_guard,
             } => {
                 emit_a32_i64_fixed_abi_entry(&mut b, &[rnlo, rnhi, rmlo, rmhi]);
-                emit_a32_i64_divisor_zero_trap(&mut b);
-                // #633: INT64_MIN / -1 overflows — trap like the i32 path
-                // (rem_s stays guard-free: rem_s(INT64_MIN, -1) == 0).
-                emit_a32_i64_divs_overflow_trap(&mut b);
+                // #494 phase 2b: two INDEPENDENT guards, two INDEPENDENT
+                // obligations. The zero guard falls to UNSAT(P ∧ divisor == 0);
+                // the #633 overflow guard falls ONLY to
+                // UNSAT(P ∧ dividend == INT64_MIN ∧ divisor == -1) — a
+                // divisor-nonzero fact alone must keep it.
+                if !elide_zero_guard {
+                    emit_a32_i64_divisor_zero_trap(&mut b);
+                }
+                if !elide_overflow_guard {
+                    // #633: INT64_MIN / -1 overflows — trap like the i32 path
+                    // (rem_s stays guard-free: rem_s(INT64_MIN, -1) == 0).
+                    emit_a32_i64_divs_overflow_trap(&mut b);
+                }
                 w(&mut b, 0xE92D_0FF0); // PUSH {R4-R11}
                 w(&mut b, 0xE021_9003); // EOR R9, R1, R3 (result sign in MSB)
                 skip_negate_if_positive(&mut b, 1);
@@ -1003,9 +1019,12 @@ impl ArmEncoder {
                 rnhi,
                 rmlo,
                 rmhi,
+                elide_zero_guard,
             } => {
                 emit_a32_i64_fixed_abi_entry(&mut b, &[rnlo, rnhi, rmlo, rmhi]);
-                emit_a32_i64_divisor_zero_trap(&mut b);
+                if !elide_zero_guard {
+                    emit_a32_i64_divisor_zero_trap(&mut b);
+                }
                 w(&mut b, 0xE92D_01F0); // PUSH {R4-R8}
                 for r in 4..8u32 {
                     w(&mut b, 0xE3A0_0000 | (r << 12)); // MOV Rr, #0
@@ -1025,9 +1044,12 @@ impl ArmEncoder {
                 rnhi,
                 rmlo,
                 rmhi,
+                elide_zero_guard,
             } => {
                 emit_a32_i64_fixed_abi_entry(&mut b, &[rnlo, rnhi, rmlo, rmhi]);
-                emit_a32_i64_divisor_zero_trap(&mut b);
+                if !elide_zero_guard {
+                    emit_a32_i64_divisor_zero_trap(&mut b);
+                }
                 w(&mut b, 0xE92D_0FF0); // PUSH {R4-R11}
                 w(&mut b, 0xE1A0_9001); // MOV R9, R1 (dividend sign)
                 skip_negate_if_positive(&mut b, 1);
@@ -5280,10 +5302,15 @@ impl ArmEncoder {
                 rnhi,
                 rmlo,
                 rmhi,
+                elide_zero_guard,
             } => {
                 let mut bytes = Vec::new();
                 emit_i64_fixed_abi_entry(&mut bytes, &[rnlo, rnhi, rmlo, rmhi]);
-                emit_i64_divisor_zero_trap(&mut bytes);
+                // #494 phase 2b: elided only under a certificate-discharged
+                // UNSAT(P ∧ divisor == 0) obligation (fact-spec pass).
+                if !elide_zero_guard {
+                    emit_i64_divisor_zero_trap(&mut bytes);
+                }
 
                 // PUSH {R4-R7} - save scratch registers (NO LR — this is inline code)
                 // 16-bit PUSH: 1011 010 M rrrrrrrr where M=0 (no LR), r=R4-R7 = 0xF0
@@ -5412,13 +5439,24 @@ impl ArmEncoder {
                 rnhi,
                 rmlo,
                 rmhi,
+                elide_zero_guard,
+                elide_overflow_guard,
             } => {
                 let mut bytes = Vec::new();
                 emit_i64_fixed_abi_entry(&mut bytes, &[rnlo, rnhi, rmlo, rmhi]);
-                emit_i64_divisor_zero_trap(&mut bytes);
-                // #633: INT64_MIN / -1 overflows — trap like the i32 path
-                // (rem_s stays guard-free: rem_s(INT64_MIN, -1) == 0).
-                emit_i64_divs_overflow_trap(&mut bytes);
+                // #494 phase 2b: two INDEPENDENT guards, two INDEPENDENT
+                // obligations. The zero guard falls to UNSAT(P ∧ divisor == 0);
+                // the #633 overflow guard falls ONLY to
+                // UNSAT(P ∧ dividend == INT64_MIN ∧ divisor == -1) — a
+                // divisor-nonzero fact alone must keep it.
+                if !elide_zero_guard {
+                    emit_i64_divisor_zero_trap(&mut bytes);
+                }
+                if !elide_overflow_guard {
+                    // #633: INT64_MIN / -1 overflows — trap like the i32 path
+                    // (rem_s stays guard-free: rem_s(INT64_MIN, -1) == 0).
+                    emit_i64_divs_overflow_trap(&mut bytes);
+                }
 
                 // PUSH {R4-R11} - save scratch registers (NO LR — inline code)
                 bytes.extend_from_slice(&0xE92Du16.to_le_bytes());
@@ -5545,10 +5583,13 @@ impl ArmEncoder {
                 rnhi,
                 rmlo,
                 rmhi,
+                elide_zero_guard,
             } => {
                 let mut bytes = Vec::new();
                 emit_i64_fixed_abi_entry(&mut bytes, &[rnlo, rnhi, rmlo, rmhi]);
-                emit_i64_divisor_zero_trap(&mut bytes);
+                if !elide_zero_guard {
+                    emit_i64_divisor_zero_trap(&mut bytes);
+                }
 
                 // PUSH {R4-R8} - save scratch registers (NO LR — inline code)
                 bytes.extend_from_slice(&0xE92Du16.to_le_bytes());
@@ -5633,10 +5674,13 @@ impl ArmEncoder {
                 rnhi,
                 rmlo,
                 rmhi,
+                elide_zero_guard,
             } => {
                 let mut bytes = Vec::new();
                 emit_i64_fixed_abi_entry(&mut bytes, &[rnlo, rnhi, rmlo, rmhi]);
-                emit_i64_divisor_zero_trap(&mut bytes);
+                if !elide_zero_guard {
+                    emit_i64_divisor_zero_trap(&mut bytes);
+                }
 
                 // PUSH {R4-R11} - save scratch registers (NO LR — inline code)
                 bytes.extend_from_slice(&0xE92Du16.to_le_bytes());
@@ -9890,6 +9934,7 @@ mod tests {
                     rnhi,
                     rmlo,
                     rmhi,
+                    elide_zero_guard: false,
                 },
                 1 => ArmOp::I64RemU {
                     rdlo,
@@ -9898,6 +9943,7 @@ mod tests {
                     rnhi,
                     rmlo,
                     rmhi,
+                    elide_zero_guard: false,
                 },
                 2 => ArmOp::I64DivS {
                     rdlo,
@@ -9906,6 +9952,8 @@ mod tests {
                     rnhi,
                     rmlo,
                     rmhi,
+                    elide_zero_guard: false,
+                    elide_overflow_guard: false,
                 },
                 _ => ArmOp::I64RemS {
                     rdlo,
@@ -9914,6 +9962,7 @@ mod tests {
                     rnhi,
                     rmlo,
                     rmhi,
+                    elide_zero_guard: false,
                 },
             }
         };
@@ -9951,6 +10000,7 @@ mod tests {
                 rnhi: Reg::R1,
                 rmlo: Reg::R2,
                 rmhi: Reg::R3,
+                elide_zero_guard: false,
             })
             .unwrap();
         let tail: Vec<u16> = code[code.len() - 12..]
@@ -9975,6 +10025,7 @@ mod tests {
             rnhi: Reg::R3,
             rmlo: Reg::R4,
             rmhi: Reg::R5,
+            elide_zero_guard: false,
         });
         assert!(result.is_err(), "swapped rd pair must be rejected loudly");
     }
@@ -10118,6 +10169,8 @@ mod tests {
                 rnhi: Reg::R1,
                 rmlo: Reg::R2,
                 rmhi: Reg::R3,
+                elide_zero_guard: false,
+                elide_overflow_guard: false,
             })
             .unwrap();
         // 26-byte marshal + 8-byte zero-trap, then the 22-byte overflow guard.
@@ -10157,6 +10210,7 @@ mod tests {
                     rnhi: Reg::R1,
                     rmlo: Reg::R2,
                     rmhi: Reg::R3,
+                    elide_zero_guard: false,
                 },
             ),
             (
@@ -10168,6 +10222,8 @@ mod tests {
                     rnhi: Reg::R1,
                     rmlo: Reg::R2,
                     rmhi: Reg::R3,
+                    elide_zero_guard: false,
+                    elide_overflow_guard: false,
                 },
             ),
         ] {
@@ -10184,6 +10240,132 @@ mod tests {
         }
     }
 
+    /// #494 phase 2b: `elide_zero_guard` drops EXACTLY the 8-byte fused
+    /// zero-trap (`ORRS.W R12,R2,R3; BNE; UDF #0`) and nothing else — the
+    /// rest of the expansion is byte-identical (splice check).
+    #[test]
+    fn test_494_i64_zero_guard_elision_is_exact_splice() {
+        let encoder = ArmEncoder::new_thumb2();
+        let mk = |elide_zero_guard: bool| {
+            encoder
+                .encode(&ArmOp::I64DivU {
+                    rdlo: Reg::R4,
+                    rdhi: Reg::R5,
+                    rnlo: Reg::R0,
+                    rnhi: Reg::R1,
+                    rmlo: Reg::R2,
+                    rmhi: Reg::R3,
+                    elide_zero_guard,
+                })
+                .unwrap()
+        };
+        let full = mk(false);
+        let elided = mk(true);
+        assert_eq!(full.len(), elided.len() + 8, "zero guard is 8 bytes");
+        // Marshal prologue (26 B) unchanged, guard (8 B) gone, tail identical.
+        assert_eq!(&full[..26], &elided[..26]);
+        assert_eq!(
+            &full[26..34],
+            &[0x52, 0xEA, 0x03, 0x0C, 0x00, 0xD1, 0x00, 0xDE],
+            "the spliced-out bytes are exactly ORRS.W; BNE; UDF #0"
+        );
+        assert_eq!(&full[34..], &elided[26..]);
+    }
+
+    /// #494 phase 2b two-guard distinction (the #633/#634 synergy): a
+    /// divisor-nonzero fact elides ONLY the zero guard — the INT64_MIN/-1
+    /// OVERFLOW guard is a separate obligation and must survive
+    /// `elide_zero_guard: true`. Pinned on div_s in all flag states.
+    #[test]
+    fn test_494_i64_divs_overflow_guard_retained_when_only_zero_elided() {
+        let encoder = ArmEncoder::new_thumb2();
+        let mk = |zero: bool, ovf: bool| {
+            encoder
+                .encode(&ArmOp::I64DivS {
+                    rdlo: Reg::R4,
+                    rdhi: Reg::R5,
+                    rnlo: Reg::R0,
+                    rnhi: Reg::R1,
+                    rmlo: Reg::R2,
+                    rmhi: Reg::R3,
+                    elide_zero_guard: zero,
+                    elide_overflow_guard: ovf,
+                })
+                .unwrap()
+        };
+        let udf_count = |code: &[u8]| {
+            code.chunks(2)
+                .filter(|c| u16::from_le_bytes([c[0], c[1]]) == 0xDE00)
+                .count()
+        };
+        let full = mk(false, false);
+        let zero_only = mk(true, false);
+        let both = mk(true, true);
+        assert_eq!(udf_count(&full), 2, "baseline: zero trap + overflow trap");
+        assert_eq!(
+            udf_count(&zero_only),
+            1,
+            "divisor-nonzero elides the zero trap ONLY — the #633 overflow \
+             guard must be retained"
+        );
+        // The retained guard is the 22-byte overflow sequence, now right
+        // after the 26-byte marshal prologue.
+        let guard: Vec<u16> = zero_only[26..48]
+            .chunks(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        assert_eq!(
+            guard,
+            vec![
+                0xEA02, 0x0C03, 0xF11C, 0x0F01, 0xD105, 0x2800, 0xD103, 0xF1B1, 0x4F00, 0xD100,
+                0xDE00,
+            ],
+            "the surviving guard is the INT64_MIN/-1 overflow trap"
+        );
+        assert_eq!(full.len(), zero_only.len() + 8);
+        assert_eq!(zero_only.len(), both.len() + 22);
+        assert_eq!(udf_count(&both), 0, "both obligations discharged ⇒ no UDF");
+    }
+
+    /// #494 phase 2b A32 twin: zero-guard elision is an exact 12-byte splice
+    /// and the A32 overflow guard survives a zero-only elision.
+    #[test]
+    fn test_494_a32_i64_guard_elision() {
+        let encoder = ArmEncoder::new_arm32();
+        let mk = |zero: bool, ovf: bool| {
+            encoder
+                .encode(&ArmOp::I64DivS {
+                    rdlo: Reg::R4,
+                    rdhi: Reg::R5,
+                    rnlo: Reg::R0,
+                    rnhi: Reg::R1,
+                    rmlo: Reg::R2,
+                    rmhi: Reg::R3,
+                    elide_zero_guard: zero,
+                    elide_overflow_guard: ovf,
+                })
+                .unwrap()
+        };
+        let full = mk(false, false);
+        let zero_only = mk(true, false);
+        let both = mk(true, true);
+        // A32 zero guard = 3 words (ORRS/BNE/UDF), overflow guard = 6 words.
+        assert_eq!(full.len(), zero_only.len() + 12);
+        assert_eq!(zero_only.len(), both.len() + 24);
+        let udf_count = |code: &[u8]| {
+            code.chunks(4)
+                .filter(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]) == 0xE7F0_00F0)
+                .count()
+        };
+        assert_eq!(udf_count(&full), 2);
+        assert_eq!(
+            udf_count(&zero_only),
+            1,
+            "A32: overflow guard retained under zero-only elision"
+        );
+        assert_eq!(udf_count(&both), 0);
+    }
+
     /// #633: A32 twin — the conditional-execution overflow guard on the
     /// ARM-mode I64DivS, and its absence from I64RemS.
     #[test]
@@ -10196,6 +10378,8 @@ mod tests {
             rnhi: Reg::R1,
             rmlo: Reg::R2,
             rmhi: Reg::R3,
+            elide_zero_guard: false,
+            elide_overflow_guard: false,
         };
         let code = encoder.encode(&mk_divs).unwrap();
         let words: Vec<u32> = code
@@ -10222,6 +10406,7 @@ mod tests {
                 rnhi: Reg::R1,
                 rmlo: Reg::R2,
                 rmhi: Reg::R3,
+                elide_zero_guard: false,
             })
             .unwrap();
         let rems_udfs = rems

--- a/crates/synth-backend/tests/a32_no_silent_nop_615.rs
+++ b/crates/synth-backend/tests/a32_no_silent_nop_615.rs
@@ -673,6 +673,8 @@ fn representatives() -> Vec<ArmOp> {
             rnhi: nh,
             rmlo: ml,
             rmhi: mh,
+            elide_zero_guard: false,
+            elide_overflow_guard: false,
         },
         I64DivU {
             rdlo: dl,
@@ -681,6 +683,7 @@ fn representatives() -> Vec<ArmOp> {
             rnhi: nh,
             rmlo: ml,
             rmhi: mh,
+            elide_zero_guard: false,
         },
         I64RemS {
             rdlo: dl,
@@ -689,6 +692,7 @@ fn representatives() -> Vec<ArmOp> {
             rnhi: nh,
             rmlo: ml,
             rmhi: mh,
+            elide_zero_guard: false,
         },
         I64RemU {
             rdlo: dl,
@@ -697,6 +701,7 @@ fn representatives() -> Vec<ArmOp> {
             rnhi: nh,
             rmlo: ml,
             rmhi: mh,
+            elide_zero_guard: false,
         },
         I64And {
             rdlo: dl,

--- a/crates/synth-backend/tests/estimator_encoder_agreement.rs
+++ b/crates/synth-backend/tests/estimator_encoder_agreement.rs
@@ -692,6 +692,7 @@ fn cases() -> Vec<Case> {
                 rnhi: Reg::R3,
                 rmlo: Reg::R4,
                 rmhi: Reg::R5,
+                elide_zero_guard: false,
             },
         ),
         agree(
@@ -703,6 +704,7 @@ fn cases() -> Vec<Case> {
                 rnhi: Reg::R3,
                 rmlo: Reg::R4,
                 rmhi: Reg::R5,
+                elide_zero_guard: false,
             },
         ),
         agree(
@@ -714,6 +716,8 @@ fn cases() -> Vec<Case> {
                 rnhi: Reg::R3,
                 rmlo: Reg::R4,
                 rmhi: Reg::R5,
+                elide_zero_guard: false,
+                elide_overflow_guard: false,
             },
         ),
         agree(
@@ -725,6 +729,73 @@ fn cases() -> Vec<Case> {
                 rnhi: Reg::R3,
                 rmlo: Reg::R4,
                 rmhi: Reg::R5,
+                elide_zero_guard: false,
+            },
+        ),
+        // #494 phase 2b: the guard-elided forms must track the encoder too —
+        // the zero guard is 8 bytes (ORRS.W + BNE + UDF), the #633 div_s
+        // overflow guard 22 bytes, and they elide INDEPENDENTLY (two separate
+        // proof obligations; divisor-nonzero alone keeps the overflow guard).
+        agree(
+            "I64DivU_zero_elided",
+            I64DivU {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+                rnhi: Reg::R3,
+                rmlo: Reg::R4,
+                rmhi: Reg::R5,
+                elide_zero_guard: true,
+            },
+        ),
+        agree(
+            "I64RemU_zero_elided",
+            I64RemU {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+                rnhi: Reg::R3,
+                rmlo: Reg::R4,
+                rmhi: Reg::R5,
+                elide_zero_guard: true,
+            },
+        ),
+        agree(
+            "I64DivS_zero_elided_ovf_retained",
+            I64DivS {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+                rnhi: Reg::R3,
+                rmlo: Reg::R4,
+                rmhi: Reg::R5,
+                elide_zero_guard: true,
+                elide_overflow_guard: false,
+            },
+        ),
+        agree(
+            "I64DivS_both_elided",
+            I64DivS {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+                rnhi: Reg::R3,
+                rmlo: Reg::R4,
+                rmhi: Reg::R5,
+                elide_zero_guard: true,
+                elide_overflow_guard: true,
+            },
+        ),
+        agree(
+            "I64RemS_zero_elided",
+            I64RemS {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                rnlo: Reg::R2,
+                rnhi: Reg::R3,
+                rmlo: Reg::R4,
+                rmhi: Reg::R5,
+                elide_zero_guard: true,
             },
         ),
         // ===================== REMAINING KNOWN GAPS =====================

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -24,6 +24,13 @@ path = "src/main.rs"
 name = "fact_spec_clamp_494"
 required-features = ["verify"]
 
+# #494 phase 2b (divisor-nonzero): same contract — the guard-elision byte
+# gates need the solver-carrying binary; the fact-spec CI job runs it via
+# `cargo test -p synth-cli --features verify --test fact_spec_div_494`.
+[[test]]
+name = "fact_spec_div_494"
+required-features = ["verify"]
+
 [features]
 default = ["riscv"]
 awsm = ["synth-backend-awsm"]

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -60,26 +60,43 @@ struct SpecializedFn {
     /// parallel side-tables (`op_offsets` feeding `.debug_line`).
     #[cfg_attr(not(feature = "verify"), allow(dead_code))]
     kept: Vec<usize>,
+    /// #494 phase 2b: div/rem sites (indices into `ops`) whose divide-by-zero
+    /// guard was certificate-elided — threaded to
+    /// `CompileConfig::fact_div_zero_elide` for the direct selector.
+    elide_div_zero: Vec<usize>,
+    /// #494 phase 2b: `div_s` sites whose INT_MIN/-1 overflow guard was
+    /// certificate-elided (a SEPARATE obligation — divisor-nonzero alone
+    /// never lands here, #633/#634).
+    elide_div_ovf: Vec<usize>,
 }
 
 /// Run the fact-spec pass (value-range facts ⇒ dead conditional-branch
-/// elision, `docs/design/proof-carrying-specialization.md`) for one function.
-/// Every elision was individually discharged by the ordeal-backed solver
-/// (UNSAT(P ∧ cond ≠ 0), certificate-checked) BEFORE this returns; admits and
-/// declines are logged per function. Returns `Some` only when the op stream
-/// actually changed — `None` means the general lowering proceeds untouched.
+/// elision; #494 phase 2b: divisor-nonzero facts ⇒ div/rem trap-guard
+/// elision marks — `docs/design/proof-carrying-specialization.md`) for one
+/// function. Every elision was individually discharged by the ordeal-backed
+/// solver (certificate-checked) BEFORE this returns; admits and declines are
+/// logged per function. Returns `Some` when the op stream changed OR at
+/// least one guard-elision mark was admitted — `None` means the general
+/// lowering proceeds untouched.
 fn maybe_fact_spec(
     func_name: &str,
     ops: &[WasmOp],
     block_arity: &[(u8, u8)],
     facts: &[WscFact],
+    params_i64: &[bool],
 ) -> Option<SpecializedFn> {
     if !fact_spec_enabled() || facts.is_empty() {
         return None;
     }
     #[cfg(feature = "verify")]
     {
-        let r = synth_verify::fact_spec::specialize_function(func_name, ops, block_arity, facts);
+        let r = synth_verify::fact_spec::specialize_function(
+            func_name,
+            ops,
+            block_arity,
+            facts,
+            params_i64,
+        );
         // Loud by contract: every decline names its site and reason; every
         // admit carries the certificate line (the evidence trail).
         for line in &r.declined {
@@ -88,26 +105,30 @@ fn maybe_fact_spec(
         for line in &r.admitted {
             eprintln!("fact-spec: ADMIT {line}");
         }
-        if r.changed() {
+        if r.changed() || !r.elide_div_zero.is_empty() || !r.elide_div_ovf.is_empty() {
             eprintln!(
                 "fact-spec: '{func_name}' specialized — {} elision(s) admitted, \
-                 {} declined ({} → {} ops)",
+                 {} declined ({} → {} ops, {} zero-guard + {} overflow-guard marks)",
                 r.admitted.len(),
                 r.declined.len(),
                 ops.len(),
-                r.ops.len()
+                r.ops.len(),
+                r.elide_div_zero.len(),
+                r.elide_div_ovf.len(),
             );
             return Some(SpecializedFn {
                 ops: r.ops,
                 block_arity: r.block_arity,
                 kept: r.kept,
+                elide_div_zero: r.elide_div_zero,
+                elide_div_ovf: r.elide_div_ovf,
             });
         }
         None
     }
     #[cfg(not(feature = "verify"))]
     {
-        let _ = (func_name, ops, block_arity, facts);
+        let _ = (func_name, ops, block_arity, facts, params_i64);
         // Decline loudly (the design doc's rule): without the solver the
         // obligation cannot be discharged, so no elision may fire — but the
         // user asked for specialization, so say why nothing happens.
@@ -1382,14 +1403,21 @@ fn compile_command(
     // per-elision ordeal obligation. No-op unless the module carried facts,
     // the flag is on, AND at least one elision was certificate-admitted.
     let mut wasm_ops = wasm_ops;
+    let mut fact_div_zero_elide = Vec::new();
+    let mut fact_div_ovf_elide = Vec::new();
     if let Some(spec) = maybe_fact_spec(
         &func_name,
         &wasm_ops,
         &current_func_block_arity,
         &current_func_facts,
+        &current_func_params_i64,
     ) {
         wasm_ops = spec.ops;
         current_func_block_arity = spec.block_arity;
+        // #494 phase 2b: certificate-discharged div/rem guard-elision marks,
+        // keyed by index into the (possibly rewritten) stream above.
+        fact_div_zero_elide = spec.elide_div_zero;
+        fact_div_ovf_elide = spec.elide_div_ovf;
     }
 
     info!("WASM operations: {:?}", wasm_ops);
@@ -1415,6 +1443,10 @@ fn compile_command(
         // `current_func_facts` in the selector behind SYNTH_FACT_SPEC.
         wsc_facts,
         current_func_facts,
+        // VCR-PERF-002 Phase 2b (#494): div/rem trap-guard elision marks —
+        // empty unless SYNTH_FACT_SPEC + facts + a discharged obligation.
+        fact_div_zero_elide,
+        fact_div_ovf_elide,
         ..CompileConfig::default()
     };
 
@@ -2419,10 +2451,16 @@ fn compile_all_exports(
             &func.ops,
             &func_config.current_func_block_arity,
             &func_config.current_func_facts,
+            &func_config.current_func_params_i64,
         );
         let (ops_for_compile, op_offsets_for_elf): (&[WasmOp], Vec<u32>) = match &spec {
             Some(s) => {
                 func_config.current_func_block_arity = s.block_arity.clone();
+                // #494 phase 2b: certificate-discharged div/rem guard-elision
+                // marks, keyed by index into the rewritten stream the backend
+                // is about to consume.
+                func_config.fact_div_zero_elide = s.elide_div_zero.clone();
+                func_config.fact_div_ovf_elide = s.elide_div_ovf.clone();
                 (
                     &s.ops,
                     s.kept

--- a/crates/synth-cli/tests/fact_spec_div_494.rs
+++ b/crates/synth-cli/tests/fact_spec_div_494.rs
@@ -1,0 +1,346 @@
+//! VCR-PERF-002 Phase 2b (#494) — end-to-end gates for the divisor-nonzero
+//! trap-guard elision (`SYNTH_FACT_SPEC`, default OFF; per-site ordeal
+//! obligations, one per GUARD — the #633/#634 two-guard distinction).
+//!
+//! Requires the `verify` feature (the pass needs the ordeal-backed solver):
+//! `cargo test -p synth-cli --features verify --test fact_spec_div_494`
+//! (the fact-spec CI job does). The execution differential (oracle 3 —
+//! specialized ≡ wasmtime ≡ unspecialized over the proven bound, plus the
+//! red force-admit divergence demo) lives in
+//! `scripts/repro/fact_spec_div_494_differential.py`; here we lock the byte
+//! evidence and the certificate trail on `scripts/repro/fact_spec_div_494.wat`:
+//!
+//! - flag OFF + facts present → byte-identical to baseline (no consumer);
+//! - flag ON + proven bounds  → the guard UDFs are GONE from qu/qs/ru, the
+//!   i64 zero guard is gone from qs64 while its INT64_MIN/-1 OVERFLOW guard
+//!   is RETAINED (divisor-nonzero alone never elides it), with one ADMIT
+//!   certificate line per discharged obligation;
+//! - flag ON + bound including 0 → Sat, loud decline, byte-identical
+//!   (the guard is restored by the OBLIGATION, not by prudence);
+//! - debug-only red lever: `SYNTH_FACT_SPEC_FORCE_ADMIT` admits the Sat site
+//!   anyway (screaming) — the guard bytes vanish, proving the harness would
+//!   catch an unsound admit; unsetting it restores baseline byte-identically.
+//!
+//! Frozen anchors are untouched by construction (no fixture carries a facts
+//! section) and additionally locked by `frozen_codegen_bytes.rs`.
+
+use object::{Object, ObjectSection, ObjectSymbol};
+use std::process::Command;
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture_wasm() -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro/fact_spec_div_494.wat");
+    let wat = std::fs::read(path).expect("read fixture wat");
+    wat::parse_bytes(&wat)
+        .expect("fixture wat must parse")
+        .into_owned()
+}
+
+// ---- schema-v1 encoders (mirror docs/design/wsc-facts-encoding.md) ----
+
+fn leb_u32(mut v: u32, out: &mut Vec<u8>) {
+    loop {
+        let mut b = (v & 0x7f) as u8;
+        v >>= 7;
+        if v != 0 {
+            b |= 0x80;
+        }
+        out.push(b);
+        if v == 0 {
+            return;
+        }
+    }
+}
+
+fn leb_s64(mut v: i64, out: &mut Vec<u8>) {
+    loop {
+        let mut b = (v & 0x7f) as u8;
+        v >>= 7;
+        let done = (v == 0 && b & 0x40 == 0) || (v == -1 && b & 0x40 != 0);
+        if !done {
+            b |= 0x80;
+        }
+        out.push(b);
+        if done {
+            return;
+        }
+    }
+}
+
+enum Fact {
+    /// kind 0x01 — value-range `[lo, hi]` on `(func, value_id)`.
+    Range(u32, u32, i64, i64),
+    /// kind 0x03 — divisor-nonzero on `(func, value_id)`.
+    NonZero(u32, u32),
+}
+
+/// Append the facts as one `wsc.facts` custom section.
+fn with_facts(mut wasm: Vec<u8>, facts: &[Fact]) -> Vec<u8> {
+    let mut payload = vec![0x01]; // version
+    leb_u32(facts.len() as u32, &mut payload);
+    for f in facts {
+        match f {
+            Fact::Range(func, vid, lo, hi) => {
+                let mut body = Vec::new();
+                leb_s64(*lo, &mut body);
+                leb_s64(*hi, &mut body);
+                payload.push(0x01);
+                leb_u32(*func, &mut payload);
+                leb_u32(*vid, &mut payload);
+                leb_u32(body.len() as u32, &mut payload);
+                payload.extend_from_slice(&body);
+            }
+            Fact::NonZero(func, vid) => {
+                payload.push(0x03);
+                leb_u32(*func, &mut payload);
+                leb_u32(*vid, &mut payload);
+                leb_u32(0, &mut payload); // empty body
+            }
+        }
+    }
+    let name = b"wsc.facts";
+    let mut content = Vec::new();
+    leb_u32(name.len() as u32, &mut content);
+    content.extend_from_slice(name);
+    content.extend_from_slice(&payload);
+    wasm.push(0x00);
+    leb_u32(content.len() as u32, &mut wasm);
+    wasm.extend_from_slice(&content);
+    wasm
+}
+
+/// The green-run facts: d ∈ [1, 64] on the i32 divisors (discharges BOTH
+/// div_s obligations), divisor-nonzero (kind 3) on the i64 divisor
+/// (discharges the zero obligation ONLY — the overflow guard must survive).
+fn proven_facts() -> Vec<Fact> {
+    vec![
+        Fact::Range(0, 1, 1, 64),
+        Fact::Range(1, 1, 1, 64),
+        Fact::Range(2, 1, 1, 64),
+        Fact::NonZero(3, 1),
+    ]
+}
+
+/// Compile on the shipped ARM path; return (.text, per-function slices, stderr).
+fn compile(wasm: &[u8], tag: &str, fact_spec: bool, force_admit: bool) -> Compiled {
+    let dir = std::env::temp_dir().join("fact_spec_div_494");
+    std::fs::create_dir_all(&dir).expect("mk tempdir");
+    let input = dir.join(format!("{tag}.wasm"));
+    let elf = dir.join(format!("{tag}.elf"));
+    std::fs::write(&input, wasm).expect("write wasm");
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        input.to_str().unwrap(),
+        "-o",
+        elf.to_str().unwrap(),
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+    ]);
+    if fact_spec {
+        cmd.env("SYNTH_FACT_SPEC", "1");
+    } else {
+        cmd.env_remove("SYNTH_FACT_SPEC");
+    }
+    if force_admit {
+        cmd.env("SYNTH_FACT_SPEC_FORCE_ADMIT", "1");
+    } else {
+        cmd.env_remove("SYNTH_FACT_SPEC_FORCE_ADMIT");
+    }
+    let out = cmd.output().expect("run synth");
+    assert!(
+        out.status.success(),
+        "compile of '{tag}' failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let bytes = std::fs::read(&elf).expect("read elf");
+    let obj = object::File::parse(&*bytes).expect("parse elf");
+    let text_section = obj.section_by_name(".text").expect(".text");
+    let text = text_section.data().expect("read .text").to_vec();
+    let text_addr = text_section.address();
+    // Function regions from the symtab (the #489 lesson: symbols, not disasm
+    // text). st_size may be 0 on this builder — slice to the next symbol.
+    let text_end = text_addr + text.len() as u64;
+    let mut syms: Vec<(String, u64)> = obj
+        .symbols()
+        .filter(|s| {
+            // Thumb function symbols may carry the interworking bit.
+            let addr = s.address() & !1;
+            !s.name().unwrap_or("").is_empty() && addr >= text_addr && addr < text_end
+        })
+        .map(|s| {
+            (
+                s.name().unwrap().to_string(),
+                (s.address() & !1) - text_addr,
+            )
+        })
+        .collect();
+    syms.sort_by_key(|&(_, a)| a);
+    let mut funcs = std::collections::HashMap::new();
+    for (i, (name, start)) in syms.iter().enumerate() {
+        let end = syms
+            .get(i + 1)
+            .map(|&(_, a)| a as usize)
+            .unwrap_or(text.len())
+            .min(text.len());
+        funcs.insert(name.clone(), text[*start as usize..end].to_vec());
+    }
+    Compiled {
+        text,
+        funcs,
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+struct Compiled {
+    text: Vec<u8>,
+    funcs: std::collections::HashMap<String, Vec<u8>>,
+    stderr: String,
+}
+
+impl Compiled {
+    /// Count aligned 16-bit words equal to `hw` in a function's region.
+    fn halfword_count(&self, func: &str, hw: u16) -> usize {
+        let code = self
+            .funcs
+            .get(func)
+            .unwrap_or_else(|| panic!("symbol '{func}' missing from symtab"));
+        code.chunks_exact(2)
+            .filter(|c| u16::from_le_bytes([c[0], c[1]]) == hw)
+            .count()
+    }
+}
+
+const UDF0: u16 = 0xDE00; // divide-by-zero trap (and the i64 overflow trap)
+const UDF1: u16 = 0xDE01; // i32 div_s INT32_MIN/-1 overflow trap
+
+/// Flag OFF is byte-identical to baseline even with facts present.
+#[test]
+fn flag_off_with_facts_is_byte_identical_494() {
+    let base = fixture_wasm();
+    let facts = with_facts(base.clone(), &proven_facts());
+    let t_base = compile(&base, "off_base", false, false);
+    let t_facts = compile(&facts, "off_facts", false, false);
+    assert_eq!(
+        t_base.text, t_facts.text,
+        "SYNTH_FACT_SPEC unset must never consume facts"
+    );
+}
+
+/// THE PHASE-2b GATE (byte evidence, oracle 2): under the proven facts every
+/// divide-by-zero guard is certificate-elided; the i32 div_s overflow guard
+/// falls to the range fact's SEPARATE obligation; and the i64 div_s overflow
+/// guard is RETAINED because divisor-nonzero alone does not discharge it
+/// (#633/#634 — oracle 5).
+#[test]
+fn proven_facts_elide_guards_and_retain_i64_overflow_guard_494() {
+    let base = fixture_wasm();
+    let facts = with_facts(base.clone(), &proven_facts());
+    let b = compile(&base, "proven_base", false, false);
+    let s = compile(&facts, "proven_spec", true, false);
+
+    // Baseline guard census: the guards are present without facts.
+    assert_eq!(b.halfword_count("qu", UDF0), 1, "qu zero guard present");
+    assert_eq!(b.halfword_count("qs", UDF0), 1, "qs zero guard present");
+    assert_eq!(b.halfword_count("qs", UDF1), 1, "qs overflow guard present");
+    assert_eq!(b.halfword_count("ru", UDF0), 1, "ru zero guard present");
+    assert_eq!(
+        b.halfword_count("qs64", UDF0),
+        2,
+        "qs64: zero trap + overflow trap"
+    );
+
+    // Specialized census: zero guards gone everywhere; i32 ovf gone (range
+    // fact proves divisor != -1); i64 ovf RETAINED (kind-3 fact cannot).
+    assert_eq!(s.halfword_count("qu", UDF0), 0, "qu zero guard elided");
+    assert_eq!(s.halfword_count("qs", UDF0), 0, "qs zero guard elided");
+    assert_eq!(s.halfword_count("qs", UDF1), 0, "qs overflow guard elided");
+    assert_eq!(s.halfword_count("ru", UDF0), 0, "ru zero guard elided");
+    assert_eq!(
+        s.halfword_count("qs64", UDF0),
+        1,
+        "qs64: zero guard elided, INT64_MIN/-1 overflow guard RETAINED \
+         (divisor ≠ 0 does not exclude -1 — the two-guard distinction)"
+    );
+
+    // Certificate trail: one ADMIT per discharged obligation — qu 1, qs 2
+    // (zero + overflow, independently), ru 1, qs64 1 (zero only) = 5.
+    let admits = s.stderr.matches("fact-spec: ADMIT").count();
+    assert_eq!(admits, 5, "stderr:\n{}", s.stderr);
+    assert!(
+        s.stderr.contains("divide-by-zero guard elided")
+            && s.stderr.contains("UNSAT(P ∧ divisor == 0)")
+            && s.stderr.contains("certificate-checked"),
+        "zero-guard admits name their obligation:\n{}",
+        s.stderr
+    );
+    assert!(
+        s.stderr.contains("overflow guard elided")
+            && s.stderr.contains("dividend == INT32_MIN ∧ divisor == -1"),
+        "the i32 overflow admit names its SEPARATE obligation:\n{}",
+        s.stderr
+    );
+    // ... and the retained i64 overflow guard declined LOUDLY.
+    assert!(
+        s.stderr.contains("fact-spec: DECLINE")
+            && s.stderr.contains("overflow-guard obligation Sat")
+            && s.stderr.contains("RETAINED"),
+        "the i64 overflow retention is a loud decline:\n{}",
+        s.stderr
+    );
+}
+
+/// A bound INCLUDING 0 is Sat: loud decline, guard bytes byte-identical to
+/// baseline — the obligation is the gate, not the fact's say-so.
+#[test]
+fn bound_including_zero_declines_and_restores_guard_byte_identically_494() {
+    let base = fixture_wasm();
+    let facts = with_facts(base.clone(), &[Fact::Range(0, 1, 0, 64)]);
+    let b = compile(&base, "sat_base", false, false);
+    let s = compile(&facts, "sat_spec", true, false);
+    assert_eq!(
+        s.stderr.matches("fact-spec: ADMIT").count(),
+        0,
+        "a Sat obligation must never admit:\n{}",
+        s.stderr
+    );
+    assert!(
+        s.stderr.contains("zero-guard obligation Sat") && s.stderr.contains("counterexample"),
+        "declines are loud and carry a model:\n{}",
+        s.stderr
+    );
+    assert_eq!(
+        b.text, s.text,
+        "declined ⇒ the general lowering, byte-identical to baseline"
+    );
+}
+
+/// RED (oracle 4, byte half): the debug-only force-admit lever elides the
+/// guard under a Sat obligation — the UDF vanishes (this is the build whose
+/// divisor=0 divergence the differential script demonstrates). Removing the
+/// forcing restores the guard byte-identically (previous test). The lever
+/// screams in the certificate line and is compiled out of release builds.
+#[test]
+fn force_admit_red_lever_elides_a_sat_guard_and_screams_494() {
+    let base = fixture_wasm();
+    let facts = with_facts(base.clone(), &[Fact::Range(0, 1, 0, 64)]);
+    let forced = compile(&facts, "forced_spec", true, true);
+    assert_eq!(
+        forced.halfword_count("qu", UDF0),
+        0,
+        "the forced build must drop the guard — that is the point of the red demo"
+    );
+    assert!(
+        forced.stderr.contains("UNSOUND FORCED ADMIT"),
+        "the forced admit must scream:\n{}",
+        forced.stderr
+    );
+}

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -229,6 +229,21 @@ pub struct CompileConfig {
     ///
     /// [`current_func_params_i64`]: CompileConfig::current_func_params_i64
     pub current_func_facts: Vec<WscFact>,
+    /// VCR-PERF-002 Phase 2b (#494, divisor-nonzero): op indices (into the op
+    /// stream passed to `compile_function`) of `div`/`rem` ops whose
+    /// DIVIDE-BY-ZERO trap guard is proven dead — the fact-spec pass
+    /// discharged `UNSAT(P ∧ divisor == 0)` per site through the
+    /// certificate-checked ordeal solver BEFORE the driver set this field.
+    /// Consumed by the ARM direct selector (`select_with_stack`); every other
+    /// path ignores it (guards stay — sound). Empty (the default) ⇒ every
+    /// guard is emitted, byte-identical to today.
+    pub fact_div_zero_elide: Vec<usize>,
+    /// VCR-PERF-002 Phase 2b (#494): op indices of `div_s` ops whose
+    /// `INT_MIN / -1` OVERFLOW trap guard is proven dead — a SEPARATE
+    /// obligation (`UNSAT(P ∧ dividend == INT_MIN ∧ divisor == -1)`). A
+    /// divisor-nonzero fact alone NEVER lands here: divisor ≠ 0 does not
+    /// exclude -1 (#633/#634 two-guard distinction). Empty ⇒ guard emitted.
+    pub fact_div_ovf_elide: Vec<usize>,
 }
 
 /// #543 — an integrator-marked volatile linear-memory segment (the DMA transfer
@@ -288,6 +303,11 @@ impl Default for CompileConfig {
             // no consumer anyway) ⇒ emitted bytes unchanged.
             wsc_facts: Vec::new(),
             current_func_facts: Vec::new(),
+            // VCR-PERF-002 Phase 2b (#494): no guard-elision marks unless the
+            // fact-spec pass discharged the per-site obligations. Empty ⇒
+            // every div/rem trap guard is emitted, byte-identical.
+            fact_div_zero_elide: Vec::new(),
+            fact_div_ovf_elide: Vec::new(),
         }
     }
 }

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -1942,6 +1942,18 @@ pub struct InstructionSelector {
     /// (`sel_dsl_mirror_pin_generated_rules_match_handwritten_arms_242`).
     /// See `docs/design/vcr-sel-001-first-increment.md`.
     sel_dsl: bool,
+    /// #494 phase 2b (divisor-nonzero fact): op indices (into the stream fed
+    /// to `select_with_stack`) of `div`/`rem` ops whose DIVIDE-BY-ZERO trap
+    /// guard is proven dead — the fact-spec pass discharged
+    /// `UNSAT(P ∧ divisor == 0)` per site through the certificate-checked
+    /// ordeal solver BEFORE selection. Empty (the default) ⇒ every guard is
+    /// emitted, byte-identical to today.
+    fact_div_zero_elide: Vec<usize>,
+    /// #494 phase 2b: op indices of `div_s` ops whose `INT_MIN / -1` OVERFLOW
+    /// trap guard is proven dead — a SEPARATE obligation
+    /// (`UNSAT(P ∧ dividend == INT_MIN ∧ divisor == -1)`; divisor ≠ 0 alone
+    /// never justifies it, #633/#634). Empty ⇒ guard emitted.
+    fact_div_ovf_elide: Vec<usize>,
 }
 
 /// `SYNTH_SEL_DSL` (VCR-SEL-001, #242): opt-IN lever, default OFF. Set (to
@@ -1982,6 +1994,8 @@ impl InstructionSelector {
             local_promote: false,
             i64_spill_slots: I64_SPILL_SLOTS,
             sel_dsl: sel_dsl_from_env(),
+            fact_div_zero_elide: Vec::new(),
+            fact_div_ovf_elide: Vec::new(),
         }
     }
 
@@ -2015,6 +2029,8 @@ impl InstructionSelector {
             local_promote: false,
             i64_spill_slots: I64_SPILL_SLOTS,
             sel_dsl: sel_dsl_from_env(),
+            fact_div_zero_elide: Vec::new(),
+            fact_div_ovf_elide: Vec::new(),
         }
     }
 
@@ -2071,6 +2087,21 @@ impl InstructionSelector {
     /// the lever without racing on the process environment.
     pub fn set_sel_dsl(&mut self, enabled: bool) {
         self.sel_dsl = enabled;
+    }
+
+    /// #494 phase 2b (divisor-nonzero fact): per-site trap-guard elision marks
+    /// for `div`/`rem` ops, keyed by op index into the stream fed to
+    /// `select_with_stack`. `zero` = sites whose divide-by-zero guard was
+    /// proven dead (`UNSAT(P ∧ divisor == 0)`); `ovf` = `div_s` sites whose
+    /// `INT_MIN / -1` overflow guard was proven dead — a SEPARATE obligation
+    /// (`UNSAT(P ∧ dividend == INT_MIN ∧ divisor == -1)`); divisor ≠ 0 alone
+    /// never elides it (#633/#634). Every mark was discharged by the fact-spec
+    /// pass through the certificate-checked ordeal solver BEFORE selection —
+    /// this setter only CONSUMES marks, it never derives them. Empty (the
+    /// default) ⇒ every guard is emitted, byte-identical to today.
+    pub fn set_fact_div_guard_elisions(&mut self, zero: Vec<usize>, ovf: Vec<usize>) {
+        self.fact_div_zero_elide = zero;
+        self.fact_div_ovf_elide = ovf;
     }
 
     /// Enable relocatable host-link mode (#197): import calls emit a direct
@@ -3286,6 +3317,9 @@ impl InstructionSelector {
                     rnhi: Reg::R1,
                     rmlo: Reg::R2,
                     rmhi: Reg::R3,
+                    // #494: select_default never consumes fact marks — full guards.
+                    elide_zero_guard: false,
+                    elide_overflow_guard: false,
                 }]
             }
 
@@ -3297,6 +3331,7 @@ impl InstructionSelector {
                     rnhi: Reg::R1,
                     rmlo: Reg::R2,
                     rmhi: Reg::R3,
+                    elide_zero_guard: false,
                 }]
             }
 
@@ -3308,6 +3343,7 @@ impl InstructionSelector {
                     rnhi: Reg::R1,
                     rmlo: Reg::R2,
                     rmhi: Reg::R3,
+                    elide_zero_guard: false,
                 }]
             }
 
@@ -3319,6 +3355,7 @@ impl InstructionSelector {
                     rnhi: Reg::R1,
                     rmlo: Reg::R2,
                     rmhi: Reg::R3,
+                    elide_zero_guard: false,
                 }]
             }
 
@@ -7023,7 +7060,11 @@ impl InstructionSelector {
                     } else {
                         // A nonzero constant divisor can never trap; only emit
                         // the div-by-zero guard when the divisor is unknown or 0.
-                        let needs_guard = cdiv.is_none_or(|c| c == 0);
+                        // #494 phase 2b: a certificate-discharged divisor-nonzero
+                        // fact (UNSAT(P ∧ divisor == 0), proven by the fact-spec
+                        // pass before selection) elides it too.
+                        let needs_guard =
+                            cdiv.is_none_or(|c| c == 0) && !self.fact_div_zero_elide.contains(&idx);
                         if needs_guard {
                             // CMP divisor, #0
                             instructions.push(ArmInstruction {
@@ -7106,8 +7147,11 @@ impl InstructionSelector {
                         });
                         stack.push(StackVal::i32(dst));
                     } else {
-                        // Trap check 1: divide by zero (dead for a nonzero const).
-                        let needs_dz_guard = cdiv.is_none_or(|c| c == 0);
+                        // Trap check 1: divide by zero (dead for a nonzero const,
+                        // or under a #494 certificate-discharged divisor-nonzero
+                        // fact — UNSAT(P ∧ divisor == 0)).
+                        let needs_dz_guard =
+                            cdiv.is_none_or(|c| c == 0) && !self.fact_div_zero_elide.contains(&idx);
                         if needs_dz_guard {
                             instructions.push(ArmInstruction {
                                 op: ArmOp::Cmp {
@@ -7130,8 +7174,13 @@ impl InstructionSelector {
                         }
 
                         // Trap check 2: signed overflow (INT_MIN / -1). Dead
-                        // unless the divisor could be -1.
-                        let needs_ovf_guard = cdiv.is_none_or(|c| c == -1);
+                        // unless the divisor could be -1. #494 phase 2b: elidable
+                        // ONLY under its OWN discharged obligation
+                        // (UNSAT(P ∧ dividend == INT_MIN ∧ divisor == -1)) — a
+                        // divisor-nonzero fact alone never elides it (#633/#634:
+                        // nonzero does not exclude -1).
+                        let needs_ovf_guard =
+                            cdiv.is_none_or(|c| c == -1) && !self.fact_div_ovf_elide.contains(&idx);
                         if needs_ovf_guard {
                             // We need a temp register for INT_MIN (0x80000000)
                             let tmp = alloc_temp_or_spill(
@@ -7254,8 +7303,11 @@ impl InstructionSelector {
                         });
                         stack.push(StackVal::i32(dst));
                     } else {
-                        // Trap check: divide by zero (dead for a nonzero const).
-                        let needs_guard = cdiv.is_none_or(|c| c == 0);
+                        // Trap check: divide by zero (dead for a nonzero const,
+                        // or under a #494 certificate-discharged divisor-nonzero
+                        // fact).
+                        let needs_guard =
+                            cdiv.is_none_or(|c| c == 0) && !self.fact_div_zero_elide.contains(&idx);
                         if needs_guard {
                             instructions.push(ArmInstruction {
                                 op: ArmOp::Cmp {
@@ -7355,8 +7407,10 @@ impl InstructionSelector {
                         stack.push(StackVal::i32(dst));
                     } else {
                         // Trap check: divide by zero (rem_s doesn't trap on
-                        // INT_MIN % -1). Dead for a nonzero constant divisor.
-                        let needs_guard = cdiv.is_none_or(|c| c == 0);
+                        // INT_MIN % -1). Dead for a nonzero constant divisor, or
+                        // under a #494 certificate-discharged divisor-nonzero fact.
+                        let needs_guard =
+                            cdiv.is_none_or(|c| c == 0) && !self.fact_div_zero_elide.contains(&idx);
                         if needs_guard {
                             instructions.push(ArmInstruction {
                                 op: ArmOp::Cmp {
@@ -10370,6 +10424,12 @@ impl InstructionSelector {
                         &live_params,
                         idx,
                     )?;
+                    // #494 phase 2b: certificate-discharged guard-elision marks
+                    // (fact-spec pass, UNSAT obligations checked BEFORE selection).
+                    // The overflow mark applies to div_s ONLY and is a separate
+                    // obligation from the zero mark (#633/#634).
+                    let elide_zero_guard = self.fact_div_zero_elide.contains(&idx);
+                    let elide_overflow_guard = self.fact_div_ovf_elide.contains(&idx);
                     let arm_op = match op {
                         I64DivS => ArmOp::I64DivS {
                             rdlo: dst_lo,
@@ -10378,6 +10438,8 @@ impl InstructionSelector {
                             rnhi: a_hi,
                             rmlo: b_lo,
                             rmhi: b_hi,
+                            elide_zero_guard,
+                            elide_overflow_guard,
                         },
                         I64DivU => ArmOp::I64DivU {
                             rdlo: dst_lo,
@@ -10386,6 +10448,7 @@ impl InstructionSelector {
                             rnhi: a_hi,
                             rmlo: b_lo,
                             rmhi: b_hi,
+                            elide_zero_guard,
                         },
                         I64RemS => ArmOp::I64RemS {
                             rdlo: dst_lo,
@@ -10394,6 +10457,7 @@ impl InstructionSelector {
                             rnhi: a_hi,
                             rmlo: b_lo,
                             rmhi: b_hi,
+                            elide_zero_guard,
                         },
                         I64RemU => ArmOp::I64RemU {
                             rdlo: dst_lo,
@@ -10402,6 +10466,7 @@ impl InstructionSelector {
                             rnhi: a_hi,
                             rmlo: b_lo,
                             rmhi: b_hi,
+                            elide_zero_guard,
                         },
                         _ => unreachable!(),
                     };
@@ -16631,6 +16696,7 @@ mod tests {
             rnhi,
             rmlo,
             rmhi,
+            ..
         } = &instrs[0].op
         {
             assert_eq!(*rnlo, Reg::R0, "Dividend low in R0");

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -475,13 +475,29 @@ pub fn estimate_arm_byte_size(op: &ArmOp) -> usize {
         // I64 division: #610 fixed-ABI wrapper (PUSH r0-r3(2) + 4×STR(16) +
         // 4×POP(8) + zero-trap(8) + 2×MOV(4) + 4×restore(8) = 46) around the
         // pre-#610 cores (74/78/126/124, the #498 exact measurements).
-        ArmOp::I64DivU { .. } => 120,
-        ArmOp::I64RemU { .. } => 124,
+        // #494 phase 2b: a certificate-discharged divisor-nonzero fact elides
+        // the fused zero-trap (ORRS.W + BNE + UDF = 8 bytes); div_s's #633
+        // overflow guard (22 bytes) is a SEPARATE obligation. Sizes must track
+        // the flags or the estimator↔encoder agreement oracle (#511) drifts.
+        ArmOp::I64DivU {
+            elide_zero_guard, ..
+        } => 120 - if *elide_zero_guard { 8 } else { 0 },
+        ArmOp::I64RemU {
+            elide_zero_guard, ..
+        } => 124 - if *elide_zero_guard { 8 } else { 0 },
         // Signed versions have additional negation logic. div_s also carries
         // the #633 INT64_MIN/-1 overflow guard (+22 bytes); rem_s deliberately
         // does NOT (rem_s(INT64_MIN, -1) == 0, no trap).
-        ArmOp::I64DivS { .. } => 194,
-        ArmOp::I64RemS { .. } => 170,
+        ArmOp::I64DivS {
+            elide_zero_guard,
+            elide_overflow_guard,
+            ..
+        } => {
+            194 - if *elide_zero_guard { 8 } else { 0 } - if *elide_overflow_guard { 22 } else { 0 }
+        }
+        ArmOp::I64RemS {
+            elide_zero_guard, ..
+        } => 170 - if *elide_zero_guard { 8 } else { 0 },
         // AND/OR/XOR: encoder always uses 32-bit Thumb-2 (.W) encoding
         ArmOp::And { .. } | ArmOp::Orr { .. } | ArmOp::Eor { .. } => 4,
         // LDR/STR with high base register or large offset need 32-bit
@@ -5315,6 +5331,10 @@ impl OptimizerBridge {
                         rnhi,
                         rmlo,
                         rmhi,
+                        // #494: the optimized path never consumes fact marks —
+                        // marked functions are routed to the direct selector.
+                        elide_zero_guard: false,
+                        elide_overflow_guard: false,
                     });
                     last_result_vreg = Some(dest_lo.0);
                     last_result_vreg_hi = Some(dest_hi.0);
@@ -5345,6 +5365,7 @@ impl OptimizerBridge {
                         rnhi,
                         rmlo,
                         rmhi,
+                        elide_zero_guard: false,
                     });
                     last_result_vreg = Some(dest_lo.0);
                     last_result_vreg_hi = Some(dest_hi.0);
@@ -5375,6 +5396,7 @@ impl OptimizerBridge {
                         rnhi,
                         rmlo,
                         rmhi,
+                        elide_zero_guard: false,
                     });
                     last_result_vreg = Some(dest_lo.0);
                     last_result_vreg_hi = Some(dest_hi.0);
@@ -5405,6 +5427,7 @@ impl OptimizerBridge {
                         rnhi,
                         rmlo,
                         rmhi,
+                        elide_zero_guard: false,
                     });
                     last_result_vreg = Some(dest_lo.0);
                     last_result_vreg_hi = Some(dest_hi.0);

--- a/crates/synth-synthesis/src/rules.rs
+++ b/crates/synth-synthesis/src/rules.rs
@@ -559,6 +559,18 @@ pub enum ArmOp {
         rnhi: Reg,
         rmlo: Reg,
         rmhi: Reg,
+        /// #494 phase 2b (divisor-nonzero fact): the encoder omits the fused
+        /// divide-by-zero trap guard (`ORRS R12, lo, hi; BNE; UDF #0`). May
+        /// be set ONLY when the fact-spec pass discharged
+        /// `UNSAT(P ∧ divisor == 0)` through the certificate-checked solver.
+        /// `false` = today's full-guard expansion, byte-identical.
+        elide_zero_guard: bool,
+        /// #494 phase 2b: the encoder omits the #633/#634 `INT64_MIN / -1`
+        /// OVERFLOW trap guard. A SEPARATE obligation from the zero guard —
+        /// divisor ≠ 0 does NOT imply divisor ≠ -1; this may be set only when
+        /// `UNSAT(P ∧ dividend == INT64_MIN ∧ divisor == -1)` was discharged.
+        /// `false` = guard emitted (the #633 fix stays in force).
+        elide_overflow_guard: bool,
     },
     I64DivU {
         rdlo: Reg,
@@ -567,6 +579,9 @@ pub enum ArmOp {
         rnhi: Reg,
         rmlo: Reg,
         rmhi: Reg,
+        /// #494 phase 2b: omit the divide-by-zero guard (see `I64DivS`).
+        /// div_u has no overflow guard — zero is its only trap.
+        elide_zero_guard: bool,
     },
     I64RemS {
         rdlo: Reg,
@@ -575,6 +590,9 @@ pub enum ArmOp {
         rnhi: Reg,
         rmlo: Reg,
         rmhi: Reg,
+        /// #494 phase 2b: omit the divide-by-zero guard (see `I64DivS`).
+        /// rem_s never carries an overflow guard (`rem_s(INT64_MIN,-1)==0`).
+        elide_zero_guard: bool,
     },
     I64RemU {
         rdlo: Reg,
@@ -583,6 +601,8 @@ pub enum ArmOp {
         rnhi: Reg,
         rmlo: Reg,
         rmhi: Reg,
+        /// #494 phase 2b: omit the divide-by-zero guard (see `I64DivS`).
+        elide_zero_guard: bool,
     },
 
     // i64 Bitwise (register pairs)

--- a/crates/synth-synthesis/tests/issue_103_i64_aapcs.rs
+++ b/crates/synth-synthesis/tests/issue_103_i64_aapcs.rs
@@ -72,6 +72,7 @@ fn rw_sets(op: &ArmOp) -> (Vec<Reg>, Vec<Reg>) {
             rnhi,
             rmlo,
             rmhi,
+            ..
         }
         | ArmOp::I64DivU {
             rdlo,
@@ -80,6 +81,7 @@ fn rw_sets(op: &ArmOp) -> (Vec<Reg>, Vec<Reg>) {
             rnhi,
             rmlo,
             rmhi,
+            ..
         }
         | ArmOp::I64RemS {
             rdlo,
@@ -88,6 +90,7 @@ fn rw_sets(op: &ArmOp) -> (Vec<Reg>, Vec<Reg>) {
             rnhi,
             rmlo,
             rmhi,
+            ..
         }
         | ArmOp::I64RemU {
             rdlo,
@@ -96,6 +99,7 @@ fn rw_sets(op: &ArmOp) -> (Vec<Reg>, Vec<Reg>) {
             rnhi,
             rmlo,
             rmhi,
+            ..
         } => (vec![*rdlo, *rdhi], vec![*rnlo, *rnhi, *rmlo, *rmhi]),
         ArmOp::I64Rotl {
             rdlo,

--- a/crates/synth-verify/src/fact_spec.rs
+++ b/crates/synth-verify/src/fact_spec.rs
@@ -54,11 +54,34 @@
 //!   (at any nesting depth) is havocked to a fresh variable, and its block
 //!   results are pushed as fresh variables.
 //! * An ADMITTED `if` region provably never executes, so state is unchanged.
-//! * `i32.div*`/`i32.rem*` are deliberately NOT tracked: they can trap, and a
-//!   deleted condition slice must be effect-free under ALL inputs, not just
-//!   P-admissible ones (the premise only justifies the branch-direction, not
-//!   trap removal — trap-guard elision is the separate divisor-nonzero fact,
-//!   out of Phase-2 scope).
+//! * `div`/`rem` (i32 AND i64) are tracked since Phase 2b (#494
+//!   divisor-nonzero), but NEVER deleted: they can trap, and a deleted
+//!   condition slice must be effect-free under ALL inputs, not just
+//!   P-admissible ones — so a div result always carries `start = None`
+//!   (non-erasable) and its value is havocked to a fresh variable. What
+//!   Phase 2b adds is per-site TRAP-GUARD elision marks consumed by the
+//!   direct selector (see "The div/rem guard obligations" below).
+//!
+//! # The div/rem guard obligations (Phase 2b, #494 divisor-nonzero)
+//!
+//! A `div`/`rem` lowering carries up to TWO trap guards, and they fall to two
+//! INDEPENDENT obligations — this is the #633/#634 two-guard distinction:
+//!
+//! ```text
+//! divide-by-zero guard (div_u/div_s/rem_u/rem_s, i32+i64):
+//!     UNSAT( P ∧ divisor == 0 )
+//! INT_MIN/-1 overflow guard (div_s ONLY; rem_s(INT_MIN,-1)==0 never traps):
+//!     UNSAT( P ∧ dividend == INT_MIN ∧ divisor == -1 )
+//! ```
+//!
+//! A divisor-nonzero fact (kind 3) discharges the first but NOT the second —
+//! `divisor ≠ 0` does not exclude `divisor == -1`, so the overflow guard is
+//! RETAINED unless the premises independently prove the second obligation
+//! (e.g. a value-range fact `divisor ∈ [1, N]` proves both). Each discharged
+//! obligation becomes a per-site elision mark ([`FactSpecResult::elide_div_zero`]
+//! / [`FactSpecResult::elide_div_ovf`], indices into the RETURNED stream);
+//! the driver threads them to the direct selector, which omits exactly that
+//! guard. Sat / Unknown / no-premise ⇒ loud decline, the guard is emitted.
 //!
 //! # Flag gating
 //!
@@ -70,7 +93,7 @@
 use crate::solver::{CheckOutcome, new_solver};
 use crate::term::{BV, Bool};
 use crate::wasm_semantics::WasmSemantics;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use synth_core::WasmOp;
 use synth_core::wsc_facts::{FactKind, WscFact};
 
@@ -90,13 +113,26 @@ pub struct FactSpecResult {
     pub admitted: Vec<String>,
     /// One line per LOUD DECLINE (the general lowering is emitted for these).
     pub declined: Vec<String>,
+    /// #494 phase 2b: indices (into the RETURNED `ops` stream) of div/rem
+    /// ops whose divide-by-zero trap guard was certificate-elided
+    /// (`UNSAT(P ∧ divisor == 0)` discharged per site).
+    pub elide_div_zero: Vec<usize>,
+    /// #494 phase 2b: indices (into the RETURNED `ops` stream) of `div_s`
+    /// ops whose `INT_MIN / -1` overflow guard was certificate-elided — a
+    /// SEPARATE obligation (`UNSAT(P ∧ dividend == INT_MIN ∧ divisor == -1)`);
+    /// a divisor-nonzero fact alone never lands here (#633/#634).
+    pub elide_div_ovf: Vec<usize>,
+    /// True when `ops` differs from the input (at least one region deletion).
+    stream_changed: bool,
 }
 
 impl FactSpecResult {
-    /// True when at least one elision was admitted (i.e. `ops` differs from
-    /// the input).
+    /// True when the op STREAM was rewritten (region deletions). Guard-elision
+    /// marks do not rewrite the stream — check
+    /// [`elide_div_zero`](Self::elide_div_zero) /
+    /// [`elide_div_ovf`](Self::elide_div_ovf) separately.
     pub fn changed(&self) -> bool {
-        !self.admitted.is_empty()
+        self.stream_changed
     }
 }
 
@@ -116,17 +152,37 @@ struct Val {
 ///
 /// `block_arity` is the decoder's ordinal side-table (one `(params, results)`
 /// entry per `Block`/`Loop`/`If` in op order); `facts` is the per-function
-/// slice (`CompileConfig::current_func_facts`). Total: every input yields a
+/// slice (`CompileConfig::current_func_facts`); `params_i64` is the declared
+/// param-width table (`CompileConfig::current_func_params_i64` — `true` ⇒
+/// param `k` is 64-bit), which fixes the symbolic width of a param
+/// `local.get` (Phase 2b tracks i64 divisors). Total: every input yields a
 /// result — inapplicable shapes surface as loud declines, never errors.
 pub fn specialize_function(
     func_name: &str,
     ops: &[WasmOp],
     block_arity: &[(u8, u8)],
     facts: &[WscFact],
+    params_i64: &[bool],
 ) -> FactSpecResult {
-    let mut pass = Pass::new(func_name, ops, block_arity, facts);
+    let mut pass = Pass::new(func_name, ops, block_arity, facts, params_i64);
     pass.walk();
     pass.finish()
+}
+
+/// #494 phase 2b RED-TEAM lever (debug builds ONLY): treat a Sat verdict on
+/// the divide-by-zero guard obligation as an admit anyway. Exists so the
+/// differential oracle can DEMONSTRATE the divergence an unsound admit would
+/// cause (wasmtime traps at divisor == 0, the forced build does not) and then
+/// show the Sat-decline restoring the guard byte-identically. Compiled out of
+/// release builds; every forced admit screams in its certificate line.
+#[cfg(debug_assertions)]
+fn force_admit_unsound() -> bool {
+    std::env::var("SYNTH_FACT_SPEC_FORCE_ADMIT").is_ok_and(|v| v != "0")
+}
+
+#[cfg(not(debug_assertions))]
+fn force_admit_unsound() -> bool {
+    false
 }
 
 struct Pass<'a> {
@@ -135,8 +191,13 @@ struct Pass<'a> {
     block_arity: &'a [(u8, u8)],
     /// op index → ordinal into `block_arity` (for `Block`/`Loop`/`If` ops).
     opener_ordinal: HashMap<usize, usize>,
-    /// op index → signed i32 range fact attached to that op's result.
-    range_facts: HashMap<usize, (i32, i32)>,
+    /// op index → signed range fact attached to that op's result (raw s64
+    /// bounds; clamped to the value's width at attach time).
+    range_facts: HashMap<usize, (i64, i64)>,
+    /// op indices carrying a divisor-nonzero fact (kind 3): `value ≠ 0`.
+    nonzero_facts: HashSet<usize>,
+    /// Declared param widths (`true` ⇒ 64-bit) — fixes `local.get` widths.
+    params_i64: &'a [bool],
     sem: WasmSemantics,
     stack: Vec<Val>,
     locals: HashMap<u32, BV>,
@@ -149,6 +210,10 @@ struct Pass<'a> {
     deletions: Vec<(usize, usize)>,
     admitted: Vec<String>,
     declined: Vec<String>,
+    /// #494 phase 2b: ORIGINAL op indices marked for zero-guard elision.
+    zero_marks: Vec<usize>,
+    /// #494 phase 2b: ORIGINAL op indices marked for overflow-guard elision.
+    ovf_marks: Vec<usize>,
 }
 
 impl<'a> Pass<'a> {
@@ -157,6 +222,7 @@ impl<'a> Pass<'a> {
         ops: &'a [WasmOp],
         block_arity: &'a [(u8, u8)],
         facts: &'a [WscFact],
+        params_i64: &'a [bool],
     ) -> Self {
         let mut opener_ordinal = HashMap::new();
         let mut ord = 0usize;
@@ -167,16 +233,25 @@ impl<'a> Pass<'a> {
             }
         }
         let mut range_facts = HashMap::new();
+        let mut nonzero_facts = HashSet::new();
         for f in facts {
-            if let FactKind::ValueRange { lo, hi } = f.kind {
-                // i32-only prototype: clamp the s64 bound into i32; a bound
-                // wholly outside i32 (or inverted) is vacuous — ignore it
-                // (the encoding doc's rule for unusable facts).
-                let lo = lo.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32;
-                let hi = hi.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32;
-                if lo <= hi && (f.value_id as usize) < ops.len() {
-                    range_facts.insert(f.value_id as usize, (lo, hi));
+            // Out-of-range value_id is vacuous (encoding doc's rule).
+            if (f.value_id as usize) >= ops.len() {
+                continue;
+            }
+            match f.kind {
+                FactKind::ValueRange { lo, hi } => {
+                    // Raw s64 bounds; clamped to the value's width when the
+                    // walk attaches the premise. An inverted bound is vacuous.
+                    if lo <= hi {
+                        range_facts.insert(f.value_id as usize, (lo, hi));
+                    }
                 }
+                // #494 phase 2b: divisor-nonzero (kind 3) — `value ≠ 0`.
+                FactKind::DivisorNonZero => {
+                    nonzero_facts.insert(f.value_id as usize);
+                }
+                _ => {}
             }
         }
         Self {
@@ -185,6 +260,8 @@ impl<'a> Pass<'a> {
             block_arity,
             opener_ordinal,
             range_facts,
+            nonzero_facts,
+            params_i64,
             // No memory model needed: memory ops are outside the tracked
             // fragment (the walk stops there).
             sem: WasmSemantics::new_with_memory(Vec::new()),
@@ -197,6 +274,8 @@ impl<'a> Pass<'a> {
             deletions: Vec::new(),
             admitted: Vec::new(),
             declined: Vec::new(),
+            zero_marks: Vec::new(),
+            ovf_marks: Vec::new(),
         }
     }
 
@@ -210,20 +289,51 @@ impl<'a> Pass<'a> {
         if let Some(bv) = self.locals.get(&idx) {
             return bv.clone();
         }
-        let v = self.fresh_var(format!("fs_l{idx}"));
+        // A not-yet-seen local's width comes from the declared param table
+        // (#494 phase 2b tracks i64 divisors); non-param locals default to
+        // 32 bits — an i64 op reading one fails the width check and declines.
+        let width = if self.params_i64.get(idx as usize).copied().unwrap_or(false) {
+            64
+        } else {
+            32
+        };
+        let v = BV::new_const(format!("fs_l{idx}"), width);
+        self.vars.push(v.clone());
         self.locals.insert(idx, v.clone());
         v
     }
 
-    /// Attach a value-range premise if a fact names op `i`'s result.
+    /// Attach the premises of every fact naming op `i`'s result, at the
+    /// value's own width.
     fn attach_fact(&mut self, i: usize, bv: &BV) {
+        let width = bv.get_size();
         if let Some(&(lo, hi)) = self.range_facts.get(&i) {
-            let lo_bv = BV::from_i64(i64::from(lo), 32);
-            let hi_bv = BV::from_i64(i64::from(hi), 32);
+            // Clamp the s64 bound to the value's width (the phase-2 rule for
+            // 32-bit values; 64-bit values take the bound verbatim). A bound
+            // that inverts after clamping is impossible for a genuine value
+            // of this width — fact validity is loom's obligation (trust
+            // split), so we keep the phase-2 clamp semantics unchanged.
+            let (lo, hi) = if width == 32 {
+                (
+                    lo.clamp(i64::from(i32::MIN), i64::from(i32::MAX)),
+                    hi.clamp(i64::from(i32::MIN), i64::from(i32::MAX)),
+                )
+            } else {
+                (lo, hi)
+            };
+            let lo_bv = BV::from_i64(lo, width);
+            let hi_bv = BV::from_i64(hi, width);
             let p = Bool::and(&[&bv.bvsge(&lo_bv), &bv.bvsle(&hi_bv)]);
             self.premises.push(p);
             self.premise_desc
-                .push(format!("value(op#{i}) ∈ [{lo}, {hi}] (signed)"));
+                .push(format!("value(op#{i}) ∈ [{lo}, {hi}] (signed, i{width})"));
+        }
+        if self.nonzero_facts.contains(&i) {
+            // #494 phase 2b: divisor-nonzero (kind 3).
+            let p = bv.ne(BV::from_i64(0, width));
+            self.premises.push(p);
+            self.premise_desc
+                .push(format!("value(op#{i}) ≠ 0 (i{width})"));
         }
     }
 
@@ -279,6 +389,127 @@ impl<'a> Pass<'a> {
     fn decline(&mut self, msg: String) {
         self.declined
             .push(format!("{}: {} — general lowering emitted", self.func, msg));
+    }
+
+    /// #494 phase 2b: discharge the per-site div/rem trap-guard obligations
+    /// for the op at `i` (`op_name`, operand width `width`, dividend `a`,
+    /// divisor `b`), recording elision marks for the lowering. TWO independent
+    /// obligations (the #633/#634 two-guard distinction):
+    ///
+    /// - zero guard (every div/rem): `UNSAT(P ∧ divisor == 0)`;
+    /// - overflow guard (`div_s` only): `UNSAT(P ∧ dividend == INT_MIN ∧
+    ///   divisor == -1)` — divisor-nonzero alone NEVER discharges this.
+    ///
+    /// Sat / Unknown / no-premise ⇒ loud decline; the guard is emitted.
+    fn try_elide_div_guards(&mut self, i: usize, op_name: &str, is_div_s: bool, a: &Val, b: &Val) {
+        let width = b.bv.get_size();
+        if self.premises.is_empty() {
+            self.decline(format!(
+                "op#{i} {op_name} — no premise reaches this site; both trap guards retained"
+            ));
+            return;
+        }
+        // Obligation 1: the divide-by-zero guard.
+        let mut solver = new_solver();
+        for p in &self.premises {
+            solver.assert(p);
+        }
+        solver.assert(&b.bv.eq(BV::from_i64(0, width)));
+        match solver.check() {
+            CheckOutcome::Unsat => {
+                self.zero_marks.push(i);
+                self.admitted.push(format!(
+                    "{}: op#{i} {op_name} — divide-by-zero guard elided:                      UNSAT(P ∧ divisor == 0) via {} (certificate-checked QF_BV;                      every Unsat carries an LRAT proof validated by ordeal-lrat);                      P = {{{}}}; divisor = {}",
+                    self.func,
+                    solver.name(),
+                    self.premise_desc.join(" ∧ "),
+                    b.bv,
+                ));
+            }
+            CheckOutcome::Sat => {
+                let cex = self.counterexample(solver.as_ref());
+                if force_admit_unsound() {
+                    // RED-TEAM lever (debug builds only): admit the Sat site
+                    // anyway so the differential oracle can demonstrate the
+                    // divergence. Screams, and still logs the model.
+                    self.zero_marks.push(i);
+                    self.admitted.push(format!(
+                        "{}: op#{i} {op_name} — divide-by-zero guard elided by                          UNSOUND FORCED ADMIT (SYNTH_FACT_SPEC_FORCE_ADMIT,                          red-team oracle lever, debug builds only) — obligation                          was Sat (counterexample: {cex}); NEVER use in production",
+                        self.func,
+                    ));
+                } else {
+                    self.decline(format!(
+                        "op#{i} {op_name} — zero-guard obligation Sat (divisor can                          be 0 under P; counterexample: {cex}); guard retained"
+                    ));
+                }
+            }
+            CheckOutcome::Unknown(reason) => {
+                self.decline(format!(
+                    "op#{i} {op_name} — zero-guard obligation Unknown ({reason});                      conservative decline, guard retained"
+                ));
+            }
+        }
+        // Obligation 2: the INT_MIN/-1 overflow guard — div_s only, and a
+        // SEPARATE proof (#633/#634): divisor ≠ 0 does not exclude -1.
+        if !is_div_s {
+            return;
+        }
+        let int_min = if width == 64 {
+            i64::MIN
+        } else {
+            i64::from(i32::MIN)
+        };
+        let mut solver = new_solver();
+        for p in &self.premises {
+            solver.assert(p);
+        }
+        solver.assert(&a.bv.eq(BV::from_i64(int_min, width)));
+        solver.assert(&b.bv.eq(BV::from_i64(-1, width)));
+        match solver.check() {
+            CheckOutcome::Unsat => {
+                self.ovf_marks.push(i);
+                self.admitted.push(format!(
+                    "{}: op#{i} {op_name} — INT{width}_MIN/-1 overflow guard elided:                      UNSAT(P ∧ dividend == INT{width}_MIN ∧ divisor == -1) via {}                      (certificate-checked QF_BV; every Unsat carries an LRAT proof                      validated by ordeal-lrat); P = {{{}}}",
+                    self.func,
+                    solver.name(),
+                    self.premise_desc.join(" ∧ "),
+                ));
+            }
+            CheckOutcome::Sat => {
+                let cex = self.counterexample(solver.as_ref());
+                self.decline(format!(
+                    "op#{i} {op_name} — overflow-guard obligation Sat (dividend ==                      INT{width}_MIN with divisor == -1 is possible under P;                      counterexample: {cex}); the #633 overflow guard is RETAINED —                      a divisor-nonzero premise alone never elides it"
+                ));
+            }
+            CheckOutcome::Unknown(reason) => {
+                self.decline(format!(
+                    "op#{i} {op_name} — overflow-guard obligation Unknown ({reason});                      conservative decline, the #633 overflow guard is RETAINED"
+                ));
+            }
+        }
+    }
+
+    /// Read the model back for an actionable counterexample string.
+    fn counterexample(&self, solver: &dyn crate::solver::BvSolver) -> String {
+        let cex: Vec<String> = self
+            .vars
+            .iter()
+            .filter_map(|v| {
+                let name = format!("{v}");
+                solver.value(v).map(|x| {
+                    if v.get_size() == 64 {
+                        format!("{name}={}", x as u64 as i64)
+                    } else {
+                        format!("{name}={}", x as u32 as i32)
+                    }
+                })
+            })
+            .collect();
+        if cex.is_empty() {
+            "<no model>".to_string()
+        } else {
+            cex.join(", ")
+        }
     }
 
     /// Discharge the per-elision obligation for the no-`else` `if` at `i`
@@ -355,8 +586,10 @@ impl<'a> Pass<'a> {
     }
 
     fn walk(&mut self) {
-        if self.range_facts.is_empty() {
-            self.decline("no usable value-range fact targets this function".to_string());
+        if self.range_facts.is_empty() && self.nonzero_facts.is_empty() {
+            self.decline(
+                "no usable value-range or divisor-nonzero fact targets this function".to_string(),
+            );
             return;
         }
         let ops = self.ops;
@@ -367,6 +600,14 @@ impl<'a> Pass<'a> {
                 WasmOp::Nop => {}
                 WasmOp::I32Const(v) => {
                     let bv = self.sem.encode_op(&WasmOp::I32Const(*v), &[]);
+                    self.attach_fact(i, &bv);
+                    self.push(bv, Some(i), i);
+                }
+                // #494 phase 2b: tracked so an i64 divisor term can be built
+                // (the i64 fragment is const/local/div-rem only — anything
+                // else stops the walk as before).
+                WasmOp::I64Const(v) => {
+                    let bv = self.sem.encode_op(&WasmOp::I64Const(*v), &[]);
                     self.attach_fact(i, &bv);
                     self.push(bv, Some(i), i);
                 }
@@ -406,6 +647,10 @@ impl<'a> Pass<'a> {
                         self.decline(format!("op#{i} unary op on empty symbolic stack"));
                         return;
                     };
+                    if a.bv.get_size() != 32 {
+                        self.decline(format!("op#{i} i32.eqz on a non-32-bit operand"));
+                        return;
+                    }
                     let bv = self.sem.encode_op(op, &[a.bv]);
                     self.attach_fact(i, &bv);
                     let start = a.start.filter(|_| a.created + 1 == i);
@@ -438,6 +683,10 @@ impl<'a> Pass<'a> {
                         self.decline(format!("op#{i} binop on underflowing symbolic stack"));
                         return;
                     };
+                    if a.bv.get_size() != 32 || b.bv.get_size() != 32 {
+                        self.decline(format!("op#{i} i32 binop on a non-32-bit operand"));
+                        return;
+                    }
                     let bv = self.sem.encode_op(op, &[a.bv, b.bv]);
                     self.attach_fact(i, &bv);
                     // Contiguity proof for the combined producer slice:
@@ -451,11 +700,63 @@ impl<'a> Pass<'a> {
                     };
                     self.push(bv, start, i);
                 }
+                // #494 phase 2b: i32/i64 div/rem — TRACKED (upgrading the
+                // phase-2 hard stop), never DELETED. The op can trap, so its
+                // result carries `start = None` (it can never sit inside an
+                // erasable condition slice); the walk instead discharges the
+                // per-site guard obligations (see the module docs' two-guard
+                // distinction) and marks the op for the lowering. Downstream
+                // soundness: if the op traps, nothing after it executes (any
+                // later admitted elision is vacuous on that path); if it does
+                // not, its result is havocked to a fresh variable.
+                WasmOp::I32DivU
+                | WasmOp::I32DivS
+                | WasmOp::I32RemU
+                | WasmOp::I32RemS
+                | WasmOp::I64DivU
+                | WasmOp::I64DivS
+                | WasmOp::I64RemU
+                | WasmOp::I64RemS => {
+                    let (Some(b), Some(a)) = (self.stack.pop(), self.stack.pop()) else {
+                        self.decline(format!("op#{i} div/rem on underflowing symbolic stack"));
+                        return;
+                    };
+                    let (op_name, expect, is_div_s) = match op {
+                        WasmOp::I32DivU => ("i32.div_u", 32, false),
+                        WasmOp::I32DivS => ("i32.div_s", 32, true),
+                        WasmOp::I32RemU => ("i32.rem_u", 32, false),
+                        WasmOp::I32RemS => ("i32.rem_s", 32, false),
+                        WasmOp::I64DivU => ("i64.div_u", 64, false),
+                        WasmOp::I64DivS => ("i64.div_s", 64, true),
+                        WasmOp::I64RemU => ("i64.rem_u", 64, false),
+                        _ => ("i64.rem_s", 64, false),
+                    };
+                    if a.bv.get_size() != expect || b.bv.get_size() != expect {
+                        self.decline(format!(
+                            "op#{i} {op_name} on operands of unexpected width                              (symbolic widths {}/{}, expected {expect})",
+                            a.bv.get_size(),
+                            b.bv.get_size()
+                        ));
+                        return;
+                    }
+                    self.try_elide_div_guards(i, op_name, is_div_s, &a, &b);
+                    // Havoc the result; `start = None` keeps a possibly-
+                    // trapping op out of every erasable condition slice.
+                    let n = self.fresh;
+                    self.fresh += 1;
+                    let v = self.fresh_var(format!("fs_d{n}"));
+                    self.attach_fact(i, &v);
+                    self.push(v, None, i);
+                }
                 WasmOp::If => {
                     let Some(cond) = self.stack.pop() else {
                         self.decline(format!("op#{i} `if` on empty symbolic stack"));
                         return;
                     };
+                    if cond.bv.get_size() != 32 {
+                        self.decline(format!("op#{i} `if` condition is not 32-bit"));
+                        return;
+                    }
                     let Some((end, has_else)) = self.matching_end(i) else {
                         self.decline(format!("op#{i} `if` without matching `end`"));
                         return;
@@ -511,6 +812,8 @@ impl<'a> Pass<'a> {
             deletions,
             admitted,
             declined,
+            zero_marks,
+            ovf_marks,
             ..
         } = self;
         if deletions.is_empty() {
@@ -520,6 +823,10 @@ impl<'a> Pass<'a> {
                 kept: (0..ops.len()).collect(),
                 admitted,
                 declined,
+                // No rewrite ⇒ original indices ARE the output indices.
+                elide_div_zero: zero_marks,
+                elide_div_ovf: ovf_marks,
+                stream_changed: false,
             };
         }
         let deleted = |i: usize| deletions.iter().any(|&(s, e)| i >= s && i <= e);
@@ -540,12 +847,29 @@ impl<'a> Pass<'a> {
                 ord += 1;
             }
         }
+        // Remap the guard-elision marks into the REWRITTEN index space. A
+        // marked div/rem can never sit inside a deleted range (deleted ranges
+        // are contiguous PURE condition slices plus proven-dead `if` regions
+        // the walk skipped over; a div result's `start = None` bars it from
+        // any erasable slice) — the filter below is defense in depth.
+        let remap = |marks: Vec<usize>| -> Vec<usize> {
+            marks
+                .into_iter()
+                .filter_map(|m| {
+                    debug_assert!(!deleted(m), "guard mark op#{m} inside a deleted range");
+                    kept.binary_search(&m).ok()
+                })
+                .collect()
+        };
         FactSpecResult {
             ops: out_ops,
             block_arity: out_arity,
+            elide_div_zero: remap(zero_marks),
+            elide_div_ovf: remap(ovf_marks),
             kept,
             admitted,
             declined,
+            stream_changed: true,
         }
     }
 }
@@ -595,7 +919,7 @@ mod tests {
     #[test]
     fn clamp_shape_elides_both_branches_under_the_proven_bound_494() {
         let ops = clamp_ops();
-        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 524, 1524)]);
+        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 524, 1524)], &[]);
         assert_eq!(r.admitted.len(), 2, "declines: {:?}", r.declined);
         assert!(r.changed());
         assert_eq!(
@@ -625,7 +949,7 @@ mod tests {
         // ch ∈ [0, 4000] does NOT make the clamp dead (ch=0 → v=476 < 1000):
         // the obligation is Sat and BOTH sites decline with a counterexample.
         let ops = clamp_ops();
-        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 0, 4000)]);
+        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 0, 4000)], &[]);
         assert_eq!(r.admitted.len(), 0);
         assert!(!r.changed());
         assert_eq!(r.ops, ops, "declined ⇒ byte-identical op stream");
@@ -644,7 +968,7 @@ mod tests {
         // ch ∈ [524, 4000]: v ≥ 1000 so the LOW clamp is dead, but v can
         // exceed 2000 so the HIGH clamp must survive.
         let ops = clamp_ops();
-        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 524, 4000)]);
+        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 524, 4000)], &[]);
         assert_eq!(r.admitted.len(), 1, "declines: {:?}", r.declined);
         assert_eq!(r.declined.len(), 1);
         assert_eq!(
@@ -671,7 +995,7 @@ mod tests {
     #[test]
     fn no_facts_changes_nothing_494() {
         let ops = clamp_ops();
-        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[]);
+        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[], &[]);
         assert!(!r.changed());
         assert_eq!(r.ops, ops);
         assert!(!r.declined.is_empty(), "the no-fact case is a loud decline");
@@ -703,7 +1027,7 @@ mod tests {
             LocalGet(1),    // 16
             End,            // 17
         ];
-        let r = specialize_function("f", &ops, CLAMP_ARITY, &[fact(0, 524, 1524)]);
+        let r = specialize_function("f", &ops, CLAMP_ARITY, &[fact(0, 524, 1524)], &[]);
         assert_eq!(
             r.admitted.len(),
             0,
@@ -727,7 +1051,7 @@ mod tests {
             LocalGet(1), // 8
             End,         // 9
         ];
-        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 0, 0)]);
+        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 0, 0)], &[]);
         assert_eq!(r.admitted.len(), 0);
         assert!(
             r.declined.iter().any(|d| d.contains("else")),
@@ -756,7 +1080,7 @@ mod tests {
             End,         // 11
         ];
         let arity = &[(0, 0), (0, 0), (0, 1)];
-        let r = specialize_function("f", &ops, arity, &[fact(0, 5, 5)]);
+        let r = specialize_function("f", &ops, arity, &[fact(0, 5, 5)], &[]);
         assert_eq!(r.admitted.len(), 1, "declines: {:?}", r.declined);
         // The condition slice starts at op 0 (LocalGet feeds the eqz), so the
         // whole deleted range is [0..=8]; only the trailing block survives.
@@ -783,7 +1107,7 @@ mod tests {
             End,         // 6
             End,         // 7
         ];
-        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 1, 1)]);
+        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 1, 1)], &[]);
         assert_eq!(r.admitted.len(), 0);
         assert!(
             r.declined
@@ -803,7 +1127,7 @@ mod tests {
             Drop,          // 2
             End,           // 3
         ];
-        let r = specialize_function("f", &ops, &[], &[fact(0, 1, 2)]);
+        let r = specialize_function("f", &ops, &[], &[fact(0, 1, 2)], &[]);
         assert!(!r.changed());
         assert!(
             r.declined.iter().any(|d| d.contains("outside the tracked")),
@@ -812,10 +1136,236 @@ mod tests {
         );
     }
 
+    fn nonzero_fact(value_id: u32) -> WscFact {
+        WscFact {
+            func_index: 0,
+            value_id,
+            kind: FactKind::DivisorNonZero,
+        }
+    }
+
+    // ================= #494 phase 2b: div/rem trap-guard elision =================
+
+    #[test]
+    fn divisor_range_excluding_zero_elides_zero_guard_all_rem_div_494() {
+        // div_u, rem_u, rem_s by a param divisor proven ∈ [1, 100]: every
+        // zero guard falls to UNSAT(P ∧ divisor == 0); the stream itself is
+        // untouched (marks only).
+        let ops = vec![
+            LocalGet(0), // 0  n
+            LocalGet(1), // 1  d  ← fact [1,100]
+            I32DivU,     // 2  → zero mark
+            Drop,        // 3
+            LocalGet(0), // 4
+            LocalGet(1), // 5  ← fact [1,100]
+            I32RemU,     // 6  → zero mark
+            Drop,        // 7
+            LocalGet(0), // 8
+            LocalGet(1), // 9  ← fact [1,100]
+            I32RemS,     // 10 → zero mark
+            End,         // 11
+        ];
+        let facts = [fact(1, 1, 100), fact(5, 1, 100), fact(9, 1, 100)];
+        let r = specialize_function("f", &ops, &[], &facts, &[]);
+        assert_eq!(
+            r.elide_div_zero,
+            vec![2, 6, 10],
+            "declines: {:?}",
+            r.declined
+        );
+        assert_eq!(
+            r.elide_div_ovf,
+            Vec::<usize>::new(),
+            "no div_s in the stream"
+        );
+        assert!(!r.changed(), "guard marks never rewrite the op stream");
+        assert_eq!(r.ops, ops);
+        assert_eq!(r.admitted.len(), 3);
+        for line in &r.admitted {
+            assert!(line.contains("divide-by-zero guard elided"), "{line}");
+            assert!(line.contains("UNSAT(P ∧ divisor == 0)"), "{line}");
+            assert!(line.contains("certificate-checked"), "{line}");
+        }
+    }
+
+    #[test]
+    fn nonzero_fact_elides_zero_guard_but_retains_div_s_overflow_guard_494() {
+        // THE TWO-GUARD DISTINCTION (#633/#634): a divisor-nonzero fact (kind
+        // 3) discharges UNSAT(P ∧ divisor == 0) but NOT the overflow
+        // obligation — divisor ≠ 0 still admits divisor == -1 with dividend
+        // == INT_MIN, so the overflow guard is RETAINED with a loud decline.
+        let ops = vec![
+            LocalGet(0), // 0
+            LocalGet(1), // 1 ← divisor-nonzero fact
+            I32DivS,     // 2
+            End,         // 3
+        ];
+        let r = specialize_function("f", &ops, &[], &[nonzero_fact(1)], &[]);
+        assert_eq!(r.elide_div_zero, vec![2], "declines: {:?}", r.declined);
+        assert_eq!(
+            r.elide_div_ovf,
+            Vec::<usize>::new(),
+            "divisor ≠ 0 must NOT elide the INT_MIN/-1 overflow guard"
+        );
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("overflow-guard obligation Sat") && d.contains("RETAINED")),
+            "{:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn positive_range_discharges_both_div_s_obligations_494() {
+        // divisor ∈ [1, 100] excludes BOTH 0 and -1 — the two obligations
+        // are discharged independently and both guards fall.
+        let ops = vec![LocalGet(0), LocalGet(1), I32DivS, End];
+        let r = specialize_function("f", &ops, &[], &[fact(1, 1, 100)], &[]);
+        assert_eq!(r.elide_div_zero, vec![2], "declines: {:?}", r.declined);
+        assert_eq!(r.elide_div_ovf, vec![2]);
+        assert_eq!(r.admitted.len(), 2, "one certificate line per obligation");
+        assert!(
+            r.admitted
+                .iter()
+                .any(|a| a.contains("overflow guard elided")
+                    && a.contains("dividend == INT32_MIN ∧ divisor == -1")),
+            "{:?}",
+            r.admitted
+        );
+    }
+
+    #[test]
+    fn range_including_zero_is_sat_and_declines_the_zero_guard_494() {
+        // divisor ∈ [0, 100]: divisor == 0 is P-admissible — the obligation
+        // is Sat, the decline is loud and carries a model, no mark is set.
+        let ops = vec![LocalGet(0), LocalGet(1), I32DivU, End];
+        let r = specialize_function("f", &ops, &[], &[fact(1, 0, 100)], &[]);
+        assert_eq!(r.elide_div_zero, Vec::<usize>::new());
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("zero-guard obligation Sat") && d.contains("counterexample")),
+            "{:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn i64_div_s_nonzero_fact_zero_guard_only_overflow_retained_494() {
+        // Oracle 5 at the pass level: i64.div_s with an i64 param divisor
+        // carrying a divisor-nonzero fact — the zero guard is proven dead,
+        // the INT64_MIN/-1 overflow guard (#633/#634) is RETAINED.
+        let ops = vec![LocalGet(0), LocalGet(1), I64DivS, End];
+        let r = specialize_function("f", &ops, &[], &[nonzero_fact(1)], &[true, true]);
+        assert_eq!(r.elide_div_zero, vec![2], "declines: {:?}", r.declined);
+        assert_eq!(
+            r.elide_div_ovf,
+            Vec::<usize>::new(),
+            "i64 overflow guard retained"
+        );
+        assert!(
+            r.declined.iter().any(|d| d.contains("RETAINED")),
+            "{:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn i64_div_s_positive_range_discharges_both_obligations_494() {
+        let ops = vec![LocalGet(0), LocalGet(1), I64DivS, End];
+        let r = specialize_function("f", &ops, &[], &[fact(1, 1, 1000)], &[true, true]);
+        assert_eq!(r.elide_div_zero, vec![2], "declines: {:?}", r.declined);
+        assert_eq!(r.elide_div_ovf, vec![2]);
+    }
+
+    #[test]
+    fn i64_div_on_undeclared_width_declines_no_marks_494() {
+        // Without the params_i64 table the divisor local is symbolically
+        // 32-bit — the width check declines rather than building a
+        // wrong-width obligation.
+        let ops = vec![LocalGet(0), LocalGet(1), I64DivU, End];
+        let r = specialize_function("f", &ops, &[], &[nonzero_fact(1)], &[]);
+        assert_eq!(r.elide_div_zero, Vec::<usize>::new());
+        assert!(
+            r.declined.iter().any(|d| d.contains("unexpected width")),
+            "{:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn div_with_no_premise_declines_loudly_494() {
+        // The function carries a fact, but no premise reaches the divisor —
+        // the obligation cannot even be posed; both guards stay.
+        let ops = vec![
+            LocalGet(0), // 0 ← fact on the DIVIDEND, not the divisor
+            LocalGet(1), // 1 unconstrained divisor
+            I32DivU,     // 2
+            End,         // 3
+        ];
+        // A fact on op 0 (the dividend): premises exist but do not constrain
+        // the divisor — Sat, decline.
+        let r = specialize_function("f", &ops, &[], &[fact(0, 1, 5)], &[]);
+        assert_eq!(r.elide_div_zero, Vec::<usize>::new());
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("zero-guard obligation Sat")),
+            "{:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn guard_marks_are_remapped_through_a_clamp_elision_494() {
+        // A clamp elision rewrites the stream; a downstream div's mark must
+        // land on the REWRITTEN index (the driver feeds the rewritten stream
+        // to the selector, which keys guards by its own op index).
+        let ops = vec![
+            LocalGet(0),    // 0  ← fact [524, 1524]
+            I32Const(476),  // 1
+            I32Add,         // 2
+            LocalSet(1),    // 3
+            LocalGet(1),    // 4  -+ low clamp (elided 4..=10)
+            I32Const(1000), // 5   |
+            I32LtS,         // 6   |
+            If,             // 7   |
+            I32Const(1000), // 8   |
+            LocalSet(1),    // 9   |
+            End,            // 10 -+
+            LocalGet(1),    // 11
+            LocalGet(0),    // 12  divisor = ch ∈ [524, 1524] ⇒ nonzero
+            I32DivU,        // 13  → zero mark (rewritten index 6)
+            End,            // 14
+        ];
+        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 524, 1524)], &[]);
+        assert!(r.changed(), "declines: {:?}", r.declined);
+        assert_eq!(r.kept, vec![0, 1, 2, 3, 11, 12, 13, 14]);
+        assert_eq!(
+            r.ops,
+            vec![
+                LocalGet(0),
+                I32Const(476),
+                I32Add,
+                LocalSet(1),
+                LocalGet(1),
+                LocalGet(0),
+                I32DivU,
+                End
+            ]
+        );
+        assert_eq!(
+            r.elide_div_zero,
+            vec![6],
+            "mark remapped from original op#13 to rewritten op#6"
+        );
+    }
+
     #[test]
     fn out_of_range_value_id_is_vacuous_494() {
         let ops = clamp_ops();
-        let r = specialize_function("f", &ops, CLAMP_ARITY, &[fact(999, 524, 1524)]);
+        let r = specialize_function("f", &ops, CLAMP_ARITY, &[fact(999, 524, 1524)], &[]);
         assert!(!r.changed());
         assert_eq!(r.ops, ops);
     }

--- a/docs/design/proof-carrying-specialization.md
+++ b/docs/design/proof-carrying-specialization.md
@@ -1,8 +1,9 @@
 # VCR-PERF-002 — Proof-carrying specialization design (#494)
 
-Status: **Phases 1–2 implemented** (fact ingestion + the single-elision
-prototype behind `SYNTH_FACT_SPEC` — see "Phasing"; Phase 3, the gale
-measurement vs the 0.45× floor, remains). Tracks `VCR-PERF-002` in
+Status: **Phases 1–2 + 2b implemented** (fact ingestion, the single-elision
+prototype, and the divisor-nonzero trap-guard elision behind
+`SYNTH_FACT_SPEC` — see "Phasing"; Phase 3, the gale measurement vs the
+0.45× floor, remains). Tracks `VCR-PERF-002` in
 `artifacts/verified-codegen-roadmap.yaml`, epic #242, GitHub #494 part (a).
 Cross-repo contract: loom#240 / loom#231 (`wsc.facts`), gale PR
 pulseengine/gale#121 (`gust_floor_bench`, the measured floor).
@@ -122,6 +123,46 @@ bounds adversarial queries to a clean conservative decline.
    sweep, specialized ≡ wasmtime ≡ unspecialized on [524,1524]), both CI-run
    by the `fact-spec-oracle` job. Fixture:
    `scripts/repro/fact_spec_clamp_494.wat`.
+
+   **Phase 2b — divisor-nonzero trap-guard elision (fact kind 3).
+   IMPLEMENTED.** The pass's symbolic walk now TRACKS `div`/`rem` (i32 and
+   i64) instead of stopping at them — the ops are never *deleted* (they can
+   trap; a div result carries no erasable producer slice), but each site
+   discharges up to TWO **independent** guard obligations and emits per-site
+   elision marks the direct selector consumes
+   (`CompileConfig::fact_div_zero_elide` / `fact_div_ovf_elide`):
+
+   | guard | applies to | obligation |
+   |---|---|---|
+   | divide-by-zero (`CMP/BNE/UDF #0`; i64: fused `ORRS R12/BNE/UDF #0`) | `div_u`, `div_s`, `rem_u`, `rem_s` | `UNSAT(P ∧ divisor == 0)` |
+   | `INT_MIN / -1` overflow (`…UDF #1`; i64: the #633 22-byte sequence) | `div_s` ONLY (`rem_s(INT_MIN,-1) == 0` never traps) | `UNSAT(P ∧ dividend == INT_MIN ∧ divisor == -1)` |
+
+   **The two-guard distinction (the #633/#634 synergy):** a divisor-nonzero
+   fact (kind 3) discharges the first obligation but NOT the second —
+   `divisor ≠ 0` does not exclude `divisor == -1`, so the overflow guard is
+   RETAINED (loud decline) unless the premises independently prove it (a
+   value-range fact `divisor ∈ [1, N]` proves both). Both fact kinds work:
+   kind 3 directly, or any value-range excluding 0. Sat / Unknown /
+   no-premise ⇒ loud decline, the guard is emitted.
+
+   Consumption is direct-selector-only: the optimized path's IR passes
+   renumber instructions, so op-index-keyed marks route the function to
+   `select_with_stack` (the #507/#509 honest-degradation pattern; never
+   fires without flag + facts + a discharged obligation). The i64 guards
+   live inside the `ArmOp::I64Div*/I64Rem*` encoder expansions, which
+   gained per-guard elision flags — estimator sizes track them
+   (estimator↔encoder agreement oracle extended with the elided variants).
+   Oracles: fact_spec unit gates (two-guard matrix, i64 width discipline,
+   mark remapping through a clamp elision) +
+   `crates/synth-cli/tests/fact_spec_div_494.rs` (byte evidence: guard UDFs
+   present without facts, absent with facts+flag, i64 overflow guard
+   retained under kind 3; Sat-decline byte-identity; the debug-only
+   `SYNTH_FACT_SPEC_FORCE_ADMIT` red lever) +
+   `scripts/repro/fact_spec_div_494_differential.py` (in-bounds sweep over
+   the proven divisor bound incl. the retained-guard trap
+   `qs64(INT64_MIN, -1)`; `--expect-decline`; `--force-admit` red
+   divergence demo), all CI-run by the `fact-spec-oracle` job. Fixture:
+   `scripts/repro/fact_spec_div_494.wat`.
 3. **Measurement vs the 0.45× floor** — gale re-measures `gust_mix` on
    `gust_floor_bench` (qemu `-icount`) and STM32F100 silicon (DWT CYCCNT).
    Kill-criterion (#494, unchanged): shipped dissolved lane **<1.0× then
@@ -136,5 +177,5 @@ bounds adversarial queries to a clean conservative decline.
   functions) — that is VCR-RA territory and independently unblocked.
 - loom's algebraic mid-end (`256*x>>8 → x`, loom#240 ask 1) — a loom change;
   it shrinks the input but is not fact-passing.
-- Fact kinds beyond value-range in the prototype — ordered by silicon payoff
-  only after Phase 3 reports.
+- Fact kinds beyond value-range and divisor-nonzero in the prototype —
+  ordered by silicon payoff only after Phase 3 reports.

--- a/scripts/repro/fact_spec_div_494.wat
+++ b/scripts/repro/fact_spec_div_494.wat
@@ -1,0 +1,42 @@
+;; VCR-PERF-002 Phase 2b (#494) — divisor-nonzero trap-guard elision fixture.
+;;
+;; Four functions dividing by a PARAM divisor (the shape where the div/rem
+;; trap guards are otherwise unavoidable — const_divisor cannot see a param):
+;;
+;;   func 0 qu   (i32) n / d  (div_u)  — 1 guard:  divide-by-zero
+;;   func 1 qs   (i32) n / d  (div_s)  — 2 guards: divide-by-zero + INT32_MIN/-1
+;;   func 2 ru   (i32) n % d  (rem_u)  — 1 guard:  divide-by-zero
+;;   func 3 qs64 (i64) n / d  (div_s)  — 2 guards: divide-by-zero + INT64_MIN/-1
+;;
+;; Every function has the same op-index layout:
+;;   0 local.get $n
+;;   1 local.get $d   <- fact target (value_id 1: the divisor's producing op)
+;;   2 div/rem
+;;   3 end
+;;
+;; The harnesses append the schema-v1 `wsc.facts` section (the .wat itself is
+;; facts-free): scripts/repro/fact_spec_div_494_differential.py and
+;; crates/synth-cli/tests/fact_spec_div_494.rs.
+;;
+;; THE TWO-GUARD DISTINCTION (#633/#634): a value-range fact d ∈ [1, 64] on
+;; func 1 discharges BOTH obligations (0 and -1 are excluded), so qs loses
+;; both guards. A divisor-nonzero fact (kind 3) on func 3 discharges ONLY
+;; UNSAT(P ∧ d == 0) — d ≠ 0 does not exclude d == -1 — so qs64 keeps the
+;; INT64_MIN/-1 overflow guard: i64.div_s(INT64_MIN, -1) still traps.
+(module
+  (func (export "qu") (param $n i32) (param $d i32) (result i32)
+    local.get $n
+    local.get $d
+    i32.div_u)
+  (func (export "qs") (param $n i32) (param $d i32) (result i32)
+    local.get $n
+    local.get $d
+    i32.div_s)
+  (func (export "ru") (param $n i32) (param $d i32) (result i32)
+    local.get $n
+    local.get $d
+    i32.rem_u)
+  (func (export "qs64") (param $n i64) (param $d i64) (result i64)
+    local.get $n
+    local.get $d
+    i64.div_s))

--- a/scripts/repro/fact_spec_div_494_differential.py
+++ b/scripts/repro/fact_spec_div_494_differential.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""VCR-PERF-002 Phase 2b (#494) — in-bounds differential for the
+divisor-nonzero trap-guard elision (oracle 3), plus the red force-admit
+divergence demonstration (oracle 4).
+
+Builds scripts/repro/fact_spec_div_494.wat WITH a schema-v1 `wsc.facts`
+section appended (green default: d ∈ [1, 64] on the i32 divisors, kind-3
+divisor-nonzero on the i64 divisor), compiles it twice — SPECIALIZED
+(SYNTH_FACT_SPEC=1) and UNSPECIALIZED — and sweeps the proven bound under
+unicorn (Thumb-2), asserting the specialized result is identical to BOTH
+wasmtime ground truth and the unspecialized synth build. Out-of-bound
+behavior is deliberately unconstrained (the bound is the contract); this
+harness only sweeps in-bounds.
+
+Two-guard distinction check (the #633/#634 synergy, oracle 5 at execution
+level): qs64 carries ONLY a divisor-nonzero fact, so its INT64_MIN/-1
+OVERFLOW guard is retained — this harness asserts qs64(INT64_MIN, -1) TRAPS
+in both wasmtime and the SPECIALIZED build (the retained guard fires), while
+sweeping nonzero divisors (including negative ones) for value agreement.
+
+Non-vacuity: the run FAILS unless the specialized compile admitted exactly 5
+certificate-backed elisions (qu 1, qs 2, ru 1, qs64 1) on stderr.
+
+Modes:
+  (default)         green run: in-bounds sweep + the retained-guard trap check.
+  --expect-decline  facts claim d ∈ [0, 64] (includes 0): assert the Sat
+                    obligation DECLINED loudly and the build is byte-identical
+                    to baseline (the guard is restored by the obligation).
+  --force-admit     RED run (debug synth builds only): same wrong bound, but
+                    SYNTH_FACT_SPEC_FORCE_ADMIT=1 forces the Sat admit —
+                    assert qu(1, 0) TRAPS in wasmtime but does NOT trap in the
+                    forced build (the divergence an unsound admit would cause,
+                    which the in-bounds sweep + certificate gate exist to
+                    prevent).
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/fact_spec_div_494_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R3,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("fact_spec_div_494.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+TRAP = "<trap>"
+
+
+# ---- schema-v1 wsc.facts encoding (docs/design/wsc-facts-encoding.md) ----
+
+def leb_u32(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7F
+        v >>= 7
+        out.append(b | (0x80 if v else 0))
+        if not v:
+            return bytes(out)
+
+
+def leb_s64(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7F
+        v >>= 7
+        done = (v == 0 and not (b & 0x40)) or (v == -1 and (b & 0x40))
+        out.append(b | (0 if done else 0x80))
+        if done:
+            return bytes(out)
+
+
+def range_fact(func_index, value_id, lo, hi):
+    body = leb_s64(lo) + leb_s64(hi)
+    return (b"\x01" + leb_u32(func_index) + leb_u32(value_id)
+            + leb_u32(len(body)) + body)
+
+
+def nonzero_fact(func_index, value_id):
+    return b"\x03" + leb_u32(func_index) + leb_u32(value_id) + leb_u32(0)
+
+
+def facts_payload(records):
+    return b"\x01" + leb_u32(len(records)) + b"".join(records)
+
+
+def append_custom_section(wasm, name, payload):
+    content = leb_u32(len(name)) + name + payload
+    return wasm + b"\x00" + leb_u32(len(content)) + content
+
+
+# ---- compile + load ----
+
+def compile_elf(wasm_path, out, fact_spec, force_admit=False):
+    env = {"PATH": "/usr/bin:/bin"}
+    if fact_spec:
+        env["SYNTH_FACT_SPEC"] = "1"
+    if force_admit:
+        env["SYNTH_FACT_SPEC_FORCE_ADMIT"] = "1"
+    r = subprocess.run(
+        [SYNTH, "compile", str(wasm_path), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env=env,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({out}): {r.stderr}")
+    return r.stderr
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"] & ~1
+    return data, base, syms
+
+
+def run_arm(code, base, addr, regs):
+    """Execute at addr with r0..r3 = regs; return (r0, r1) or TRAP."""
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(base & ~0xFFFF, 0x20000)
+    mu.mem_write(base, code)
+    mu.mem_map(0x90000, 0x10000)
+    ret = 0x90100
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    for reg, val in zip((UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2,
+                         UC_ARM_REG_R3), regs):
+        mu.reg_write(reg, val & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_SP, 0x98000)
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    try:
+        mu.emu_start(addr | 1, ret, timeout=5_000_000)
+    except UcError:
+        return TRAP  # UDF (or other fault) = trap
+    return (mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF,
+            mu.reg_read(UC_ARM_REG_R1) & 0xFFFFFFFF)
+
+
+def call_wasmtime(store, func, args):
+    try:
+        return func(store, *args)
+    except Exception:
+        return TRAP
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--expect-decline", action="store_true",
+                    help="claim d ∈ [0,64]: assert Sat loud-decline + byte-identity")
+    ap.add_argument("--force-admit", action="store_true",
+                    help="RED: wrong bound + SYNTH_FACT_SPEC_FORCE_ADMIT — "
+                         "demonstrate the divisor=0 divergence")
+    args = ap.parse_args()
+
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth first")
+
+    base_wasm = bytes(wasmtime.wat2wasm(WAT.read_text()))
+    tmp = Path("/tmp")
+
+    # ---------- red / decline legs: the claim includes 0 ----------
+    if args.expect_decline or args.force_admit:
+        wasm = append_custom_section(
+            base_wasm, b"wsc.facts",
+            facts_payload([range_fact(0, 1, 0, 64)]))
+        wasm_path = tmp / "fact_spec_div_494_wrong.wasm"
+        wasm_path.write_bytes(wasm)
+        spec_elf = str(tmp / "fact_spec_div_494_wrong_spec.elf")
+        base_elf = str(tmp / "fact_spec_div_494_wrong_base.elf")
+        stderr = compile_elf(wasm_path, spec_elf, fact_spec=True,
+                             force_admit=args.force_admit)
+        compile_elf(wasm_path, base_elf, fact_spec=False)
+        scode, sbase, ssyms = load(spec_elf)
+        bcode, _, _ = load(base_elf)
+
+        if args.expect_decline:
+            if "fact-spec: ADMIT" in stderr:
+                sys.exit(f"expected DECLINE under d ∈ [0,64], got an admit:\n{stderr}")
+            if "zero-guard obligation Sat" not in stderr:
+                sys.exit(f"decline must name the Sat obligation:\n{stderr}")
+            if scode != bcode:
+                sys.exit("declined build must be byte-identical to baseline")
+            print("ORACLE: PASS (Sat obligation declined loudly; guard restored "
+                  "byte-identically)")
+            return
+
+        # --force-admit: the unsound build must DIVERGE at divisor == 0.
+        if "UNSOUND FORCED ADMIT" not in stderr:
+            sys.exit("force-admit run must scream UNSOUND FORCED ADMIT "
+                     "(release synth builds compile the lever out):\n" + stderr)
+        eng = wasmtime.Engine()
+        st = wasmtime.Store(eng)
+        inst = wasmtime.Instance(st, wasmtime.Module(eng, wasm), [])
+        qu = inst.exports(st)["qu"]
+        gt = call_wasmtime(st, qu, (7, 0))
+        got = run_arm(scode, sbase, ssyms["qu"], (7, 0))
+        print(f"qu(7, 0): wasmtime={gt} forced-specialized={got}")
+        if gt != TRAP:
+            sys.exit("wasmtime must trap on divide-by-zero")
+        if got == TRAP:
+            sys.exit("forced build still trapped — the red lever did not elide "
+                     "the guard (vacuous red run)")
+        print("ORACLE: PASS (red) — the forced admit DIVERGES exactly as the "
+              "certificate gate predicts: wasmtime traps, the unsound build "
+              "returns a value. This is the wrong-code class the per-site "
+              "obligation + this harness exist to prevent.")
+        return
+
+    # ---------- green leg: proven facts ----------
+    wasm = append_custom_section(
+        base_wasm, b"wsc.facts",
+        facts_payload([
+            range_fact(0, 1, 1, 64),
+            range_fact(1, 1, 1, 64),
+            range_fact(2, 1, 1, 64),
+            nonzero_fact(3, 1),
+        ]))
+    wasm_path = tmp / "fact_spec_div_494.wasm"
+    wasm_path.write_bytes(wasm)
+    spec_elf = str(tmp / "fact_spec_div_494_spec.elf")
+    base_elf = str(tmp / "fact_spec_div_494_base.elf")
+    stderr_spec = compile_elf(wasm_path, spec_elf, fact_spec=True)
+    compile_elf(wasm_path, base_elf, fact_spec=False)
+
+    admits = stderr_spec.count("fact-spec: ADMIT")
+    declines = stderr_spec.count("fact-spec: DECLINE")
+    print(f"specialized compile: {admits} ADMIT, {declines} DECLINE")
+    # Non-vacuity: qu 1 (zero), qs 2 (zero + overflow, independent
+    # obligations), ru 1 (zero), qs64 1 (zero only — overflow RETAINED).
+    if admits != 5:
+        sys.exit(f"expected 5 certificate-backed guard elisions, got {admits}:\n"
+                 f"{stderr_spec}")
+    if "RETAINED" not in stderr_spec:
+        sys.exit("the retained i64 overflow guard must decline loudly:\n"
+                 + stderr_spec)
+
+    scode, sbase, ssyms = load(spec_elf)
+    bcode, bbase, bsyms = load(base_elf)
+
+    eng = wasmtime.Engine()
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, wasmtime.Module(eng, wasm), [])
+    ex = inst.exports(st)
+
+    fails = 0
+
+    def check(tag, gt, got_spec, got_base):
+        nonlocal fails
+        if not (got_spec == gt == got_base):
+            fails += 1
+            if fails <= 10:
+                print(f"FAIL {tag}: wasmtime={gt} specialized={got_spec} "
+                      f"unspecialized={got_base}")
+
+    # i32 sweep over the proven bound d ∈ [1, 64].
+    ns = [0, 1, 7, 12345, 2**31 - 1, -8 & 0xFFFFFFFF]
+    count = 0
+    for fn in ("qu", "qs", "ru"):
+        f = ex[fn]
+        for n in ns:
+            n_signed = n - 2**32 if n >= 2**31 else n
+            for d in range(1, 65):
+                gt = call_wasmtime(st, f, (n_signed, d))
+                gt = gt & 0xFFFFFFFF if gt != TRAP else gt
+                got_s = run_arm(scode, sbase, ssyms[fn], (n, d))
+                got_s = got_s[0] if got_s != TRAP else got_s
+                got_b = run_arm(bcode, bbase, bsyms[fn], (n, d))
+                got_b = got_b[0] if got_b != TRAP else got_b
+                check(f"{fn}({n_signed}, {d})", gt, got_s, got_b)
+                count += 1
+
+    # i64 sweep: the kind-3 claim is d ≠ 0 — nonzero divisors on both sides
+    # of zero (the negative ones exercise the sign-handling around the
+    # retained overflow guard).
+    f64 = ex["qs64"]
+    n64s = [0, 1, 9_000_000_000, 2**63 - 1, -5, -(2**63)]
+    d64s = [d for d in range(-8, 65) if d != 0]
+    for n in n64s:
+        for d in d64s:
+            if n == -(2**63) and d == -1:
+                continue  # the trap case is asserted separately below
+            gt = call_wasmtime(st, f64, (n, d))
+            nu, du = n & (2**64 - 1), d & (2**64 - 1)
+            got_s = run_arm(scode, sbase, ssyms["qs64"],
+                            (nu & 0xFFFFFFFF, nu >> 32, du & 0xFFFFFFFF, du >> 32))
+            got_b = run_arm(bcode, bbase, bsyms["qs64"],
+                            (nu & 0xFFFFFFFF, nu >> 32, du & 0xFFFFFFFF, du >> 32))
+            gtv = gt & (2**64 - 1) if gt != TRAP else gt
+            gsv = got_s[0] | (got_s[1] << 32) if got_s != TRAP else got_s
+            gbv = got_b[0] | (got_b[1] << 32) if got_b != TRAP else got_b
+            check(f"qs64({n}, {d})", gtv, gsv, gbv)
+            count += 1
+
+    # TWO-GUARD DISTINCTION at execution level (oracle 5): the divisor-nonzero
+    # fact elided qs64's zero guard, but INT64_MIN / -1 must STILL trap — the
+    # retained #633 overflow guard fires in the SPECIALIZED build too.
+    n, d = -(2**63), -1
+    gt = call_wasmtime(st, f64, (n, d))
+    nu, du = n & (2**64 - 1), d & (2**64 - 1)
+    got_s = run_arm(scode, sbase, ssyms["qs64"],
+                    (nu & 0xFFFFFFFF, nu >> 32, du & 0xFFFFFFFF, du >> 32))
+    print(f"qs64(INT64_MIN, -1): wasmtime={gt} specialized={got_s}")
+    if gt != TRAP or got_s != TRAP:
+        sys.exit("qs64(INT64_MIN, -1) must trap in BOTH wasmtime and the "
+                 "specialized build — the retained overflow guard is the "
+                 "two-guard distinction (#633/#634)")
+    count += 1
+
+    print(f"swept {count} in-bounds cases")
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails}/{count})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part of #494 (VCR-PERF-002, epic #242). Phase 2b: the **divisor-nonzero fact kind** (kind 3 in `docs/design/wsc-facts-encoding.md`, parsed since #624) gets its consumer — a `divisor-nonzero` fact, or any value-range fact excluding 0, on a div/rem divisor elides the divide-by-zero trap guard, under exactly phase 2's (#629) obligation discipline: **UNSAT discharged via the ordeal-backed certificate-checked `BvSolver` BEFORE emission, certificate logged; Sat/Unknown/no-premise → loud decline, general lowering with the guard.**

## The obligation table (the two-guard distinction, #633/#634)

A div/rem lowering carries up to TWO guards; they fall to two **independent** obligations:

| guard | ops | obligation | discharged by kind-3 (divisor ≠ 0)? | discharged by divisor ∈ [1,N]? |
|---|---|---|---|---|
| divide-by-zero (`CMP/BNE/UDF #0`; i64: fused `ORRS R12/BNE/UDF #0`, 8 B Thumb / 12 B A32) | `div_u` `div_s` `rem_u` `rem_s`, i32+i64 | `UNSAT(P ∧ divisor == 0)` | **yes** | **yes** |
| `INT_MIN / -1` overflow (i32: `…UDF #1`; i64: the #633 22 B / 24 B sequence) | `div_s` ONLY (`rem_s(INT_MIN,-1) == 0` never traps) | `UNSAT(P ∧ dividend == INT_MIN ∧ divisor == -1)` | **NO — guard RETAINED** (divisor ≠ 0 does not exclude −1) | yes (1 ≤ d excludes −1) |

#634 just *added* the i64 div_s overflow guard — this lane never elides it off a nonzero premise: it falls only to its own obligation.

## Mechanics

- `fact_spec.rs` walk upgrade: div/rem (the ops phase 2 deliberately left untracked) are now tracked — never **deleted** (they can trap; a div result always carries `start = None`, keeping it out of every erasable condition slice), but each site discharges the obligations above and emits per-site marks (`FactSpecResult::elide_div_zero/elide_div_ovf`, remapped through any clamp-elision rewrite of the stream). i64 divisor terms get their width from `current_func_params_i64`; width mismatches decline.
- Marks travel via `CompileConfig::fact_div_zero_elide/fact_div_ovf_elide` to the **direct selector only** — the optimized path's IR passes renumber instructions, so marked functions route to `select_with_stack` (the #507/#509 honest-degradation pattern; never fires without `SYNTH_FACT_SPEC` + facts + a discharged obligation).
- i32 guards are selector-emitted → simply skipped when marked. i64 guards live inside the `ArmOp::I64Div*/I64Rem*` encoder expansions → the variants gain per-guard elision flags (Thumb-2 + A32 twins), and `estimate_arm_byte_size` tracks the flags — the #511 estimator↔encoder agreement oracle is extended with the 5 elided variants so the mirror cannot drift.

## Red → green evidence

- **RED (forced unsound admit):** `SYNTH_FACT_SPEC_FORCE_ADMIT` (debug builds only, compiled out of release) admits a *Sat* zero-guard site under a bound *including 0*. The differential demonstrates the exact wrong-code class: `qu(7, 0)` → wasmtime **traps**, the forced build **returns 0**. The lever screams `UNSOUND FORCED ADMIT` in its certificate line. CI runs this leg (`--force-admit`).
- **GREEN (forcing removed):** the same bound-including-0 facts hit the Sat verdict → loud decline with a model counterexample → guard restored **byte-identically** to baseline (pinned in `fact_spec_div_494.rs` and the `--expect-decline` differential leg).
- **Retention at execution level:** `qs64(INT64_MIN, -1)` traps in BOTH wasmtime and the *specialized* build — the retained #633 guard fires even with the zero guard elided.

## Byte evidence (fixture `scripts/repro/fact_spec_div_494.wat`, cortex-m4)

| fn | facts | baseline | specialized | guards |
|---|---|---|---|---|
| `qu` (i32 div_u) | d ∈ [1,64] | 16 B, 1×`UDF #0` | 12 B, 0 UDF | zero elided |
| `qs` (i32 div_s) | d ∈ [1,64] | 36 B, `UDF #0`+`UDF #1` | 12 B, 0 UDF | both elided — two separate certificates |
| `ru` (i32 rem_u) | d ∈ [1,64] | 20 B, 1×`UDF #0` | 16 B, 0 UDF | zero elided |
| `qs64` (i64 div_s) | kind 3 only | 214 B, 2×`UDF #0` | 206 B, **1×`UDF #0`** | zero elided, **overflow RETAINED** |

Total `.text` 446 → 406 B. 5 ADMIT certificate lines (one per obligation), 1 loud RETAINED decline.

## Oracles (all CI-gated by the extended `fact-spec-oracle` job)

1. **Certificate:** ADMIT lines name the obligation (`UNSAT(P ∧ divisor == 0)` / `dividend == INT_MIN ∧ divisor == -1`), engine, premises.
2. **Byte:** guard sequences present without facts, absent with facts+flag; i64 elision is an exact splice (encoder pins: 8 B zero / 22 B overflow Thumb, 12/24 A32).
3. **Differential:** 1584-case in-bounds sweep, specialized ≡ wasmtime ≡ unspecialized over the proven bound (unicorn, symtab pattern).
4. **Red:** force-admit divergence demo + Sat-decline byte-identity (above).
5. **i64 overflow retention:** pinned at unit (`i64_div_s_nonzero_fact_zero_guard_only_overflow_retained_494`), encoder, e2e byte, and execution (trap) levels.
6. **Frozen anchors:** bit-identical (no fixture carries a facts section; flag default OFF); `frozen_codegen_bytes` 10/10; workspace + fmt + chunked clippy green.

Refs #494 #242 #633 #634. Design doc + `verified-codegen-roadmap.yaml` updated (status stays `implemented` — the phase-3 gale kill-criterion is still unmeasured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)