### PR TITLE
fix(cf): #500 optimized-path forward-branch shapes fixed-or-declined; #498 estimator gap allowlist emptied (#242)

### DIFF
--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -2630,9 +2630,7 @@ impl ArmEncoder {
                     } else {
                         // Full 32-bit value: MOVW low16 + MOVT high16
                         let mut bytes = self.encode_thumb32_movw(rd, uimm & 0xFFFF)?;
-                        bytes.extend(
-                            self.encode_thumb32_movt_raw(reg_to_bits(rd), uimm >> 16)?,
-                        );
+                        bytes.extend(self.encode_thumb32_movt_raw(reg_to_bits(rd), uimm >> 16)?);
                         Ok(bytes)
                     }
                 } else if let Operand2::Reg(rm) = op2 {

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -2606,14 +2606,34 @@ impl ArmEncoder {
                 let rd_bits = reg_to_bits(rd) as u16;
 
                 if let Operand2::Imm(imm) = op2 {
-                    if *imm <= 255 && rd_bits < 8 {
+                    // #498: the old test here was the SIGNED `*imm <= 255`,
+                    // so a negative immediate (e.g. -1) fell into the 16-bit
+                    // MOVS arm and encoded the wrong VALUE (#(imm & 0xFF) =
+                    // #0xFF). A positive imm above 0xFFFF was equally wrong:
+                    // MOVW truncates to 16 bits. Split on the UNSIGNED value:
+                    // imm8 → MOVS, imm16 → MOVW, anything wider (negative or
+                    // >0xFFFF) → the full-value MOVW+MOVT pair. No emitter
+                    // produces the wide shape today (both selectors
+                    // materialize wide constants as explicit Movw/Movt or
+                    // Movw+Mvn), so this is byte-identical on shipped paths —
+                    // it retires the latent wrong-value encodings the
+                    // `estimator_encoder_agreement` oracle had pinned.
+                    let uimm = *imm as u32;
+                    if uimm <= 255 && rd_bits < 8 {
                         // MOVS Rd, #imm8 (16-bit): 0010 0 Rd imm8
                         let imm_bits = (*imm as u16) & 0xFF;
                         let instr: u16 = 0x2000 | (rd_bits << 8) | imm_bits;
                         Ok(instr.to_le_bytes().to_vec())
+                    } else if uimm <= 0xFFFF {
+                        // Use 32-bit MOVW for 16-bit immediates
+                        self.encode_thumb32_movw(rd, uimm)
                     } else {
-                        // Use 32-bit MOVW for larger immediates
-                        self.encode_thumb32_movw(rd, *imm as u32)
+                        // Full 32-bit value: MOVW low16 + MOVT high16
+                        let mut bytes = self.encode_thumb32_movw(rd, uimm & 0xFFFF)?;
+                        bytes.extend(
+                            self.encode_thumb32_movt_raw(reg_to_bits(rd), uimm >> 16)?,
+                        );
+                        Ok(bytes)
                     }
                 } else if let Operand2::Reg(rm) = op2 {
                     let rm_bits = reg_to_bits(rm) as u16;

--- a/crates/synth-backend/tests/estimator_encoder_agreement.rs
+++ b/crates/synth-backend/tests/estimator_encoder_agreement.rs
@@ -15,20 +15,17 @@
 //! estimator and the real encoder. This oracle pins one against the other for
 //! every op the optimized path emits, at the operand shapes it emits them in.
 //!
-//! ## Scope — the estimator-side gaps are now CLOSED; two survivors remain.
+//! ## Scope — the gap allowlist is EMPTY: every on-path op agrees exactly.
 //!
-//! The #498 estimator-alignment step (this PR) corrected every gap that was a
-//! pure estimator under/over-count against a CORRECT encoder length. Those are
-//! estimator-only edits (`estimate_arm_byte_size` in synth-synthesis) — they do
-//! not change emitted `.text` (verified: frozen anchors bit-identical), only the
-//! branch-displacement bookkeeping the estimator feeds. The oracle now asserts
-//! EXACT agreement for them, so any future drift fails loudly. Two divergences
-//! remain pinned as `KNOWN_GAP` because they are NOT simple table errors:
-//!
-//! - a NEW estimator drift (an added op left at the `_ => 2` default, or a
-//!   changed encoding) fails the agreement assertion loudly, and
-//! - a re-closure of one of the two survivors fails the "gap closed" check,
-//!   forcing the gap to be removed from the list.
+//! The #498 estimator-alignment step corrected every gap that was a pure
+//! estimator under/over-count against a CORRECT encoder length (estimator-only
+//! edits — no emitted `.text` change, only the branch-displacement bookkeeping
+//! the estimator feeds). The follow-up (#498/#500 lane) closed the two former
+//! `KNOWN_GAP` survivors as well, so the oracle now asserts EXACT agreement for
+//! EVERY case: a NEW estimator drift (an added op left at the `_ => 2` default,
+//! or a changed encoding) fails loudly, and a divergence that genuinely cannot
+//! be closed must be reintroduced here as a documented, pinned exception — not
+//! silently tolerated.
 //!
 //! ## Findings recorded here (correct + extend #498's original report)
 //! - #498 claimed `Cmp` high-reg drifts. It does NOT: the 16-bit CMP (T2,
@@ -45,33 +42,29 @@
 //!   `I64Popcnt` (200) and `I64Extend32S` (8) OVER-estimated. CLOSED: pinned to
 //!   the exact encoder lengths (74/78/126/124, 172, 6). (#610 later wrapped the
 //!   div/rem and rot expansions in the fixed-ABI marshal/restore + zero-divisor
-//!   trap — now 120/124/172/170 and 102, still exact-pinned here.)
-//! - SURVIVOR (structural): far branches (`BOffset`/`BCondOffset` with a large
-//!   displacement) need the 4-byte `.w` form but the estimator runs BEFORE
-//!   displacements are known, on a 0-offset placeholder, so it sizes them 2 —
-//!   a chicken-and-egg the single-pass estimator cannot resolve. Making it
-//!   offset-sensitive would either be cosmetic (production always sees offset 0)
-//!   or entangle with the displacement-resolution pass (byte-changing). Left as
-//!   a documented structural gap, not an estimator-table fix.
-//! - SURVIVOR (encoder-side, deferred): `Mov` with a small NEGATIVE immediate:
-//!   estimator sizes 4 (prudent), but the encoder's `if *imm <= 255` is a
-//!   *signed* test and emits a 2-byte `MOVS Rd, #(imm & 0xFF)` — a wrong-value
-//!   0xFF, a latent ENCODER bug for negative imm8. Aligning the estimator DOWN
-//!   to 2 would endorse a buggy encoding; the real fix is encoder-side (emits
-//!   different bytes → frozen-affecting → a separate gated PR). Kept pinned.
+//!   trap — now 120/124 and 102; #633 added the div_s INT64_MIN/-1 overflow
+//!   guard and #632 the popcnt result-carry, so div_s/rem_s/popcnt sit at
+//!   194/170/180 — still exact-pinned here.)
+//! - CLOSED (was the structural survivor): far branches (`BOffset`/
+//!   `BCondOffset` beyond the 2-byte short form) — the estimator is now
+//!   offset-sensitive, mirroring the encoder's exact range split (B.N imm11 /
+//!   B<cond>.N imm8 → 2, `.w` → 4). Production behavior is unchanged: the
+//!   bridge sizes branches on the offset-0 PLACEHOLDER (always short), and its
+//!   resolution pass now DECLINES any displacement that outgrows the short
+//!   form (#498 far-branch guard in `ir_to_arm`) instead of letting the wide
+//!   encoding silently shift the layout — the chicken-and-egg is resolved by
+//!   refusing the egg, loudly.
+//! - CLOSED (was the encoder-side survivor): `Mov` with a negative (or
+//!   >0xFFFF) immediate. The encoder's signed `*imm <= 255` test emitted a
+//!   wrong-VALUE 2-byte `MOVS Rd, #(imm & 0xFF)` for negative imm, and MOVW
+//!   truncated positives above 16 bits. The encoder now splits on the unsigned
+//!   value (imm8 MOVS / imm16 MOVW / full-width MOVW+MOVT = 8 bytes) and the
+//!   estimator mirrors it. No emitter produces the wide shape (both selectors
+//!   materialize wide constants as explicit Movw/Movt or Movw+Mvn), so shipped
+//!   bytes are unchanged — verified by the frozen anchors.
 
 use synth_backend::ArmEncoder;
 use synth_synthesis::{ArmOp, Condition, MemAddr, Operand2, Reg, estimate_arm_byte_size};
-
-/// A documented divergence: the optimized-path estimator and the encoder
-/// disagree on this op's size today. Pinned to the exact measured pair so a
-/// regression (new drift) or a fix (gap closed) both trip the oracle.
-struct Gap {
-    est: usize,
-    enc: usize,
-    /// Why it diverges and which direction the branch lands.
-    _reason: &'static str,
-}
 
 fn mem(base: Reg) -> MemAddr {
     MemAddr {
@@ -82,32 +75,14 @@ fn mem(base: Reg) -> MemAddr {
 }
 
 /// One oracle case: a representative instruction at an operand shape the
-/// optimized path actually emits, and whether agreement is expected (`None`) or
-/// a documented `KNOWN_GAP` (`Some`).
+/// optimized path actually emits. Estimator and encoder must agree exactly.
 struct Case {
     label: &'static str,
     op: ArmOp,
-    gap: Option<Gap>,
 }
 
 fn agree(label: &'static str, op: ArmOp) -> Case {
-    Case {
-        label,
-        op,
-        gap: None,
-    }
-}
-
-fn gap(label: &'static str, op: ArmOp, est: usize, enc: usize, reason: &'static str) -> Case {
-    Case {
-        label,
-        op,
-        gap: Some(Gap {
-            est,
-            enc,
-            _reason: reason,
-        }),
-    }
+    Case { label, op }
 }
 
 /// The agreement cases. Operand shapes mirror what `ir_to_arm` emits: sub-word
@@ -798,40 +773,43 @@ fn cases() -> Vec<Case> {
                 elide_zero_guard: true,
             },
         ),
-        // ===================== REMAINING KNOWN GAPS =====================
-        // Two survivors, NOT simple estimator table errors — kept pinned.
-        // Far branches: the estimator sizes the 0-offset placeholder (it runs
-        // before displacements are resolved) as 2, but a far target needs the
-        // 4-byte form. Chicken-and-egg in the single-pass estimator.
-        gap(
-            "BOffset_far",
-            BOffset { offset: 5000 },
-            2,
-            4,
-            "far B needs T4 (4); estimator _=>2 on the pre-resolution placeholder. Under-estimate.",
-        ),
-        gap(
+        // === Former KNOWN_GAP survivors, now CLOSED (#498/#500 lane) ===
+        // Far branches: estimator now offset-sensitive, mirroring the
+        // encoder's short/`.w` range split. (Production only ever feeds the
+        // short form: the bridge sizes offset-0 placeholders and its
+        // resolution pass declines displacements that outgrow them.)
+        agree("BOffset_far", BOffset { offset: 5000 }),
+        agree(
             "BCondOffset_far",
             BCondOffset {
                 cond: Condition::EQ,
                 offset: 5000,
             },
-            2,
-            4,
-            "far Bcc needs T3 (4); estimator _=>2 on the pre-resolution placeholder. Under-estimate.",
         ),
-        // Negative small immediate: estimator prudently sizes 4; the encoder's
-        // signed `imm <= 255` test wrongly emits a 2-byte MOVS #(imm&0xFF).
-        // Latent ENCODER bug (wrong value), surfaced here. Tracked separately.
-        gap(
+        agree(
+            "BCondOffset_far_neg",
+            BCondOffset {
+                cond: Condition::NE,
+                offset: -200,
+            },
+        ),
+        // Negative / wide MOV immediates: the encoder now emits the
+        // full-value MOVW+MOVT pair (8 bytes) instead of the wrong-value
+        // 2-byte MOVS #(imm&0xFF) (negative) or a truncated MOVW (>0xFFFF);
+        // the estimator mirrors the three-way imm8/imm16/full split.
+        agree(
             "Mov_imm_neg",
             Mov {
                 rd: Reg::R0,
                 op2: Operand2::Imm(-1),
             },
-            4,
-            2,
-            "estimator 4 (prudent); encoder emits wrong-value 2-byte MOVS #0xFF (signed imm<=255 bug).",
+        ),
+        agree(
+            "Mov_imm_wide",
+            Mov {
+                rd: Reg::R0,
+                op2: Operand2::Imm(0x12345),
+            },
         ),
     ]
 }
@@ -1102,9 +1080,10 @@ fn coverage(op: &ArmOp) -> Coverage {
     }
 }
 
-/// The estimator must agree with the encoder for every op the optimized path
-/// emits — or the divergence must be a documented `KNOWN_GAP` pinned to its
-/// exact measured (estimate, encoder) pair.
+/// The estimator must agree with the encoder EXACTLY for every op the
+/// optimized path emits. The gap allowlist is empty (#498 closed); a genuine
+/// new divergence must be fixed in the estimator or reintroduced here as a
+/// documented, pinned exception.
 #[test]
 fn estimator_encoder_agreement() {
     let enc = ArmEncoder::new_thumb2();
@@ -1125,32 +1104,11 @@ fn estimator_encoder_agreement() {
             .unwrap_or_else(|e| panic!("{}: encoder rejected the op: {e:?}", case.label))
             .len();
 
-        match case.gap {
-            None => {
-                if est != real {
-                    surprises.push(format!(
-                        "NEW DRIFT {}: estimator {est} != encoder {real} \
-                         (fix the estimator, or add a documented KNOWN_GAP)",
-                        case.label
-                    ));
-                }
-            }
-            Some(g) => {
-                if (est, real) != (g.est, g.enc) {
-                    surprises.push(format!(
-                        "KNOWN_GAP CHANGED {}: was (est {}, enc {}), now (est {est}, enc {real}) \
-                         — update or remove the gap",
-                        case.label, g.est, g.enc
-                    ));
-                }
-                if est == real {
-                    surprises.push(format!(
-                        "GAP CLOSED {}: estimator and encoder now agree ({est}) \
-                         — remove it from KNOWN_GAP",
-                        case.label
-                    ));
-                }
-            }
+        if est != real {
+            surprises.push(format!(
+                "NEW DRIFT {}: estimator {est} != encoder {real} (fix the estimator)",
+                case.label
+            ));
         }
     }
 

--- a/crates/synth-backend/tests/estimator_encoder_agreement.rs
+++ b/crates/synth-backend/tests/estimator_encoder_agreement.rs
@@ -54,8 +54,8 @@
 //!   form (#498 far-branch guard in `ir_to_arm`) instead of letting the wide
 //!   encoding silently shift the layout — the chicken-and-egg is resolved by
 //!   refusing the egg, loudly.
-//! - CLOSED (was the encoder-side survivor): `Mov` with a negative (or
-//!   >0xFFFF) immediate. The encoder's signed `*imm <= 255` test emitted a
+//! - CLOSED (was the encoder-side survivor): `Mov` with a negative (or wider
+//!   than 0xFFFF) immediate. The encoder's signed `*imm <= 255` test emitted a
 //!   wrong-VALUE 2-byte `MOVS Rd, #(imm & 0xFF)` for negative imm, and MOVW
 //!   truncated positives above 16 bits. The encoder now splits on the unsigned
 //!   value (imm8 MOVS / imm16 MOVW / full-width MOVW+MOVT = 8 bytes) and the

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -8311,34 +8311,91 @@ impl InstructionSelector {
                 Br(depth) => {
                     // Branch to the Nth enclosing block/loop
                     // block_labels + if_labels are combined into the block_labels stack
-                    let target_idx = block_labels.len().saturating_sub(1 + *depth as usize);
-                    if target_idx < block_labels.len() {
-                        // #509: land a carried value in the target block's
-                        // designated result register BEFORE the jump (no-op for
-                        // void targets and plain loop back-edges).
-                        edge_value_move(
-                            &mut block_labels,
-                            target_idx,
-                            &mut stack,
-                            &mut next_temp,
-                            &mut instructions,
-                            &mut spill,
-                            &live_params,
-                            idx,
-                        )?;
-                        // Loop: branch back to start; block: forward to end.
-                        instructions.push(ArmInstruction {
-                            op: ArmOp::B {
-                                label: block_labels[target_idx].label.clone(),
-                            },
-                            source_line: Some(idx),
-                        });
-                    } else {
-                        // Depth exceeds stack — branch to function return
-                        instructions.push(ArmInstruction {
-                            op: ArmOp::Bx { rm: Reg::LR },
-                            source_line: Some(idx),
-                        });
+                    //
+                    // #500: `checked_sub`, not `saturating_sub`. The old clamp
+                    // sent a FUNCTION-LEVEL `br` (depth reaching the implicit
+                    // function body, e.g. `br 1` inside one block) to
+                    // `block_labels[0]` — the OUTERMOST block's end — so code
+                    // after that block still executed (`br_func(1)` also stored
+                    // the post-block value; red in
+                    // `cf_shapes_500_differential.py`). And the old
+                    // depth-exceeds-EMPTY-stack arm emitted a bare `bx lr`,
+                    // skipping the frame dealloc + callee-saved pop. A
+                    // function-level `br` IS a `return` — lower it exactly like
+                    // the `Return` arm below.
+                    match block_labels.len().checked_sub(1 + *depth as usize) {
+                        Some(target_idx) => {
+                            // #509: land a carried value in the target block's
+                            // designated result register BEFORE the jump (no-op for
+                            // void targets and plain loop back-edges).
+                            edge_value_move(
+                                &mut block_labels,
+                                target_idx,
+                                &mut stack,
+                                &mut next_temp,
+                                &mut instructions,
+                                &mut spill,
+                                &live_params,
+                                idx,
+                            )?;
+                            // Loop: branch back to start; block: forward to end.
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::B {
+                                    label: block_labels[target_idx].label.clone(),
+                                },
+                                source_line: Some(idx),
+                            });
+                        }
+                        None => {
+                            // Function-level branch == return: result to R0,
+                            // deallocate the frame, pop callee-saved + PC
+                            // (mirrors the `Return` arm; the push-trim post-pass
+                            // rewrites this Pop symmetrically with the prologue).
+                            if !stack.is_empty() {
+                                let val = pop_operand(
+                                    &mut stack,
+                                    &mut next_temp,
+                                    &mut instructions,
+                                    &mut spill,
+                                    &live_params,
+                                    idx,
+                                )?;
+                                if val != Reg::R0 {
+                                    instructions.push(ArmInstruction {
+                                        op: ArmOp::Mov {
+                                            rd: Reg::R0,
+                                            op2: Operand2::Reg(val),
+                                        },
+                                        source_line: Some(idx),
+                                    });
+                                    cf.add_instruction();
+                                }
+                            }
+                            if layout.frame_size > 0 {
+                                instructions.push(ArmInstruction {
+                                    op: ArmOp::Add {
+                                        rd: Reg::SP,
+                                        rn: Reg::SP,
+                                        op2: Operand2::Imm(layout.frame_size),
+                                    },
+                                    source_line: Some(idx),
+                                });
+                                cf.add_instruction();
+                            }
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Pop {
+                                    regs: vec![
+                                        Reg::R4,
+                                        Reg::R5,
+                                        Reg::R6,
+                                        Reg::R7,
+                                        Reg::R8,
+                                        Reg::PC,
+                                    ],
+                                },
+                                source_line: Some(idx),
+                            });
+                        }
                     }
                     cf.add_instruction();
                 }
@@ -8361,43 +8418,138 @@ impl InstructionSelector {
                     // wasm `br_if : [t*] i32 -> [t*]`), and the mov on the
                     // not-taken path is dead — R_res is reserved for the
                     // block's extent and only meaningful at its join.
-                    let target_idx = block_labels.len().saturating_sub(1 + *depth as usize);
-                    if target_idx < block_labels.len() {
-                        let mut edge_reserved = live_params.clone();
-                        edge_reserved.push(cond_reg);
-                        edge_value_move(
-                            &mut block_labels,
-                            target_idx,
-                            &mut stack,
-                            &mut next_temp,
-                            &mut instructions,
-                            &mut spill,
-                            &edge_reserved,
-                            idx,
-                        )?;
-                    }
+                    //
+                    // #500: `checked_sub`, not `saturating_sub` — the old clamp
+                    // sent a FUNCTION-LEVEL `br_if` to the outermost block's
+                    // end (or, with no open blocks, silently emitted a lone
+                    // CMP with no branch at all). A function-level `br_if` is
+                    // a CONDITIONAL return: the whole return sequence sits
+                    // inside the taken region (behind a BEQ over it), so the
+                    // fall-through path — where the operand stack stays live —
+                    // executes none of it.
+                    match block_labels.len().checked_sub(1 + *depth as usize) {
+                        Some(target_idx) => {
+                            let mut edge_reserved = live_params.clone();
+                            edge_reserved.push(cond_reg);
+                            edge_value_move(
+                                &mut block_labels,
+                                target_idx,
+                                &mut stack,
+                                &mut next_temp,
+                                &mut instructions,
+                                &mut spill,
+                                &edge_reserved,
+                                idx,
+                            )?;
 
-                    // CMP cond_reg, #0
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Cmp {
-                            rn: cond_reg,
-                            op2: Operand2::Imm(0),
-                        },
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
+                            // CMP cond_reg, #0
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Cmp {
+                                    rn: cond_reg,
+                                    op2: Operand2::Imm(0),
+                                },
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
 
-                    // BNE target_label (branch if non-zero)
-                    if target_idx < block_labels.len() {
-                        instructions.push(ArmInstruction {
-                            op: ArmOp::Bcc {
-                                cond: Condition::NE,
-                                label: block_labels[target_idx].label.clone(),
-                            },
-                            source_line: Some(idx),
-                        });
+                            // BNE target_label (branch if non-zero)
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Bcc {
+                                    cond: Condition::NE,
+                                    label: block_labels[target_idx].label.clone(),
+                                },
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                        }
+                        None => {
+                            // PEEK the would-be result BEFORE the CMP (a spilled
+                            // top may need a reload, which must not sit between
+                            // CMP and Bcc). The stack is NOT popped: on the
+                            // fall-through path the value stays live.
+                            let val = if stack.is_empty() {
+                                None
+                            } else {
+                                let mut peek_reserved = live_params.clone();
+                                peek_reserved.push(cond_reg);
+                                Some(peek_operand(
+                                    &mut stack,
+                                    &mut next_temp,
+                                    &mut instructions,
+                                    &mut spill,
+                                    &peek_reserved,
+                                    idx,
+                                )?)
+                            };
+                            let skip = self.alloc_label("brif_fnret_skip");
+
+                            // CMP cond_reg, #0
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Cmp {
+                                    rn: cond_reg,
+                                    op2: Operand2::Imm(0),
+                                },
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+
+                            // BEQ over the return sequence (not taken → return)
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Bcc {
+                                    cond: Condition::EQ,
+                                    label: skip.clone(),
+                                },
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+
+                            // Taken region: result to R0, frame dealloc, pop+PC
+                            // (mirrors the `Return` arm).
+                            if let Some(val) = val
+                                && val != Reg::R0
+                            {
+                                instructions.push(ArmInstruction {
+                                    op: ArmOp::Mov {
+                                        rd: Reg::R0,
+                                        op2: Operand2::Reg(val),
+                                    },
+                                    source_line: Some(idx),
+                                });
+                                cf.add_instruction();
+                            }
+                            if layout.frame_size > 0 {
+                                instructions.push(ArmInstruction {
+                                    op: ArmOp::Add {
+                                        rd: Reg::SP,
+                                        rn: Reg::SP,
+                                        op2: Operand2::Imm(layout.frame_size),
+                                    },
+                                    source_line: Some(idx),
+                                });
+                                cf.add_instruction();
+                            }
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Pop {
+                                    regs: vec![
+                                        Reg::R4,
+                                        Reg::R5,
+                                        Reg::R6,
+                                        Reg::R7,
+                                        Reg::R8,
+                                        Reg::PC,
+                                    ],
+                                },
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Label { name: skip },
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                        }
                     }
-                    cf.add_instruction();
                 }
 
                 BrTable { targets, default } => {

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -537,11 +537,49 @@ pub fn estimate_arm_byte_size(op: &ArmOp) -> usize {
         | ArmOp::Ldrsb { .. } => 4,
         // BL is always 32-bit
         ArmOp::Bl { .. } => 4,
-        // MOV with high register (R8-R15) or large immediate needs MOVW (4 bytes)
+        // Branches: 2-byte short forms when the halfword displacement fits
+        // (B.N imm11 / B<cond>.N imm8), 4-byte `.w` otherwise — mirrors the
+        // encoder's range test exactly (#498). In production `ir_to_arm` sizes
+        // these on the offset-0 PLACEHOLDER (pre-resolution) and its resolution
+        // pass declines any displacement that outgrows the short form, so the
+        // 2-byte estimate is the only one that ever feeds `byte_offsets`; the
+        // far arms keep the estimator a faithful per-op encoder mirror for the
+        // post-resolution consumers (`resolved_branch_geometry`) and the
+        // agreement oracle.
+        ArmOp::BOffset { offset } => {
+            if (-1024..=1022).contains(offset) {
+                2
+            } else {
+                4
+            }
+        }
+        ArmOp::BCondOffset { offset, .. } => {
+            if (-128..=127).contains(offset) {
+                2
+            } else {
+                4
+            }
+        }
+        // MOV immediate, mirroring the encoder's three-way split (#498):
+        //   - 0..=255 into a low register: 2-byte MOVS
+        //   - 16-bit range (or a high rd): 4-byte MOVW
+        //   - negative / above 0xFFFF: 8-byte MOVW+MOVT pair (the encoder's
+        //     old signed `imm <= 255` test emitted a wrong-value 2-byte
+        //     MOVS #(imm&0xFF) here — fixed encoder-side alongside this arm;
+        //     no emitter produces this shape today, both paths materialize
+        //     wide constants as explicit Movw/Movt or Movw+Mvn upstream)
         ArmOp::Mov {
             rd,
             op2: Operand2::Imm(v),
-        } if reg_num(rd) > 7 || *v > 255 || *v < 0 => 4,
+        } => {
+            if (*v as u32) > 0xFFFF {
+                8
+            } else if reg_num(rd) > 7 || *v > 255 {
+                4
+            } else {
+                2
+            }
+        }
         ArmOp::Mov { .. } => 2,
         // SUB/ADD with high registers need 32-bit encoding
         ArmOp::Sub {
@@ -2119,36 +2157,52 @@ impl OptimizerBridge {
 
                 // Br: unconditional branch to label. No stack effect at IR
                 // level (the wasm validator handles unreachable stack after Br).
+                //
+                // #500: a branch whose depth reaches the FUNCTION level (depth
+                // >= block_stack.len(), i.e. `br N` targeting the implicit
+                // function body) has no label to land on — the old
+                // `saturating_sub` silently clamped it onto the OUTERMOST
+                // block's end (code after that block still executed) or, with
+                // no open blocks, onto the bogus id 0. Both are the
+                // unresolved/misresolved-forward-branch miscompile class.
+                // Decline to the direct selector, whose function-end label
+                // lowering handles function-level branches.
                 WasmOp::Br(depth) => {
-                    let target_idx = block_stack.len().saturating_sub(1 + *depth as usize);
-                    if target_idx < block_stack.len() {
-                        let (_block_type, target_inst) = block_stack[target_idx];
-                        Opcode::Branch {
-                            target: target_inst,
-                        }
-                    } else {
-                        Opcode::Branch { target: 0 }
+                    let Some(target_idx) = block_stack.len().checked_sub(1 + *depth as usize)
+                    else {
+                        return Err(synth_core::Error::validation(
+                            "optimized lowering path does not support a function-level \
+                             `br` (depth reaches the implicit function body); the \
+                             direct instruction selector lowers it — issue #500",
+                        ));
+                    };
+                    let (_block_type, target_inst) = block_stack[target_idx];
+                    Opcode::Branch {
+                        target: target_inst,
                     }
                 }
 
                 // BrIf: pops cond (i32). The value beneath remains on the
                 // wasm stack — slot_stack reflects that: pop 1 only.
+                // Function-level depth declines like `Br` above (#500).
                 WasmOp::BrIf(depth) => {
                     let cond_v = slot_stack.pop().ok_or_else(|| {
                         synth_core::Error::validation(
                             "wasm stack underflow in wasm_to_ir (slot_stack pop on empty)",
                         )
                     })?;
-                    let target_idx = block_stack.len().saturating_sub(1 + *depth as usize);
-                    let target = if target_idx < block_stack.len() {
-                        let (_block_type, target_inst) = block_stack[target_idx];
-                        target_inst
-                    } else {
-                        0
+                    let Some(target_idx) = block_stack.len().checked_sub(1 + *depth as usize)
+                    else {
+                        return Err(synth_core::Error::validation(
+                            "optimized lowering path does not support a function-level \
+                             `br_if` (depth reaches the implicit function body); the \
+                             direct instruction selector lowers it — issue #500",
+                        ));
                     };
+                    let (_block_type, target_inst) = block_stack[target_idx];
                     Opcode::CondBranch {
                         cond: OptReg(cond_v),
-                        target,
+                        target: target_inst,
                     }
                 }
 
@@ -2398,6 +2452,30 @@ impl OptimizerBridge {
                 // with the wasm op index for any downstream pass that
                 // relies on positional alignment.
                 WasmOp::Nop | WasmOp::Unreachable | WasmOp::Return => {
+                    // #500: `return` is representable here only as a Nop
+                    // placeholder — the real epilogue is emitted once at the
+                    // function end, and the callee-saved push/pop frame is
+                    // wrapped around the body AFTER this lowering, so a
+                    // mid-body `bx lr` would skip the pop. The placeholder is
+                    // therefore correct ONLY in tail position (everything
+                    // after it structural `End`s/`Nop`s). A non-tail `return`
+                    // used to be silently dropped — execution fell THROUGH
+                    // into the code after it (`early_ret(1)` also stored the
+                    // post-return value; red in
+                    // `cf_shapes_500_differential.py`). Decline it to the
+                    // direct selector, whose `Return` arm deallocates the
+                    // frame and returns correctly mid-function.
+                    if matches!(wasm_op, WasmOp::Return)
+                        && wasm_ops[wasm_idx + 1..]
+                            .iter()
+                            .any(|op| !matches!(op, WasmOp::End | WasmOp::Nop))
+                    {
+                        return Err(synth_core::Error::validation(
+                            "optimized lowering path does not support a non-tail \
+                             `return`; the direct instruction selector lowers it — \
+                             issue #500",
+                        ));
+                    }
                     instructions.push(Instruction {
                         id: inst_id,
                         opcode: Opcode::Nop,
@@ -2585,6 +2663,27 @@ impl OptimizerBridge {
 
         // Preprocess: convert if-else patterns to select
         let preprocessed = self.preprocess_wasm_ops(wasm_ops);
+
+        // #500: a real `if`/`else` that SURVIVES the select-idiom preprocessing
+        // has no IR lowering — `wasm_to_ir` dropped `WasmOp::If`/`Else` to
+        // `Opcode::Nop`, so BOTH arms executed unconditionally (the condition
+        // was never even tested; `real_ifelse(1)` stored the else-arm's value —
+        // a silent miscompile, red in `cf_shapes_500_differential.py`). Decline
+        // to the direct selector, whose label-form `If`/`Else`/`End` lowering
+        // is correct. Same honest-degradation pattern as #120/#372/#374. The
+        // check runs on the PREPROCESSED stream so the select-idiom shapes
+        // (patterns 1–3) stay on the optimized path.
+        if preprocessed
+            .iter()
+            .any(|op| matches!(op, WasmOp::If | WasmOp::Else))
+        {
+            return Err(Error::UnsupportedInstruction(
+                "optimized lowering path does not support a non-select `if`/`else` \
+                 (WasmOp::If survived preprocessing); the direct instruction \
+                 selector lowers it — issue #500"
+                    .to_string(),
+            ));
+        }
 
         // Convert to IR
         let (mut instructions, mut cfg) = self.wasm_to_ir(&preprocessed)?;
@@ -5949,28 +6048,65 @@ impl OptimizerBridge {
         byte_offsets.push(current_offset); // End marker for target lookups
 
         for (branch_arm_idx, target_ir_idx, is_conditional) in pending_branches {
-            // Find where the target label is in ARM instructions
-            if let Some(&target_arm_idx) = ir_to_arm_idx.get(&target_ir_idx) {
-                // Calculate the Thumb branch displacement
-                // Formula: imm8 = (target_addr - (branch_addr + 4)) / 2
-                // This is because PC points to branch_addr + 4 during execution
-                let branch_byte_pos = byte_offsets[branch_arm_idx] as i32;
-                let target_byte_pos = byte_offsets[target_arm_idx] as i32;
+            // Find where the target label is in ARM instructions.
+            //
+            // #500: a MISSING target used to be skipped silently, leaving the
+            // offset-0 placeholder in the stream — `br_if` landed on the very
+            // next instruction, mid-shape (the #483-class miscompile, broadened
+            // by #500 to the if/else and sequential-block shapes). Any branch
+            // whose target id never got a label is a lowering bug or an
+            // unsupported shape; decline LOUDLY so the backend falls back to
+            // the direct selector instead of emitting wrong code.
+            let Some(&target_arm_idx) = ir_to_arm_idx.get(&target_ir_idx) else {
+                return Err(Error::synthesis(format!(
+                    "optimized path: branch at ARM index {branch_arm_idx} targets \
+                     IR id {target_ir_idx}, but no label with that id was emitted — \
+                     unresolvable forward-branch shape (#500); falling back to \
+                     direct selector"
+                )));
+            };
+            // Calculate the Thumb branch displacement
+            // Formula: imm8 = (target_addr - (branch_addr + 4)) / 2
+            // This is because PC points to branch_addr + 4 during execution
+            let branch_byte_pos = byte_offsets[branch_arm_idx] as i32;
+            let target_byte_pos = byte_offsets[target_arm_idx] as i32;
 
-                // Halfword offset is the raw encoded value for imm8
-                let halfword_offset = (target_byte_pos - branch_byte_pos - 4) / 2;
+            // Halfword offset is the raw encoded value for imm8
+            let halfword_offset = (target_byte_pos - branch_byte_pos - 4) / 2;
 
-                // Patch the branch instruction
-                if is_conditional {
-                    arm_instrs[branch_arm_idx] = ArmOp::BCondOffset {
-                        cond: crate::rules::Condition::NE,
-                        offset: halfword_offset,
-                    };
-                } else {
-                    arm_instrs[branch_arm_idx] = ArmOp::BOffset {
-                        offset: halfword_offset,
-                    };
-                }
+            // #498: `byte_offsets` sized this branch as the 2-byte short form
+            // (the estimator runs on the offset-0 placeholder). If the resolved
+            // displacement only fits the 4-byte `.w` encoding, the encoder would
+            // emit 2 extra bytes the offset table never accounted for — shifting
+            // every subsequent instruction and corrupting THIS displacement and
+            // any branch spanning it. That was a silent latent miscompile for
+            // large functions; decline to the direct selector (whose label-form
+            // resolution re-runs after layout) instead.
+            let fits_short = if is_conditional {
+                // 16-bit B<cond> (T1): imm8, -256..+254 bytes = -128..=127 hw
+                (-128..=127).contains(&halfword_offset)
+            } else {
+                // 16-bit B (T2): imm11, -2048..+2044 bytes = -1024..=1022 hw
+                (-1024..=1022).contains(&halfword_offset)
+            };
+            if !fits_short {
+                return Err(Error::synthesis(format!(
+                    "optimized path: resolved branch displacement {halfword_offset} \
+                     halfwords exceeds the 2-byte Thumb short form the offset table \
+                     assumed (#498 far-branch); falling back to direct selector"
+                )));
+            }
+
+            // Patch the branch instruction
+            if is_conditional {
+                arm_instrs[branch_arm_idx] = ArmOp::BCondOffset {
+                    cond: crate::rules::Condition::NE,
+                    offset: halfword_offset,
+                };
+            } else {
+                arm_instrs[branch_arm_idx] = ArmOp::BOffset {
+                    offset: halfword_offset,
+                };
             }
         }
 

--- a/crates/synth-synthesis/tests/regression_call_result_vreg.rs
+++ b/crates/synth-synthesis/tests/regression_call_result_vreg.rs
@@ -57,17 +57,44 @@ fn fib_wasm_ops() -> Vec<WasmOp> {
 /// #188: the optimized path must DECLINE a function containing calls so the
 /// backend falls back to the direct selector. (Previously it lowered the calls
 /// itself without modelling the caller-saved clobber — the miscompile.)
+///
+/// Pinned on a straight-line call sequence (no `if`/`else`): since #500 a real
+/// `if`/`else` declines EARLIER, at `optimize_full` — see the companion test
+/// below — so a call-only stream is what isolates the #188 `ir_to_arm` decline.
 #[test]
 fn optimized_path_declines_functions_with_calls() {
     let bridge = OptimizerBridge::new();
+    // `f(n) = g(n) + n` — a local call, no control flow.
+    let ops = vec![
+        WasmOp::LocalGet(0),
+        WasmOp::Call(1),
+        WasmOp::LocalGet(0),
+        WasmOp::I32Add,
+        WasmOp::End,
+    ];
     let (ir, _cfg, _stats) = bridge
-        .optimize_full(&fib_wasm_ops())
-        .expect("optimize_full should succeed for valid input");
+        .optimize_full(&ops)
+        .expect("optimize_full should succeed for a straight-line local call");
     let res = bridge.ir_to_arm(&ir, /* num_params = */ 1);
     assert!(
         res.is_err(),
         "ir_to_arm must decline call-containing functions (#188) so the backend \
          falls back to the direct selector — got Ok"
+    );
+}
+
+/// #500: a real `if`/`else` that survives the select-idiom preprocessing has no
+/// IR lowering (it used to be Nop'd — BOTH arms executed unconditionally), so
+/// `optimize_full` must decline it up front. The fib body pins this: it reaches
+/// neither the call lowering nor `ir_to_arm`.
+#[test]
+fn optimized_path_declines_real_if_else() {
+    let bridge = OptimizerBridge::new();
+    let res = bridge.optimize_full(&fib_wasm_ops());
+    assert!(
+        res.is_err(),
+        "optimize_full must decline a non-select `if`/`else` (#500) so the \
+         backend falls back to the direct selector — got Ok"
     );
 }
 

--- a/scripts/repro/cf_shapes_500.wat
+++ b/scripts/repro/cf_shapes_500.wat
@@ -1,0 +1,61 @@
+(module
+  (memory 1)
+  (export "memory" (memory 0))
+
+  ;; #500 shape A — an if/else DESUGARED as nested block + br_if + br (the
+  ;; issue's repro A). The br_if targets the INNER block's end while an
+  ;; unconditional br to the OUTER end sits between the br_if and that end.
+  ;; c==0 -> store 200 at addr 4; c!=0 -> store 100 at addr 4.
+  (func (export "ifelse") (param $c i32)
+    (block $end
+      (block $else
+        (br_if $else (i32.eqz (local.get $c)))
+        (i32.store (i32.const 4) (i32.const 100))
+        (br $end))
+      (i32.store (i32.const 4) (i32.const 200))))
+
+  ;; #500 shape B — two sequential (sibling) blocks, each exited by a br_if.
+  ;; The first block is followed by more top-level content (the second block),
+  ;; the trigger the issue isolates. a==0 -> skip store 11; b==0 -> skip
+  ;; store16 22.
+  (func (export "seqblocks") (param $a i32) (param $b i32)
+    (block $b1
+      (br_if $b1 (i32.eqz (local.get $a)))
+      (i32.store (i32.const 8) (i32.const 11)))
+    (block $b2
+      (br_if $b2 (i32.eqz (local.get $b)))
+      (i32.store16 (i32.const 12) (i32.const 22))))
+
+  ;; #500 shape C — a REAL `if`/`else` construct (decodes to WasmOp::If/Else,
+  ;; not the block+br_if desugaring). c!=0 -> store 300; c==0 -> store 400.
+  (func (export "real_ifelse") (param $c i32)
+    (if (local.get $c)
+      (then (i32.store (i32.const 16) (i32.const 300)))
+      (else (i32.store (i32.const 16) (i32.const 400)))))
+
+  ;; #500 shape C' — `if` with no else. c!=0 -> store 55 at 20; always store
+  ;; 66 at 24 afterwards (the join must be reached in both directions).
+  (func (export "real_if") (param $c i32)
+    (if (local.get $c)
+      (then (i32.store (i32.const 20) (i32.const 55))))
+    (i32.store (i32.const 24) (i32.const 66)))
+
+  ;; #500 shape D — function-level `br` (depth reaches the implicit function
+  ;; body). c!=0 -> store 77 then RETURN (88 must NOT run); c==0 -> skip to
+  ;; block end, store 88 only.
+  (func (export "br_func") (param $c i32)
+    (block $b
+      (br_if $b (i32.eqz (local.get $c)))
+      (i32.store (i32.const 28) (i32.const 77))
+      (br 1))
+    (i32.store (i32.const 32) (i32.const 88)))
+
+  ;; #500 shape E — early (non-tail) `return`. c!=0 -> store 99 then RETURN
+  ;; (111 must NOT run); c==0 -> store 111 only.
+  (func (export "early_ret") (param $c i32)
+    (block $b
+      (br_if $b (i32.eqz (local.get $c)))
+      (i32.store (i32.const 36) (i32.const 99))
+      (return))
+    (i32.store (i32.const 40) (i32.const 111)))
+)

--- a/scripts/repro/cf_shapes_500_differential.py
+++ b/scripts/repro/cf_shapes_500_differential.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""#500 (epic #242) — EXECUTION-validate optimized-path forward-branch shapes.
+
+#483 fixed the single `block`+`br_if` forward-exit; #500 shows the class is
+broader. This harness pins the remaining named shapes:
+
+  - ifelse      — if/else desugared as nested block + br_if + br (issue repro A)
+  - seqblocks   — two sequential sibling blocks, each exited by br_if (repro B)
+  - real_ifelse — a REAL wasm `if`/`else` construct (WasmOp::If/Else)
+  - real_if     — `if` with no else, content after the join
+  - br_func     — function-level `br` (depth reaches the implicit function body)
+  - early_ret   — early (non-tail) `return` with live code after the block
+
+Each function is compiled on the OPTIMIZED (non-`--relocatable`) path, executed
+under unicorn (Thumb, linear memory mapped at the absolute base the optimized
+path materializes), and its MEMORY is compared bit-identically against wasmtime
+ground truth across both branch directions. The functions store to disjoint
+addresses, so memory is the observable.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/cf_shapes_500_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("cf_shapes_500.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+# Absolute linear-memory base the optimized (non-relocatable) path materializes
+# for a const address: `movw ip,#0x100; movt ip,#0x2000` → 0x20000100 (see #197).
+LINMEM = 0x20000100
+MEM_WINDOW = 64  # bytes of memory compared against ground truth
+# function -> list of arg tuples exercising both branch directions
+CASES = {
+    "ifelse": [(0,), (1,)],
+    "seqblocks": [(0, 0), (0, 1), (1, 0), (1, 1)],
+    "real_ifelse": [(0,), (1,)],
+    "real_if": [(0,), (1,)],
+    "br_func": [(0,), (1,)],
+    "early_ret": [(0,), (1,)],
+}
+
+
+def compile_optimized(out):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"},
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed: {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+    return data, base, syms
+
+
+def wasm_mem(func, args):
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    inst.exports(st)[func](st, *args)
+    return bytes(inst.exports(st)["memory"].read(st, 0, MEM_WINDOW))
+
+
+def run_arm(code, base, addr, args):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(base & ~0xFFFF, 0x20000)
+    mu.mem_write(base, code)
+    mu.mem_map(LINMEM & ~0xFFFF, 0x20000)  # page-aligned region covering LINMEM
+    mu.mem_map(0x90000, 0x10000)
+    ret = 0x90100
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    regs = [UC_ARM_REG_R0, UC_ARM_REG_R1]
+    for reg, val in zip(regs, args):
+        mu.reg_write(reg, val & 0xFFFFFFFF)
+    # Declined shapes fall back to the DIRECT selector, whose memory accesses
+    # are fp/R11-relative (the runtime linear-memory base register); seed it
+    # like the startup code does. Optimized-path functions either materialize
+    # the absolute base inline (ip) or re-materialize R11 themselves
+    # (base-CSE), so the seed is invisible to them.
+    mu.reg_write(UC_ARM_REG_R11, LINMEM)
+    mu.reg_write(UC_ARM_REG_SP, 0x98000)
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    mu.emu_start(addr | 1, ret, timeout=5_000_000)
+    return bytes(mu.mem_read(LINMEM, MEM_WINDOW))
+
+
+def main():
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth first")
+    elf = "/tmp/cf_shapes_500.elf"
+    compile_optimized(elf)
+    code, base, syms = load(elf)
+
+    fails = 0
+    for func, arglists in CASES.items():
+        if func not in syms:
+            fails += 1
+            print(f"FAIL {func}: SYMBOL MISSING from ELF symtab")
+            continue
+        for args in arglists:
+            gt = wasm_mem(func, args)
+            try:
+                got = run_arm(code, base, syms[func], args)
+            except Exception as e:  # unicorn faults on garbage addresses
+                fails += 1
+                print(f"FAIL {func}{args}: unicorn fault: {e}")
+                continue
+            ok = got == gt
+            if not ok:
+                fails += 1
+            print(f"{'OK  ' if ok else 'FAIL'} {func}{args}")
+            if not ok:
+                diff = [(i, gt[i], got[i]) for i in range(MEM_WINDOW) if gt[i] != got[i]]
+                print(f"     mem diffs (off, wasmtime, synth): {diff}")
+
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #500. Advances #498. Part of epic #242 (VCR-ORACLE / Track C honest-degradation discipline).

> **Salvage provenance:** this lane's implementation was authored in the `lane-500-498` worktree by a session that hit its limit with the work uncommitted. Committed as-found (commit 1), then assessed against the contract, verified end-to-end, and repaired where verification demanded (commit 2: a stale test expectation + lint). All red/green evidence below was produced fresh on this branch.
>
> **Rebase note for lane-377:** this branch touches `arm_encoder.rs`, `instruction_selector.rs`, `optimizer_bridge.rs` — lane-377 overlaps these files and will rebase over this PR.

## #500 — per-shape verdict table

Every shape from the issue (plus the two the class implies), pinned by the new execution differential `scripts/repro/cf_shapes_500_differential.py` (`cf_shapes_500.wat`, unicorn vs wasmtime, memory bit-compare, both branch directions):

| Shape | wat | main (086968a) | Verdict on this branch |
|---|---|---|---|
| A `ifelse` | nested block + br_if + br (desugared if/else) | **OK** (already fixed by #483) | stays on **optimized** path, correct |
| B `seqblocks` | two sibling blocks, each br_if-exited | **OK** (already fixed by #483) | stays on **optimized** path, correct |
| C `real_ifelse` | real `if`/`else` construct | **MISCOMPILE** — `If`/`Else` Nop'd, BOTH arms executed (`real_ifelse(1)` stored the else-arm's 400) | **honest decline** at `optimize_full` → direct selector, correct |
| C′ `real_if` | `if` with no else, content after join | **MISCOMPILE** — then-arm executed unconditionally (`real_if(0)` stored 55) | **honest decline** → direct selector, correct |
| D `br_func` | function-level `br` (depth = implicit function body) | **MISCOMPILE** — `saturating_sub` clamped onto the outermost block's end; post-block code still ran (`br_func(1)` also stored 88) | **honest decline** on optimized path; direct selector **fixed** (function-level `br` = full return: result→R0, frame dealloc, `pop {r4-r8,pc}` — old direct arm emitted a bare `bx lr`, skipping the epilogue) |
| E `early_ret` | non-tail `return` | **MISCOMPILE** — `return` dropped to Nop, fell through (`early_ret(1)` also stored 111) | **honest decline** on optimized path → direct selector's `Return` arm, correct |

Also in the class, no repro shape reaches it today but pinned defensively:
- **unresolvable branch target** in `ir_to_arm`'s resolution pass: a missing label used to be *skipped silently*, leaving the offset-0 placeholder → br_if landed on the very next instruction (the literal #483-class bug). Now declines loudly.
- direct selector **function-level `br_if`** = conditional return (BEQ over the return sequence; stack *peeked*, not popped, so the fall-through path keeps its operands live; reload-before-CMP so a spill reload can't sit between CMP and Bcc).

Red → green (full outputs in the harness, `SYNTH=<binary> python scripts/repro/cf_shapes_500_differential.py`):

```
=== baseline main (086968a) ===         === with fix ===
FAIL real_ifelse(1,)  mem (16, 44, 144)  OK   (all 14 cases)
FAIL real_if(0,)      mem (20, 0, 55)    ORACLE: PASS
FAIL br_func(1,)      mem (32, 0, 88)
FAIL early_ret(1,)    mem (40, 0, 111)
ORACLE: FAIL (4)
```

`resolved_branch_geometry` (#604/#607) discipline is respected: the geometry mapper sizes resolved streams via `estimate_arm_byte_size`, and the new far-branch decline guarantees every *surviving* numeric branch fits the 2-byte short form — so the estimator's new offset-sensitivity agrees with the layout the bridge actually froze, and no shipped stream's geometry shifts (frozen fixtures bit-identical, below).

## #498 — estimator gap allowlist: 2 → 0

The `estimator_encoder_agreement` oracle's `KNOWN_GAP` machinery is **deleted**; every case now asserts exact agreement.

| Former gap | Was | Closed by |
|---|---|---|
| `BOffset`/`BCondOffset` far ("structural survivor") | est 2 / enc 4 — chicken-and-egg: estimator runs pre-resolution on the offset-0 placeholder | estimator now mirrors the encoder's short/`.w` range split (B.N imm11 / B<cond>.N imm8 → 2, else 4); the bridge's resolution pass **declines** any displacement outgrowing the short form its offset table assumed (previously a silent latent layout-shift miscompile for large functions) — the chicken-and-egg resolved by refusing the egg, loudly |
| `Mov` negative imm ("encoder-side survivor") | est 4 / enc 2 **wrong-value** — signed `*imm <= 255` emitted `MOVS Rd, #(imm & 0xFF)` for negative imm; MOVW truncated >0xFFFF | encoder splits on the **unsigned** value: imm8 MOVS / imm16 MOVW / full-width MOVW+MOVT (8 bytes); estimator mirrors the three-way split. No emitter produces the wide shape today (both selectors materialize wide constants as explicit Movw/Movt or Movw+Mvn), so shipped bytes are unchanged — verified by the frozen anchors |

New agreement cases: `BOffset_far`, `BCondOffset_far`, `BCondOffset_far_neg`, `Mov_imm_neg`, `Mov_imm_wide`.

## Test repair (commit 2)

`optimized_path_declines_functions_with_calls` asserted `optimize_full` **succeeds** on fib then `ir_to_arm` declines (#188) — but fib contains a real `if`/`else`, which now declines earlier. Split the pin: a straight-line local-call stream isolates the #188 `ir_to_arm` decline; the fib body pins the new #500 `optimize_full` decline (`optimized_path_declines_real_if_else`).

## Verification (re-run in full after rebasing onto #636, which touches the same three files)

- `cf_shapes_500_differential.py`: baseline main **FAIL (4)** → this branch **PASS** (14/14)
- `estimator_encoder_agreement`: **ok** (allowlist empty, exact agreement everywhere)
- `cargo test -p synth-cli --test frozen_codegen_bytes`: **10/10 ok** — shipped `.text` untouched
- `cargo test --workspace`: green
- `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
