### PR TITLE
fix(decoder): float-typed global accesses loud-skip — the last silent float path (GI-FPU-001, #369)

### DIFF
--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1380,8 +1380,8 @@ fn compile_command(
                 anyhow::bail!(
                     "function '{}' contains an unsupported operator ({}) the '{}' \
                      backend cannot lower — it was dropped at decode, so refusing \
-                     to emit a silent miscompile (#369, #554). Implement the op or \
-                     compile a function the backend supports.",
+                     to emit a silent miscompile (GI-FPU-001; #369, #554). Implement \
+                     the op or compile a function the backend supports.",
                     name,
                     reason,
                     backend.name()
@@ -2517,7 +2517,7 @@ fn compile_all_exports(
             eprintln!(
                 "warning: skipping function '{name}': contains an unsupported \
                  operator ({reason}) the {} backend cannot lower — emitting no \
-                 code for it rather than a silent miscompile (#369)",
+                 code for it rather than a silent miscompile (GI-FPU-001, #369)",
                 backend.name()
             );
             skipped_funcs.push((name.clone(), format!("unsupported operator: {reason}")));

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -325,6 +325,14 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     // section. `None` until (and unless) the first such section is seen —
     // duplicates are ignored (one prover, one section; encoding doc rule).
     let mut wsc_facts: Option<Vec<crate::wsc_facts::WscFact>> = None;
+    // GI-FPU-001 (#369): f32/f64-typed globals in the FULL global index space
+    // (imports first, then defined). `global.get`/`global.set` decode fine
+    // (they are type-agnostic ops), but there is no float lowering: the
+    // f32.const/f64.const initializer is silently dropped (`init_i32: None`
+    // → slot zeroed), so a read returns 0.0 instead of the init — a silent
+    // wrong value. Functions touching a float global loud-skip instead.
+    let mut num_imported_globals = 0u32;
+    let mut float_globals: std::collections::HashSet<u32> = std::collections::HashSet::new();
 
     for payload in Parser::new(0).parse_all(wasm_bytes) {
         let payload = payload.context("Failed to parse WASM payload")?;
@@ -433,7 +441,19 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                             }
                             (ImportKind::Table, 0)
                         }
-                        wasmparser::TypeRef::Global(_) => (ImportKind::Global, 0),
+                        wasmparser::TypeRef::Global(g) => {
+                            // GI-FPU-001 (#369): imported globals come first in
+                            // the global index space — record float-typed ones
+                            // so accesses loud-skip their function.
+                            if matches!(
+                                g.content_type,
+                                wasmparser::ValType::F32 | wasmparser::ValType::F64
+                            ) {
+                                float_globals.insert(num_imported_globals);
+                            }
+                            num_imported_globals += 1;
+                            (ImportKind::Global, 0)
+                        }
                         _ => continue,
                     };
                     imports.push(ImportEntry {
@@ -515,6 +535,17 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                         wasmparser::ValType::V128 => 16,
                         _ => 4,
                     };
+                    // GI-FPU-001 (#369): a float-typed global's initializer is
+                    // NOT captured (`init_i32` only decodes `i32.const`), so
+                    // its slot would be silently zeroed — record it so any
+                    // function accessing it loud-skips instead of reading a
+                    // silently-wrong 0.0.
+                    if matches!(
+                        global.ty.content_type,
+                        wasmparser::ValType::F32 | wasmparser::ValType::F64
+                    ) {
+                        float_globals.insert(num_imported_globals + idx as u32);
+                    }
                     globals.push(WasmGlobal {
                         index: idx as u32,
                         init_i32,
@@ -625,7 +656,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
             }
             Payload::CodeSectionEntry(body) => {
                 let (ops, op_offsets, block_arity, unsupported) =
-                    decode_function_body(&body, &type_block_arity)?;
+                    decode_function_body(&body, &type_block_arity, &float_globals)?;
                 let actual_index = num_imported_funcs + func_index;
                 let export_name = export_names.get(&actual_index).cloned();
 
@@ -737,6 +768,10 @@ pub fn decode_wasm_functions(wasm_bytes: &[u8]) -> Result<Vec<FunctionOps>> {
     let mut name_section_names: HashMap<u32, String> = HashMap::new();
     // #509: (param_count, result_count) per type index, for FuncType blocktypes.
     let mut type_block_arity: Vec<(u8, u8)> = Vec::new();
+    // GI-FPU-001 (#369): float-typed globals (full index space, imports first)
+    // whose accesses must loud-skip — see `decode_wasm_module`.
+    let mut num_imported_globals = 0u32;
+    let mut float_globals: std::collections::HashSet<u32> = std::collections::HashSet::new();
 
     for payload in Parser::new(0).parse_all(wasm_bytes) {
         let payload = payload.context("Failed to parse WASM payload")?;
@@ -765,8 +800,34 @@ pub fn decode_wasm_functions(wasm_bytes: &[u8]) -> Result<Vec<FunctionOps>> {
                 // to individual imports (see the ImportSection handler above).
                 for import in imports.into_imports() {
                     let import = import.context("Failed to parse import")?;
-                    if matches!(import.ty, wasmparser::TypeRef::Func(_)) {
-                        num_imported_funcs += 1;
+                    match import.ty {
+                        wasmparser::TypeRef::Func(_) => num_imported_funcs += 1,
+                        wasmparser::TypeRef::Global(g) => {
+                            // GI-FPU-001 (#369): see `decode_wasm_module` —
+                            // float-typed global accesses must loud-skip.
+                            if matches!(
+                                g.content_type,
+                                wasmparser::ValType::F32 | wasmparser::ValType::F64
+                            ) {
+                                float_globals.insert(num_imported_globals);
+                            }
+                            num_imported_globals += 1;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Payload::GlobalSection(reader) => {
+                // GI-FPU-001 (#369): record f32/f64-typed defined globals so
+                // `decode_function_body` flags accesses (their initializer is
+                // dropped on this path too — same silent-zero hazard).
+                for (idx, global) in reader.into_iter().enumerate() {
+                    let global = global.context("Failed to parse global")?;
+                    if matches!(
+                        global.ty.content_type,
+                        wasmparser::ValType::F32 | wasmparser::ValType::F64
+                    ) {
+                        float_globals.insert(num_imported_globals + idx as u32);
                     }
                 }
             }
@@ -780,7 +841,7 @@ pub fn decode_wasm_functions(wasm_bytes: &[u8]) -> Result<Vec<FunctionOps>> {
             }
             Payload::CodeSectionEntry(body) => {
                 let (ops, op_offsets, block_arity, unsupported) =
-                    decode_function_body(&body, &type_block_arity)?;
+                    decode_function_body(&body, &type_block_arity, &float_globals)?;
                 let actual_index = num_imported_funcs + func_index;
                 let export_name = export_names.get(&actual_index).cloned();
 
@@ -892,6 +953,7 @@ type DecodedBody = (Vec<WasmOp>, Vec<u32>, Vec<(u8, u8)>, Option<String>);
 fn decode_function_body(
     body: &wasmparser::FunctionBody,
     type_block_arity: &[(u8, u8)],
+    float_globals: &std::collections::HashSet<u32>,
 ) -> Result<DecodedBody> {
     let mut ops = Vec::new();
     // VCR-DBG-001 step 1: parallel to `ops` — the module-relative wasm byte
@@ -916,6 +978,21 @@ fn decode_function_body(
             | wasmparser::Operator::If { blockty } = &op
             {
                 block_arity.push(blocktype_arity(blockty, type_block_arity));
+            }
+            // GI-FPU-001 (#369): `global.get`/`global.set` decode fine (the
+            // ops are type-agnostic), but an f32/f64-typed global has no
+            // float lowering — its const initializer is dropped (slot zeroed),
+            // so a read returns a silently-wrong 0.0. Flag the function for
+            // the same loud-skip the scalar float ops get.
+            if unsupported.is_none()
+                && let WasmOp::GlobalGet(i) | WasmOp::GlobalSet(i) = &wasm_op
+                && float_globals.contains(i)
+            {
+                unsupported = Some(format!(
+                    "{wasm_op:?} on an f32/f64-typed global — float globals \
+                     have no lowering, the initializer would be silently \
+                     zeroed (GI-FPU-001)"
+                ));
             }
             ops.push(wasm_op);
             op_offsets.push(offset as u32);
@@ -1944,6 +2021,102 @@ mod tests {
             iadd.unsupported.is_none(),
             "a pure-integer function must NOT be flagged: {:?}",
             iadd.unsupported
+        );
+    }
+
+    #[test]
+    fn test_369_float_global_access_flags_function_unsupported() {
+        // GI-FPU-001 (#369): `global.get`/`global.set` on an f32/f64-typed
+        // global decode fine (the ops are type-agnostic), but the float
+        // initializer is dropped (`init_i32: None` -> slot zeroed), so a read
+        // returned a silently-wrong 0.0 instead of the init (verified: the
+        // 2.5f bit pattern 0x40200000 was absent from the output ELF). The
+        // access must flag the function for the loud-skip path. Accesses to
+        // integer globals stay clean.
+        let wat = r#"
+            (module
+                (global $fg f32 (f32.const 2.5))
+                (global $dg (mut f64) (f64.const 1.5))
+                (global $ig (mut i32) (i32.const 7))
+                (func (export "fget") (result f32) global.get $fg)
+                (func (export "dset") (param f64) local.get 0 global.set $dg)
+                (func (export "iget") (result i32) global.get $ig))
+        "#;
+        let wasm = wat::parse_str(wat).expect("parse");
+
+        // Both decode entry points must flag (the CLI compiles through both:
+        // decode_wasm_module on the all-exports/module paths,
+        // decode_wasm_functions on the single-function path).
+        let module = decode_wasm_module(&wasm).expect("decode module");
+        for functions in [
+            &module.functions,
+            &decode_wasm_functions(&wasm).expect("decode fns"),
+        ] {
+            let by_name = |n: &str| {
+                functions
+                    .iter()
+                    .find(|f| f.export_name.as_deref() == Some(n))
+                    .unwrap()
+            };
+            let fget = by_name("fget");
+            assert!(
+                fget.unsupported.is_some(),
+                "global.get of an f32 global must flag the function (loud-skip), got {:?}",
+                fget.unsupported
+            );
+            let reason = fget.unsupported.as_deref().unwrap();
+            assert!(
+                reason.contains("GlobalGet") && reason.contains("GI-FPU-001"),
+                "diagnostic should name the op and GI-FPU-001: {reason:?}"
+            );
+            let dset = by_name("dset");
+            assert!(
+                dset.unsupported
+                    .as_deref()
+                    .is_some_and(|r| r.contains("GlobalSet")),
+                "global.set of an f64 global must flag the function, got {:?}",
+                dset.unsupported
+            );
+            assert!(
+                by_name("iget").unsupported.is_none(),
+                "an i32 global access must NOT be flagged: {:?}",
+                by_name("iget").unsupported
+            );
+        }
+    }
+
+    #[test]
+    fn test_369_imported_float_global_shifts_index_space() {
+        // GI-FPU-001 (#369): imported globals come FIRST in the global index
+        // space. An imported f64 global at index 0 must be flagged, and the
+        // defined i32 global at index 1 must NOT be mistaken for it.
+        let wat = r#"
+            (module
+                (import "env" "fg" (global f64))
+                (global $ig i32 (i32.const 3))
+                (func (export "fget") (result f64) global.get 0)
+                (func (export "iget") (result i32) global.get 1))
+        "#;
+        let wasm = wat::parse_str(wat).expect("parse");
+        let functions = decode_wasm_functions(&wasm).expect("decode");
+        let by_name = |n: &str| {
+            functions
+                .iter()
+                .find(|f| f.export_name.as_deref() == Some(n))
+                .unwrap()
+        };
+        assert!(
+            by_name("fget")
+                .unsupported
+                .as_deref()
+                .is_some_and(|r| r.contains("GI-FPU-001")),
+            "imported f64 global access must flag: {:?}",
+            by_name("fget").unsupported
+        );
+        assert!(
+            by_name("iget").unsupported.is_none(),
+            "defined i32 global at shifted index 1 must NOT flag: {:?}",
+            by_name("iget").unsupported
         );
     }
 


### PR DESCRIPTION
Closes the last silent-float gap of **GI-FPU-001** (#369; the #619 frontier survey). jess tracks the arc as AFD-024.

## Where GI-FPU-001 stood on main (verified per backend, v0.33.1)

PR #371 (decode loud-skip) + PR #556 (#554 single-function bail) already made every scalar float **op** loud. Verified on origin/main with a 12-module matrix (arith f32/f64, compares, trunc/convert, load/store, const, both reinterprets, float local, float global) × (ARM default, ARM `--relocatable`/direct, `-b riscv`, `-b aarch64`):

- **f32/f64 arithmetic, compares, converts, loads/stores, const, reinterprets** — all loud on all four paths: `warning: skipping function 'f': contains an unsupported operator (F32Add) …` / single-function `Error: … refusing to emit a silent miscompile`. 
- **Float locals/params without float ops** — compile as pure 4/8-byte bit moves (bit-correct; f64 params ride the #359 pair machinery). Deliberately not flagged.
- **Float-typed GLOBALS — the remaining silent wrong-value path (ARM, both paths):**

```wat
(module (global $g f32 (f32.const 2.5))
        (func (export "f") (result f32) (global.get $g)))
```

| | origin/main | this PR |
|---|---|---|
| ARM default (`-t cortex-m4f`) | **rc=0, silent** — 0x40200000 (2.5f) absent from the ELF, read returns **0.0**; wasmtime: **2.5** | loud-skip naming `GlobalGet(0) … (GI-FPU-001)` |
| ARM `--relocatable` (direct) | **rc=0, silent, same** | loud-skip, same diagnostic |
| `-b riscv` / `-b aarch64` | loud only **by accident** (`GlobalGet` itself is unsupported there) | loud at decode, uniformly |

Root cause: `global.get`/`global.set` are type-agnostic ops that decode fine, but `init_i32` only captures a leading `i32.const` — an `f32.const`/`f64.const` initializer records `None` and the slot is **zeroed** (`init_i32.unwrap_or(0)`).

## Fix

Both decode entry points (`decode_wasm_module` + the lighter `decode_wasm_functions` — the CLI compiles through both) track f32/f64-typed globals in the **full index space (imported globals first)** and flag any function whose `GlobalGet`/`GlobalSet` touches one, routing it through the existing #371/#556 loud-skip / honest-bail machinery. The two CLI diagnostics now also name **GI-FPU-001** explicitly.

## Oracles

1. New decoder tests (**red on origin/main**): float-global get/set flags the function with a reason naming the op + GI-FPU-001; imported f64 global shifts the index space correctly; i32-global accesses stay unflagged. Existing #369/#554 loud-skip tests untouched and green.
2. **Frozen anchors 10/10 byte-identical** (`frozen_codegen_bytes`); the only float fixture in-tree is the #554 loud-skip repro.
3. `cargo test --workspace` rc=0 (106 suites, 0 failures), `cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` rc=0.

## Sibling finding (out of scope, filing separately)

`(global i64 (i64.const 4886718345))` + `global.get` is **also silently zeroed** — same `init_i32`-only mechanism, integer class (#643 landed pair get/set but not non-i32 initializers). Tracked in a follow-up issue.

## What GI-FPU-002 (real VFP, #619) will need

- **Decode**: scalar `f32.*`/`f64.*` arms in `convert_operator` (+ `WasmOp` float variants beyond the dead prototypes), float `const` payload capture, and float global-init capture (un-flagging the accesses this PR flags).
- **Select/allocate**: VFP lowering in `select_with_stack` (S0–S15/D0–D15 register class alongside the integer allocator; the existing `f32_vfp_encoding_test`/`f64_vfp_encoding_test` encoder is ready), FPU gating per target (m4f=fpv4-sp, m7=fpv5-sp, m7dp=fpv5-d16; honest reject on M0/M3 stays).
- **ABI/metadata**: AAPCS-VFP arg passing decision + `Tag_FP_arch`/`Tag_ABI_VFP_args` build attributes so the mode is verifiable from the artifact (#369's ask).
- **Oracle**: qemu `mps2-an386` hard-float semihosting differential (#619 offers the probe) + falcon-v1.56 numeric gate.

Refs #369, #619, #554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)