### PR TITLE
feat(vcr-sel): increment 2 — i32 comparisons + register shifts + rotr in the verified selector DSL (#242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -395,9 +395,42 @@ artifacts:
       (sel_dsl_mirror_pin_generated_rules_match_handwritten_arms_242) asserts
       hand-written ≡ generated ArmOp sequences for all 7 rules; frozen
       byte-gate green with the flag OFF (by construction) AND with
-      SYNTH_SEL_DSL=1. NOT yet done (hence not verified): the default flip and
-      its full-differential re-freeze ritual; select_with_stack/optimizer_bridge
-      migration; div/rem (VCR-ISA-001-gated).
+      SYNTH_SEL_DSL=1.
+
+      INCREMENT 2 LANDED (2026-07-08, flag-off,
+      docs/design/vcr-sel-001-increment-2.md): +14 rules = 21 total, each with
+      its 1:1 Qed (21/21, 0 Admitted, 0 holdout theorems). (a) i32 register
+      shifts shl/shr_s/shr_u + rotr — measured TIER-A (single instruction, NO
+      scratch; the inc-1 side-condition machinery turned out unneeded for
+      shifts, remains exercised by rotl alone), discharged by the same
+      synth_binop_proof_poly; delegated in BOTH selectors (Delegation::Both),
+      byte-identical. (b) The ten i32 comparisons — the CMP+SetCond shape,
+      modeled per the Compilation.v convention as CMP; MOV rd #0; MOVcc rd #1;
+      NO aliasing side conditions (CMP latches NZCV before rd is written, so
+      the universal quantifier admits every aliasing); 7/10 discharged by
+      synth_cmp_binop_proof_poly (synth_cmp_binop_proof generalized to
+      universally-quantified registers) + the same three manual scripts
+      (ne/lt_s/lt_u) as their CorrectnessI32.v ancestors, register-generalized
+      verbatim. DELEGATION HONESTY: comparisons delegate in
+      select_with_stack's reg-reg arm (the load-bearing CMP+SetCond emission,
+      byte-identical by construction; the #258 imm-fold peephole stays
+      hand-written on both flag settings, pinned) because select_default's
+      comparison arms are a blind bare-Cmp lowering that never materializes
+      the 0/1 result — production-unreachable AND unprovable as T1
+      result-correspondence, so they stay hand-written (the increment's
+      documented holdout; this choice also keeps the flip strictly
+      byte-invisible). Mirror-pins:
+      sel_dsl_mirror_pin_generated_rules_match_handwritten_arms_242 (the 11
+      select_default-delegated rules) +
+      sel_dsl_mirror_pin_select_with_stack_rules_byte_identical_242 (the 14
+      select_with_stack-delegated rules, with a non-vacuity window check that
+      the delegation actually fired) +
+      sel_dsl_cmp_imm_fold_path_stays_handwritten_and_byte_identical_242.
+      FLIP EVIDENCE: with all 21 rules mirror-pinned byte-identical, nothing
+      byte-visible remains before the SYNTH_SEL_DSL default-on flip — the
+      flip is a later PR with the standard re-freeze ritual. NOT yet done
+      (hence not verified): that default flip; optimizer_bridge + the
+      remaining select_with_stack families; div/rem (VCR-ISA-001-gated).
     status: implemented
     tags: [codegen, selector, isle, verified-dsl, rocq, track-a, novel, release-v0.12.1]
     links:

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -378,19 +378,35 @@ All fully proved (Qed); no new axioms.
 | StateMonad.v | 3 | 0 | Infra |
 | WasmValues.v | 2 | 0 | Infra |
 | VcrSelPilot.v | 7 | 0 | T1 (register-polymorphic; VCR-SEL-001 go/abandon measurement, post-recount) |
-| VcrSelRules.v | 7 | 0 | T1 (register-polymorphic; the WIRED VCR-SEL-001 increment-1 rule table, 1:1 rule<->theorem, coverage-gated by `//coq:vcr_sel_rules_coverage`, post-recount) |
+| VcrSelRules.v | 21 | 0 | T1 (register-polymorphic; the WIRED VCR-SEL-001 increment-1+2 rule table, 1:1 rule<->theorem, coverage-gated by `//coq:vcr_sel_rules_coverage`, post-recount) |
 
-## VCR-SEL-001 increment 1 (2026-07-07): VcrSelRules.v
+## VCR-SEL-001 increments 1 (2026-07-07) + 2 (2026-07-08): VcrSelRules.v
 
 The wired selector-DSL rule table's obligations: one universally-quantified
-T1 theorem per rule in `crates/synth-synthesis/src/sel_dsl` — the tier-A six
+T1 theorem per rule in `crates/synth-synthesis/src/sel_dsl`.
+
+Increment 1 — the tier-A six
 (`rule_i32_{add,sub,mul,and,or,xor}_correct`, discharged by
 `synth_binop_proof_poly` verbatim) plus `rule_i32_rotl_correct` (stepped
 proof with the explicit `rs <> rn` scratch non-aliasing hypothesis the rule
-table carries as a side condition). **7 Qed / 0 Admitted**, same T1 bound as
-the pilot ("the ARM sequence computes the named result", not WASM
-refinement). These 14 Qed (pilot + rules) post-date and are NOT in the
-2026-06-04 recount above.
+table carries as a side condition).
+
+Increment 2 — the i32 register shifts + rotr
+(`rule_i32_{shl,shr_s,shr_u,rotr}_correct`: measured tier-A, single
+instruction, no scratch — discharged by the same `synth_binop_proof_poly`)
+plus the ten i32 comparisons
+(`rule_i32_{eq,ne,lt_s,lt_u,gt_s,gt_u,le_s,le_u,ge_s,ge_u}_correct`, the
+CMP+SetCond shape modeled as `CMP; MOV rd #0; MOVcc rd #1` per the
+Compilation.v convention; NO aliasing side conditions — CMP latches NZCV
+before `rd` is written, so the universal quantifier admits every aliasing.
+Seven close with `synth_cmp_binop_proof_poly` — the fixed-register
+`synth_cmp_binop_proof` generalized to universally-quantified registers —
+and `ne`/`lt_s`/`lt_u` use the same manual scripts as their
+CorrectnessI32.v ancestors, register-generalized verbatim).
+
+**21 Qed / 0 Admitted**, same T1 bound as the pilot ("the ARM sequence
+computes the named result", not WASM refinement). These 28 Qed (pilot +
+rules) post-date and are NOT in the 2026-06-04 recount above.
 
 ## Phase History
 

--- a/coq/Synth/Synth/VcrSelRules.v
+++ b/coq/Synth/Synth/VcrSelRules.v
@@ -1,4 +1,4 @@
-(** * VCR-SEL-001 increment 1: Rocq obligations of the wired selector rule table
+(** * VCR-SEL-001 increments 1+2: Rocq obligations of the wired selector rule table
 
     One universally-quantified T1 theorem per rule in the checked-in DSL table
     [crates/synth-synthesis/src/sel_dsl/mod.rs] (RULES), naming 1:1:
@@ -20,12 +20,26 @@
     checks [coq/vcr_sel_rules.manifest] (pinned to the Rust RULES table by a
     cargo test) against this file and rejects unfinished (non-Qed) proofs.
 
-    Tier A (no-scratch single-instruction: add/sub/mul/and/or/xor) discharges
-    with [synth_binop_proof_poly] — verbatim [synth_binop_proof] (Tactics.v)
+    Tier A (no-scratch single-instruction: add/sub/mul/and/or/xor, and since
+    increment 2 the register shifts shl/shr_s/shr_u + rotr) discharges with
+    [synth_binop_proof_poly] — verbatim [synth_binop_proof] (Tactics.v)
     modulo the lowering-unfold target, exactly as the pilot measured (6/6).
     Tier B ([rule_i32_rotl], RSB scratch + ROR) carries the explicit
     [rs <> rn] scratch non-aliasing hypothesis — the side condition the DSL
-    records in the rule table and the generated Rust enforces at runtime. *)
+    records in the rule table and the generated Rust enforces at runtime.
+
+    INCREMENT 2 also adds the ten i32 comparisons (the Rust CMP+SetCond
+    shape; [ArmOp::SetCond rd cond] is modeled here — following the
+    established Compilation.v convention — as [MOV rd #0; MOVcc rd #1], so
+    each rule is the three-instruction flat program
+    [CMP rn (Reg rm); MOV rd (Imm 0); MOVcc rd (Imm 1)]). Comparisons need
+    NO aliasing side conditions: CMP latches NZCV into the state's flags
+    before [rd] is written, so the universal quantifier admits every
+    rd/rn/rm aliasing. Discharge is [synth_cmp_binop_proof] (Tactics.v)
+    generalized to universally-quantified registers
+    ([synth_cmp_binop_proof_poly] below), with the same three manual
+    variants (ne / lt_s / lt_u) the fixed-register proofs in
+    CorrectnessI32.v use, parameterized over registers verbatim. *)
 
 From Stdlib Require Import List.
 From Stdlib Require Import ZArith.
@@ -39,6 +53,7 @@ Require Import Synth.WASM.WasmInstructions.
 Require Import Synth.WASM.WasmSemantics.
 Require Import Synth.Synth.Compilation.
 Require Import Synth.Synth.Tactics.
+Require Import Synth.ARM.ArmFlagLemmas.
 Import ListNotations.
 
 Open Scope Z_scope.
@@ -59,12 +74,50 @@ Definition rule_i32_xor (rd rn rm : arm_reg) : arm_program := [EOR rd rn (Reg rm
 Definition rule_i32_rotl (rd rn rm rs : arm_reg) : arm_program :=
   [RSB rs rm (Imm (I32.repr 32)); ROR_reg rd rn rs].
 
+(** ** Increment 2: i32 register shifts + rotr — tier A (single instruction,
+    no scratch; the shift amount is masked mod 32 by the I32 semantics of
+    LSL_reg/LSR_reg/ASR_reg/ROR_reg, matching WASM). *)
+
+Definition rule_i32_shl   (rd rn rm : arm_reg) : arm_program := [LSL_reg rd rn rm].
+Definition rule_i32_shr_s (rd rn rm : arm_reg) : arm_program := [ASR_reg rd rn rm].
+Definition rule_i32_shr_u (rd rn rm : arm_reg) : arm_program := [LSR_reg rd rn rm].
+Definition rule_i32_rotr  (rd rn rm : arm_reg) : arm_program := [ROR_reg rd rn rm].
+
+(** ** Increment 2: i32 comparisons — the Rust rule emits
+    [Cmp {rn, Reg(rm)}; SetCond {rd, cond}]; per the established
+    Compilation.v convention the [SetCond] pseudo-op is modeled as
+    [MOV rd #0; MOVcc rd #1] over the flags CMP latched. No aliasing side
+    conditions: the flags transfer is through NZCV, not a register, so the
+    theorems below hold for EVERY rd/rn/rm assignment. *)
+
+Definition rule_i32_eq (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVEQ rd (Imm I32.one)].
+Definition rule_i32_ne (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVNE rd (Imm I32.one)].
+Definition rule_i32_lt_s (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVLT rd (Imm I32.one)].
+Definition rule_i32_lt_u (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVLO rd (Imm I32.one)].
+Definition rule_i32_gt_s (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVGT rd (Imm I32.one)].
+Definition rule_i32_gt_u (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVHI rd (Imm I32.one)].
+Definition rule_i32_le_s (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVLE rd (Imm I32.one)].
+Definition rule_i32_le_u (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVLS rd (Imm I32.one)].
+Definition rule_i32_ge_s (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVGE rd (Imm I32.one)].
+Definition rule_i32_ge_u (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVHS rd (Imm I32.one)].
+
 (** ** The discharge tactic — verbatim [synth_binop_proof] (Tactics.v) modulo
     the lowering-unfold target, as measured by the pilot. *)
 Ltac synth_binop_proof_poly :=
   intros wstate astate v1 v2 stack' rd rn rm Hstack HR0 HR1 Hwasm;
   unfold rule_i32_add, rule_i32_sub, rule_i32_mul,
-         rule_i32_and, rule_i32_or, rule_i32_xor;
+         rule_i32_and, rule_i32_or, rule_i32_xor,
+         rule_i32_shl, rule_i32_shr_s, rule_i32_shr_u, rule_i32_rotr;
   unfold exec_program, exec_instr;
   simpl;
   rewrite HR0, HR1;
@@ -177,3 +230,228 @@ Proof.
     rewrite HR0, HR1.
     symmetry. apply I32.rotl_rotr_sub.
 Qed.
+
+(** ** Increment-2 tier-A theorems: register shifts + rotr — discharged by
+    the SAME [synth_binop_proof_poly], exactly like the ALU six (the shift
+    rules are single-instruction no-scratch shapes; their fixed-register
+    ancestors in CorrectnessI32.v already close with [synth_binop_proof]). *)
+
+Theorem rule_i32_shl_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32Shl wstate =
+    Some (mkWasmState (VI32 (I32.shl v1 v2) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_shl rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = I32.shl v1 v2.
+Proof. synth_binop_proof_poly. Qed.
+
+Theorem rule_i32_shr_s_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32ShrS wstate =
+    Some (mkWasmState (VI32 (I32.shrs v1 v2) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_shr_s rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = I32.shrs v1 v2.
+Proof. synth_binop_proof_poly. Qed.
+
+Theorem rule_i32_shr_u_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32ShrU wstate =
+    Some (mkWasmState (VI32 (I32.shru v1 v2) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_shr_u rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = I32.shru v1 v2.
+Proof. synth_binop_proof_poly. Qed.
+
+Theorem rule_i32_rotr_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32Rotr wstate =
+    Some (mkWasmState (VI32 (I32.rotr v1 v2) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_rotr rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = I32.rotr v1 v2.
+Proof. synth_binop_proof_poly. Qed.
+
+(** ** Increment-2 comparison discharge tactic — verbatim
+    [synth_cmp_binop_proof] (Tactics.v) modulo (a) the three extra register
+    binders and (b) the lowering-unfold target, mirroring how
+    [synth_binop_proof_poly] generalizes [synth_binop_proof]. *)
+Ltac synth_cmp_binop_proof_poly flag_lemma :=
+  intros wstate astate v1 v2 stack' rd rn rm Hstack HR0 HR1 Hwasm;
+  unfold rule_i32_eq, rule_i32_ne, rule_i32_lt_s, rule_i32_lt_u,
+         rule_i32_gt_s, rule_i32_gt_u, rule_i32_le_s, rule_i32_le_u,
+         rule_i32_ge_s, rule_i32_ge_u;
+  simpl;
+  rewrite HR0, HR1; simpl;
+  rewrite flag_lemma;
+  destruct (_ v1 v2);
+  (eexists; split; [reflexivity | apply get_set_reg_eq]).
+
+(** ** Increment-2 comparison theorems — quantified over ARBITRARY rd rn rm
+    (no side conditions: CMP latches NZCV before rd is written, so every
+    aliasing is admitted). Seven close with the poly tactic + the same flag
+    lemma their fixed-register ancestors use; ne / lt_s / lt_u use the same
+    manual scripts as CorrectnessI32.v, register-generalized verbatim. *)
+
+Theorem rule_i32_eq_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32Eq wstate =
+    Some (mkWasmState
+            (VI32 (if I32.eq v1 v2 then I32.one else I32.zero) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_eq rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = (if I32.eq v1 v2 then I32.one else I32.zero).
+Proof. synth_cmp_binop_proof_poly z_flag_sub_eq. Qed.
+
+Theorem rule_i32_ne_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32Ne wstate =
+    Some (mkWasmState
+            (VI32 (if I32.ne v1 v2 then I32.one else I32.zero) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_ne rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = (if I32.ne v1 v2 then I32.one else I32.zero).
+Proof.
+  intros wstate astate v1 v2 stack' rd rn rm Hstack HR0 HR1 Hwasm.
+  unfold rule_i32_ne; simpl.
+  rewrite HR0, HR1; simpl.
+  rewrite <- flags_ne.
+  destruct (compute_z_flag (I32.sub v1 v2));
+  (eexists; split; [reflexivity | apply get_set_reg_eq]).
+Qed.
+
+Theorem rule_i32_lt_s_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32LtS wstate =
+    Some (mkWasmState
+            (VI32 (if I32.lts v1 v2 then I32.one else I32.zero) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_lt_s rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = (if I32.lts v1 v2 then I32.one else I32.zero).
+Proof.
+  intros wstate astate v1 v2 stack' rd rn rm Hstack HR0 HR1 Hwasm.
+  unfold rule_i32_lt_s; simpl.
+  rewrite HR0, HR1; simpl.
+  rewrite <- nv_flag_sub_lts.
+  destruct (Bool.eqb (compute_n_flag (I32.sub v1 v2)) (compute_v_flag_sub v1 v2));
+  (eexists; split; [reflexivity | apply get_set_reg_eq]).
+Qed.
+
+Theorem rule_i32_lt_u_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32LtU wstate =
+    Some (mkWasmState
+            (VI32 (if I32.ltu v1 v2 then I32.one else I32.zero) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_lt_u rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = (if I32.ltu v1 v2 then I32.one else I32.zero).
+Proof.
+  intros wstate astate v1 v2 stack' rd rn rm Hstack HR0 HR1 Hwasm.
+  unfold rule_i32_lt_u; simpl.
+  rewrite HR0, HR1; simpl.
+  rewrite <- flags_ltu.
+  destruct (compute_c_flag_sub v1 v2);
+  (eexists; split; [reflexivity | apply get_set_reg_eq]).
+Qed.
+
+Theorem rule_i32_gt_s_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32GtS wstate =
+    Some (mkWasmState
+            (VI32 (if I32.gts v1 v2 then I32.one else I32.zero) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_gt_s rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = (if I32.gts v1 v2 then I32.one else I32.zero).
+Proof. synth_cmp_binop_proof_poly flags_gts. Qed.
+
+Theorem rule_i32_gt_u_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32GtU wstate =
+    Some (mkWasmState
+            (VI32 (if I32.gtu v1 v2 then I32.one else I32.zero) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_gt_u rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = (if I32.gtu v1 v2 then I32.one else I32.zero).
+Proof. synth_cmp_binop_proof_poly flags_gtu. Qed.
+
+Theorem rule_i32_le_s_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32LeS wstate =
+    Some (mkWasmState
+            (VI32 (if I32.les v1 v2 then I32.one else I32.zero) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_le_s rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = (if I32.les v1 v2 then I32.one else I32.zero).
+Proof. synth_cmp_binop_proof_poly flags_les. Qed.
+
+Theorem rule_i32_le_u_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32LeU wstate =
+    Some (mkWasmState
+            (VI32 (if I32.leu v1 v2 then I32.one else I32.zero) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_le_u rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = (if I32.leu v1 v2 then I32.one else I32.zero).
+Proof. synth_cmp_binop_proof_poly flags_leu. Qed.
+
+Theorem rule_i32_ge_s_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32GeS wstate =
+    Some (mkWasmState
+            (VI32 (if I32.ges v1 v2 then I32.one else I32.zero) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_ge_s rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = (if I32.ges v1 v2 then I32.one else I32.zero).
+Proof. synth_cmp_binop_proof_poly flags_ges. Qed.
+
+Theorem rule_i32_ge_u_correct : forall wstate astate v1 v2 stack' rd rn rm,
+  wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  get_reg astate rn = v1 ->
+  get_reg astate rm = v2 ->
+  exec_wasm_instr I32GeU wstate =
+    Some (mkWasmState
+            (VI32 (if I32.geu v1 v2 then I32.one else I32.zero) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_ge_u rd rn rm) astate = Some astate' /\
+    get_reg astate' rd = (if I32.geu v1 v2 then I32.one else I32.zero).
+Proof. synth_cmp_binop_proof_poly flags_geu. Qed.

--- a/coq/vcr_sel_rules.manifest
+++ b/coq/vcr_sel_rules.manifest
@@ -10,3 +10,17 @@ rule_i32_and
 rule_i32_or
 rule_i32_xor
 rule_i32_rotl
+rule_i32_shl
+rule_i32_shr_s
+rule_i32_shr_u
+rule_i32_rotr
+rule_i32_eq
+rule_i32_ne
+rule_i32_lt_s
+rule_i32_lt_u
+rule_i32_gt_s
+rule_i32_gt_u
+rule_i32_le_s
+rule_i32_le_u
+rule_i32_ge_s
+rule_i32_ge_u

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -1933,19 +1933,26 @@ pub struct InstructionSelector {
     /// compiles with the default pool keeps its frame byte-identical by
     /// construction.
     i64_spill_slots: usize,
-    /// VCR-SEL-001 increment 1 (#242): serve the migrated `select_default`
-    /// arms (the tier-A i32 ALU six + `i32.rotl`) from the generated,
-    /// Rocq-proved rule table [`crate::sel_dsl::generated`] instead of the
-    /// hand-written lowering. Default OFF (read from `SYNTH_SEL_DSL`) — OFF
-    /// keeps every arm on its original hand-written body, byte-identical by
-    /// construction. The two implementations are mirror-pinned per op
-    /// (`sel_dsl_mirror_pin_generated_rules_match_handwritten_arms_242`).
-    /// See `docs/design/vcr-sel-001-first-increment.md`.
+    /// VCR-SEL-001 increments 1+2 (#242): serve the migrated selector arms
+    /// from the generated, Rocq-proved rule table
+    /// [`crate::sel_dsl::generated`] instead of the hand-written lowering —
+    /// increment 1: `select_default`'s tier-A i32 ALU six + `i32.rotl`;
+    /// increment 2: the i32 register shifts + `rotr` (both selectors) and
+    /// the ten i32 comparisons (`select_with_stack`'s reg-reg CMP+SetCond
+    /// arm — `select_default`'s blind bare-`Cmp` comparison arms never
+    /// materialize the 0/1 result and stay hand-written). Default OFF (read
+    /// from `SYNTH_SEL_DSL`) — OFF keeps every arm on its original
+    /// hand-written body, and ON is byte-identical by construction. The two
+    /// implementations are mirror-pinned per op
+    /// (`sel_dsl_mirror_pin_generated_rules_match_handwritten_arms_242`,
+    /// `sel_dsl_mirror_pin_select_with_stack_rules_byte_identical_242`).
+    /// See `docs/design/vcr-sel-001-first-increment.md` and
+    /// `docs/design/vcr-sel-001-increment-2.md`.
     sel_dsl: bool,
 }
 
 /// `SYNTH_SEL_DSL` (VCR-SEL-001, #242): opt-IN lever, default OFF. Set (to
-/// anything but `0`) ⇒ the migrated `select_default` arms delegate to the
+/// anything but `0`) ⇒ the migrated selector arms delegate to the
 /// generated rule table.
 fn sel_dsl_from_env() -> bool {
     std::env::var("SYNTH_SEL_DSL").is_ok_and(|v| v != "0")
@@ -2394,10 +2401,31 @@ impl InstructionSelector {
                 }
             }
 
-            // Shifts: WASM pops both value (rn) and shift amount (rm) from stack
-            I32Shl => vec![ArmOp::LslReg { rd, rn, rm }],
-            I32ShrS => vec![ArmOp::AsrReg { rd, rn, rm }],
-            I32ShrU => vec![ArmOp::LsrReg { rd, rn, rm }],
+            // Shifts: WASM pops both value (rn) and shift amount (rm) from stack.
+            // VCR-SEL-001 increment 2 (#242): delegated to the Rocq-proved rules
+            // behind SYNTH_SEL_DSL, byte-identical by construction (single
+            // identical instruction).
+            I32Shl => {
+                if self.sel_dsl {
+                    crate::sel_dsl::generated::rule_i32_shl(rd, rn, rm)
+                } else {
+                    vec![ArmOp::LslReg { rd, rn, rm }]
+                }
+            }
+            I32ShrS => {
+                if self.sel_dsl {
+                    crate::sel_dsl::generated::rule_i32_shr_s(rd, rn, rm)
+                } else {
+                    vec![ArmOp::AsrReg { rd, rn, rm }]
+                }
+            }
+            I32ShrU => {
+                if self.sel_dsl {
+                    crate::sel_dsl::generated::rule_i32_shr_u(rd, rn, rm)
+                } else {
+                    vec![ArmOp::LsrReg { rd, rn, rm }]
+                }
+            }
 
             // Rotate operations: shift amount from stack register
             I32Rotl => {
@@ -2423,7 +2451,13 @@ impl InstructionSelector {
                 }
             }
 
-            I32Rotr => vec![ArmOp::RorReg { rd, rn, rm }],
+            I32Rotr => {
+                if self.sel_dsl {
+                    crate::sel_dsl::generated::rule_i32_rotr(rd, rn, rm)
+                } else {
+                    vec![ArmOp::RorReg { rd, rn, rm }]
+                }
+            }
 
             // Bit count operations
             I32Clz => vec![ArmOp::Clz { rd, rm }],
@@ -9785,6 +9819,15 @@ impl InstructionSelector {
                     } else {
                         None
                     };
+                    // VCR-SEL-001 increment 2 (#242): the plain reg-reg
+                    // CMP+SetCond pair is served from the Rocq-proved rule
+                    // table behind SYNTH_SEL_DSL — `reg_operands` records the
+                    // operand registers so the delegation below can call the
+                    // rule with the exact registers the hand-written arm
+                    // uses (byte-identical by construction; the #258
+                    // imm-fold peephole stays hand-written, outside the
+                    // reg-reg rule's shape).
+                    let mut reg_operands = None;
                     let cmp_op = if let Some((is_neg, mag)) = fold {
                         let _b = pop_operand(
                             &mut stack,
@@ -9831,6 +9874,7 @@ impl InstructionSelector {
                             &live_params,
                             idx,
                         )?;
+                        reg_operands = Some((a, b));
                         ArmOp::Cmp {
                             rn: a,
                             op2: Operand2::Reg(b),
@@ -9861,17 +9905,38 @@ impl InstructionSelector {
                         I32GeU => Condition::HS,
                         _ => unreachable!(),
                     };
-                    instructions.push(ArmInstruction {
-                        op: cmp_op,
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
-                    // SetCond rd, <cond> — materializes 0/1 based on flags
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::SetCond { rd: dst, cond },
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
+                    // VCR-SEL-001 increment 2 (#242): behind SYNTH_SEL_DSL
+                    // (default OFF) the reg-reg pair comes from the generated
+                    // Rocq-proved rule — [Cmp {rn:a, Reg(b)}, SetCond {dst,
+                    // cond}], byte-identical to the hand-written emission
+                    // below (mirror-pinned per op). OFF, or on the imm-fold
+                    // path, keeps the original hand-written body.
+                    let dsl_ops = if self.sel_dsl {
+                        reg_operands.and_then(|(a, b)| crate::sel_dsl::i32_cmp_rule(op, dst, a, b))
+                    } else {
+                        None
+                    };
+                    if let Some(rule_ops) = dsl_ops {
+                        for rule_op in rule_ops {
+                            instructions.push(ArmInstruction {
+                                op: rule_op,
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                        }
+                    } else {
+                        instructions.push(ArmInstruction {
+                            op: cmp_op,
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                        // SetCond rd, <cond> — materializes 0/1 based on flags
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::SetCond { rd: dst, cond },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    }
                     stack.push(StackVal::i32(dst));
                 }
 
@@ -9972,11 +10037,30 @@ impl InstructionSelector {
                         },
                         _ => unreachable!(),
                     };
-                    instructions.push(ArmInstruction {
-                        op: shift_op,
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
+                    // VCR-SEL-001 increment 2 (#242): behind SYNTH_SEL_DSL the
+                    // single shift instruction comes from the generated
+                    // Rocq-proved rule — the identical ArmOp, byte-identical
+                    // by construction (mirror-pinned per op).
+                    let dsl_ops = if self.sel_dsl {
+                        crate::sel_dsl::i32_shift_rule(op, dst, value, shift_amt)
+                    } else {
+                        None
+                    };
+                    if let Some(rule_ops) = dsl_ops {
+                        for rule_op in rule_ops {
+                            instructions.push(ArmInstruction {
+                                op: rule_op,
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                        }
+                    } else {
+                        instructions.push(ArmInstruction {
+                            op: shift_op,
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    }
                     stack.push(StackVal::i32(dst));
                 }
 
@@ -11253,18 +11337,32 @@ mod tests {
         }
     }
 
-    /// VCR-SEL-001 increment 1 (#242) — gate 1, the #511/#513 mirror-pinning
-    /// pattern: for EVERY rule in the DSL table, lower its op through BOTH the
+    /// VCR-SEL-001 increments 1+2 (#242) — gate 1, the #511/#513
+    /// mirror-pinning pattern: for every rule delegated in `select_default`
+    /// (`Delegation::SelectDefault`/`Both`), lower its op through BOTH the
     /// hand-written `select_default` arm (flag OFF) and the generated
     /// Rocq-proved rule (flag ON) from identical selector state, and assert
     /// the emitted `ArmOp` sequences are EQUAL. Same-ArmOps ⇒ same encoded
     /// bytes, so the two must-agree implementations are pinned before the
-    /// `SYNTH_SEL_DSL` flag can matter — increment 1 migrates structure,
+    /// `SYNTH_SEL_DSL` flag can matter — the migration moves structure,
     /// never bytes. Uses `set_sel_dsl` (not the env var) so parallel tests
     /// never race on the process environment.
+    ///
+    /// Comparison rules (`Delegation::SelectWithStack`) are NOT probed here:
+    /// `select_default`'s comparison arms are a blind bare-`Cmp` lowering
+    /// (never materializes the 0/1 result; production-unreachable —
+    /// `select_with_stack` owns comparisons) and stay hand-written. Their
+    /// mirror-pin is
+    /// `sel_dsl_mirror_pin_select_with_stack_rules_byte_identical_242`.
     #[test]
     fn sel_dsl_mirror_pin_generated_rules_match_handwritten_arms_242() {
+        use crate::sel_dsl::Delegation;
+        let mut probed = 0;
         for rule in crate::sel_dsl::RULES {
+            if rule.delegation == Delegation::SelectWithStack {
+                continue;
+            }
+            probed += 1;
             let ops = vec![rule.op.clone()];
 
             // Empty rule set ⇒ the pattern matcher never fires and every op
@@ -11290,8 +11388,173 @@ mod tests {
             assert_eq!(
                 baseline, generated,
                 "{}: generated rule diverges from the hand-written arm — \
-                 increment 1 migrates structure, never bytes",
+                 the migration moves structure, never bytes",
                 rule.name
+            );
+        }
+        // Non-vacuity: increment 1's seven + increment 2's four shifts.
+        assert_eq!(probed, 11, "unexpected select_default-delegated rule count");
+    }
+
+    /// VCR-SEL-001 increment 2 (#242) — gate 1 for the rules delegated in
+    /// `select_with_stack` (the ten comparisons: `Delegation::SelectWithStack`;
+    /// the four register shifts: `Delegation::Both`). For each, lower a
+    /// two-param probe (`local.get 0; local.get 1; <op>`) through
+    /// `select_with_stack` with the flag OFF and ON and assert the FULL
+    /// emitted sequences are equal. Non-vacuity (the RMW-vacuity gotcha):
+    /// locate the hand-written emission window in the OFF sequence, extract
+    /// the registers the selector chose, and assert the window equals the
+    /// generated rule's output for exactly those registers — proving the
+    /// delegation actually fired and the rule reproduces the hand-written
+    /// arm byte-for-byte.
+    #[test]
+    fn sel_dsl_mirror_pin_select_with_stack_rules_byte_identical_242() {
+        use crate::sel_dsl::Delegation;
+        use synth_core::WasmOp;
+        let mut probed = 0;
+        for rule in crate::sel_dsl::RULES {
+            if rule.delegation == Delegation::SelectDefault {
+                continue;
+            }
+            probed += 1;
+            let ops = vec![WasmOp::LocalGet(0), WasmOp::LocalGet(1), rule.op.clone()];
+
+            let mut handwritten = InstructionSelector::new(vec![]);
+            handwritten.set_sel_dsl(false);
+            let baseline: Vec<ArmOp> = handwritten
+                .select_with_stack(&ops, 2)
+                .unwrap_or_else(|e| panic!("{}: hand-written arm failed: {e}", rule.name))
+                .into_iter()
+                .map(|i| i.op)
+                .collect();
+
+            let mut dsl = InstructionSelector::new(vec![]);
+            dsl.set_sel_dsl(true);
+            let generated: Vec<ArmOp> = dsl
+                .select_with_stack(&ops, 2)
+                .unwrap_or_else(|e| panic!("{}: generated rule failed: {e}", rule.name))
+                .into_iter()
+                .map(|i| i.op)
+                .collect();
+
+            assert_eq!(
+                baseline, generated,
+                "{}: SYNTH_SEL_DSL=1 diverges from the hand-written \
+                 select_with_stack arm — the migration moves structure, never bytes",
+                rule.name
+            );
+
+            // Non-vacuity: find the hand-written window, extract the chosen
+            // registers, and check it equals the rule's own output for them.
+            let is_cmp_rule = rule
+                .seq
+                .iter()
+                .any(|t| matches!(t, crate::sel_dsl::TemplateOp::SetCond { .. }));
+            let (window, rule_ops) = if is_cmp_rule {
+                let i = baseline
+                    .iter()
+                    .position(|o| matches!(o, ArmOp::Cmp { .. }))
+                    .unwrap_or_else(|| panic!("{}: no Cmp in probe output", rule.name));
+                let (rn, rm) = match &baseline[i] {
+                    ArmOp::Cmp {
+                        rn,
+                        op2: Operand2::Reg(rm),
+                    } => (*rn, *rm),
+                    other => panic!("{}: probe Cmp is not reg-reg: {other:?}", rule.name),
+                };
+                let rd = match &baseline[i + 1] {
+                    ArmOp::SetCond { rd, .. } => *rd,
+                    other => panic!("{}: no SetCond after Cmp: {other:?}", rule.name),
+                };
+                (
+                    baseline[i..i + 2].to_vec(),
+                    crate::sel_dsl::i32_cmp_rule(&rule.op, rd, rn, rm)
+                        .unwrap_or_else(|| panic!("{}: cmp dispatch missing", rule.name)),
+                )
+            } else {
+                let i = baseline
+                    .iter()
+                    .position(|o| {
+                        matches!(
+                            o,
+                            ArmOp::LslReg { .. }
+                                | ArmOp::LsrReg { .. }
+                                | ArmOp::AsrReg { .. }
+                                | ArmOp::RorReg { .. }
+                        )
+                    })
+                    .unwrap_or_else(|| panic!("{}: no shift op in probe output", rule.name));
+                let (rd, rn, rm) = match &baseline[i] {
+                    ArmOp::LslReg { rd, rn, rm }
+                    | ArmOp::LsrReg { rd, rn, rm }
+                    | ArmOp::AsrReg { rd, rn, rm }
+                    | ArmOp::RorReg { rd, rn, rm } => (*rd, *rn, *rm),
+                    _ => unreachable!(),
+                };
+                (
+                    baseline[i..i + 1].to_vec(),
+                    crate::sel_dsl::i32_shift_rule(&rule.op, rd, rn, rm)
+                        .unwrap_or_else(|| panic!("{}: shift dispatch missing", rule.name)),
+                )
+            };
+            assert_eq!(
+                window, rule_ops,
+                "{}: the hand-written emission window does not equal the \
+                 generated rule's output for the same registers",
+                rule.name
+            );
+        }
+        // Ten comparisons + four shifts.
+        assert_eq!(
+            probed, 14,
+            "unexpected select_with_stack-delegated rule count"
+        );
+    }
+
+    /// VCR-SEL-001 increment 2 (#242): the #258 imm-fold comparison peephole
+    /// (`cmp a, #C` / `cmn a, #-C`) is OUTSIDE the reg-reg rule's shape — the
+    /// delegation must skip it and stay byte-identical with the flag ON.
+    #[test]
+    fn sel_dsl_cmp_imm_fold_path_stays_handwritten_and_byte_identical_242() {
+        use synth_core::WasmOp;
+        for (c, opv) in [(5i32, WasmOp::I32Eq), (-7i32, WasmOp::I32LtS)] {
+            let ops = vec![WasmOp::LocalGet(0), WasmOp::I32Const(c), opv];
+
+            let mut handwritten = InstructionSelector::new(vec![]);
+            handwritten.set_sel_dsl(false);
+            let baseline: Vec<ArmOp> = handwritten
+                .select_with_stack(&ops, 1)
+                .expect("hand-written fold path failed")
+                .into_iter()
+                .map(|i| i.op)
+                .collect();
+
+            let mut dsl = InstructionSelector::new(vec![]);
+            dsl.set_sel_dsl(true);
+            let generated: Vec<ArmOp> = dsl
+                .select_with_stack(&ops, 1)
+                .expect("fold path with flag ON failed")
+                .into_iter()
+                .map(|i| i.op)
+                .collect();
+
+            assert_eq!(
+                baseline, generated,
+                "imm-fold comparison path must stay byte-identical under SYNTH_SEL_DSL=1"
+            );
+            // The fold actually fired (imm cmp/cmn present, no reg-reg Cmp).
+            assert!(
+                baseline.iter().any(|o| matches!(
+                    o,
+                    ArmOp::Cmp {
+                        op2: Operand2::Imm(_),
+                        ..
+                    } | ArmOp::Cmn {
+                        op2: Operand2::Imm(_),
+                        ..
+                    }
+                )),
+                "probe did not exercise the imm-fold path"
             );
         }
     }

--- a/crates/synth-synthesis/src/sel_dsl/generated.rs
+++ b/crates/synth-synthesis/src/sel_dsl/generated.rs
@@ -1,8 +1,9 @@
 //! GENERATED FILE — DO NOT EDIT BY HAND.
 //!
 //! Emitted by `crate::sel_dsl::generate_lowering_source()` from the declarative
-//! rule table [`crate::sel_dsl::RULES`] (VCR-SEL-001 increment 1, #242,
-//! `docs/design/vcr-sel-001-first-increment.md`). Pinned up-to-date by the
+//! rule table [`crate::sel_dsl::RULES`] (VCR-SEL-001 increments 1+2, #242,
+//! `docs/design/vcr-sel-001-first-increment.md` +
+//! `docs/design/vcr-sel-001-increment-2.md`). Pinned up-to-date by the
 //! `generated_lowering_is_up_to_date` test; regenerate with
 //! `SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl`.
 //!
@@ -12,7 +13,7 @@
 //! result in `rd` for EVERY register assignment satisfying the stated side
 //! conditions.
 
-use crate::rules::{ArmOp, Operand2, Reg};
+use crate::rules::{ArmOp, Condition, Operand2, Reg};
 
 /// `i32.add`: rd = rn + rm
 ///
@@ -94,4 +95,192 @@ pub fn rule_i32_rotl(rd: Reg, rn: Reg, rm: Reg, rs: Reg) -> Result<Vec<ArmOp>, &
         },
         ArmOp::RorReg { rd, rn, rm: rs },
     ])
+}
+
+/// `i32.shl`: rd = rn << rm
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_shl_correct` (Qed).
+pub fn rule_i32_shl(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::LslReg { rd, rn, rm }]
+}
+
+/// `i32.shr_s`: rd = rn >> rm (arithmetic)
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_shr_s_correct` (Qed).
+pub fn rule_i32_shr_s(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::AsrReg { rd, rn, rm }]
+}
+
+/// `i32.shr_u`: rd = rn >> rm (logical)
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_shr_u_correct` (Qed).
+pub fn rule_i32_shr_u(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::LsrReg { rd, rn, rm }]
+}
+
+/// `i32.rotr`: rd = rn rotated right by rm
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_rotr_correct` (Qed).
+pub fn rule_i32_rotr(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::RorReg { rd, rn, rm }]
+}
+
+/// `i32.eq`: rd = if rn == rm {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_eq_correct` (Qed).
+pub fn rule_i32_eq(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![
+        ArmOp::Cmp {
+            rn,
+            op2: Operand2::Reg(rm),
+        },
+        ArmOp::SetCond {
+            rd,
+            cond: Condition::EQ,
+        },
+    ]
+}
+
+/// `i32.ne`: rd = if rn != rm {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_ne_correct` (Qed).
+pub fn rule_i32_ne(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![
+        ArmOp::Cmp {
+            rn,
+            op2: Operand2::Reg(rm),
+        },
+        ArmOp::SetCond {
+            rd,
+            cond: Condition::NE,
+        },
+    ]
+}
+
+/// `i32.lt_s`: rd = if rn < rm (signed) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_lt_s_correct` (Qed).
+pub fn rule_i32_lt_s(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![
+        ArmOp::Cmp {
+            rn,
+            op2: Operand2::Reg(rm),
+        },
+        ArmOp::SetCond {
+            rd,
+            cond: Condition::LT,
+        },
+    ]
+}
+
+/// `i32.lt_u`: rd = if rn < rm (unsigned) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_lt_u_correct` (Qed).
+pub fn rule_i32_lt_u(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![
+        ArmOp::Cmp {
+            rn,
+            op2: Operand2::Reg(rm),
+        },
+        ArmOp::SetCond {
+            rd,
+            cond: Condition::LO,
+        },
+    ]
+}
+
+/// `i32.gt_s`: rd = if rn > rm (signed) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_gt_s_correct` (Qed).
+pub fn rule_i32_gt_s(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![
+        ArmOp::Cmp {
+            rn,
+            op2: Operand2::Reg(rm),
+        },
+        ArmOp::SetCond {
+            rd,
+            cond: Condition::GT,
+        },
+    ]
+}
+
+/// `i32.gt_u`: rd = if rn > rm (unsigned) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_gt_u_correct` (Qed).
+pub fn rule_i32_gt_u(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![
+        ArmOp::Cmp {
+            rn,
+            op2: Operand2::Reg(rm),
+        },
+        ArmOp::SetCond {
+            rd,
+            cond: Condition::HI,
+        },
+    ]
+}
+
+/// `i32.le_s`: rd = if rn <= rm (signed) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_le_s_correct` (Qed).
+pub fn rule_i32_le_s(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![
+        ArmOp::Cmp {
+            rn,
+            op2: Operand2::Reg(rm),
+        },
+        ArmOp::SetCond {
+            rd,
+            cond: Condition::LE,
+        },
+    ]
+}
+
+/// `i32.le_u`: rd = if rn <= rm (unsigned) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_le_u_correct` (Qed).
+pub fn rule_i32_le_u(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![
+        ArmOp::Cmp {
+            rn,
+            op2: Operand2::Reg(rm),
+        },
+        ArmOp::SetCond {
+            rd,
+            cond: Condition::LS,
+        },
+    ]
+}
+
+/// `i32.ge_s`: rd = if rn >= rm (signed) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_ge_s_correct` (Qed).
+pub fn rule_i32_ge_s(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![
+        ArmOp::Cmp {
+            rn,
+            op2: Operand2::Reg(rm),
+        },
+        ArmOp::SetCond {
+            rd,
+            cond: Condition::GE,
+        },
+    ]
+}
+
+/// `i32.ge_u`: rd = if rn >= rm (unsigned) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_ge_u_correct` (Qed).
+pub fn rule_i32_ge_u(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![
+        ArmOp::Cmp {
+            rn,
+            op2: Operand2::Reg(rm),
+        },
+        ArmOp::SetCond {
+            rd,
+            cond: Condition::HS,
+        },
+    ]
 }

--- a/crates/synth-synthesis/src/sel_dsl/mod.rs
+++ b/crates/synth-synthesis/src/sel_dsl/mod.rs
@@ -1,11 +1,20 @@
-//! VCR-SEL-001 increment 1 (#242) — the Rocq-discharged selector rule DSL.
+//! VCR-SEL-001 increments 1+2 (#242) — the Rocq-discharged selector rule DSL.
 //!
-//! Scope: `docs/design/vcr-sel-001-first-increment.md`. This module is the
+//! Scope: `docs/design/vcr-sel-001-first-increment.md` (increment 1) and
+//! `docs/design/vcr-sel-001-increment-2.md` (increment 2). This module is the
 //! **checked-in rule table**: a declarative `op → parameterized ARM sequence`
-//! (registers as variables, side conditions explicit) for the pilot-measured
-//! tier-A i32 ALU class (`add/sub/mul/and/or/xor`, 6/6 auto-discharge) plus one
-//! tier-B scratch-using shape (`i32.rotl`), included deliberately so the rule
-//! format carries a scratch non-aliasing side condition from day one.
+//! (registers as variables, side conditions explicit) for:
+//!
+//! - increment 1: the pilot-measured tier-A i32 ALU class
+//!   (`add/sub/mul/and/or/xor`, 6/6 auto-discharge) plus one tier-B
+//!   scratch-using shape (`i32.rotl`), included deliberately so the rule
+//!   format carries a scratch non-aliasing side condition from day one;
+//! - increment 2: the i32 register-shift family (`shl/shr_s/shr_u` + `rotr`,
+//!   all single-instruction tier-A — no scratch needed, measured) and the ten
+//!   i32 comparisons (`eq/ne/lt_s/lt_u/gt_s/gt_u/le_s/le_u/ge_s/ge_u`, the
+//!   CMP+SetCond shape — no side conditions either: the flags transfer through
+//!   NZCV, not a register, so every rd/rn/rm aliasing is admitted by the
+//!   universal quantifier).
 //!
 //! The table is turned into plain Rust lowering functions by
 //! [`generate_lowering_source`] and the output is **committed to the tree** at
@@ -73,6 +82,74 @@ pub enum SideCondition {
     NotAlias(RegVar, RegVar),
 }
 
+/// Which hand-written selector arm delegates to this rule behind
+/// `SYNTH_SEL_DSL` — i.e. where the rule is byte-identically wired.
+///
+/// Increment 1 wired `select_default` only. Increment 2 steps the comparison
+/// family into `select_with_stack` because that is where the load-bearing
+/// hand-written CMP+SetCond arm lives: `select_default`'s comparison arms are
+/// a *blind* bare-`Cmp` lowering (the 0/1 result is never materialized —
+/// production-unreachable, `select_with_stack` owns comparisons), so a rule
+/// byte-matching them would be unprovable as T1 result-correspondence. Those
+/// arms stay hand-written — an honest holdout, documented in
+/// `docs/design/vcr-sel-001-increment-2.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Delegation {
+    /// Wired in `select_default`'s match arm only (increment 1 pattern).
+    SelectDefault,
+    /// Wired in `select_with_stack`'s arm only (the load-bearing path).
+    SelectWithStack,
+    /// Wired in both selectors' arms (byte-identical in each).
+    Both,
+}
+
+/// A condition code for the `SetCond` template shape — mirrors
+/// `crate::rules::Condition` (and the Coq flat model's `MOVcc` family, which
+/// is how `ArmOp::SetCond` is modeled in `VcrSelRules.v`: `MOV rd #0;
+/// MOVcc rd #1`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CondCode {
+    /// Equal (Z == 1).
+    Eq,
+    /// Not equal (Z == 0).
+    Ne,
+    /// Signed less-than (N != V).
+    Lt,
+    /// Unsigned lower (C == 0).
+    Lo,
+    /// Signed greater-than (Z == 0 && N == V).
+    Gt,
+    /// Unsigned higher (C == 1 && Z == 0).
+    Hi,
+    /// Signed less-or-equal (Z == 1 || N != V).
+    Le,
+    /// Unsigned lower-or-same (C == 0 || Z == 1).
+    Ls,
+    /// Signed greater-or-equal (N == V).
+    Ge,
+    /// Unsigned higher-or-same (C == 1).
+    Hs,
+}
+
+impl CondCode {
+    /// The `crate::rules::Condition` variant path this code renders to in the
+    /// generated lowering function.
+    pub const fn rust_name(self) -> &'static str {
+        match self {
+            CondCode::Eq => "Condition::EQ",
+            CondCode::Ne => "Condition::NE",
+            CondCode::Lt => "Condition::LT",
+            CondCode::Lo => "Condition::LO",
+            CondCode::Gt => "Condition::GT",
+            CondCode::Hi => "Condition::HI",
+            CondCode::Le => "Condition::LE",
+            CondCode::Ls => "Condition::LS",
+            CondCode::Ge => "Condition::GE",
+            CondCode::Hs => "Condition::HS",
+        }
+    }
+}
+
 /// One ARM instruction template over register variables. Shapes cover exactly
 /// what the increment-1 rules need; new op classes add shapes alongside their
 /// rules (+ theorems).
@@ -94,6 +171,16 @@ pub enum TemplateOp {
     RsbImm { rd: RegVar, rn: RegVar, imm: u32 },
     /// `ArmOp::RorReg { rd, rn, rm }`
     RorReg { rd: RegVar, rn: RegVar, rm: RegVar },
+    /// `ArmOp::LslReg { rd, rn, rm }`
+    LslReg { rd: RegVar, rn: RegVar, rm: RegVar },
+    /// `ArmOp::LsrReg { rd, rn, rm }`
+    LsrReg { rd: RegVar, rn: RegVar, rm: RegVar },
+    /// `ArmOp::AsrReg { rd, rn, rm }`
+    AsrReg { rd: RegVar, rn: RegVar, rm: RegVar },
+    /// `ArmOp::Cmp { rn, op2: Reg(rm) }` — flags only, no register written
+    CmpReg { rn: RegVar, rm: RegVar },
+    /// `ArmOp::SetCond { rd, cond }` — rd = if cond over current NZCV {1} else {0}
+    SetCond { rd: RegVar, cond: CondCode },
 }
 
 /// One declarative lowering rule: `op → parameterized ARM sequence`.
@@ -112,6 +199,9 @@ pub struct SelRule {
     pub side_conditions: &'static [SideCondition],
     /// The emitted instruction sequence, over register variables.
     pub seq: &'static [TemplateOp],
+    /// Which hand-written selector arm delegates to this rule (mirror-pin
+    /// target: the delegation must be byte-identical there).
+    pub delegation: Delegation,
     /// One-line human description for the generated function's doc comment.
     pub doc: &'static str,
 }
@@ -141,6 +231,7 @@ pub const RULES: &[SelRule] = &[
             rn: Rn,
             rm: Rm,
         }],
+        delegation: Delegation::SelectDefault,
         doc: "`i32.add`: rd = rn + rm",
     },
     SelRule {
@@ -153,6 +244,7 @@ pub const RULES: &[SelRule] = &[
             rn: Rn,
             rm: Rm,
         }],
+        delegation: Delegation::SelectDefault,
         doc: "`i32.sub`: rd = rn - rm",
     },
     SelRule {
@@ -165,6 +257,7 @@ pub const RULES: &[SelRule] = &[
             rn: Rn,
             rm: Rm,
         }],
+        delegation: Delegation::SelectDefault,
         doc: "`i32.mul`: rd = rn * rm",
     },
     SelRule {
@@ -177,6 +270,7 @@ pub const RULES: &[SelRule] = &[
             rn: Rn,
             rm: Rm,
         }],
+        delegation: Delegation::SelectDefault,
         doc: "`i32.and`: rd = rn & rm",
     },
     SelRule {
@@ -189,6 +283,7 @@ pub const RULES: &[SelRule] = &[
             rn: Rn,
             rm: Rm,
         }],
+        delegation: Delegation::SelectDefault,
         doc: "`i32.or`: rd = rn | rm",
     },
     SelRule {
@@ -201,6 +296,7 @@ pub const RULES: &[SelRule] = &[
             rn: Rn,
             rm: Rm,
         }],
+        delegation: Delegation::SelectDefault,
         doc: "`i32.xor`: rd = rn ^ rm",
     },
     SelRule {
@@ -220,9 +316,262 @@ pub const RULES: &[SelRule] = &[
                 rm: Rs,
             },
         ],
+        delegation: Delegation::SelectDefault,
         doc: "`i32.rotl`: rotate left by rm = rotate right by (32 - rm), via scratch rs",
     },
+    // ---- increment 2: i32 register shifts + rotr (all tier-A: single
+    // instruction, no scratch, no side conditions) ----
+    SelRule {
+        name: "rule_i32_shl",
+        op: WasmOp::I32Shl,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[TemplateOp::LslReg {
+            rd: Rd,
+            rn: Rn,
+            rm: Rm,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i32.shl`: rd = rn << rm",
+    },
+    SelRule {
+        name: "rule_i32_shr_s",
+        op: WasmOp::I32ShrS,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[TemplateOp::AsrReg {
+            rd: Rd,
+            rn: Rn,
+            rm: Rm,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i32.shr_s`: rd = rn >> rm (arithmetic)",
+    },
+    SelRule {
+        name: "rule_i32_shr_u",
+        op: WasmOp::I32ShrU,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[TemplateOp::LsrReg {
+            rd: Rd,
+            rn: Rn,
+            rm: Rm,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i32.shr_u`: rd = rn >> rm (logical)",
+    },
+    SelRule {
+        name: "rule_i32_rotr",
+        op: WasmOp::I32Rotr,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[TemplateOp::RorReg {
+            rd: Rd,
+            rn: Rn,
+            rm: Rm,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i32.rotr`: rd = rn rotated right by rm",
+    },
+    // ---- increment 2: i32 comparisons — the CMP+SetCond shape. NO side
+    // conditions: CMP latches NZCV before SetCond writes rd, so every
+    // rd/rn/rm aliasing is admitted (the flags transfer is not a register).
+    // Delegated in select_with_stack (the load-bearing arm) ONLY:
+    // select_default's blind bare-Cmp comparison arms never materialize the
+    // 0/1 result and stay hand-written (unprovable-as-T1 holdout). ----
+    SelRule {
+        name: "rule_i32_eq",
+        op: WasmOp::I32Eq,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[
+            TemplateOp::CmpReg { rn: Rn, rm: Rm },
+            TemplateOp::SetCond {
+                rd: Rd,
+                cond: CondCode::Eq,
+            },
+        ],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i32.eq`: rd = if rn == rm {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i32_ne",
+        op: WasmOp::I32Ne,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[
+            TemplateOp::CmpReg { rn: Rn, rm: Rm },
+            TemplateOp::SetCond {
+                rd: Rd,
+                cond: CondCode::Ne,
+            },
+        ],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i32.ne`: rd = if rn != rm {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i32_lt_s",
+        op: WasmOp::I32LtS,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[
+            TemplateOp::CmpReg { rn: Rn, rm: Rm },
+            TemplateOp::SetCond {
+                rd: Rd,
+                cond: CondCode::Lt,
+            },
+        ],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i32.lt_s`: rd = if rn < rm (signed) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i32_lt_u",
+        op: WasmOp::I32LtU,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[
+            TemplateOp::CmpReg { rn: Rn, rm: Rm },
+            TemplateOp::SetCond {
+                rd: Rd,
+                cond: CondCode::Lo,
+            },
+        ],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i32.lt_u`: rd = if rn < rm (unsigned) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i32_gt_s",
+        op: WasmOp::I32GtS,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[
+            TemplateOp::CmpReg { rn: Rn, rm: Rm },
+            TemplateOp::SetCond {
+                rd: Rd,
+                cond: CondCode::Gt,
+            },
+        ],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i32.gt_s`: rd = if rn > rm (signed) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i32_gt_u",
+        op: WasmOp::I32GtU,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[
+            TemplateOp::CmpReg { rn: Rn, rm: Rm },
+            TemplateOp::SetCond {
+                rd: Rd,
+                cond: CondCode::Hi,
+            },
+        ],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i32.gt_u`: rd = if rn > rm (unsigned) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i32_le_s",
+        op: WasmOp::I32LeS,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[
+            TemplateOp::CmpReg { rn: Rn, rm: Rm },
+            TemplateOp::SetCond {
+                rd: Rd,
+                cond: CondCode::Le,
+            },
+        ],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i32.le_s`: rd = if rn <= rm (signed) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i32_le_u",
+        op: WasmOp::I32LeU,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[
+            TemplateOp::CmpReg { rn: Rn, rm: Rm },
+            TemplateOp::SetCond {
+                rd: Rd,
+                cond: CondCode::Ls,
+            },
+        ],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i32.le_u`: rd = if rn <= rm (unsigned) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i32_ge_s",
+        op: WasmOp::I32GeS,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[
+            TemplateOp::CmpReg { rn: Rn, rm: Rm },
+            TemplateOp::SetCond {
+                rd: Rd,
+                cond: CondCode::Ge,
+            },
+        ],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i32.ge_s`: rd = if rn >= rm (signed) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i32_ge_u",
+        op: WasmOp::I32GeU,
+        params: &[Rd, Rn, Rm],
+        side_conditions: &[],
+        seq: &[
+            TemplateOp::CmpReg { rn: Rn, rm: Rm },
+            TemplateOp::SetCond {
+                rd: Rd,
+                cond: CondCode::Hs,
+            },
+        ],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i32.ge_u`: rd = if rn >= rm (unsigned) {1} else {0}",
+    },
 ];
+
+/// Dispatch an i32 comparison op to its generated Rocq-proved rule
+/// (increment 2). Returns `None` for non-comparison ops so the caller's
+/// hand-written arm keeps ownership — the delegation is byte-identical
+/// where it fires (mirror-pinned) and a no-op everywhere else.
+pub fn i32_cmp_rule(
+    op: &WasmOp,
+    rd: crate::rules::Reg,
+    rn: crate::rules::Reg,
+    rm: crate::rules::Reg,
+) -> Option<Vec<crate::rules::ArmOp>> {
+    Some(match op {
+        WasmOp::I32Eq => generated::rule_i32_eq(rd, rn, rm),
+        WasmOp::I32Ne => generated::rule_i32_ne(rd, rn, rm),
+        WasmOp::I32LtS => generated::rule_i32_lt_s(rd, rn, rm),
+        WasmOp::I32LtU => generated::rule_i32_lt_u(rd, rn, rm),
+        WasmOp::I32GtS => generated::rule_i32_gt_s(rd, rn, rm),
+        WasmOp::I32GtU => generated::rule_i32_gt_u(rd, rn, rm),
+        WasmOp::I32LeS => generated::rule_i32_le_s(rd, rn, rm),
+        WasmOp::I32LeU => generated::rule_i32_le_u(rd, rn, rm),
+        WasmOp::I32GeS => generated::rule_i32_ge_s(rd, rn, rm),
+        WasmOp::I32GeU => generated::rule_i32_ge_u(rd, rn, rm),
+        _ => return None,
+    })
+}
+
+/// Dispatch an i32 register-shift/rotate op to its generated Rocq-proved rule
+/// (increment 2). Same contract as [`i32_cmp_rule`].
+pub fn i32_shift_rule(
+    op: &WasmOp,
+    rd: crate::rules::Reg,
+    rn: crate::rules::Reg,
+    rm: crate::rules::Reg,
+) -> Option<Vec<crate::rules::ArmOp>> {
+    Some(match op {
+        WasmOp::I32Shl => generated::rule_i32_shl(rd, rn, rm),
+        WasmOp::I32ShrS => generated::rule_i32_shr_s(rd, rn, rm),
+        WasmOp::I32ShrU => generated::rule_i32_shr_u(rd, rn, rm),
+        WasmOp::I32Rotr => generated::rule_i32_rotr(rd, rn, rm),
+        _ => return None,
+    })
+}
 
 /// Render a struct field, using field-init shorthand when the bound variable
 /// name matches the field name (keeps the generated file rustfmt/clippy-clean).
@@ -281,6 +630,42 @@ fn template_expr(t: &TemplateOp, indent: usize) -> String {
             field("rn", rn),
             field("rm", rm)
         ),
+        TemplateOp::LslReg { rd, rn, rm } => format!(
+            "ArmOp::LslReg {{ {}, {}, {} }}",
+            field("rd", rd),
+            field("rn", rn),
+            field("rm", rm)
+        ),
+        TemplateOp::LsrReg { rd, rn, rm } => format!(
+            "ArmOp::LsrReg {{ {}, {}, {} }}",
+            field("rd", rd),
+            field("rn", rn),
+            field("rm", rm)
+        ),
+        TemplateOp::AsrReg { rd, rn, rm } => format!(
+            "ArmOp::AsrReg {{ {}, {}, {} }}",
+            field("rd", rd),
+            field("rn", rn),
+            field("rm", rm)
+        ),
+        TemplateOp::CmpReg { rn, rm } => {
+            let ind = " ".repeat(indent);
+            let fld = " ".repeat(indent + 4);
+            format!(
+                "ArmOp::Cmp {{\n{fld}{},\n{fld}op2: Operand2::Reg({}),\n{ind}}}",
+                field("rn", rn),
+                rm.rust_name()
+            )
+        }
+        TemplateOp::SetCond { rd, cond } => {
+            let ind = " ".repeat(indent);
+            let fld = " ".repeat(indent + 4);
+            format!(
+                "ArmOp::SetCond {{\n{fld}{},\n{fld}cond: {},\n{ind}}}",
+                field("rd", rd),
+                cond.rust_name()
+            )
+        }
     }
 }
 
@@ -295,8 +680,9 @@ pub fn generate_lowering_source() -> String {
         "//! GENERATED FILE — DO NOT EDIT BY HAND.\n\
          //!\n\
          //! Emitted by `crate::sel_dsl::generate_lowering_source()` from the declarative\n\
-         //! rule table [`crate::sel_dsl::RULES`] (VCR-SEL-001 increment 1, #242,\n\
-         //! `docs/design/vcr-sel-001-first-increment.md`). Pinned up-to-date by the\n\
+         //! rule table [`crate::sel_dsl::RULES`] (VCR-SEL-001 increments 1+2, #242,\n\
+         //! `docs/design/vcr-sel-001-first-increment.md` +\n\
+         //! `docs/design/vcr-sel-001-increment-2.md`). Pinned up-to-date by the\n\
          //! `generated_lowering_is_up_to_date` test; regenerate with\n\
          //! `SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl`.\n\
          //!\n\
@@ -305,7 +691,7 @@ pub fn generate_lowering_source() -> String {
          //! `//coq:vcr_sel_rules_coverage`): the emitted sequence computes the op's\n\
          //! result in `rd` for EVERY register assignment satisfying the stated side\n\
          //! conditions.\n\n\
-         use crate::rules::{ArmOp, Operand2, Reg};\n",
+         use crate::rules::{ArmOp, Condition, Operand2, Reg};\n",
     );
 
     for rule in RULES {

--- a/docs/design/vcr-sel-001-increment-2.md
+++ b/docs/design/vcr-sel-001-increment-2.md
@@ -1,0 +1,91 @@
+# VCR-SEL-001 — Increment 2 scope (comparisons + register shifts)
+
+Status: **implemented, flag-off** (2026-07-08). Extends the increment-1 DSL
+(`docs/design/vcr-sel-001-first-increment.md`, PR #623) with the next op
+families the pilot showed tractable. Epic #242; long-arc issues #73/#166.
+
+## Op families
+
+- **In:**
+  - the ten i32 comparisons (`eq/ne/lt_s/lt_u/gt_s/gt_u/le_s/le_u/ge_s/ge_u`)
+    — the CMP+SetCond shape;
+  - the i32 register shifts (`shl/shr_s/shr_u`) + `rotr`.
+- **Out (unchanged from increment 1):** div/rem (VCR-ISA-001-gated on the flat
+  executor's no-op `BCondOffset`), i64 pairs, memory, control flow.
+
+## Measurement results (what generalization actually cost)
+
+- **Shifts + rotr are tier-A**, not scratch-using: each lowers to a single
+  `LslReg/AsrReg/LsrReg/RorReg` instruction, so the increment-1 scratch
+  non-aliasing machinery is *not needed* — `synth_binop_proof_poly` discharges
+  all four unchanged (their fixed-register ancestors in `CorrectnessI32.v`
+  already close with `synth_binop_proof`). The side-condition machinery
+  remains exercised by `rule_i32_rotl` alone.
+- **Comparisons generalize with NO side conditions**: `CMP` latches NZCV into
+  the state's flags *before* `rd` is written, so the flags transfer is not
+  through a register and the universal quantifier admits every `rd/rn/rm`
+  aliasing. Discharge: `synth_cmp_binop_proof_poly` — verbatim
+  `synth_cmp_binop_proof` (Tactics.v) modulo the extra register binders and
+  the lowering-unfold target, applied with the same per-op flag lemma the
+  fixed-register proofs use. Seven of ten close with the tactic; `ne`, `lt_s`
+  and `lt_u` use the same manual scripts as their `CorrectnessI32.v`
+  ancestors, register-generalized verbatim. **0 holdouts: 14/14 Qed.**
+- The Rust `ArmOp::SetCond { rd, cond }` pseudo-op is modeled in
+  `VcrSelRules.v` as `MOV rd #0; MOVcc rd #1` — the established
+  `Compilation.v` convention for the same Rust shape.
+
+## Where the delegation lands — and the one honest holdout
+
+Increment 1 wired `select_default` only. Increment 2 keeps that pattern for
+the shifts, but the comparison family delegates in **`select_with_stack`**:
+
+- `select_default`'s comparison arms are a **blind bare-`Cmp` lowering** —
+  the 0/1 result is never materialized into a register. They are
+  production-unreachable (`select_with_stack` owns comparisons; the wildcard
+  fallthrough never sees them), and a rule byte-matching them would be
+  **unprovable as T1 result-correspondence** (there is no result register to
+  state the theorem about). Those arms stay hand-written. This is the
+  increment's deliberate holdout, and it keeps the eventual default flip
+  strictly byte-invisible: delegating the CMP+SetCond rule into
+  `select_default` would have *changed* that dead path's shape under the
+  flag.
+- `select_with_stack`'s reg-reg comparison emission (`Cmp {rn:a, Reg(b)}` +
+  `SetCond {dst, cond}`) is exactly the rule's shape — the delegation is
+  byte-identical by construction. The #258 imm-fold peephole (`cmp a, #C` /
+  `cmn a, #-C`) is outside the reg-reg rule's shape and stays hand-written
+  on both flag settings (pinned by
+  `sel_dsl_cmp_imm_fold_path_stays_handwritten_and_byte_identical_242`).
+- The four shifts delegate in **both** selectors (`Delegation::Both`) — the
+  identical single instruction in each.
+
+This is the first (deliberate, byte-identical) step of the DSL into the
+load-bearing `select_with_stack` path — motivation (ii) of the artifact
+(collapsing the selector accretion), pulled forward because the comparison
+shape only exists there.
+
+## Gates (same two as increment 1, in order)
+
+1. **Mirror-pinning per op** —
+   `sel_dsl_mirror_pin_generated_rules_match_handwritten_arms_242`
+   (select_default OFF/ON, 11 rules: inc-1 seven + four shifts) and
+   `sel_dsl_mirror_pin_select_with_stack_rules_byte_identical_242`
+   (select_with_stack OFF/ON, 14 rules: ten comparisons + four shifts, with a
+   non-vacuity check that the hand-written emission window equals the rule's
+   output for the registers the selector actually chose).
+2. **Frozen fixtures under the flag** — `SYNTH_SEL_DSL=1` keeps the frozen
+   byte-gate green (and OFF ≡ baseline holds by construction).
+
+## Rocq obligations
+
+21 rules ↔ 21 Qed (7 increment-1 + 14 increment-2), 1:1 naming, coverage
+gated by `//coq:vcr_sel_rules_coverage` against `coq/vcr_sel_rules.manifest`
+(pinned to the Rust `RULES` table by a cargo test). A rule without its Qed
+cannot merge.
+
+## What remains before the SYNTH_SEL_DSL default flip
+
+Nothing byte-visible: every delegation is mirror-pinned byte-identical, so
+the flip changes which *code* serves the arms, not what they emit. The flip
+itself is a later PR with the standard re-freeze ritual (flip default →
+full differential → CI-pinned opt-out), one release, never bundled with a
+byte-changing lever.


### PR DESCRIPTION
## VCR-SEL-001 increment 2 (epic #242; long-arc #73/#166)

Extends the increment-1 verified selector rule DSL (PR #623) with the next op families the pilot showed tractable: the ten i32 comparisons, the three i32 register shifts, and `rotr`. **+14 rules = 21 total, 21/21 Qed, 0 Admitted**, flag-off (`SYNTH_SEL_DSL`, default OFF, OFF ≡ baseline by construction). Design doc: `docs/design/vcr-sel-001-increment-2.md`.

### Rule table (new rules)

| Rule | Shape | Side conditions | Discharge | Delegation |
|---|---|---|---|---|
| `rule_i32_shl` | `LslReg rd, rn, rm` | none (tier-A) | `synth_binop_proof_poly` | Both selectors |
| `rule_i32_shr_s` | `AsrReg rd, rn, rm` | none (tier-A) | `synth_binop_proof_poly` | Both selectors |
| `rule_i32_shr_u` | `LsrReg rd, rn, rm` | none (tier-A) | `synth_binop_proof_poly` | Both selectors |
| `rule_i32_rotr` | `RorReg rd, rn, rm` | none (tier-A) | `synth_binop_proof_poly` | Both selectors |
| `rule_i32_eq/ne/lt_s/lt_u/gt_s/gt_u/le_s/le_u/ge_s/ge_u` | `CMP rn, rm; SetCond rd` (modeled `CMP; MOV rd #0; MOVcc rd #1` per the Compilation.v convention) | **none** — CMP latches NZCV before `rd` is written, so the universal quantifier admits every `rd/rn/rm` aliasing | 7/10 `synth_cmp_binop_proof_poly`; `ne`/`lt_s`/`lt_u` manual scripts register-generalized verbatim from their `CorrectnessI32.v` ancestors | `select_with_stack` reg-reg arm only |

Measurement result worth noting: shifts + rotr turned out **tier-A** (single instruction, no scratch) — the increment-1 side-condition machinery is not needed for them and remains exercised by `rule_i32_rotl` alone.

### Qed count + honest holdouts

- **21/21 Qed** in `coq/Synth/Synth/VcrSelRules.v`, 1:1 rule↔theorem naming, coverage-gated by `//coq:vcr_sel_rules_coverage` against `coq/vcr_sel_rules.manifest` (itself pinned to the Rust `RULES` table by `sel_dsl::tests::manifest_matches_rule_table`). A rule without its Qed cannot merge. 0 proof holdouts this increment.
- **Delegation holdout (documented, deliberate):** `select_default`'s comparison arms are a blind bare-`Cmp` lowering that never materializes the 0/1 result — production-unreachable (`select_with_stack` owns comparisons) and **unprovable as T1 result-correspondence** (no result register to state the theorem about). They stay hand-written; this also keeps the eventual flip strictly byte-invisible.
- The #258 `cmp`-imm-fold peephole is outside the reg-reg rule's shape and stays hand-written on both flag settings, pinned by `sel_dsl_cmp_imm_fold_path_stays_handwritten_and_byte_identical_242`.
- Still out (unchanged from inc-1): div/rem (VCR-ISA-001-gated), i64 pairs, memory, control flow, optimizer_bridge.

This is the DSL's first (deliberate, byte-identical) step into the load-bearing `select_with_stack` path — motivation (ii) of the artifact, pulled forward because the comparison shape only exists there.

### Verification evidence

- **Rocq gate:** `bazel test //coq:verify_proofs` — `rocq_proofs` PASSED (all Qed compile), `vcr_sel_rules_coverage` PASSED (21 rules ↔ 21 Qed, no Admitted/admit).
- **Mirror-pins (must-agree pinning, #511/#513 pattern):** `sel_dsl_mirror_pin_generated_rules_match_handwritten_arms_242` (11 select_default-delegated rules) + `sel_dsl_mirror_pin_select_with_stack_rules_byte_identical_242` (14 select_with_stack-delegated rules, with a non-vacuity window check that the delegation actually fired) — both green.
- **OFF-byte-identity:** `cargo test -p synth-cli --test frozen_codegen_bytes` — 10/10 green with the flag OFF **and** with `SYNTH_SEL_DSL=1`.
- **Full sweep:** `cargo test --workspace` — 105 suites, 0 failures. `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Generated Rust is committed (`sel_dsl/generated.rs`), staleness-pinned by `sel_dsl::tests::generated_lowering_is_up_to_date`.

### What remains before the SYNTH_SEL_DSL default flip

Nothing byte-visible: every delegation is mirror-pinned byte-identical, so the flip changes which *code* serves the arms, not what they emit. The flip is a later PR with the standard re-freeze ritual (flip default → full differential → CI-pinned opt-out), one release, never bundled with a byte-changing lever.

### Provenance

Salvaged from an interrupted session (2026-07-08, session limit); the salvage was committed verbatim, then every gate above was run before push. Rebased onto `origin/main` (v0.32.1, 086968a) immediately before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)