### PR TITLE
chore(release): v0.35.0 — North-Star wave: verified i64 pair rules, Sail bridge, VER gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-07-08
+
+**The North-Star acceleration wave: the verified selector DSL enters the i64
+pair family (27 rules / 27 Qed — ~40% of integer-compute ops DSL-served),
+Track B unblocks with Sail/ASL bridge lemmas proving our flag semantics
+equal to ARM's own spec, and the VCR-VER-001 falsification gate is
+demonstrated — a formerly load-bearing greedy fix is reversed.**
+
+### Added
+
+- **VCR-SEL-001 increment 3 (#661, epic #242):** rules for i64
+  add/sub/and/or/xor + eqz — pair-result T1 theorems (both words proven),
+  with the #632 clobber class encoded as explicit pair-aliasing hypotheses
+  in the theorems AND runtime Err in the generated lowerings. 27/27 Qed,
+  no model extension needed; anchors green even with SYNTH_SEL_DSL=1
+  (migration byte-invisible). Held out honestly: mul/div/shifts/rotates
+  and binary i64 comparisons (increment 4).
+- **VCR-ISA-001 spike (#660):** GO on transcribe-and-bridge —
+  coq/Synth/ARM/SailArmBridge.v (23 Qed) proves our ADD/ADDS/CMP semantics
+  AND all four NZCV flag computations equal to hand-transcribed sail-arm
+  (ASL-derived) definitions with file:line provenance. Importing the
+  generated 42 MB Coq model is NO-GO (stdpp-unstable pins, historic ~40 GB
+  RAM); measured cost ~0.5–1 day per remaining op class. Full report in
+  docs/design/vcr-isa-001-spike.md.
+- **VCR-VER-001 demonstrated (#659):** the #209 reciprocal-mult cost-gate
+  reversal (deleted in PR #322 once spill-retry subsumed it) is now
+  recorded as the gate's passing instance; the #496 decline-on-exhaustion
+  reversal is correctness-complete behind its flag but cycle-regressive on
+  i32 shapes — the named missing capability (post-exhaustion code quality:
+  allocation-time spill slots unreached by frame-slot-DCE/stack-fwd) is the
+  next allocator lever. Evidence: scripts/repro/vcr_ver_001_gate.md.
+
+### Fixed
+
+- **RV32 bounds/mask soundness (#655, PR #658):** offset folded before the
+  mask (the #651 twin), final-byte clamp, and — audit finding — i64
+  loads/stores had NO guard at all in either bounds mode; both now guard
+  the full 8-byte access. Differential: 10 red → all green.
+
 ## [0.34.0] - 2026-07-08
 
 **Multi-table call_indirect ships (falcon's fused-component blocker); float

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,14 +2060,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2125,11 +2125,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.34.0"
+version = "0.35.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2184,14 +2184,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2199,11 +2199,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.34.0"
+version = "0.35.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.34.0"
+version = "0.35.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.34.0"
+version = "0.35.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.34.0",
+    version = "0.35.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.34.0" }
+synth-core = { path = "../synth-core", version = "0.35.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.34.0" }
+synth-core = { path = "../synth-core", version = "0.35.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.34.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.34.0" }
+synth-core = { path = "../synth-core", version = "0.35.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.35.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.34.0" }
+synth-core = { path = "../synth-core", version = "0.35.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,7 +15,7 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.34.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.34.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.35.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.35.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -44,23 +44,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.34.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.34.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.34.0" }
-synth-backend = { path = "../synth-backend", version = "0.34.0" }
+synth-core = { path = "../synth-core", version = "0.35.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.35.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.35.0" }
+synth-backend = { path = "../synth-backend", version = "0.35.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.34.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.35.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.34.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.34.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.34.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.35.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.35.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.35.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.34.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.35.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.34.0" }
+synth-core = { path = "../synth-core", version = "0.35.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.34.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.35.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.34.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.34.0" }
-synth-opt = { path = "../synth-opt", version = "0.34.0" }
+synth-core = { path = "../synth-core", version = "0.35.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.35.0" }
+synth-opt = { path = "../synth-opt", version = "0.35.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -20,12 +20,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.34.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.34.0" }
-synth-opt = { path = "../synth-opt", version = "0.34.0" }
+synth-core = { path = "../synth-core", version = "0.35.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.35.0" }
+synth-opt = { path = "../synth-opt", version = "0.35.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.34.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.35.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"


### PR DESCRIPTION
Release PR: pin sweep + CHANGELOG for v0.35.0.

Scope: #661 (SEL DSL inc-3: 27 rules/27 Qed, i64 pairs, ~40% coverage) · #660 (VCR-ISA-001 spike: Sail/ASL bridge lemmas, GO on transcribe-and-bridge) · #659 (VCR-VER-001 gate demonstrated) · #658 (#655 RV32 bounds soundness + unguarded-i64 audit fix).

Tag v0.35.0 on green merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)