### PR TITLE
feat(vcr-sel): increment 4 — i32 bit-manip + binary I64SetCond comparison rules, 40/40 Qed (#242)

### DIFF
--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -378,9 +378,9 @@ All fully proved (Qed); no new axioms.
 | StateMonad.v | 3 | 0 | Infra |
 | WasmValues.v | 2 | 0 | Infra |
 | VcrSelPilot.v | 7 | 0 | T1 (register-polymorphic; VCR-SEL-001 go/abandon measurement, post-recount) |
-| VcrSelRules.v | 21 | 0 | T1 (register-polymorphic; the WIRED VCR-SEL-001 increment-1+2 rule table, 1:1 rule<->theorem, coverage-gated by `//coq:vcr_sel_rules_coverage`, post-recount) |
+| VcrSelRules.v | 40 | 0 | T1 (register-polymorphic; the WIRED VCR-SEL-001 increment-1+2+3+4 rule table, 1:1 rule<->theorem, coverage-gated by `//coq:vcr_sel_rules_coverage`, post-recount) |
 
-## VCR-SEL-001 increments 1 (2026-07-07) + 2 (2026-07-08): VcrSelRules.v
+## VCR-SEL-001 increments 1 (2026-07-07) + 2 + 3 + 4 (2026-07-08): VcrSelRules.v
 
 The wired selector-DSL rule table's obligations: one universally-quantified
 T1 theorem per rule in `crates/synth-synthesis/src/sel_dsl`.
@@ -404,9 +404,87 @@ Seven close with `synth_cmp_binop_proof_poly` — the fixed-register
 and `ne`/`lt_s`/`lt_u` use the same manual scripts as their
 CorrectnessI32.v ancestors, register-generalized verbatim).
 
-**21 Qed / 0 Admitted**, same T1 bound as the pilot ("the ARM sequence
-computes the named result", not WASM refinement). These 28 Qed (pilot +
+Increment 3 — the i64 register-pair family
+(`rule_i64_{add,sub,and,or,xor}_correct`, quantified over SIX registers
+under three explicit aliasing hypotheses, pair-result T1 proving BOTH words;
+plus `rule_i64_eqz_correct`, the `I64SetCondZ` pseudo-op shape).
+
+Increment 4 — the scratch-using/multi-instruction tier + the binary
+`I64SetCond` comparison family
+(`rule_i32_{clz,popcnt}_correct` via `synth_unop_proof_poly`;
+`rule_i32_ctz_correct`, the two-instruction RBIT+CLZ scratch=dest shape,
+stepped proof closing with `I32.clz_rbit`;
+`rule_i64_{eq,ne,lt_s,lt_u,gt_s,gt_u,le_s,le_u,ge_s,ge_u}_correct` via
+`synth_i64_setcond_proof_poly` against `i64_setcond_bits_spec` — pseudo-op
+tier: the encoder's CMP-lo/SBCS-hi expansion is below the flat executor,
+see `docs/design/vcr-sel-001-increment-4.md`).
+
+**40 Qed / 0 Admitted**, same T1 bound as the pilot ("the ARM sequence
+computes the named result", not WASM refinement). These 47 Qed (pilot +
 rules) post-date and are NOT in the 2026-06-04 recount above.
+
+## DSL coverage vs model relevance (per-op-family metric, #667)
+
+The Rocq suite proves things in two very different places, and #73's
+"retirement by subtraction" of the divergent monolithic model is only
+measurable if they are counted separately:
+
+- **DSL-served** — the op's *shipped* lowering is a `sel_dsl` rule with a
+  1:1 Qed theorem in `VcrSelRules.v`, register-polymorphic, mirror-pinned
+  byte-identical to the hand-written arm(s) (behind `SYNTH_SEL_DSL`,
+  default OFF). These proofs are about the code that ships.
+- **model-only** — the op is proven only against `compile_wasm_to_arm`
+  (Compilation.v), the fixed-register model that diverges from the shipped
+  Rust selector in documented ways (#73). Evidence about a model, not the
+  binary.
+- **unverified** — the shipped selector lowers the op but no Rocq theorem
+  covers it in either form.
+
+Every op family the shipped ARM selectors lower, as of increment 4
+(update this table whenever a rule lands or a model arm is retired):
+
+| Op family | ops | DSL-served | model-only | unverified |
+|---|---|---|---|---|
+| i32 ALU (add/sub/mul/and/or/xor) | 6 | **6** | 0 | 0 |
+| i32 shifts/rotates (shl/shr_s/shr_u/rotr/rotl) | 5 | **5** | 0 | 0 |
+| i32 binary comparisons (eq..ge_u) | 10 | **10** | 0 | 0 |
+| i32.eqz (CMP-imm shape) | 1 | 0 | 1 | 0 |
+| i32 bit-manip (clz/ctz/popcnt) | 3 | **3**¹ | 0 | 0 |
+| i32 div/rem (trap-guarded) | 4 | 0 | 4² | 0 |
+| i32 sign-extend (extend8_s/16_s) | 2 | 0 | 0 | 2 |
+| i32.const | 1 | 0 | 1 | 0 |
+| i64 pair ALU (add/sub/and/or/xor) | 5 | **5** | 0 | 0 |
+| i64 comparisons (eqz + eq..ge_u) | 11 | **11**¹ | 0 | 0 |
+| i64 mul/div/rem | 4 | 0 | 4 | 0 |
+| i64 shifts/rotates (pair pseudo-ops) | 5 | 0 | 5 | 0 |
+| i64 bit-manip (clz/ctz/popcnt) | 3 | 0 | 3 | 0 |
+| i64 wrap/extend (wrap_i64, extend_i32_s/u) | 3 | 0 | 3 | 0 |
+| i64 sign-extend (extend8/16/32_s) | 3 | 0 | 0 | 3 |
+| i64.const | 1 | 0 | 1 | 0 |
+| f32/f64 arithmetic + comparisons³ | 40 | 0 | 40 | 0 |
+| conversions (trunc/convert/demote/promote) | 18 | 0 | 18 | 0 |
+| memory load/store (i32/i64/f32/f64, basic) | 8 | 0 | 8 | 0 |
+| bulk memory (memory.copy/fill), memory.size/grow | 4 | 0 | 0 | 4 |
+| locals/globals (get/set/tee) | 5 | 0 | 5 | 0 |
+| parametric (drop/select/nop) | 3 | 0 | 3 | 0 |
+| control flow (block/loop/br/br_if/return/call/…) | ~10 | 0 | 0 | ~10 |
+| **Total (≈)** | **155** | **40 (26%)** | **96 (62%)** | **19 (12%)** |
+
+¹ pseudo-op tier: `popcnt`, `i64.eqz` and the ten binary i64 comparisons are
+proven at the `ArmOp` pseudo-op boundary (the selector's emission, which is
+what the DSL owns); the encoder expansions below that boundary
+(shift-and-add popcnt, the CMP-lo/SBCS-hi chain) are covered by the
+differential oracles, not Rocq — see `docs/design/vcr-sel-001-increment-4.md`.
+² the 4 i32 div/rem model proofs are the T3 trap-guard admits (#73,
+`BCondOffset` executor gap).
+³ the f32/f64 model rows ride the 21 VFP axioms; the shipped ARM path
+additionally gates FPU ops behind the #369/GI-FPU work.
+
+**Retirement criterion (#73):** a `compile_wasm_to_arm` arm may be deleted
+(and its Correctness* theorem retired) once its family is DSL-served — the
+DSL theorem is strictly stronger (register-polymorphic, mirror-pinned to
+the shipped bytes). The model-only column is the shrinking measure; report
+it per release.
 
 ## Phase History
 

--- a/coq/Synth/Synth/VcrSelRules.v
+++ b/coq/Synth/Synth/VcrSelRules.v
@@ -1,4 +1,4 @@
-(** * VCR-SEL-001 increments 1+2+3: Rocq obligations of the wired selector rule table
+(** * VCR-SEL-001 increments 1+2+3+4: Rocq obligations of the wired selector rule table
 
     One universally-quantified T1 theorem per rule in the checked-in DSL table
     [crates/synth-synthesis/src/sel_dsl/mod.rs] (RULES), naming 1:1:
@@ -681,3 +681,302 @@ Proof.
   rewrite i64_setcondz_bits_spec.
   eexists. split; [reflexivity | apply get_set_reg_eq].
 Qed.
+
+(** ** Increment 4: scratch-using and multi-instruction shapes + the binary
+    [I64SetCond] comparison family.
+
+    i32 bit-manipulation:
+
+    - [rule_i32_clz] — single [CLZ] (tier A, unary);
+    - [rule_i32_ctz] — the TWO-instruction [RBIT rd rm; CLZ rd rd] shape
+      with the scratch=dest trick: instruction 1 writes the bit-reversed
+      value into [rd] itself, instruction 2 reads it back — NO extra
+      scratch register and NO aliasing side condition (every rd/rm
+      aliasing is admitted: RBIT reads [rm] before writing [rd], and the
+      second instruction only reads [rd]). Stepped proof closing with the
+      [I32.clz_rbit] axiom, exactly like the fixed-register ancestor
+      ([i32_ctz_correct], CorrectnessI32.v), register-generalized;
+    - [rule_i32_popcnt] — HONEST TIER NOTE: at the [ArmOp] level the
+      selector emits a single [Popcnt] pseudo-op, which is what the rule
+      mirrors and what this file proves (against the axiomatized
+      [I32.popcnt], like the ancestors). The encoder's shift-and-add
+      expansion BELOW the ArmOp boundary (where the #632 clobber lived)
+      is not modeled here — same pseudo-op-tier honesty as [i64.eqz] and
+      the [I64SetCond] family below.
+
+    The binary i64 comparison family ([rule_i64_eq] .. [rule_i64_ge_u]) —
+    the shape #615 re-implemented on A32 and where cond-mapping bugs
+    live. Both selectors emit ONE [ArmOp::I64SetCond] pseudo-op per
+    comparison; the rules mirror that pseudo-op with the condition the
+    hand-written arms choose (LO=Cond_CC, HS=Cond_CS), and each theorem
+    discharges against the [i64_setcond_bits_spec] axiom — the
+    register-generalized form of the fixed-register ancestors in
+    CorrectnessI64Comparisons.v. No side conditions: the pseudo-op reads
+    all four operand halves before writing [rd], so every aliasing is
+    admitted.
+
+    WHAT THE FLAT EXECUTOR CANNOT EXPRESS (the honest bound): the
+    encoder expands [I64SetCond] to the dual-precision flags-chain
+    [CMP lo,lo; SBCS rd,hi,hi; MOVcc] (ordered conditions, with the
+    GT/LE/HI/LS operand swap) or [CMP lo,lo; CMPEQ hi,hi; MOVcc]
+    (EQ/NE). Verifying THAT expansion (rather than the pseudo-op) needs
+    three things the flat model lacks today: (a) a flag-SETTING SBC
+    ([SBCS] — the model's [SBC] reads C but writes no flags), (b)
+    conditionally-executed flags-writers ([CMPEQ] — the model's only
+    conditional forms are the register-writing [MOVcc] family), and (c)
+    three-operand borrow-aware C/V flag helpers ([compute_c_flag_sub] /
+    [compute_v_flag_sub] are two-operand). That is the same executor gap
+    the VCR-ISA-001 spike hit with [BCondOffset] (a no-op in the flat
+    executor): pseudo-op-tier proofs are the honest ceiling until the
+    Sail-generated model lands. Documented in
+    docs/design/vcr-sel-001-increment-4.md. *)
+
+Definition rule_i32_clz (rd rm : arm_reg) : arm_program := [CLZ rd rm].
+Definition rule_i32_ctz (rd rm : arm_reg) : arm_program := [RBIT rd rm; CLZ rd rd].
+Definition rule_i32_popcnt (rd rm : arm_reg) : arm_program := [POPCNT rd rm].
+
+(** The binary I64SetCond comparison rules — 1:1 with the Rust table.
+    Condition mapping is the hand-written arms' (and Compilation.v's):
+    lt_u -> Cond_CC (LO), gt_u -> Cond_HI, le_u -> Cond_LS,
+    ge_u -> Cond_CS (HS). *)
+Definition rule_i64_eq (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_EQ].
+Definition rule_i64_ne (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_NE].
+Definition rule_i64_lt_s (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_LT].
+Definition rule_i64_lt_u (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_CC].
+Definition rule_i64_gt_s (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_GT].
+Definition rule_i64_gt_u (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_HI].
+Definition rule_i64_le_s (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_LE].
+Definition rule_i64_le_u (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_LS].
+Definition rule_i64_ge_s (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_GE].
+Definition rule_i64_ge_u (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_CS].
+
+(** ** Increment-4 discharge tactics.
+
+    [synth_unop_proof_poly] — verbatim [synth_unop_proof] (Tactics.v)
+    modulo the two register binders and the lowering-unfold target,
+    mirroring how [synth_binop_proof_poly] generalizes
+    [synth_binop_proof]. Closes the single-instruction unary shapes
+    (clz, popcnt).
+
+    [synth_i64_setcond_proof_poly] — the register-generalized form of
+    the CorrectnessI64Comparisons.v ancestors' uniform script: expose
+    the pseudo-op step, substitute the four operand-half reads, reduce
+    the [i64_setcond_bits_spec] axiom on the concrete condition. *)
+
+Ltac synth_unop_proof_poly :=
+  intros wstate astate v stack' rd rm Hstack HR0 Hwasm;
+  unfold rule_i32_clz, rule_i32_popcnt;
+  unfold exec_program, exec_instr;
+  simpl;
+  rewrite HR0;
+  eexists; split;
+  [ reflexivity
+  | simpl; apply get_set_reg_eq ].
+
+Ltac synth_i64_setcond_proof_poly :=
+  intros astate lo1 hi1 lo2 hi2 rd rnlo rnhi rmlo rmhi HR0 HR1 HR2 HR3;
+  unfold rule_i64_eq, rule_i64_ne, rule_i64_lt_s, rule_i64_lt_u,
+         rule_i64_gt_s, rule_i64_gt_u, rule_i64_le_s, rule_i64_le_u,
+         rule_i64_ge_s, rule_i64_ge_u;
+  simpl;
+  rewrite HR0, HR1, HR2, HR3;
+  rewrite i64_setcond_bits_spec; simpl;
+  eexists; split; [reflexivity | apply get_set_reg_eq].
+
+(** ** Increment-4 i32 bit-manipulation theorems — quantified over
+    ARBITRARY rd rm (no side conditions; see the section comment). *)
+
+Theorem rule_i32_clz_correct : forall wstate astate v stack' rd rm,
+  wstate.(stack) = VI32 v :: stack' ->
+  get_reg astate rm = v ->
+  exec_wasm_instr I32Clz wstate =
+    Some (mkWasmState (VI32 (I32.clz v) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_clz rd rm) astate = Some astate' /\
+    get_reg astate' rd = I32.clz v.
+Proof. synth_unop_proof_poly. Qed.
+
+(** The two-instruction scratch=dest shape: RBIT writes the reversed
+    value into [rd], CLZ reads it back from [rd] — stepped proof closing
+    with [I32.clz_rbit], like [rule_i32_rotl_correct]'s structure but
+    with no aliasing hypothesis needed (the "scratch" IS the dest). *)
+Theorem rule_i32_ctz_correct : forall wstate astate v stack' rd rm,
+  wstate.(stack) = VI32 v :: stack' ->
+  get_reg astate rm = v ->
+  exec_wasm_instr I32Ctz wstate =
+    Some (mkWasmState (VI32 (I32.ctz v) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_ctz rd rm) astate = Some astate' /\
+    get_reg astate' rd = I32.ctz v.
+Proof.
+  intros wstate astate v stack' rd rm Hstack HR0 Hwasm.
+  unfold rule_i32_ctz.
+  set (s1 := set_reg astate rd (I32.rbit (get_reg astate rm))).
+  set (s2 := set_reg s1 rd (I32.clz (get_reg s1 rd))).
+  exists s2. split.
+  - subst s2 s1. simpl. reflexivity.
+  - subst s2. rewrite get_set_reg_eq.
+    subst s1. rewrite get_set_reg_eq.
+    rewrite HR0. apply I32.clz_rbit.
+Qed.
+
+(** Pseudo-op-tier T1: proves the [POPCNT] ArmOp the selector emits
+    (against the axiomatized [I32.popcnt]); the encoder's shift-and-add
+    expansion below the ArmOp boundary is outside the model. *)
+Theorem rule_i32_popcnt_correct : forall wstate astate v stack' rd rm,
+  wstate.(stack) = VI32 v :: stack' ->
+  get_reg astate rm = v ->
+  exec_wasm_instr I32Popcnt wstate =
+    Some (mkWasmState (VI32 (I32.popcnt v) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_popcnt rd rm) astate = Some astate' /\
+    get_reg astate' rd = I32.popcnt v.
+Proof. synth_unop_proof_poly. Qed.
+
+(** ** Increment-4 binary I64SetCond theorems — quantified over all FIVE
+    registers (result + two operand pairs), no side conditions.
+    Pseudo-op-tier T1 against [i64_setcond_bits_spec], the
+    register-generalized CorrectnessI64Comparisons.v ancestors. *)
+
+Theorem rule_i64_eq_correct :
+  forall astate lo1 hi1 lo2 hi2 rd rnlo rnhi rmlo rmhi,
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = lo2 ->
+  get_reg astate rmhi = hi2 ->
+  exists astate',
+    exec_program (rule_i64_eq rd rnlo rnhi rmlo rmhi) astate = Some astate' /\
+    get_reg astate' rd =
+      (if I64.eq (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof. synth_i64_setcond_proof_poly. Qed.
+
+Theorem rule_i64_ne_correct :
+  forall astate lo1 hi1 lo2 hi2 rd rnlo rnhi rmlo rmhi,
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = lo2 ->
+  get_reg astate rmhi = hi2 ->
+  exists astate',
+    exec_program (rule_i64_ne rd rnlo rnhi rmlo rmhi) astate = Some astate' /\
+    get_reg astate' rd =
+      (if I64.ne (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof. synth_i64_setcond_proof_poly. Qed.
+
+Theorem rule_i64_lt_s_correct :
+  forall astate lo1 hi1 lo2 hi2 rd rnlo rnhi rmlo rmhi,
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = lo2 ->
+  get_reg astate rmhi = hi2 ->
+  exists astate',
+    exec_program (rule_i64_lt_s rd rnlo rnhi rmlo rmhi) astate = Some astate' /\
+    get_reg astate' rd =
+      (if I64.lts (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof. synth_i64_setcond_proof_poly. Qed.
+
+Theorem rule_i64_lt_u_correct :
+  forall astate lo1 hi1 lo2 hi2 rd rnlo rnhi rmlo rmhi,
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = lo2 ->
+  get_reg astate rmhi = hi2 ->
+  exists astate',
+    exec_program (rule_i64_lt_u rd rnlo rnhi rmlo rmhi) astate = Some astate' /\
+    get_reg astate' rd =
+      (if I64.ltu (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof. synth_i64_setcond_proof_poly. Qed.
+
+Theorem rule_i64_gt_s_correct :
+  forall astate lo1 hi1 lo2 hi2 rd rnlo rnhi rmlo rmhi,
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = lo2 ->
+  get_reg astate rmhi = hi2 ->
+  exists astate',
+    exec_program (rule_i64_gt_s rd rnlo rnhi rmlo rmhi) astate = Some astate' /\
+    get_reg astate' rd =
+      (if I64.gts (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof. synth_i64_setcond_proof_poly. Qed.
+
+Theorem rule_i64_gt_u_correct :
+  forall astate lo1 hi1 lo2 hi2 rd rnlo rnhi rmlo rmhi,
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = lo2 ->
+  get_reg astate rmhi = hi2 ->
+  exists astate',
+    exec_program (rule_i64_gt_u rd rnlo rnhi rmlo rmhi) astate = Some astate' /\
+    get_reg astate' rd =
+      (if I64.gtu (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof. synth_i64_setcond_proof_poly. Qed.
+
+Theorem rule_i64_le_s_correct :
+  forall astate lo1 hi1 lo2 hi2 rd rnlo rnhi rmlo rmhi,
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = lo2 ->
+  get_reg astate rmhi = hi2 ->
+  exists astate',
+    exec_program (rule_i64_le_s rd rnlo rnhi rmlo rmhi) astate = Some astate' /\
+    get_reg astate' rd =
+      (if I64.les (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof. synth_i64_setcond_proof_poly. Qed.
+
+Theorem rule_i64_le_u_correct :
+  forall astate lo1 hi1 lo2 hi2 rd rnlo rnhi rmlo rmhi,
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = lo2 ->
+  get_reg astate rmhi = hi2 ->
+  exists astate',
+    exec_program (rule_i64_le_u rd rnlo rnhi rmlo rmhi) astate = Some astate' /\
+    get_reg astate' rd =
+      (if I64.leu (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof. synth_i64_setcond_proof_poly. Qed.
+
+Theorem rule_i64_ge_s_correct :
+  forall astate lo1 hi1 lo2 hi2 rd rnlo rnhi rmlo rmhi,
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = lo2 ->
+  get_reg astate rmhi = hi2 ->
+  exists astate',
+    exec_program (rule_i64_ge_s rd rnlo rnhi rmlo rmhi) astate = Some astate' /\
+    get_reg astate' rd =
+      (if I64.ges (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof. synth_i64_setcond_proof_poly. Qed.
+
+Theorem rule_i64_ge_u_correct :
+  forall astate lo1 hi1 lo2 hi2 rd rnlo rnhi rmlo rmhi,
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = lo2 ->
+  get_reg astate rmhi = hi2 ->
+  exists astate',
+    exec_program (rule_i64_ge_u rd rnlo rnhi rmlo rmhi) astate = Some astate' /\
+    get_reg astate' rd =
+      (if I64.geu (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
+       then I32.one else I32.zero).
+Proof. synth_i64_setcond_proof_poly. Qed.

--- a/coq/vcr_sel_rules.manifest
+++ b/coq/vcr_sel_rules.manifest
@@ -30,3 +30,16 @@ rule_i64_and
 rule_i64_or
 rule_i64_xor
 rule_i64_eqz
+rule_i32_clz
+rule_i32_ctz
+rule_i32_popcnt
+rule_i64_eq
+rule_i64_ne
+rule_i64_lt_s
+rule_i64_lt_u
+rule_i64_gt_s
+rule_i64_gt_u
+rule_i64_le_s
+rule_i64_le_u
+rule_i64_ge_s
+rule_i64_ge_u

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -2643,19 +2643,37 @@ impl InstructionSelector {
                 }
             }
 
-            // Bit count operations
-            I32Clz => vec![ArmOp::Clz { rd, rm }],
+            // Bit count operations — VCR-SEL-001 increment 4 (#242): behind
+            // SYNTH_SEL_DSL (default OFF) these delegate to the Rocq-proved
+            // rules (clz single-CLZ; ctz the two-instruction RBIT+CLZ
+            // scratch=dest shape; popcnt the pseudo-op), byte-identical by
+            // construction (mirror-pinned per op).
+            I32Clz => {
+                if self.sel_dsl {
+                    crate::sel_dsl::generated::rule_i32_clz(rd, rm)
+                } else {
+                    vec![ArmOp::Clz { rd, rm }]
+                }
+            }
 
             I32Ctz => {
-                // Count trailing zeros: RBIT + CLZ
-                vec![ArmOp::Rbit { rd, rm }, ArmOp::Clz { rd, rm: rd }]
+                if self.sel_dsl {
+                    crate::sel_dsl::generated::rule_i32_ctz(rd, rm)
+                } else {
+                    // Count trailing zeros: RBIT + CLZ
+                    vec![ArmOp::Rbit { rd, rm }, ArmOp::Clz { rd, rm: rd }]
+                }
             }
 
             I32Popcnt => {
-                // Population count - no native ARM instruction
-                // Use Popcnt pseudo-op which the encoder expands to a parallel
-                // bit-count algorithm (shift-and-add with masks)
-                vec![ArmOp::Popcnt { rd, rm }]
+                if self.sel_dsl {
+                    crate::sel_dsl::generated::rule_i32_popcnt(rd, rm)
+                } else {
+                    // Population count - no native ARM instruction
+                    // Use Popcnt pseudo-op which the encoder expands to a parallel
+                    // bit-count algorithm (shift-and-add with masks)
+                    vec![ArmOp::Popcnt { rd, rm }]
+                }
             }
 
             I32Const(val) => {
@@ -3398,114 +3416,47 @@ impl InstructionSelector {
                 }
             }
 
-            I64Eq => {
-                vec![ArmOp::I64SetCond {
-                    rd: Reg::R0,
-                    rn_lo: Reg::R0,
-                    rn_hi: Reg::R1,
-                    rm_lo: Reg::R2,
-                    rm_hi: Reg::R3,
-                    cond: Condition::EQ,
-                }]
-            }
-
-            I64Ne => {
-                vec![ArmOp::I64SetCond {
-                    rd: Reg::R0,
-                    rn_lo: Reg::R0,
-                    rn_hi: Reg::R1,
-                    rm_lo: Reg::R2,
-                    rm_hi: Reg::R3,
-                    cond: Condition::NE,
-                }]
-            }
-
-            I64LtS => {
-                vec![ArmOp::I64SetCond {
-                    rd: Reg::R0,
-                    rn_lo: Reg::R0,
-                    rn_hi: Reg::R1,
-                    rm_lo: Reg::R2,
-                    rm_hi: Reg::R3,
-                    cond: Condition::LT,
-                }]
-            }
-
-            I64LtU => {
-                vec![ArmOp::I64SetCond {
-                    rd: Reg::R0,
-                    rn_lo: Reg::R0,
-                    rn_hi: Reg::R1,
-                    rm_lo: Reg::R2,
-                    rm_hi: Reg::R3,
-                    cond: Condition::LO,
-                }]
-            }
-
-            I64LeS => {
-                vec![ArmOp::I64SetCond {
-                    rd: Reg::R0,
-                    rn_lo: Reg::R0,
-                    rn_hi: Reg::R1,
-                    rm_lo: Reg::R2,
-                    rm_hi: Reg::R3,
-                    cond: Condition::LE,
-                }]
-            }
-
-            I64LeU => {
-                vec![ArmOp::I64SetCond {
-                    rd: Reg::R0,
-                    rn_lo: Reg::R0,
-                    rn_hi: Reg::R1,
-                    rm_lo: Reg::R2,
-                    rm_hi: Reg::R3,
-                    cond: Condition::LS,
-                }]
-            }
-
-            I64GtS => {
-                vec![ArmOp::I64SetCond {
-                    rd: Reg::R0,
-                    rn_lo: Reg::R0,
-                    rn_hi: Reg::R1,
-                    rm_lo: Reg::R2,
-                    rm_hi: Reg::R3,
-                    cond: Condition::GT,
-                }]
-            }
-
-            I64GtU => {
-                vec![ArmOp::I64SetCond {
-                    rd: Reg::R0,
-                    rn_lo: Reg::R0,
-                    rn_hi: Reg::R1,
-                    rm_lo: Reg::R2,
-                    rm_hi: Reg::R3,
-                    cond: Condition::HI,
-                }]
-            }
-
-            I64GeS => {
-                vec![ArmOp::I64SetCond {
-                    rd: Reg::R0,
-                    rn_lo: Reg::R0,
-                    rn_hi: Reg::R1,
-                    rm_lo: Reg::R2,
-                    rm_hi: Reg::R3,
-                    cond: Condition::GE,
-                }]
-            }
-
-            I64GeU => {
-                vec![ArmOp::I64SetCond {
-                    rd: Reg::R0,
-                    rn_lo: Reg::R0,
-                    rn_hi: Reg::R1,
-                    rm_lo: Reg::R2,
-                    rm_hi: Reg::R3,
-                    cond: Condition::HS,
-                }]
+            // Binary i64 comparisons — VCR-SEL-001 increment 4 (#242): one
+            // I64SetCond pseudo-op over the fixed (R0:R1, R2:R3) pairs.
+            // Behind SYNTH_SEL_DSL (default OFF) the pseudo-op comes from
+            // the generated Rocq-proved rule (mirror-pinned per op); OFF
+            // keeps the hand-written emission, byte-identical by
+            // construction.
+            I64Eq | I64Ne | I64LtS | I64LtU | I64LeS | I64LeU | I64GtS | I64GtU | I64GeS
+            | I64GeU => {
+                if self.sel_dsl {
+                    crate::sel_dsl::i64_setcond_rule(
+                        wasm_op,
+                        Reg::R0,
+                        Reg::R0,
+                        Reg::R1,
+                        Reg::R2,
+                        Reg::R3,
+                    )
+                    .expect("binary i64 comparison has a generated rule")
+                } else {
+                    let cond = match wasm_op {
+                        I64Eq => Condition::EQ,
+                        I64Ne => Condition::NE,
+                        I64LtS => Condition::LT,
+                        I64LtU => Condition::LO,
+                        I64LeS => Condition::LE,
+                        I64LeU => Condition::LS,
+                        I64GtS => Condition::GT,
+                        I64GtU => Condition::HI,
+                        I64GeS => Condition::GE,
+                        I64GeU => Condition::HS,
+                        _ => unreachable!(),
+                    };
+                    vec![ArmOp::I64SetCond {
+                        rd: Reg::R0,
+                        rn_lo: Reg::R0,
+                        rn_hi: Reg::R1,
+                        rm_lo: Reg::R2,
+                        rm_hi: Reg::R3,
+                        cond,
+                    }]
+                }
             }
 
             // i64 multiply: UMULL + MLA cross products
@@ -11146,11 +11097,30 @@ impl InstructionSelector {
                             idx,
                         )?
                     };
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Clz { rd: dst, rm: src },
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
+                    // VCR-SEL-001 increment 4 (#242): behind SYNTH_SEL_DSL the
+                    // single CLZ comes from the generated Rocq-proved rule —
+                    // the identical ArmOp, byte-identical by construction
+                    // (mirror-pinned per op).
+                    let dsl_ops = if self.sel_dsl {
+                        crate::sel_dsl::i32_unary_rule(op, dst, src)
+                    } else {
+                        None
+                    };
+                    if let Some(rule_ops) = dsl_ops {
+                        for rule_op in rule_ops {
+                            instructions.push(ArmInstruction {
+                                op: rule_op,
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                        }
+                    } else {
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Clz { rd: dst, rm: src },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    }
                     stack.push(StackVal::i32(dst));
                 }
 
@@ -11176,16 +11146,35 @@ impl InstructionSelector {
                             idx,
                         )?
                     };
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Rbit { rd: dst, rm: src },
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Clz { rd: dst, rm: dst },
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
+                    // VCR-SEL-001 increment 4 (#242): behind SYNTH_SEL_DSL the
+                    // two-instruction RBIT+CLZ scratch=dest shape comes from
+                    // the generated Rocq-proved rule, byte-identical by
+                    // construction (mirror-pinned per op).
+                    let dsl_ops = if self.sel_dsl {
+                        crate::sel_dsl::i32_unary_rule(op, dst, src)
+                    } else {
+                        None
+                    };
+                    if let Some(rule_ops) = dsl_ops {
+                        for rule_op in rule_ops {
+                            instructions.push(ArmInstruction {
+                                op: rule_op,
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                        }
+                    } else {
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Rbit { rd: dst, rm: src },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Clz { rd: dst, rm: dst },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    }
                     stack.push(StackVal::i32(dst));
                 }
 
@@ -11212,11 +11201,29 @@ impl InstructionSelector {
                             idx,
                         )?
                     };
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Popcnt { rd: dst, rm: src },
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
+                    // VCR-SEL-001 increment 4 (#242): pseudo-op-tier rule —
+                    // the identical ArmOp::Popcnt, byte-identical by
+                    // construction (mirror-pinned per op).
+                    let dsl_ops = if self.sel_dsl {
+                        crate::sel_dsl::i32_unary_rule(op, dst, src)
+                    } else {
+                        None
+                    };
+                    if let Some(rule_ops) = dsl_ops {
+                        for rule_op in rule_ops {
+                            instructions.push(ArmInstruction {
+                                op: rule_op,
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                        }
+                    } else {
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Popcnt { rd: dst, rm: src },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    }
                     stack.push(StackVal::i32(dst));
                 }
 
@@ -11347,18 +11354,38 @@ impl InstructionSelector {
                         I64GeU => Condition::HS,
                         _ => unreachable!(),
                     };
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::I64SetCond {
-                            rd: dst,
-                            rn_lo: a_lo,
-                            rn_hi: a_hi,
-                            rm_lo: b_lo,
-                            rm_hi: b_hi,
-                            cond,
-                        },
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
+                    // VCR-SEL-001 increment 4 (#242): behind SYNTH_SEL_DSL the
+                    // I64SetCond pseudo-op comes from the generated
+                    // Rocq-proved rule — the identical ArmOp (same condition
+                    // mapping), byte-identical by construction (mirror-pinned
+                    // per op).
+                    let dsl_ops = if self.sel_dsl {
+                        crate::sel_dsl::i64_setcond_rule(op, dst, a_lo, a_hi, b_lo, b_hi)
+                    } else {
+                        None
+                    };
+                    if let Some(rule_ops) = dsl_ops {
+                        for rule_op in rule_ops {
+                            instructions.push(ArmInstruction {
+                                op: rule_op,
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                        }
+                    } else {
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::I64SetCond {
+                                rd: dst,
+                                rn_lo: a_lo,
+                                rn_hi: a_hi,
+                                rm_lo: b_lo,
+                                rm_hi: b_hi,
+                                cond,
+                            },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    }
                     stack.push(StackVal::i32(dst));
                 }
 
@@ -12405,8 +12432,9 @@ mod tests {
             );
         }
         // Non-vacuity: increment 1's seven + increment 2's four shifts +
-        // increment 3's six i64 pair-family rules.
-        assert_eq!(probed, 17, "unexpected select_default-delegated rule count");
+        // increment 3's six i64 pair-family rules + increment 4's three i32
+        // bit-manipulation and ten binary I64SetCond comparison rules.
+        assert_eq!(probed, 30, "unexpected select_default-delegated rule count");
     }
 
     /// VCR-SEL-001 increment 2 (#242) — gate 1 for the rules delegated in
@@ -12469,7 +12497,42 @@ mod tests {
                 .seq
                 .iter()
                 .any(|t| matches!(t, crate::sel_dsl::TemplateOp::SetCond { .. }));
-            let (window, rule_ops) = if is_cmp_rule {
+            let is_unary_rule = rule.seq.iter().any(|t| {
+                matches!(
+                    t,
+                    crate::sel_dsl::TemplateOp::Clz { .. }
+                        | crate::sel_dsl::TemplateOp::Rbit { .. }
+                        | crate::sel_dsl::TemplateOp::Popcnt { .. }
+                )
+            });
+            let (window, rule_ops) = if is_unary_rule {
+                // Increment 4's i32 bit-manipulation shapes: the window starts
+                // at the first Clz/Rbit/Popcnt and spans the rule's length
+                // (ctz is the two-instruction RBIT+CLZ scratch=dest shape).
+                let i = baseline
+                    .iter()
+                    .position(|o| {
+                        matches!(
+                            o,
+                            ArmOp::Clz { .. } | ArmOp::Rbit { .. } | ArmOp::Popcnt { .. }
+                        )
+                    })
+                    .unwrap_or_else(|| panic!("{}: no bit-manip op in probe output", rule.name));
+                let (rd, rm) = match &baseline[i] {
+                    ArmOp::Clz { rd, rm } | ArmOp::Rbit { rd, rm } | ArmOp::Popcnt { rd, rm } => {
+                        (*rd, *rm)
+                    }
+                    _ => unreachable!(),
+                };
+                let rule_ops = crate::sel_dsl::i32_unary_rule(&rule.op, rd, rm)
+                    .unwrap_or_else(|| panic!("{}: unary dispatch missing", rule.name));
+                assert!(
+                    baseline.len() >= i + rule_ops.len(),
+                    "{}: probe output too short for the rule window",
+                    rule.name
+                );
+                (baseline[i..i + rule_ops.len()].to_vec(), rule_ops)
+            } else if is_cmp_rule {
                 let i = baseline
                     .iter()
                     .position(|o| matches!(o, ArmOp::Cmp { .. }))
@@ -12523,9 +12586,10 @@ mod tests {
                 rule.name
             );
         }
-        // Ten comparisons + four shifts.
+        // Ten comparisons + four shifts + increment 4's three i32
+        // bit-manipulation rules.
         assert_eq!(
-            probed, 14,
+            probed, 17,
             "unexpected select_with_stack-delegated rule count"
         );
     }
@@ -12599,6 +12663,34 @@ mod tests {
                 (
                     baseline[i..i + 1].to_vec(),
                     crate::sel_dsl::generated::rule_i64_eqz(rd, rn_lo, rn_hi),
+                )
+            } else if rule
+                .seq
+                .iter()
+                .any(|t| matches!(t, crate::sel_dsl::TemplateOp::I64SetCond { .. }))
+            {
+                // Increment 4's binary comparison family: the window is the
+                // single I64SetCond pseudo-op; extract the FIVE registers the
+                // hand-written arm chose (result + both operand pairs).
+                let i = baseline
+                    .iter()
+                    .position(|o| matches!(o, ArmOp::I64SetCond { .. }))
+                    .unwrap_or_else(|| panic!("{}: no I64SetCond in probe output", rule.name));
+                let (rd, rn_lo, rn_hi, rm_lo, rm_hi) = match &baseline[i] {
+                    ArmOp::I64SetCond {
+                        rd,
+                        rn_lo,
+                        rn_hi,
+                        rm_lo,
+                        rm_hi,
+                        ..
+                    } => (*rd, *rn_lo, *rn_hi, *rm_lo, *rm_hi),
+                    _ => unreachable!(),
+                };
+                (
+                    baseline[i..i + 1].to_vec(),
+                    crate::sel_dsl::i64_setcond_rule(&rule.op, rd, rn_lo, rn_hi, rm_lo, rm_hi)
+                        .unwrap_or_else(|| panic!("{}: setcond dispatch missing", rule.name)),
                 )
             } else {
                 // The pair window is the two-instruction sequence starting at
@@ -12701,8 +12793,9 @@ mod tests {
                 rule.name
             );
         }
-        // Five binary pair rules + i64.eqz.
-        assert_eq!(probed, 6, "unexpected i64 pair rule count");
+        // Five binary pair rules + i64.eqz + increment 4's ten binary
+        // I64SetCond comparison rules.
+        assert_eq!(probed, 16, "unexpected i64 pair rule count");
     }
 
     /// VCR-SEL-001 increment 2 (#242): the #258 imm-fold comparison peephole

--- a/crates/synth-synthesis/src/sel_dsl/generated.rs
+++ b/crates/synth-synthesis/src/sel_dsl/generated.rs
@@ -1,10 +1,11 @@
 //! GENERATED FILE — DO NOT EDIT BY HAND.
 //!
 //! Emitted by `crate::sel_dsl::generate_lowering_source()` from the declarative
-//! rule table [`crate::sel_dsl::RULES`] (VCR-SEL-001 increments 1+2+3, #242,
+//! rule table [`crate::sel_dsl::RULES`] (VCR-SEL-001 increments 1+2+3+4, #242,
 //! `docs/design/vcr-sel-001-first-increment.md` +
 //! `docs/design/vcr-sel-001-increment-2.md` +
-//! `docs/design/vcr-sel-001-increment-3.md`). Pinned up-to-date by the
+//! `docs/design/vcr-sel-001-increment-3.md` +
+//! `docs/design/vcr-sel-001-increment-4.md`). Pinned up-to-date by the
 //! `generated_lowering_is_up_to_date` test; regenerate with
 //! `SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl`.
 //!
@@ -506,4 +507,165 @@ pub fn rule_i64_xor(
 /// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_eqz_correct` (Qed).
 pub fn rule_i64_eqz(rd: Reg, rn_lo: Reg, rn_hi: Reg) -> Vec<ArmOp> {
     vec![ArmOp::I64SetCondZ { rd, rn_lo, rn_hi }]
+}
+
+/// `i32.clz`: rd = count of leading zero bits of rm
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_clz_correct` (Qed).
+pub fn rule_i32_clz(rd: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::Clz { rd, rm }]
+}
+
+/// `i32.ctz`: rd = count of trailing zero bits of rm, via RBIT + CLZ (scratch=dest)
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_ctz_correct` (Qed).
+pub fn rule_i32_ctz(rd: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::Rbit { rd, rm }, ArmOp::Clz { rd, rm: rd }]
+}
+
+/// `i32.popcnt`: rd = count of set bits of rm (pseudo-op, encoder-expanded)
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_popcnt_correct` (Qed).
+pub fn rule_i32_popcnt(rd: Reg, rm: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::Popcnt { rd, rm }]
+}
+
+/// `i64.eq`: rd = if (rn_hi:rn_lo) == (rm_hi:rm_lo) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_eq_correct` (Qed).
+pub fn rule_i64_eq(rd: Reg, rn_lo: Reg, rn_hi: Reg, rm_lo: Reg, rm_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64SetCond {
+        rd,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+        cond: Condition::EQ,
+    }]
+}
+
+/// `i64.ne`: rd = if (rn_hi:rn_lo) != (rm_hi:rm_lo) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_ne_correct` (Qed).
+pub fn rule_i64_ne(rd: Reg, rn_lo: Reg, rn_hi: Reg, rm_lo: Reg, rm_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64SetCond {
+        rd,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+        cond: Condition::NE,
+    }]
+}
+
+/// `i64.lt_s`: rd = if (rn_hi:rn_lo) < (rm_hi:rm_lo) (signed) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_lt_s_correct` (Qed).
+pub fn rule_i64_lt_s(rd: Reg, rn_lo: Reg, rn_hi: Reg, rm_lo: Reg, rm_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64SetCond {
+        rd,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+        cond: Condition::LT,
+    }]
+}
+
+/// `i64.lt_u`: rd = if (rn_hi:rn_lo) < (rm_hi:rm_lo) (unsigned) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_lt_u_correct` (Qed).
+pub fn rule_i64_lt_u(rd: Reg, rn_lo: Reg, rn_hi: Reg, rm_lo: Reg, rm_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64SetCond {
+        rd,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+        cond: Condition::LO,
+    }]
+}
+
+/// `i64.gt_s`: rd = if (rn_hi:rn_lo) > (rm_hi:rm_lo) (signed) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_gt_s_correct` (Qed).
+pub fn rule_i64_gt_s(rd: Reg, rn_lo: Reg, rn_hi: Reg, rm_lo: Reg, rm_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64SetCond {
+        rd,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+        cond: Condition::GT,
+    }]
+}
+
+/// `i64.gt_u`: rd = if (rn_hi:rn_lo) > (rm_hi:rm_lo) (unsigned) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_gt_u_correct` (Qed).
+pub fn rule_i64_gt_u(rd: Reg, rn_lo: Reg, rn_hi: Reg, rm_lo: Reg, rm_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64SetCond {
+        rd,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+        cond: Condition::HI,
+    }]
+}
+
+/// `i64.le_s`: rd = if (rn_hi:rn_lo) <= (rm_hi:rm_lo) (signed) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_le_s_correct` (Qed).
+pub fn rule_i64_le_s(rd: Reg, rn_lo: Reg, rn_hi: Reg, rm_lo: Reg, rm_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64SetCond {
+        rd,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+        cond: Condition::LE,
+    }]
+}
+
+/// `i64.le_u`: rd = if (rn_hi:rn_lo) <= (rm_hi:rm_lo) (unsigned) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_le_u_correct` (Qed).
+pub fn rule_i64_le_u(rd: Reg, rn_lo: Reg, rn_hi: Reg, rm_lo: Reg, rm_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64SetCond {
+        rd,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+        cond: Condition::LS,
+    }]
+}
+
+/// `i64.ge_s`: rd = if (rn_hi:rn_lo) >= (rm_hi:rm_lo) (signed) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_ge_s_correct` (Qed).
+pub fn rule_i64_ge_s(rd: Reg, rn_lo: Reg, rn_hi: Reg, rm_lo: Reg, rm_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64SetCond {
+        rd,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+        cond: Condition::GE,
+    }]
+}
+
+/// `i64.ge_u`: rd = if (rn_hi:rn_lo) >= (rm_hi:rm_lo) (unsigned) {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_ge_u_correct` (Qed).
+pub fn rule_i64_ge_u(rd: Reg, rn_lo: Reg, rn_hi: Reg, rm_lo: Reg, rm_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64SetCond {
+        rd,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+        cond: Condition::HS,
+    }]
 }

--- a/crates/synth-synthesis/src/sel_dsl/mod.rs
+++ b/crates/synth-synthesis/src/sel_dsl/mod.rs
@@ -1,8 +1,9 @@
-//! VCR-SEL-001 increments 1+2+3 (#242) — the Rocq-discharged selector rule DSL.
+//! VCR-SEL-001 increments 1+2+3+4 (#242) — the Rocq-discharged selector rule DSL.
 //!
 //! Scope: `docs/design/vcr-sel-001-first-increment.md` (increment 1),
-//! `docs/design/vcr-sel-001-increment-2.md` (increment 2) and
-//! `docs/design/vcr-sel-001-increment-3.md` (increment 3). This module is the
+//! `docs/design/vcr-sel-001-increment-2.md` (increment 2),
+//! `docs/design/vcr-sel-001-increment-3.md` (increment 3) and
+//! `docs/design/vcr-sel-001-increment-4.md` (increment 4). This module is the
 //! **checked-in rule table**: a declarative `op → parameterized ARM sequence`
 //! (registers as variables, side conditions explicit) for:
 //!
@@ -25,6 +26,16 @@
 //!   so a rule format that could not state "the destination must not be
 //!   clobbered before use" is exactly how #632-class bugs happen. Each pair
 //!   theorem proves BOTH result words.
+//! - increment 4: the scratch-using and multi-instruction tier the pilot
+//!   called out — i32 bit-manipulation (`clz` single-`CLZ`; `ctz` the
+//!   TWO-instruction `RBIT rd; CLZ rd, rd` shape with the scratch=dest trick,
+//!   no extra register and no side condition; `popcnt` at pseudo-op tier)
+//!   plus the binary i64 comparison family (`i64.eq/ne/lt_s/lt_u/gt_s/gt_u/
+//!   le_s/le_u/ge_s/ge_u`, the single-`I64SetCond`-pseudo-op shape both
+//!   selectors emit — the shape whose encoder expansion is the
+//!   CMP-lo/SBCS-hi flags-chain #615 re-implemented on A32; the rules and
+//!   theorems live at the pseudo-op tier the flat Rocq executor can express,
+//!   see `docs/design/vcr-sel-001-increment-4.md` for the honest bound).
 //!
 //! The table is turned into plain Rust lowering functions by
 //! [`generate_lowering_source`] and the output is **committed to the tree** at
@@ -223,6 +234,22 @@ pub enum TemplateOp {
         rn_lo: RegVar,
         rn_hi: RegVar,
     },
+    /// `ArmOp::Clz { rd, rm }` — count leading zeros
+    Clz { rd: RegVar, rm: RegVar },
+    /// `ArmOp::Rbit { rd, rm }` — reverse bits (the ctz shape's first step)
+    Rbit { rd: RegVar, rm: RegVar },
+    /// `ArmOp::Popcnt { rd, rm }` — population-count pseudo-op (encoder-expanded)
+    Popcnt { rd: RegVar, rm: RegVar },
+    /// `ArmOp::I64SetCond { rd, rn_lo, rn_hi, rm_lo, rm_hi, cond }` —
+    /// rd = if (rn_hi:rn_lo) <cond> (rm_hi:rm_lo) {1} else {0}
+    I64SetCond {
+        rd: RegVar,
+        rn_lo: RegVar,
+        rn_hi: RegVar,
+        rm_lo: RegVar,
+        rm_hi: RegVar,
+        cond: CondCode,
+    },
 }
 
 /// One declarative lowering rule: `op → parameterized ARM sequence`.
@@ -282,6 +309,12 @@ const I64_PAIR_SIDE_CONDITIONS: &[SideCondition] = &[
 
 /// The parameter order shared by every binary i64 pair rule.
 const I64_PAIR_PARAMS: &[RegVar] = &[RdLo, RdHi, RnLo, RnHi, RmLo, RmHi];
+
+/// The parameter order shared by every binary `I64SetCond` comparison rule
+/// (increment 4): the single i32 result register plus the two operand pairs.
+/// NO side conditions — the pseudo-op reads all four operand halves before
+/// writing `rd`, so every aliasing is admitted by the universal quantifier.
+const I64_SETCOND_PARAMS: &[RegVar] = &[Rd, RnLo, RnHi, RmLo, RmHi];
 
 /// The increment-1 rule table: the tier-A six + tier-B `i32.rotl`.
 ///
@@ -723,6 +756,215 @@ pub const RULES: &[SelRule] = &[
         delegation: Delegation::Both,
         doc: "`i64.eqz`: rd = if (rn_hi:rn_lo) == 0 {1} else {0}",
     },
+    // ---- increment 4: i32 bit manipulation. `clz` is single-instruction
+    // tier A; `ctz` is the TWO-instruction RBIT+CLZ shape with the
+    // scratch=dest trick (instruction 1 writes the bit-reversed value into
+    // rd itself, instruction 2 reads it back — no extra scratch register
+    // and NO side condition: RBIT reads rm before writing rd, and the
+    // second instruction only reads rd); `popcnt` is pseudo-op-tier (the
+    // rule mirrors the single ArmOp::Popcnt the selector emits; the
+    // encoder's shift-and-add expansion below the ArmOp boundary is
+    // outside the Rocq model — same honest tier as i64.eqz/I64SetCond). ----
+    SelRule {
+        name: "rule_i32_clz",
+        op: WasmOp::I32Clz,
+        params: &[Rd, Rm],
+        side_conditions: &[],
+        seq: &[TemplateOp::Clz { rd: Rd, rm: Rm }],
+        delegation: Delegation::Both,
+        doc: "`i32.clz`: rd = count of leading zero bits of rm",
+    },
+    SelRule {
+        name: "rule_i32_ctz",
+        op: WasmOp::I32Ctz,
+        params: &[Rd, Rm],
+        side_conditions: &[],
+        seq: &[
+            TemplateOp::Rbit { rd: Rd, rm: Rm },
+            TemplateOp::Clz { rd: Rd, rm: Rd },
+        ],
+        delegation: Delegation::Both,
+        doc: "`i32.ctz`: rd = count of trailing zero bits of rm, via RBIT + CLZ (scratch=dest)",
+    },
+    SelRule {
+        name: "rule_i32_popcnt",
+        op: WasmOp::I32Popcnt,
+        params: &[Rd, Rm],
+        side_conditions: &[],
+        seq: &[TemplateOp::Popcnt { rd: Rd, rm: Rm }],
+        delegation: Delegation::Both,
+        doc: "`i32.popcnt`: rd = count of set bits of rm (pseudo-op, encoder-expanded)",
+    },
+    // ---- increment 4: the binary i64 comparison family — the
+    // single-I64SetCond-pseudo-op shape BOTH selectors emit (the pseudo-op
+    // whose encoder expansion is the CMP-lo/SBCS-hi dual-precision
+    // flags-chain, with the GT/LE/HI/LS operand swap — the #615 A32 shape
+    // where cond-mapping bugs live). The rules and their theorems are
+    // pseudo-op-tier T1 against the i64_setcond_bits_spec axiom; the
+    // expansion itself is below what the flat Rocq executor can express
+    // (no SBCS, no conditional CMP — see
+    // docs/design/vcr-sel-001-increment-4.md). No side conditions: the
+    // pseudo-op reads all four operand halves before writing rd. ----
+    SelRule {
+        name: "rule_i64_eq",
+        op: WasmOp::I64Eq,
+        params: I64_SETCOND_PARAMS,
+        side_conditions: &[],
+        seq: &[TemplateOp::I64SetCond {
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+            cond: CondCode::Eq,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i64.eq`: rd = if (rn_hi:rn_lo) == (rm_hi:rm_lo) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i64_ne",
+        op: WasmOp::I64Ne,
+        params: I64_SETCOND_PARAMS,
+        side_conditions: &[],
+        seq: &[TemplateOp::I64SetCond {
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+            cond: CondCode::Ne,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i64.ne`: rd = if (rn_hi:rn_lo) != (rm_hi:rm_lo) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i64_lt_s",
+        op: WasmOp::I64LtS,
+        params: I64_SETCOND_PARAMS,
+        side_conditions: &[],
+        seq: &[TemplateOp::I64SetCond {
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+            cond: CondCode::Lt,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i64.lt_s`: rd = if (rn_hi:rn_lo) < (rm_hi:rm_lo) (signed) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i64_lt_u",
+        op: WasmOp::I64LtU,
+        params: I64_SETCOND_PARAMS,
+        side_conditions: &[],
+        seq: &[TemplateOp::I64SetCond {
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+            cond: CondCode::Lo,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i64.lt_u`: rd = if (rn_hi:rn_lo) < (rm_hi:rm_lo) (unsigned) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i64_gt_s",
+        op: WasmOp::I64GtS,
+        params: I64_SETCOND_PARAMS,
+        side_conditions: &[],
+        seq: &[TemplateOp::I64SetCond {
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+            cond: CondCode::Gt,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i64.gt_s`: rd = if (rn_hi:rn_lo) > (rm_hi:rm_lo) (signed) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i64_gt_u",
+        op: WasmOp::I64GtU,
+        params: I64_SETCOND_PARAMS,
+        side_conditions: &[],
+        seq: &[TemplateOp::I64SetCond {
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+            cond: CondCode::Hi,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i64.gt_u`: rd = if (rn_hi:rn_lo) > (rm_hi:rm_lo) (unsigned) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i64_le_s",
+        op: WasmOp::I64LeS,
+        params: I64_SETCOND_PARAMS,
+        side_conditions: &[],
+        seq: &[TemplateOp::I64SetCond {
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+            cond: CondCode::Le,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i64.le_s`: rd = if (rn_hi:rn_lo) <= (rm_hi:rm_lo) (signed) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i64_le_u",
+        op: WasmOp::I64LeU,
+        params: I64_SETCOND_PARAMS,
+        side_conditions: &[],
+        seq: &[TemplateOp::I64SetCond {
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+            cond: CondCode::Ls,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i64.le_u`: rd = if (rn_hi:rn_lo) <= (rm_hi:rm_lo) (unsigned) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i64_ge_s",
+        op: WasmOp::I64GeS,
+        params: I64_SETCOND_PARAMS,
+        side_conditions: &[],
+        seq: &[TemplateOp::I64SetCond {
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+            cond: CondCode::Ge,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i64.ge_s`: rd = if (rn_hi:rn_lo) >= (rm_hi:rm_lo) (signed) {1} else {0}",
+    },
+    SelRule {
+        name: "rule_i64_ge_u",
+        op: WasmOp::I64GeU,
+        params: I64_SETCOND_PARAMS,
+        side_conditions: &[],
+        seq: &[TemplateOp::I64SetCond {
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+            cond: CondCode::Hs,
+        }],
+        delegation: Delegation::Both,
+        doc: "`i64.ge_u`: rd = if (rn_hi:rn_lo) >= (rm_hi:rm_lo) (unsigned) {1} else {0}",
+    },
 ];
 
 /// Dispatch an i32 comparison op to its generated Rocq-proved rule
@@ -792,6 +1034,50 @@ pub fn i64_pair_rule(
     })
 }
 
+/// Dispatch an i32 unary bit-manipulation op (`clz/ctz/popcnt`) to its
+/// generated Rocq-proved rule (increment 4). Same contract as
+/// [`i32_cmp_rule`]: `None` for ops outside the family so the caller's
+/// hand-written arm keeps ownership.
+pub fn i32_unary_rule(
+    op: &WasmOp,
+    rd: crate::rules::Reg,
+    rm: crate::rules::Reg,
+) -> Option<Vec<crate::rules::ArmOp>> {
+    Some(match op {
+        WasmOp::I32Clz => generated::rule_i32_clz(rd, rm),
+        WasmOp::I32Ctz => generated::rule_i32_ctz(rd, rm),
+        WasmOp::I32Popcnt => generated::rule_i32_popcnt(rd, rm),
+        _ => return None,
+    })
+}
+
+/// Dispatch a binary i64 comparison op to its generated Rocq-proved
+/// `I64SetCond` rule (increment 4). Same contract as [`i32_cmp_rule`]; no
+/// side conditions (the pseudo-op reads all four operand halves before
+/// writing `rd`), so the return is infallible where it fires.
+pub fn i64_setcond_rule(
+    op: &WasmOp,
+    rd: crate::rules::Reg,
+    rn_lo: crate::rules::Reg,
+    rn_hi: crate::rules::Reg,
+    rm_lo: crate::rules::Reg,
+    rm_hi: crate::rules::Reg,
+) -> Option<Vec<crate::rules::ArmOp>> {
+    Some(match op {
+        WasmOp::I64Eq => generated::rule_i64_eq(rd, rn_lo, rn_hi, rm_lo, rm_hi),
+        WasmOp::I64Ne => generated::rule_i64_ne(rd, rn_lo, rn_hi, rm_lo, rm_hi),
+        WasmOp::I64LtS => generated::rule_i64_lt_s(rd, rn_lo, rn_hi, rm_lo, rm_hi),
+        WasmOp::I64LtU => generated::rule_i64_lt_u(rd, rn_lo, rn_hi, rm_lo, rm_hi),
+        WasmOp::I64GtS => generated::rule_i64_gt_s(rd, rn_lo, rn_hi, rm_lo, rm_hi),
+        WasmOp::I64GtU => generated::rule_i64_gt_u(rd, rn_lo, rn_hi, rm_lo, rm_hi),
+        WasmOp::I64LeS => generated::rule_i64_le_s(rd, rn_lo, rn_hi, rm_lo, rm_hi),
+        WasmOp::I64LeU => generated::rule_i64_le_u(rd, rn_lo, rn_hi, rm_lo, rm_hi),
+        WasmOp::I64GeS => generated::rule_i64_ge_s(rd, rn_lo, rn_hi, rm_lo, rm_hi),
+        WasmOp::I64GeU => generated::rule_i64_ge_u(rd, rn_lo, rn_hi, rm_lo, rm_hi),
+        _ => return None,
+    })
+}
+
 /// Render a struct field, using field-init shorthand when the bound variable
 /// name matches the field name (keeps the generated file rustfmt/clippy-clean).
 fn field(name: &str, var: RegVar) -> String {
@@ -838,6 +1124,38 @@ fn template_expr(t: &TemplateOp, indent: usize) -> String {
             field("rn_lo", rn_lo),
             field("rn_hi", rn_hi)
         ),
+        TemplateOp::Clz { rd, rm } => {
+            format!("ArmOp::Clz {{ {}, {} }}", field("rd", rd), field("rm", rm))
+        }
+        TemplateOp::Rbit { rd, rm } => {
+            format!("ArmOp::Rbit {{ {}, {} }}", field("rd", rd), field("rm", rm))
+        }
+        TemplateOp::Popcnt { rd, rm } => format!(
+            "ArmOp::Popcnt {{ {}, {} }}",
+            field("rd", rd),
+            field("rm", rm)
+        ),
+        TemplateOp::I64SetCond {
+            rd,
+            rn_lo,
+            rn_hi,
+            rm_lo,
+            rm_hi,
+            cond,
+        } => {
+            let ind = " ".repeat(indent);
+            let fld = " ".repeat(indent + 4);
+            format!(
+                "ArmOp::I64SetCond {{\n{fld}{},\n{fld}{},\n{fld}{},\n{fld}{},\n{fld}{},\n\
+                 {fld}cond: {},\n{ind}}}",
+                field("rd", rd),
+                field("rn_lo", rn_lo),
+                field("rn_hi", rn_hi),
+                field("rm_lo", rm_lo),
+                field("rm_hi", rm_hi),
+                cond.rust_name()
+            )
+        }
         TemplateOp::Mul { rd, rn, rm } => format!(
             "ArmOp::Mul {{ {}, {}, {} }}",
             field("rd", rd),
@@ -909,10 +1227,11 @@ pub fn generate_lowering_source() -> String {
         "//! GENERATED FILE — DO NOT EDIT BY HAND.\n\
          //!\n\
          //! Emitted by `crate::sel_dsl::generate_lowering_source()` from the declarative\n\
-         //! rule table [`crate::sel_dsl::RULES`] (VCR-SEL-001 increments 1+2+3, #242,\n\
+         //! rule table [`crate::sel_dsl::RULES`] (VCR-SEL-001 increments 1+2+3+4, #242,\n\
          //! `docs/design/vcr-sel-001-first-increment.md` +\n\
          //! `docs/design/vcr-sel-001-increment-2.md` +\n\
-         //! `docs/design/vcr-sel-001-increment-3.md`). Pinned up-to-date by the\n\
+         //! `docs/design/vcr-sel-001-increment-3.md` +\n\
+         //! `docs/design/vcr-sel-001-increment-4.md`). Pinned up-to-date by the\n\
          //! `generated_lowering_is_up_to_date` test; regenerate with\n\
          //! `SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl`.\n\
          //!\n\
@@ -982,11 +1301,21 @@ pub fn generate_lowering_source() -> String {
         } else {
             ("Ok(vec![", "])")
         };
+        // rustfmt collapses a multi-element `vec![..]` onto one line when it
+        // fits max_width and every element is itself single-line — mirror
+        // that so the committed file stays a rustfmt fixpoint.
+        let one_line_body: Vec<String> = rule.seq.iter().map(|t| template_expr(t, 4)).collect();
+        let one_line = format!("    {open}{}{close}\n", one_line_body.join(", "));
+        // `one_line` is single-line iff its only '\n' is the trailing one
+        // (an element with an exploded rendering embeds more).
+        let fits_one_line = one_line.matches('\n').count() == 1 && one_line.len() <= 101;
         if rule.seq.len() == 1 {
             out.push_str(&format!(
                 "    {open}{}{close}\n",
                 template_expr(&rule.seq[0], 4)
             ));
+        } else if fits_one_line {
+            out.push_str(&one_line);
         } else {
             out.push_str(&format!("    {open}\n"));
             for t in rule.seq {

--- a/docs/design/vcr-sel-001-increment-4.md
+++ b/docs/design/vcr-sel-001-increment-4.md
@@ -1,0 +1,149 @@
+# VCR-SEL-001 — Increment 4 scope (scratch-using / multi-instruction shapes + the I64SetCond family)
+
+Status: **implemented, flag-off** (2026-07-08). Extends the increment-1/2/3
+DSL (`docs/design/vcr-sel-001-first-increment.md`,
+`docs/design/vcr-sel-001-increment-2.md`,
+`docs/design/vcr-sel-001-increment-3.md`; PRs #623/#639/#661) into the tier
+the pilot called out and increments 1–3 deferred: scratch-using and
+multi-instruction shapes, plus the binary i64 comparison family. Epic #242.
+
+## Op families
+
+- **In:**
+  - `i32.clz` — single `CLZ` (tier A, unary; first unary rule in the table);
+  - `i32.ctz` — the **two-instruction `RBIT rd, rm; CLZ rd, rd` shape with
+    the scratch=dest trick**: instruction 1 writes the bit-reversed value
+    into `rd` itself and instruction 2 reads it back, so the shape needs no
+    extra scratch register and — unlike `i32.rotl`'s `rs <> rn` — **no
+    aliasing side condition** (RBIT reads `rm` before writing `rd`; the
+    second instruction only reads `rd`). Stepped proof closing with the
+    `I32.clz_rbit` axiom, the register-generalized `i32_ctz_correct`;
+  - `i32.popcnt` — included at **pseudo-op tier** (see the honesty note);
+  - the **binary `I64SetCond` comparison family** —
+    `i64.eq/ne/lt_s/lt_u/gt_s/gt_u/le_s/le_u/ge_s/ge_u`, ten rules over FIVE
+    register variables (`rd` + both operand pairs), each mirroring the single
+    `ArmOp::I64SetCond` pseudo-op BOTH selectors emit, with the hand-written
+    arms' condition mapping (`lt_u → LO/Cond_CC`, `ge_u → HS/Cond_CS`, …).
+    No side conditions: the pseudo-op reads all four operand halves before
+    writing `rd`, so the universal quantifier admits every aliasing —
+    including `select_default`'s in-place `rd = rn_lo = R0`.
+- **Already present (checked, not re-added):** the i32 rotr-by-register twin
+  landed in increment 2 (`rule_i32_rotr`, tier A single `ROR_reg`).
+- **Out (later increments):** i64 mul/div/rem, i64 pair shifts/rotates
+  (multi-instruction with branches), i64 clz/ctz/popcnt pseudo-ops, i32.eqz
+  (the CMP-imm shape — the reg-reg rule format has no immediate-operand
+  CMP template yet), memory, globals, control flow.
+
+## The I64SetCond verdict (the highest-value target, honestly bounded)
+
+This family is the shape #615 re-implemented on A32 and where cond-mapping
+bugs live. What increment 4 verifies and what it cannot:
+
+**Verified (pseudo-op tier T1):** both selectors lower a binary i64
+comparison to ONE `ArmOp::I64SetCond` pseudo-op. The rules mirror exactly
+that — so the mirror-pins are byte-identical at the ArmOp level — and each
+theorem discharges against the `i64_setcond_bits_spec` axiom, which pins the
+pseudo-op's result to the WASM-spec
+`if I64.<cmp> (combine_i32 lo hi) … then 1 else 0` form. This is the
+register-generalized form of the fixed-register ancestors in
+`CorrectnessI64Comparisons.v` — the **condition-code mapping** (the #615 bug
+class at the selector level: which `Condition` goes with which WASM op) is
+now covered for every register assignment, in both selectors.
+
+**Not verified — the flat-executor gap, documented exactly:** the encoder
+expands the pseudo-op to the dual-precision flags-chain
+
+- ordered: `CMP lo,lo; SBCS rd,hi,hi; MOV+MOVcc` — with the operand-swap
+  trick for GT/LE/HI/LS (compare `(rm, rn)` and test the LT/GE/LO/HS
+  complement);
+- EQ/NE: `CMP lo,lo; CMPEQ hi,hi; MOV+MOVcc` (compare highs only if lows
+  equal).
+
+Proving THAT expansion equal to `i64_setcond_bits` needs three things the
+flat Rocq executor (`ArmSemantics.v`) lacks today:
+
+1. **`SBCS`** — a flag-*setting* subtract-with-carry. The model's `SBC`
+   reads C but writes no flags, so the chain's second link (N/Z/C/V from
+   `hi1 - hi2 - borrow`) is inexpressible.
+2. **Conditionally-executed flags-writers** — `CMPEQ` (the EQ/NE chain).
+   The model's only conditional forms are the register-writing `MOVcc`
+   family; there is no conditional CMP.
+3. **Three-operand borrow-aware flag helpers** — `compute_c_flag_sub` /
+   `compute_v_flag_sub` are two-operand; the SBCS link needs the
+   carry-in-aware variants.
+
+This is the same executor gap the VCR-ISA-001 spike hit with `BCondOffset`
+(a no-op in the flat executor, which is why the div/rem trap guards are the
+remaining T3 admits): control- and flags-chain-shaped expansions are below
+the flat model's floor. Pseudo-op-tier proofs are the honest ceiling until
+the Sail-generated ISA model (VCR-ISA-001) or a PC-indexed executor lands.
+The expansion itself stays covered by the differential oracles (and got its
+A32 no-silent-NOP gate in #615's fix).
+
+## The popcnt honesty note
+
+At the ArmOp level `i32.popcnt` is a single `Popcnt` pseudo-op in both
+selectors — that is what the rule mirrors (mirror-pinnable byte-identically)
+and what `rule_i32_popcnt_correct` proves, against the axiomatized
+`I32.popcnt` (exactly like the fixed-register ancestor and like
+`i64.eqz`/`I64SetCond`). The encoder's ~15-instruction shift-and-add
+expansion below the ArmOp boundary — where the #632 clobber actually lived —
+is **not modeled and not provable in the flat executor** (it is also not
+expressible as a rule without breaking the "migrate structure, never bytes"
+invariant: the selector emits the pseudo-op, not the expansion). Included at
+pseudo-op tier rather than held out, because the established DSL boundary is
+the selector's ArmOp emission; the expansion is encoder territory
+(VCR-ISA-001 / the encoder oracles). Anyone reading "popcnt: DSL-served"
+must read it with this asterisk — `coq/STATUS.md`'s coverage table carries
+the same footnote.
+
+## Rocq obligations
+
+40 rules ↔ 40 Qed (7 + 14 + 6 + 13), 1:1 naming, coverage gated by
+`//coq:vcr_sel_rules_coverage` against `coq/vcr_sel_rules.manifest`.
+Discharge for the thirteen new theorems:
+
+- clz / popcnt — `synth_unop_proof_poly` (verbatim `synth_unop_proof`
+  modulo binders and unfold target, the same generalization move as
+  `synth_binop_proof_poly`);
+- ctz — stepped two-instruction proof (`set`/`subst` through both states,
+  `get_set_reg_eq` twice, close with `I32.clz_rbit`) — the
+  `rule_i32_rotl_correct` structure with no aliasing hypothesis;
+- the ten comparisons — `synth_i64_setcond_proof_poly`, the uniform
+  CorrectnessI64Comparisons.v script register-generalized (expose the
+  pseudo-op step, substitute the four half-reads, reduce
+  `i64_setcond_bits_spec` on the concrete condition). **No new axiom.**
+
+**0 holdouts: 13/13 attempted rules discharged** (the deliberate holdouts —
+the encoder expansions — are below the rule boundary, not failed rule
+attempts; the kill-criterion's ≥70% bar is met at 100% again.)
+
+## Where the delegation lands
+
+All thirteen rules are `Delegation::Both`:
+
+- `select_default`: the `I32Clz`/`I32Ctz`/`I32Popcnt` arms and the (merged)
+  binary i64 comparison arm delegate behind `SYNTH_SEL_DSL` (default OFF);
+- `select_with_stack`: the i32 unary arms (allocated `dst`/`src`) and the
+  `I64SetCond` arm (stack-tracked pairs, `alloc_temp_or_spill` result)
+  delegate the emission window, hand-written otherwise.
+
+## Gates (same two as increments 1–3, in order)
+
+1. **Mirror-pinning per op** — the select_default loop now pins 30 rules;
+   the select_with_stack loop 17 (with a unary window branch); the i64
+   dedicated loop 16 (with an I64SetCond window branch). All include the
+   RMW-vacuity window check: the hand-written emission window must equal the
+   rule's output for the selector's own chosen registers.
+2. **Frozen fixtures** — OFF ≡ baseline by construction (every delegation is
+   flag-gated); the `.text` byte gate (`frozen_codegen_bytes.rs`) green
+   flag-off AND flag-on (the delegations are byte-identical, so
+   `SYNTH_SEL_DSL=1` must not move a fixture byte).
+
+## What remains before the SYNTH_SEL_DSL default flip
+
+Unchanged from increments 2–3: nothing byte-visible — the flip changes which
+*code* serves the arms, not what they emit. The flip itself is a later PR
+with the standard re-freeze ritual, one release, never bundled with a
+byte-changing lever. 40/40 rules (100%) still serve behind the default-OFF
+flag.


### PR DESCRIPTION
## VCR-SEL-001 increment 4 (epic #242)

Extends the Rocq-discharged selector DSL into the **scratch-using and multi-instruction tier** the pilot called out and increments 1–3 deferred, plus the **binary i64 comparison family** — the highest-value target (the shape #615 re-implemented on A32, where cond-mapping bugs live). Design doc: `docs/design/vcr-sel-001-increment-4.md`.

### Rules (27 → 40, all 1:1 Qed, 0 Admitted)

| Rule | Shape | Discharge |
|---|---|---|
| `rule_i32_clz` | single `CLZ` (first unary rule) | `synth_unop_proof_poly` |
| `rule_i32_ctz` | **two-instruction `RBIT rd, rm; CLZ rd, rd`** — the scratch=dest trick: no extra scratch register, **no aliasing side condition** (RBIT reads before writing; instr 2 only reads rd) | stepped proof closing with `I32.clz_rbit` |
| `rule_i32_popcnt` | pseudo-op tier (mirrors the single `ArmOp::Popcnt` the selector emits) | `synth_unop_proof_poly` |
| `rule_i64_{eq,ne,lt_s,lt_u,gt_s,gt_u,le_s,le_u,ge_s,ge_u}` | the single-`I64SetCond`-pseudo-op shape **both** selectors emit, over FIVE register variables, no side conditions (the pseudo-op reads all four operand halves before writing rd) | `synth_i64_setcond_proof_poly` against `i64_setcond_bits_spec` — the register-generalized CorrectnessI64Comparisons.v ancestors |

i32 rotr-by-register: already served since increment 2 (checked, nothing re-added).

### The I64SetCond verdict (honest bound, documented)

**Verified:** the condition-code mapping (which `Condition` serves which WASM op — the selector-level #615 bug class) for every register assignment, in both selectors, pseudo-op-tier T1.
**Not expressible in the flat executor** — the encoder's `CMP lo,lo; SBCS rd,hi,hi; MOVcc` expansion (with the GT/LE/HI/LS operand swap) needs three things `ArmSemantics.v` lacks: (a) **SBCS** (flag-*setting* SBC — the model's SBC writes no flags), (b) **conditionally-executed flags-writers** (`CMPEQ` for the EQ/NE chain; only `MOVcc` exists), (c) **three-operand borrow-aware C/V helpers**. Same executor gap as the VCR-ISA-001 `BCondOffset` spike — pseudo-op tier is the honest ceiling until the Sail model lands. Fully documented in the design doc + VcrSelRules.v header.

Same asterisk for popcnt: the theorem covers the selector's ArmOp emission; the encoder's shift-and-add expansion (where #632 lived) stays oracle-covered, not Rocq-covered.

### #667: DSL-coverage vs model-relevance metric

`coq/STATUS.md` gains the per-op-family table — **DSL-served (rule+Qed) / `compile_wasm_to_arm`-model-only / unverified** — so #73's retirement-by-subtraction of the divergent monolithic model is measurable per release. Current: **40 ops DSL-served (~26%), ~96 model-only (~62%), ~19 unverified (~12%)**; retirement criterion stated (a model arm may be deleted once its family is DSL-served).

### Gates

- **Rocq:** `bazel test //coq:verify_proofs` green (proofs + `vcr_sel_rules_coverage`, manifest 27→40)
- **Mirror-pins (gate 1):** select_default loop 17→30 probes; select_with_stack loop 14→17 (new unary window branch); i64 loop 6→16 (new I64SetCond window branch) — all with the RMW-vacuity window check (hand-written emission window ≡ rule output for the selector's own registers)
- **OFF ≡ baseline** by construction (every delegation flag-gated, `SYNTH_SEL_DSL` default OFF)
- **Frozen anchors 10/10 flag-OFF *and* flag-ON** (`SYNTH_SEL_DSL=1` moves no fixture byte)
- fmt --check clean, clippy -D warnings clean (all 17 crates), full per-crate test sweep green

### Flip status

Unchanged ritual: 40/40 rules (100%) serve behind the default-OFF flag; the flip is a later dedicated PR, never bundled with a byte-changing lever.

Part of #242; metric from #667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)