### PR TITLE
fix(codegen): read-before-write non-param local reads 0, not param-register garbage (#457)

### DIFF
--- a/crates/synth-backend-aarch64/src/backend.rs
+++ b/crates/synth-backend-aarch64/src/backend.rs
@@ -71,9 +71,20 @@ impl Backend for AArch64Backend {
         &self,
         name: &str,
         ops: &[WasmOp],
-        _config: &CompileConfig,
+        config: &CompileConfig,
     ) -> Result<CompiledFunction, BackendError> {
-        let num_params = count_params(ops);
+        // #457: cap the access-pattern inference with the declared count when
+        // the driver supplied one — a read-before-write non-param local (wasm
+        // zero-init) is otherwise indistinguishable from a param and would be
+        // read from an argument register (caller garbage). The reclassified
+        // local then hits the selector's "non-param locals not yet supported"
+        // guard: a LOUD skip instead of a silent miscompile (milestone-1
+        // contract; frame-slot zero-init lands with non-param local support).
+        let inferred = count_params(ops);
+        let num_params = match config.current_func_param_count {
+            Some(declared) => inferred.min(declared),
+            None => inferred,
+        };
         let words = selector::select(ops, num_params)
             .map_err(|e| BackendError::CompilationFailed(e.to_string()))?;
         let code: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
@@ -119,7 +130,19 @@ impl Backend for AArch64Backend {
                      (#369, #554)"
                 )));
             }
-            let compiled = self.compile_function(&name, &func.ops, config)?;
+            // #457: THIS function's declared param count (imports-first full
+            // index) caps the param-count inference in `compile_function`.
+            let declared_params = config.func_arg_counts.get(func.index as usize).copied();
+            let func_config = if declared_params.is_some() {
+                Some(CompileConfig {
+                    current_func_param_count: declared_params,
+                    ..config.clone()
+                })
+            } else {
+                None
+            };
+            let cfg = func_config.as_ref().unwrap_or(config);
+            let compiled = self.compile_function(&name, &func.ops, cfg)?;
             elf_funcs.push(ElfFunction {
                 name: compiled.name.clone(),
                 code: compiled.code.clone(),

--- a/crates/synth-backend-riscv/src/backend.rs
+++ b/crates/synth-backend-riscv/src/backend.rs
@@ -79,10 +79,25 @@ impl Backend for RiscVBackend {
         let mut elf_funcs = Vec::new();
         for func in &exports {
             let name = func.export_name.clone().unwrap();
-            let compiled = compile_function_with_opts(&name, &func.ops, config, opts)?;
+            // #457: THIS function's DECLARED param count (imports-first full
+            // index) caps the access-pattern param inference, so a
+            // read-before-write local gets a zero-inited frame slot instead of
+            // an argument-register home. None when the driver supplied no
+            // arg-count table (hand-built modules) — pure inference, as before.
+            let declared_params = config.func_arg_counts.get(func.index as usize).copied();
+            let func_config = if declared_params.is_some() {
+                Some(CompileConfig {
+                    current_func_param_count: declared_params,
+                    ..config.clone()
+                })
+            } else {
+                None
+            };
+            let cfg = func_config.as_ref().unwrap_or(config);
+            let compiled = compile_function_with_opts(&name, &func.ops, cfg, opts)?;
             elf_funcs.push(RiscVElfFunction {
                 name: compiled.name.clone(),
-                ops: compile_to_riscv_ops(&func.ops, config, opts, &compiled)?,
+                ops: compile_to_riscv_ops(&func.ops, cfg, opts, &compiled)?,
             });
             functions.push(compiled);
         }
@@ -151,7 +166,7 @@ fn compile_function_with_opts(
 ) -> Result<CompiledFunction, BackendError> {
     ensure_supported_target(&config.target)?;
 
-    let num_params = count_params(ops);
+    let num_params = effective_num_params(ops, config);
     // #312: pass the decoder's "returns i64" tables down so call-fed i64
     // locals get 8-byte frame slots and i64 call results the a0:a1 pair.
     let selection = select_with_result_types(
@@ -224,6 +239,22 @@ fn count_params(wasm_ops: &[WasmOp]) -> u32 {
         .unwrap_or(0)
 }
 
+/// #457: cap the access-pattern param inference with the DECLARED count when
+/// the driver supplied one. A read-before-write non-param local (which WASM
+/// zero-initializes) is indistinguishable from a param to `count_params` — it
+/// was homed in an argument register and read caller garbage instead of 0.
+/// `min` (not a plain override) keeps every function whose inference is <= the
+/// declared count byte-identical: the inference can only exceed the declared
+/// count via a read-first local index >= it — exactly the read-before-write
+/// locals. The selector zero-inits the reclassified locals' frame slots.
+fn effective_num_params(ops: &[WasmOp], config: &CompileConfig) -> u32 {
+    let inferred = count_params(ops);
+    match config.current_func_param_count {
+        Some(declared) => inferred.min(declared),
+        None => inferred,
+    }
+}
+
 /// Re-encode the selector's output to flat bytes — the same pipeline the ELF
 /// builder uses, but exposed for `compile_function` (which doesn't return ELF).
 fn encode_function_bytes(f: &RiscVElfFunction) -> Result<Vec<u8>, BackendError> {
@@ -273,7 +304,7 @@ fn compile_to_riscv_ops(
     opts: SelectorOptions,
     _compiled: &CompiledFunction,
 ) -> Result<Vec<crate::riscv_op::RiscVOp>, BackendError> {
-    let num_params = count_params(ops);
+    let num_params = effective_num_params(ops, config);
     let selection = select_with_result_types(
         ops,
         num_params,
@@ -368,6 +399,39 @@ mod tests {
             WasmOp::LocalGet(1), // re-read
         ];
         assert_eq!(count_params(&ops), 1);
+    }
+
+    /// #457: the declared param count caps the inference — a read-before-write
+    /// local (inference: param) is reclassified onto the zero-inited frame
+    /// path. `min`, not override: declared >= inferred changes nothing.
+    #[test]
+    fn effective_num_params_caps_inference_457() {
+        let ops = vec![
+            WasmOp::LocalGet(0), // param
+            WasmOp::LocalGet(1), // read-before-write local → inference says param
+            WasmOp::I32Add,
+            WasmOp::End,
+        ];
+        assert_eq!(count_params(&ops), 2);
+        let unknown = CompileConfig {
+            target: TargetSpec::riscv32imac(),
+            ..Default::default()
+        };
+        assert_eq!(effective_num_params(&ops, &unknown), 2);
+        let declared = CompileConfig {
+            current_func_param_count: Some(1),
+            ..unknown.clone()
+        };
+        assert_eq!(effective_num_params(&ops, &declared), 1);
+        let over_declared = CompileConfig {
+            current_func_param_count: Some(4),
+            ..unknown.clone()
+        };
+        assert_eq!(
+            effective_num_params(&ops, &over_declared),
+            2,
+            "declared >= inferred keeps the inference (byte-identity)"
+        );
     }
 
     #[test]

--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -388,6 +388,36 @@ fn select_attempt(
             });
         }
     }
+    // #457: zero-init the FRAME slot of every read-before-write non-param
+    // local (wasm mandates non-param locals read 0 before their first write).
+    // These were previously misclassified as params by `count_params` — with
+    // the declared-count cap (#457) they land in `local_offsets`, and a
+    // `sw zero, off(sp)` at entry makes the mandated 0 observable. Write-first
+    // locals are skipped (their first access overwrites the slot), so every
+    // function without read-before-write frame locals is byte-identical. An
+    // i64 local zeroes both words of its 8-byte slot. The stores sit before
+    // the body like the promoted zero-inits; `preserve_callee_saved` opens the
+    // frame around them (a local slot forces `local_bytes > 0`).
+    let rbw = synth_synthesis::read_before_write_locals(wasm_ops, num_params);
+    let mut rbw_slots: Vec<(i32, bool)> = rbw
+        .iter()
+        .filter_map(|idx| ctx.local_offsets.get(idx).copied())
+        .collect();
+    rbw_slots.sort_unstable();
+    for (off, is_i64) in rbw_slots {
+        ctx.out.push(RiscVOp::Sw {
+            rs1: Reg::SP,
+            rs2: Reg::ZERO,
+            imm: off,
+        });
+        if is_i64 {
+            ctx.out.push(RiscVOp::Sw {
+                rs1: Reg::SP,
+                rs2: Reg::ZERO,
+                imm: off + 4,
+            });
+        }
+    }
     ctx.lower_seq(wasm_ops)?;
     // #226: if any allocation ran out of registers that weren't pinning a live
     // vstack value, the function needs spilling we don't yet do — skip it rather
@@ -8215,6 +8245,63 @@ mod tests {
             WasmOp::End,
         ];
         assert!(compute_local_promotion(&with_call, 1, &no_i64).0.is_empty());
+    }
+
+    /// #457: a read-before-write non-param FRAME local (not promoted — a single
+    /// read fails the promotion cost gate) must get a prologue `sw zero, off(sp)`
+    /// so its `lw` observes the wasm-mandated 0 instead of stale stack memory.
+    #[test]
+    fn rbw_frame_local_is_zero_inited_457() {
+        // (param i32)(local i32) → p0 + local1; local 1 accessed ONCE (read) so
+        // the promotion cost gate declines it → frame slot.
+        let ops = [
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32Add,
+            WasmOp::End,
+        ];
+        let out = s(&ops, 1);
+        let zeroed: Vec<i32> = out
+            .iter()
+            .filter_map(|op| match op {
+                RiscVOp::Sw {
+                    rs1: Reg::SP,
+                    rs2: Reg::ZERO,
+                    imm,
+                } => Some(*imm),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !zeroed.is_empty(),
+            "read-before-write frame local must be zero-inited: {out:?}"
+        );
+
+        // Byte-neutrality guard: a write-first frame local gets NO zero-init.
+        let wf = [
+            WasmOp::I32Const(7),
+            WasmOp::LocalSet(1),
+            WasmOp::Block, // control flow → promotion declines → frame slot
+            WasmOp::LocalGet(1),
+            WasmOp::LocalGet(0),
+            WasmOp::I32Add,
+            WasmOp::LocalSet(1),
+            WasmOp::End,
+            WasmOp::LocalGet(1),
+            WasmOp::End,
+        ];
+        let out = s(&wf, 1);
+        assert!(
+            !out.iter().any(|op| matches!(
+                op,
+                RiscVOp::Sw {
+                    rs1: Reg::SP,
+                    rs2: Reg::ZERO,
+                    ..
+                }
+            )),
+            "write-first local must not be zero-inited: {out:?}"
+        );
     }
 
     /// Three promotable locals exhaust exactly the s8/s9/s10 budget in

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -86,15 +86,22 @@ impl Backend for ArmBackend {
                 .func_params_i64
                 .get(func.index as usize)
                 .filter(|p| !p.is_empty());
-            let func_config = if params.is_some() || !func.block_arity.is_empty() {
-                Some(CompileConfig {
-                    current_func_params_i64: params.cloned().unwrap_or_default(),
-                    current_func_block_arity: func.block_arity.clone(),
-                    ..config.clone()
-                })
-            } else {
-                None
-            };
+            // #457: THIS function's DECLARED param count (imports-first full
+            // index), so the backend can cap the access-pattern inference that
+            // mistook a read-before-write local for a param. `None` when the
+            // driver supplied no arg-count table (hand-built modules).
+            let declared_params = config.func_arg_counts.get(func.index as usize).copied();
+            let func_config =
+                if params.is_some() || !func.block_arity.is_empty() || declared_params.is_some() {
+                    Some(CompileConfig {
+                        current_func_params_i64: params.cloned().unwrap_or_default(),
+                        current_func_block_arity: func.block_arity.clone(),
+                        current_func_param_count: declared_params,
+                        ..config.clone()
+                    })
+                } else {
+                    None
+                };
             let cfg = func_config.as_ref().unwrap_or(config);
             let compiled = self.compile_function(&name, &func.ops, cfg)?;
             functions.push(compiled);
@@ -284,7 +291,26 @@ fn compile_wasm_to_arm(
     };
     let wasm_ops: &[WasmOp] = &rewritten;
 
-    let num_params = count_params(wasm_ops);
+    // #457: `count_params` INFERS the param count from access patterns (a local
+    // whose first access is a read is assumed to be a param), so a
+    // read-before-write NON-PARAM local — which WASM zero-initializes — was
+    // indistinguishable from a param: it got homed in a parameter register and
+    // read caller garbage instead of 0. When the driver supplied the DECLARED
+    // count (`current_func_param_count`, from the module's type section), cap
+    // the inference with it. `min` (not a plain override) keeps every function
+    // whose inference is <= declared byte-identical: the inferred count can only
+    // EXCEED the declared one via a read-first local index >= the declared count
+    // — i.e. exactly the read-before-write locals this issue is about.
+    let inferred_params = count_params(wasm_ops);
+    let num_params = match config.current_func_param_count {
+        Some(declared) => inferred_params.min(declared),
+        None => inferred_params,
+    };
+    // A read-before-write non-param local exists iff the capped count dropped.
+    // Such locals need the wasm-mandated zero-init, which only the direct
+    // selector emits — the optimized path's `ir_to_arm` maps a non-param
+    // local's vreg onto an r4+ temp with no initialization (caller garbage).
+    let has_rbw_local = num_params < inferred_params;
 
     let bounds_config = match config.effective_safety_bounds() {
         SafetyBounds::None => BoundsCheckConfig::None,
@@ -552,6 +578,9 @@ fn compile_wasm_to_arm(
         || has_value_carry
         || has_wide_param
         || has_fact_div_elide
+        // #457: route read-before-write non-param locals to the direct
+        // selector, whose prologue zero-init lands the wasm-mandated 0.
+        || has_rbw_local
     {
         if std::env::var("SYNTH_PATH_DEBUG").is_ok() {
             eprintln!("[path-debug] direct (pre-gate)");
@@ -1383,6 +1412,71 @@ mod tests {
 
         let no_params = vec![WasmOp::I32Const(5), WasmOp::I32Const(3), WasmOp::I32Add];
         assert_eq!(count_params(&no_params), 0);
+    }
+
+    /// #457: the declared param count caps the access-pattern inference. The
+    /// repro shape `(param i32)(local i32) → p0 + local1` reads local 1 before
+    /// any write, so `count_params` infers 2 — with the declared count (1) the
+    /// local is reclassified onto the zero-inited frame path instead of being
+    /// read from R1 (caller garbage).
+    #[test]
+    fn declared_param_count_caps_inference_457() {
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32Add,
+            WasmOp::End,
+        ];
+        // The inference alone still says 2 (the misclassification this caps).
+        assert_eq!(count_params(&ops), 2);
+
+        let backend = ArmBackend::new();
+        let inferred = backend
+            .compile_function("rbw", &ops, &CompileConfig::default())
+            .unwrap();
+        let declared = backend
+            .compile_function(
+                "rbw",
+                &ops,
+                &CompileConfig {
+                    current_func_param_count: Some(1),
+                    ..CompileConfig::default()
+                },
+            )
+            .unwrap();
+        // The cap is consumed: the declared-count compile reclassifies local 1
+        // and must emit different code than the param-misclassified one.
+        assert_ne!(
+            inferred.code, declared.code,
+            "declared param count must reach the selector"
+        );
+        // The zero-init is present: a 16-bit Thumb `movs rN, #0`
+        // (0x2000 | rd<<8 → LE bytes [0x00, 0x20+rd]) somewhere in the body.
+        let has_movs_zero = declared
+            .code
+            .chunks_exact(2)
+            .any(|h| h[0] == 0x00 && (0x20..=0x27).contains(&h[1]));
+        assert!(
+            has_movs_zero,
+            "declared-count compile must zero-init the read-before-write local; code: {:02x?}",
+            declared.code
+        );
+        // A declared count that matches (or exceeds) the inference changes
+        // nothing — byte-identity for every function without rbw locals.
+        let matching = backend
+            .compile_function(
+                "rbw",
+                &ops,
+                &CompileConfig {
+                    current_func_param_count: Some(2),
+                    ..CompileConfig::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            matching.code, inferred.code,
+            "declared >= inferred must stay byte-identical"
+        );
     }
 
     #[test]

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1245,6 +1245,10 @@ fn compile_command(
     // `i64.shr_u x 32` returned 32 (the shift amount) instead of the high word.
     // Empty for the demo path (all-i32 demos).
     let mut current_func_params_i64: Vec<bool> = Vec::new(); // #359/#518/#599
+    // #457: declared param count of THIS function — caps the access-pattern
+    // param inference (a read-before-write local is otherwise indistinguishable
+    // from a param). None for the demo path (no module signature).
+    let mut current_func_param_count: Option<u32> = None;
     let mut func_ret_i64: Vec<bool> = Vec::new(); // #311: call-result pair tagging
     let mut type_ret_i64: Vec<bool> = Vec::new(); // #311: call_indirect results
     let mut current_func_block_arity: Vec<(u8, u8)> = Vec::new(); // #509: value-carrying branches
@@ -1286,6 +1290,7 @@ fn compile_command(
             func_ret_i64 = module.func_ret_i64;
             type_ret_i64 = module.type_ret_i64;
             let module_func_params_i64 = module.func_params_i64;
+            let module_func_arg_counts = module.func_arg_counts;
             // VCR-PERF-002 Phase 1 (#494): whatever facts loom forwarded
             // (empty for a section-less module — the overwhelmingly common
             // case — and for any malformed section, per the fail-safe rule).
@@ -1333,6 +1338,8 @@ fn compile_command(
             if let Some(p) = module_func_params_i64.get(func.index as usize) {
                 current_func_params_i64 = p.clone();
             }
+            // #457: THIS function's declared param count from the type section.
+            current_func_param_count = module_func_arg_counts.get(func.index as usize).copied();
             current_func_block_arity = func.block_arity.clone();
             // VCR-PERF-002 Phase 1 (#494): THIS function's facts slice, the
             // `current_func_params_i64` pattern (`compile_function` carries no
@@ -1435,6 +1442,9 @@ fn compile_command(
         // Without these the selector materialized constants into the param's
         // live high register (i64.shr_u/shr_s returned the shift amount).
         current_func_params_i64,
+        // #457: declared param count — caps the param-count inference so a
+        // read-before-write local lands in a zero-inited frame slot.
+        current_func_param_count,
         func_ret_i64,
         type_ret_i64,
         current_func_block_arity,
@@ -2416,6 +2426,10 @@ fn compile_all_exports(
                 fc.current_func_params_i64 = p.clone();
             }
             fc.current_func_block_arity = func.block_arity.clone();
+            // #457: THIS function's DECLARED param count, so the backends can
+            // cap the access-pattern param inference that mistook a
+            // read-before-write non-param local for a param.
+            fc.current_func_param_count = config.func_arg_counts.get(func.index as usize).copied();
             // VCR-PERF-002 Phase 1 (#494): THIS function's wsc.facts slice
             // (`compile_function` carries no function index — the same reason
             // `current_func_params_i64` exists). Not yet consumed.

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -156,6 +156,24 @@ pub struct CompileConfig {
     /// driver loop, because `compile_function` is shared across backends and
     /// carries no function index. Empty → assume i32.
     pub current_func_params_i64: Vec<bool>,
+    /// #457: DECLARED parameter count of the function CURRENTLY being compiled,
+    /// from the module's type section (`func_arg_counts[func.index]`). Set per
+    /// function by the driver loops like [`current_func_params_i64`].
+    ///
+    /// The backends otherwise INFER the param count from local-access patterns
+    /// (`count_params`: a local whose first access is a read is assumed to be a
+    /// param) — which cannot distinguish a param from a read-before-write
+    /// non-param local. WASM zero-initializes non-param locals, so such a local
+    /// must read 0; the inference instead homed it in a parameter register and
+    /// read caller garbage (#457). The backends cap the inferred count at this
+    /// declared count when it is present, which reclassifies exactly the
+    /// read-before-write locals (an inferred count can only exceed the declared
+    /// one via a read-first index >= the declared count) and leaves every other
+    /// function's codegen byte-identical.
+    ///
+    /// `None` → declared signature unknown (hand-built op streams, direct
+    /// `compile_function` callers) → pure inference, the legacy behaviour.
+    pub current_func_param_count: Option<u32>,
     /// #509: blocktype-arity side-table of the function CURRENTLY being compiled
     /// — `(param_count, result_count)` of the k-th `Block`/`Loop`/`If` in its op
     /// stream (ordinal-keyed; see [`FunctionOps::block_arity`]). Set per function
@@ -292,6 +310,9 @@ impl Default for CompileConfig {
             type_ret_i64: Vec::new(),
             func_params_i64: Vec::new(),
             current_func_params_i64: Vec::new(),
+            // #457: None ⇒ declared signature unknown ⇒ param-count inference
+            // only (unit tests / hand-built op streams); driver loops fill it.
+            current_func_param_count: None,
             // #509: empty ⇒ legacy void-block lowering (unit tests / hand-built
             // op streams); the driver loops fill it per function.
             current_func_block_arity: Vec::new(),

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -1139,6 +1139,37 @@ struct LocalLayout {
     spill_area_reserved: bool,
 }
 
+/// #457: the non-param locals whose FIRST access (in op order) is a read
+/// (`local.get`). WASM zero-initializes non-param locals, so such a read must
+/// observe 0 — the prologue zeroes their frame slots explicitly. A local whose
+/// first access is a write is skipped (its first access overwrites the slot
+/// before any read), keeping every function without read-before-write locals
+/// byte-identical. This is the same op-order first-access rule the RV32
+/// promotion zero-init (#472) and `count_params` use. `pub` because the RV32
+/// selector drives its frame-slot zero-init from the same set.
+pub fn read_before_write_locals(
+    wasm_ops: &[WasmOp],
+    num_params: u32,
+) -> std::collections::BTreeSet<u32> {
+    use std::collections::BTreeSet;
+    let mut seen: BTreeSet<u32> = BTreeSet::new();
+    let mut rbw: BTreeSet<u32> = BTreeSet::new();
+    for op in wasm_ops {
+        match op {
+            WasmOp::LocalGet(idx) if *idx >= num_params => {
+                if seen.insert(*idx) {
+                    rbw.insert(*idx);
+                }
+            }
+            WasmOp::LocalSet(idx) | WasmOp::LocalTee(idx) if *idx >= num_params => {
+                seen.insert(*idx);
+            }
+            _ => {}
+        }
+    }
+    rbw
+}
+
 /// Compute the stack-frame layout for non-parameter locals in a function.
 ///
 /// Walks the wasm op stream once to:
@@ -6007,6 +6038,49 @@ impl InstructionSelector {
                 },
                 source_line: None,
             });
+        }
+
+        // #457: WASM zero-initializes non-param locals, so a local READ before
+        // any write must observe 0 — not the caller garbage the old param-count
+        // inference exposed (the local was homed in a parameter register), and
+        // not stale frame memory. Zero the frame slot of every read-before-write
+        // local once at entry; an i64 local zeroes both words of its 8-byte
+        // slot. Write-first locals are untouched (their first access overwrites
+        // the slot), so functions without read-before-write locals keep a
+        // byte-identical prologue. R4 is a safe scratch: it is pushed above, no
+        // body value lives in it yet, and a promoted local homed in R4 is
+        // write-before-read by construction (`compute_local_promotion` declines
+        // read-first locals).
+        let rbw_zero_init: Vec<(i32, bool)> = read_before_write_locals(wasm_ops, num_params)
+            .iter()
+            .filter_map(|idx| layout.locals.get(idx).copied())
+            .collect();
+        if !rbw_zero_init.is_empty() {
+            instructions.push(ArmInstruction {
+                op: ArmOp::Mov {
+                    rd: Reg::R4,
+                    op2: Operand2::Imm(0),
+                },
+                source_line: None,
+            });
+            for (off, is_i64) in rbw_zero_init {
+                instructions.push(ArmInstruction {
+                    op: ArmOp::Str {
+                        rd: Reg::R4,
+                        addr: MemAddr::imm(Reg::SP, off),
+                    },
+                    source_line: None,
+                });
+                if is_i64 {
+                    instructions.push(ArmInstruction {
+                        op: ArmOp::Str {
+                            rd: Reg::R4,
+                            addr: MemAddr::imm(Reg::SP, off + 4),
+                        },
+                        source_line: None,
+                    });
+                }
+            }
         }
 
         // Virtual operand stack: each entry is a register-resident or spilled

--- a/crates/synth-synthesis/src/lib.rs
+++ b/crates/synth-synthesis/src/lib.rs
@@ -18,7 +18,8 @@ pub use control_flow::{
 };
 pub use instruction_selector::{
     ArmInstruction, BoundsCheckConfig, InstructionSelector, RegisterState, SelectionStats,
-    infer_i64_locals, validate_instructions, validate_instructions_with_helium,
+    infer_i64_locals, read_before_write_locals, validate_instructions,
+    validate_instructions_with_helium,
 };
 pub use optimizer_bridge::{
     OptimizationConfig, OptimizationStats, OptimizerBridge, estimate_arm_byte_size,

--- a/crates/synth-synthesis/tests/rbw_local_zero_init_457.rs
+++ b/crates/synth-synthesis/tests/rbw_local_zero_init_457.rs
@@ -1,0 +1,130 @@
+//! #457: a read-before-write NON-PARAM local must observe the wasm-mandated 0.
+//!
+//! `count_params` (the backends' access-pattern param inference) mistook such a
+//! local for a parameter — it was read from a parameter register (caller
+//! garbage). With the declared-count cap the local lands in a frame slot, and
+//! the direct selector's prologue must ZERO that slot before the body runs
+//! (`movs r,#0; str r,[sp,#off]`). These tests pin the zero-init emission and
+//! the classification helper; the classification cap itself is pinned in
+//! `synth-backend` (`arm_backend.rs`) and `synth-backend-riscv`.
+
+use synth_synthesis::{
+    ArmInstruction, ArmOp, InstructionSelector, Operand2, Reg, WasmOp, read_before_write_locals,
+};
+
+fn lower(wasm_ops: &[WasmOp], num_params: u32) -> Vec<ArmInstruction> {
+    let mut sel = InstructionSelector::new(vec![]);
+    sel.select_with_stack(wasm_ops, num_params)
+        .expect("select_with_stack")
+}
+
+/// The prologue zero-init: a `mov rz,#0` whose register is then stored to an
+/// SP-relative slot, BEFORE the first non-prologue op. Returns the zeroed
+/// SP offsets.
+fn zeroed_sp_offsets(instrs: &[ArmInstruction]) -> Vec<i32> {
+    let mut zero_reg: Option<Reg> = None;
+    let mut offs = Vec::new();
+    for i in instrs {
+        match &i.op {
+            ArmOp::Mov {
+                rd,
+                op2: Operand2::Imm(0),
+            } => zero_reg = Some(*rd),
+            ArmOp::Str { rd, addr } if Some(*rd) == zero_reg && addr.base == Reg::SP => {
+                offs.push(addr.offset);
+            }
+            // Stop at the first op that isn't prologue-shaped: the zero-init
+            // must dominate the body.
+            ArmOp::Push { .. } | ArmOp::Sub { .. } | ArmOp::Str { .. } => {}
+            _ => break,
+        }
+    }
+    offs
+}
+
+/// The #457 repro shape: `(param i32) (local i32)`, `p0 + local1` — local 1 is
+/// read before any write, so the prologue must zero its frame slot.
+#[test]
+fn rbw_i32_local_frame_slot_is_zero_inited_457() {
+    let ops = vec![
+        WasmOp::LocalGet(0),
+        WasmOp::LocalGet(1),
+        WasmOp::I32Add,
+        WasmOp::End,
+    ];
+    let instrs = lower(&ops, 1);
+    let offs = zeroed_sp_offsets(&instrs);
+    assert!(
+        !offs.is_empty(),
+        "read-before-write local 1 must get a prologue zero-init store, got: {:?}",
+        instrs.iter().map(|i| &i.op).collect::<Vec<_>>()
+    );
+}
+
+/// An i64 read-before-write local zeroes BOTH words of its 8-byte slot.
+#[test]
+fn rbw_i64_local_zeroes_both_words_457() {
+    let ops = vec![
+        WasmOp::LocalGet(1),
+        WasmOp::LocalSet(1), // tags local 1 as touched; first access is the READ
+        WasmOp::LocalGet(1),
+        WasmOp::I64Const(1),
+        WasmOp::I64Add,
+        WasmOp::LocalSet(1),
+        WasmOp::I32Const(0),
+        WasmOp::End,
+    ];
+    // Make local 1 i64 via an i64-producing write AFTER the first read:
+    // infer_i64_locals sees the I64Add-fed LocalSet.
+    let instrs = lower(&ops, 0);
+    let offs = zeroed_sp_offsets(&instrs);
+    assert!(
+        offs.len() >= 2,
+        "i64 rbw local must zero both slot words (off, off+4), got offsets {offs:?}"
+    );
+    assert!(
+        offs.windows(2).any(|w| w[1] == w[0] + 4),
+        "expected adjacent word zero-init (off, off+4), got {offs:?}"
+    );
+}
+
+/// Byte-neutrality guard: a WRITE-first local gets NO zero-init — functions
+/// without read-before-write locals keep their pre-#457 prologue.
+#[test]
+fn write_first_local_gets_no_zero_init_457() {
+    let ops = vec![
+        WasmOp::I32Const(7),
+        WasmOp::LocalSet(1),
+        WasmOp::LocalGet(0),
+        WasmOp::LocalGet(1),
+        WasmOp::I32Add,
+        WasmOp::End,
+    ];
+    let instrs = lower(&ops, 1);
+    assert!(
+        zeroed_sp_offsets(&instrs).is_empty(),
+        "write-first local must not be zero-inited (prologue must stay byte-identical)"
+    );
+}
+
+/// The classification helper: first-access-in-op-order, params excluded.
+#[test]
+fn read_before_write_locals_classification_457() {
+    use WasmOp::*;
+    // local 1 read-first, local 2 write-first, param 0 excluded.
+    let ops = vec![
+        LocalGet(0),
+        LocalGet(1),
+        I32Add,
+        LocalSet(2),
+        LocalGet(2),
+        End,
+    ];
+    let rbw = read_before_write_locals(&ops, 1);
+    assert!(rbw.contains(&1), "read-first local 1 is rbw");
+    assert!(!rbw.contains(&2), "write-first local 2 is not rbw");
+    assert!(!rbw.contains(&0), "param 0 is never rbw");
+    // A tee counts as a write.
+    let tee = vec![LocalTee(1), LocalGet(1), End];
+    assert!(!read_before_write_locals(&tee, 0).contains(&1));
+}

--- a/scripts/repro/read_before_write_local_zeroinit.wat
+++ b/scripts/repro/read_before_write_local_zeroinit.wat
@@ -1,28 +1,37 @@
-;; PRE-EXISTING MISCOMPILE — read-before-write non-param local is not zero-inited.
+;; #457 — read-before-write non-param local must observe the wasm-mandated 0.
 ;;
 ;; Found while building the VCR-RA local-promotion validation fixture (#390, #242).
 ;; wasm zero-initializes non-param locals, so `rbw(p0)` must return p0 + 0 = p0.
-;; synth's ARM backend instead emits `adds r2, r0, r1; mov r0, r2` — it reads the
-;; INCOMING r1 (no second param exists; r1 is caller garbage) rather than 0.
 ;;
-;; ROOT CAUSE: `count_params` (crates/synth-backend/src/arm_backend.rs:126) infers
-;; the param count from access patterns — a local whose FIRST access is a read is
-;; assumed to be a param (`is_read_first` → num_params = max(read-first idx)+1).
-;; A zero-init read-before-write local is indistinguishable from a param to this
-;; heuristic, so it is homed in the param register and read instead of zeroed.
-;;
-;; Observed (./target/debug/synth compile ... --target cortex-m4 --relocatable):
-;;   00000000 <func_0>:
+;; ROOT CAUSE (fixed in #457): `count_params` (arm_backend.rs / riscv
+;; backend.rs / aarch64 backend.rs) infers the param count from access patterns
+;; — a local whose FIRST access is a read is assumed to be a param
+;; (`is_read_first` → num_params = max(read-first idx)+1). A zero-init
+;; read-before-write local is indistinguishable from a param to this heuristic,
+;; so it was homed in the param register and read caller garbage instead of 0:
+;;   00000000 <func_0>:                 (pre-fix --relocatable output)
 ;;      0: b510   push {r4, lr}
 ;;      2: 1842   adds r2, r0, r1   <-- reads r1 (garbage), should add 0
 ;;      4: 4610   mov  r0, r2
 ;;      6: bd10   pop  {r4, pc}
 ;;
-;; Expected: r0 = r0 (+ 0). This is a real correctness gap independent of the
-;; promotion lever; promotion v1 must therefore DECLINE read-before-write locals
-;; (promote only write-before-read locals, frame fallback otherwise) until the
-;; param-count heuristic is fixed to consult the declared signature.
+;; FIX: the driver plumbs the DECLARED param count
+;; (`CompileConfig::current_func_param_count`, from the type section) and the
+;; backends cap the inference with it (`min` — a function whose inference is
+;; <= declared stays byte-identical). The reclassified local lands in a frame
+;; slot which the direct selector / RV32 selector zero-initialize at entry;
+;; the ARM optimized path detect-and-declines the shape to the direct selector.
+;;
+;; Oracle: read_before_write_local_zeroinit_differential.py (unicorn-vs-wasmtime,
+;; dirty-register + dirty-frame passes; gates ARM direct, ARM optimized, RV32).
 (module
+  ;; 1 param + 1 never-written local: must return p0 + 0 = p0.
   (func (export "rbw") (param i32) (result i32)
-    (local i32) ;; local 1: never written → must read 0
-    (i32.add (local.get 0) (local.get 1))))
+    (local i32)
+    (i32.add (local.get 0) (local.get 1)))
+  ;; 0 params (the declared-count-0 edge: a param-width table that is EMPTY for
+  ;; this function must still cap the inference) + 1 never-written local:
+  ;; must return 0.
+  (func (export "rbw0") (result i32)
+    (local i32)
+    (local.get 0)))

--- a/scripts/repro/read_before_write_local_zeroinit_differential.py
+++ b/scripts/repro/read_before_write_local_zeroinit_differential.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""#457 read-before-write local zero-init oracle (ARM direct + optimized, RV32).
+
+`read_before_write_local_zeroinit.wat` declares ONE i32 param and ONE never-
+written i32 local, and returns `p0 + local1`. WASM zero-initializes non-param
+locals, so `rbw(p0)` must return `p0 + 0 = p0`. The pre-#457 backends inferred
+the param count from access patterns (`count_params`: first-access-is-a-read ⇒
+param), so the read-before-write local was homed in the SECOND parameter
+register and the function returned `p0 + <caller garbage>`.
+
+wasmtime is ground truth; unicorn runs synth's output. The harness dispatches
+on the ELF machine (EM_ARM Thumb vs EM_RISCV RV32) so the same script gates all
+three lowering paths:
+
+  synth compile scripts/repro/read_before_write_local_zeroinit.wat \
+        -o /tmp/rbw_reloc.elf --target cortex-m4 --relocatable   # ARM direct
+  synth compile scripts/repro/read_before_write_local_zeroinit.wat \
+        -o /tmp/rbw_opt.elf --target cortex-m4                   # ARM optimized*
+  synth compile scripts/repro/read_before_write_local_zeroinit.wat \
+        -o /tmp/rbw_rv.elf -b riscv                              # RV32
+  /tmp/venv/bin/python scripts/repro/read_before_write_local_zeroinit_differential.py <elf>
+
+(*with the #457 fix the optimized path detect-and-declines the shape to the
+direct selector — the gate holds whichever selector emitted the bytes.)
+
+Every vector runs twice: CLEAN (registers/stack as unicorn zero-fills them) and
+DIRTY (r1..r3 / a1..a3 loaded with non-zero sentinels and the frame window below
+SP pre-filled with 0xA5). The dirty pass is the load-bearing one: unicorn's
+zero-filled memory and registers would let a garbage read return a coincidental
+0 and hide the bug; the sentinels make a mis-homed local or an un-zeroed frame
+slot leak visibly into the result. Symbols come from the ELF symtab, never from
+disassembly text (host-independent — the PR #489 lesson).
+
+Exits nonzero on any mismatch so it can gate a release.
+"""
+
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import (
+    UC_ARCH_ARM,
+    UC_ARCH_RISCV,
+    UC_MODE_RISCV32,
+    UC_MODE_THUMB,
+    Uc,
+)
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R3,
+    UC_ARM_REG_SP,
+)
+from unicorn.riscv_const import (
+    UC_RISCV_REG_A0,
+    UC_RISCV_REG_A1,
+    UC_RISCV_REG_A2,
+    UC_RISCV_REG_A3,
+    UC_RISCV_REG_RA,
+    UC_RISCV_REG_SP,
+)
+
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/rbw_reloc.elf"
+WAT = Path(__file__).with_name("read_before_write_local_zeroinit.wat")
+
+# Ground truth: wasmtime. rbw(p0) must be p0 (the local reads 0); rbw0() — the
+# 0-declared-params edge — must be 0.
+eng = wasmtime.Engine()
+mod = wasmtime.Module(eng, WAT.read_bytes())
+st = wasmtime.Store(eng)
+inst = wasmtime.Instance(st, mod, [])
+gt = inst.exports(st)["rbw"]
+gt0 = inst.exports(st)["rbw0"]
+
+e = ELFFile(open(ELF, "rb"))
+text_sec = e.get_section_by_name(".text")
+text, text_addr = text_sec.data(), text_sec["sh_addr"]
+symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+syms = {s.name: s["st_value"] for s in symtab.iter_symbols()}
+is_riscv = e["e_machine"] == "EM_RISCV"
+
+CODE, STK = 0x10000, 0x90000
+SP0 = STK + 0x8000
+RET = CODE + 0xFF00  # a mapped nop pad — unicorn stops when PC reaches it
+
+# Non-zero sentinels for the registers a second/third/fourth param WOULD occupy
+# — exactly what the pre-#457 misclassification read for the rbw local.
+SENTINEL = 0xDEADBEEF
+
+
+def run_arm(sym, args, dirty):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x10000)
+    mu.mem_write(CODE + text_addr, text)
+    mu.mem_map(STK, 0x10000)
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")  # nop; nop
+    arg_regs = (UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3)
+    if dirty:
+        mu.mem_write(SP0 - 0x400, b"\xa5" * 0x400)
+        for reg in arg_regs[len(args) :]:
+            mu.reg_write(reg, SENTINEL)
+    for reg, val in zip(arg_regs, args):
+        mu.reg_write(reg, val)
+    mu.reg_write(UC_ARM_REG_SP, SP0)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    # Thumb symbols carry bit 0 in the symtab already on ET_REL; mask + re-set
+    # so both ET_REL (rbw=0x1) and ET_EXEC (rbw=0xa1) resolve identically.
+    entry = CODE + text_addr + (syms[sym] & ~1)
+    mu.emu_start(entry | 1, RET, timeout=5_000_000)
+    return mu.reg_read(UC_ARM_REG_R0)
+
+
+def run_rv32(sym, args, dirty):
+    mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+    mu.mem_map(CODE, 0x10000)
+    mu.mem_write(CODE + text_addr, text)
+    mu.mem_map(STK, 0x10000)
+    arg_regs = (UC_RISCV_REG_A0, UC_RISCV_REG_A1, UC_RISCV_REG_A2, UC_RISCV_REG_A3)
+    if dirty:
+        mu.mem_write(SP0 - 0x400, b"\xa5" * 0x400)
+        for reg in arg_regs[len(args) :]:
+            mu.reg_write(reg, SENTINEL)
+    for reg, val in zip(arg_regs, args):
+        mu.reg_write(reg, val)
+    mu.reg_write(UC_RISCV_REG_SP, SP0)
+    # RA must land on a MAPPED pad (the #220 unicorn gotcha).
+    mu.reg_write(UC_RISCV_REG_RA, RET)
+    mu.emu_start(CODE + text_addr + syms[sym], RET, timeout=5_000_000)
+    return mu.reg_read(UC_RISCV_REG_A0)
+
+
+run = run_rv32 if is_riscv else run_arm
+
+ok = True
+for p0 in (0, 1, 12345, 0x7FFFFFFF, 0xDEADBEEF, 0xFFFFFFFF):
+    sp0 = p0 - (1 << 32) if p0 >= 1 << 31 else p0
+    exp = gt(st, sp0) & 0xFFFFFFFF
+    clean = run("rbw", (p0,), dirty=False) & 0xFFFFFFFF
+    dirty = run("rbw", (p0,), dirty=True) & 0xFFFFFFFF
+    good = clean == exp and dirty == exp
+    if not good:
+        ok = False
+    m = "OK  " if good else "FAIL"
+    print(
+        f"{m} rbw({p0:#010x}) clean={clean:#010x} dirty={dirty:#010x} "
+        f"expect={exp:#010x}"
+    )
+
+# The 0-declared-params edge: every argument register is garbage; result must
+# still be the zero-inited local (0).
+exp0 = gt0(st) & 0xFFFFFFFF
+clean0 = run("rbw0", (), dirty=False) & 0xFFFFFFFF
+dirty0 = run("rbw0", (), dirty=True) & 0xFFFFFFFF
+good0 = clean0 == exp0 and dirty0 == exp0
+if not good0:
+    ok = False
+print(
+    f"{'OK  ' if good0 else 'FAIL'} rbw0() clean={clean0:#010x} "
+    f"dirty={dirty0:#010x} expect={exp0:#010x}"
+)
+
+print("ORACLE:", "PASS" if ok else "FAIL")
+sys.exit(0 if ok else 1)


### PR DESCRIPTION
Fixes #457.

## The bug (live on origin/main, all three paths)

WASM zero-initializes non-param locals, but `count_params` (ARM `arm_backend.rs`, RV32 `backend.rs`, aarch64 `backend.rs`) **infers** the param count from access patterns: a local whose first access is a read is assumed to be a param. A read-before-write non-param local is indistinguishable from a param to that heuristic, so it was homed in a parameter register and read **caller garbage** instead of the mandated 0:

```
00000000 <func_0>:            (rbw = (param i32)(local i32) → p0 + local1)
   0: b510   push {r4, lr}
   2: 1842   adds r2, r0, r1   <-- reads r1; the function has ONE param
   4: 4610   mov  r0, r2
   6: bd10   pop  {r4, pc}
```

Reproduced at `origin/main` (v0.32.1) on **ARM direct** (`--relocatable`), **ARM optimized** (default image path) and **RV32** — the issue's "may be partially fixed" hope did not hold: #472 zero-inits only *promoted* locals, and the repro local (single access) fails the promotion cost gate.

## The fix

1. **Classification** — new `CompileConfig::current_func_param_count`: the *declared* count from the module type section, plumbed per function by the CLI driver loops and each backend's `compile_module` (the `current_func_params_i64` pattern). Backends cap the inference with `min(inferred, declared)`. The inference can only *exceed* the declared count via a read-first local index ≥ it, so **every function without rbw locals emits byte-identical code** — `frozen_codegen_bytes` is untouched (verified). `None` ⇒ pure inference (hand-built op streams, legacy behaviour).
2. **Zero-init** — the ARM direct selector's prologue zeroes each read-before-write local's frame slot (`movs r4,#0` + `str` per slot; both words of an i64 slot). The RV32 selector emits `sw zero, off(sp)` beside its #472 promoted-local zero-init. Write-first locals get nothing (byte-neutrality, pinned by test).
3. **Routing** — the ARM optimized path detect-and-declines the shape to the direct selector (`has_rbw_local`, same pattern as the #507/#509 gates): its `ir_to_arm` maps a non-param local vreg onto an uninitialized `r4+` temp. aarch64 (milestone-1, no non-param locals) now hits its loud "not yet supported" skip instead of silently miscompiling.

## Red → green

`scripts/repro/read_before_write_local_zeroinit_differential.py` — unicorn-vs-wasmtime, symtab-based (PR #489 lesson), dispatches ARM Thumb / RV32 on the ELF machine; every vector runs a **clean** and a **dirty** pass (arg registers seeded with `0xDEADBEEF`, frame window pre-filled `0xA5`) so a mis-homed local or un-zeroed slot leaks visibly. Includes the 0-declared-params edge (`rbw0`).

| ELF | origin/main | this PR |
|---|---|---|
| ARM `--relocatable` (direct) | **FAIL** `dirty=0xdeadbeef` | PASS |
| ARM default (optimized) | **FAIL** `dirty=0xdeadbeef` | PASS |
| RV32 (`-b riscv`) | **FAIL** `dirty=0xdeadbeef` | PASS |

## Verification

- `cargo test --workspace` green (106 suites)
- `cargo test -p synth-cli --test frozen_codegen_bytes` — all 10 pass, **no fixture bytes changed**
- New unit tests: declared-count cap (ARM + RV32, incl. `declared >= inferred` byte-identity), zero-init emission (i32 + both i64 words, ARM + RV32), write-first no-op guard, classification helper
- `cargo clippy --workspace --all-targets -- -D warnings` + `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)