### PR TITLE
spike(vcr-isa-001): Sail/ASL-derived semantics bridge — AArch32 ADD/ADDS/CMP proven ≡ ArmSemantics.v (#242)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -559,6 +559,32 @@ artifacts:
       model supplies natively) is the precondition. This also gates VCR-SEL-001
       coverage of the control-flow op class (div/rem) — straight-line and
       scratch-using ops generalize without it, control-flow ops do not.
+
+      FEASIBILITY SPIKE DONE (2026-07-08, docs/design/vcr-isa-001-spike.md):
+      the 2026-06-10 gate is answered. Tool: VERIFIED alive (Sail 0.20 via
+      nixpkgs ships --coq, bbv|stdpp styles; coq-sail maintained). Generated
+      ARM model IMPORT: REFUTED as a build path — sail-arm arm-v9.4-a covers
+      all of T32/A32 (instrs32.sail) but its Coq snapshot is a single 42 MB
+      armv9.v pinned to stdpp-unstable + git-pinned coq-sail-stdpp (the 2019
+      v8.5 snapshot needed ~40 GB RAM on Coq 8.9.1) — incompatible with the
+      hermetic Rocq 9 Bazel toolchain and CI. WORKING ALTERNATIVE LANDED:
+      per-instruction transcribe-and-bridge — coq/Synth/ARM/SailArmBridge.v
+      (in //coq:verify_proofs, 23 Qed / 0 Admitted) hand-transcribes
+      AddWithCarry + the AArch32 ADD/CMP register-form execute clauses from
+      sail-arm @ 1bf2e5574ba9 with file:line provenance, and proves
+      ArmSemantics.v's ADD/ADDS/CMP ≡ the transcription on registers AND all
+      four NZCV flags (the six hand-written compute_*_flag definitions equal
+      ASL's AddWithCarry outputs — the foundation under every CMP-based
+      comparison lowering). Abstraction gaps documented in-file: shift_n=0,
+      d<>15 (no PC — the executor gap above is NOT closed by the bridge and
+      stays this item's core prerequisite), no IT blocks, bits(32) as Z mod
+      2^32. Measured cost: flag machinery proven once (~230 lines incl.
+      reusable mod-case/testbit/NOT helpers + blast tactics); remaining
+      AddWithCarry family (SUB/SUBS/CMN/RSB) near-free, ~0.5-1 day per
+      remaining straight-line op class; memory ops widest gap (byte-addressed
+      Sail memory vs Z->I32 model). RISC-V half unmeasured — sail-riscv's
+      maintained Coq export may admit the import path there; re-evaluate
+      separately.
     status: proposed
     tags: [semantics, sail, isa, trust, rocq, track-b, unblocks-admits]
     links:
@@ -578,6 +604,13 @@ artifacts:
         bounded feasibility SPIKE (can the Sail RV32 Rocq export build + one
         instruction's semantics be related to ArmSemantics/RiscvSemantics?)
         must precede any release commitment.
+        GATE ANSWERED for the ARM half (spike 2026-07-08, evidence
+        docs/design/vcr-isa-001-spike.md + coq/Synth/ARM/SailArmBridge.v):
+        one instruction family bridged end-to-end with Qed proofs; criterion
+        for the item REVISED accordingly — re-discharge is per-instruction
+        transcribe-and-bridge against provenance-pinned Sail source, not
+        against an imported generated model. RV32 export build remains
+        unmeasured (the spike's ARM no-go on import does not transfer).
 
   - id: VCR-WASM-001
     type: sw-req

--- a/coq/BUILD.bazel
+++ b/coq/BUILD.bazel
@@ -73,6 +73,16 @@ rocq_library(
     deps = [":arm_semantics"],
 )
 
+# VCR-ISA-001 spike (#242): Sail/ASL-derived semantics bridge — AArch32
+# ADD/ADDS/CMP (register) transcribed from rems-project/sail-arm with
+# line-level provenance, proven ≡ ArmSemantics.v on registers + NZCV.
+rocq_library(
+    name = "sail_arm_bridge",
+    srcs = ["Synth/ARM/SailArmBridge.v"],
+    include_path = "Synth",
+    deps = [":base", ":common", ":arm_state", ":arm_instructions", ":arm_semantics"],
+)
+
 rocq_library(
     name = "arm_refinement",
     srcs = ["Synth/ARM/ArmRefinement.v"],
@@ -232,6 +242,7 @@ rocq_proof_test(
         ":correctness_complete",
         ":extraction",
         ":arm_refinement",
+        ":sail_arm_bridge",
         ":vcr_sel_pilot",
         ":vcr_sel_rules",
     ],

--- a/coq/Synth/ARM/SailArmBridge.v
+++ b/coq/Synth/ARM/SailArmBridge.v
@@ -1,0 +1,476 @@
+(** * VCR-ISA-001 SPIKE — Sail/ASL-derived semantics bridge (AArch32 ADD/ADDS/CMP, register forms)
+
+    GOAL (epic #242, VCR-ISA-001). ArmSemantics.v is a HAND-WRITTEN ARM model:
+    every correctness theorem in this suite (including the 21 VCR-SEL-001 rule
+    theorems) is "consistent with our own model" — a modeling bug is invisible
+    to the proofs. VCR-ISA-001 wants the model anchored on an INDEPENDENTLY
+    derived semantics: Arm's own machine-readable ASL specification, as
+    translated to Sail by the REMS asl_to_sail tool (rems-project/sail-arm).
+
+    WHAT THIS FILE IS. The spike's measured outcome (docs/design/
+    vcr-isa-001-spike.md) is that importing the Sail-GENERATED Rocq model
+    wholesale is a no-go at synth's scale: the arm-v9.4-a Coq snapshot is a
+    single 42 MB armv9.v pinned to stdpp-unstable + coq-sail-stdpp, and the
+    older v8.5 snapshot needed ~40 GB RAM on Coq 8.9.1. The viable re-basing
+    path is per instruction: transcribe the Sail execute semantics BY HAND,
+    with line-level provenance to the Sail source, and prove a BRIDGE lemma
+    that ArmSemantics.v's instruction ≡ the transcription on the shared state
+    projection. This file does that end-to-end for ONE instruction family —
+    AArch32 ADD (register): ADD (result only), ADDS (result + NZCV), and, as
+    the subtraction-flags counterpart the comparison rules rest on, CMP
+    (register) — so the per-instruction cost and the abstraction gaps are
+    measured facts, not estimates.
+
+    PROVENANCE. All quoted Sail is from rems-project/sail-arm @ master
+    (commit 1bf2e5574ba9, 2026-06-19), model arm-v9.4-a, which the repo README
+    states is derived from the 2023-03 version of Arm's ASL specification via
+    the automatic asl_to_sail translation:
+
+      - AddWithCarry              arm-v9.4-a/src/v8_base.sail:13337
+      - execute ADD (register)    arm-v9.4-a/src/instrs32.sail:457
+        (execute_aarch32_instrs_ADD_r_Op_A_txt)
+      - decode T1 (16-bit Thumb)  arm-v9.4-a/src/instrs32.sail:512
+        (shift_t = SRType_LSL, shift_n = 0, setflags = !InITBlock())
+      - execute CMP (register)    instrs32.sail
+        (execute_aarch32_instrs_CMP_r_Op_A_txt:
+         "AddWithCarry(R[n], NOT(shifted), '1')", flags-only)
+      - Shift_C amount=0 identity arm-v9.4-a/src/v8_base.sail:41273
+        ("if amount == 0 then (result, carry_out) = (value_name, carry_in)")
+
+    THE TRANSCRIBED SLICE. The ADD execute clause, restricted to what synth's
+    encoder emits for this instruction:
+
+      function execute_aarch32_instrs_ADD_r_Op_A_txt
+               (d, m, n, setflags, shift_n, shift_t) = {
+          let shifted : bits(32) = Shift(R_read(m), shift_t, shift_n, PSTATE.C);
+          (result, nzcv) = AddWithCarry(R_read(n), shifted, 0b0);
+          if d == 15 then { ... ALUWritePC ... } else {
+              R_set(d) = result;
+              if setflags then {
+                  (PSTATE.N @ PSTATE.Z @ PSTATE.C @ PSTATE.V) = nzcv
+              };
+          }
+      }
+
+    ABSTRACTION GAPS (explicit, in trade for tractability):
+      1. shift_n = 0: synth emits plain register forms (no shifted operand),
+         and Shift_C with amount 0 is the identity on the value and the carry
+         (v8_base.sail:41273), so [shifted = R_read(m)] and PSTATE.C is not
+         read. The RegShift operand2 form is outside this bridge (it is also
+         only half-modeled in ArmSemantics.v's eval_operand2).
+      2. d <> 15: the ALUWritePC branch is out of scope — ArmSemantics.v has
+         no PC-indexed executor (the known VCR-ISA-001 gap that also blocks
+         the div/rem trap-guard admits), and synth's selector never assigns
+         PC via ADD.
+      3. ConditionPassed() = true: unconditional execution; synth does not
+         emit ADD inside IT blocks.
+      4. bits(32) is rendered as I32.int (Z modulo 2^32): Sail/ASL UInt maps
+         to I32.unsigned, SInt to I32.signed, bit extraction result<31> to
+         Z.testbit. The residual trust is the fidelity of this hand
+         transcription — reviewable line-by-line against the quoted Sail —
+         instead of the fidelity of the whole hand-written model.
+
+    THE BRIDGE. [sail_bridge_add_reg], [sail_bridge_adds_reg] and
+    [sail_bridge_cmp_reg] prove that exec_instr's ADD/ADDS/CMP agree with the
+    transcription EXACTLY (register write and all four NZCV flags — no flag
+    is ignored). In particular the six hand-written flag definitions
+    (compute_n_flag / compute_z_flag / compute_c_flag_add /
+    compute_v_flag_add / compute_c_flag_sub / compute_v_flag_sub), on which
+    Compilation.v's CMP-based comparison lowerings and the VcrSelRules.v
+    comparison rules ultimately rest, are proven equal to ASL's AddWithCarry
+    flag outputs. *)
+
+From Stdlib Require Import ZArith.
+From Stdlib Require Import List.
+From Stdlib Require Import Bool.
+From Stdlib Require Import Lia.
+Require Import Synth.Common.Base.
+Require Import Synth.Common.Integers.
+Require Import Synth.ARM.ArmState.
+Require Import Synth.ARM.ArmInstructions.
+Require Import Synth.ARM.ArmSemantics.
+
+Import ListNotations.
+Open Scope Z_scope.
+
+(** ** Transcription of the Sail definitions *)
+
+(** [AddWithCarry] — v8_base.sail:13337 (N = 32):
+
+      function AddWithCarry (x, y, carry_in) = {
+          let 'unsigned_sum = UInt(x) + UInt(y) + UInt(carry_in);
+          let 'signed_sum = SInt(x) + SInt(y) + UInt(carry_in);
+          let result : bits('N) = unsigned_sum['N - 1 .. 0];
+          let n : bits(1) = [result['N - 1]];
+          let z : bits(1) = if IsZero(result) then 0b1 else 0b0;
+          let c : bits(1) = if UInt(result) == unsigned_sum then 0b0 else 0b1;
+          let v : bits(1) = if SInt(result) == signed_sum then 0b0 else 0b1;
+          return((result, ((n @ z) @ c) @ v))
+      }
+
+    Rendering: UInt = I32.unsigned, SInt = I32.signed,
+    unsigned_sum<31..0> = I32.repr unsigned_sum, result<31> = Z.testbit _ 31,
+    IsZero = (=? 0). The nzcv tuple is kept in ASL order (n, z, c, v). *)
+Definition sail_add_with_carry (x y : I32.int) (carry_in : bool)
+    : I32.int * (bool * bool * bool * bool) :=
+  let carry : Z := if carry_in then 1 else 0 in
+  let unsigned_sum := I32.unsigned x + I32.unsigned y + carry in
+  let signed_sum := I32.signed x + I32.signed y + carry in
+  let result := I32.repr unsigned_sum in
+  let n := Z.testbit (I32.unsigned result) 31 in
+  let z := Z.eqb (I32.unsigned result) 0 in
+  let c := negb (Z.eqb (I32.unsigned result) unsigned_sum) in
+  let v := negb (Z.eqb (I32.signed result) signed_sum) in
+  (result, (n, z, c, v)).
+
+(** [NOT] on bits(32) — used by the SUB/CMP execute clauses
+    ("AddWithCarry(R[n], NOT(shifted), '1')"). Bitwise complement over Z,
+    brought back into range by repr — the same rendering ArmSemantics.v uses
+    for MVN. *)
+Definition sail_not (y : I32.int) : I32.int :=
+  I32.repr (Z.lnot (I32.unsigned y)).
+
+(** The ADD (register) execute clause, d <> 15, shift_n = 0 (gaps 1-3 above):
+    [shifted = R_read(m)], so the addition is AddWithCarry(R[n], R[m], '0'). *)
+Definition sail_add_r_result (rn_val rm_val : I32.int) : I32.int :=
+  fst (sail_add_with_carry rn_val rm_val false).
+
+Definition sail_add_r_flags (rn_val rm_val : I32.int) : condition_flags :=
+  let '(_, (n, z, c, v)) := sail_add_with_carry rn_val rm_val false in
+  mkFlags n z c v.
+
+(** The CMP (register) execute clause, shift_n = 0: flags-only,
+    AddWithCarry(R[n], NOT(R[m]), '1'). *)
+Definition sail_cmp_r_flags (rn_val rm_val : I32.int) : condition_flags :=
+  let '(_, (n, z, c, v)) := sail_add_with_carry rn_val (sail_not rm_val) true in
+  mkFlags n z c v.
+
+(** ** Arithmetic helpers *)
+
+Lemma modulus_val : I32.modulus = 4294967296.
+Proof. reflexivity. Qed.
+
+Lemma half_modulus_val : I32.half_modulus = 2147483648.
+Proof. reflexivity. Qed.
+
+Lemma modulus_nz : I32.modulus <> 0.
+Proof. rewrite modulus_val. lia. Qed.
+
+Lemma unsigned_range : forall x : I32.int,
+  0 <= I32.unsigned x < I32.modulus.
+Proof.
+  intros. unfold I32.unsigned. apply Z.mod_pos_bound.
+  rewrite modulus_val. lia.
+Qed.
+
+(** The Sail-side sum-of-unsigneds representative equals our I32.add. *)
+Lemma repr_add_unsigned : forall x y : I32.int,
+  I32.repr (I32.unsigned x + I32.unsigned y) = I32.add x y.
+Proof.
+  intros. unfold I32.add, I32.repr, I32.unsigned.
+  symmetry. apply Z.add_mod. apply modulus_nz.
+Qed.
+
+(** The Sail-side CMP representative (x + NOT y + 1) equals our I32.sub. *)
+Lemma repr_sub_unsigned : forall x y : I32.int,
+  I32.repr (I32.unsigned x + (I32.modulus - 1 - I32.unsigned y) + 1)
+  = I32.sub x y.
+Proof.
+  intros. unfold I32.sub, I32.repr, I32.unsigned.
+  replace (x mod I32.modulus + (I32.modulus - 1 - y mod I32.modulus) + 1)
+    with ((x mod I32.modulus - y mod I32.modulus) + 1 * I32.modulus) by lia.
+  rewrite Z_mod_plus_full.
+  rewrite <- Zminus_mod. reflexivity.
+Qed.
+
+(** Splitting the mod of a sum of two in-range values. *)
+Lemma sum_mod_cases : forall a b,
+  0 <= a < I32.modulus -> 0 <= b < I32.modulus ->
+  ((a + b) mod I32.modulus = a + b /\ a + b < I32.modulus) \/
+  ((a + b) mod I32.modulus = a + b - I32.modulus /\ I32.modulus <= a + b).
+Proof.
+  intros a b Ha Hb.
+  destruct (Z_lt_ge_dec (a + b) I32.modulus) as [L | G].
+  - left. split; [apply Z.mod_small; lia | lia].
+  - right. split; [| lia].
+    assert (Hrw : a + b = (a + b - I32.modulus) + 1 * I32.modulus) by lia.
+    rewrite Hrw at 1.
+    rewrite Z_mod_plus_full. apply Z.mod_small. lia.
+Qed.
+
+(** Splitting the mod of a difference of two in-range values. *)
+Lemma diff_mod_cases : forall a b,
+  0 <= a < I32.modulus -> 0 <= b < I32.modulus ->
+  ((a - b) mod I32.modulus = a - b /\ b <= a) \/
+  ((a - b) mod I32.modulus = a - b + I32.modulus /\ a < b).
+Proof.
+  intros a b Ha Hb.
+  destruct (Z_le_gt_dec b a) as [L | G].
+  - left. split; [apply Z.mod_small; lia | lia].
+  - right. split; [| lia].
+    assert (Hrw : a - b = (a - b + I32.modulus) + (-1) * I32.modulus) by lia.
+    rewrite Hrw at 1.
+    rewrite Z_mod_plus_full. apply Z.mod_small. lia.
+Qed.
+
+(** Bit 31 of an in-range value is its top (sign) bit. *)
+Lemma testbit31_ge : forall u,
+  0 <= u < I32.modulus ->
+  Z.testbit u 31 = (I32.half_modulus <=? u).
+Proof.
+  intros u Hu. rewrite modulus_val in Hu.
+  assert (E : Z.testbit u 31 = Z.odd (u / 2 ^ 31)).
+  { rewrite <- Z.bit0_odd. rewrite <- Z.shiftr_div_pow2 by lia.
+    rewrite Z.shiftr_spec by lia. reflexivity. }
+  rewrite E.
+  assert (Hdiv : u / 2 ^ 31 = (if I32.half_modulus <=? u then 1 else 0)).
+  { change (2 ^ 31) with 2147483648.
+    destruct (Z.leb_spec I32.half_modulus u) as [L | L];
+      rewrite half_modulus_val in L.
+    - assert (1 <= u / 2147483648) by (apply Z.div_le_lower_bound; lia).
+      assert (u / 2147483648 < 2) by (apply Z.div_lt_upper_bound; lia).
+      lia.
+    - apply Z.div_small. lia. }
+  rewrite Hdiv. destruct (I32.half_modulus <=? u); reflexivity.
+Qed.
+
+(** [NOT(y)] = modulus - 1 - y on the unsigned view. *)
+Lemma unsigned_not : forall y : I32.int,
+  I32.unsigned (sail_not y) = I32.modulus - 1 - I32.unsigned y.
+Proof.
+  intros. unfold sail_not, I32.repr, I32.unsigned.
+  rewrite Zmod_mod.
+  pose proof (unsigned_range y) as Hy. unfold I32.unsigned in Hy.
+  assert (L : Z.lnot (y mod I32.modulus) = - (y mod I32.modulus) - 1)
+    by (unfold Z.lnot; lia).
+  rewrite L.
+  replace (- (y mod I32.modulus) - 1)
+    with ((I32.modulus - 1 - y mod I32.modulus) + (-1) * I32.modulus) by lia.
+  rewrite Z_mod_plus_full.
+  apply Z.mod_small. lia.
+Qed.
+
+(** [NOT(y)] = -1 - y on the signed view (two's complement identity). *)
+Lemma signed_not : forall y : I32.int,
+  I32.signed (sail_not y) = - 1 - I32.signed y.
+Proof.
+  intros. unfold I32.signed. cbv zeta.
+  rewrite unsigned_not.
+  pose proof (unsigned_range y) as Hy.
+  assert (HMH : I32.modulus = 2 * I32.half_modulus) by reflexivity.
+  assert (HH : 0 < I32.half_modulus) by (rewrite half_modulus_val; lia).
+  destruct (Z.ltb_spec0 (I32.modulus - 1 - I32.unsigned y) I32.half_modulus);
+    destruct (Z.ltb_spec0 (I32.unsigned y) I32.half_modulus); lia.
+Qed.
+
+(** ** Tactics: reduce boolean [if]s (all conditions here are Z.ltb),
+    then blast the remaining decidable comparisons. *)
+
+Ltac destruct_ifs :=
+  repeat match goal with
+  | |- context [if ?b then _ else _] =>
+      let E := fresh "Eif" in
+      destruct b eqn:E;
+      repeat match goal with
+             | H : (_ <? _) = true |- _ => apply Z.ltb_lt in H
+             | H : (_ <? _) = false |- _ => apply Z.ltb_ge in H
+             end
+  end.
+
+Ltac bool_blast :=
+  repeat first
+    [ progress cbn [negb andb orb]
+    | match goal with
+      | |- context [Z.eqb ?a ?b] => destruct (Z.eqb_spec a b)
+      | |- context [Z.ltb ?a ?b] => destruct (Z.ltb_spec0 a b)
+      | |- context [Z.leb ?a ?b] => destruct (Z.leb_spec0 a b)
+      end ];
+  try reflexivity; try lia.
+
+(** ** Per-flag bridges: the hand-written flag definitions of
+    ArmSemantics.v equal the ASL AddWithCarry outputs. *)
+
+(** N: ASL "result<31>" ≡ our "signed result < 0". *)
+Lemma sail_bridge_n_flag : forall r : I32.int,
+  Z.testbit (I32.unsigned r) 31 = compute_n_flag r.
+Proof.
+  intros.
+  rewrite (testbit31_ge _ (unsigned_range r)).
+  unfold compute_n_flag, I32.signed. cbv zeta.
+  pose proof (unsigned_range r) as Hr.
+  assert (HMH : I32.modulus = 2 * I32.half_modulus) by reflexivity.
+  assert (HH : 0 < I32.half_modulus) by (rewrite half_modulus_val; lia).
+  destruct_ifs; bool_blast.
+Qed.
+
+(** Z: ASL "IsZero(result)" ≡ our "result == 0". *)
+Lemma sail_bridge_z_flag : forall r : I32.int,
+  (I32.unsigned r =? 0) = compute_z_flag r.
+Proof.
+  intros. unfold compute_z_flag, I32.eq.
+  assert (E : I32.unsigned I32.zero = 0) by reflexivity.
+  rewrite E. reflexivity.
+Qed.
+
+(** C (addition): ASL "UInt(result) != unsigned_sum" ≡ our unsigned-overflow
+    test "max_unsigned < ux + uy". *)
+Lemma sail_bridge_c_flag_add : forall x y : I32.int,
+  negb (I32.unsigned (I32.add x y) =? I32.unsigned x + I32.unsigned y)
+  = compute_c_flag_add x y.
+Proof.
+  intros.
+  pose proof (unsigned_range x) as Hx.
+  pose proof (unsigned_range y) as Hy.
+  pose proof modulus_nz as Hnz.
+  assert (Hu : I32.unsigned (I32.add x y)
+               = (I32.unsigned x + I32.unsigned y) mod I32.modulus).
+  { unfold I32.add, I32.repr, I32.unsigned.
+    rewrite Zmod_mod. apply Z.add_mod. apply modulus_nz. }
+  unfold compute_c_flag_add, I32.max_unsigned. cbv zeta.
+  rewrite Hu.
+  destruct (sum_mod_cases _ _ Hx Hy) as [[E L] | [E L]]; rewrite E; bool_blast.
+Qed.
+
+(** V (addition): ASL "SInt(result) != signed_sum" ≡ our sign-pattern test
+    "(pos + pos = neg) or (neg + neg = pos)". *)
+Lemma sail_bridge_v_flag_add : forall x y : I32.int,
+  negb (I32.signed (I32.add x y) =? I32.signed x + I32.signed y)
+  = compute_v_flag_add x y (I32.add x y).
+Proof.
+  intros.
+  pose proof (unsigned_range x) as Hx.
+  pose proof (unsigned_range y) as Hy.
+  assert (HMH : I32.modulus = 2 * I32.half_modulus) by reflexivity.
+  assert (HH : 0 < I32.half_modulus) by (rewrite half_modulus_val; lia).
+  assert (Hu : I32.unsigned (I32.add x y)
+               = (I32.unsigned x + I32.unsigned y) mod I32.modulus).
+  { unfold I32.add, I32.repr, I32.unsigned.
+    rewrite Zmod_mod. apply Z.add_mod. apply modulus_nz. }
+  unfold compute_v_flag_add, I32.signed. cbv zeta.
+  rewrite Hu.
+  destruct (sum_mod_cases _ _ Hx Hy) as [[E L] | [E L]]; rewrite E;
+    destruct_ifs; bool_blast.
+Qed.
+
+(** C (subtraction/CMP): ASL "UInt(result) != UInt(x) + UInt(NOT y) + 1"
+    ≡ our no-borrow test "uy <= ux". *)
+Lemma sail_bridge_c_flag_sub : forall x y : I32.int,
+  negb (I32.unsigned (I32.sub x y)
+        =? I32.unsigned x + (I32.modulus - 1 - I32.unsigned y) + 1)
+  = compute_c_flag_sub x y.
+Proof.
+  intros.
+  pose proof (unsigned_range x) as Hx.
+  pose proof (unsigned_range y) as Hy.
+  pose proof modulus_nz as Hnz.
+  assert (Hu : I32.unsigned (I32.sub x y)
+               = (I32.unsigned x - I32.unsigned y) mod I32.modulus).
+  { unfold I32.sub, I32.repr, I32.unsigned.
+    rewrite Zmod_mod. apply Zminus_mod. }
+  unfold compute_c_flag_sub. cbv zeta.
+  rewrite Hu.
+  destruct (diff_mod_cases _ _ Hx Hy) as [[E L] | [E L]]; rewrite E; bool_blast.
+Qed.
+
+(** V (subtraction/CMP): ASL "SInt(result) != SInt(x) + SInt(NOT y) + 1"
+    ≡ our sign-pattern test "(pos - neg = neg) or (neg - pos = pos)". *)
+Lemma sail_bridge_v_flag_sub : forall x y : I32.int,
+  negb (I32.signed (I32.sub x y) =? I32.signed x + (- 1 - I32.signed y) + 1)
+  = compute_v_flag_sub x y.
+Proof.
+  intros.
+  pose proof (unsigned_range x) as Hx.
+  pose proof (unsigned_range y) as Hy.
+  assert (HMH : I32.modulus = 2 * I32.half_modulus) by reflexivity.
+  assert (HH : 0 < I32.half_modulus) by (rewrite half_modulus_val; lia).
+  assert (Hu : I32.unsigned (I32.sub x y)
+               = (I32.unsigned x - I32.unsigned y) mod I32.modulus).
+  { unfold I32.sub, I32.repr, I32.unsigned.
+    rewrite Zmod_mod. apply Zminus_mod. }
+  unfold compute_v_flag_sub, I32.signed. cbv zeta.
+  rewrite Hu.
+  destruct (diff_mod_cases _ _ Hx Hy) as [[E L] | [E L]]; rewrite E;
+    destruct_ifs; bool_blast.
+Qed.
+
+(** ** Whole-instruction correspondence *)
+
+(** The transcribed AddWithCarry result equals our I32.add. *)
+Lemma sail_add_r_result_eq : forall x y,
+  sail_add_r_result x y = I32.add x y.
+Proof.
+  intros. unfold sail_add_r_result, sail_add_with_carry.
+  cbv beta iota zeta. cbn [fst].
+  rewrite Z.add_0_r. apply repr_add_unsigned.
+Qed.
+
+(** The transcribed AddWithCarry NZCV equals our ADDS flag computation. *)
+Lemma sail_add_r_flags_eq : forall x y,
+  sail_add_r_flags x y
+  = update_flags_arith (I32.add x y) (compute_c_flag_add x y)
+                       (compute_v_flag_add x y (I32.add x y)).
+Proof.
+  intros. unfold sail_add_r_flags, sail_add_with_carry.
+  cbv beta iota zeta.
+  rewrite !Z.add_0_r.
+  rewrite repr_add_unsigned.
+  unfold update_flags_arith.
+  (* the Z component is definitionally equal (f_equal closes it); N/C/V need
+     the per-flag bridges — sail_bridge_z_flag records the Z fact anyway *)
+  f_equal.
+  - apply sail_bridge_n_flag.
+  - apply sail_bridge_c_flag_add.
+  - apply sail_bridge_v_flag_add.
+Qed.
+
+(** The transcribed CMP NZCV equals our CMP flag computation. *)
+Lemma sail_cmp_r_flags_eq : forall x y,
+  sail_cmp_r_flags x y
+  = update_flags_arith (I32.sub x y) (compute_c_flag_sub x y)
+                       (compute_v_flag_sub x y).
+Proof.
+  intros. unfold sail_cmp_r_flags, sail_add_with_carry.
+  cbv beta iota zeta.
+  rewrite unsigned_not, signed_not.
+  rewrite repr_sub_unsigned.
+  unfold update_flags_arith.
+  f_equal.
+  - apply sail_bridge_n_flag.
+  - apply sail_bridge_c_flag_sub.
+  - apply sail_bridge_v_flag_sub.
+Qed.
+
+(** *** The bridge theorems — ArmSemantics.v ≡ the Sail/ASL transcription
+    on the full observable state (destination register + NZCV). *)
+
+(** ADD (register), setflags = false — e.g. T2 encoding outside an IT block,
+    or the T3/A1 encodings with S=0. Sail: R_set(d) = result, PSTATE
+    untouched. Ours: exec_instr (ADD ...). The states agree EXACTLY. *)
+Theorem sail_bridge_add_reg : forall s rd rn rm,
+  exec_instr (ADD rd rn (Reg rm)) s
+  = Some (set_reg s rd (sail_add_r_result (get_reg s rn) (get_reg s rm))).
+Proof.
+  intros. rewrite sail_add_r_result_eq. reflexivity.
+Qed.
+
+(** ADDS (register), setflags = true — e.g. the T1 encoding outside an IT
+    block ("setflags = !InITBlock()", instrs32.sail:512). Result register AND
+    all four PSTATE.{N,Z,C,V} agree EXACTLY. *)
+Theorem sail_bridge_adds_reg : forall s rd rn rm,
+  exec_instr (ADDS rd rn (Reg rm)) s
+  = Some (set_flags
+            (set_reg s rd (sail_add_r_result (get_reg s rn) (get_reg s rm)))
+            (sail_add_r_flags (get_reg s rn) (get_reg s rm))).
+Proof.
+  intros. rewrite sail_add_r_result_eq, sail_add_r_flags_eq. reflexivity.
+Qed.
+
+(** CMP (register): flags-only, "AddWithCarry(R[n], NOT(shifted), '1')".
+    All four PSTATE.{N,Z,C,V} agree EXACTLY — this is the foundation under
+    every CMP+conditional lowering in Compilation.v and VcrSelRules.v. *)
+Theorem sail_bridge_cmp_reg : forall s rn rm,
+  exec_instr (CMP rn (Reg rm)) s
+  = Some (set_flags s (sail_cmp_r_flags (get_reg s rn) (get_reg s rm))).
+Proof.
+  intros. rewrite sail_cmp_r_flags_eq. reflexivity.
+Qed.

--- a/coq/_CoqProject
+++ b/coq/_CoqProject
@@ -17,6 +17,7 @@ Synth/ARM/ArmInstructions.v
 Synth/ARM/ArmSemantics.v
 Synth/ARM/ArmFlagLemmas.v
 Synth/ARM/ArmRefinement.v
+Synth/ARM/SailArmBridge.v
 
 # WebAssembly semantics
 Synth/WASM/WasmValues.v

--- a/docs/design/vcr-isa-001-spike.md
+++ b/docs/design/vcr-isa-001-spike.md
@@ -1,0 +1,135 @@
+# VCR-ISA-001 Feasibility Spike — Sail/ASL-derived ARM semantics (2026-07-08)
+
+**Verdict: GO — but on the transcribe-and-bridge path, not the import path.**
+Importing the Sail-generated Rocq model wholesale is a no-go at synth's scale
+(measured below). Hand-transcribing the Sail execute semantics per instruction
+with line-level provenance, then proving a bridge lemma against
+`ArmSemantics.v`, works end-to-end today: this spike shipped
+`coq/Synth/ARM/SailArmBridge.v` with **23 Qed (3 bridge theorems + 6 per-flag
+lemmas + helpers) / 0 Admitted**
+covering the AArch32 ADD (register) family — ADD, ADDS (all four NZCV flags),
+and CMP — compiled by the existing hermetic Rocq 9 Bazel toolchain and wired
+into `//coq:verify_proofs` (green).
+
+Epic: #242. Roadmap artifact: `artifacts/verified-codegen-roadmap.yaml`
+(VCR-ISA-001, stays `proposed`; this document is the spike evidence the
+2026-06-10 deep-research gate demanded).
+
+## 1. Survey: what exists for Sail→Rocq today
+
+Verified directly against the repositories on 2026-07-08 (not from memory):
+
+| Artifact | State | Evidence |
+|---|---|---|
+| Sail tool Rocq backend | **Alive.** Sail 0.20.0 ships `--coq` (`--coq-lib-style {bbv\|stdpp}`), plus a newer `--lean` target. Installable in seconds via `nix-shell -p ocamlPackages.sail` (cached). | ran `sail --help` locally |
+| Rocq support library | `rems-project/coq-sail` maintained (bbv and stdpp flavours; opam `coq-sail` / `coq-sail-stdpp`). | repo README |
+| **sail-arm arm-v9.4-a** | Full AArch32+AArch64 model derived from Arm's 2023-03 ASL by `asl_to_sail`. `src/instrs32.sail` (1.9 MB) contains every T32/A32 instruction incl. all four ADD (register) encodings. `gen_coq` Makefile target exists. | repo listing; quoted sources below |
+| arm-v9.4-a **Coq snapshot** | `snapshots/coq/armv9.v` is a **single 42 MB .v file** (+1 MB types), requiring stdpp-**unstable** (not in opam, MPI-SWS GitLab pin) and `coq-sail-stdpp` pinned from git. | `snapshots/coq/README` |
+| arm-v8.5-a Coq snapshot (2019) | 11.8 MB `aarch64.v`, "requires ~**40 GB** memory to build", checked against **Coq 8.9.1** + bbv 1.1, generated from a `coq-experimental` branch with manual fixes. AArch64 only. | `arm-v8.5-a/snapshots/coq/README.md` |
+| sail-riscv | Coq export documented (`riscv_coq_build`, `generated_definitions/coq/RV64/riscv.v`); the RISC-V side of VCR-ISA-001 remains the easier half, but note upstream builds RV64-first and the concurrency-interface/stdpp churn applies there too. | riscv/sail-riscv docs |
+
+Conclusion of the survey: **the tool is healthy; the generated-ARM-model
+artifact is the blocker.** A 42 MB monolithic `.v` pinned to unreleased
+library versions cannot join synth's hermetic Rocq 9 / `Stdlib`-prefix Bazel
+build, and its historical build cost (40 GB-class) is far outside CI. Nobody
+proves against the full generated ARM model directly — even REMS' own Islaris
+works from per-instruction Isla traces instead, for exactly this reason.
+
+## 2. What the spike built (the crown)
+
+`coq/Synth/ARM/SailArmBridge.v` — provenance-annotated transcription + bridge:
+
+- **Transcribed from Sail** (rems-project/sail-arm @ `1bf2e5574ba9`,
+  2026-06-19, arm-v9.4-a, quoted verbatim in comments):
+  - `AddWithCarry` (`v8_base.sail:13337`) → `sail_add_with_carry`
+    (result + n/z/c/v exactly as ASL computes them: `result<31>`,
+    `IsZero`, `UInt(result) != unsigned_sum`, `SInt(result) != signed_sum`);
+  - `execute_aarch32_instrs_ADD_r_Op_A_txt` (`instrs32.sail:457`) and the
+    CMP clause (`AddWithCarry(R[n], NOT(shifted), '1')`), at `shift_n = 0`;
+  - `NOT` → `sail_not` (same `Z.lnot`+`repr` rendering as our MVN).
+- **Bridge theorems (all Qed):**
+  - `sail_bridge_add_reg` — `exec_instr (ADD rd rn (Reg rm))` produces
+    exactly `R[d] := fst (AddWithCarry (R[n], R[m], '0'))`;
+  - `sail_bridge_adds_reg` — ADDS agrees on the register **and all four
+    NZCV flags** with the ASL nzcv output;
+  - `sail_bridge_cmp_reg` — CMP's flags equal ASL's
+    `AddWithCarry(R[n], NOT(R[m]), '1')` nzcv.
+  - Per-flag lemmas prove the six hand-written flag definitions
+    (`compute_{n,z}_flag`, `compute_{c,v}_flag_{add,sub}`) equal ASL's
+    formulations — these are the definitions every CMP-based comparison
+    lowering (Compilation.v, VcrSelRules.v's 10 comparison rules) rests on.
+    The two formulations are genuinely different (e.g. ASL's V is
+    "`SInt(result) != SInt(x)+SInt(y)`", ours is the sign-pattern test), so
+    the lemmas are non-vacuous: a modeling bug in either side would fail them.
+
+Documented abstraction gaps (in the file header): `shift_n = 0` (synth emits
+plain register forms), `d != 15` (no PC in our executor — the known
+VCR-ISA-001 executor gap), `ConditionPassed() = true` (no IT blocks),
+`bits(32)` rendered as `I32.int` (Z mod 2^32). The residual trust moves from
+"the whole hand-written model is right" to "this 20-line quoted transcription
+is faithful" — reviewable token-by-token against the Sail source.
+
+## 3. Measured cost per instruction
+
+Actual spike effort for the ADD family, as data for the migration estimate:
+
+| Piece | Cost |
+|---|---|
+| Locate + quote Sail source (execute clause, decode, helpers) | ~15 min/instruction family (the model is greppable; helpers like `AddWithCarry`/`Shift_C` amortize across the whole ALU class) |
+| Transcription (`sail_add_with_carry`, `sail_not`, slice defs) | ~40 lines Rocq |
+| Bridge proofs | ~230 lines Rocq incl. reusable helpers (`sum/diff_mod_cases`, `testbit31_ge`, `unsigned/signed_not`, `destruct_ifs`/`bool_blast` tactics). Two build iterations to green. |
+| Reusable residue for the next instructions | the helpers + tactics: SUB/SUBS/RSB/CMN are the same `AddWithCarry` shape (near-zero new machinery); AND/ORR/EOR/MVN/MOV/shifts are flag-free or simpler |
+
+Extrapolation for the integer core ArmSemantics.v actually models (~25
+distinct straight-line op shapes after the AddWithCarry family is done):
+roughly **0.5–1 day of proof work per remaining instruction class**, most far
+cheaper than ADD because the flag machinery (the hard 60%) is now proven once.
+The genuinely new costs are: register-shift semantics (`Shift_C` with
+amount != 0), `MUL/UMULL` (no flags in our model — easy), `CLZ/RBIT` (our
+side is axiomatized via `I32.clz`/`I32.rbit`, so the bridge would first need
+those axioms replaced by definitions), and loads/stores (our memory model is
+`Z -> I32.int` vs Sail's byte-addressed memory + translation — the widest gap,
+needs a deliberate abstraction statement, not a mechanical bridge).
+
+## 4. Risks
+
+1. **Transcription fidelity is hand-checked, not machine-checked.** Mitigation
+   used here: verbatim Sail quotes with file:line + commit hash next to every
+   definition; a reviewer diffs the two syntaxes side by side. Optional
+   hardening later: differential-test the transcription against a Sail-built
+   C emulator or unicorn on random operands (fits the existing VCR-ORACLE
+   harness pattern).
+2. **The PC-gap is NOT closed by this path alone.** The trap-guard admits
+   (i32 div/rem) need a PC-indexed executor in *our* model; the Sail model has
+   one natively, but bridging control flow means first giving `exec_program` a
+   PC (a prerequisite refactor tracked in the VCR-ISA-001 yaml). The bridge
+   pattern extends once that lands (Sail's `_PC` projection ↔ our index).
+3. **Sail model version drift.** Pinned by commit hash in the provenance
+   comments; bumping is a re-diff, not a re-proof, unless Arm's ASL for the
+   instruction changed (which is itself signal).
+4. **Generated-import remains attractive for RISC-V.** sail-riscv's Coq
+   export is institutionally maintained; if upstream lands a current
+   Rocq-9-compatible export, the import path can be re-evaluated for the
+   RV32 side independently — the ARM conclusion does not transfer 1:1.
+
+## 5. Recommendation
+
+- **GO** on VCR-ISA-001 via **per-instruction transcribe-and-bridge**,
+  prioritized: (1) the remaining AddWithCarry family (SUB/SUBS/CMN/RSB —
+  cheap now), (2) the flag-free ALU/shift class, (3) the PC-executor refactor
+  (unblocks div/rem admits, the item's original motivation), (4) memory ops
+  last (needs the memory-model abstraction statement).
+- **NO-GO** on importing `gen_coq` output of sail-arm into the build (42 MB
+  monolith, unreleased dep pins, 40 GB-class build memory, Rocq-version lag).
+- The spike satisfies the deep-research gate of 2026-06-10 ("bounded
+  feasibility spike must precede any release commitment"): substrate
+  freshness is now VERIFIED for the tool (Sail 0.20 via nixpkgs, `--coq`
+  alive) and REFUTED for the generated-ARM-artifact path, with the working
+  alternative landed in-tree.
+
+## Artifacts
+
+- `coq/Synth/ARM/SailArmBridge.v` — 23 Qed / 0 Admitted, in
+  `//coq:verify_proofs` (green).
+- `coq/BUILD.bazel` `:sail_arm_bridge`, `coq/_CoqProject` entry.
+- This report.


### PR DESCRIPTION
## VCR-ISA-001 feasibility spike (epic #242, Track B)

Bounded research spike: can we anchor `ArmSemantics.v` on an independently-derived ISA semantics (Sail, generated from Arm's own ASL) so a modeling bug can't hide? Deliverable is a decision-quality report + minimal working code — **not** a migration.

### Survey (verified against the repos, not from memory)

- **Sail tool: alive.** Sail 0.20 (nixpkgs `ocamlPackages.sail`, installs in seconds) ships the `--coq` target (bbv|stdpp styles); `rems-project/coq-sail` is maintained.
- **T32/A32 coverage: yes.** `sail-arm` arm-v9.4-a (derived from Arm's 2023-03 ASL via asl_to_sail) contains every AArch32 instruction incl. all four ADD (register) encodings (`instrs32.sail`, 1.9 MB).
- **Importing the generated Coq: NO-GO.** The arm-v9.4-a Coq snapshot is a single **42 MB** `armv9.v` + 1 MB types, pinned to **stdpp-unstable** (not in opam) and git-pinned `coq-sail-stdpp`; the 2019 v8.5 snapshot README says the build needs **~40 GB RAM** and was checked against **Coq 8.9.1**. That cannot join our hermetic Rocq 9 / `Stdlib`-prefix Bazel toolchain or CI.

### The bridge (the spike's crown) — landed, all Qed

`coq/Synth/ARM/SailArmBridge.v` (**23 Qed / 0 Admitted**, in `//coq:verify_proofs`, green): hand-transcribes `AddWithCarry` (`v8_base.sail:13337`) and the AArch32 ADD/CMP register-form execute clauses (`instrs32.sail:457`) from `sail-arm @ 1bf2e5574ba9` with file:line provenance comments, then proves:

- `sail_bridge_add_reg` — our `ADD` ≡ `R[d] := AddWithCarry(R[n], R[m], '0').result`
- `sail_bridge_adds_reg` — our `ADDS` ≡ same, **plus all four NZCV flags**
- `sail_bridge_cmp_reg` — our `CMP` flags ≡ `AddWithCarry(R[n], NOT(R[m]), '1')` nzcv

The six hand-written flag definitions (`compute_{n,z}_flag`, `compute_{c,v}_flag_{add,sub}`) are proven equal to ASL's formulations — genuinely different formulas (ASL's V is `SInt(result) != signed_sum`; ours is the sign-pattern test), so the lemmas are non-vacuous. These definitions are the foundation under every CMP-based comparison lowering in `Compilation.v` and `VcrSelRules.v`.

Documented abstraction gaps (file header): `shift_n = 0`, `d ≠ 15` (the PC-executor gap is NOT closed by this and remains the item's core prerequisite for the div/rem admits), no IT blocks, `bits(32)` as Z mod 2^32.

### Cost per instruction (measured, not estimated)

~40 lines transcription + ~230 lines proof for the whole ADD family, with the flag machinery (the hard 60%) now reusable: SUB/SUBS/CMN/RSB near-free, ~0.5–1 day per remaining straight-line op class, memory ops widest gap. Full analysis in `docs/design/vcr-isa-001-spike.md`.

### Recommendation

**GO** on VCR-ISA-001 via per-instruction transcribe-and-bridge (priority: AddWithCarry family → flag-free ALU → PC-executor refactor → memory). **NO-GO** on importing `gen_coq` output. RISC-V half unmeasured — sail-riscv's maintained Coq export may admit the import path there; evaluate separately.

Roadmap: VCR-ISA-001 stays `proposed`; the 2026-06-10 deep-research gate ("bounded feasibility spike must precede release commitment") is now answered with in-tree evidence.

- [x] `bazel test //coq:verify_proofs` green (rocq_proofs + vcr_sel_rules_coverage)
- [x] `rivet validate` — 0 non-xref errors (same as main baseline)
- [x] No Rust touched

Refs #242 (VCR-ISA-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)