### PR TITLE
fix(trap-semantics): unreachable traps on every backend (#665); rv32 rem_s drops the spurious INT_MIN/-1 guard (#666)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,42 @@ jobs:
       - name: Run two-move execution oracle
         run: python scripts/repro/cmp_select_two_move_differential.py
 
+  trap-semantics-oracle:
+    name: trap-semantics oracle (#665 unreachable + #666 rem_s)
+    # #665: wasm `unreachable` must TRAP (WASM §4.4.5) — it was decoder-dropped
+    # to a no-op on EVERY backend, falling through panic/abort guards. #666:
+    # rv32 rem_s wrongly carried div_s's INT_MIN/-1 ebreak guard —
+    # irem_s(INT_MIN,-1) = 0, no trap (§4.3.2). Both EXECUTION-validated under
+    # unicorn (thumb2 + rv32) against wasmtime ground truth, including the
+    # non-vacuity direction (a guarded `unreachable` NOT taken runs normally;
+    # rem_s zero-divisor + div_s overflow traps are KEPT). Isolated job:
+    # emulation deps pip-installed here ONLY.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Run unreachable trap oracle (#665, thumb2 + rv32)
+        run: SYNTH=./target/debug/synth python scripts/repro/unreachable_665_differential.py
+      - name: Run rem_s trap-table oracle (#666, rv32)
+        run: SYNTH=./target/debug/synth python scripts/repro/rem_s_666_differential.py
+
   fact-spec-oracle:
     name: fact-spec elision oracle (#494 phases 2 + 2b)
     # VCR-PERF-002 Phase 2 (#494): the proof-carrying-specialization lever

--- a/crates/synth-backend-aarch64/src/encoder.rs
+++ b/crates/synth-backend-aarch64/src/encoder.rs
@@ -67,6 +67,13 @@ pub fn ret() -> u32 {
     0xD65F_03C0
 }
 
+/// `brk #imm16` — A64 breakpoint/trap. Used for wasm `unreachable` (#665):
+/// WASM §4.4.5 requires an unconditional trap, the A64 analogue of Thumb-2
+/// `udf #0` / RV32 `ebreak`.
+pub fn brk(imm16: u16) -> u32 {
+    0xD420_0000 | ((imm16 as u32) << 5)
+}
+
 /// Materialize a 32-bit constant into `wd` with `movz` + optional `movk`.
 /// Returns 1 or 2 words.
 pub fn mov_imm32(rd: Reg, value: u32) -> Vec<u32> {

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -79,6 +79,12 @@ pub fn select(ops: &[WasmOp], num_params: u32) -> Result<Vec<u32>, SelectError> 
                 }
                 stack.push(dst);
             }
+            // #665: wasm `unreachable` traps unconditionally (WASM §4.4.5) —
+            // emit `brk #0`, the A64 analogue of Thumb-2 `udf #0` / RV32
+            // `ebreak`. It pushes nothing; everything after it is
+            // wasm-validated dead code, and the trailing `End` epilogue after
+            // the trap is harmless.
+            WasmOp::Unreachable => words.push(enc::brk(0)),
             WasmOp::I32Add => binop(&mut words, &mut stack, enc::add)?,
             WasmOp::I32Sub => binop(&mut words, &mut stack, enc::sub)?,
             WasmOp::I32Mul => binop(&mut words, &mut stack, enc::mul)?,

--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -1553,7 +1553,16 @@ impl Selector {
                 self.bin_with_zero_trap(op, |rd, rs1, rs2| RiscVOp::Divu { rd, rs1, rs2 })?
             }
             I32RemS => {
-                self.bin_with_signed_div_traps(op, |rd, rs1, rs2| RiscVOp::Rem { rd, rs1, rs2 })?
+                // #666: rem_s carries ONLY the zero-divisor guard. WASM §4.3.2
+                // defines irem_s(INT_MIN, -1) = 0 (no trap) — the INT_MIN/-1
+                // overflow trap belongs to div_s alone. The div_s guard was
+                // wrongly shared here, so rem_s(INT_MIN,-1) spuriously
+                // ebreak'd. RISC-V M-ext `rem` already returns 0 for the
+                // overflow case (RISC-V unprivileged spec §7.2, "the remainder
+                // of an overflowing signed division is zero"), so the bare
+                // instruction is exactly wasm-correct. Twin of the ARM #633
+                // fix-guard (test_633_i64_rems_has_no_overflow_guard).
+                self.bin_with_zero_trap(op, |rd, rs1, rs2| RiscVOp::Rem { rd, rs1, rs2 })?
             }
             I32RemU => {
                 self.bin_with_zero_trap(op, |rd, rs1, rs2| RiscVOp::Remu { rd, rs1, rs2 })?
@@ -2130,8 +2139,12 @@ impl Selector {
     }
 
     /// Variant of `bin_with_zero_trap` that also guards `INT_MIN / -1`, which
-    /// `div`/`rem` would silently return as `INT_MIN` / `0` respectively — WASM
-    /// semantics require a trap. See `docs/binary-safety-design.md` §3.3.
+    /// `div` would silently return as `INT_MIN` — WASM `idiv_s` semantics
+    /// require a trap. See `docs/binary-safety-design.md` §3.3.
+    ///
+    /// `div_s` ONLY — never `rem_s` (#666): WASM `irem_s(INT_MIN, -1)` is
+    /// defined as 0 (no trap), and RISC-V `rem` already returns 0 for that
+    /// case, so `rem_s` takes plain [`Self::bin_with_zero_trap`].
     ///
     /// Sequence:
     /// ```text
@@ -6213,8 +6226,15 @@ mod tests {
         assert_eq!(bne_count, 1, "only zero-divisor guard expected for div_u");
     }
 
+    /// #666 fix-guard twin (RV32 analogue of the ARM #633 pin,
+    /// `test_633_i64_rems_has_no_overflow_guard`): i32 `rem_s` must carry ONLY
+    /// the zero-divisor guard — WASM §4.3.2 defines `irem_s(INT_MIN, -1) = 0`
+    /// (no trap), and RISC-V M-ext `rem` already returns 0 for that case, so
+    /// the INT_MIN/-1 `ebreak` belongs to `div_s` alone. This test previously
+    /// pinned the BUG (asserting rem_s got the overflow guard too, which made
+    /// `rem_s(INT_MIN, -1)` spuriously trap).
     #[test]
-    fn rv32_signed_rem_also_gets_overflow_guard() {
+    fn rv32_signed_rem_carries_only_zero_guard_666() {
         let opts = SelectorOptions::wasm_compliant();
         let out = s_with_opts(
             &[
@@ -6235,8 +6255,38 @@ mod tests {
                 }
             )
         });
-        assert!(bne_count >= 3);
-        assert!(count(&out, |op| matches!(op, RiscVOp::Rem { .. })) == 1);
+        assert_eq!(
+            bne_count, 1,
+            "rem_s must emit only the zero-divisor BNE (no INT_MIN/-1 guard): {out:?}"
+        );
+        assert_eq!(
+            count(&out, |op| matches!(op, RiscVOp::Ebreak)),
+            1,
+            "rem_s must emit exactly one ebreak (the zero-divisor trap): {out:?}"
+        );
+        assert_eq!(count(&out, |op| matches!(op, RiscVOp::Rem { .. })), 1);
+    }
+
+    /// #666 twin, other direction: `div_s` KEEPS both guards under
+    /// wasm-compliant options — removing the rem_s over-trap must not weaken
+    /// the div_s overflow trap.
+    #[test]
+    fn rv32_signed_div_still_carries_both_guards_666() {
+        let opts = SelectorOptions::wasm_compliant();
+        let out = s_with_opts(
+            &[
+                WasmOp::LocalGet(0),
+                WasmOp::LocalGet(1),
+                WasmOp::I32DivS,
+                WasmOp::End,
+            ],
+            2,
+            opts,
+        );
+        assert!(
+            count(&out, |op| matches!(op, RiscVOp::Ebreak)) >= 2,
+            "div_s keeps the zero-divisor AND INT_MIN/-1 ebreaks: {out:?}"
+        );
     }
 
     /// Two-arg call: top-of-stack args move to a0 and a1 in source order.

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -1016,7 +1016,7 @@ pub struct FunctionOps {
     /// function (diagnostic + symbol absent → link error names it) instead —
     /// the #180/#185 "unsupported op must Err, never silently continue"
     /// contract. `None` once every op decoded or was intentionally ignorable
-    /// (Nop/Unreachable).
+    /// (Nop).
     pub unsupported: Option<String>,
     /// #509: blocktype arity side-table — `(param_count, result_count)` of the
     /// k-th `Block`/`Loop`/`If` op in `ops`, in order of appearance.
@@ -1109,7 +1109,7 @@ fn decode_function_body(
             op_offsets.push(offset as u32);
         } else if unsupported.is_none() && !is_intentionally_ignored(&op) {
             // The op was DROPPED by `convert_operator` (`_ => None`) and is not
-            // an intentional no-op (Nop/Unreachable) — record it so the
+            // an intentional no-op (Nop) — record it so the
             // function is loud-skipped rather than silently miscompiled (#369).
             unsupported = Some(format!("{op:?}"));
         }
@@ -1122,9 +1122,13 @@ fn decode_function_body(
 /// carry no value-affecting semantics for our backend, so dropping them is
 /// correct (NOT a silent miscompile). Everything else that decodes to `None`
 /// is an unsupported op that must loud-skip its function (#369).
+///
+/// #665: `Unreachable` is NOT on this list — it traps (WASM §4.4.5), so it
+/// decodes to `WasmOp::Unreachable` and every backend lowers it to a trap
+/// instruction (or loud-declines). Only `Nop` is genuinely ignorable.
 fn is_intentionally_ignored(op: &wasmparser::Operator) -> bool {
     use wasmparser::Operator::*;
-    matches!(op, Nop | Unreachable)
+    matches!(op, Nop)
 }
 
 /// Convert a wasmparser Operator to our WasmOp enum
@@ -1312,8 +1316,16 @@ fn convert_operator(op: &wasmparser::Operator) -> Option<WasmOp> {
         // End is needed for control flow pattern matching
         End => Some(WasmOp::End),
 
-        // Nop/Unreachable - skip these
-        Nop | Unreachable => None,
+        // #665: `unreachable` MUST reach the backends — WASM Core §4.4.5
+        // requires it to trap unconditionally. It was previously dropped here
+        // (treated like Nop), so every backend compiled it to a no-op and
+        // control FELL THROUGH panic!/abort/unreachable-default guards with
+        // undefined register state. The selector arms (ARM: UDF #0, RV32:
+        // ebreak) already existed; they just never received the op.
+        Unreachable => Some(WasmOp::Unreachable),
+
+        // Nop - skip (genuinely no semantics)
+        Nop => None,
 
         // Drop is needed for br_if pattern matching
         Drop => Some(WasmOp::Drop),

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -2526,15 +2526,31 @@ impl OptimizerBridge {
                     continue;
                 }
 
+                // #665: `unreachable` must TRAP (WASM §4.4.5). The optimized
+                // path's local `Opcode` enum has no trap opcode, and adding
+                // one would ripple through the #513 mirror-pinned
+                // reg_effect/rewrite_op machinery — so decline to the direct
+                // selector, whose `Unreachable` arm emits `UDF #0`. Same
+                // decline-don't-drop pattern as #120 floats and the #500
+                // non-tail `return` (this arm previously lumped `unreachable`
+                // in with Nop as a placeholder — a silent fall-through).
+                WasmOp::Unreachable => {
+                    return Err(synth_core::Error::validation(
+                        "optimized lowering path does not support `unreachable` \
+                         (no trap opcode in the bridge IR); the direct \
+                         instruction selector lowers it to UDF #0 — issue #665",
+                    ));
+                }
+
                 // ===== Stack-neutral control-flow / no-op ops =====
                 //
-                // Nop / Unreachable / Return have no slot_stack effect at
+                // Nop / Return have no slot_stack effect at
                 // this layer (Return's value handling is done later by the
                 // function-epilogue codegen in `ir_to_arm`). They still
                 // emit an IR Nop placeholder so the IR length is in lockstep
                 // with the wasm op index for any downstream pass that
                 // relies on positional alignment.
-                WasmOp::Nop | WasmOp::Unreachable | WasmOp::Return => {
+                WasmOp::Nop | WasmOp::Return => {
                     // #500: `return` is representable here only as a Nop
                     // placeholder — the real epilogue is emitted once at the
                     // function end, and the callee-saved push/pop frame is

--- a/scripts/repro/rem_s_666.wat
+++ b/scripts/repro/rem_s_666.wat
@@ -1,0 +1,12 @@
+;; #666 — rv32 i32.rem_s(INT_MIN, -1) spuriously trapped.
+;;
+;; WASM Core §4.3.2: irem_s(INT_MIN, -1) = 0, NO trap — only idiv_s traps on
+;; the INT_MIN/-1 overflow. The rv32 selector shared div_s's INT_MIN/-1
+;; ebreak guard with rem_s; RISC-V M-ext `rem` already returns 0 for the
+;; overflow case, so the guard was pure over-trap. Twin of the ARM #633
+;; fix-guard pin.
+(module
+  (func (export "rems") (param i32 i32) (result i32)
+    (i32.rem_s (local.get 0) (local.get 1)))
+  (func (export "divs") (param i32 i32) (result i32)
+    (i32.div_s (local.get 0) (local.get 1))))

--- a/scripts/repro/rem_s_666_differential.py
+++ b/scripts/repro/rem_s_666_differential.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""#666 — rv32 i32.rem_s(INT_MIN,-1) must return 0, not trap (WASM §4.3.2).
+
+The rv32 selector shared div_s's INT_MIN/-1 overflow `ebreak` guard with
+rem_s; WASM defines irem_s(INT_MIN,-1) = 0 with NO trap (only idiv_s traps on
+that overflow). RISC-V M-ext `rem` already returns 0 for the overflowing case
+(unprivileged spec §7.2), so after dropping the guard the bare instruction is
+exactly wasm-correct. Twin of the ARM #633 fix-guard pin
+(`test_633_i64_rems_has_no_overflow_guard`); the RV32 unit pin is
+`rv32_signed_rem_carries_only_zero_guard_666`.
+
+Table (rems/divs from scripts/repro/rem_s_666.wat, rv32 under unicorn, each
+row cross-checked against wasmtime ground truth):
+
+  rems(INT_MIN,-1) -> 0      NO trap   <- RED on pre-fix synth (spurious ebreak)
+  rems(INT_MIN, 1) -> 0
+  rems(7, 3)       -> 1
+  rems(-7, 3)      -> -1                (remainder takes the dividend sign)
+  rems(7, 0)       -> TRAP              (zero-divisor guard KEPT)
+  divs(INT_MIN,-1) -> TRAP              (div_s overflow guard KEPT)
+  divs(7, 0)       -> TRAP
+  divs(7, 3)       -> 2
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/rem_s_666_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_RISCV, UC_MODE_RISCV32, Uc, UcError
+from unicorn.riscv_const import (
+    UC_RISCV_REG_A0,
+    UC_RISCV_REG_A1,
+    UC_RISCV_REG_RA,
+    UC_RISCV_REG_SP,
+)
+
+WAT = Path(__file__).with_name("rem_s_666.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+TRAP = "TRAP"
+INT_MIN = -(2**31)
+CODE, STK, RET = 0x100000, 0x90000, 0x200000
+
+CASES = [
+    ("rems", (INT_MIN, -1), 0),  # the #666 over-trap
+    ("rems", (INT_MIN, 1), 0),
+    ("rems", (7, 3), 1),
+    ("rems", (-7, 3), -1),
+    ("rems", (7, 0), TRAP),
+    ("divs", (INT_MIN, -1), TRAP),
+    ("divs", (7, 0), TRAP),
+    ("divs", (7, 3), 2),
+]
+
+
+def compile_elf(out):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "-b", "riscv", "-t", "rv32imac",
+         "--all-exports", "--relocatable"],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"},
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed: {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"] - base
+    return code, syms
+
+
+def wasm_result(func, args):
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    try:
+        return inst.exports(st)[func](st, *args) & 0xFFFFFFFF
+    except Exception:
+        return TRAP
+
+
+def run_rv(code, fa, args):
+    mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(STK - 0x8000, 0x10000)
+    mu.mem_map(RET, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_RISCV_REG_A0, args[0] & 0xFFFFFFFF)
+    mu.reg_write(UC_RISCV_REG_A1, args[1] & 0xFFFFFFFF)
+    mu.reg_write(UC_RISCV_REG_SP, STK)
+    mu.reg_write(UC_RISCV_REG_RA, RET)
+    try:
+        mu.emu_start(CODE + fa, RET, timeout=5_000_000, count=10_000)
+    except UcError:
+        return TRAP  # ebreak -> breakpoint exception
+    return mu.reg_read(UC_RISCV_REG_A0) & 0xFFFFFFFF
+
+
+def main():
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth first")
+    elf = "/tmp/rem_s_666_rv.o"
+    compile_elf(elf)
+    code, syms = load(elf)
+
+    fails = 0
+    for func, args, expected in CASES:
+        want = expected if expected == TRAP else expected & 0xFFFFFFFF
+        gt = wasm_result(func, args)
+        if gt != want:
+            sys.exit(f"harness bug: wasmtime {func}{args} = {gt}, expected {want}")
+        if func not in syms:
+            fails += 1
+            print(f"FAIL {func}{args}: SYMBOL MISSING from ELF symtab")
+            continue
+        got = run_rv(code, syms[func], args)
+        ok = got == gt
+        fails += 0 if ok else 1
+        print(f"{'OK  ' if ok else 'FAIL'} {func}{args}: synth={got} wasmtime={gt}")
+
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/unreachable_665.wat
+++ b/scripts/repro/unreachable_665.wat
@@ -1,0 +1,26 @@
+;; #665 — WASM `unreachable` MUST trap (WASM Core §4.4.5).
+;;
+;; synth compiled `unreachable` to a NO-OP on every backend: the decoder
+;; dropped it as "intentionally ignorable" (wasm_decoder.rs), so control fell
+;; through panic!/abort/exhaustiveness guards and returned undefined register
+;; state. The selector trap arms (ARM: UDF #0, RV32: ebreak) existed but never
+;; received the op.
+;;
+;; - boom:    body is just `unreachable` — must trap on entry (issue repro 1).
+;; - guarded: error-guard shape — `unreachable` only on the negative branch
+;;   (issue repro 2). guarded(-5) must trap; guarded(5) must return 1
+;;   (NON-VACUITY: the trap instruction must not break the normal path).
+;; - guarded_br: same guard desugared as block + br_if (the shape front-ends
+;;   emit), exercising `unreachable` in straight-line dead-end position.
+(module
+  (func (export "boom") (param i32 i32) (result i32)
+    unreachable)
+  (func (export "guarded") (param i32) (result i32)
+    (if (result i32) (i32.ge_s (local.get 0) (i32.const 0))
+      (then (i32.const 1))
+      (else (unreachable))))
+  (func (export "guarded_br") (param i32) (result i32)
+    (block
+      (br_if 0 (i32.ge_s (local.get 0) (i32.const 0)))
+      (unreachable))
+    (i32.const 1)))

--- a/scripts/repro/unreachable_665_differential.py
+++ b/scripts/repro/unreachable_665_differential.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""#665 — `unreachable` must TRAP (WASM Core §4.4.5), on BOTH ISAs.
+
+synth compiled wasm `unreachable` to a NO-OP: the decoder dropped it as
+"intentionally ignorable" (`wasm_decoder.rs` lumped it with Nop), so no backend
+ever received the op — control fell through every panic!/abort/exhaustiveness
+guard and returned undefined register state. The selector trap arms (ARM:
+`UDF #0`, RV32: `ebreak`) already existed; this harness proves they now fire.
+
+Functions (scripts/repro/unreachable_665.wat):
+  - boom(x,y)      body is `unreachable`      -> must trap on entry
+  - guarded(x)     if x>=0 then 1 else unreachable
+  - guarded_br(x)  block + br_if guard, `unreachable` in the dead-end
+
+Oracle, per ISA under unicorn, vs wasmtime ground truth:
+  - the trap cases MUST fault (unicorn exception), like wasmtime traps;
+  - the guarded positive direction MUST return 1 normally (NON-VACUITY: the
+    emitted trap instruction cannot break the live path).
+
+RED on pre-fix synth: boom/guarded fall through and "return" garbage instead
+of faulting. On RV32, `guarded` (if/else-with-result whose else arm is
+`unreachable`) currently LOUD-DECLINES (#343 arity check) — the symbol is
+absent, which the contract allows (trap or loud-decline, never fall-through);
+the harness accepts absence for that one function on RV32 and prints it.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/unreachable_665_differential.py
+Exits nonzero on any fall-through/mismatch.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_ARCH_RISCV, UC_MODE_RISCV32, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+from unicorn.riscv_const import (
+    UC_RISCV_REG_A0,
+    UC_RISCV_REG_A1,
+    UC_RISCV_REG_RA,
+    UC_RISCV_REG_S11,
+    UC_RISCV_REG_SP,
+)
+
+WAT = Path(__file__).with_name("unreachable_665.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+TRAP = "TRAP"
+LINMEM = 0x20000100  # optimized-path absolute linear-memory base (#197)
+
+# function -> [(args, expected)]; expected is a value or TRAP.
+CASES = [
+    ("boom", (7, 9), TRAP),
+    ("guarded", (5,), 1),  # non-vacuity: live path still returns
+    ("guarded", (-5,), TRAP),
+    ("guarded_br", (5,), 1),
+    ("guarded_br", (-5,), TRAP),
+]
+# RV32 loud-declines this function today (#343 if/else result-arity check on
+# an else arm that is pure `unreachable`) — absence is an acceptable outcome
+# there; presence must then trap like everywhere else.
+RV32_MAY_DECLINE = {"guarded"}
+
+
+def compile_elf(out, backend_args):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, *backend_args, "--all-exports"],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"},
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({backend_args}): {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"] - base
+    return code, base, syms
+
+
+def wasm_expected(func, args):
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    try:
+        return inst.exports(st)[func](st, *args) & 0xFFFFFFFF
+    except Exception:
+        return TRAP
+
+
+def run_arm(code, fa, args):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(0, 0x20000)
+    mu.mem_write(0, code)
+    mu.mem_map(LINMEM & ~0xFFFF, 0x20000)
+    mu.mem_map(0x90000, 0x10000)
+    ret = 0x90100
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    for reg, val in zip((UC_ARM_REG_R0, UC_ARM_REG_R1), args):
+        mu.reg_write(reg, val & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_R11, LINMEM)
+    mu.reg_write(UC_ARM_REG_SP, 0x98000)
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    try:
+        mu.emu_start((fa & ~1) | 1, ret, timeout=5_000_000, count=10_000)
+    except UcError:
+        return TRAP  # UDF #0 -> undefined-instruction exception
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def run_rv(code, fa, args):
+    CODE, STK, RET = 0x100000, 0x90000, 0x200000
+    mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(LINMEM & ~0xFFFF, 0x20000)
+    mu.mem_map(STK - 0x8000, 0x10000)
+    mu.mem_map(RET, 0x1000)
+    mu.mem_write(CODE, code)
+    for reg, val in zip((UC_RISCV_REG_A0, UC_RISCV_REG_A1), args):
+        mu.reg_write(reg, val & 0xFFFFFFFF)
+    mu.reg_write(UC_RISCV_REG_SP, STK)
+    mu.reg_write(UC_RISCV_REG_S11, LINMEM)
+    mu.reg_write(UC_RISCV_REG_RA, RET)
+    try:
+        mu.emu_start(CODE + fa, RET, timeout=5_000_000, count=10_000)
+    except UcError:
+        return TRAP  # ebreak -> breakpoint exception
+    return mu.reg_read(UC_RISCV_REG_A0) & 0xFFFFFFFF
+
+
+def main():
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth first")
+    arm_elf, rv_elf = "/tmp/unr665_arm.elf", "/tmp/unr665_rv.o"
+    compile_elf(arm_elf, ["-b", "arm", "--target", "cortex-m4"])
+    compile_elf(rv_elf, ["-b", "riscv", "-t", "rv32imac", "--relocatable"])
+    arm = load(arm_elf)
+    rv = load(rv_elf)
+
+    fails = 0
+    for func, args, expected in CASES:
+        gt = wasm_expected(func, args)
+        if gt != expected:
+            sys.exit(f"harness bug: wasmtime {func}{args} = {gt}, expected {expected}")
+        for isa, (code, _base, syms), runner in (
+            ("thumb2", arm, run_arm),
+            ("rv32", rv, run_rv),
+        ):
+            if func not in syms:
+                if isa == "rv32" and func in RV32_MAY_DECLINE:
+                    print(f"note {isa:6} {func}{args}: loud-declined (absent) — allowed")
+                    continue
+                fails += 1
+                print(f"FAIL {isa:6} {func}{args}: SYMBOL MISSING from ELF symtab")
+                continue
+            got = runner(code, syms[func], args)
+            ok = got == gt
+            fails += 0 if ok else 1
+            print(f"{'OK  ' if ok else 'FAIL'} {isa:6} {func}{args}: "
+                  f"synth={got} wasmtime={gt}")
+
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

One lane, two trap-semantics bugs — same theme, disjoint files.

### #665 — `unreachable` compiled to a NO-OP on thumb-2 AND rv32

Root cause was ONE decode drop, not per-backend misses: `convert_operator` (synth-core `wasm_decoder.rs`) returned `None` for `Unreachable` and `is_intentionally_ignored` whitelisted it alongside `Nop`, so **no backend ever received the op**. The selector trap arms (ARM `UDF #0` in both `select_with_stack` and `select_default`, RV32 `ebreak`) already existed as dead code.

Per-path status after the fix:

| path | before | after |
|---|---|---|
| decoder | dropped as "intentional no-op" | decodes to `WasmOp::Unreachable` |
| ARM direct (`select_with_stack`) | never received op | existing `UDF #0` arm fires |
| ARM `select_default` | never received op | existing `UDF #0` arm fires |
| ARM optimized (bridge) | lumped with Nop → IR placeholder | typed loud-DECLINE → direct selector emits `UDF #0` (same pattern as #120 floats / #500 non-tail return; no new `Opcode` through the #513 mirror-pinned reg_effect/rewrite_op machinery, no new ArmOp so the #511 estimator oracle is untouched — `Udf` was already covered by the div-zero guards) |
| RV32 | never received op | existing `ebreak` arm fires |
| aarch64 | loud-decline (unknown op) | new `brk #0` encoder + selector arm |

Known gap kept visible (contract-compliant, never falls through): rv32 loud-declines the `if/else`-with-result shape whose `else` arm is pure `unreachable` (#343 arity check) — noted in the oracle.

### #666 — rv32 `i32.rem_s(INT_MIN,-1)` spuriously trapped

The selector shared div_s's INT_MIN/-1 overflow `ebreak` guard with rem_s via `bin_with_signed_div_traps`. WASM §4.3.2: `irem_s(INT_MIN,-1) = 0`, NO trap — only `idiv_s` traps there. RISC-V M-ext `rem` already returns 0 for the overflow case (unprivileged spec §7.2), so rem_s now takes plain `bin_with_zero_trap`: **zero-divisor guard KEPT**, bare `rem` is exactly wasm-correct. Disasm-verified: `rems` = 1 ebreak, `divs` = 2 ebreaks.

The pre-existing test `rv32_signed_rem_also_gets_overflow_guard` **pinned the bug**; rewritten as the #633-twin fix-guard pins (`rv32_signed_rem_carries_only_zero_guard_666` + `rv32_signed_div_still_carries_both_guards_666`), mirroring ARM's `test_633_i64_rems_has_no_overflow_guard`.

## Oracles — red on origin/main, green here (new CI job `trap-semantics-oracle`)

**`scripts/repro/unreachable_665_differential.py`** (thumb2 + rv32 under unicorn vs wasmtime):
- red on main: `boom(7,9)` "returned" 7 (arg fall-through) on BOTH ISAs; `guarded(-5)` returned 0; `guarded_br(-5)` fell through — 5 FAILs
- green here: all trap cases fault like wasmtime; non-vacuity `guarded(5)`/`guarded_br(5)` return 1 normally

**`scripts/repro/rem_s_666_differential.py`** (rv32 trap table):
- red on main: `rems(INT_MIN,-1)` spurious TRAP (wasmtime: 0)
- green here: `rems(INT_MIN,-1)→0`, `rems(INT_MIN,1)→0`, `rems(7,3)→1`, `rems(-7,3)→-1`, `rems(7,0)` traps, `divs(INT_MIN,-1)` traps, `divs(7,0)` traps, `divs(7,3)→2` — 8/8

## Gates

- Frozen anchors **10/10 bit-identical** (verified no frozen fixture — control_step / flight_seam / flight_seam_flat / signed_div_const — contains `unreachable`)
- `cargo test --workspace`: 108/108 suites green
- `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean

Fixes #665
Fixes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)