### PR TITLE
chore(release): v0.34.0 — multi-table call_indirect + global inits + sound mask bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-07-08
+
+**Multi-table call_indirect ships (falcon's fused-component blocker); float
+and i64 global initializers actually reach the image; the mask bounds mode
+becomes sound. Six gale filings closed same-day across two waves.**
+
+### Added
+
+- **Multi-table call_indirect (#650, PR #653).** Tables form one contiguous
+  region at R11 (table N at a compile-time constant offset — sound because
+  tables are provably fixed-size per #646); the dispatch folds the offset
+  via R12; the #642 bounds guard checks the dispatched table's own size and
+  the closed-world type verification runs per (table, expected-type).
+  Single-table modules are byte-identical BY CONSTRUCTION (offset-0 emits
+  the literal pre-#650 sequence — verified by whole-ELF cmp across three
+  targets). New CI oracle: two-table aliasing canary + per-table OOB traps,
+  26/26 (both ISAs).
+
+### Fixed
+
+- **Global initializers never reached the self-contained image (#649,
+  PR #652; float side GI-FPU-001, PR #648).** The decoder only captured
+  i32.const inits, and the default Cortex-M image never materialized the
+  globals table at all — R9 was uninitialized and reads returned
+  vector-table garbage. Now the startup stub sets R9 and stores every init
+  word (width-aware #645 layout, i64 = two words); float-typed globals
+  loud-skip (GI-FPU-001). New oracle executes the image's real reset path
+  in unicorn: 4 divergences → 0. Sibling filed: #655 (RV32 mask-order twin).
+- **--safety-bounds mask applied the mask before the static offset (#651,
+  PR #654)** — the offset escaped the bound; AND the old mask used the
+  memory SIZE (not size-1), remapping in-bounds accesses to 0. All 8 mask
+  sites now share one helper: min((operand + offset) & (size-1),
+  size - access_size), with the u33-soundness argument documented and
+  large offsets materialized (no decline). Mini-interpreter oracle: 8/8
+  FAIL → 8/8 ok. Non-power-of-two memories decline loudly under mask.
+
 ## [0.33.1] - 2026-07-08
 
 **Two more gale-filed silent miscompiles fixed same-day: call_indirect gets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,14 +2060,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2125,11 +2125,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.33.1"
+version = "0.34.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2184,14 +2184,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2199,11 +2199,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.33.1"
+version = "0.34.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.33.1"
+version = "0.34.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.33.1"
+version = "0.34.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.33.1",
+    version = "0.34.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.33.1" }
+synth-core = { path = "../synth-core", version = "0.34.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.33.1" }
+synth-core = { path = "../synth-core", version = "0.34.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.33.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.33.1" }
+synth-core = { path = "../synth-core", version = "0.34.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.34.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.33.1" }
+synth-core = { path = "../synth-core", version = "0.34.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.33.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.33.1", optional = true }
+synth-core = { path = "../synth-core", version = "0.34.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.34.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -44,23 +44,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.33.1" }
-synth-frontend = { path = "../synth-frontend", version = "0.33.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.33.1" }
-synth-backend = { path = "../synth-backend", version = "0.33.1" }
+synth-core = { path = "../synth-core", version = "0.34.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.34.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.34.0" }
+synth-backend = { path = "../synth-backend", version = "0.34.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.33.1" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.34.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.33.1", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.33.1", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.33.1", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.34.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.34.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.34.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.33.1", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.34.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.33.1" }
+synth-core = { path = "../synth-core", version = "0.34.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.33.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.34.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.33.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.33.1" }
-synth-opt = { path = "../synth-opt", version = "0.33.1" }
+synth-core = { path = "../synth-core", version = "0.34.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.34.0" }
+synth-opt = { path = "../synth-opt", version = "0.34.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -20,12 +20,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.33.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.33.1" }
-synth-opt = { path = "../synth-opt", version = "0.33.1" }
+synth-core = { path = "../synth-core", version = "0.34.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.34.0" }
+synth-opt = { path = "../synth-opt", version = "0.34.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.33.1", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.34.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"


### PR DESCRIPTION
Release PR: pin sweep + CHANGELOG for v0.34.0.

Scope: #653 (multi-table call_indirect — #650, falcon unblock) · #652 (#649 i64 global inits reach the image via R9-table startup materialization) · #648 (GI-FPU-001 float-global loud-skip completion) · #654 (#651 mask-offset order + size-vs-size-1 latent fix).

Tag v0.34.0 on green merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)