### PR TITLE
fix(codegen): call_indirect bounds guard + compile-time type check — OOB/wrong-type traps per WASM §4.4.8 (#642)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,6 +450,45 @@ jobs:
           SYNTH: ./target/debug/synth
         run: python scripts/repro/callee_saved_490_differential.py
 
+  call-indirect-642-oracle:
+    name: call_indirect bounds-guard oracle (Thumb-2 + A32)
+    # VCR-ORACLE-001 (#242, #642): call_indirect emitted NO table bounds check
+    # and NO type check — an out-of-bounds index read past the table and BLXed
+    # whatever word lay there (uncontrolled indirect branch) where WASM Core
+    # §4.4.8 mandates a trap. EXECUTE the fixture under unicorn on BOTH ISAs
+    # (Thumb-2 cortex-m3 + A32 cortex-r5, table linked at r11) vs the wasmtime
+    # oracle: in-bounds indices must match; OOB indices must stop AT A UDF.
+    # Non-vacuous red: the words past the table are seeded with a valid decoy
+    # function, so an unguarded build "succeeds" at the OOB call and the
+    # harness fails loudly on the decoy's return value. The type check is
+    # discharged at compile time (closed-world table verification in the
+    # selector); its decline paths are unit-gated in synth-core/synth-synthesis.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Run call_indirect bounds-guard oracle
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/repro/call_indirect_642_differential.py
+
   block-brif-483-oracle:
     name: optimized-path block/br_if lowering oracle
     # VCR-ORACLE-001 (#242, #483): EXECUTE optimized-path functions with forward

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -350,6 +350,10 @@ fn compile_wasm_to_arm(
         // imports (rewritten to the wasm field name by build_relocatable_elf)
         // instead of `__meld_dispatch_import`.
         selector.set_relocatable(config.relocatable);
+        // #642: call_indirect guard inputs (compile-time table size for the
+        // bounds guard + closed-world type verdicts). Without them, every
+        // call_indirect lowering declines loudly.
+        selector.set_call_indirect_guards(config.call_indirect_guards.clone());
         // #237: native-pointer ABI — wasm statics become __synth_wasm_data-relative.
         selector.set_native_pointer_abi(config.native_pointer_abi, config.linear_memory_bytes);
         // #311: i64 call results are register PAIRS — tag them.

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -127,16 +127,41 @@ impl ArmEncoder {
     /// `i` is a 4-byte code address, R12 is the encoder-scratch register):
     ///
     /// ```text
+    /// MOVW r12, #size        ; #642: table size (compile-time immediate)
+    /// [MOVT r12, #size>>16]  ; only when size exceeds 16 bits
+    /// CMP  idx, r12          ; bounds guard: index >= size must TRAP
+    /// BLO  +1 insn           ; skip the trap when in bounds
+    /// UDF                    ; WASM Core §4.4.8 out-of-bounds trap
     /// MOV r12, idx, LSL #2   ; table byte offset
     /// LDR r12, [r11, r12]    ; load function pointer
     /// BLX r12                ; indirect call
     /// ```
     ///
-    /// Bounds and type-signature checks are not emitted — parity with the
-    /// Thumb-2 path (tracked separately, see #594's note).
-    fn encode_arm_call_indirect(table_index_reg: &Reg) -> Vec<u8> {
+    /// The §4.4.8 type check is discharged at COMPILE time by the selector's
+    /// closed-world verification (the raw code-pointer table carries no
+    /// runtime type ids) — see the #642 selector guard.
+    fn encode_arm_call_indirect(table_index_reg: &Reg, table_size: u32) -> Vec<u8> {
         let idx = reg_to_bits(table_index_reg);
-        let mut bytes = Vec::with_capacity(12);
+        let mut bytes = Vec::with_capacity(32);
+        // MOVW r12, #(size & 0xFFFF) — cond=E 0011 0000 imm4 Rd imm12.
+        let size_lo = table_size & 0xFFFF;
+        let movw: u32 = 0xE300_0000 | ((size_lo >> 12) << 16) | (12 << 12) | (size_lo & 0xFFF);
+        bytes.extend_from_slice(&movw.to_le_bytes());
+        // MOVT r12, #(size >> 16) — only for a table size above 16 bits.
+        let size_hi = table_size >> 16;
+        if size_hi != 0 {
+            let movt: u32 = 0xE340_0000 | ((size_hi >> 12) << 16) | (12 << 12) | (size_hi & 0xFFF);
+            bytes.extend_from_slice(&movt.to_le_bytes());
+        }
+        // CMP idx, r12 — cond=E, opcode=1010, S=1, Rn=idx, Rm=r12.
+        let cmp: u32 = 0xE150_000C | (idx << 16);
+        bytes.extend_from_slice(&cmp.to_le_bytes());
+        // BLO +1 insn (skip the UDF when index < size) — cond=LO(0011),
+        // imm24=0: target = branch + 8.
+        bytes.extend_from_slice(&0x3A00_0000u32.to_le_bytes());
+        // UDF — permanently undefined (same trap idiom as the A32 div-by-zero
+        // guards): call_indirect out-of-bounds trap.
+        bytes.extend_from_slice(&0xE7F0_00F0u32.to_le_bytes());
         // MOV r12, idx, LSL #2 — data-processing MOV, register op2 with
         // imm5=2/LSL: cond=E, opcode=1101, S=0, Rd=r12.
         let mov: u32 = 0xE1A0C000 | (2 << 7) | idx;
@@ -1157,10 +1182,12 @@ impl ArmEncoder {
         // as the Thumb-2 path (R11 = function-pointer table base, R12 scratch):
         //   MOV r12, idx, LSL #2 ; LDR r12, [r11, r12] ; BLX r12
         if let ArmOp::CallIndirect {
-            table_index_reg, ..
+            table_index_reg,
+            table_size,
+            ..
         } = op
         {
-            return Ok(Self::encode_arm_call_indirect(table_index_reg));
+            return Ok(Self::encode_arm_call_indirect(table_index_reg, *table_size));
         }
         let instr: u32 = match op {
             // Data processing instructions
@@ -3643,25 +3670,64 @@ impl ArmEncoder {
 
             // CallIndirect - indirect function call via table lookup
             // table_index_reg contains the table index
-            // Generates: LSL R12, idx, #2; LDR R12, [R12, table_base]; BLX R12
+            // Generates (#642): MOVW ip,#size [; MOVT]; CMP idx,ip; BLO +1;
+            //                   UDF #0; LSL R12,idx,#2; LDR R12,[R11,R12]; BLX R12
             ArmOp::CallIndirect {
                 rd: _,
                 type_idx: _,
                 table_index_reg,
+                table_size,
             } => {
                 let idx_reg = reg_to_bits(table_index_reg);
                 let mut bytes = Vec::new();
 
-                // For now, we generate code that:
-                // 1. Multiplies index by 4 (function pointer size)
-                // 2. Loads function pointer from table (assumes table base in R11)
-                // 3. Calls the function via BLX
+                // The expansion:
+                // 1. Bounds guard (#642): trap (UDF #0, WASM Core §4.4.8) when
+                //    index >= table size. Without it an out-of-bounds index
+                //    reads past the table and BLXes whatever word lies there —
+                //    an uncontrolled indirect branch instead of a trap.
+                // 2. Multiplies index by 4 (function pointer size)
+                // 3. Loads function pointer from table (table base in R11)
+                // 4. Calls the function via BLX
                 //
-                // Table base setup must be done by caller/runtime.
-                // This is a simplified implementation - full support needs:
-                // - Table base address resolution
-                // - Type signature checking
-                // - Bounds checking
+                // Table base setup must be done by caller/runtime. The type
+                // check §4.4.8 also requires is discharged at COMPILE time:
+                // the selector only emits this op after verifying the closed-
+                // world property that every table entry's signature equals the
+                // expected type (the raw code-pointer table carries no runtime
+                // type ids to compare) — see the #642 selector guard.
+
+                // MOVW R12, #(size & 0xFFFF) — Thumb-2 T3:
+                // 11110 i 100100 imm4 | 0 imm3 Rd imm8 (Rd=R12).
+                let size_lo = *table_size & 0xFFFF;
+                let hw1: u16 =
+                    (0xF240 | (((size_lo >> 11) & 1) << 10) | ((size_lo >> 12) & 0xF)) as u16;
+                let hw2: u16 =
+                    ((((size_lo >> 8) & 0x7) << 12) | (12 << 8) | (size_lo & 0xFF)) as u16;
+                bytes.extend_from_slice(&hw1.to_le_bytes());
+                bytes.extend_from_slice(&hw2.to_le_bytes());
+                // MOVT R12, #(size >> 16) — only when the table size exceeds
+                // 16 bits (never in practice, but the guard must not compare
+                // against a truncated size).
+                let size_hi = *table_size >> 16;
+                if size_hi != 0 {
+                    let hw1: u16 =
+                        (0xF2C0 | (((size_hi >> 11) & 1) << 10) | ((size_hi >> 12) & 0xF)) as u16;
+                    let hw2: u16 =
+                        ((((size_hi >> 8) & 0x7) << 12) | (12 << 8) | (size_hi & 0xFF)) as u16;
+                    bytes.extend_from_slice(&hw1.to_le_bytes());
+                    bytes.extend_from_slice(&hw2.to_le_bytes());
+                }
+                // CMP idx, R12 — 16-bit T2 (high-register capable):
+                // 010001 01 N Rm(4) Rn(3), Rn full = N:Rn3.
+                let cmp: u16 = (0x4500 | ((idx_reg & 8) << 4) | (12 << 3) | (idx_reg & 7)) as u16;
+                bytes.extend_from_slice(&cmp.to_le_bytes());
+                // BLO +1 insn (skip the UDF when index < size) — B<cond>.N
+                // imm8=0: target = branch + 4. LO = unsigned lower.
+                bytes.extend_from_slice(&0xD300u16.to_le_bytes());
+                // UDF #0 — call_indirect out-of-bounds trap (same trap idiom as
+                // the div-by-zero guards).
+                bytes.extend_from_slice(&0xDE00u16.to_le_bytes());
 
                 // LSL R12, idx_reg, #2 (multiply index by 4)
                 // Thumb-2 MOV with shift: 11101010 010 S 1111 | 0 imm3 Rd imm2 type Rm
@@ -8740,8 +8806,10 @@ mod tests {
     /// #594 regression: `call_indirect` on the A32 path (`--target cortex-r5`)
     /// was encoded as a literal NOP (0xE1A00000) — the call never happened and
     /// the function silently returned the leftover table-index value. The A32
-    /// encoder must emit the same three-instruction expansion as Thumb-2:
-    /// `MOV r12, idx, LSL #2; LDR r12, [r11, r12]; BLX r12`.
+    /// encoder must emit a real dispatch expansion, since #642 guarded by an
+    /// inline bounds check:
+    /// `MOVW r12, #size; CMP idx, r12; BLO +1; UDF;
+    ///  MOV r12, idx, LSL #2; LDR r12, [r11, r12]; BLX r12`.
     #[test]
     fn test_encode_arm32_call_indirect_is_real_call_594() {
         use synth_synthesis::{ArmOp, Reg};
@@ -8751,22 +8819,37 @@ mod tests {
                 rd: Reg::R0,
                 type_idx: 0,
                 table_index_reg: Reg::R0,
+                table_size: 4,
             })
             .unwrap();
         assert_eq!(
             bytes.len(),
-            12,
-            "expected MOV + LDR + BLX (3 words): {bytes:02x?}"
+            28,
+            "expected MOVW + CMP + BLO + UDF + MOV + LDR + BLX (7 words): {bytes:02x?}"
         );
-        let mov = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
-        let ldr = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
-        let blx = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        let words: Vec<u32> = bytes
+            .chunks_exact(4)
+            .map(|w| u32::from_le_bytes(w.try_into().unwrap()))
+            .collect();
+        // #642 bounds guard: MOVW r12, #4; CMP r0, r12; BLO +1; UDF
+        assert_eq!(words[0], 0xE300_C004, "MOVW r12,#4: {:#010x}", words[0]);
+        assert_eq!(words[1], 0xE150_000C, "CMP r0,r12: {:#010x}", words[1]);
+        assert_eq!(words[2], 0x3A00_0000, "BLO +1 insn: {:#010x}", words[2]);
+        assert_eq!(words[3], 0xE7F0_00F0, "UDF: {:#010x}", words[3]);
         // MOV r12, r0, LSL #2 = 0xE1A0C100
-        assert_eq!(mov, 0xE1A0_C100, "MOV r12,r0,LSL#2: {mov:#010x}");
+        assert_eq!(
+            words[4], 0xE1A0_C100,
+            "MOV r12,r0,LSL#2: {:#010x}",
+            words[4]
+        );
         // LDR r12, [r11, r12] = 0xE79BC00C
-        assert_eq!(ldr, 0xE79B_C00C, "LDR r12,[r11,r12]: {ldr:#010x}");
+        assert_eq!(
+            words[5], 0xE79B_C00C,
+            "LDR r12,[r11,r12]: {:#010x}",
+            words[5]
+        );
         // BLX r12 = 0xE12FFF3C
-        assert_eq!(blx, 0xE12F_FF3C, "BLX r12: {blx:#010x}");
+        assert_eq!(words[6], 0xE12F_FF3C, "BLX r12: {:#010x}", words[6]);
         // The bug: a single NOP word. Must never come back.
         assert!(
             !bytes
@@ -8775,16 +8858,40 @@ mod tests {
             "call_indirect must not contain a NOP (#594): {bytes:02x?}"
         );
 
-        // A non-R0 index register lands in the MOV's Rm field.
+        // A non-R0 index register lands in the MOV's Rm and CMP's Rn fields.
         let bytes = enc
             .encode(&ArmOp::CallIndirect {
                 rd: Reg::R0,
                 type_idx: 0,
                 table_index_reg: Reg::R4,
+                table_size: 4,
             })
             .unwrap();
-        let mov = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let cmp = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        assert_eq!(cmp, 0xE154_000C, "CMP r4,r12: {cmp:#010x}");
+        let mov = u32::from_le_bytes(bytes[16..20].try_into().unwrap());
         assert_eq!(mov, 0xE1A0_C104, "MOV r12,r4,LSL#2: {mov:#010x}");
+    }
+
+    /// #642: a table size above 16 bits must not be silently truncated by the
+    /// MOVW — the A32 guard adds a MOVT for the high half.
+    #[test]
+    fn test_encode_arm32_call_indirect_wide_table_size_642() {
+        use synth_synthesis::{ArmOp, Reg};
+        let enc = ArmEncoder::new_arm32();
+        let bytes = enc
+            .encode(&ArmOp::CallIndirect {
+                rd: Reg::R0,
+                type_idx: 0,
+                table_index_reg: Reg::R0,
+                table_size: 0x0002_0003,
+            })
+            .unwrap();
+        assert_eq!(bytes.len(), 32, "MOVT arm adds one word: {bytes:02x?}");
+        let movw = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let movt = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        assert_eq!(movw, 0xE300_C003, "MOVW r12,#3: {movw:#010x}");
+        assert_eq!(movt, 0xE340_C002, "MOVT r12,#2: {movt:#010x}");
     }
 
     /// #597 anchor (justified correctness RE-PIN of the #594-era freeze): the
@@ -8811,32 +8918,79 @@ mod tests {
                 rd: Reg::R0,
                 type_idx: 0,
                 table_index_reg: Reg::R0,
+                table_size: 4,
             })
             .unwrap();
         assert_eq!(
             bytes,
-            vec![0x4F, 0xEA, 0x80, 0x0C, 0x5B, 0xF8, 0x0C, 0xC0, 0xE0, 0x47],
-            "Thumb-2 CallIndirect: mov.w ip,r0,LSL#2; ldr.w ip,[r11,ip]; blx ip: {bytes:02x?}"
+            vec![
+                // #642 bounds guard: movw ip,#4; cmp r0,ip; blo +1; udf #0
+                0x40, 0xF2, 0x04, 0x0C, // movw ip, #4
+                0x60, 0x45, // cmp r0, ip
+                0x00, 0xD3, // blo .+4 (skip the udf)
+                0x00, 0xDE, // udf #0 — OOB index trap (WASM §4.4.8)
+                // #597-pinned dispatch
+                0x4F, 0xEA, 0x80, 0x0C, // mov.w ip, r0, lsl #2
+                0x5B, 0xF8, 0x0C, 0xC0, // ldr.w ip, [r11, ip]
+                0xE0, 0x47, // blx ip
+            ],
+            "Thumb-2 CallIndirect: bounds guard + mov.w/ldr.w/blx dispatch: {bytes:02x?}"
         );
-        // The #597 bug bytes (ASR #32 first word) must never come back.
-        assert_ne!(
-            &bytes[0..4],
-            &[0x4F, 0xEA, 0x20, 0x0C],
+        // The #597 bug bytes (ASR #32 dispatch first word) must never come back.
+        assert!(
+            !bytes.windows(4).any(|w| w == [0x4F, 0xEA, 0x20, 0x0C]),
             "mov.w ip, rm, ASR #32 — the #597 type-field bug"
         );
 
-        // A non-R0 index register lands in the mov.w's Rm field (hw2 bits 3:0).
+        // A non-R0 index register lands in the mov.w's Rm field (hw2 bits 3:0)
+        // and the cmp's Rn field.
         let bytes = enc
             .encode(&ArmOp::CallIndirect {
                 rd: Reg::R0,
                 type_idx: 0,
                 table_index_reg: Reg::R4,
+                table_size: 4,
             })
             .unwrap();
+        assert_eq!(&bytes[4..6], &[0x64, 0x45], "cmp r4, ip: {bytes:02x?}");
         assert_eq!(
-            &bytes[0..4],
+            &bytes[10..14],
             &[0x4F, 0xEA, 0x84, 0x0C],
             "mov.w ip, r4, LSL #2: {bytes:02x?}"
+        );
+    }
+
+    /// #642: the Thumb-2 bounds guard for a high-register index (R8 — the top
+    /// of the allocatable pool) uses the high-reg-capable 16-bit CMP (T2) with
+    /// the N bit set; a table size above 16 bits adds a MOVT.
+    #[test]
+    fn test_encode_thumb_call_indirect_guard_shapes_642() {
+        use synth_synthesis::{ArmOp, Reg};
+        let enc = ArmEncoder::new_thumb2();
+        let bytes = enc
+            .encode(&ArmOp::CallIndirect {
+                rd: Reg::R0,
+                type_idx: 0,
+                table_index_reg: Reg::R8,
+                table_size: 3,
+            })
+            .unwrap();
+        // cmp r8, ip — T2: 0x4500 | N(1)<<7 | Rm(12)<<3 | Rn(0) = 0x45E0
+        assert_eq!(&bytes[4..6], &[0xE0, 0x45], "cmp r8, ip: {bytes:02x?}");
+
+        let bytes = enc
+            .encode(&ArmOp::CallIndirect {
+                rd: Reg::R0,
+                type_idx: 0,
+                table_index_reg: Reg::R0,
+                table_size: 0x0002_0003,
+            })
+            .unwrap();
+        // movw ip,#3 then movt ip,#2 — the size must not be truncated.
+        assert_eq!(
+            &bytes[0..8],
+            &[0x40, 0xF2, 0x03, 0x0C, 0xC0, 0xF2, 0x02, 0x0C],
+            "movw ip,#3; movt ip,#2: {bytes:02x?}"
         );
     }
 

--- a/crates/synth-backend/tests/a32_no_silent_nop_615.rs
+++ b/crates/synth-backend/tests/a32_no_silent_nop_615.rs
@@ -649,6 +649,7 @@ fn representatives() -> Vec<ArmOp> {
             rd: Reg::R0,
             type_idx: 0,
             table_index_reg: Reg::R2,
+            table_size: 4, // #642: bounds-guard immediate
         },
         I64Add {
             rdlo: dl,

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1260,6 +1260,9 @@ fn compile_command(
     // consumed by any codegen path (Phase 2 is the gated elision).
     let mut wsc_facts: Vec<WscFact> = Vec::new();
     let mut current_func_facts: Vec<WscFact> = Vec::new();
+    // #642: call_indirect guard inputs (compile-time table size + closed-world
+    // type verdicts). Default = decline every call_indirect (demo path).
+    let mut call_indirect_guards = synth_core::CallIndirectGuards::default();
     let (wasm_ops, func_name): (Vec<WasmOp>, String) = match (&input, &demo) {
         (Some(path), _) => {
             info!("Compiling WASM file: {}", path.display());
@@ -1290,6 +1293,9 @@ fn compile_command(
             // conditionally for the SBOM, so the tables never reached the config.
             let module = decode_wasm_module(&wasm_bytes)
                 .context("Failed to decode WASM module (signature tables)")?;
+            // #642: compute the call_indirect guard inputs BEFORE the
+            // module's vectors are moved out below.
+            call_indirect_guards = module.call_indirect_guards();
             func_ret_i64 = module.func_ret_i64;
             type_ret_i64 = module.type_ret_i64;
             // #643: capture the declared global slot widths (indexed by
@@ -1471,6 +1477,9 @@ fn compile_command(
         // empty unless SYNTH_FACT_SPEC + facts + a discharged obligation.
         fact_div_zero_elide,
         fact_div_ovf_elide,
+        // #642: call_indirect guard inputs — the default declines every
+        // call_indirect lowering, so the demo path (no module) stays safe.
+        call_indirect_guards,
         ..CompileConfig::default()
     };
 
@@ -2153,6 +2162,7 @@ fn compile_all_exports(
         all_type_ret_i64,  // #311: per-type returns-i64 (call_indirect)
         all_func_params_i64, // #359: per-function declared param widths (stack-arg ABI)
         all_wsc_facts,     // VCR-PERF-002 Phase 1 (#494): loom wsc.facts premises
+        all_call_indirect_guards, // #642: table size + closed-world type verdicts
     ) = if path.extension().is_some_and(|ext| ext == "wast") {
         info!("Parsing WAST (extracting all modules)...");
         let contents = String::from_utf8(file_bytes).context("WAST file is not valid UTF-8")?;
@@ -2251,6 +2261,10 @@ fn compile_all_exports(
             Vec::new(),
             Vec::new(), // #359: WAST fixture suite is i32-only — no stack params
             Vec::new(), // #494: facts are a loom-emitted-.wasm channel; WAST fixtures carry none
+            // #642: the multi-module WAST merge has no single table image to
+            // verify — the default guards DECLINE any call_indirect (the WAST
+            // fixture suite carries none), never an unchecked branch.
+            synth_core::CallIndirectGuards::default(),
         )
     } else {
         let wasm_bytes = if path.extension().is_some_and(|ext| ext == "wat") {
@@ -2268,6 +2282,9 @@ fn compile_all_exports(
         let module = decode_wasm_module(&wasm_bytes).context("Failed to decode WASM module")?;
         sbom_wasm_bytes = Some(wasm_bytes);
 
+        // #642: call_indirect guard inputs — computed while the module is
+        // still whole (before its vectors are moved out below).
+        let guards = module.call_indirect_guards();
         let func_arg_counts = module.func_arg_counts;
         let type_arg_counts = module.type_arg_counts;
         let memories = module.memories;
@@ -2342,6 +2359,7 @@ fn compile_all_exports(
             module.type_ret_i64,
             module.func_params_i64,
             module.wsc_facts,
+            guards, // #642
         )
     };
 
@@ -2428,6 +2446,9 @@ fn compile_all_exports(
         // `current_func_facts` in the compile loop below; Phase 2 reads it in
         // the selector behind SYNTH_FACT_SPEC.
         wsc_facts: all_wsc_facts.clone(),
+        // #642: call_indirect guard inputs (compile-time table size for the
+        // bounds guard + closed-world type verdicts). Default = decline.
+        call_indirect_guards: all_call_indirect_guards,
         ..CompileConfig::default()
     };
 

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -270,6 +270,14 @@ pub struct CompileConfig {
     /// divisor-nonzero fact alone NEVER lands here: divisor ≠ 0 does not
     /// exclude -1 (#633/#634 two-guard distinction). Empty ⇒ guard emitted.
     pub fact_div_ovf_elide: Vec<usize>,
+    /// #642: `call_indirect` guard inputs — the compile-time table size for
+    /// the runtime bounds check and the per-expected-type closed-world type
+    /// verdicts — computed from the decoded module by
+    /// [`crate::wasm_decoder::DecodedModule::call_indirect_guards`] and set by
+    /// the driver loops. The default (`table_size: None`, empty verdicts)
+    /// DECLINES every `call_indirect` lowering: an unchecked indirect branch
+    /// is never emitted (WASM Core §4.4.8 requires OOB/type-mismatch traps).
+    pub call_indirect_guards: crate::wasm_decoder::CallIndirectGuards,
 }
 
 /// #543 — an integrator-marked volatile linear-memory segment (the DMA transfer
@@ -339,6 +347,10 @@ impl Default for CompileConfig {
             // every div/rem trap guard is emitted, byte-identical.
             fact_div_zero_elide: Vec::new(),
             fact_div_ovf_elide: Vec::new(),
+            // #642: no guard inputs ⇒ every call_indirect lowering declines
+            // loudly (never an unchecked indirect branch). Driver loops fill
+            // this from the decoded module.
+            call_indirect_guards: crate::wasm_decoder::CallIndirectGuards::default(),
         }
     }
 }

--- a/crates/synth-core/src/lib.rs
+++ b/crates/synth-core/src/lib.rs
@@ -25,8 +25,8 @@ pub use safety_manifest::SafetyManifest;
 pub use sbom::{CycloneDxSbom, SbomInputs};
 pub use target::*;
 pub use wasm_decoder::{
-    DecodedModule, FunctionOps, ImportEntry, ImportKind, WasmMemory, decode_wasm_functions,
-    decode_wasm_module,
+    CallIndirectGuards, DecodedModule, ElemSegmentInfo, FunctionOps, ImportEntry, ImportKind,
+    WasmMemory, decode_wasm_functions, decode_wasm_module,
 };
 pub use wasm_op::WasmOp;
 pub use wsc_facts::{FactKind, WSC_FACTS_SECTION_NAME, WscFact, WscFactsParse, parse_wsc_facts};

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -79,6 +79,47 @@ impl WasmMemory {
     }
 }
 
+/// #642: one element segment's statically-decoded shape — see
+/// [`DecodedModule::elem_segments`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ElemSegmentInfo {
+    /// Const i32 offset of an ACTIVE table-0 segment; `None` = placement not
+    /// statically verifiable (passive/declared segment, non-const offset, or
+    /// a table other than 0).
+    pub offset: Option<u32>,
+    /// The segment's function indices in slot order; `None` = contents not
+    /// statically verifiable (an entry was not a plain `ref.func`).
+    pub funcs: Option<Vec<u32>>,
+}
+
+/// #642: everything the `call_indirect` lowering needs to emit its guards —
+/// computed once per module by [`DecodedModule::call_indirect_guards`] and
+/// threaded to the instruction selector via `CompileConfig`.
+///
+/// WASM Core §4.4.8 requires `call_indirect` to trap when `index >=
+/// table.size` and when the callee's type does not match the instruction's
+/// expected type. synth's table is a raw array of 4-byte code pointers
+/// (linked at R11 by the runtime/harness) with no size field and no type
+/// ids, so:
+///  - the BOUNDS check is emitted at runtime against the compile-time
+///    `table_size` immediate (sound: the table cannot change size —
+///    `table.grow`/`table.set` are unsupported ops whose functions
+///    loud-skip at decode), and
+///  - the TYPE check is discharged at COMPILE time: for expected type `t`,
+///    `type_reject[t]` is `None` only when every slot of the table is
+///    verifiably initialized with a function whose signature structurally
+///    equals type `t` (the closed-world property — no runtime mismatch is
+///    then possible). Otherwise it holds the reason, and the lowering
+///    declines LOUDLY rather than emit an unchecked indirect branch.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CallIndirectGuards {
+    /// Compile-time size of table 0 (entries); `None` = no sound bound known.
+    pub table_size: Option<u32>,
+    /// Per type index: `None` = closed-world type property VERIFIED for this
+    /// expected type; `Some(reason)` = not verifiable (the lowering declines).
+    pub type_reject: Vec<Option<String>>,
+}
+
 /// Decoded WASM module with functions and memory
 #[derive(Debug, Clone)]
 pub struct DecodedModule {
@@ -125,6 +166,29 @@ pub struct DecodedModule {
     /// reachable function performs a `call_indirect`. Empty for modules with no
     /// element section (every leaf/direct-call module), keeping output identical.
     pub elem_func_indices: Vec<u32>,
+    /// #642: compile-time size (in entries) of table 0, from the table section
+    /// or an imported table whose limits pin it exactly (`max == initial`).
+    /// `None` = no table, or an imported table with growable limits — the
+    /// `call_indirect` bounds guard then has no sound immediate and the
+    /// lowering declines. A DEFINED table's size is exact: `table.grow`/
+    /// `table.set` are unsupported ops (their functions loud-skip at decode),
+    /// so nothing synth compiles can resize or retype the table.
+    pub table_size: Option<u32>,
+    /// #642: per element segment, everything the closed-world `call_indirect`
+    /// type check needs. `offset` is the const i32 placement of an ACTIVE
+    /// table-0 segment (`None` = passive/declared/non-const offset/other
+    /// table — statically unverifiable placement); `funcs` are the segment's
+    /// function indices in slot order (`None` = an entry was not a plain
+    /// `ref.func`, e.g. `ref.null` — statically unverifiable contents).
+    pub elem_segments: Vec<ElemSegmentInfo>,
+    /// #642: type index per function, indexed by the FULL function index
+    /// (imports first, then locally-defined ones).
+    pub func_type_indices: Vec<u32>,
+    /// #642: canonical structural signature per type index (params/results
+    /// rendered as a string) — used for the closed-world `call_indirect` type
+    /// check, which must compare SIGNATURES, not raw type indices (a module
+    /// may carry structurally-identical duplicate types).
+    pub type_signatures: Vec<String>,
     /// VCR-PERF-002 Phase 1 (#494): proven invariants from loom's `wsc.facts`
     /// custom section, keyed by `(function index, value id)` — see
     /// `docs/design/wsc-facts-encoding.md` (schema v1) and
@@ -134,6 +198,92 @@ pub struct DecodedModule {
     /// ingestion only: NO codegen path consumes these yet, so emitted bytes
     /// are unchanged whether or not a module carries the section.
     pub wsc_facts: Vec<crate::wsc_facts::WscFact>,
+}
+
+impl DecodedModule {
+    /// #642: compute the `call_indirect` guard inputs — the compile-time table
+    /// size for the runtime bounds check, and the per-expected-type
+    /// closed-world verdict that discharges the type check at compile time.
+    /// See [`CallIndirectGuards`] for the soundness argument.
+    pub fn call_indirect_guards(&self) -> CallIndirectGuards {
+        let n_types = self.type_signatures.len();
+        let reject_all = |table_size: Option<u32>, reason: String| CallIndirectGuards {
+            table_size,
+            type_reject: vec![Some(reason); n_types],
+        };
+
+        let Some(size) = self.table_size else {
+            return reject_all(
+                None,
+                "module has no table with a compile-time-fixed size".to_string(),
+            );
+        };
+
+        // Reconstruct the table image: slot -> initializing function index.
+        let mut slots: Vec<Option<u32>> = vec![None; size as usize];
+        for seg in &self.elem_segments {
+            let (Some(off), Some(funcs)) = (seg.offset, seg.funcs.as_ref()) else {
+                return reject_all(
+                    Some(size),
+                    "element segment is not statically verifiable (passive/declared \
+                     segment, non-const offset, non-zero table, or non-`ref.func` \
+                     entry)"
+                        .to_string(),
+                );
+            };
+            for (k, &f) in funcs.iter().enumerate() {
+                let Some(slot) = slots.get_mut(off as usize + k) else {
+                    return reject_all(
+                        Some(size),
+                        format!(
+                            "element segment (offset {off}, {} entries) writes past the \
+                             declared table size {size}",
+                            funcs.len()
+                        ),
+                    );
+                };
+                *slot = Some(f);
+            }
+        }
+        // An uninitialized slot is a null funcref: calling it must trap, and
+        // the raw code-pointer table has no runtime representation of null to
+        // check against — so it breaks the closed world for EVERY type.
+        if let Some(i) = slots.iter().position(|s| s.is_none()) {
+            return reject_all(
+                Some(size),
+                format!(
+                    "table slot {i} is uninitialized (null funcref) — a \
+                     `call_indirect` reaching it must trap, and the raw \
+                     code-pointer table has no runtime null/type id to check"
+                ),
+            );
+        }
+
+        let type_reject = (0..n_types)
+            .map(|t| {
+                for f in slots.iter().flatten() {
+                    let Some(&fty) = self.func_type_indices.get(*f as usize) else {
+                        return Some(format!(
+                            "table entry references function {f} with no known type"
+                        ));
+                    };
+                    if self.type_signatures.get(fty as usize) != self.type_signatures.get(t) {
+                        return Some(format!(
+                            "table entry (function {f}, type {fty}) has a different \
+                             signature than expected type {t} — a runtime type check \
+                             is not implementable on the raw code-pointer table"
+                        ));
+                    }
+                }
+                None
+            })
+            .collect();
+
+        CallIndirectGuards {
+            table_size: Some(size),
+            type_reject,
+        }
+    }
 }
 
 /// Decode a WASM binary and extract functions, memory, and data segments
@@ -158,6 +308,13 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     // #509: (param_count, result_count) per type index, for FuncType blocktypes.
     let mut type_block_arity: Vec<(u8, u8)> = Vec::new();
     let mut elem_func_indices: Vec<u32> = Vec::new();
+    // #642: call_indirect guard inputs — table 0's fixed size, per-segment
+    // static shapes, per-function type index, per-type canonical signature.
+    let mut table_size: Option<u32> = None;
+    let mut saw_table = false;
+    let mut elem_segments: Vec<ElemSegmentInfo> = Vec::new();
+    let mut func_type_indices: Vec<u32> = Vec::new();
+    let mut type_signatures: Vec<String> = Vec::new();
     // #394 Tier-1.x: function index → developer-facing name from the wasm
     // `name` custom section (function-names subsection). Applied to
     // `FunctionOps.debug_name` after the parse loop — the custom section
@@ -217,6 +374,15 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                         type_arg_counts.push(count);
                         type_ret_i64.push(ret_i64);
                         type_params_i64.push(params_i64);
+                        // #642: canonical structural signature for the
+                        // closed-world call_indirect type check (compares
+                        // SIGNATURES so duplicate types stay interchangeable).
+                        type_signatures.push(match &sub_ty.composite_type.inner {
+                            wasmparser::CompositeInnerType::Func(f) => {
+                                format!("{:?}->{:?}", f.params(), f.results())
+                            }
+                            other => format!("non-func:{other:?}"),
+                        });
                     }
                 }
             }
@@ -234,6 +400,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                             num_imported_funcs += 1;
                             // Record the imported function's arg count at its
                             // full function index (imports come first).
+                            func_type_indices.push(type_idx); // #642
                             func_arg_counts
                                 .push(type_arg_counts.get(type_idx as usize).copied().unwrap_or(0));
                             func_ret_i64.push(
@@ -251,7 +418,21 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                             (ImportKind::Function(type_idx), idx)
                         }
                         wasmparser::TypeRef::Memory(_) => (ImportKind::Memory, 0),
-                        wasmparser::TypeRef::Table(_) => (ImportKind::Table, 0),
+                        wasmparser::TypeRef::Table(t) => {
+                            // #642: an imported table 0 only yields a SOUND
+                            // compile-time bound when its limits pin the size
+                            // exactly (max == initial) — a growable import
+                            // could be larger at runtime, and a bounds guard
+                            // against `initial` would trap spec-valid calls.
+                            if !saw_table {
+                                saw_table = true;
+                                table_size = match (u32::try_from(t.initial), t.maximum) {
+                                    (Ok(init), Some(max)) if u64::from(init) == max => Some(init),
+                                    _ => None,
+                                };
+                            }
+                            (ImportKind::Table, 0)
+                        }
                         wasmparser::TypeRef::Global(_) => (ImportKind::Global, 0),
                         _ => continue,
                     };
@@ -270,6 +451,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                 // (issue #195).
                 for ty in reader {
                     let type_idx = ty.context("Failed to parse function type index")?;
+                    func_type_indices.push(type_idx); // #642
                     func_arg_counts
                         .push(type_arg_counts.get(type_idx as usize).copied().unwrap_or(0));
                     func_ret_i64.push(
@@ -284,6 +466,20 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                             .cloned()
                             .unwrap_or_default(),
                     );
+                }
+            }
+            Payload::TableSection(reader) => {
+                // #642: a DEFINED table's compile-time size is exact — its
+                // initial size is its permanent size, because nothing synth
+                // compiles can resize it (`table.grow` is an unsupported op
+                // whose function loud-skips at decode). Only table 0 matters:
+                // the call_indirect lowering declines non-zero table indices.
+                for table in reader {
+                    let table = table.context("Failed to parse table")?;
+                    if !saw_table {
+                        saw_table = true;
+                        table_size = u32::try_from(table.ty.initial).ok();
+                    }
                 }
             }
             Payload::MemorySection(reader) => {
@@ -351,26 +547,72 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                 // form whose `ref.func` entries name the functions.
                 for elem in reader {
                     let elem = elem.context("Failed to parse element segment")?;
+                    // #642: the segment's static placement — a const i32
+                    // offset of an ACTIVE table-0 segment; anything else is
+                    // unverifiable and poisons the closed-world type check.
+                    let seg_offset: Option<u32> = match &elem.kind {
+                        wasmparser::ElementKind::Active {
+                            table_index,
+                            offset_expr,
+                        } if table_index.unwrap_or(0) == 0 => {
+                            let mut ops = offset_expr.get_operators_reader();
+                            match ops.read() {
+                                Ok(wasmparser::Operator::I32Const { value }) => {
+                                    u32::try_from(value).ok()
+                                }
+                                _ => None,
+                            }
+                        }
+                        _ => None,
+                    };
+                    let mut seg_funcs: Option<Vec<u32>> = Some(Vec::new());
                     match elem.items {
                         wasmparser::ElementItems::Functions(funcs) => {
                             for f in funcs {
-                                elem_func_indices
-                                    .push(f.context("Failed to parse element func index")?);
+                                let f = f.context("Failed to parse element func index")?;
+                                elem_func_indices.push(f);
+                                if let Some(v) = seg_funcs.as_mut() {
+                                    v.push(f);
+                                }
                             }
                         }
                         wasmparser::ElementItems::Expressions(_, exprs) => {
                             for expr in exprs {
                                 let expr = expr.context("Failed to parse element expr")?;
-                                for op in expr.get_operators_reader() {
-                                    if let wasmparser::Operator::RefFunc { function_index } =
-                                        op.context("Failed to parse element op")?
-                                    {
-                                        elem_func_indices.push(function_index);
+                                // #642: an entry is verifiable only when it is
+                                // a single plain `ref.func` (reader yields the
+                                // op + the implicit `end`). `ref.null` or any
+                                // computed entry poisons the segment.
+                                let mut entry_func: Option<u32> = None;
+                                let mut plain = true;
+                                for (k, op) in expr.get_operators_reader().into_iter().enumerate() {
+                                    match (k, op.context("Failed to parse element op")?) {
+                                        (0, wasmparser::Operator::RefFunc { function_index }) => {
+                                            elem_func_indices.push(function_index);
+                                            entry_func = Some(function_index);
+                                        }
+                                        (_, wasmparser::Operator::End) => {}
+                                        (_, wasmparser::Operator::RefFunc { function_index }) => {
+                                            // Keep the pre-#642 reachability
+                                            // behaviour: every ref.func seen
+                                            // anywhere is a possible target.
+                                            elem_func_indices.push(function_index);
+                                            plain = false;
+                                        }
+                                        _ => plain = false,
                                     }
+                                }
+                                match (plain, entry_func, seg_funcs.as_mut()) {
+                                    (true, Some(f), Some(v)) => v.push(f),
+                                    _ => seg_funcs = None,
                                 }
                             }
                         }
                     }
+                    elem_segments.push(ElemSegmentInfo {
+                        offset: seg_offset,
+                        funcs: seg_funcs,
+                    });
                 }
             }
             Payload::ExportSection(exports) => {
@@ -448,6 +690,10 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
         func_params_i64,
         globals,
         elem_func_indices,
+        table_size,
+        elem_segments,
+        func_type_indices,
+        type_signatures,
         wsc_facts: wsc_facts.unwrap_or_default(),
     })
 }
@@ -1866,5 +2112,170 @@ mod tests {
                 "h: loop params captured"
             );
         }
+    }
+
+    /// #642: the decoder captures table 0's compile-time size, per-segment
+    /// element shapes and per-function type indices, and the closed-world
+    /// verdict VERIFIES a fully-covered homogeneous table.
+    #[test]
+    fn test_call_indirect_guards_closed_world_verified_642() {
+        // The #642 repro shape: 3-entry table, fully covered, one signature.
+        let wat = r#"
+            (module
+                (type $bin (func (param i32 i32) (result i32)))
+                (table 3 funcref)
+                (elem (i32.const 0) $add $sub $mul)
+                (func $add (param i32 i32) (result i32)
+                    (i32.add (local.get 0) (local.get 1)))
+                (func $sub (param i32 i32) (result i32)
+                    (i32.sub (local.get 0) (local.get 1)))
+                (func $mul (param i32 i32) (result i32)
+                    (i32.mul (local.get 0) (local.get 1)))
+                (func (export "f") (param i32 i32) (result i32)
+                    (call_indirect (type $bin)
+                        (local.get 0) (i32.const 10) (local.get 1)))
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("parse");
+        let module = decode_wasm_module(&wasm).expect("decode");
+
+        assert_eq!(module.table_size, Some(3), "table section min size");
+        assert_eq!(
+            module.elem_segments,
+            vec![ElemSegmentInfo {
+                offset: Some(0),
+                funcs: Some(vec![0, 1, 2]),
+            }]
+        );
+        // 2 type-section entries ($bin + the export's (i32 i32)->i32 dedups
+        // to one in practice, but don't assume — just check func 0..2 share
+        // a signature with type 0).
+        assert_eq!(module.func_type_indices.len(), 4);
+
+        let guards = module.call_indirect_guards();
+        assert_eq!(guards.table_size, Some(3));
+        // Type index 0 ($bin) must be VERIFIED: every table entry has its
+        // exact signature.
+        assert_eq!(
+            guards.type_reject.first(),
+            Some(&None),
+            "closed-world type check must verify the homogeneous table: {:?}",
+            guards.type_reject
+        );
+    }
+
+    /// #642: a heterogeneous table (an entry whose signature differs from the
+    /// expected type) must REJECT that expected type — the raw code-pointer
+    /// table cannot be runtime-type-checked, so the lowering has to decline.
+    #[test]
+    fn test_call_indirect_guards_heterogeneous_table_rejects_642() {
+        let wat = r#"
+            (module
+                (type $bin (func (param i32 i32) (result i32)))
+                (type $un (func (param i32) (result i32)))
+                (table 2 funcref)
+                (elem (i32.const 0) $add $neg)
+                (func $add (type $bin)
+                    (i32.add (local.get 0) (local.get 1)))
+                (func $neg (type $un)
+                    (i32.sub (i32.const 0) (local.get 0)))
+                (func (export "f") (param i32 i32) (result i32)
+                    (call_indirect (type $bin)
+                        (local.get 0) (i32.const 10) (local.get 1)))
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("parse");
+        let module = decode_wasm_module(&wasm).expect("decode");
+        let guards = module.call_indirect_guards();
+        assert_eq!(guards.table_size, Some(2));
+        // BOTH expected types must be rejected: the table holds one function
+        // of each signature, so neither type's closed world holds.
+        assert!(
+            guards.type_reject[0].is_some() && guards.type_reject[1].is_some(),
+            "heterogeneous table must reject every expected type: {:?}",
+            guards.type_reject
+        );
+    }
+
+    /// #642: an uninitialized table slot (elem covers less than the declared
+    /// size) is a null funcref — calling it must trap, which the raw
+    /// code-pointer table cannot express at runtime → reject all types.
+    #[test]
+    fn test_call_indirect_guards_null_slot_rejects_642() {
+        let wat = r#"
+            (module
+                (type $s (func (result i32)))
+                (table 3 funcref)
+                (elem (i32.const 0) $f0 $f1)
+                (func $f0 (result i32) (i32.const 10))
+                (func $f1 (result i32) (i32.const 11))
+                (func (export "run") (param i32) (result i32)
+                    (call_indirect (type $s) (local.get 0)))
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("parse");
+        let module = decode_wasm_module(&wasm).expect("decode");
+        let guards = module.call_indirect_guards();
+        assert_eq!(guards.table_size, Some(3));
+        assert!(
+            guards.type_reject.iter().all(|r| r.is_some()),
+            "slot 2 is a null funcref — every type must be rejected: {:?}",
+            guards.type_reject
+        );
+        assert!(
+            guards.type_reject[0].as_deref().unwrap().contains("slot 2"),
+            "reason names the uninitialized slot: {:?}",
+            guards.type_reject[0]
+        );
+    }
+
+    /// #642: no table at all → no compile-time bound → table_size None and
+    /// every type rejected (the lowering declines).
+    #[test]
+    fn test_call_indirect_guards_no_table_642() {
+        let wat = r#"
+            (module
+                (func (export "f") (param i32) (result i32) (local.get 0))
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("parse");
+        let module = decode_wasm_module(&wasm).expect("decode");
+        assert_eq!(module.table_size, None);
+        let guards = module.call_indirect_guards();
+        assert_eq!(guards.table_size, None);
+        assert!(guards.type_reject.iter().all(|r| r.is_some()));
+    }
+
+    /// #642: duplicate-but-structurally-identical types stay interchangeable —
+    /// the closed-world check compares SIGNATURES, not type indices.
+    #[test]
+    fn test_call_indirect_guards_duplicate_types_verified_642() {
+        let wat = r#"
+            (module
+                (type $a (func (result i32)))
+                (type $b (func (result i32)))
+                (table 1 funcref)
+                (elem (i32.const 0) $f)
+                (func $f (type $a) (i32.const 7))
+                (func (export "run") (param i32) (result i32)
+                    (call_indirect (type $b) (local.get 0)))
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("parse");
+        let module = decode_wasm_module(&wasm).expect("decode");
+        let guards = module.call_indirect_guards();
+        // $f has type $a; the call expects $b — structurally identical, so
+        // BOTH type indices must verify. (A third type — the export's
+        // (i32)->i32 — is correctly rejected: different signature.)
+        assert_eq!(
+            &guards.type_reject[0..2],
+            &[None, None],
+            "structural signature comparison must accept duplicate types: {:?}",
+            guards.type_reject
+        );
+        assert!(
+            guards.type_reject[2].is_some(),
+            "the structurally-different third type must still be rejected"
+        );
     }
 }

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -2000,6 +2000,13 @@ pub struct InstructionSelector {
     /// (`UNSAT(P ∧ dividend == INT_MIN ∧ divisor == -1)`; divisor ≠ 0 alone
     /// never justifies it, #633/#634). Empty ⇒ guard emitted.
     fact_div_ovf_elide: Vec<usize>,
+    /// #642: `call_indirect` guard inputs — compile-time table size (for the
+    /// encoder's runtime bounds guard) + per-expected-type closed-world type
+    /// verdicts (the compile-time discharge of the §4.4.8 type check). Set
+    /// from `CompileConfig::call_indirect_guards` by the backend; the default
+    /// (no table size, no verdicts) DECLINES every `call_indirect` — an
+    /// unchecked indirect branch is never emitted.
+    call_indirect_guards: synth_core::CallIndirectGuards,
 }
 
 /// `SYNTH_SEL_DSL` (VCR-SEL-001, #242): opt-IN lever, default OFF. Set (to
@@ -2043,6 +2050,7 @@ impl InstructionSelector {
             sel_dsl: sel_dsl_from_env(),
             fact_div_zero_elide: Vec::new(),
             fact_div_ovf_elide: Vec::new(),
+            call_indirect_guards: synth_core::CallIndirectGuards::default(),
         }
     }
 
@@ -2079,6 +2087,7 @@ impl InstructionSelector {
             sel_dsl: sel_dsl_from_env(),
             fact_div_zero_elide: Vec::new(),
             fact_div_ovf_elide: Vec::new(),
+            call_indirect_guards: synth_core::CallIndirectGuards::default(),
         }
     }
 
@@ -2150,6 +2159,14 @@ impl InstructionSelector {
     pub fn set_fact_div_guard_elisions(&mut self, zero: Vec<usize>, ovf: Vec<usize>) {
         self.fact_div_zero_elide = zero;
         self.fact_div_ovf_elide = ovf;
+    }
+
+    /// #642: thread the module's `call_indirect` guard inputs (compile-time
+    /// table size + closed-world type verdicts) — see
+    /// `synth_core::CallIndirectGuards`. Without this, every `call_indirect`
+    /// lowering declines loudly.
+    pub fn set_call_indirect_guards(&mut self, guards: synth_core::CallIndirectGuards) {
+        self.call_indirect_guards = guards;
     }
 
     /// Enable relocatable host-link mode (#197): import calls emit a direct
@@ -2791,14 +2808,50 @@ impl InstructionSelector {
 
             CallIndirect {
                 type_index,
-                table_index: _,
+                table_index,
             } => {
-                // Table index is on top of stack (in rn), call target via table lookup
-                // For now, generate the pseudo-instruction; ARM encoder will expand
+                // Table index is on top of stack (in rn), call target via table lookup.
+                // #642: same guard preconditions as the select_with_stack arm —
+                // WASM §4.4.8 requires OOB/type-mismatch traps, so without a
+                // compile-time table size (for the encoder's bounds guard) and
+                // a verified closed-world type verdict, decline loudly rather
+                // than emit an unchecked indirect branch.
+                let table_size = self.call_indirect_guards.table_size.ok_or_else(|| {
+                    synth_core::Error::synthesis(
+                        "call_indirect: no compile-time table size available for the \
+                         bounds guard — refusing to emit an unchecked indirect branch \
+                         (#642)"
+                            .to_string(),
+                    )
+                })?;
+                if *table_index != 0 {
+                    return Err(synth_core::Error::synthesis(format!(
+                        "call_indirect: table index {table_index} is not supported \
+                         (only table 0 is linked at R11) — #642"
+                    )));
+                }
+                match self
+                    .call_indirect_guards
+                    .type_reject
+                    .get(*type_index as usize)
+                {
+                    Some(None) => {} // closed-world type property verified
+                    other => {
+                        return Err(synth_core::Error::synthesis(format!(
+                            "call_indirect (expected type {type_index}): closed-world \
+                             type check not verified ({}) — refusing to emit an \
+                             unchecked indirect branch (#642)",
+                            other
+                                .and_then(|r| r.as_deref())
+                                .unwrap_or("no verdict for this type index")
+                        )));
+                    }
+                }
                 vec![ArmOp::CallIndirect {
                     rd,
                     type_idx: *type_index,
                     table_index_reg: rn, // Table index from stack
+                    table_size,
                 }]
             }
 
@@ -9057,7 +9110,57 @@ impl InstructionSelector {
                     stack.push(result_reg);
                 }
 
-                CallIndirect { type_index, .. } => {
+                CallIndirect {
+                    type_index,
+                    table_index,
+                } => {
+                    // #642: WASM Core §4.4.8 requires call_indirect to TRAP on
+                    // an out-of-bounds index and on a type mismatch. The
+                    // bounds check needs the compile-time table size (the raw
+                    // code-pointer table has no runtime size field); the type
+                    // check is discharged HERE at compile time via the
+                    // closed-world verdict (every table slot verifiably holds
+                    // a function of the expected signature — the table cannot
+                    // change: table.grow/table.set are unsupported ops that
+                    // loud-skip their functions). If either input is missing,
+                    // DECLINE loudly — never emit an unchecked indirect branch.
+                    let table_size = self.call_indirect_guards.table_size.ok_or_else(|| {
+                        synth_core::Error::synthesis(
+                            "call_indirect: no compile-time table size available for the \
+                             bounds guard (module has no table, or an imported table \
+                             without exact limits) — refusing to emit an unchecked \
+                             indirect branch (#642)"
+                                .to_string(),
+                        )
+                    })?;
+                    if *table_index != 0 {
+                        return Err(synth_core::Error::synthesis(format!(
+                            "call_indirect: table index {table_index} is not supported \
+                             (only table 0 is linked at R11) — #642"
+                        )));
+                    }
+                    match self
+                        .call_indirect_guards
+                        .type_reject
+                        .get(*type_index as usize)
+                    {
+                        Some(None) => {} // closed-world type property verified
+                        Some(Some(reason)) => {
+                            return Err(synth_core::Error::synthesis(format!(
+                                "call_indirect (expected type {type_index}): closed-world \
+                                 type check failed — {reason}; refusing to emit an \
+                                 unchecked indirect branch (#642)"
+                            )));
+                        }
+                        None => {
+                            return Err(synth_core::Error::synthesis(format!(
+                                "call_indirect: no closed-world type verdict for type \
+                                 index {type_index} — refusing to emit an unchecked \
+                                 indirect branch (#642)"
+                            )));
+                        }
+                    }
+
                     // Top of stack is the table index; the call arguments sit
                     // BELOW it on the operand stack.
                     let mut table_idx_reg = pop_operand(
@@ -9162,6 +9265,9 @@ impl InstructionSelector {
                             rd: Reg::R0,
                             type_idx: *type_index,
                             table_index_reg: table_idx_reg,
+                            // #642: the encoder emits `CMP idx, size; BLO ok;
+                            // UDF #0` before the table load.
+                            table_size,
                         },
                         source_line: Some(idx),
                     });
@@ -13134,6 +13240,89 @@ mod tests {
                 "CallIndirect 5th arg must be stored to the outgoing stack: {arm:#?}"
             );
         }
+    }
+
+    /// #642: with the guard inputs threaded (compile-time table size + a
+    /// VERIFIED closed-world type verdict), the CallIndirect lowering emits
+    /// the pseudo-op carrying the table size the encoder turns into the
+    /// `CMP idx, size; BLO ok; UDF #0` bounds guard.
+    #[test]
+    fn test_642_call_indirect_emits_bounds_guarded_dispatch() {
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        selector.set_func_arg_counts(Vec::new(), vec![0]);
+        selector.set_call_indirect_guards(synth_core::CallIndirectGuards {
+            table_size: Some(3),
+            type_reject: vec![None], // type 0 verified
+        });
+        let wasm_ops = vec![
+            WasmOp::I32Const(1), // table index
+            WasmOp::CallIndirect {
+                type_index: 0,
+                table_index: 0,
+            },
+        ];
+        let arm = selector
+            .select_with_stack(&wasm_ops, 0)
+            .expect("verified call_indirect must lower");
+        assert!(
+            arm.iter()
+                .any(|i| matches!(&i.op, ArmOp::CallIndirect { table_size: 3, .. })),
+            "the pseudo-op must carry the compile-time table size: {arm:#?}"
+        );
+    }
+
+    /// #642: WITHOUT guard inputs (no module context — the default), the
+    /// CallIndirect lowering must DECLINE with a typed error, never emit the
+    /// unchecked indirect branch.
+    #[test]
+    fn test_642_call_indirect_declines_without_guards() {
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        selector.set_func_arg_counts(Vec::new(), vec![0]);
+        let wasm_ops = vec![
+            WasmOp::I32Const(0),
+            WasmOp::CallIndirect {
+                type_index: 0,
+                table_index: 0,
+            },
+        ];
+        let err = selector
+            .select_with_stack(&wasm_ops, 0)
+            .expect_err("call_indirect without a table size must decline");
+        assert!(
+            err.to_string().contains("#642"),
+            "the decline names the tracking issue: {err}"
+        );
+    }
+
+    /// #642: a REJECTED closed-world type verdict (heterogeneous table / null
+    /// slot) must decline with the recorded reason — the raw code-pointer
+    /// table cannot be runtime-type-checked.
+    #[test]
+    fn test_642_call_indirect_declines_rejected_type() {
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        selector.set_func_arg_counts(Vec::new(), vec![0]);
+        selector.set_call_indirect_guards(synth_core::CallIndirectGuards {
+            table_size: Some(3),
+            type_reject: vec![Some("table slot 2 is uninitialized".to_string())],
+        });
+        let wasm_ops = vec![
+            WasmOp::I32Const(0),
+            WasmOp::CallIndirect {
+                type_index: 0,
+                table_index: 0,
+            },
+        ];
+        let err = selector
+            .select_with_stack(&wasm_ops, 0)
+            .expect_err("a rejected type verdict must decline");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("#642") && msg.contains("slot 2 is uninitialized"),
+            "the decline carries the closed-world reason: {msg}"
+        );
     }
 
     /// #359: a non-param local AND a >4-arg call coexist — the outgoing-arg area

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -2734,6 +2734,23 @@ impl OptimizerBridge {
             )));
         }
 
+        // #642: `call_indirect` has no IR opcode either — it previously fell
+        // through `wasm_to_ir`'s `_ => Opcode::Nop` fallback. Decline
+        // EXPLICITLY so the backend falls back to the direct selector, which
+        // emits the guarded dispatch (runtime bounds check + compile-time
+        // closed-world type check, WASM Core §4.4.8). Same decline pattern as
+        // #120/#372/#374.
+        if wasm_ops
+            .iter()
+            .any(|op| matches!(op, WasmOp::CallIndirect { .. }))
+        {
+            return Err(Error::UnsupportedInstruction(
+                "optimized lowering path does not support call_indirect; the direct \
+                 instruction selector emits the guarded table dispatch — issue #642"
+                    .to_string(),
+            ));
+        }
+
         // Issue #178/#180: the optimized linear-memory miscompilation was
         // root-caused to the Thumb encoder, NOT this lowering — `ArmOp::Add`
         // (and `Adds`/`Subs`) unconditionally used the 16-bit form, whose 3-bit

--- a/crates/synth-synthesis/src/rules.rs
+++ b/crates/synth-synthesis/src/rules.rs
@@ -526,6 +526,15 @@ pub enum ArmOp {
         rd: Reg,
         type_idx: u32,
         table_index_reg: Reg,
+        /// #642: compile-time size of table 0 in entries. The encoder emits a
+        /// bounds guard (`CMP idx, size; BLO ok; UDF #0`) before the table
+        /// load — WASM Core §4.4.8 requires `index >= table.size` to TRAP,
+        /// not perform an uncontrolled indirect branch. The size is a
+        /// compile-time immediate because the raw code-pointer table synth
+        /// targets has no runtime size field, and the table cannot change
+        /// size at runtime (`table.grow`/`table.set` are unsupported ops →
+        /// their functions loud-skip at decode).
+        table_size: u32,
     },
 
     // ========================================================================

--- a/crates/synth-verify/src/arm_semantics.rs
+++ b/crates/synth-verify/src/arm_semantics.rs
@@ -479,6 +479,9 @@ impl ArmSemantics {
                 rd,
                 type_idx,
                 table_index_reg,
+                // #642: the bounds guard is a control-flow effect (trap), not
+                // modeled by the symbolic call result.
+                table_size: _,
             } => {
                 // Indirect function call through table
                 let _table_index = state.get_reg(table_index_reg).clone();

--- a/crates/synth-verify/tests/comprehensive_verification.rs
+++ b/crates/synth-verify/tests/comprehensive_verification.rs
@@ -1998,6 +1998,7 @@ fn verify_call_indirect() {
                     rd: Reg::R0,
                     type_idx,
                     table_index_reg: Reg::R1,
+                    table_size: 4, // #642: bounds-guard immediate
                 },
             );
 

--- a/scripts/repro/call_indirect_642_differential.py
+++ b/scripts/repro/call_indirect_642_differential.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""#642 — call_indirect bounds-guard oracle: OOB index must TRAP, not branch.
+
+The Thumb-2 `call_indirect` expansion (`lsl.w ip, idx, #2; ldr.w ip, [r11,
+ip]; blx ip`) had NO bounds check and NO type check: an out-of-bounds index
+read past the table and BLXed whatever word lay there — an uncontrolled
+indirect branch where WASM Core §4.4.8 mandates a deterministic trap. The fix
+prepends `movw ip, #size; cmp idx, ip; blo +1; udf #0` (the type check is
+discharged at compile time via the closed-world table verification — the raw
+code-pointer table carries no runtime type ids).
+
+This harness compiles the fixture via the direct-selector path, then for each
+case runs BOTH engines:
+  - wasmtime (oracle): in-bounds indices return add/sub/mul results; OOB
+    indices trap.
+  - unicorn (synth's code, table linked at r11): in-bounds results must match
+    wasmtime; OOB indices must stop at a `udf` (0xDExx) — the §4.4.8 trap.
+
+RED-CASE NON-VACUITY: the words PAST the 3-entry table are seeded with a
+valid Thumb decoy (`movs r0, #0x5A; bx lr`), so on an unguarded build the OOB
+index does NOT fault — it "successfully" calls the decoy and returns 0x5A,
+which is precisely the uncontrolled-indirect-branch hole. The harness fails
+loudly on that outcome (this is what origin/main does).
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/call_indirect_642_differential.py
+Exits nonzero on any mismatch, missed trap, or decoy execution.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_PC,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("call_indirect_642_oob.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+CODE, TABLE, STK = 0x1000000, 0x3000000, 0x6000000
+RET = CODE + 0xFFF0  # return pad (inside the CODE map)
+DECOY = CODE + 0xFF00  # decoy "function" the unguarded build would call
+A = 5
+IN_BOUNDS = [0, 1, 2]
+OOB = [3, 5, 99]
+
+
+def compile_direct(out: str, target: str) -> None:
+    """Compile via the direct-selector path (the one that lowers call_indirect)."""
+    r = subprocess.run(
+        [
+            SYNTH,
+            "compile",
+            str(WAT),
+            "-o",
+            out,
+            "--target",
+            target,
+            "--all-exports",
+            "--relocatable",
+            "--no-optimize",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if r.returncode != 0:
+        print(f"COMPILE FAILED:\n{r.stdout}\n{r.stderr}")
+        sys.exit(1)
+
+
+def wasmtime_oracle():
+    """Ground truth: result per in-bounds index; OOB indices must trap."""
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_text())
+    results = {}
+    for idx in IN_BOUNDS + OOB:
+        store = wasmtime.Store(engine)  # fresh instance per call (stateful)
+        f = wasmtime.Instance(store, module, []).exports(store)["f"]
+        try:
+            results[idx] = f(store, A, idx) & 0xFFFFFFFF
+        except wasmtime.Trap:
+            results[idx] = "trap"
+    return results
+
+
+def run_unicorn(text: bytes, syms: dict, idx: int, a32: bool):
+    """Execute f(A, idx); returns ('ok', r0) or ('trap-udf', pc) or a failure."""
+    mu = Uc(UC_ARCH_ARM, UC_MODE_ARM if a32 else UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x100000)
+    mu.mem_map(TABLE, 0x10000)
+    mu.mem_map(STK, 0x100000)
+    mu.mem_write(CODE, text)
+    if a32:
+        # Return pad: A32 NOPs. Decoy: `mov r0, #0x5A; bx lr`.
+        mu.mem_write(RET, struct.pack("<II", 0xE320F000, 0xE320F000))
+        mu.mem_write(DECOY, struct.pack("<II", 0xE3A0005A, 0xE12FFF1E))
+        thumb_bit = 0
+    else:
+        # Return pad: Thumb NOPs. Decoy: `movs r0, #0x5A; bx lr`.
+        mu.mem_write(RET, struct.pack("<HH", 0xBF00, 0xBF00))
+        mu.mem_write(DECOY, struct.pack("<HH", 0x205A, 0x4770))
+        thumb_bit = 1
+    # table[i] = code address (Thumb: bit 0 SET for BLX interwork); slots PAST
+    # the declared 3-entry table are seeded with the decoy — a "valid" word an
+    # unguarded OOB load would happily BLX (the #642 hole, non-vacuous red).
+    entries = [syms["func_0"], syms["func_1"], syms["func_2"]]
+    for i, off in enumerate(entries):
+        mu.mem_write(TABLE + 4 * i, struct.pack("<I", (CODE + off) | thumb_bit))
+    for i in range(len(entries), 128):
+        mu.mem_write(TABLE + 4 * i, struct.pack("<I", DECOY | thumb_bit))
+
+    mu.reg_write(UC_ARM_REG_R0, A)
+    mu.reg_write(UC_ARM_REG_R1, idx)
+    mu.reg_write(UC_ARM_REG_R11, TABLE)
+    mu.reg_write(UC_ARM_REG_SP, STK + 0x80000)
+    mu.reg_write(UC_ARM_REG_LR, RET | thumb_bit)
+    try:
+        mu.emu_start((CODE + syms["f"]) | thumb_bit, RET, count=2000)
+    except UcError as e:
+        pc = mu.reg_read(UC_ARM_REG_PC)
+        # A deterministic §4.4.8 trap = execution stopped ON a udf
+        # (Thumb 0xDExx / A32 0xE7F000F0).
+        if CODE <= pc < CODE + len(text):
+            if a32:
+                w = struct.unpack("<I", text[pc - CODE : pc - CODE + 4])[0]
+                if w == 0xE7F000F0:
+                    return ("trap-udf", pc)
+            else:
+                hw = struct.unpack("<H", text[pc - CODE : pc - CODE + 2])[0]
+                if hw & 0xFF00 == 0xDE00:
+                    return ("trap-udf", pc)
+        return ("fault", f"{e} at pc={pc:#x} (NOT a udf trap)")
+    return ("ok", mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF)
+
+
+def run_isa(oracle: dict, target: str, a32: bool) -> int:
+    elf_path = f"/tmp/ci642_{'a32' if a32 else 'thumb'}.o"
+    compile_direct(elf_path, target)
+
+    with open(elf_path, "rb") as fh:
+        e = ELFFile(fh)
+        text = bytes(e.get_section_by_name(".text").data())
+        # Symbols from the symtab, never from disasm text (host-dependent).
+        st = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+        syms = {s.name: s["st_value"] & ~1 for s in st.iter_symbols() if s.name}
+    for need in ("f", "func_0", "func_1", "func_2"):
+        if need not in syms:
+            print(f"SYMBOL MISSING: {need}")
+            return 1
+
+    isa = "A32" if a32 else "Thumb-2"
+    fails = 0
+    for idx in IN_BOUNDS:
+        want = oracle[idx]
+        kind, got = run_unicorn(text, syms, idx, a32)
+        ok = kind == "ok" and got == want
+        fails += 0 if ok else 1
+        got_s = f"{got:#x}" if isinstance(got, int) else got
+        print(
+            f"[{isa}] f({A},{idx}) = {kind}:{got_s} (wasmtime: {want:#x}) "
+            f"{'OK' if ok else 'MISMATCH'}"
+        )
+
+    for idx in OOB:
+        assert oracle[idx] == "trap", f"oracle must trap OOB index {idx}"
+        kind, got = run_unicorn(text, syms, idx, a32)
+        ok = kind == "trap-udf"
+        fails += 0 if ok else 1
+        if ok:
+            print(f"[{isa}] f({A},{idx}) = udf trap at {got:#x} (wasmtime: trap) OK")
+        elif kind == "ok" and got == 0x5A:
+            print(
+                f"[{isa}] f({A},{idx}) = {got:#x} — the DECOY past the table was "
+                "CALLED: uncontrolled indirect branch, no bounds guard (#642) MISMATCH"
+            )
+        else:
+            print(f"[{isa}] f({A},{idx}) = {kind}:{got} (wasmtime: trap) MISMATCH")
+    return fails
+
+
+def main() -> int:
+    oracle = wasmtime_oracle()
+    print(f"wasmtime oracle: {oracle}")
+
+    # Both ISAs share the #642 gap and the fix: Thumb-2 (cortex-m3) and the
+    # #596-added A32 expansion (cortex-r5).
+    fails = run_isa(oracle, "cortex-m3", a32=False)
+    fails += run_isa(oracle, "cortex-r5", a32=True)
+
+    if fails == 0:
+        print("ORACLE: PASS")
+        return 0
+    print(f"ORACLE: FAIL — {fails} case(s) diverged from wasmtime (#642)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repro/call_indirect_642_oob.wat
+++ b/scripts/repro/call_indirect_642_oob.wat
@@ -1,0 +1,23 @@
+;; #642: Thumb-2 call_indirect emitted NO table bounds check and NO type
+;; check — an out-of-bounds index read past the table and BLXed whatever
+;; word lay there: an uncontrolled indirect branch instead of the WASM Core
+;; §4.4.8 trap. In-bounds dispatch was correct (the #594/#597 arc), which is
+;; exactly why a probe driving only valid indices cannot see it.
+;;
+;; wasmtime oracle (a=5): f(5,0)=15 (add), f(5,1)=-5 (sub), f(5,2)=50 (mul);
+;; f(5,5) and f(5,99) TRAP ("undefined element" / OOB table access).
+;;
+;; The table is fully covered by the elem segment and every entry shares
+;; $bin — the closed-world property the compile-time type check verifies.
+(module
+  (type $bin (func (param i32 i32) (result i32)))
+  (table 3 funcref)
+  (elem (i32.const 0) $add $sub $mul)
+  (func $add (param i32 i32) (result i32)
+    (i32.add (local.get 0) (local.get 1)))
+  (func $sub (param i32 i32) (result i32)
+    (i32.sub (local.get 0) (local.get 1)))
+  (func $mul (param i32 i32) (result i32)
+    (i32.mul (local.get 0) (local.get 1)))
+  (func (export "f") (param i32 i32) (result i32)
+    (call_indirect (type $bin) (local.get 0) (i32.const 10) (local.get 1))))


### PR DESCRIPTION
Fixes #642.

## The hole

The Thumb-2 (and A32, #596) `call_indirect` expansion was three unguarded instructions off a runtime index:

```
lsl.w  ip, idx, #2
ldr.w  ip, [r11, ip]
blx    ip
```

No `cmp`/bounds branch, no type comparison — an out-of-bounds or wrong-typed index performed an **uncontrolled indirect branch** where WASM Core §4.4.8 mandates a deterministic trap. In-bounds dispatch was correct (the #594/#597 arc only ever fixed *indexing*), which is exactly why index-valid probes never saw it.

## Guard design

**Bounds check — runtime, both ISAs.** The expansion now prepends:

```
movw ip, #table_size   ; (+ movt when size > 16 bits)
cmp  idx, ip
blo  +1                ; skip the trap when in bounds
udf  #0                ; §4.4.8 OOB trap (same idiom as the div-by-zero guards)
```

Where does the table size live at runtime? **Nowhere** — the table is a raw array of 4-byte code pointers linked at `r11` by the runtime/harness, with no size field. The size is therefore a **compile-time immediate**, and it is *sound and exact* for a defined table: `table.grow`/`table.set` are unsupported ops whose functions loud-skip at decode, so nothing synth compiles can resize (or retype) the table. An imported table only yields a bound when its limits pin the size (`max == initial`); otherwise the lowering **declines loudly** (a guard against `initial` on a growable import would trap spec-valid calls).

**Type check — discharged at compile time (closed world).** The raw code-pointer table stores no type ids, so a runtime tag compare is not implementable with the current layout. Instead `DecodedModule::call_indirect_guards()` verifies, per expected type `t`: every slot in `[0, table_size)` is initialized by a const-offset active element segment with a plain `ref.func`, and every entry's signature **structurally** equals `types[t]` (signature comparison, not index comparison — duplicate types stay interchangeable). Under that property no runtime mismatch is possible; the check compiles away. Any hole — an uninitialized (null-funcref) slot, a heterogeneous entry, a passive/computed segment, a non-zero table index — records a reason and the lowering **declines loudly with it**. The unchecked branch is never left behind:

- `CompileConfig::call_indirect_guards` **defaults to decline** (no module context ⇒ no `call_indirect`),
- the optimized path now declines `call_indirect` **explicitly** (it previously fell through `wasm_to_ir`'s `_ => Opcode::Nop`),
- both direct selectors (`select_with_stack` + `select_default`) gate on the verdicts.

This is the (b) strategy from the issue triage: dissolved images have homogeneous fully-covered tables (the repro verifies), and extending table *emission* with type ids is moot while synth doesn't emit the table at all.

## Red → green evidence

`scripts/repro/call_indirect_642_differential.py` (new CI job `call-indirect-642-oracle`): unicorn vs wasmtime on **both ISAs**, table at `r11`, and — non-vacuity — the words *past* the 3-entry table seeded with a valid decoy function (`movs r0, #0x5A; bx lr`), so an unguarded build doesn't fault, it *calls the decoy*.

**origin/main (a1541c0), both ISAs red:**
```
[Thumb-2] f(5,3)  = 0x5a — the DECOY past the table was CALLED: uncontrolled indirect branch, no bounds guard (#642) MISMATCH
[Thumb-2] f(5,5)  = 0x5a — … MISMATCH
[Thumb-2] f(5,99) = 0x5a — … MISMATCH
[A32]     f(5,3)  = 0x5a — … MISMATCH   (+5, 99)
ORACLE: FAIL — 6 case(s) diverged from wasmtime (#642)
```

**this branch, 12/12 green:**
```
[Thumb-2] f(5,0)=0xf f(5,1)=0xfffffffb f(5,2)=0x32  (= wasmtime)
[Thumb-2] f(5,3)/f(5,5)/f(5,99) = udf trap (wasmtime: trap) OK
[A32]     same 6/6 OK
ORACLE: PASS
```

## Both-ISA status

- **Thumb-2** (cortex-m3): guarded, encoding pin updated (`test_encode_thumb_call_indirect_lsl2_597` + new `_guard_shapes_642` covering the high-reg CMP T2 form and the >16-bit MOVT arm).
- **A32** (cortex-r5): guarded, `test_encode_arm32_call_indirect_is_real_call_594` updated + new wide-size pin; the #594 A32 differential stays green (now executes the guard in-bounds).
- **RISC-V / AArch64**: no `call_indirect` lowering exists (falls to `Unsupported` → loud-skip) — no shared gap.

## Gates

- `cargo test --workspace`: **2012 passed, 0 failed** (was 2004; +5 decoder closed-world tests, +3 selector decline/emit tests, +2 encoder pins, net of split assertions)
- Frozen anchors: `frozen_codegen_bytes` **10/10 untouched** (fixtures carry no `call_indirect`)
- `estimator_encoder_agreement` (#511): green — `CallIndirect` is a direct-selector-only op, already in the oracle's not-on-optimized-path exclusion list, and the direct path's `resolve_label_branches` sizes by *actual encoding*, so the bigger expansion is measured, not estimated
- `#594`/`#597` differentials: green on the fixed build
- `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)