### PR TITLE
chore(release): v0.33.0 — correctness wave + SEL DSL inc-2 + divisor-nonzero facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-07-08
+
+**The correctness wave: four MORE live optimized-path miscompiles closed
+(#500 class), safety-bounds actually enforced on both paths (#377 — the
+direct path's existing check was a fallthrough no-op), zero-init locals
+(#457), the estimator gap allowlist reaches zero (#498), the verified
+selector DSL grows to 21 Rocq-proven rules, and certified divisor-nonzero
+guard elision lands.**
+
+### Fixed
+
+- **Four optimized-path miscompiles (#500 class, PR #641):** real if/else
+  (both arms executed), real if without else (then ran unconditionally),
+  function-level br (post-block code ran), non-tail return (dropped). Each
+  now honestly declines to the direct selector, whose function-level br /
+  br_if / Return arms were fixed to emit full return epilogues. 14-case CF
+  differential red (4 FAIL on v0.32.1) → 14/14. Defense: ir_to_arm declines
+  loudly on any unresolvable branch target (the literal #483 silent-skip).
+- **--safety-bounds software was a silent no-op on the optimized path AND a
+  fallthrough no-op on the direct path (#377, PR #640):** the direct path's
+  `Bhs Trap_Handler` resolved to offset-0 in self-contained images — the
+  compare ran, the trap never fired. Both paths now emit inline
+  `CMP/BLO+UDF` guards; 13/13 OOB vectors trap (was 6/13 on both paths).
+  `mask` loud-declines to direct; `mpu` proven path-independent by pinned
+  test. Base-CSE disabled under software mode (folded addressing would
+  bypass the guard).
+- **Read-before-write non-param locals read caller garbage (#457, PR #638,
+  all three backends):** count_params inferred params from access patterns,
+  homing wasm-zero-initialized locals in param registers. Fixed with the
+  declared param count from the type section (min(inferred, declared)),
+  prologue zero-init on ARM-direct + RV32, optimized-path decline routing,
+  and a loud skip on aarch64.
+- **Estimator gap allowlist 2 → 0 (#498, PR #641):** far branch
+  displacements (bridge now declines what outgrows the short form — a
+  latent layout-shift miscompile) and negative/wide Mov immediates (the
+  encoder emitted wrong-value `MOVS #(imm&0xFF)` for negative imm — fixed
+  with unsigned imm8/imm16/MOVW+MOVT). KNOWN_GAP machinery deleted.
+
+### Added
+
+- **VCR-SEL-001 increment 2 (#639, epic #242):** +14 rules → **21 total /
+  21 Qed / 0 Admitted** in the verified selector DSL — the ten i32
+  comparisons, register shifts (shl/shr_s/shr_u), and rotr. Coverage check
+  unweakened; OFF ≡ baseline byte-identical even with delegation on.
+- **Divisor-nonzero fact elision (#636, #494 phase 2b, VCR-PERF-002):**
+  kind-3 wsc.facts premises elide div/rem zero-trap guards under a per-site
+  ordeal UNSAT certificate; the #634 INT64_MIN/-1 overflow guard falls only
+  to its own separate obligation (pinned at four levels). Marked functions
+  route to the direct selector; fixture .text 446→406 B.
+
 ## [0.32.1] - 2026-07-08
 
 **Two gale-filed silent i64 miscompiles fixed same-day (#632/#633), plus two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,14 +2060,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2125,11 +2125,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.32.1"
+version = "0.33.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2184,14 +2184,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2199,11 +2199,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.32.1"
+version = "0.33.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.32.1"
+version = "0.33.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.32.1"
+version = "0.33.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.32.1",
+    version = "0.33.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.32.1" }
+synth-core = { path = "../synth-core", version = "0.33.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.32.1" }
+synth-core = { path = "../synth-core", version = "0.33.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.32.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.32.1" }
+synth-core = { path = "../synth-core", version = "0.33.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.33.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.32.1" }
+synth-core = { path = "../synth-core", version = "0.33.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.32.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.32.1", optional = true }
+synth-core = { path = "../synth-core", version = "0.33.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.33.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -44,23 +44,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.32.1" }
-synth-frontend = { path = "../synth-frontend", version = "0.32.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.32.1" }
-synth-backend = { path = "../synth-backend", version = "0.32.1" }
+synth-core = { path = "../synth-core", version = "0.33.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.33.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.33.0" }
+synth-backend = { path = "../synth-backend", version = "0.33.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.32.1" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.33.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.32.1", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.32.1", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.32.1", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.33.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.33.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.33.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.32.1", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.33.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.32.1" }
+synth-core = { path = "../synth-core", version = "0.33.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.32.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.33.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.32.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.32.1" }
-synth-opt = { path = "../synth-opt", version = "0.32.1" }
+synth-core = { path = "../synth-core", version = "0.33.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.33.0" }
+synth-opt = { path = "../synth-opt", version = "0.33.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -20,12 +20,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.32.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.32.1" }
-synth-opt = { path = "../synth-opt", version = "0.32.1" }
+synth-core = { path = "../synth-core", version = "0.33.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.33.0" }
+synth-opt = { path = "../synth-opt", version = "0.33.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.32.1", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.33.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"


### PR DESCRIPTION
Release PR: pin sweep + CHANGELOG for v0.33.0.

Scope: #641 (four #500-class optimized-path miscompiles + estimator allowlist→0) · #640 (#377 safety-bounds enforced both paths, incl. the direct path's fallthrough-no-op trap) · #638 (#457 zero-init locals, 3 backends) · #639 (VCR-SEL-001 inc-2: 21 rules/21 Qed) · #636 (#494 phase 2b divisor-nonzero certified elision).

Tag v0.33.0 on green merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)