### PR TITLE
fix(safety-bounds): #377 — software bounds enforced on the optimized path; inline UDF trap fixes the direct path's fallthrough no-op

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -545,6 +545,14 @@ fn compile_wasm_to_arm(
         // from its fold set, and the bridge-level const-CSE declines wholesale
         // while any range is marked. Empty (the default) ⇒ byte-identical.
         bridge.set_volatile_segments(config.volatile_segments.clone());
+        // #377: thread `--safety-bounds` to the bridge. Pre-fix the optimized
+        // path ignored it — `software`/`mask` were SILENT NO-OPS on the path
+        // that lowers the bulk of a flight loop's i32 loads/stores (byte-
+        // identical to `none`, while the safety manifest claimed otherwise).
+        // `Software` now emits the inline guard per access; `Masking` declines
+        // memory-accessing functions to the direct selector; `None`/`Mpu` are
+        // byte-identical to before.
+        bridge.set_bounds_check(bounds_config);
         // `ir_to_arm` now returns `Result` — an `Err` means the optimized path
         // hit an unmapped vreg (issue-#93-class). Treat it identically to an
         // `optimize_full` failure: fall back to the direct selector rather
@@ -1513,6 +1521,118 @@ mod tests {
         assert_eq!(
             l.code, s.code,
             "--bounds-check should produce the same bytes as --safety-bounds=software"
+        );
+    }
+
+    /// #377: `--safety-bounds software` must be enforced on the OPTIMIZED path
+    /// too. Pre-fix, `software` was byte-identical to `none` there (a silent
+    /// no-op while the safety manifest claimed enforcement). The compiled
+    /// bytes must now (a) differ from `none` and (b) contain the inline
+    /// `CMP ip, sl` + `UDF` guard.
+    #[test]
+    fn arm_safety_bounds_software_enforced_on_optimized_path_377() {
+        let backend = ArmBackend::new();
+        // Dynamic-address store+load: the optimized path accepts this shape
+        // (no calls, no i64 params, ≤4 params).
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32Store {
+                offset: 4,
+                align: 2,
+            },
+            WasmOp::LocalGet(0),
+            WasmOp::I32Load {
+                offset: 0,
+                align: 2,
+            },
+        ];
+        // no_optimize NOT set — this exercises the optimized path.
+        let cfg_none = CompileConfig::default();
+        let cfg_sw = CompileConfig {
+            safety_bounds: SafetyBounds::Software,
+            ..Default::default()
+        };
+        let n = backend.compile_function("st", &ops, &cfg_none).unwrap();
+        let s = backend.compile_function("st", &ops, &cfg_sw).unwrap();
+        assert_ne!(
+            n.code, s.code,
+            "#377: software bounds must CHANGE optimized-path codegen (was a silent no-op)"
+        );
+        // Thumb-2 `UDF #0` is 0xDE00 (LE bytes: 00 DE); `CMP ip, sl` (T2
+        // high-reg) is 0x45D4 (LE: D4 45). Both must appear — one guard per
+        // access, trap inline.
+        let has_udf = s.code.windows(2).any(|w| w == [0x00, 0xDE]);
+        let has_cmp_ip_sl = s.code.windows(2).any(|w| w == [0xD4, 0x45]);
+        assert!(has_udf, "#377: inline UDF trap missing from optimized path");
+        assert!(
+            has_cmp_ip_sl,
+            "#377: CMP ip, sl bounds compare missing from optimized path"
+        );
+        // And `none` must contain NO UDF (the function has no other trap).
+        assert!(
+            !n.code.windows(2).any(|w| w == [0x00, 0xDE]),
+            "none must not contain a UDF for this function"
+        );
+    }
+
+    /// #377: `mpu` on the optimized path is codegen-passthrough — identical
+    /// bytes to `none` on BOTH paths (hardware enforcement is target-level;
+    /// synth does not emit MPU region programming — tracked separately in
+    /// #377's fix-direction discussion). This pins path-parity for `mpu`.
+    #[test]
+    fn arm_safety_bounds_mpu_optimized_path_parity_377() {
+        let backend = ArmBackend::new();
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32Load {
+                offset: 0,
+                align: 2,
+            },
+        ];
+        let cfg_none = CompileConfig::default();
+        let cfg_mpu = CompileConfig {
+            safety_bounds: SafetyBounds::Mpu,
+            ..Default::default()
+        };
+        let n = backend.compile_function("ld", &ops, &cfg_none).unwrap();
+        let m = backend.compile_function("ld", &ops, &cfg_mpu).unwrap();
+        assert_eq!(
+            n.code, m.code,
+            "Mpu and None must produce identical bytes on the optimized path too"
+        );
+    }
+
+    /// #377: `mask` on the optimized path declines to the direct selector
+    /// (honest degradation) — the compiled function must equal the
+    /// `--no-optimize` masking bytes, i.e. the flag is honored, never dropped.
+    #[test]
+    fn arm_safety_bounds_mask_optimized_path_declines_to_direct_377() {
+        let backend = ArmBackend::new();
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32Store {
+                offset: 0,
+                align: 2,
+            },
+        ];
+        let cfg_mask_opt = CompileConfig {
+            safety_bounds: SafetyBounds::Mask,
+            ..Default::default()
+        };
+        let cfg_mask_direct = CompileConfig {
+            no_optimize: true,
+            safety_bounds: SafetyBounds::Mask,
+            ..Default::default()
+        };
+        let o = backend.compile_function("st", &ops, &cfg_mask_opt).unwrap();
+        let d = backend
+            .compile_function("st", &ops, &cfg_mask_direct)
+            .unwrap();
+        assert_eq!(
+            o.code, d.code,
+            "#377: mask on the optimized path must fall back to the direct selector's masking"
         );
     }
 

--- a/crates/synth-backend/tests/estimator_encoder_agreement.rs
+++ b/crates/synth-backend/tests/estimator_encoder_agreement.rs
@@ -134,6 +134,35 @@ fn cases() -> Vec<Case> {
                 op2: Operand2::Reg(Reg::R8),
             },
         ),
+        // #377: the software bounds guard's end-address compute
+        // (`ADD R12, Raddr, #off+size-1`) — high rd forces the 32-bit ADD.W
+        // regardless of the immediate. Previously an estimator hole (`_ => 2`).
+        agree(
+            "Add_imm_hi_small",
+            Add {
+                rd: Reg::R12,
+                rn: r0,
+                op2: Operand2::Imm(3),
+            },
+        ),
+        agree(
+            "Add_imm_hi_large",
+            Add {
+                rd: Reg::R12,
+                rn: Reg::R4,
+                op2: Operand2::Imm(0x103),
+            },
+        ),
+        // Low-reg small-imm ADD stays 16-bit (`ADDS #imm3`) — pin that the new
+        // high-rd arm did not disturb it.
+        agree(
+            "Add_imm_lo_small",
+            Add {
+                rd: r0,
+                rn: Reg::R1,
+                op2: Operand2::Imm(7),
+            },
+        ),
         agree(
             "Sub_lo",
             Sub {

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -262,7 +262,7 @@ enum Commands {
         /// Accepted values:
         /// - `none`     — no inline check, no MPU/PMP setup (fastest, unsafe)
         /// - `mpu`      — rely on ARM MPU / RV32 PMP hardware enforcement
-        /// - `software` — emit CMP/BHS (ARM) or BGEU+EBREAK (RV32) per access
+        /// - `software` — emit CMP + inline UDF trap (ARM) or BGEU+EBREAK (RV32) per access
         /// - `mask`     — AND addr with `mem_size - 1` (requires power-of-two size)
         #[arg(long, value_name = "MODE")]
         safety_bounds: Option<String>,

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -23,7 +23,7 @@ pub enum BoundsCheckConfig {
     /// Equivalent to `None` from the selector's point of view but distinguished
     /// here so the safety-manifest can record the intent.
     Mpu,
-    /// Software bounds checking with CMP/BHS before each access
+    /// Software bounds checking with CMP + inline UDF trap before each access
     /// R10 holds the memory size, initialized by startup code
     Software,
     /// Masking: AND address with (memory_size - 1) for power-of-2 sizes
@@ -4788,7 +4788,7 @@ impl InstructionSelector {
                 // Software bounds check: verify last byte of access is in bounds
                 // ADD temp, addr_reg, #(offset + access_size - 1)
                 // CMP temp, R10 (memory size)
-                // BHS Trap_Handler
+                // BLO +0 (skip UDF) / UDF #0 (#377 inline trap)
                 let temp = Reg::R12;
                 let end_offset = offset + (access_size as i32) - 1;
                 vec![
@@ -4801,9 +4801,19 @@ impl InstructionSelector {
                         rn: temp,
                         op2: Operand2::Reg(Reg::R10),
                     },
-                    ArmOp::Bhs {
-                        label: "Trap_Handler".to_string(),
+                    // #377: inline UDF trap (BLO +0 skips it when in-bounds).
+                    // The previous `Bhs Trap_Handler` label branch resolved to
+                    // an offset-0 fallthrough NO-OP in a self-contained image
+                    // (the label is external, so `resolve_label_branches`
+                    // leaves the placeholder) — the check ran but never
+                    // trapped. Same inline pattern as the #374 bulk-memory
+                    // and div-by-zero guards; works identically under
+                    // `--relocatable` (UDF → UsageFault → platform handler).
+                    ArmOp::BCondOffset {
+                        cond: Condition::LO,
+                        offset: 0,
                     },
+                    ArmOp::Udf { imm: 0 },
                     load_op,
                 ]
             }
@@ -4862,9 +4872,19 @@ impl InstructionSelector {
                         rn: temp,
                         op2: Operand2::Reg(Reg::R10),
                     },
-                    ArmOp::Bhs {
-                        label: "Trap_Handler".to_string(),
+                    // #377: inline UDF trap (BLO +0 skips it when in-bounds).
+                    // The previous `Bhs Trap_Handler` label branch resolved to
+                    // an offset-0 fallthrough NO-OP in a self-contained image
+                    // (the label is external, so `resolve_label_branches`
+                    // leaves the placeholder) — the check ran but never
+                    // trapped. Same inline pattern as the #374 bulk-memory
+                    // and div-by-zero guards; works identically under
+                    // `--relocatable` (UDF → UsageFault → platform handler).
+                    ArmOp::BCondOffset {
+                        cond: Condition::LO,
+                        offset: 0,
                     },
+                    ArmOp::Udf { imm: 0 },
                     store_op,
                 ]
             }
@@ -4908,7 +4928,7 @@ impl InstructionSelector {
                 // Software bounds check: verify last byte of 8-byte access is in bounds
                 // ADD temp, addr_reg, #(offset + 8 - 1)
                 // CMP temp, R10 (memory size)
-                // BHS Trap_Handler
+                // BLO +0 (skip UDF) / UDF #0 (#377 inline trap)
                 let temp = Reg::R12;
                 let end_offset = offset + (access_size as i32) - 1;
                 vec![
@@ -4921,9 +4941,19 @@ impl InstructionSelector {
                         rn: temp,
                         op2: Operand2::Reg(Reg::R10),
                     },
-                    ArmOp::Bhs {
-                        label: "Trap_Handler".to_string(),
+                    // #377: inline UDF trap (BLO +0 skips it when in-bounds).
+                    // The previous `Bhs Trap_Handler` label branch resolved to
+                    // an offset-0 fallthrough NO-OP in a self-contained image
+                    // (the label is external, so `resolve_label_branches`
+                    // leaves the placeholder) — the check ran but never
+                    // trapped. Same inline pattern as the #374 bulk-memory
+                    // and div-by-zero guards; works identically under
+                    // `--relocatable` (UDF → UsageFault → platform handler).
+                    ArmOp::BCondOffset {
+                        cond: Condition::LO,
+                        offset: 0,
                     },
+                    ArmOp::Udf { imm: 0 },
                     load_op,
                 ]
             }
@@ -4977,9 +5007,19 @@ impl InstructionSelector {
                         rn: temp,
                         op2: Operand2::Reg(Reg::R10),
                     },
-                    ArmOp::Bhs {
-                        label: "Trap_Handler".to_string(),
+                    // #377: inline UDF trap (BLO +0 skips it when in-bounds).
+                    // The previous `Bhs Trap_Handler` label branch resolved to
+                    // an offset-0 fallthrough NO-OP in a self-contained image
+                    // (the label is external, so `resolve_label_branches`
+                    // leaves the placeholder) — the check ran but never
+                    // trapped. Same inline pattern as the #374 bulk-memory
+                    // and div-by-zero guards; works identically under
+                    // `--relocatable` (UDF → UsageFault → platform handler).
+                    ArmOp::BCondOffset {
+                        cond: Condition::LO,
+                        offset: 0,
                     },
+                    ArmOp::Udf { imm: 0 },
                     store_op,
                 ]
             }
@@ -5030,9 +5070,19 @@ impl InstructionSelector {
                         rn: temp,
                         op2: Operand2::Reg(Reg::R10),
                     },
-                    ArmOp::Bhs {
-                        label: "Trap_Handler".to_string(),
+                    // #377: inline UDF trap (BLO +0 skips it when in-bounds).
+                    // The previous `Bhs Trap_Handler` label branch resolved to
+                    // an offset-0 fallthrough NO-OP in a self-contained image
+                    // (the label is external, so `resolve_label_branches`
+                    // leaves the placeholder) — the check ran but never
+                    // trapped. Same inline pattern as the #374 bulk-memory
+                    // and div-by-zero guards; works identically under
+                    // `--relocatable` (UDF → UsageFault → platform handler).
+                    ArmOp::BCondOffset {
+                        cond: Condition::LO,
+                        offset: 0,
                     },
+                    ArmOp::Udf { imm: 0 },
                     load_op,
                 ]
             }
@@ -5083,9 +5133,19 @@ impl InstructionSelector {
                         rn: temp,
                         op2: Operand2::Reg(Reg::R10),
                     },
-                    ArmOp::Bhs {
-                        label: "Trap_Handler".to_string(),
+                    // #377: inline UDF trap (BLO +0 skips it when in-bounds).
+                    // The previous `Bhs Trap_Handler` label branch resolved to
+                    // an offset-0 fallthrough NO-OP in a self-contained image
+                    // (the label is external, so `resolve_label_branches`
+                    // leaves the placeholder) — the check ran but never
+                    // trapped. Same inline pattern as the #374 bulk-memory
+                    // and div-by-zero guards; works identically under
+                    // `--relocatable` (UDF → UsageFault → platform handler).
+                    ArmOp::BCondOffset {
+                        cond: Condition::LO,
+                        offset: 0,
                     },
+                    ArmOp::Udf { imm: 0 },
                     store_op,
                 ]
             }
@@ -5144,9 +5204,19 @@ impl InstructionSelector {
                         rn: temp,
                         op2: Operand2::Reg(Reg::R10),
                     },
-                    ArmOp::Bhs {
-                        label: "Trap_Handler".to_string(),
+                    // #377: inline UDF trap (BLO +0 skips it when in-bounds).
+                    // The previous `Bhs Trap_Handler` label branch resolved to
+                    // an offset-0 fallthrough NO-OP in a self-contained image
+                    // (the label is external, so `resolve_label_branches`
+                    // leaves the placeholder) — the check ran but never
+                    // trapped. Same inline pattern as the #374 bulk-memory
+                    // and div-by-zero guards; works identically under
+                    // `--relocatable` (UDF → UsageFault → platform handler).
+                    ArmOp::BCondOffset {
+                        cond: Condition::LO,
+                        offset: 0,
                     },
+                    ArmOp::Udf { imm: 0 },
                     load_op,
                 ]
             }
@@ -5210,9 +5280,19 @@ impl InstructionSelector {
                         rn: temp,
                         op2: Operand2::Reg(Reg::R10),
                     },
-                    ArmOp::Bhs {
-                        label: "Trap_Handler".to_string(),
+                    // #377: inline UDF trap (BLO +0 skips it when in-bounds).
+                    // The previous `Bhs Trap_Handler` label branch resolved to
+                    // an offset-0 fallthrough NO-OP in a self-contained image
+                    // (the label is external, so `resolve_label_branches`
+                    // leaves the placeholder) — the check ran but never
+                    // trapped. Same inline pattern as the #374 bulk-memory
+                    // and div-by-zero guards; works identically under
+                    // `--relocatable` (UDF → UsageFault → platform handler).
+                    ArmOp::BCondOffset {
+                        cond: Condition::LO,
+                        offset: 0,
                     },
+                    ArmOp::Udf { imm: 0 },
                     store_op,
                 ]
             }
@@ -11544,8 +11624,11 @@ mod tests {
         }];
         let arm_instrs = selector.select(&wasm_ops).unwrap();
 
-        // Should be: ADD temp, addr, #(offset+access_size-1); CMP temp, R10; BHS trap; LDR
-        assert_eq!(arm_instrs.len(), 4);
+        // Should be: ADD temp, addr, #(offset+access_size-1); CMP temp, R10;
+        // BLO +0 (skip trap); UDF #0; LDR  (#377: inline trap, not the old
+        // `Bhs Trap_Handler` which fell through as a no-op in self-contained
+        // images)
+        assert_eq!(arm_instrs.len(), 5);
 
         // First: ADD to calculate end-of-access address (offset=4, access_size=4 -> 4+4-1=7)
         match &arm_instrs[0].op {
@@ -11573,16 +11656,24 @@ mod tests {
             other => panic!("Expected Cmp against R10, got {:?}", other),
         }
 
-        // Third: BHS to trap handler
+        // Third: BLO +0 — skips the UDF when in-bounds (#377)
         match &arm_instrs[2].op {
-            ArmOp::Bhs { label } => {
-                assert_eq!(label, "Trap_Handler");
+            ArmOp::BCondOffset { cond, offset } => {
+                assert_eq!(*cond, Condition::LO);
+                assert_eq!(*offset, 0);
             }
-            other => panic!("Expected Bhs to Trap_Handler, got {:?}", other),
+            other => panic!("Expected BCondOffset LO +0, got {:?}", other),
         }
 
-        // Fourth: The actual LDR
+        // Fourth: the inline UDF trap (#377 — a real trap in a self-contained
+        // image, unlike the old external `Bhs Trap_Handler` fallthrough)
         match &arm_instrs[3].op {
+            ArmOp::Udf { imm: 0 } => {}
+            other => panic!("Expected Udf #0, got {:?}", other),
+        }
+
+        // Fifth: The actual LDR
+        match &arm_instrs[4].op {
             ArmOp::Ldr { .. } => {}
             other => panic!("Expected Ldr instruction, got {:?}", other),
         }
@@ -15309,12 +15400,20 @@ mod tests {
         }];
         let arm_instrs = selector.select(&wasm_ops).unwrap();
 
-        // With software bounds checking: ADD + CMP + BHS + LDRB
-        assert_eq!(arm_instrs.len(), 4);
+        // With software bounds checking (#377 inline trap):
+        // ADD + CMP + BLO +0 + UDF + LDRB
+        assert_eq!(arm_instrs.len(), 5);
         assert!(matches!(&arm_instrs[0].op, ArmOp::Add { .. }));
         assert!(matches!(&arm_instrs[1].op, ArmOp::Cmp { .. }));
-        assert!(matches!(&arm_instrs[2].op, ArmOp::Bhs { .. }));
-        assert!(matches!(&arm_instrs[3].op, ArmOp::Ldrb { .. }));
+        assert!(matches!(
+            &arm_instrs[2].op,
+            ArmOp::BCondOffset {
+                cond: Condition::LO,
+                offset: 0
+            }
+        ));
+        assert!(matches!(&arm_instrs[3].op, ArmOp::Udf { imm: 0 }));
+        assert!(matches!(&arm_instrs[4].op, ArmOp::Ldrb { .. }));
     }
 
     #[test]
@@ -15331,9 +15430,11 @@ mod tests {
         }];
         let arm_instrs = selector.select(&wasm_ops).unwrap();
 
-        // With software bounds checking: ADD + CMP + BHS + STRH
-        assert_eq!(arm_instrs.len(), 4);
-        assert!(matches!(&arm_instrs[3].op, ArmOp::Strh { .. }));
+        // With software bounds checking (#377 inline trap):
+        // ADD + CMP + BLO +0 + UDF + STRH
+        assert_eq!(arm_instrs.len(), 5);
+        assert!(matches!(&arm_instrs[3].op, ArmOp::Udf { imm: 0 }));
+        assert!(matches!(&arm_instrs[4].op, ArmOp::Strh { .. }));
     }
 
     #[test]

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -12,6 +12,7 @@
 //! 5. ARM encoding with branch resolution
 
 use crate::Condition;
+use crate::instruction_selector::BoundsCheckConfig;
 use crate::rules::ArmOp;
 use synth_cfg::{Cfg, CfgBuilder};
 use synth_core::WasmOp;
@@ -44,6 +45,52 @@ fn fold_mem_offset(base: u32, offset: u32) -> (u32, i32) {
     } else {
         (base, offset as i32)
     }
+}
+
+/// #377: inline software bounds guard for an optimized-path linear-memory
+/// access — the mirror of the direct selector's check shape
+/// (`generate_load_with_bounds_check`): trap unless
+/// `addr + offset + access_size - 1 < R10` (R10 = memory size in bytes,
+/// initialized by startup code).
+///
+/// ```text
+/// ADD  R12, Raddr, #(offset + access_size - 1)   ; end address (wasm space)
+/// CMP  R12, R10
+/// BLO  +0                                        ; in-bounds: skip the UDF
+/// UDF  #0                                        ; out-of-bounds: trap
+/// ```
+///
+/// The trap is an inline `UDF` (the #374 bulk-memory / div-by-zero pattern),
+/// NOT a `Bhs Trap_Handler` label branch — the label form resolves to an
+/// offset-0 fallthrough no-op in a self-contained image (the second half of
+/// #377). `BLO +0` targets `branch_byte + 4`, exactly skipping the 2-byte UDF —
+/// the same pre-resolved numeric-guard geometry as the DivS/DivU zero traps,
+/// which every downstream pass (`resolved_branch_geometry*`) already maps.
+///
+/// R12 is free here: it is the encoder scratch (never allocator-assigned), and
+/// every access sequence below re-materializes its base into R12 AFTER this
+/// guard runs.
+fn push_software_bounds_guard(
+    arm_instrs: &mut Vec<ArmOp>,
+    r_addr: crate::rules::Reg,
+    offset: u32,
+    access_size: u32,
+) {
+    use crate::rules::{Operand2, Reg};
+    arm_instrs.push(ArmOp::Add {
+        rd: Reg::R12,
+        rn: r_addr,
+        op2: Operand2::Imm((offset + access_size - 1) as i32),
+    });
+    arm_instrs.push(ArmOp::Cmp {
+        rn: Reg::R12,
+        op2: Operand2::Reg(Reg::R10),
+    });
+    arm_instrs.push(ArmOp::BCondOffset {
+        cond: Condition::LO,
+        offset: 0,
+    });
+    arm_instrs.push(ArmOp::Udf { imm: 0 });
 }
 
 /// The linear-memory base the optimized (absolute) path materializes.
@@ -538,6 +585,19 @@ pub fn estimate_arm_byte_size(op: &ArmOp) -> usize {
             rn,
             op2: Operand2::Reg(rm),
         } if reg_num(rd) > 7 || reg_num(rn) > 7 || reg_num(rm) > 7 => 4,
+        // #377: ADD rd, rn, #imm with a HIGH rd — always the 32-bit ADD.W form
+        // (the encoder's 16-bit `ADDS #imm3` requires rd AND rn low AND
+        // imm <= 7). The software bounds guard's end-address compute
+        // (`ADD R12, Raddr, #off+size-1`) is this shape; without this arm it
+        // fell to the `_ => 2` default and drifted every spanning branch by 2
+        // bytes. Scoped to high-rd so pre-existing low-reg imm-ADD sizing is
+        // untouched (the low-reg imm > 7 form remains a known gap of the
+        // `_ => 2` default — no optimized-path site emits it).
+        ArmOp::Add {
+            rd,
+            op2: Operand2::Imm(_),
+            ..
+        } if reg_num(rd) > 7 => 4,
         // Most 16-bit Thumb instructions (MOV low, CMP low, B, etc.)
         _ => 2,
     }
@@ -564,6 +624,14 @@ pub struct OptimizerBridge {
     /// marked (a constant cannot be classified address-vs-data at that level —
     /// conservative v1). Empty (the default) ⇒ byte-identical behavior.
     volatile_segments: Vec<synth_core::backend::VolatileRange>,
+    /// #377: the `--safety-bounds` mode, threaded from the backend. Pre-fix the
+    /// optimized path ignored it entirely — `software`/`mask` were silent
+    /// no-ops on the path that lowers the bulk of a flight loop's i32
+    /// loads/stores. `Software` now emits an inline guard before every
+    /// `MemLoad`/`MemStore`/`MemLoadSubword`/`MemStoreSubword`; `Masking`
+    /// declines the function to the direct selector (which implements it);
+    /// `None`/`Mpu` emit no inline guard (byte-identical to before).
+    bounds_check: BoundsCheckConfig,
 }
 
 impl OptimizerBridge {
@@ -574,6 +642,7 @@ impl OptimizerBridge {
             num_imports: 0,
             spill_on_exhaust: None,
             volatile_segments: Vec::new(),
+            bounds_check: BoundsCheckConfig::None,
         }
     }
 
@@ -584,7 +653,13 @@ impl OptimizerBridge {
             num_imports: 0,
             spill_on_exhaust: None,
             volatile_segments: Vec::new(),
+            bounds_check: BoundsCheckConfig::None,
         }
+    }
+
+    /// #377: set the `--safety-bounds` mode (see [`OptimizerBridge::bounds_check`]).
+    pub fn set_bounds_check(&mut self, bounds_check: BoundsCheckConfig) {
+        self.bounds_check = bounds_check;
     }
 
     /// Set the number of imported functions (see [`OptimizerBridge::num_imports`]).
@@ -2762,6 +2837,33 @@ impl OptimizerBridge {
             ));
         }
 
+        // #377: `--safety-bounds mask` — the masking transform mutates the
+        // address register in place (`AND addr, addr, R10`), which is unsound
+        // here: a vreg's ARM register may be read again later (the optimized
+        // path is not single-use), and the access sequence has no second
+        // scratch to mask into (R12 already carries the materialized base).
+        // Decline to the direct selector, which implements masking. Honest
+        // degradation (the #359/#188/#518 pattern) — the flag is always
+        // honored, never silently dropped.
+        if self.bounds_check == BoundsCheckConfig::Masking
+            && instructions.iter().any(|inst| {
+                matches!(
+                    inst.opcode,
+                    Opcode::MemLoad { .. }
+                        | Opcode::MemStore { .. }
+                        | Opcode::MemLoadSubword { .. }
+                        | Opcode::MemStoreSubword { .. }
+                )
+            })
+        {
+            return Err(synth_core::Error::synthesis(
+                "optimized path declines linear-memory accesses under \
+                 --safety-bounds mask (in-place AND is unsound on this path — \
+                 see #377); falling back to direct selector"
+                    .to_string(),
+            ));
+        }
+
         let mut arm_instrs = Vec::new();
         let mut vreg_to_arm: HashMap<u32, Reg> = HashMap::new();
 
@@ -2812,12 +2914,19 @@ impl OptimizerBridge {
         // DMA ranges — an access inside a marked window is excluded from the
         // fold set (it keeps its verbatim per-access materialize-and-access
         // codegen), while accesses outside still fold.
-        let base_cse: Option<BaseCsePlan> =
-            if !std::env::var("SYNTH_BASE_CSE").is_ok_and(|v| v == "0") {
-                plan_base_cse(instructions, &self.volatile_segments)
-            } else {
-                None
-            };
+        // #377: base-CSE is disabled while software bounds checks are active.
+        // The folded arm replaces the dynamic-address materialization with a
+        // direct `[R11,#imm]` access, so the per-access guard below (which
+        // reads the address REGISTER) would have nothing to check against —
+        // supporting a const-end compare is possible but not worth the second
+        // code shape; safety mode trades the size win for uniform checking.
+        let base_cse: Option<BaseCsePlan> = if self.bounds_check == BoundsCheckConfig::Software {
+            None
+        } else if !std::env::var("SYNTH_BASE_CSE").is_ok_and(|v| v == "0") {
+            plan_base_cse(instructions, &self.volatile_segments)
+        } else {
+            None
+        };
         if base_cse.is_some() {
             param_reserved_regs.push(BASE_CSE_REG);
         }
@@ -5528,6 +5637,12 @@ impl OptimizerBridge {
                         );
                         vreg_to_arm.insert(dest.0, rd);
 
+                        // #377: --safety-bounds software — guard BEFORE the base
+                        // materialization (R12 still free).
+                        if self.bounds_check == BoundsCheckConfig::Software {
+                            push_software_bounds_guard(&mut arm_instrs, r_addr, *offset, 4);
+                        }
+
                         // Linear memory base 0x20000100 (SRAM, above stack area).
                         // #382: fold a large static offset (> imm12) into the
                         // compile-time-constant base so the access immediate is 0.
@@ -5577,6 +5692,11 @@ impl OptimizerBridge {
                     } else {
                         let r_addr = get_arm_reg(addr, &vreg_to_arm, &spilled_vregs)?;
                         let r_src = get_arm_reg(src, &vreg_to_arm, &spilled_vregs)?;
+
+                        // #377: --safety-bounds software guard (see MemLoad).
+                        if self.bounds_check == BoundsCheckConfig::Software {
+                            push_software_bounds_guard(&mut arm_instrs, r_addr, *offset, 4);
+                        }
 
                         // Linear memory base 0x20000100 (SRAM, above stack area).
                         // #382: fold a large static offset (> imm12) into the
@@ -5646,6 +5766,11 @@ impl OptimizerBridge {
                         );
                         vreg_to_arm.insert(dest.0, rd);
 
+                        // #377: --safety-bounds software guard (see MemLoad).
+                        if self.bounds_check == BoundsCheckConfig::Software {
+                            push_software_bounds_guard(&mut arm_instrs, r_addr, *offset, *width);
+                        }
+
                         // #382: fold a large static offset (> imm12) into the
                         // compile-time-constant base so the access immediate is 0.
                         let (base, mem_off) = fold_mem_offset(0x20000100, *offset);
@@ -5698,6 +5823,11 @@ impl OptimizerBridge {
                     } else {
                         let r_addr = get_arm_reg(addr, &vreg_to_arm, &spilled_vregs)?;
                         let r_src = get_arm_reg(src, &vreg_to_arm, &spilled_vregs)?;
+
+                        // #377: --safety-bounds software guard (see MemLoad).
+                        if self.bounds_check == BoundsCheckConfig::Software {
+                            push_software_bounds_guard(&mut arm_instrs, r_addr, *offset, *width);
+                        }
 
                         // #382: fold a large static offset (> imm12) into the
                         // compile-time-constant base so the access immediate is 0.
@@ -7247,6 +7377,211 @@ mod tests {
 
         // Should have run optimizations
         assert!(stats.passes_run > 0);
+    }
+
+    // ─── #377: --safety-bounds on the OPTIMIZED path ────────────────────────
+
+    /// Lower `wasm_ops` through the full optimized path with the given bounds
+    /// mode.
+    fn lower_with_bounds(
+        wasm_ops: &[WasmOp],
+        num_params: usize,
+        bounds: BoundsCheckConfig,
+    ) -> Result<Vec<ArmOp>> {
+        let mut bridge = OptimizerBridge::with_config(OptimizationConfig::all());
+        bridge.set_bounds_check(bounds);
+        let (ir, _cfg, _stats) = bridge.optimize_full(wasm_ops)?;
+        bridge.ir_to_arm(&ir, num_params)
+    }
+
+    /// The #377 guard shape: `ADD R12,addr,#end; CMP R12,R10; BLO +0; UDF #0`
+    /// immediately before the access. Returns how many complete guards appear.
+    fn count_guards(ops: &[ArmOp]) -> usize {
+        use crate::rules::{Operand2, Reg};
+        ops.windows(4)
+            .filter(|w| {
+                matches!(
+                    &w[0],
+                    ArmOp::Add {
+                        rd: Reg::R12,
+                        op2: Operand2::Imm(_),
+                        ..
+                    }
+                ) && matches!(
+                    &w[1],
+                    ArmOp::Cmp {
+                        rn: Reg::R12,
+                        op2: Operand2::Reg(Reg::R10)
+                    }
+                ) && matches!(
+                    &w[2],
+                    ArmOp::BCondOffset {
+                        cond: Condition::LO,
+                        offset: 0
+                    }
+                ) && matches!(&w[3], ArmOp::Udf { imm: 0 })
+            })
+            .count()
+    }
+
+    /// #377: every one of the four optimized-path memory opcodes gets the
+    /// software guard (previously: byte-identical to `none` — a silent no-op).
+    #[test]
+    fn optimized_path_software_bounds_guards_all_memory_shapes_377() {
+        // (LocalGet addr, [value]) → i32.store / i32.load / i32.store16 / i32.load8_u
+        let cases: Vec<(Vec<WasmOp>, usize)> = vec![
+            (
+                vec![
+                    WasmOp::LocalGet(0),
+                    WasmOp::LocalGet(1),
+                    WasmOp::I32Store {
+                        offset: 4,
+                        align: 2,
+                    },
+                ],
+                2,
+            ),
+            (
+                vec![
+                    WasmOp::LocalGet(0),
+                    WasmOp::I32Load {
+                        offset: 0,
+                        align: 2,
+                    },
+                ],
+                1,
+            ),
+            (
+                vec![
+                    WasmOp::LocalGet(0),
+                    WasmOp::LocalGet(1),
+                    WasmOp::I32Store16 {
+                        offset: 0,
+                        align: 1,
+                    },
+                ],
+                2,
+            ),
+            (
+                vec![
+                    WasmOp::LocalGet(0),
+                    WasmOp::I32Load8U {
+                        offset: 0,
+                        align: 0,
+                    },
+                ],
+                1,
+            ),
+        ];
+        for (ops, num_params) in cases {
+            let none = lower_with_bounds(&ops, num_params, BoundsCheckConfig::None).unwrap();
+            let sw = lower_with_bounds(&ops, num_params, BoundsCheckConfig::Software).unwrap();
+            assert_eq!(count_guards(&none), 0, "no guard under None: {ops:?}");
+            assert_eq!(
+                count_guards(&sw),
+                1,
+                "exactly one guard under Software: {ops:?} → {sw:?}"
+            );
+            assert!(
+                sw.len() == none.len() + 4,
+                "guard adds exactly 4 ops: {ops:?}"
+            );
+        }
+    }
+
+    /// #377: the guard end-offset is `offset + access_size - 1` (the last byte
+    /// of the access, mirroring the direct selector's check).
+    #[test]
+    fn optimized_path_software_guard_uses_end_of_access_377() {
+        use crate::rules::{Operand2, Reg};
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32Store {
+                offset: 4,
+                align: 2,
+            },
+        ];
+        let sw = lower_with_bounds(&ops, 2, BoundsCheckConfig::Software).unwrap();
+        assert!(
+            sw.iter().any(|op| matches!(
+                op,
+                ArmOp::Add {
+                    rd: Reg::R12,
+                    op2: Operand2::Imm(7),
+                    ..
+                }
+            )),
+            "end offset must be 4 (offset) + 4 (size) - 1 = 7: {sw:?}"
+        );
+    }
+
+    /// #377: `Mpu` emits no inline guard on the optimized path — identical to
+    /// `None` (hardware enforcement is external; path parity with the direct
+    /// selector's `is_passthrough` handling).
+    #[test]
+    fn optimized_path_mpu_is_passthrough_377() {
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32Store {
+                offset: 0,
+                align: 2,
+            },
+        ];
+        let none = lower_with_bounds(&ops, 2, BoundsCheckConfig::None).unwrap();
+        let mpu = lower_with_bounds(&ops, 2, BoundsCheckConfig::Mpu).unwrap();
+        assert_eq!(none, mpu, "Mpu must be codegen-identical to None");
+    }
+
+    /// #377: `Masking` DECLINES memory-accessing functions to the direct
+    /// selector (in-place AND is unsound on this path) — never a silent no-op.
+    #[test]
+    fn optimized_path_masking_declines_memory_access_377() {
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32Store {
+                offset: 0,
+                align: 2,
+            },
+        ];
+        let err = lower_with_bounds(&ops, 2, BoundsCheckConfig::Masking).unwrap_err();
+        assert!(
+            err.to_string().contains("#377"),
+            "masking must decline with the #377 message, got: {err}"
+        );
+        // ...but a function with NO memory access stays on the optimized path.
+        let pure = vec![WasmOp::LocalGet(0), WasmOp::I32Const(1), WasmOp::I32Add];
+        assert!(lower_with_bounds(&pure, 1, BoundsCheckConfig::Masking).is_ok());
+    }
+
+    /// #377: with bounds checks OFF the lowering is untouched — the flag-off
+    /// stream (and thus every frozen fixture, none of which set
+    /// `--safety-bounds`) is byte-identical to a bridge that never heard of
+    /// bounds modes.
+    #[test]
+    fn optimized_path_none_is_byte_identical_377() {
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32Store {
+                offset: 4,
+                align: 2,
+            },
+            WasmOp::LocalGet(0),
+            WasmOp::I32Load {
+                offset: 0,
+                align: 2,
+            },
+        ];
+        let default_bridge = {
+            let bridge = OptimizerBridge::with_config(OptimizationConfig::all());
+            let (ir, _cfg, _stats) = bridge.optimize_full(&ops).unwrap();
+            bridge.ir_to_arm(&ir, 2).unwrap()
+        };
+        let explicit_none = lower_with_bounds(&ops, 2, BoundsCheckConfig::None).unwrap();
+        assert_eq!(default_bridge, explicit_none);
     }
 
     #[test]

--- a/scripts/repro/safety_bounds_377.wat
+++ b/scripts/repro/safety_bounds_377.wat
@@ -1,0 +1,31 @@
+;; #377 — --safety-bounds software must be enforced on the OPTIMIZED codegen
+;; path (not just the direct selector). Each export is a minimal dynamic-address
+;; linear-memory access of one of the four optimized-path memory opcodes
+;; (MemStore, MemLoad, MemStoreSubword, MemLoadSubword). All bodies are simple
+;; i32 leaf functions so the optimized path (ir_to_arm) accepts them — the
+;; whole point is to exercise THAT path; the same module compiled with
+;; --no-optimize exercises the direct selector for path parity.
+(module
+  (memory (export "memory") 1)
+
+  ;; i32.store: mem[a+4] = v   (static offset so the guard covers offset+size-1)
+  (func (export "st") (param i32 i32)
+    local.get 0
+    local.get 1
+    i32.store offset=4)
+
+  ;; i32.load: return mem[a]
+  (func (export "ld") (param i32) (result i32)
+    local.get 0
+    i32.load)
+
+  ;; i32.store16: subword store
+  (func (export "st16") (param i32 i32)
+    local.get 0
+    local.get 1
+    i32.store16)
+
+  ;; i32.load8_u: subword load
+  (func (export "ld8") (param i32) (result i32)
+    local.get 0
+    i32.load8_u))

--- a/scripts/repro/safety_bounds_377_differential.py
+++ b/scripts/repro/safety_bounds_377_differential.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""#377 — `--safety-bounds software` optimized-path enforcement differential.
+
+Pre-fix, `--safety-bounds software` emitted NO bounds check on the optimized
+codegen path (`ir_to_arm`) — the path that lowers the bulk of a flight loop's
+i32 loads/stores. The direct selector emitted the check but its `Bhs
+Trap_Handler` resolved to an offset-0 fallthrough in a self-contained image, so
+NEITHER path actually trapped. This harness is the value-level gate for both:
+
+  - ELF A: default compile        -> optimized path (asserted via SYNTH_PATH_DEBUG)
+  - ELF B: --no-optimize compile  -> direct selector
+
+For each path and each vector, **wasmtime is ground truth**; **unicorn** runs
+synth's Thumb-2 output. Vectors cover in-bounds, exact-boundary (must NOT
+trap), first-OOB (must trap: the guard is end-inclusive `addr+off+size-1 <
+size`), and far-OOB. The inline trap is a `UDF` -> UC_ERR_INSN_INVALID: that IS
+the wasm trap (on silicon UsageFault/HardFault). Any OTHER unicorn fault (e.g.
+WRITE_UNMAPPED) means an out-of-bounds access was let through — reported as ERR,
+never counted as a match. On pre-fix main the OOB vectors FAIL on both paths.
+
+Covers all four optimized-path memory opcodes: MemStore (`st`), MemLoad
+(`ld`), MemStoreSubword (`st16`), MemLoadSubword (`ld8`).
+
+Run:
+  synth compile scripts/repro/safety_bounds_377.wat -o /tmp/sb377_opt.elf \
+        --target cortex-m4 --all-exports --safety-bounds software
+  synth compile scripts/repro/safety_bounds_377.wat -o /tmp/sb377_dir.elf \
+        --target cortex-m4 --all-exports --safety-bounds software --no-optimize
+  /tmp/synthvenv/bin/python scripts/repro/safety_bounds_377_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import subprocess
+import sys
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import (
+    UC_ARCH_ARM,
+    UC_ERR_INSN_INVALID,
+    UC_MODE_THUMB,
+    Uc,
+    UcError,
+)
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_PC,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R10,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WASM = "scripts/repro/safety_bounds_377.wat"
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+
+MEM_BYTES = 0x10000  # 1 page = 64 KiB (matches the wat `(memory 1)`)
+CODE = 0x00200000
+# The optimized path materializes the ABSOLUTE linear-memory base 0x20000100;
+# the direct path is R11-relative. Point both at the same window so one
+# harness serves both: map the 4 KiB-aligned page below and treat
+# LIN = 0x20000100 as byte 0 of linear memory.
+LIN_PAGE = 0x20000000
+LIN = 0x20000100
+STK = 0x30010000
+RET = 0x00300000
+
+# (fn, addr, val, expect_trap)
+# `st` writes mem[addr+4] (offset=4, size 4): last byte = addr+7.
+# `ld` reads mem[addr] (size 4): last byte = addr+3.
+# `st16` (size 2): last byte = addr+1. `ld8` (size 1): last byte = addr.
+VECTORS = [
+    ("st", 100, 0xDEADBEEF, False),            # plain in-bounds
+    ("st", MEM_BYTES - 8, 0x11223344, False),  # exact boundary: addr+4+4==size
+    ("st", MEM_BYTES - 7, 0x55667788, True),   # first OOB byte -> trap
+    ("st", MEM_BYTES, 0x99AABBCC, True),       # addr at size -> trap
+    ("st", 2 * MEM_BYTES, 0x0BADF00D, True),   # far OOB -> trap
+    ("ld", 200, 0, False),
+    ("ld", MEM_BYTES - 4, 0, False),           # exact boundary read
+    ("ld", MEM_BYTES - 3, 0, True),            # straddles the end -> trap
+    ("ld", 3 * MEM_BYTES, 0, True),            # far OOB -> trap
+    ("st16", MEM_BYTES - 2, 0xCAFE, False),    # boundary halfword
+    ("st16", MEM_BYTES - 1, 0xBABE, True),     # straddle -> trap
+    ("ld8", MEM_BYTES - 1, 0, False),          # last byte readable
+    ("ld8", MEM_BYTES, 0, True),               # one past -> trap
+]
+
+
+def pattern():
+    return bytes((i * 31 + 7) & 0xFF for i in range(MEM_BYTES))
+
+
+def compile_elves():
+    subprocess.run(["wat2wasm", WASM, "-o", "/tmp/sb377.wasm"], check=True)
+    outs = {}
+    for name, extra in (("optimized", []), ("direct", ["--no-optimize"])):
+        elf = f"/tmp/sb377_{name}.elf"
+        env = dict(os.environ, SYNTH_PATH_DEBUG="1")
+        r = subprocess.run(
+            [SYNTH, "compile", WASM, "-o", elf, "--target", "cortex-m4",
+             "--all-exports", "--safety-bounds", "software"] + extra,
+            capture_output=True, text=True, env=env, check=True,
+        )
+        if name == "optimized" and "optimized (ir_to_arm ok)" not in r.stderr:
+            print("ERROR: the 'optimized' ELF did not take the optimized path —"
+                  " the #377 gate would be vacuous. stderr:\n" + r.stderr)
+            sys.exit(2)
+        outs[name] = elf
+    return outs
+
+
+def load_text_and_syms(elf_path):
+    f = ELFFile(open(elf_path, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for sec in f.iter_sections():
+        if sec["sh_type"] == "SHT_SYMTAB":
+            for s in sec.iter_symbols():
+                if s["st_value"]:
+                    syms[s.name] = s["st_value"] & ~1  # clear Thumb bit
+    return code, base, syms
+
+
+def wasmtime_run(module, engine, fn, a, v):
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    mem = inst.exports(store)["memory"]
+    mem.write(store, pattern(), 0)
+    ret = None
+    try:
+        if fn.startswith("st"):
+            inst.exports(store)[fn](store, a, v)
+        else:
+            ret = inst.exports(store)[fn](store, a)
+        trapped = False
+    except wasmtime.Trap:
+        trapped = True
+    img = bytes(mem.read(store, 0, MEM_BYTES))
+    return trapped, ret, img
+
+
+def unicorn_run(code, base, syms, fn, a, v):
+    fa = syms[fn]
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x10000)
+    mu.mem_map(LIN_PAGE, 0x11000)  # covers LIN..LIN+64K (+0x100 lead-in)
+    mu.mem_map(STK - 0x10000, 0x10000)
+    mu.mem_map(RET, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.mem_write(LIN, pattern())
+    mu.reg_write(UC_ARM_REG_SP, STK)
+    mu.reg_write(UC_ARM_REG_R11, LIN)        # direct path: linmem base
+    mu.reg_write(UC_ARM_REG_R10, MEM_BYTES)  # memory size (bytes) for bounds
+    mu.reg_write(UC_ARM_REG_R0, a & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_R1, v & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    try:
+        mu.emu_start((CODE + fa - base) | 1, RET, count=100000)
+    except UcError as e:
+        if e.errno == UC_ERR_INSN_INVALID:
+            # UDF: the inline software-bounds trap. Verify it's a real UDF so a
+            # stray decode error can't masquerade as a pass.
+            pc = mu.reg_read(UC_ARM_REG_PC)
+            half = bytes(mu.mem_read(pc, 2))
+            if half[1] == 0xDE:  # Thumb UDF #imm8 = 0xDExx
+                return True, None, bytes(mu.mem_read(LIN, MEM_BYTES))
+        return f"ERR:{e}", None, b""
+    ret = mu.reg_read(UC_ARM_REG_R0)
+    return False, ret, bytes(mu.mem_read(LIN, MEM_BYTES))
+
+
+def main():
+    elves = compile_elves()
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, open("/tmp/sb377.wasm", "rb").read())
+
+    total_fails = 0
+    for path_name, elf in elves.items():
+        code, base, syms = load_text_and_syms(elf)
+        print(f"=== {path_name} path ({elf}) ===")
+        fails = 0
+        for fn, a, v, exp_trap in VECTORS:
+            gt_trap, gt_ret, gt_img = wasmtime_run(module, engine, fn, a, v)
+            sy_trap, sy_ret, sy_img = unicorn_run(code, base, syms, fn, a, v)
+            assert gt_trap == exp_trap, f"vector expectation wrong: {fn}({a})"
+            if isinstance(sy_trap, str):
+                ok, detail = False, sy_trap
+            elif gt_trap:
+                ok = bool(sy_trap) and sy_img == gt_img
+                detail = f"trap synth={sy_trap} wasmtime={gt_trap}"
+            else:
+                ok = (not sy_trap) and sy_img == gt_img
+                detail = "image identical"
+                if fn.startswith("ld") and ok:
+                    ok = (sy_ret & 0xFFFFFFFF) == (gt_ret & 0xFFFFFFFF)
+                    detail = f"ret synth=0x{sy_ret:08x} wasmtime=0x{gt_ret & 0xFFFFFFFF:08x}"
+                elif sy_img != gt_img:
+                    d = next(i for i in range(MEM_BYTES) if sy_img[i] != gt_img[i])
+                    detail = (f"mem differs @{d}: synth=0x{sy_img[d]:02x} "
+                              f"wasmtime=0x{gt_img[d]:02x}")
+            fails += 0 if ok else 1
+            print(f"  {fn}(addr={a}) trap={exp_trap}: "
+                  f"{'OK' if ok else 'MISMATCH'}  [{detail}]")
+        print(f"  {len(VECTORS) - fails}/{len(VECTORS)} match on {path_name}\n")
+        total_fails += fails
+    print("ORACLE: PASS" if total_fails == 0 else f"ORACLE: FAIL ({total_fails})")
+    sys.exit(1 if total_fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #377. Flight-safety: jess pins `--safety-bounds software` for PX4.

## The bug (two halves)

1. **Optimized path**: `--safety-bounds software`/`mask` were **silent no-ops** on the optimized codegen path (`ir_to_arm`) — the path that lowers the bulk of a flight loop's i32 loads/stores compiled **byte-identical to `none`** while the safety manifest claimed enforcement.
2. **Direct path**: the existing check never actually trapped either — its `Bhs Trap_Handler` label branch resolves to an offset-0 **fallthrough no-op** in a self-contained image (the label is external, so `resolve_label_branches` leaves the placeholder). The CMP ran; the trap didn't.

## Policy chosen, per mode

| Mode | Optimized path (before) | Optimized path (now) | Direct path (now) |
|---|---|---|---|
| `software` | silent no-op | **inline per-access guard**: `ADD R12,addr,#off+size-1; CMP R12,R10; BLO +0; UDF #0` | same shape — `Bhs Trap_Handler` → inline `BLO +0; UDF #0` in all 8 access shapes |
| `mask` | silent no-op | **loud decline** → routes memory-accessing functions to the direct selector (in-place `AND addr,R10` is unsound on the non-single-use optimized path) | unchanged (implements masking) |
| `mpu` | passthrough | passthrough — **path-parity pinned by test** (bytes == `none` on both paths) | unchanged |
| `none` | — | byte-identical to before (pinned by test) | unchanged |

Why `software` = implement (not decline): it's the mode jess pins, and declining every memory-accessing function would forfeit the optimized path exactly where PX4 needs it. The guard mirrors the direct selector's end-of-access check (`addr+offset+size-1 < R10`) and uses the same pre-resolved numeric-guard geometry (`BLO +0` skipping a 2-byte `UDF`) as the DivS/DivU zero traps, which `resolved_branch_geometry` (#604/#607) already maps — no new branch class. R12 is the encoder scratch (never allocator-assigned, #212) and is re-materialized after the guard. Base-CSE is disabled under `software` (its folded `[R11,#imm]` arm bypasses the register-shape guard); safety mode trades the size win for uniform checking. Inline `UDF` is the #374 bulk-memory/div-trap pattern and works identically under `--relocatable` (UDF → UsageFault → platform handler).

**Estimator**: the guard's `ADD R12,…,#imm` (high rd → always 32-bit ADD.W) was an `estimate_arm_byte_size` hole (`_ => 2` default) that drifted every spanning branch by 2 bytes; new arm added + 3 pinned cases in `estimator_encoder_agreement` (the #511 oracle).

## Red → green evidence

`scripts/repro/safety_bounds_377_differential.py` — wasmtime ground truth vs unicorn running synth's Thumb-2, both paths (optimized path asserted non-vacuous via `SYNTH_PATH_DEBUG`), 13 vectors covering in-bounds / exact-boundary (must NOT trap) / first-OOB-byte / far-OOB across all four memory opcode shapes (`MemStore`/`MemLoad`/`MemStoreSubword`/`MemLoadSubword`). A far-OOB access that unicorn faults on (`UNMAPPED`) is reported ERR, never a match — only a genuine `UDF` counts as the trap.

| Build | optimized path | direct path |
|---|---|---|
| origin/main `086968a` (v0.32.1) | **6/13** — all 7 OOB vectors leak | **6/13** — all 7 OOB vectors leak |
| this branch | **13/13** | **13/13** |

## Verification

- 8 new unit tests: guard on all four opcode shapes + exactly-one-guard, end-offset `off+size-1`, mask declines with the #377 message (pure functions stay optimized), mpu ≡ none bytes on both paths, flag-off stream byte-identical (frozen fixtures don't use `--safety-bounds`)
- `estimator_encoder_agreement` green (incl. 3 new high-rd ADD-imm cases)
- Full workspace: 105 test suites green; `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean

## Salvage provenance

Recovered from an interrupted session (agent hit its session limit at 170 tool uses, worktree `lane-377`, uncommitted). This PR completes the verification (baseline red run, workspace tests, fmt/clippy) and lands the on-disk state; rebased onto current origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)