### PR TITLE
fix(riscv): #655 — mask bounds the EFFECTIVE address (offset folded before the AND, final byte clamped); i64 loads/stores gain the guard

### DIFF
--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -48,8 +48,13 @@ pub enum RvBoundsMode {
         /// `>=` this triggers the trap.
         mem_size: u32,
     },
-    /// AND-mask: `andi addr, addr, (mem_size - 1)` — power-of-two only.
-    /// Wraps on OOB rather than trapping; matches the ARM "Masking" mode.
+    /// AND-mask of the EFFECTIVE address (#655, mirroring ARM PR #654):
+    /// `masked = min((operand + offset) & (mem_size - 1), mem_size - access_size)`
+    /// — the static offset is folded BEFORE the AND (so it cannot escape the
+    /// bound) and the start is clamped so the access's FINAL byte stays inside
+    /// the memory. Power-of-two sizes only (enforced at compile time in
+    /// `build_options`). Wraps on OOB rather than trapping; matches the ARM
+    /// "Masking" mode.
     Mask {
         /// Must be `mem_size - 1`, where `mem_size` is a power of two.
         mask: u32,
@@ -2344,30 +2349,45 @@ impl Selector {
     // ────────── Memory ──────────
 
     /// Emit the per-access safety guard before a load/store, returning a
-    /// (possibly rewritten) address register. The returned register is what
-    /// later code uses as the effective wasm-side address.
+    /// (possibly rewritten) address register **and the residual static offset**
+    /// the caller must use in the subsequent access's addressing mode. Modes
+    /// that consume the offset into the guarded address (Mask) return `0` so
+    /// nothing is re-added after the bound is applied; pass-through modes
+    /// return `offset` unchanged.
     ///
     /// Behaviour by mode:
     /// - `None` / `Pmp`: pass-through (no instructions emitted; PMP handles
-    ///   faults via hardware).
+    ///   faults via hardware). Returns `(addr, offset)`.
     /// - `Software { mem_size }`: emit
     ///   `addi guard, addr, +(offset + access_size - 1)`
     ///   `lui/addi mlim, mem_size`
     ///   `bgeu guard, mlim, Ltrap`
     ///   `j Lok ; Ltrap: ebreak ; Lok:`
     ///   The check guards the last byte of the access, matching the ARM
-    ///   software-bounds-check from §3.1.
-    /// - `Mask { mask }`: emit `andi rd, addr, mask` (when `mask` fits in 12 bits)
-    ///   or `lui/addi mtmp, mask; and rd, addr, mtmp` otherwise. The result is
-    ///   the masked address; the caller uses *that* for the subsequent access.
+    ///   software-bounds-check from §3.1. Returns `(addr, offset)` — the
+    ///   access itself is unchanged, the guard traps first when OOB.
+    /// - `Mask { mask }` (#655, the #651 class — RISC-V twin of ARM PR #654):
+    ///   compute `masked = min((operand + offset) & mask, size - access_size)`
+    ///   and return `(masked, 0)`. The static offset is folded BEFORE the AND
+    ///   (a post-mask offset escapes the bound by up to ~4 GiB), and the start
+    ///   is clamped so the access's FINAL byte stays inside the memory (the
+    ///   AND bounds only the first byte; a multi-byte access starting in the
+    ///   last `access_size - 1` bytes would overhang).
+    ///
+    ///   u33 soundness of ADD-then-AND: `ea = operand + offset < 2^33` (both
+    ///   u32). The RV `add` computes `ea mod 2^32`; every set bit of `mask`
+    ///   (= size-1 < 2^32) lies below bit 32, so
+    ///   `(ea mod 2^32) & mask == ea & mask` — the u33 carry is annihilated
+    ///   by the AND either way. Arbitrary 32-bit offsets are handled exactly;
+    ///   no decline needed.
     fn emit_bounds_check(
         &mut self,
         addr: Reg,
         offset: u32,
         access_size: u32,
-    ) -> Result<Reg, SelectorError> {
+    ) -> Result<(Reg, u32), SelectorError> {
         match self.options.bounds {
-            RvBoundsMode::None | RvBoundsMode::Pmp => Ok(addr),
+            RvBoundsMode::None | RvBoundsMode::Pmp => Ok((addr, offset)),
             RvBoundsMode::Software { mem_size } => {
                 let end_byte = offset.checked_add(access_size.saturating_sub(1)).ok_or(
                     SelectorError::ImmediateTooLarge {
@@ -2419,14 +2439,41 @@ impl Selector {
                 self.out.push(RiscVOp::Label { name: trap_label });
                 self.out.push(RiscVOp::Ebreak);
                 self.out.push(RiscVOp::Label { name: ok_label });
-                Ok(addr)
+                Ok((addr, offset))
             }
             RvBoundsMode::Mask { mask } => {
                 let masked = self.alloc_temp();
+                // 1. Fold the static offset FIRST: ea = operand + offset.
+                //    Masking the operand alone would let any non-zero static
+                //    offset escape the bound when the caller re-adds it (#655).
+                let ea = if offset == 0 {
+                    addr
+                } else {
+                    if offset < 2048 {
+                        self.out.push(RiscVOp::Addi {
+                            rd: masked,
+                            rs1: addr,
+                            imm: offset as i32,
+                        });
+                    } else {
+                        let otmp = self.alloc_temp();
+                        emit_load_imm(&mut self.out, otmp, offset as i32);
+                        self.out.push(RiscVOp::Add {
+                            rd: masked,
+                            rs1: addr,
+                            rs2: otmp,
+                        });
+                    }
+                    masked
+                };
+                // 2. AND with mask = size-1 (the size-vs-size-1 audit: the
+                //    mask is built as `mem_size - 1` in `build_options`, and
+                //    the power-of-two contract is enforced there at compile
+                //    time — a non-power-of-two size declines loudly).
                 if mask <= 0x7FF {
                     self.out.push(RiscVOp::Andi {
                         rd: masked,
-                        rs1: addr,
+                        rs1: ea,
                         imm: mask as i32,
                     });
                 } else {
@@ -2434,18 +2481,51 @@ impl Selector {
                     emit_load_imm(&mut self.out, mtmp, mask as i32);
                     self.out.push(RiscVOp::And {
                         rd: masked,
-                        rs1: addr,
+                        rs1: ea,
                         rs2: mtmp,
                     });
                 }
-                Ok(masked)
+                // 3. Clamp the start to size - access_size so the access's
+                //    FINAL byte (start + access_size - 1) stays inside the
+                //    bound — mirrors #654's CMP/IT-HI clamp and #640's
+                //    `offset + access_size - 1` software-guard rule. Skipped
+                //    for byte accesses (a single byte cannot overhang). The
+                //    clamp never alters a wasm-defined access: a masked start
+                //    above size - access_size for an in-range ea implies
+                //    `ea + access_size - 1 >= size`, which wasm traps — the
+                //    mask profile deliberately replaces that trap with a
+                //    deterministic in-bounds access (wrap-not-trap, design
+                //    doc §3.1 path C).
+                if access_size > 1 {
+                    // = size - access_size; saturate for the pathological
+                    // mem_size < access_size case (every access clamps to 0).
+                    let limit_val = mask.saturating_sub(access_size - 1);
+                    let limit = self.alloc_temp();
+                    emit_load_imm(&mut self.out, limit, limit_val as i32);
+                    let ok_label = self.fresh_label("Lmask_ok");
+                    // bgeu limit, masked, Lmask_ok → start is in bounds,
+                    // skip the clamp; otherwise masked = limit.
+                    self.out.push(RiscVOp::Branch {
+                        cond: Branch::Geu,
+                        rs1: limit,
+                        rs2: masked,
+                        label: ok_label.clone(),
+                    });
+                    self.out.push(RiscVOp::Addi {
+                        rd: masked,
+                        rs1: limit,
+                        imm: 0,
+                    });
+                    self.out.push(RiscVOp::Label { name: ok_label });
+                }
+                Ok((masked, 0))
             }
         }
     }
 
     fn lower_load_word(&mut self, op: &WasmOp, offset: u32) -> Result<(), SelectorError> {
         let addr = self.pop_i32(op)?;
-        let addr = self.emit_bounds_check(addr, offset, 4)?;
+        let (addr, offset) = self.emit_bounds_check(addr, offset, 4)?;
         let dst = self.alloc_temp();
         // tmp = base + addr
         let tmp = self.alloc_temp();
@@ -2475,7 +2555,7 @@ impl Selector {
             LoadKind::I8S | LoadKind::I8U => 1,
             LoadKind::I16S | LoadKind::I16U => 2,
         };
-        let addr = self.emit_bounds_check(addr, offset, access_size)?;
+        let (addr, offset) = self.emit_bounds_check(addr, offset, access_size)?;
         let dst = self.alloc_temp();
         let tmp = self.alloc_temp();
         self.out.push(RiscVOp::Add {
@@ -2524,7 +2604,7 @@ impl Selector {
             StoreKind::Half => 2,
             StoreKind::Word => 4,
         };
-        let addr = self.emit_bounds_check(addr, offset, access_size)?;
+        let (addr, offset) = self.emit_bounds_check(addr, offset, access_size)?;
         let tmp = self.alloc_temp();
         self.out.push(RiscVOp::Add {
             rd: tmp,
@@ -3093,6 +3173,9 @@ impl Selector {
     /// memory layout, matching wasm's spec (lo at lower address).
     fn lower_i64_load(&mut self, op: &WasmOp, offset: u32) -> Result<(), SelectorError> {
         let addr = self.pop_i32(op)?;
+        // #655 audit: i64 accesses were emitted with NO guard in Software and
+        // Mask modes — guard the full 8-byte access like the i32 lowerings.
+        let (addr, offset) = self.emit_bounds_check(addr, offset, 8)?;
         let tmp = self.alloc_temp();
         let lo = self.alloc_temp();
         let hi = self.alloc_temp();
@@ -3129,6 +3212,11 @@ impl Selector {
     fn lower_i64_store(&mut self, op: &WasmOp, offset: u32) -> Result<(), SelectorError> {
         let (lo, hi) = self.pop_i64(op)?;
         let addr = self.pop_i32(op)?;
+        // #655 audit: i64 accesses were emitted with NO guard in Software and
+        // Mask modes — guard the full 8-byte access like the i32 lowerings.
+        // (Popped operands are op-pinned, so the guard's scratch allocations
+        // cannot land on lo/hi/addr.)
+        let (addr, offset) = self.emit_bounds_check(addr, offset, 8)?;
         let tmp = self.alloc_temp();
         self.out.push(RiscVOp::Add {
             rd: tmp,
@@ -5871,6 +5959,167 @@ mod tests {
                 op,
                 RiscVOp::And { .. } | RiscVOp::Andi { .. }
             )) >= 1
+        );
+    }
+
+    /// #655 (the #651 class, RISC-V twin): in Mask mode the static offset must
+    /// be folded BEFORE the AND — the access's own immediate must be 0, so
+    /// nothing is re-added after the bound is applied. The pre-fix lowering
+    /// emitted `and masked, addr, mask` then `lw dst, offset(base+masked)`,
+    /// letting the offset escape the bound.
+    #[test]
+    fn rv32_mask_folds_offset_before_and_655() {
+        let opts = SelectorOptions {
+            bounds: RvBoundsMode::Mask { mask: 0xFFFF },
+            signed_div_overflow_trap: true,
+        };
+        let out = s_with_opts(
+            &[
+                WasmOp::LocalGet(0),
+                WasmOp::I32Load {
+                    offset: 0x7FF,
+                    align: 2,
+                },
+                WasmOp::End,
+            ],
+            1,
+            opts,
+        );
+        // The word load's immediate must be 0 — the offset was consumed by
+        // the masked effective-address computation.
+        let lw_imms: Vec<i32> = out
+            .iter()
+            .filter_map(|op| match op {
+                RiscVOp::Lw { imm, .. } => Some(*imm),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            lw_imms,
+            vec![0],
+            "mask mode must consume the static offset (residual imm 0), got {lw_imms:?}"
+        );
+        // An offset-folding add must appear BEFORE the mask AND.
+        let and_pos = out
+            .iter()
+            .position(|op| matches!(op, RiscVOp::And { .. } | RiscVOp::Andi { .. }))
+            .expect("mask AND expected");
+        let addi_pos = out
+            .iter()
+            .position(|op| matches!(op, RiscVOp::Addi { imm: 0x7FF, .. }))
+            .expect("offset fold (addi +0x7FF) expected");
+        assert!(
+            addi_pos < and_pos,
+            "offset must be folded before the AND (addi at {addi_pos}, and at {and_pos})"
+        );
+    }
+
+    /// #655: multi-byte accesses in Mask mode must clamp the start to
+    /// `size - access_size` (bgeu + copy) so the FINAL byte stays in bounds;
+    /// byte accesses cannot overhang and must NOT pay the clamp.
+    #[test]
+    fn rv32_mask_clamps_final_byte_for_multibyte_only_655() {
+        let opts = SelectorOptions {
+            bounds: RvBoundsMode::Mask { mask: 0xFFFF },
+            signed_div_overflow_trap: true,
+        };
+        let word = s_with_opts(
+            &[
+                WasmOp::LocalGet(0),
+                WasmOp::I32Load {
+                    offset: 0,
+                    align: 2,
+                },
+                WasmOp::End,
+            ],
+            1,
+            opts,
+        );
+        assert!(
+            count(&word, |op| matches!(
+                op,
+                RiscVOp::Branch {
+                    cond: Branch::Geu,
+                    ..
+                }
+            )) >= 1,
+            "word access must emit the final-byte clamp (bgeu), got: {word:?}"
+        );
+        let byte = s_with_opts(
+            &[
+                WasmOp::LocalGet(0),
+                WasmOp::I32Load8U {
+                    offset: 0,
+                    align: 0,
+                },
+                WasmOp::End,
+            ],
+            1,
+            opts,
+        );
+        assert_eq!(
+            count(&byte, |op| matches!(op, RiscVOp::Branch { .. })),
+            0,
+            "byte access cannot overhang — no clamp branch expected, got: {byte:?}"
+        );
+    }
+
+    /// #655 audit: i64 load/store were emitted with NO guard in Software and
+    /// Mask modes. Both must now guard the full 8-byte access.
+    #[test]
+    fn rv32_i64_load_store_guarded_655() {
+        let sw = SelectorOptions {
+            bounds: RvBoundsMode::Software { mem_size: 0x10000 },
+            signed_div_overflow_trap: true,
+        };
+        let load = s_with_opts(
+            &[
+                WasmOp::LocalGet(0),
+                WasmOp::I64Load {
+                    offset: 0,
+                    align: 3,
+                },
+                WasmOp::Drop,
+                WasmOp::End,
+            ],
+            1,
+            sw,
+        );
+        assert!(
+            count(&load, |op| matches!(
+                op,
+                RiscVOp::Branch {
+                    cond: Branch::Geu,
+                    ..
+                }
+            )) >= 1
+                && count(&load, |op| matches!(op, RiscVOp::Ebreak)) >= 1,
+            "software mode must guard i64.load (bgeu + ebreak), got: {load:?}"
+        );
+        let mask = SelectorOptions {
+            bounds: RvBoundsMode::Mask { mask: 0xFFFF },
+            signed_div_overflow_trap: true,
+        };
+        let store = s_with_opts(
+            &[
+                WasmOp::LocalGet(0),
+                WasmOp::LocalGet(0),
+                WasmOp::I64ExtendI32U,
+                WasmOp::I64Store {
+                    offset: 0,
+                    align: 3,
+                },
+                WasmOp::End,
+            ],
+            1,
+            mask,
+        );
+        assert!(
+            count(&store, |op| matches!(
+                op,
+                RiscVOp::And { .. } | RiscVOp::Andi { .. }
+            )) >= 1,
+            "mask mode must mask i64.store's effective address, got: {store:?}"
         );
     }
 

--- a/scripts/repro/mask_bounds_655.wat
+++ b/scripts/repro/mask_bounds_655.wat
@@ -1,0 +1,46 @@
+;; #655 — RV32 emit_bounds_check masked the OPERAND before the static offset
+;; was folded (the #651 class, RISC-V twin of ARM PR #654), and i64 accesses
+;; carried no guard at all. Exercised by mask_bounds_655_riscv_differential.py
+;; under `--safety-bounds mask` and `--safety-bounds software`.
+;;
+;; All static offsets stay <= 2047 so the module also compiles on pre-fix
+;; synth (larger offsets fail loudly in offset_to_imm there); the huge-offset
+;; case lives in mask_bounds_655_hugeoff.wat.
+(module
+  (memory 1) ;; 64 KiB — power of two, so mask mode is accepted
+
+  ;; RED (offset escape): in-bound operand + static offset pushes the access
+  ;; past the 64 KiB bound. Pre-fix: `and` the operand, then re-add 2044 in
+  ;; the addressing mode -> reads/writes outside the memory window.
+  (func (export "load_off_esc") (param i32) (result i32)
+    (i32.load offset=2044 (local.get 0)))
+  (func (export "store_off_esc") (param i32 i32)
+    (i32.store offset=2044 (local.get 0) (local.get 1)))
+
+  ;; RED (final-byte overhang): a word load starting in the last 3 bytes must
+  ;; clamp to size-4 so the FINAL byte stays inside the bound.
+  (func (export "load_word") (param i32) (result i32)
+    (i32.load (local.get 0)))
+
+  ;; Exactness guard: byte access at size-1 must be preserved exactly
+  ;; (the ARM twin's latent size-vs-size-1 remap bug; RV32's mask was already
+  ;; size-1 — this pins it).
+  (func (export "load8") (param i32) (result i32)
+    (i32.load8_u (local.get 0)))
+
+  ;; RED (offset escape, halfword): ea == size wraps to 0 under mask
+  ;; semantics; pre-fix it read one past the window.
+  (func (export "load16_off") (param i32) (result i32)
+    (i32.load16_u offset=254 (local.get 0)))
+
+  ;; RED (i64 gap): i64 accesses had NO guard in Software and Mask modes.
+  (func (export "load_i64_lo") (param i32) (result i32)
+    (i32.wrap_i64 (i64.load (local.get 0))))
+  (func (export "load_i64_hi") (param i32) (result i32)
+    (i32.wrap_i64 (i64.shr_u (i64.load (local.get 0)) (i64.const 32))))
+  (func (export "store_i64") (param i32 i32)
+    (i64.store (local.get 0)
+      (i64.or
+        (i64.extend_i32_u (local.get 1))
+        (i64.shl (i64.extend_i32_u (local.get 1)) (i64.const 32)))))
+)

--- a/scripts/repro/mask_bounds_655_hugeoff.wat
+++ b/scripts/repro/mask_bounds_655_hugeoff.wat
@@ -1,0 +1,10 @@
+;; #655 companion — a static offset far beyond imm12. Mask mode folds the
+;; offset into the masked effective address (residual access imm 0), so this
+;; now COMPILES and is bounded exactly (u33 ADD-then-AND soundness); pre-fix
+;; synth rejects it in offset_to_imm. Only compiled under
+;; `--safety-bounds mask` by mask_bounds_655_riscv_differential.py.
+(module
+  (memory 1)
+  (func (export "load_off_huge") (param i32) (result i32)
+    (i32.load offset=0xffff0000 (local.get 0)))
+)

--- a/scripts/repro/mask_bounds_655_riscv_differential.py
+++ b/scripts/repro/mask_bounds_655_riscv_differential.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""#655 — RV32 mask/software bounds: EXECUTION-validate the effective-address fix.
+
+The #651 class, RISC-V twin of ARM PR #654: `emit_bounds_check`'s Mask arm
+masked the OPERAND, then the caller re-added the static offset in the access's
+addressing mode — any non-zero offset escaped the bound. It also never clamped
+a multi-byte access's FINAL byte, and i64 accesses carried NO guard at all
+(Software and Mask alike).
+
+The oracle is the mask-semantics MODEL (PR #654's contract):
+
+    masked = min((operand + offset) & (size-1), size - access_size)
+
+Every exported function of mask_bounds_655.wat runs under unicorn
+(UC_ARCH_RISCV) with the 64 KiB linear memory holding a deterministic byte
+pattern and 0xEE sentinel bytes ABOVE the window; loads must return the
+model's value (an escape reads sentinel — mismatch), stores must land at the
+model address and leave the sentinel region untouched. For in-bounds inputs
+the model coincides with wasm semantics, so those rows double as exactness
+guards. Software mode additionally must TRAP (ebreak) on any access whose
+final byte is out of bounds — including i64 (the unguarded-on-main gap).
+
+RED on pre-fix main (offset escape, halfword wrap, word overhang, i64 rows,
+software-i64 no-trap, huge-offset compile), GREEN on the #655 branch.
+
+Run (needs unicorn + pyelftools):
+  /tmp/synthvenv/bin/python scripts/repro/mask_bounds_655_riscv_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import subprocess
+import sys
+
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_RISCV, UC_MODE_RISCV32, Uc, UcError
+from unicorn.riscv_const import (
+    UC_RISCV_REG_A0,
+    UC_RISCV_REG_A1,
+    UC_RISCV_REG_RA,
+    UC_RISCV_REG_S11,
+    UC_RISCV_REG_SP,
+)
+
+WAT = "scripts/repro/mask_bounds_655.wat"
+WAT_HUGE = "scripts/repro/mask_bounds_655_hugeoff.wat"
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+CODE, LIN, STK, RET = 0x100000, 0x40000, 0x90000, 0x200000
+SIZE = 0x10000  # (memory 1) = 64 KiB
+SENTINEL = 0xEE
+
+# Deterministic, position-dependent linear-memory pattern. The (i >> 8) term
+# breaks the natural period-256 aliasing of a pure affine byte pattern, so two
+# distinct in-window addresses (bug vs model) can't read the same word.
+PATTERN = bytes(((i * 131 + (i >> 8) * 17 + 7) & 0xFF) for i in range(SIZE))
+
+
+def model(operand, offset, access):
+    """PR #654's mask-semantics contract for the guarded start address."""
+    return min((operand + offset) & (SIZE - 1), SIZE - access)
+
+
+def le(mem, addr, n):
+    return int.from_bytes(mem[addr : addr + n], "little")
+
+
+def compile_elf(wat, out, mode):
+    r = subprocess.run(
+        [SYNTH, "compile", wat, "-o", out, "-b", "riscv", "-t", "rv32imac",
+         "--all-exports", "--relocatable", "--safety-bounds", mode],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"},
+    )
+    return r
+
+
+def syms_and_code(elf):
+    """Symbol addresses from the ELF symtab (never disasm text — host-dep)."""
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    base = text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"] - base
+    return syms, text.data()
+
+
+def run_rv(code, fa, args):
+    """Run one export; return (a0, linear_memory_bytes) or ('ERR:…', mem)."""
+    mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+    mu.mem_map(CODE, 0x20000)
+    # Linear memory: 64 KiB pattern window + 64 KiB sentinel ABOVE it, all
+    # mapped — an escaping access must be DETECTED by value/byte checks, not
+    # masked by an unmapped-page fault.
+    mu.mem_map(LIN, 0x20000)
+    mu.mem_write(LIN, PATTERN + bytes([SENTINEL]) * SIZE)
+    mu.mem_map(STK - 0x8000, 0x10000)
+    mu.mem_map(RET, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_RISCV_REG_SP, STK)
+    mu.reg_write(UC_RISCV_REG_S11, LIN)  # s11 = __linear_memory_base
+    for r, v in zip((UC_RISCV_REG_A0, UC_RISCV_REG_A1), args):
+        mu.reg_write(r, v & 0xFFFFFFFF)
+    mu.reg_write(UC_RISCV_REG_RA, RET)
+    try:
+        mu.emu_start(CODE + fa, RET, count=5000)
+    except UcError as e:
+        return f"ERR:{e}", mu.mem_read(LIN, 0x20000)
+    return mu.reg_read(UC_RISCV_REG_A0) & 0xFFFFFFFF, mu.mem_read(LIN, 0x20000)
+
+
+# (export, args, access_size, wat_offset) — loads return the LE value at the
+# model address. Rows marked RED miscompiled (escaped / read unguarded) on
+# pre-fix main.
+LOAD_CASES = [
+    # RED: in-bound operand, offset 2044 escapes -> pre-fix read sentinel.
+    ("load_off_esc", (0xFFFC,), 4, 2044),
+    ("load_off_esc", (0xF000,), 4, 2044),   # fully in-bounds: exactness
+    # RED: word overhang — start size-2 must clamp to size-4.
+    ("load_word", (0xFFFE,), 4, 0),
+    ("load_word", (0x1234,), 4, 0),          # in-bounds exactness
+    # Exactness at the last byte (size-vs-size-1 pin).
+    ("load8", (0xFFFF,), 1, 0),
+    ("load8", (0x0000,), 1, 0),
+    # RED: ea == size wraps to 0 under mask semantics.
+    ("load16_off", (0xFF02,), 2, 254),
+    ("load16_off", (0x0100,), 2, 254),       # in-bounds exactness
+    # RED: i64 had NO guard — start size-4 must clamp to size-8.
+    ("load_i64_lo", (0xFFFC,), 8, 0),
+    ("load_i64_hi", (0xFFFC,), 8, 0),
+    ("load_i64_lo", (0x2000,), 8, 0),         # in-bounds exactness
+    ("load_i64_hi", (0x2000,), 8, 0),
+]
+
+
+def expected_load(func, operand, access, offset):
+    m = model(operand, offset, access)
+    if func == "load_i64_hi":
+        return le(PATTERN, m + 4, 4)
+    n = min(access, 4)
+    return le(PATTERN, m, n)
+
+
+def check_mask_loads(syms, code):
+    fails = 0
+    for func, args, access, offset in LOAD_CASES:
+        got, _ = run_rv(code, syms[func], args)
+        want = expected_load(func, args[0], access, offset)
+        ok = got == want
+        fails += 0 if ok else 1
+        shown = f"0x{got:08x}" if isinstance(got, int) else got
+        tag = "" if ok else "  <-- MISMATCH (escaped the bound?)"
+        print(f"mask {func}{args}: got={shown} model=0x{want:08x}{tag}")
+    return fails
+
+
+def check_mask_stores(syms, code):
+    fails = 0
+    # RED: store with escaping offset — pre-fix wrote into the sentinel.
+    for func, args, access, offset, val_bytes in [
+        ("store_off_esc", (0xFFFC, 0xDEADBEEF), 4, 2044,
+         (0xDEADBEEF).to_bytes(4, "little")),
+        ("store_off_esc", (0x1000, 0xCAFEF00D), 4, 2044,
+         (0xCAFEF00D).to_bytes(4, "little")),
+        # RED: i64 store, start size-4 -> clamp to size-8; value = v|v<<32.
+        ("store_i64", (0xFFFC, 0x0BADF00D), 8, 0,
+         (0x0BADF00D).to_bytes(4, "little") * 2),
+    ]:
+        res, mem = run_rv(code, syms[func], args)
+        if isinstance(res, str):
+            print(f"mask {func}{args}: {res}  <-- TRAPPED (mask must not trap)")
+            fails += 1
+            continue
+        m = model(args[0], offset, access)
+        landed = bytes(mem[m : m + access]) == val_bytes
+        sentinel_ok = all(b == SENTINEL for b in mem[SIZE : 2 * SIZE])
+        ok = landed and sentinel_ok
+        fails += 0 if ok else 1
+        why = "" if ok else (
+            "  <-- ESCAPED: wrote outside the window" if not sentinel_ok
+            else f"  <-- value not at model addr 0x{m:04x}"
+        )
+        print(f"mask {func}{args}: model_addr=0x{m:04x} landed={landed} "
+              f"sentinel_intact={sentinel_ok}{why}")
+    return fails
+
+
+def check_software(syms, code):
+    """Software mode: OOB final byte must TRAP — including i64 (the gap)."""
+    fails = 0
+    cases = [
+        # (func, args, must_trap)
+        ("load_i64_lo", (0xFFFC,), True),   # RED: i64 was unguarded
+        ("store_i64", (0xFFFC, 0x11223344), True),
+        ("load_word", (0xFFFE,), True),      # i32 guard regression pin
+        ("load_off_esc", (0xFFFC,), True),
+        ("load_word", (0x1234,), False),     # in-bounds must NOT trap
+        ("load_i64_lo", (0x2000,), False),
+        ("load8", (0xFFFF,), False),
+    ]
+    for func, args, must_trap in cases:
+        got, _ = run_rv(code, syms[func], args)
+        trapped = isinstance(got, str)
+        ok = trapped == must_trap
+        fails += 0 if ok else 1
+        tag = "" if ok else (
+            "  <-- NO TRAP (unguarded access escaped)" if must_trap
+            else "  <-- SPURIOUS TRAP on an in-bounds access"
+        )
+        shown = got if trapped else f"0x{got:08x}"
+        print(f"software {func}{args}: {shown} "
+              f"(want {'trap' if must_trap else 'value'}){tag}")
+    return fails
+
+
+def check_huge_offset():
+    """Mask mode folds arbitrary 32-bit offsets (u33-sound) — must compile
+    and match the model; pre-fix synth rejects it in offset_to_imm."""
+    elf = "/tmp/mask_bounds_655_huge.o"
+    r = compile_elf(WAT_HUGE, elf, "mask")
+    if r.returncode != 0:
+        print(f"mask hugeoff: COMPILE FAILED  <-- pre-fix offset_to_imm decline\n"
+              f"  {r.stderr.strip().splitlines()[-1] if r.stderr else ''}")
+        return 1
+    syms, code = syms_and_code(elf)
+    fails = 0
+    for operand in (0, 0x1234, 0xFFFC):
+        got, _ = run_rv(code, syms["load_off_huge"], (operand,))
+        want = expected_load("load_off_huge", operand, 4, 0xFFFF0000)
+        ok = got == want
+        fails += 0 if ok else 1
+        shown = f"0x{got:08x}" if isinstance(got, int) else got
+        tag = "" if ok else "  <-- MISMATCH"
+        print(f"mask load_off_huge({operand:#x}): got={shown} "
+              f"model=0x{want:08x}{tag}")
+    return fails
+
+
+def main():
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — `cargo build --release -p synth-cli` first")
+
+    fails = 0
+    mask_elf, sw_elf = "/tmp/mask_bounds_655_mask.o", "/tmp/mask_bounds_655_sw.o"
+    for elf, mode in ((mask_elf, "mask"), (sw_elf, "software")):
+        r = compile_elf(WAT, elf, mode)
+        if r.returncode != 0:
+            sys.exit(f"compile failed ({mode}): {r.stderr}")
+
+    syms, code = syms_and_code(mask_elf)
+    missing = [f for f, *_ in LOAD_CASES if f not in syms]
+    if missing:
+        sys.exit(f"SYMBOL MISSING in mask build: {missing}")
+    fails += check_mask_loads(syms, code)
+    fails += check_mask_stores(syms, code)
+
+    sw_syms, sw_code = syms_and_code(sw_elf)
+    fails += check_software(sw_syms, sw_code)
+
+    fails += check_huge_offset()
+
+    print("ORACLE: PASS" if fails == 0 else f"ORACLE: FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #655 — the #651 class, RISC-V twin of ARM PR #654.

## Sites audited (grep bounds/mask over `synth-backend-riscv`)

| Site | Pre-fix state | Now |
|---|---|---|
| `emit_bounds_check` Mask arm | masked the **operand**, caller re-added the static offset in the access imm — offset escaped the bound; no final-byte clamp | the `mask_effective_address` semantics, in RV32 instructions |
| `lower_load_word` / `lower_load_subword` / `lower_store` | re-added `offset` after the mask | consume the residual offset returned by the guard (0 under Mask) |
| `lower_i64_load` / `lower_i64_store` | **NO guard at all** — in Software *and* Mask modes | guard the full 8-byte access like the i32 lowerings |
| `emit_bounds_check` Software arm | already correct: folds `offset + access_size - 1`, `bgeu guard, size` on the final byte (size with `>=` on the last byte ≡ size-1 bound on it) | unchanged |
| Mask value (size vs size-1) | already `mem_size - 1` (`build_options`), non-power-of-two **declines loudly** at compile time — RV32 never had ARM's latent R10-is-SIZE remap | pinned by the oracle's exactness rows |

## The fix

`emit_bounds_check` now returns `(reg, residual_offset)`. The Mask arm computes

```
masked = min((operand + offset) & (size-1), size - access_size)
```

```
[addi/li+add ea, addr, offset]   ; fold the static offset FIRST
 andi/li+and masked, ea, size-1  ; bound the first byte
[li limit, size-access_size      ; clamp the START so the FINAL byte
 bgeu limit, masked, Lok         ;   (start + access_size - 1) stays inside
 mv masked, limit ; Lok:]        ;   — skipped for byte accesses
 lw/sw …, 0(base+masked)         ; residual offset 0 — nothing re-added
```

u33 soundness of ADD-then-AND (mirrors #654): `ea = operand + offset < 2^33`; the RV `add` computes `ea mod 2^32` and every set bit of `size-1 < 2^32` lies below bit 32, so the u33 carry is annihilated by the AND either way. Arbitrary 32-bit static offsets are handled exactly — Mask mode now **accepts offsets > 2047** that `offset_to_imm` previously declined.

## Red → green

`scripts/repro/mask_bounds_655_riscv_differential.py` (+ 2 `.wat`) — unicorn RV32 execution vs the mask-semantics model, with a deterministic non-periodic pattern in the 64 KiB window and an `0xEE` sentinel region above it (escapes are detected by value/byte checks, not by an unmapped-page fault); Software mode additionally asserts trap/no-trap.

- **origin/main (22517cb): ORACLE: FAIL (10)** — offset-escape load (`0xeeeeeeee` from the sentinel) + store (`sentinel_intact=False`), word final-byte overhang, halfword wrap at `ea == size`, i64 mask escapes (lo *and* hi), software-mode i64 load **and** store return instead of trapping, huge-offset compile decline.
- **this branch: ORACLE: PASS** — all red rows green, plus in-bounds exactness rows (byte load at `size-1`, word/halfword/i64 in-bounds) and software in-bounds no-trap rows.

Selector shape tests: `rv32_mask_folds_offset_before_and_655` (access imm must be 0; the offset-add precedes the AND), `rv32_mask_clamps_final_byte_for_multibyte_only_655` (word clamps, byte doesn't pay), `rv32_i64_load_store_guarded_655`.

## Gates

- frozen anchors **10/10** (`frozen_codegen_bytes`, including the RV32 gate — the default RV32 bounds mode is `None`, which emits nothing; fixtures don't use `--safety-bounds`, goldens untouched)
- `cargo test --workspace`: 107 suites, 0 failures
- `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean
- rebased onto `origin/main` (22517cb, post-v0.34.0)

Refs #651, #654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
