### PR TITLE
feat(vcr-ra): post-exhaustion code quality — the capability PR #659 named missing (#242)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -611,7 +611,12 @@ fn compile_wasm_to_arm(
         && wasm_ops
             .iter()
             .any(|op| matches!(op, WasmOp::GlobalGet(_) | WasmOp::GlobalSet(_)));
-    let arm_instrs = if config.no_optimize
+    // VCR-VER-001 (#242): `post_exhaust` scopes the post-exhaustion cleanup
+    // extensions to functions whose bytes the #580 spill-on-exhaustion
+    // machinery actually shaped (bridge-reported). Everything else — the
+    // direct path, non-exhausted optimized functions — stays byte-identical
+    // flag-on (the `vcr_ver_001_gate_242` lock's contract).
+    let (arm_instrs, post_exhaust) = if config.no_optimize
         || config.relocatable
         || has_br_table
         || has_value_carry
@@ -625,7 +630,7 @@ fn compile_wasm_to_arm(
         if std::env::var("SYNTH_PATH_DEBUG").is_ok() {
             eprintln!("[path-debug] direct (pre-gate)");
         }
-        select_direct()?
+        (select_direct()?, false)
     } else {
         let opt_config = if config.loom_compat {
             OptimizationConfig::loom_compat()
@@ -664,13 +669,16 @@ fn compile_wasm_to_arm(
                 if std::env::var("SYNTH_PATH_DEBUG").is_ok() {
                     eprintln!("[path-debug] optimized (ir_to_arm ok)");
                 }
-                arm_ops
-                    .into_iter()
-                    .map(|op| ArmInstruction {
-                        op,
-                        source_line: None,
-                    })
-                    .collect()
+                (
+                    arm_ops
+                        .into_iter()
+                        .map(|op| ArmInstruction {
+                            op,
+                            source_line: None,
+                        })
+                        .collect(),
+                    bridge.spill_on_exhaust_fired(),
+                )
             }
             // Issue #120: the optimized path declines modules it cannot lower
             // (notably scalar f32/f64 ops — the IR has no float opcodes). Fall
@@ -681,7 +689,7 @@ fn compile_wasm_to_arm(
                 if std::env::var("SYNTH_PATH_DEBUG").is_ok() {
                     eprintln!("[path-debug] direct (fallback: {e})");
                 }
-                select_direct()?
+                (select_direct()?, false)
             }
         }
     };
@@ -745,7 +753,17 @@ fn compile_wasm_to_arm(
             Reg::R7,
             Reg::R8,
         ];
-        let (out, stats) = synth_synthesis::liveness::reallocate_function(&arm_instrs, &POOL);
+        // VCR-VER-001 (#242): on a function the spill-on-exhaustion machinery
+        // shaped, the terminal segment gets relaxed live-out pinning (only
+        // R0/R1 are observable past `bx lr` at this pre-prologue position) so
+        // the colourer can lower R4-R8-homed tails into caller-saved R0-R3 —
+        // shrinking the `push {r4-r8,lr}` the #580 exhaustion shapes pay for.
+        // `post_exhaust == false` selects the shipping pass bit for bit.
+        let (out, stats) = synth_synthesis::liveness::reallocate_function_post_exhaust(
+            &arm_instrs,
+            &POOL,
+            post_exhaust,
+        );
         if std::env::var("SYNTH_REALLOC_STATS").is_ok() {
             eprintln!(
                 "[range-realloc] {} segments: {} reallocated, {} declined ({} validator-rejected), {} need spill (step 4)",
@@ -956,13 +974,57 @@ fn compile_wasm_to_arm(
     // and restores the pre-flip bytes (CI-gated by
     // `frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes`). Any
     // other value (or unset) runs the pass.
+    // VCR-VER-001 post-exhaustion extensions (#242, the PR #659 verdict): with
+    // `SYNTH_SPILL_ON_EXHAUST` active the #580 allocation-time Belady spill
+    // keeps exhausted functions on the optimized path, and its slots present
+    // shapes the shipping pass structurally cannot fire on (fresh-monotonic
+    // slots defeat the overwrite-only DCE; the eviction store's source is
+    // redefined immediately, defeating store→reload forwarding; R2/R3 are
+    // never touched again, so the rename-target deadness proof declines them).
+    // `post_exhaust` (bridge-scoped, see above) enables const
+    // rematerialization of spilled constants, R2/R3 exit-dead rename targets,
+    // and per-pair pressure commit — see `apply_spill_realloc_post_exhaust`.
+    // Flag off (the default): `false` selects the shipping behavior bit for
+    // bit.
     let arm_instrs = if !std::env::var("SYNTH_SPILL_REALLOC").is_ok_and(|v| v == "0") {
-        let (out, n) = synth_synthesis::liveness::apply_spill_realloc(&arm_instrs);
+        let (out, n) =
+            synth_synthesis::liveness::apply_spill_realloc_post_exhaust(&arm_instrs, post_exhaust);
         let (out, d) = synth_synthesis::liveness::eliminate_dead_frame_stores(&out);
-        let (out, u) = synth_synthesis::liveness::eliminate_unread_frame_stores(&out);
+        let (mut out, u) = synth_synthesis::liveness::eliminate_unread_frame_stores(&out);
+        let (mut tn, mut td, mut tu) = (n, d, u);
+        // Post-exhaustion only: iterate the triple to a bounded fixpoint. Each
+        // dissolved spill pair frees registers and removes stores, exposing
+        // rename windows and holder chains the previous iteration could not
+        // prove — the allocation-time Belady slots (#580) routinely need two
+        // or three rounds where the shipping single round suffices for the
+        // default path's slots. Every iteration is individually gate-proven
+        // (value-trace equality, pool pressure, strict shrink), so iterating
+        // composes soundly; the bound keeps compile time deterministic.
+        if post_exhaust {
+            let mut progress = n + d + u > 0;
+            for _ in 0..3 {
+                if !progress {
+                    break;
+                }
+                let (o, n) =
+                    synth_synthesis::liveness::apply_spill_realloc_post_exhaust(&out, true);
+                let (o, d) = synth_synthesis::liveness::eliminate_dead_frame_stores(&o);
+                let (o, u) = synth_synthesis::liveness::eliminate_unread_frame_stores(&o);
+                progress = n + d + u > 0;
+                (tn, td, tu) = (tn + n, td + d, tu + u);
+                out = o;
+            }
+            // The cleanup can leave the spill frame with zero surviving
+            // accesses (every reload rematerialized/dissolved, every store
+            // swept) — the balanced `sub sp,#K`/`add sp,#K` is then pure
+            // overhead. `elide_dead_frame` proves that and removes the pair;
+            // its early run (post-realloc) could not, because the spill
+            // traffic was still in the stream at that point.
+            out = synth_synthesis::liveness::elide_dead_frame(&out).unwrap_or(out);
+        }
         if std::env::var("SYNTH_FUSE_STATS").is_ok() {
             eprintln!(
-                "[spill-realloc] {n} reload(s) forwarded/eliminated, {d} newly-dead frame store(s) removed, {u} unread-slot store(s) removed"
+                "[spill-realloc] {tn} reload(s) forwarded/eliminated, {td} newly-dead frame store(s) removed, {tu} unread-slot store(s) removed"
             );
         }
         out

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -2685,6 +2685,23 @@ pub fn validate_segment_rewrite(
     orig: &[ArmInstruction],
     rewritten: &[ArmInstruction],
 ) -> Result<(), RewriteViolation> {
+    validate_segment_rewrite_exempting(orig, rewritten, &BTreeSet::new())
+}
+
+/// [`validate_segment_rewrite`] with caller-supplied additional exit
+/// exemptions: registers whose EXIT value the caller has proven unobservable,
+/// so their identity equations are not seeded. Used by the VCR-VER-001
+/// post-exhaustion terminal-segment re-allocation (#242): a segment followed
+/// only by `bx lr` — on the optimized path BEFORE `ensure_callee_saved_prologue`
+/// runs — has function-level dead-outs the segment-local seed cannot know
+/// (R2/R3/R12 caller-saved; R4-R8 will be saved/restored by the prologue pass
+/// sized on the REWRITTEN body). The empty set is exactly the shipping
+/// validator.
+pub fn validate_segment_rewrite_exempting(
+    orig: &[ArmInstruction],
+    rewritten: &[ArmInstruction],
+    exempt: &BTreeSet<Reg>,
+) -> Result<(), RewriteViolation> {
     if orig.len() != rewritten.len() {
         return Err(RewriteViolation::LengthMismatch {
             orig: orig.len(),
@@ -2726,6 +2743,7 @@ pub fn validate_segment_rewrite(
         .iter()
         .flat_map(|(eo, _)| eo.defs.iter())
         .filter(|r| !(ends_in_return && aapcs_dead_at_return.contains(r)))
+        .filter(|r| !exempt.contains(r))
         .map(|r| (*r, *r))
         .collect();
 
@@ -3195,6 +3213,34 @@ pub fn reallocate_function(
     instrs: &[ArmInstruction],
     pool: &[Reg],
 ) -> (Vec<ArmInstruction>, ReallocStats) {
+    reallocate_function_post_exhaust(instrs, pool, false)
+}
+
+/// [`reallocate_function`] with the VCR-VER-001 post-exhaustion extension
+/// (#242): TERMINAL-SEGMENT relaxed live-out pinning. `post_exhaust = false`
+/// is the shipping pass bit for bit.
+///
+/// The shipping pass pins, per physical register, the LAST range opened —
+/// segment-local soundness cannot know which live-outs a later segment reads.
+/// For the segment followed by nothing but the `bx lr` return, the live-outs
+/// ARE knowable at function level: R0 (and R1 for an i64 result) carry the
+/// return value; R2/R3/R12 are AAPCS caller-saved; and R4-R8's exit values
+/// are unobservable **at this pipeline position** because
+/// `ensure_callee_saved_prologue` + `shrink_callee_saved_saves` run AFTER
+/// this pass and size the save/restore on the REWRITTEN body (any callee-
+/// saved register the recolored body still clobbers gets pushed/popped; one
+/// it no longer touches needs no save at all). So with `post_exhaust` the
+/// terminal segment pins only R0/R1's last ranges, letting the colourer lower
+/// R4-R8-homed tails into the caller-saved R0-R3 — which is exactly what
+/// shrinks the over-wide `push {r4-r8, lr}` the #580 exhaustion shapes pay
+/// for (a spilled `signed_div_const` fits R0-R3 entirely: no push, no pop).
+/// The VCR-RA-003 validator remains the acceptance gate, run with the same
+/// function-level exemptions ([`validate_segment_rewrite_exempting`]).
+pub fn reallocate_function_post_exhaust(
+    instrs: &[ArmInstruction],
+    pool: &[Reg],
+    post_exhaust: bool,
+) -> (Vec<ArmInstruction>, ReallocStats) {
     use crate::optimizer_bridge::estimate_arm_byte_size;
     let mut stats = ReallocStats::default();
     // #606: resolved numeric branches make join points invisible and byte
@@ -3210,7 +3256,26 @@ pub fn reallocate_function(
             }
             let seg = &instrs[start..end];
             stats.segments += 1;
-            match try_reallocate_segment(seg, pool) {
+            // Post-exhaustion: the terminal segment (followed ONLY by the
+            // `bx lr` return — the optimized-path shape before the prologue
+            // pass runs) gets relaxed live-out pinning, justified above.
+            // Restricted to segments with NO frame reload: when spill traffic
+            // remains, R2/R3 must stay untouched for the downstream
+            // spill-rechoice pass ([`apply_spill_realloc_post_exhaust`]),
+            // whose exit-dead rename targets they are — recoloring tails into
+            // them here starves that pass and nets MORE stack traffic (the
+            // relaxation only pays where the body already fits, e.g. the
+            // spilled `signed_div_const`, whose sole frame access is a dead
+            // store the later sweep deletes).
+            let relaxed_exit = post_exhaust
+                && end < instrs.len()
+                && instrs[end..]
+                    .iter()
+                    .all(|i| matches!(&i.op, ArmOp::Bx { rm: Reg::LR }))
+                && !seg
+                    .iter()
+                    .any(|i| matches!(&i.op, ArmOp::Ldr { addr, .. } if addr.base == Reg::SP));
+            match try_reallocate_segment(seg, pool, relaxed_exit) {
                 SegmentOutcome::Rewritten(new) => {
                     // #606 span byte-freeze: inside a branch→target span the
                     // rewrite must not change the segment's byte size, or the
@@ -3272,8 +3337,24 @@ enum SegmentOutcome {
     ValidatorRejected,
 }
 
-fn try_reallocate_segment(seg: &[ArmInstruction], pool: &[Reg]) -> SegmentOutcome {
+fn try_reallocate_segment(
+    seg: &[ArmInstruction],
+    pool: &[Reg],
+    relaxed_exit: bool,
+) -> SegmentOutcome {
+    let dbg = std::env::var("SYNTH_POSTEX_DEBUG").is_ok();
+    if dbg {
+        eprintln!(
+            "[postex-dbg] realloc segment len={} relaxed={relaxed_exit} first={:?} last={:?}",
+            seg.len(),
+            seg.first().map(|i| &i.op),
+            seg.last().map(|i| &i.op)
+        );
+    }
     let Some(ranges) = straight_line_value_ranges(seg) else {
+        if dbg {
+            eprintln!("[postex-dbg] realloc decline: value_ranges=None");
+        }
         return SegmentOutcome::Declined;
     };
     if ranges.is_empty() {
@@ -3284,7 +3365,10 @@ fn try_reallocate_segment(seg: &[ArmInstruction], pool: &[Reg]) -> SegmentOutcom
 
     // Pins: inputs (def == 0) and per-register last-opened ranges (live-outs)
     // keep their original register. Reserved-register ranges are identity-
-    // assigned outside the colouring.
+    // assigned outside the colouring. With `relaxed_exit` (VCR-VER-001
+    // terminal segment, see `reallocate_function_post_exhaust`) only R0/R1's
+    // last-opened ranges are live-out-pinned — every other register's exit
+    // value is unobservable past the `bx lr` this segment feeds.
     let mut last_opened: BTreeMap<Reg, usize> = BTreeMap::new();
     for r in &ranges {
         last_opened.insert(r.reg, r.vreg); // ranges are in creation order
@@ -3300,7 +3384,9 @@ fn try_reallocate_segment(seg: &[ArmInstruction], pool: &[Reg]) -> SegmentOutcom
             }
             Some(&idx) => {
                 pool_nodes.insert(r.vreg);
-                if r.def == 0 || last_opened.get(&r.reg) == Some(&r.vreg) {
+                let exit_pinned = last_opened.get(&r.reg) == Some(&r.vreg)
+                    && (!relaxed_exit || matches!(r.reg, Reg::R0 | Reg::R1));
+                if r.def == 0 || exit_pinned {
                     pins.insert(r.vreg, idx);
                 }
             }
@@ -3351,22 +3437,54 @@ fn try_reallocate_segment(seg: &[ArmInstruction], pool: &[Reg]) -> SegmentOutcom
 
     // Defense-in-depth: re-check every interference edge against the final
     // assignment, independently of the colourer (cf. verify_allocation).
+    // VCR-VER-001 relaxed-exit segments additionally skip edges where BOTH
+    // endpoints are reserved-register ranges: those are identity-assigned by
+    // construction and never renamed, so two ranges of the same reserved
+    // register (e.g. the SP input/def ranges of a frame `sub sp,sp,#K` at
+    // instruction 0, "interfering" via the co-defined corner) sharing their
+    // register is exactly the original code's behavior — declining on it
+    // rejected every frame-carrying #580 segment wholesale. Pool↔pool and
+    // pool↔reserved edges are still enforced, and the VCR-RA-003 validator
+    // below independently proves the dataflow either way.
     for (n, nbrs) in &adj {
         for m in nbrs {
+            if relaxed_exit && !pool_nodes.contains(n) && !pool_nodes.contains(m) {
+                continue;
+            }
             match (assignment.get(n), assignment.get(m)) {
                 (Some(a), Some(b)) if a != b => {}
-                _ => return SegmentOutcome::Declined,
+                _ => {
+                    if std::env::var("SYNTH_POSTEX_DEBUG").is_ok() {
+                        eprintln!(
+                            "[postex-dbg] realloc edge-recheck decline: {n}~{m} -> {:?}/{:?}",
+                            assignment.get(n),
+                            assignment.get(m)
+                        );
+                    }
+                    return SegmentOutcome::Declined;
+                }
             }
         }
     }
 
+    // With relaxed exit pinning the validator gets the SAME function-level
+    // exemptions the pins used: exit identity is not required of registers
+    // whose value is unobservable past the terminal `bx lr` (R2/R3/R12
+    // caller-saved; R4-R8 saved/restored by the later prologue pass sized on
+    // the rewritten body). Empty set = the shipping validator.
+    let exempt: BTreeSet<Reg> = if relaxed_exit {
+        use Reg::*;
+        BTreeSet::from([R2, R3, R4, R5, R6, R7, R8, R12])
+    } else {
+        BTreeSet::new()
+    };
     match apply_range_coloring(seg, &assignment) {
         // VCR-RA-003: the rewrite is accepted only if the backward-dataflow
         // translation validator can independently prove it preserves the
         // original segment's dataflow (exit live-outs + entry inputs pinned).
         // The edge-recheck above stays as defense in depth; this is the
         // acceptance gate the pass cannot bypass.
-        Some(new) => match validate_segment_rewrite(seg, &new) {
+        Some(new) => match validate_segment_rewrite_exempting(seg, &new, &exempt) {
             Ok(()) => SegmentOutcome::Rewritten(new),
             Err(v) => {
                 if std::env::var("SYNTH_VALIDATOR_DEBUG").is_ok() {
@@ -3375,7 +3493,12 @@ fn try_reallocate_segment(seg: &[ArmInstruction], pool: &[Reg]) -> SegmentOutcom
                 SegmentOutcome::ValidatorRejected
             }
         },
-        None => SegmentOutcome::Declined,
+        None => {
+            if std::env::var("SYNTH_POSTEX_DEBUG").is_ok() {
+                eprintln!("[postex-dbg] realloc decline: apply_range_coloring=None");
+            }
+            SegmentOutcome::Declined
+        }
     }
 }
 
@@ -4451,6 +4574,73 @@ fn sp_slot(addr: &MemAddr) -> Option<i32> {
     (addr.base == Reg::SP && addr.offset_reg.is_none()).then_some(addr.offset)
 }
 
+/// VCR-VER-001 post-exhaustion reach (#242, the PR #659 verdict): which of
+/// {R2, R3} are provably DEAD at program point `at` — i.e. no instruction
+/// reachable from `at` can read the register's current value.
+///
+/// This is the function-level fact [`rename_kill_def`]'s segment-local
+/// deadness proof cannot see: the optimized path's allocation-time Belady
+/// spill (`SYNTH_SPILL_ON_EXHAUST`, #580) draws scratch from R4-R8 only, so
+/// R2/R3 are frequently never touched again after a segment — and a register
+/// never touched again used to be declined as "possibly live-out". At function
+/// scope that conservatism is resolvable: scan forward from `at` and prove no
+/// read precedes a pure redefinition or the function's end.
+///
+/// ONLY R2 and R3 are candidates, deliberately:
+///  - they are AAPCS caller-saved argument registers, so introducing a NEW
+///    write to them (what the rename does) never violates the callee-saved
+///    contract even when the function's push list does not include them
+///    (renaming onto an unsaved R4-R8 would clobber the caller's value);
+///  - they never carry a return value (R0, and R1 for i64, do — a return is a
+///    read of those, invisible to any instruction scan), so "reaches a return"
+///    is proof of deadness for R2/R3 and would NOT be for R0/R1.
+///
+/// The scan is a linear may-reach walk with the #606 discipline: any branch
+/// (label-form, resolved `BOffset`/`BCondOffset`, table, call, non-`bx lr`
+/// indirect) or unmodeled op ⇒ control may reach a read this scan cannot see ⇒
+/// conservative LIVE. A `Label` is a pure marker (a jump INTO it adds no read
+/// on paths leaving `at`) and the scan continues through it. `pop {…, pc}` and
+/// `bx lr` are returns ⇒ DEAD; a plain `Pop`/def containing the candidate is a
+/// pure redefinition ⇒ DEAD; falling off the end ⇒ DEAD.
+fn scratch_dead_at(instrs: &[ArmInstruction], at: usize) -> BTreeSet<Reg> {
+    let mut dead = BTreeSet::new();
+    'cand: for t in [Reg::R2, Reg::R3] {
+        for ins in &instrs[at..] {
+            match &ins.op {
+                // Return: R0/R1 may carry the result; R2/R3 provably do not.
+                ArmOp::Bx { rm: Reg::LR } => {
+                    dead.insert(t);
+                    continue 'cand;
+                }
+                ArmOp::Pop { regs } if regs.contains(&Reg::PC) => {
+                    // `pop {…, pc}` return — same as `bx lr` for R2/R3.
+                    dead.insert(t);
+                    continue 'cand;
+                }
+                // A label is a marker, not an instruction: code after it is
+                // still linearly reachable from `at` and stays in the scan.
+                ArmOp::Label { .. } => {}
+                op => match reg_effect(op) {
+                    Some(eff) => {
+                        if eff.uses.contains(&t) {
+                            continue 'cand; // read reachable → LIVE
+                        }
+                        if eff.defs.contains(&t) {
+                            dead.insert(t); // pure redefinition → DEAD
+                            continue 'cand;
+                        }
+                    }
+                    // Branch / call / unmodeled: a read may be reachable on an
+                    // edge this linear scan cannot follow → conservative LIVE.
+                    None => continue 'cand,
+                },
+            }
+        }
+        dead.insert(t); // fell off the end: nothing left that could read t
+    }
+    dead
+}
+
 /// VCR-RA-001 spill-reload forwarding (#242, spike step): replace or delete a
 /// frame-slot reload whose value is provably already in a register.
 ///
@@ -4507,6 +4697,33 @@ fn sp_slot(addr: &MemAddr) -> Option<i32> {
 /// Pure; DEFAULT-ON via the `arm_backend.rs` wiring (`SYNTH_SPILL_REALLOC=0`
 /// is the opt-out).
 pub fn apply_spill_realloc(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
+    apply_spill_realloc_post_exhaust(instrs, false)
+}
+
+/// [`apply_spill_realloc`] with the VCR-VER-001 post-exhaustion extensions
+/// (#242, the PR #659 verdict — "post-exhaustion code quality on the optimized
+/// path"). `post_exhaust = false` is byte-for-byte the shipping default-on
+/// pass. `post_exhaust = true` (wired to `SYNTH_SPILL_ON_EXHAUST`, so it is
+/// only ever active alongside the #580 allocation-time Belady spill whose
+/// slots it exists to clean up) additionally enables, per segment:
+///  - stage 1 CONSTANT REMATERIALIZATION: a reload of a slot provably holding
+///    a known single-instruction constant materialization is rewritten to that
+///    materialization (`ldr rd,[sp,#N]` → `movs/movw rd,#C`) when no register
+///    still holds the value — the store then dies and the flag-shared
+///    unread-store sweep removes it (`high_pressure_i32`'s spilled consts);
+///  - stage 2 EXIT-DEAD RENAME TARGETS: [`rename_kill_def`] may rename a
+///    clobbering def onto R2/R3 when [`scratch_dead_at`] proves the register
+///    dead at segment exit — the case the segment-local proof declines as
+///    "never touched again → possibly live-out" even though the bridge's
+///    R4-R8-only scratch pool structurally never touches R2/R3 again;
+///  - stage 2 PER-PAIR pressure commit: the pool-pressure gate (c) is checked
+///    per dissolved pair instead of once at the end, so one pair that would
+///    push the segment past the pool no longer discards every other pair's
+///    sound dissolve.
+pub fn apply_spill_realloc_post_exhaust(
+    instrs: &[ArmInstruction],
+    post_exhaust: bool,
+) -> (Vec<ArmInstruction>, usize) {
     use crate::optimizer_bridge::estimate_arm_byte_size;
     // #606: resolved numeric branches make join points invisible and byte
     // layout load-bearing — decline the whole function if unmappable.
@@ -4520,13 +4737,20 @@ pub fn apply_spill_realloc(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, u
             return;
         }
         let seg = &instrs[start..end];
+        // Post-exhaustion only: registers provably dead at segment EXIT — the
+        // function-level fact stage 2's segment-local rename proof lacks.
+        let exit_dead = if post_exhaust {
+            scratch_dead_at(instrs, end)
+        } else {
+            BTreeSet::new()
+        };
         // Stage 1: slot-value forwarding between reloads.
-        let (mut cur, mut n) = match spill_forward_segment(seg) {
+        let (mut cur, mut n) = match spill_forward_segment(seg, post_exhaust) {
             Some((rewritten, n)) => (rewritten, n),
             None => (seg.to_vec(), 0),
         };
         // Stage 2: Belady spill-plan re-choice on the surviving reloads.
-        if let Some((rewritten, m)) = spill_rechoice_segment(&cur) {
+        if let Some((rewritten, m)) = spill_rechoice_segment(&cur, &exit_dead, post_exhaust) {
             cur = rewritten;
             n += m;
         }
@@ -4566,12 +4790,49 @@ pub fn apply_spill_realloc(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, u
     (out, total)
 }
 
+/// Retarget a single-instruction constant materialization onto `rd`. Only the
+/// two [`const_materialization`] shapes participate (`mov rd,#imm` /
+/// `movw rd,#imm16`) — both are pure full-width defs, so the clone reproduces
+/// the stored word exactly. A `movw` later modified by `movt` never reaches
+/// here: the `movt` kills the tracked shape (it is an RMW def of the register).
+fn retarget_const_shape(op: &ArmOp, rd: Reg) -> Option<ArmOp> {
+    match op {
+        ArmOp::Movw { imm16, .. } => Some(ArmOp::Movw { rd, imm16: *imm16 }),
+        ArmOp::Mov {
+            op2: Operand2::Imm(v),
+            ..
+        } => Some(ArmOp::Mov {
+            rd,
+            op2: Operand2::Imm(*v),
+        }),
+        _ => None,
+    }
+}
+
 /// One segment of [`apply_spill_realloc`]: `Some((rewritten, count))` iff at
 /// least one reload was forwarded/deleted AND every commit gate holds;
 /// `None` ⇒ caller keeps the original segment bytes.
-fn spill_forward_segment(seg: &[ArmInstruction]) -> Option<(Vec<ArmInstruction>, usize)> {
+///
+/// With `post_exhaust` (VCR-VER-001, #242) the pass additionally tracks which
+/// slots hold a KNOWN single-instruction constant (the defining `mov`/`movw`
+/// shape, killed on any redefinition of the source register — including
+/// `Movt`'s RMW — and on every event that already resets the holder sets) and
+/// REMATERIALIZES a reload with no surviving register holder
+/// (`ldr rd,[sp,#N]` → the retargeted materialization). Soundness is the same
+/// by-construction argument as forwarding: the replacement writes `rd` with
+/// the exact word the load would have fetched. Rematerialization never
+/// extends a live range (unlike forwarding it introduces no new read), so the
+/// pressure gate (c) is unaffected.
+fn spill_forward_segment(
+    seg: &[ArmInstruction],
+    post_exhaust: bool,
+) -> Option<(Vec<ArmInstruction>, usize)> {
     // slot #N → set of R0–R8 registers currently holding slot N's value.
     let mut holders: BTreeMap<i32, BTreeSet<Reg>> = BTreeMap::new();
+    // Post-exhaustion const tracking: register → its materializing op shape,
+    // and slot → the shape whose value the slot provably holds.
+    let mut reg_const: BTreeMap<Reg, ArmOp> = BTreeMap::new();
+    let mut slot_const: BTreeMap<i32, ArmOp> = BTreeMap::new();
     // Staged edits: index → Some(op) = replace, None = delete.
     let mut staged: BTreeMap<usize, Option<ArmOp>> = BTreeMap::new();
 
@@ -4606,28 +4867,54 @@ fn spill_forward_segment(seg: &[ArmInstruction]) -> Option<(Vec<ArmInstruction>,
                             set.insert(rd);
                         }
                     }
+                    reg_const.remove(&rd);
+                    if let Some(shape) = slot_const.get(&slot) {
+                        reg_const.insert(rd, shape.clone());
+                    }
                 } else {
                     // Ordinary reload: rd is redefined and now holds slot's value.
                     for set in holders.values_mut() {
                         set.remove(&rd);
                     }
+                    reg_const.remove(&rd);
                     if !is_reserved_reg(rd) {
                         holders.entry(slot).or_default().insert(rd);
+                        // Post-exhaustion rematerialization: the slot holds a
+                        // known constant and no register does — re-derive it
+                        // instead of loading it (the store then goes unread
+                        // and dies in the flag-shared unread-store sweep).
+                        if post_exhaust
+                            && let Some(shape) = slot_const.get(&slot)
+                            && let Some(remat) = retarget_const_shape(shape, rd)
+                        {
+                            staged.insert(i, Some(remat));
+                            reg_const.insert(rd, shape.clone());
+                        }
                     }
                 }
             }
             // Full-word store to a pinnable slot: the slot now holds rd's value.
             ArmOp::Str { rd, addr } if sp_slot(addr).is_some() => {
+                let slot = sp_slot(addr).unwrap();
                 let mut set = BTreeSet::new();
                 if !is_reserved_reg(*rd) {
                     set.insert(*rd);
                 }
-                holders.insert(sp_slot(addr).unwrap(), set);
+                holders.insert(slot, set);
+                match reg_const.get(rd) {
+                    Some(shape) => {
+                        slot_const.insert(slot, shape.clone());
+                    }
+                    None => {
+                        slot_const.remove(&slot);
+                    }
+                }
             }
             // Any [sp] access we cannot pin to a single whole word slot:
             // register offset (unresolvable) or sub-word (partial overlap).
             ArmOp::Ldr { addr, .. } | ArmOp::Str { addr, .. } if addr.base == Reg::SP => {
                 holders.clear();
+                slot_const.clear();
             }
             ArmOp::Ldrb { addr, .. }
             | ArmOp::Ldrsb { addr, .. }
@@ -4638,9 +4925,15 @@ fn spill_forward_segment(seg: &[ArmInstruction]) -> Option<(Vec<ArmInstruction>,
                 if addr.base == Reg::SP =>
             {
                 holders.clear();
+                slot_const.clear();
             }
-            // SP moves + stack memory touched — every slot name is invalidated.
-            ArmOp::Push { .. } | ArmOp::Pop { .. } => holders.clear(),
+            // SP moves + stack memory touched — every slot name is invalidated
+            // (and `Pop` redefines its whole register list: drop reg consts).
+            ArmOp::Push { .. } | ArmOp::Pop { .. } => {
+                holders.clear();
+                slot_const.clear();
+                reg_const.clear();
+            }
             // Register-to-register copy propagates value identity.
             ArmOp::Mov {
                 rd,
@@ -4662,6 +4955,14 @@ fn spill_forward_segment(seg: &[ArmInstruction]) -> Option<(Vec<ArmInstruction>,
                         }
                     }
                 }
+                match reg_const.get(&rm).cloned() {
+                    Some(shape) if !is_reserved_reg(rd) => {
+                        reg_const.insert(rd, shape);
+                    }
+                    _ => {
+                        reg_const.remove(&rd);
+                    }
+                }
             }
             op => {
                 // Segment precondition guarantees Some; `?` stays sound if the
@@ -4669,12 +4970,21 @@ fn spill_forward_segment(seg: &[ArmInstruction]) -> Option<(Vec<ArmInstruction>,
                 let eff = reg_effect(op)?;
                 if eff.defs.contains(&Reg::SP) {
                     holders.clear();
-                } else {
-                    for d in &eff.defs {
-                        for set in holders.values_mut() {
-                            set.remove(d);
-                        }
+                    slot_const.clear();
+                }
+                for d in &eff.defs {
+                    for set in holders.values_mut() {
+                        set.remove(d);
                     }
+                    // Kills the tracked const on ANY def, including `Movt`'s
+                    // RMW of a previously tracked `movw` (its shape alone
+                    // would reproduce only the low half — must not survive).
+                    reg_const.remove(d);
+                }
+                if let Some((rd_c, _)) = const_materialization(op)
+                    && !is_reserved_reg(rd_c)
+                {
+                    reg_const.insert(rd_c, op.clone());
                 }
             }
         }
@@ -4941,8 +5251,17 @@ fn collect_spill_pairs(seg: &[ArmInstruction]) -> Vec<SpillPair> {
 ///    uses), and such a def EXISTS in the segment — so `t`'s incoming value is
 ///    dead at `k` (never read again) and `t`'s exit value is that later def's,
 ///    unchanged by the rename. A `t` never touched again could be live-out:
-///    rejected.
-fn rename_kill_def(scratch: &mut [ArmInstruction], k: usize, r: Reg) -> Option<()> {
+///    rejected — UNLESS the caller proves it dead at segment exit
+///    (`exit_dead`, from [`scratch_dead_at`]: the VCR-VER-001 post-exhaustion
+///    extension, empty outside `SYNTH_SPILL_ON_EXHAUST`). Only R2/R3 ever
+///    appear there (caller-saved, never return-carrying), so the new write the
+///    rename introduces cannot violate the callee-saved contract.
+fn rename_kill_def(
+    scratch: &mut [ArmInstruction],
+    k: usize,
+    r: Reg,
+    exit_dead: &BTreeSet<Reg>,
+) -> Option<()> {
     // The def's live range: reads of `r` strictly after `k`, up to and
     // including any reads AT the next def of `r` (operands are consumed
     // before the write). No next def in the segment ⇒ the value may be
@@ -4990,7 +5309,9 @@ fn rename_kill_def(scratch: &mut [ArmInstruction], k: usize, r: Reg) -> Option<(
                 return true; // pure redefinition → dead in between
             }
         }
-        false // never touched again → possibly live-out → decline
+        // Never touched again in the segment → possibly live-out → decline,
+        // unless the caller's function-level scan proved t dead at exit.
+        exit_dead.contains(&t)
     })?;
 
     let rename: BTreeMap<Reg, Reg> = [(r, target)].into_iter().collect();
@@ -5006,7 +5327,11 @@ fn rename_kill_def(scratch: &mut [ArmInstruction], k: usize, r: Reg) -> Option<(
 /// rename every kill-def of the holder inside the window, then delete the
 /// reload (or fold it to `mov rd,holder` when it targets another register).
 /// `None` ⇒ some kill-def could not be renamed; caller keeps the input.
-fn dissolve_spill_pair(seg: &[ArmInstruction], pair: &SpillPair) -> Option<Vec<ArmInstruction>> {
+fn dissolve_spill_pair(
+    seg: &[ArmInstruction],
+    pair: &SpillPair,
+    exit_dead: &BTreeSet<Reg>,
+) -> Option<Vec<ArmInstruction>> {
     let mut scratch = seg.to_vec();
     // Rename kill-defs left to right; each rename removes that def of the
     // holder, so re-scanning always terminates.
@@ -5014,7 +5339,7 @@ fn dissolve_spill_pair(seg: &[ArmInstruction], pair: &SpillPair) -> Option<Vec<A
     while i < pair.load {
         let eff = reg_effect(&scratch[i].op)?;
         if eff.defs.contains(&pair.holder) {
-            rename_kill_def(&mut scratch, i, pair.holder)?;
+            rename_kill_def(&mut scratch, i, pair.holder, exit_dead)?;
         }
         i += 1;
     }
@@ -5055,7 +5380,15 @@ fn dissolve_spill_pair(seg: &[ArmInstruction], pair: &SpillPair) -> Option<Vec<A
 ///      the #483-class conservatism).
 ///
 /// Returns `Some((rewritten, reloads_dissolved))` or `None` to keep the input.
-fn spill_rechoice_segment(seg: &[ArmInstruction]) -> Option<(Vec<ArmInstruction>, usize)> {
+///
+/// `exit_dead` / `post_exhaust`: the VCR-VER-001 post-exhaustion extensions
+/// (see [`apply_spill_realloc_post_exhaust`]); `(&empty, false)` is the
+/// shipping default behavior, bit for bit.
+fn spill_rechoice_segment(
+    seg: &[ArmInstruction],
+    exit_dead: &BTreeSet<Reg>,
+    post_exhaust: bool,
+) -> Option<(Vec<ArmInstruction>, usize)> {
     use crate::optimizer_bridge::estimate_arm_byte_size;
     // Cheap prefilter: nothing to re-choose without a word [sp,#N] reload.
     if !seg
@@ -5064,13 +5397,34 @@ fn spill_rechoice_segment(seg: &[ArmInstruction]) -> Option<(Vec<ArmInstruction>
     {
         return None;
     }
-    // Guard (d) + baseline for guard (a).
-    let baseline = segment_value_trace(seg)?;
+    // Guard (d) + baseline for guard (a). A rename onto an EXIT-DEAD register
+    // (the post-exhaustion extension) legitimately changes that register's
+    // exit value — [`scratch_dead_at`] proved no reachable instruction can
+    // observe it — so the equality is taken modulo the exit-dead registers'
+    // exit entries (both sides stripped; a no-op when `exit_dead` is empty,
+    // i.e. in the shipping flag-off configuration).
+    let strip = |mut t: SegmentTrace| {
+        for r in exit_dead {
+            t.exit_regs.remove(r);
+        }
+        t
+    };
+    let dbg = std::env::var("SYNTH_POSTEX_DEBUG").is_ok();
+    let baseline = strip(segment_value_trace(seg)?);
     // Only segments where the Belady MIN plan beats the executed traffic.
     let report = segment_spill_choice(seg, ALLOCATABLE_POOL, 0)?;
     if report.belady_reloads + report.belady_spill_stores
         >= report.actual_reloads + report.actual_spill_stores
     {
+        if dbg {
+            eprintln!(
+                "[postex-dbg] prefilter: belady {}+{} >= actual {}+{}",
+                report.belady_reloads,
+                report.belady_spill_stores,
+                report.actual_reloads,
+                report.actual_spill_stores
+            );
+        }
         return None;
     }
 
@@ -5080,9 +5434,30 @@ fn spill_rechoice_segment(seg: &[ArmInstruction]) -> Option<(Vec<ArmInstruction>
     // Back to front: deleting a reload only shifts positions after it, so
     // earlier pairs' recorded positions stay valid.
     for pair in pairs.iter().rev() {
-        if let Some(candidate) = dissolve_spill_pair(&cur, pair)
-            // Guard (a), per pair: value flow provably unchanged.
-            && segment_value_trace(&candidate).as_ref() == Some(&baseline)
+        let candidate = dissolve_spill_pair(&cur, pair, exit_dead);
+        if dbg {
+            let c = &candidate;
+            eprintln!(
+                "[postex-dbg] pair store={} load={} holder={:?} rd={:?}: dissolve={} trace_eq={:?} pressure={:?}",
+                pair.store,
+                pair.load,
+                pair.holder,
+                pair.rd,
+                c.is_some(),
+                c.as_ref()
+                    .map(|c| segment_value_trace(c).map(&strip).as_ref() == Some(&baseline)),
+                c.as_ref().map(|c| pool_peak_pressure(c)),
+            );
+        }
+        if let Some(candidate) = candidate
+            // Guard (a), per pair: value flow provably unchanged (modulo
+            // exit-dead registers' unobservable exit values, above).
+            && segment_value_trace(&candidate).map(&strip).as_ref() == Some(&baseline)
+            // Post-exhaustion: guard (c) PER PAIR — one over-pressure pair
+            // must not discard every other pair's sound dissolve (the final
+            // all-or-nothing check below would).
+            && (!post_exhaust
+                || pool_peak_pressure(&candidate).is_some_and(|p| p <= ALLOCATABLE_POOL))
         {
             cur = candidate;
             dissolved += 1;
@@ -5092,12 +5467,22 @@ fn spill_rechoice_segment(seg: &[ArmInstruction]) -> Option<(Vec<ArmInstruction>
         return None;
     }
     // Guard (b): strictly fewer instructions AND strictly smaller bytes.
+    // Post-exhaustion relaxation: a count-neutral rewrite (every dissolve was
+    // a `ldr`→`mov` fold, no deletion) is accepted when the bytes still
+    // strictly shrink — the fold un-reads the feeding store, which the
+    // flag-shared unread-store sweep then deletes, so the instruction-count
+    // win lands one pass later. Never count growth, never byte growth.
     let bytes = |s: &[ArmInstruction]| {
         s.iter()
             .map(|i| estimate_arm_byte_size(&i.op))
             .sum::<usize>()
     };
-    if cur.len() >= seg.len() || bytes(&cur) >= bytes(seg) {
+    let count_ok = if post_exhaust {
+        cur.len() <= seg.len()
+    } else {
+        cur.len() < seg.len()
+    };
+    if !count_ok || bytes(&cur) >= bytes(seg) {
         return None;
     }
     // Guard (c): the re-chosen residency fits the pool.
@@ -10757,7 +11142,7 @@ mod tests {
             reshuffle_segment(),
             dead_def_segment(),
         ] {
-            if let SegmentOutcome::Rewritten(new) = try_reallocate_segment(&seg, &VPOOL) {
+            if let SegmentOutcome::Rewritten(new) = try_reallocate_segment(&seg, &VPOOL, false) {
                 assert_eq!(
                     validate_segment_rewrite(&seg, &new),
                     Ok(()),
@@ -11155,7 +11540,7 @@ mod tests {
         ] {
             // The pass's own rewrite where it produces one, plus the identity
             // rewrite — both are valid pairs the mutations corrupt.
-            if let SegmentOutcome::Rewritten(new) = try_reallocate_segment(&seg, &VPOOL) {
+            if let SegmentOutcome::Rewritten(new) = try_reallocate_segment(&seg, &VPOOL, false) {
                 corpus.push((seg.clone(), new));
             }
             corpus.push((seg.clone(), seg));
@@ -11877,5 +12262,201 @@ mod tests {
             s.belady_reloads, 1,
             "an out-of-segment slot value must be loaded in the ideal world too"
         );
+    }
+
+    // ---- VCR-VER-001 post-exhaustion extensions (#242, the PR #659 verdict) ----
+
+    /// The allocation-time Belady eviction shape: store a live value, reuse the
+    /// register, reload before the final use — with R2 never touched (the #580
+    /// bridge draws scratch from R4-R8 only). The segment-local rename proof
+    /// declines R2 ("never touched again → possibly live-out"); the
+    /// post-exhaustion function-level scan proves it dead at exit.
+    fn postex_eviction_shape() -> Vec<ArmInstruction> {
+        vec![
+            sp_str(Reg::R4, 4),              // evict v1 (held in r4)
+            movw(Reg::R4, 7),                // the clobbering def (why v1 was evicted)
+            add3(Reg::R5, Reg::R4, Reg::R4), // consume the new value
+            sp_ldr(Reg::R4, 4),              // reload v1
+            // Final use READS r0 (so r0 is a live segment input the old rule
+            // rightly rejects as a rename target — only exit-dead R2/R3 work).
+            add3(Reg::R0, Reg::R0, Reg::R4),
+            ins(ArmOp::Bx { rm: Reg::LR }),
+        ]
+    }
+
+    #[test]
+    fn postex_exit_dead_rename_dissolves_belady_pair_242() {
+        let seq = postex_eviction_shape();
+        // Shipping behavior (flag off): R2 cannot be proven dead → the pair
+        // survives → bytes unchanged.
+        let (out_off, n_off) = apply_spill_realloc(&seq);
+        assert_eq!(n_off, 0, "flag-off: rename target undecidable, no rewrite");
+        assert_eq!(out_off, seq, "flag-off bytes are bit-identical");
+        // Post-exhaustion: the clobbering def renames onto exit-dead R2, the
+        // reload dissolves, and no [sp] LOAD survives.
+        let (out_on, n_on) = apply_spill_realloc_post_exhaust(&seq, true);
+        assert!(n_on >= 1, "the reload must be dissolved, got {n_on}");
+        assert!(
+            !out_on
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Ldr { addr, .. } if addr.base == Reg::SP)),
+            "no frame reload survives: {out_on:?}"
+        );
+    }
+
+    #[test]
+    fn postex_exit_dead_declines_when_r2_r3_read_later_242() {
+        // Same shape but R2 and R3 are READ after the segment-side window —
+        // the function-level scan must call them live and keep the pair.
+        let mut seq = postex_eviction_shape();
+        seq.insert(
+            5,
+            add3(Reg::R0, Reg::R2, Reg::R3), // reads both candidates before bx lr
+        );
+        let (out_on, n_on) = apply_spill_realloc_post_exhaust(&seq, true);
+        assert_eq!(n_on, 0, "R2/R3 live at exit: nothing may be renamed");
+        assert_eq!(out_on, seq);
+    }
+
+    #[test]
+    fn postex_const_reload_rematerializes_242() {
+        // A spilled CONSTANT: the slot provably holds `movw #42`'s value, no
+        // register still does at the reload → the reload rematerializes and
+        // the whole-function unread-store sweep can then drop the store.
+        let seq = vec![
+            movw(Reg::R4, 42),
+            sp_str(Reg::R4, 8),
+            movw(Reg::R4, 7), // clobber the holder: no register keeps 42
+            add3(Reg::R5, Reg::R4, Reg::R4),
+            sp_ldr(Reg::R6, 8), // reload of the constant
+            add3(Reg::R0, Reg::R6, Reg::R5),
+            ins(ArmOp::Bx { rm: Reg::LR }),
+        ];
+        let (out_off, n_off) = apply_spill_realloc(&seq);
+        // Flag off: stage 1 has no holder to forward from; stage 2 may not
+        // fire either (rename targets undecidable). Bytes unchanged.
+        assert_eq!((out_off.clone(), n_off), (seq.clone(), 0));
+        let (out_on, n_on) = apply_spill_realloc_post_exhaust(&seq, true);
+        assert!(n_on >= 1);
+        assert!(
+            out_on.iter().any(|i| matches!(
+                &i.op,
+                ArmOp::Movw {
+                    rd: Reg::R6,
+                    imm16: 42
+                }
+            )),
+            "the reload becomes a rematerialized movw: {out_on:?}"
+        );
+        assert!(
+            !out_on
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Ldr { addr, .. } if addr.base == Reg::SP)),
+            "no frame reload survives"
+        );
+    }
+
+    #[test]
+    fn postex_remat_blocked_by_movt_rmw_242() {
+        // `movw` then `movt` on the same register: the tracked single-
+        // instruction shape must be killed by the RMW — rematerializing only
+        // the low half would be a wrong value (the #582-class discipline:
+        // never treat a spill of a NON-reproducible value as reproducible).
+        let seq = vec![
+            movw(Reg::R4, 42),
+            ins(ArmOp::Movt {
+                rd: Reg::R4,
+                imm16: 1,
+            }),
+            sp_str(Reg::R4, 8),
+            movw(Reg::R4, 7),
+            add3(Reg::R5, Reg::R4, Reg::R4),
+            sp_ldr(Reg::R6, 8),
+            add3(Reg::R0, Reg::R6, Reg::R5),
+        ];
+        let (out_on, _) = apply_spill_realloc_post_exhaust(&seq, true);
+        assert!(
+            out_on
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Ldr { addr, .. } if addr.base == Reg::SP)),
+            "the reload must SURVIVE: the slot value is movw+movt, not remat-able"
+        );
+        assert!(
+            !out_on
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Movw { rd: Reg::R6, .. })),
+            "no low-half-only rematerialization may appear"
+        );
+    }
+
+    #[test]
+    fn postex_scratch_dead_at_conservative_on_branches_242() {
+        // A resolved numeric branch after the point: control may reach a read
+        // the linear scan cannot see → both candidates stay live.
+        let seq = vec![
+            movw(Reg::R0, 1),
+            ins(ArmOp::BCondOffset {
+                cond: crate::rules::Condition::NE,
+                offset: 0,
+            }),
+            ins(ArmOp::Bx { rm: Reg::LR }),
+        ];
+        assert!(scratch_dead_at(&seq, 1).is_empty());
+        // From AFTER the branch, the return proves R2/R3 dead.
+        assert_eq!(scratch_dead_at(&seq, 2), BTreeSet::from([Reg::R2, Reg::R3]));
+    }
+
+    #[test]
+    fn postex_relaxed_exit_recolors_terminal_segment_242() {
+        // A frame-carrying terminal segment homed in callee-saved r4/r5 whose
+        // only frame access is a dead store (the spilled `signed_div_const`
+        // shape). Shipping pins every live-out → identity/decline; relaxed
+        // exit pinning lowers the body into caller-saved registers.
+        let seq = vec![
+            ins(ArmOp::Sub {
+                rd: Reg::SP,
+                rn: Reg::SP,
+                op2: Operand2::Imm(8),
+            }),
+            movw(Reg::R4, 10),
+            add3(Reg::R5, Reg::R4, Reg::R4),
+            sp_str(Reg::R5, 4), // dead store (never reloaded)
+            add3(Reg::R0, Reg::R5, Reg::R4),
+            ins(ArmOp::Add {
+                rd: Reg::SP,
+                rn: Reg::SP,
+                op2: Operand2::Imm(8),
+            }),
+            ins(ArmOp::Bx { rm: Reg::LR }),
+        ];
+        const RPOOL: [Reg; 9] = [
+            Reg::R0,
+            Reg::R1,
+            Reg::R2,
+            Reg::R3,
+            Reg::R4,
+            Reg::R5,
+            Reg::R6,
+            Reg::R7,
+            Reg::R8,
+        ];
+        let (out_off, stats_off) = reallocate_function(&seq, &RPOOL);
+        assert_eq!(out_off, seq, "flag-off: bit-identical");
+        assert_eq!(stats_off.reallocated, 0);
+        let (out_on, stats_on) = reallocate_function_post_exhaust(&seq, &RPOOL, true);
+        assert_eq!(stats_on.reallocated, 1, "relaxed exit must recolor");
+        assert!(
+            !out_on.iter().any(|i| {
+                reg_effect(&i.op).is_some_and(|e| {
+                    e.defs
+                        .iter()
+                        .chain(e.uses.iter())
+                        .any(|r| matches!(r, Reg::R4 | Reg::R5 | Reg::R6 | Reg::R7 | Reg::R8))
+                })
+            }),
+            "the recolored body avoids callee-saved registers: {out_on:?}"
+        );
+        // The result register is still pinned.
+        assert!(matches!(&out_on[4].op, ArmOp::Add { rd: Reg::R0, .. }));
     }
 }

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -686,6 +686,13 @@ pub struct OptimizerBridge {
     /// declines the function to the direct selector (which implements it);
     /// `None`/`Mpu` emit no inline guard (byte-identical to before).
     bounds_check: BoundsCheckConfig,
+    /// VCR-VER-001 (#242): whether the LAST `ir_to_arm` call's output was
+    /// actually shaped by the spill-on-exhaustion machinery (a pre-step
+    /// reinstate/evict fired, or a constant-divisor guard was elided). The
+    /// backend scopes the post-exhaustion cleanup extensions to exactly these
+    /// functions, so a flag-on compile leaves every untouched function
+    /// byte-identical (the `vcr_ver_001_gate_242` lock's contract).
+    spill_on_exhaust_fired: std::cell::Cell<bool>,
 }
 
 impl OptimizerBridge {
@@ -697,6 +704,7 @@ impl OptimizerBridge {
             spill_on_exhaust: None,
             volatile_segments: Vec::new(),
             bounds_check: BoundsCheckConfig::None,
+            spill_on_exhaust_fired: std::cell::Cell::new(false),
         }
     }
 
@@ -708,7 +716,14 @@ impl OptimizerBridge {
             spill_on_exhaust: None,
             volatile_segments: Vec::new(),
             bounds_check: BoundsCheckConfig::None,
+            spill_on_exhaust_fired: std::cell::Cell::new(false),
         }
+    }
+
+    /// VCR-VER-001 (#242): did the last [`OptimizerBridge::ir_to_arm`] output
+    /// get shaped by the spill-on-exhaustion machinery? See the field doc.
+    pub fn spill_on_exhaust_fired(&self) -> bool {
+        self.spill_on_exhaust_fired.get()
     }
 
     /// #377: set the `--safety-bounds` mode (see [`OptimizerBridge::bounds_check`]).
@@ -2918,6 +2933,38 @@ impl OptimizerBridge {
     /// it always was — it just no longer kills the process. Callers in the
     /// fuzz/AOT pipeline propagate the `Err` instead of crashing.
     pub fn ir_to_arm(&self, instructions: &[Instruction], num_params: usize) -> Result<Vec<ArmOp>> {
+        self.spill_on_exhaust_fired.set(false);
+        let (out, acted, guards_elided) = self.ir_to_arm_impl(instructions, num_params, true)?;
+        // VCR-VER-001 scoping (#242): constant-divisor guard elision is part
+        // of the post-exhaustion QUALITY story — it exists so a function that
+        // only compiles on this path *because of the spill lever* is not worse
+        // than its direct lowering. A function the exhaustion machinery never
+        // touched must stay byte-identical flag-on (the `vcr_ver_001_gate_242`
+        // contract), so if guards were elided but no pre-step action fired,
+        // rebuild without elision. (One extra lowering pass for exactly the
+        // functions in that corner; allocation is deterministic, so the
+        // rebuild differs only by the reinstated guards.)
+        if guards_elided > 0 && !acted {
+            let (out, acted, _) = self.ir_to_arm_impl(instructions, num_params, false)?;
+            self.spill_on_exhaust_fired.set(acted);
+            return Ok(out);
+        }
+        self.spill_on_exhaust_fired.set(acted || guards_elided > 0);
+        Ok(out)
+    }
+
+    /// The lowering behind [`OptimizerBridge::ir_to_arm`]. Returns the ARM
+    /// stream plus two VCR-VER-001 facts: whether the spill-on-exhaustion
+    /// pre-step ACTED (reinstated a spilled source / evicted for a dest or
+    /// pair — i.e. flag-on-only behavior shaped the bytes), and how many
+    /// constant-divisor trap guards were elided (`elide_div_guards` gates the
+    /// elision; `false` keeps every guard, byte-identical to shipping).
+    fn ir_to_arm_impl(
+        &self,
+        instructions: &[Instruction],
+        num_params: usize,
+        elide_div_guards: bool,
+    ) -> Result<(Vec<ArmOp>, bool, usize)> {
         use crate::rules::{ArmOp, Operand2, Reg};
         use std::collections::HashMap;
 
@@ -3441,6 +3488,55 @@ impl OptimizerBridge {
         };
         let spill_on_exhaust = spill_pairs.is_some();
         let pair_partner: HashMap<u32, (u32, bool)> = spill_pairs.unwrap_or_default();
+        // VCR-VER-001 post-exhaustion quality (#242, the PR #659 verdict):
+        // single-def `Const` values, consulted by the DivS/DivU/RemS/RemU
+        // handlers to elide trap guards a constant divisor makes unreachable
+        // (divide-by-zero when c ≠ 0; the DivS INT_MIN/-1 overflow when
+        // c ∉ {0, -1}) — the direct selector's #209 Opt-1a guard elision,
+        // which the optimized path lacked and which is what made a spilled
+        // `signed_div_const` compile WORSE than its direct lowering (34→76 B).
+        // Gated on `spill_on_exhaust` twice over: (a) flag off ⇒ empty map ⇒
+        // byte-identical, and (b) the scope gate has already proven every
+        // opcode is in the modeled i32 subset, so `spill_i32_def` enumerates
+        // EVERY def and a multi-defined vreg can never smuggle in a stale
+        // constant (only the first def of a vreg may register a value).
+        // VCR-VER-001 (#242): tracks whether flag-on-only machinery actually
+        // shaped this function's bytes (pre-step reinstate/evict) and how many
+        // divisor guards were elided — the wrapper's scoping facts.
+        let mut exhaust_acted = false;
+        let mut guards_elided = 0usize;
+        let exhaust_const_vals: HashMap<u32, i32> = if spill_on_exhaust && elide_div_guards {
+            let mut vals = HashMap::new();
+            let mut defined = std::collections::HashSet::new();
+            let mut total = true; // every op's defs enumerable, or no map at all
+            for inst in instructions.iter() {
+                let Some(defs) = spill_exhaust_defs(&inst.opcode) else {
+                    total = false;
+                    break;
+                };
+                for d in defs {
+                    if !defined.insert(d) {
+                        vals.remove(&d); // redefined: never trust the value
+                    } else if let Opcode::Const { dest, value } = &inst.opcode
+                        && dest.0 == d
+                    {
+                        vals.insert(d, *value);
+                    }
+                }
+            }
+            if total { vals } else { HashMap::new() }
+        } else {
+            HashMap::new()
+        };
+        // NOTE (VCR-VER-001, measured dead end): widening the reload pool
+        // with caller-saved R2/R3 was tried and REVERTED — reload targets in
+        // R2/R3 consume exactly the exit-dead rename targets the post-hoc
+        // spill-rechoice pass (`apply_spill_realloc_post_exhaust`) needs, and
+        // eviction COUNT is dest-driven (R4-R8 only), so the net effect was
+        // strictly worse (spill_rung_581 +8.8% → +14.7% on the cycle proxy).
+        // The genuine allocation-time fix is dest allocation over the full
+        // R0-R8 pool — `alloc_i32_scratch`'s fixed R4-R8 pool is the
+        // residual named in scripts/repro/vcr_ver_001_gate.md.
         // Belady next-use table: for each vreg, the (sorted) instruction
         // positions where it is read. "Farthest next use" picks the victim.
         // i64 sources contribute BOTH halves (#587).
@@ -3557,6 +3653,7 @@ impl OptimizerBridge {
                         vreg_to_arm.insert(v_hi, p_hi);
                         operand_regs.push(p_lo);
                         operand_regs.push(p_hi);
+                        exhaust_acted = true;
                         continue;
                     }
                     // A free pool register, by `alloc_i32_scratch`'s in-use
@@ -3570,6 +3667,7 @@ impl OptimizerBridge {
                     let rd = free
                         .or_else(|| {
                             spill_evict_farthest(
+                                &SPILL_ON_EXHAUST_POOL,
                                 spill_idx,
                                 &operand_regs,
                                 &use_positions,
@@ -3618,6 +3716,7 @@ impl OptimizerBridge {
                     });
                     vreg_to_arm.insert(*v, rd);
                     operand_regs.push(rd);
+                    exhaust_acted = true;
                 }
                 if let Some(d) = spill_i32_scratch_dest(&inst.opcode)
                     && !vreg_to_arm.contains_key(&d)
@@ -3630,6 +3729,7 @@ impl OptimizerBridge {
                     });
                     if pool_full {
                         let freed = spill_evict_farthest(
+                            &SPILL_ON_EXHAUST_POOL,
                             spill_idx,
                             &operand_regs,
                             &use_positions,
@@ -3677,6 +3777,7 @@ impl OptimizerBridge {
                         {
                             r12_exhausted.set(true);
                         }
+                        exhaust_acted |= freed.is_some();
                     }
                 }
                 // #587: pre-free a legal even pair for handlers that call
@@ -3696,7 +3797,7 @@ impl OptimizerBridge {
                     && find_free_spill_pair(&vreg_to_arm, &local_to_reg, &param_reserved_regs, &[])
                         .is_none()
                 {
-                    let _ = spill_evict_pair_farthest(
+                    let freed_pair = spill_evict_pair_farthest(
                         spill_idx,
                         &operand_regs,
                         &use_positions,
@@ -3710,6 +3811,7 @@ impl OptimizerBridge {
                         &mut next_spill_offset,
                         &mut arm_instrs,
                     );
+                    exhaust_acted |= freed_pair.is_some();
                 }
             }
 
@@ -3984,52 +4086,71 @@ impl OptimizerBridge {
                     );
                     vreg_to_arm.insert(dest.0, rd);
 
+                    // VCR-VER-001 (#242): a single-def constant divisor makes
+                    // the trap conditions statically decidable — elide the
+                    // guards a nonzero (and, for overflow, non-minus-one)
+                    // constant can never fire (the direct selector's #209
+                    // Opt-1a elision; empty map ⇒ both guards stay, flag-off
+                    // byte-identical).
+                    let divisor = exhaust_const_vals.get(&src2.0).copied();
+                    let elide_zero = matches!(divisor, Some(c) if c != 0);
+                    let elide_ovf = matches!(divisor, Some(c) if c != 0 && c != -1);
+
                     // Trap check 1: divide by zero
-                    arm_instrs.push(ArmOp::Cmp {
-                        rn: rm,
-                        op2: Operand2::Imm(0),
-                    });
-                    arm_instrs.push(ArmOp::BCondOffset {
-                        cond: Condition::NE,
-                        offset: 0,
-                    });
-                    arm_instrs.push(ArmOp::Udf { imm: 0 });
+                    if elide_zero {
+                        guards_elided += 1;
+                    } else {
+                        arm_instrs.push(ArmOp::Cmp {
+                            rn: rm,
+                            op2: Operand2::Imm(0),
+                        });
+                        arm_instrs.push(ArmOp::BCondOffset {
+                            cond: Condition::NE,
+                            offset: 0,
+                        });
+                        arm_instrs.push(ArmOp::Udf { imm: 0 });
+                    }
 
                     // Trap check 2: signed overflow (INT_MIN / -1)
-                    // Load INT_MIN (0x80000000) into R12
-                    arm_instrs.push(ArmOp::Movw {
-                        rd: Reg::R12,
-                        imm16: 0,
-                    });
-                    arm_instrs.push(ArmOp::Movt {
-                        rd: Reg::R12,
-                        imm16: 0x8000,
-                    });
-                    // CMP dividend, INT_MIN
-                    arm_instrs.push(ArmOp::Cmp {
-                        rn,
-                        op2: Operand2::Reg(Reg::R12),
-                    });
-                    // BNE.N +3 (skip overflow check if dividend != INT_MIN)
-                    // Skip 8 bytes: CMN.W(4) + BNE(2) + UDF(2)
-                    // Branch target = PC + (imm8 << 1) = B+4 + 6 = B+10 (SDIV)
-                    arm_instrs.push(ArmOp::BCondOffset {
-                        cond: Condition::NE,
-                        offset: 3,
-                    });
-                    // CMN divisor, #1 (check if divisor == -1: -1 + 1 = 0 sets Z flag)
-                    // CMN.W is 4 bytes
-                    arm_instrs.push(ArmOp::Cmn {
-                        rn: rm,
-                        op2: Operand2::Imm(1),
-                    });
-                    // BNE.N +0 (skip UDF if divisor != -1)
-                    arm_instrs.push(ArmOp::BCondOffset {
-                        cond: Condition::NE,
-                        offset: 0,
-                    });
-                    // UDF #1 (trap on overflow)
-                    arm_instrs.push(ArmOp::Udf { imm: 1 });
+                    if elide_ovf {
+                        guards_elided += 1;
+                    }
+                    if !elide_ovf {
+                        // Load INT_MIN (0x80000000) into R12
+                        arm_instrs.push(ArmOp::Movw {
+                            rd: Reg::R12,
+                            imm16: 0,
+                        });
+                        arm_instrs.push(ArmOp::Movt {
+                            rd: Reg::R12,
+                            imm16: 0x8000,
+                        });
+                        // CMP dividend, INT_MIN
+                        arm_instrs.push(ArmOp::Cmp {
+                            rn,
+                            op2: Operand2::Reg(Reg::R12),
+                        });
+                        // BNE.N +3 (skip overflow check if dividend != INT_MIN)
+                        // Skip 8 bytes: CMN.W(4) + BNE(2) + UDF(2)
+                        // Branch target = PC + (imm8 << 1) = B+4 + 6 = B+10 (SDIV)
+                        arm_instrs.push(ArmOp::BCondOffset {
+                            cond: Condition::NE,
+                            offset: 3,
+                        });
+                        // CMN divisor, #1 (check if divisor == -1: -1 + 1 = 0 sets Z flag)
+                        // CMN.W is 4 bytes
+                        arm_instrs.push(ArmOp::Cmn {
+                            rn: rm,
+                            op2: Operand2::Imm(1),
+                        });
+                        // BNE.N +0 (skip UDF if divisor != -1)
+                        arm_instrs.push(ArmOp::BCondOffset {
+                            cond: Condition::NE,
+                            offset: 0,
+                        });
+                        // UDF #1 (trap on overflow)
+                        arm_instrs.push(ArmOp::Udf { imm: 1 });
+                    }
 
                     arm_instrs.push(ArmOp::Sdiv { rd, rn, rm });
                     last_result_vreg = Some(dest.0);
@@ -4046,16 +4167,21 @@ impl OptimizerBridge {
                     );
                     vreg_to_arm.insert(dest.0, rd);
 
-                    // Trap check: divide by zero
-                    arm_instrs.push(ArmOp::Cmp {
-                        rn: rm,
-                        op2: Operand2::Imm(0),
-                    });
-                    arm_instrs.push(ArmOp::BCondOffset {
-                        cond: Condition::NE,
-                        offset: 0,
-                    });
-                    arm_instrs.push(ArmOp::Udf { imm: 0 });
+                    // Trap check: divide by zero. VCR-VER-001 (#242): elided
+                    // for a single-def nonzero constant divisor (see DivS).
+                    if matches!(exhaust_const_vals.get(&src2.0), Some(c) if *c != 0) {
+                        guards_elided += 1;
+                    } else {
+                        arm_instrs.push(ArmOp::Cmp {
+                            rn: rm,
+                            op2: Operand2::Imm(0),
+                        });
+                        arm_instrs.push(ArmOp::BCondOffset {
+                            cond: Condition::NE,
+                            offset: 0,
+                        });
+                        arm_instrs.push(ArmOp::Udf { imm: 0 });
+                    }
 
                     arm_instrs.push(ArmOp::Udiv { rd, rn, rm });
                     last_result_vreg = Some(dest.0);
@@ -4073,16 +4199,22 @@ impl OptimizerBridge {
                     );
                     vreg_to_arm.insert(dest.0, rd);
 
-                    // Trap check: divide by zero (rem_s doesn't trap on INT_MIN % -1)
-                    arm_instrs.push(ArmOp::Cmp {
-                        rn: rm,
-                        op2: Operand2::Imm(0),
-                    });
-                    arm_instrs.push(ArmOp::BCondOffset {
-                        cond: Condition::NE,
-                        offset: 0,
-                    });
-                    arm_instrs.push(ArmOp::Udf { imm: 0 });
+                    // Trap check: divide by zero (rem_s doesn't trap on INT_MIN % -1).
+                    // VCR-VER-001 (#242): elided for a single-def nonzero
+                    // constant divisor (see DivS).
+                    if matches!(exhaust_const_vals.get(&src2.0), Some(c) if *c != 0) {
+                        guards_elided += 1;
+                    } else {
+                        arm_instrs.push(ArmOp::Cmp {
+                            rn: rm,
+                            op2: Operand2::Imm(0),
+                        });
+                        arm_instrs.push(ArmOp::BCondOffset {
+                            cond: Condition::NE,
+                            offset: 0,
+                        });
+                        arm_instrs.push(ArmOp::Udf { imm: 0 });
+                    }
 
                     // Use MLS: rd = ra - rn * rm, where ra = dividend, result of div in temp
                     arm_instrs.push(ArmOp::Sdiv {
@@ -4110,16 +4242,21 @@ impl OptimizerBridge {
                     );
                     vreg_to_arm.insert(dest.0, rd);
 
-                    // Trap check: divide by zero
-                    arm_instrs.push(ArmOp::Cmp {
-                        rn: rm,
-                        op2: Operand2::Imm(0),
-                    });
-                    arm_instrs.push(ArmOp::BCondOffset {
-                        cond: Condition::NE,
-                        offset: 0,
-                    });
-                    arm_instrs.push(ArmOp::Udf { imm: 0 });
+                    // Trap check: divide by zero. VCR-VER-001 (#242): elided
+                    // for a single-def nonzero constant divisor (see DivS).
+                    if matches!(exhaust_const_vals.get(&src2.0), Some(c) if *c != 0) {
+                        guards_elided += 1;
+                    } else {
+                        arm_instrs.push(ArmOp::Cmp {
+                            rn: rm,
+                            op2: Operand2::Imm(0),
+                        });
+                        arm_instrs.push(ArmOp::BCondOffset {
+                            cond: Condition::NE,
+                            offset: 0,
+                        });
+                        arm_instrs.push(ArmOp::Udf { imm: 0 });
+                    }
 
                     arm_instrs.push(ArmOp::Udiv {
                         rd: Reg::R12,
@@ -6489,7 +6626,7 @@ impl OptimizerBridge {
             ));
         }
 
-        Ok(arm_instrs)
+        Ok((arm_instrs, exhaust_acted, guards_elided))
     }
 }
 
@@ -6979,6 +7116,51 @@ fn spill_i32_sources(op: &Opcode) -> Vec<u32> {
 /// `Const` has its own, larger pool with eviction; `Load`/`Call` bind fixed
 /// registers). Used by the pre-step to free a pool register BEFORE the handler
 /// runs, so `alloc_i32_scratch` never reaches its R12 exhaustion fallback.
+/// EVERY vreg `op` defines, total over the spill-on-exhaust modeled subset
+/// ([`spill_on_exhaust_supported`]) — or `None` for anything outside it.
+/// Used by the VCR-VER-001 single-def `Const` scan: the divisor-guard elision
+/// must see every def (a missed redefinition could smuggle a stale constant),
+/// so a single `None` disables the whole map — decline-to-empty, never a
+/// wrong value.
+fn spill_exhaust_defs(op: &Opcode) -> Option<Vec<u32>> {
+    // i32 scratch dests + the local-backed `Load`/`TeeStore` dests.
+    if let Opcode::Load { dest, .. } | Opcode::TeeStore { dest, .. } = op {
+        return Some(vec![dest.0]);
+    }
+    if let Some(d) = spill_i32_scratch_dest(op) {
+        return Some(vec![d]);
+    }
+    // i64 pair defs (I64Const/Load/Add/.../Extend).
+    if let Some((lo, hi)) = spill_pair_def(op) {
+        return Some(vec![lo, hi]);
+    }
+    match op {
+        // i64 ops with an i32 destination.
+        Opcode::I64Eq { dest, .. }
+        | Opcode::I64Ne { dest, .. }
+        | Opcode::I64LtS { dest, .. }
+        | Opcode::I64LtU { dest, .. }
+        | Opcode::I64LeS { dest, .. }
+        | Opcode::I64LeU { dest, .. }
+        | Opcode::I64GtS { dest, .. }
+        | Opcode::I64GtU { dest, .. }
+        | Opcode::I64GeS { dest, .. }
+        | Opcode::I64GeU { dest, .. }
+        | Opcode::I64Eqz { dest, .. }
+        | Opcode::I32WrapI64 { dest, .. } => Some(vec![dest.0]),
+        // Modeled ops that define no vreg.
+        Opcode::Nop
+        | Opcode::Label { .. }
+        | Opcode::Store { .. }
+        | Opcode::MemStore { .. }
+        | Opcode::MemStoreSubword { .. }
+        | Opcode::GlobalSet { .. }
+        | Opcode::Return { .. } => Some(vec![]),
+        // Anything else: not enumerable here — disable the const map.
+        _ => None,
+    }
+}
+
 fn spill_i32_scratch_dest(op: &Opcode) -> Option<u32> {
     match op {
         Opcode::Add { dest, .. }
@@ -7042,6 +7224,7 @@ fn spill_i32_scratch_dest(op: &Opcode) -> Option<u32> {
 /// table cannot see.
 #[allow(clippy::too_many_arguments)]
 fn spill_evict_farthest(
+    pool: &[crate::rules::Reg],
     cur_idx: usize,
     avoid: &[crate::rules::Reg],
     use_positions: &std::collections::HashMap<u32, Vec<usize>>,
@@ -7057,12 +7240,15 @@ fn spill_evict_farthest(
 ) -> Option<crate::rules::Reg> {
     use crate::rules::Reg;
     // Deterministic candidate order: sort by vreg id (HashMap iteration order
-    // must never influence emitted bytes).
+    // must never influence emitted bytes). `pool` is the register set whose
+    // freeing helps the caller: the widened reload pool for source
+    // reinstatement, exactly `SPILL_ON_EXHAUST_POOL` for dest pre-freeing
+    // (`alloc_i32_scratch` cannot draw from R2/R3 — VCR-VER-001).
     let mut candidates: Vec<(u32, Reg)> = vreg_to_arm
         .iter()
         .map(|(&v, &r)| (v, r))
         .filter(|&(v, r)| {
-            SPILL_ON_EXHAUST_POOL.contains(&r)
+            pool.contains(&r)
                 && !local_vregs.contains(&v)
                 && !premapped_vregs.contains(&v)
                 // #587 pair guard: i64 halves are only ever spilled as
@@ -9361,6 +9547,209 @@ mod tests {
         assert!(
             store_regs.len() >= 2 && store_regs[0] == Reg::R4 && store_regs[1] == Reg::R5,
             "freeing (R4,R5) must displace its two singles first; got STRs {store_regs:?}: {arm:#?}"
+        );
+    }
+
+    // ---- VCR-VER-001: constant-divisor trap-guard elision (#242) ----
+
+    /// `p0 / C` as IR: a single-def Const divisor feeding a DivS/DivU.
+    fn const_div_ir(div: bool, signed: bool, c: i32) -> Vec<Instruction> {
+        let ops = vec![
+            Opcode::Load {
+                dest: vr(0),
+                addr: 0,
+            },
+            Opcode::Const {
+                dest: vr(1),
+                value: c,
+            },
+            match (div, signed) {
+                (true, true) => Opcode::DivS {
+                    dest: vr(2),
+                    src1: vr(0),
+                    src2: vr(1),
+                },
+                (true, false) => Opcode::DivU {
+                    dest: vr(2),
+                    src1: vr(0),
+                    src2: vr(1),
+                },
+                (false, true) => Opcode::RemS {
+                    dest: vr(2),
+                    src1: vr(0),
+                    src2: vr(1),
+                },
+                (false, false) => Opcode::RemU {
+                    dest: vr(2),
+                    src1: vr(0),
+                    src2: vr(1),
+                },
+            },
+        ];
+        ops.into_iter().map(inst).collect()
+    }
+
+    fn udf_count(arm: &[ArmOp]) -> usize {
+        arm.iter()
+            .filter(|op| matches!(op, ArmOp::Udf { .. }))
+            .count()
+    }
+
+    /// `const_div_ir` under REGISTER PRESSURE: six pad constants live across
+    /// the division exhaust the R4-R8 pool, so the flag-on pre-step must act
+    /// (the population the guard elision is scoped to).
+    fn pressure_div_ir(div: bool, signed: bool, c: i32) -> Vec<Instruction> {
+        let mut ops = vec![Opcode::Load {
+            dest: vr(0),
+            addr: 0,
+        }];
+        for i in 0..6u32 {
+            ops.push(Opcode::Const {
+                dest: vr(1 + i),
+                value: (11 * (i + 1)) as i32,
+            });
+        }
+        ops.push(Opcode::Const {
+            dest: vr(7),
+            value: c,
+        });
+        ops.push(match (div, signed) {
+            (true, true) => Opcode::DivS {
+                dest: vr(8),
+                src1: vr(0),
+                src2: vr(7),
+            },
+            (true, false) => Opcode::DivU {
+                dest: vr(8),
+                src1: vr(0),
+                src2: vr(7),
+            },
+            (false, true) => Opcode::RemS {
+                dest: vr(8),
+                src1: vr(0),
+                src2: vr(7),
+            },
+            (false, false) => Opcode::RemU {
+                dest: vr(8),
+                src1: vr(0),
+                src2: vr(7),
+            },
+        });
+        // Fold the pads + the quotient so everything is live across the div.
+        let mut acc = 8u32;
+        for i in 0..6u32 {
+            ops.push(Opcode::Add {
+                dest: vr(9 + i),
+                src1: vr(acc),
+                src2: vr(1 + i),
+            });
+            acc = 9 + i;
+        }
+        ops.into_iter().map(inst).collect()
+    }
+
+    #[test]
+    fn test_242_div_const_guards_elided_on_exhausted_function() {
+        // Nonzero, non-minus-one constant divisor UNDER PRESSURE (the spill
+        // machinery fires): both DivS guards go.
+        let mut bridge = OptimizerBridge::new();
+        bridge.set_spill_on_exhaust(true);
+        let arm = bridge
+            .ir_to_arm(&pressure_div_ir(true, true, 1000), 1)
+            .unwrap();
+        assert!(
+            bridge.spill_on_exhaust_fired(),
+            "precondition: the pressure shape must exercise the machinery"
+        );
+        assert_eq!(udf_count(&arm), 0, "no trap guard may survive: {arm:#?}");
+        assert!(
+            arm.iter().any(|op| matches!(op, ArmOp::Sdiv { .. })),
+            "the division itself must remain"
+        );
+        // DivU / RemS / RemU: the zero guard goes too.
+        for (div, signed) in [(true, false), (false, true), (false, false)] {
+            let arm = bridge
+                .ir_to_arm(&pressure_div_ir(div, signed, 7), 1)
+                .unwrap();
+            assert_eq!(udf_count(&arm), 0, "div={div} signed={signed}: {arm:#?}");
+        }
+    }
+
+    #[test]
+    fn test_242_div_const_guards_kept_flag_off() {
+        // Flag off: byte-identical to shipping — every guard stays.
+        let mut bridge = OptimizerBridge::new();
+        bridge.set_spill_on_exhaust(false);
+        let arm = bridge
+            .ir_to_arm(&const_div_ir(true, true, 1000), 1)
+            .unwrap();
+        assert_eq!(udf_count(&arm), 2, "flag-off keeps both DivS guards");
+        assert!(!bridge.spill_on_exhaust_fired());
+    }
+
+    #[test]
+    fn test_242_div_const_guards_kept_on_untouched_function_flag_on() {
+        // THE SCOPING CONTRACT (`vcr_ver_001_gate_242`): a function the
+        // exhaustion machinery never touches must stay byte-identical flag-on
+        // — the wrapper detects elision-without-action and rebuilds with the
+        // guards in place.
+        let mut on = OptimizerBridge::new();
+        on.set_spill_on_exhaust(true);
+        let arm_on = on.ir_to_arm(&const_div_ir(true, true, 1000), 1).unwrap();
+        assert!(!on.spill_on_exhaust_fired(), "no pressure: nothing fired");
+        let mut off = OptimizerBridge::new();
+        off.set_spill_on_exhaust(false);
+        let arm_off = off.ir_to_arm(&const_div_ir(true, true, 1000), 1).unwrap();
+        assert_eq!(arm_on, arm_off, "flag-on must be byte-identical here");
+        assert_eq!(udf_count(&arm_on), 2);
+    }
+
+    #[test]
+    fn test_242_div_const_guards_kept_for_trapping_constants() {
+        let mut bridge = OptimizerBridge::new();
+        bridge.set_spill_on_exhaust(true);
+        // C = 0 always traps: both guards stay (the zero guard IS the trap).
+        let arm = bridge
+            .ir_to_arm(&pressure_div_ir(true, true, 0), 1)
+            .unwrap();
+        assert_eq!(udf_count(&arm), 2, "zero divisor keeps every guard");
+        // C = -1: zero guard elided, INT_MIN/-1 overflow guard MUST stay.
+        let arm = bridge
+            .ir_to_arm(&pressure_div_ir(true, true, -1), 1)
+            .unwrap();
+        assert_eq!(udf_count(&arm), 1, "-1 divisor keeps the overflow guard");
+        assert!(
+            arm.iter().any(|op| matches!(op, ArmOp::Udf { imm: 1 })),
+            "the surviving guard is the overflow trap"
+        );
+        // RemS by -1 never overflows: zero guard elided, nothing else exists.
+        let arm = bridge
+            .ir_to_arm(&pressure_div_ir(false, true, -1), 1)
+            .unwrap();
+        assert_eq!(udf_count(&arm), 0, "rem_s by -1 needs no guard");
+    }
+
+    #[test]
+    fn test_242_div_const_map_distrusts_redefined_vreg() {
+        // The divisor vreg is redefined after the Const — the single-def scan
+        // must poison it and KEEP the guards (a stale constant here would be
+        // a silent unsoundness, the #582 class).
+        let mut ops = const_div_ir(true, true, 1000);
+        ops.insert(
+            2,
+            inst(Opcode::Add {
+                dest: vr(1), // redefines the "constant" vreg
+                src1: vr(0),
+                src2: vr(0),
+            }),
+        );
+        let mut bridge = OptimizerBridge::new();
+        bridge.set_spill_on_exhaust(true);
+        let arm = bridge.ir_to_arm(&ops, 1).unwrap();
+        assert_eq!(
+            udf_count(&arm),
+            2,
+            "redefined divisor vreg: every guard must stay: {arm:#?}"
         );
     }
 }

--- a/scripts/repro/postex_cycle_proxy.py
+++ b/scripts/repro/postex_cycle_proxy.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""VCR-VER-001 post-exhaustion cycle proxy (#242) — the PR #659 gate table,
+reproducible.
+
+For each pressure fixture, compiles the default path twice (flag off = the
+#496 decline to the direct selector; SYNTH_SPILL_ON_EXHAUST=1 = the #580
+allocation-time Belady spill + the post-exhaustion cleanup extensions), runs
+the differential vectors under unicorn, and reports the weighted cycle proxy:
+dynamic instructions + data-memory accesses (first-order M4: LDR/STR ~ 2 cyc,
+everything else ~ 1). Every run is execution-matched against wasmtime — a
+result mismatch fails the script, so the measurement doubles as an oracle.
+
+Run:
+  SYNTH=target/debug/synth python scripts/repro/postex_cycle_proxy.py
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import (
+    UC_ARCH_ARM,
+    UC_HOOK_CODE,
+    UC_HOOK_MEM_READ,
+    UC_HOOK_MEM_WRITE,
+    UC_MODE_THUMB,
+    Uc,
+)
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_SP,
+)
+
+HERE = Path(__file__).parent
+SYNTH = os.environ.get("SYNTH", "target/debug/synth")
+
+# (fixture, export, param regs, result kind, vectors)
+FIXTURES = [
+    (
+        "spill_on_exhaust_242.wat",
+        "hp",
+        2,
+        "i32",
+        [
+            (0, 0),
+            (1, 2),
+            (3000, 50),
+            (0x7FFFFFFF, 1),
+            (0xFFFFFFFF, 0x80000000),
+            (12345, 0xDEADBEEF),
+            (7, 3),
+            (0x12345678, 0x9ABCDEF0),
+        ],
+    ),
+    (
+        "spill_rung_581.wat",
+        "hp",
+        2,
+        "i32",
+        [(1, 2), (0, 0), (7, 3), (0xFFFFFFFF, 1), (12345, 54321), (2, 1)],
+    ),
+    (
+        "high_pressure_i32.wat",
+        "high_pressure",
+        2,
+        "i32",
+        [
+            (0, 0),
+            (1, 2),
+            (3000, 50),
+            (0x7FFFFFFF, 1),
+            (0xFFFFFFFF, 0x80000000),
+            (12345, 0xDEADBEEF),
+        ],
+    ),
+    (
+        "signed_div_const.wasm",
+        "filter_axis_decide",
+        3,
+        "i32",
+        [
+            (1000, 100, 500),
+            (0xFFFFF830, 5, 5),  # -2000
+            (7, 3, 0),
+            (0x80000000, 0, 0),
+            (123456, 0xFFFFFCEB, 42),  # -789
+        ],
+    ),
+    (
+        "i64_pair_exhaust_587.wat",
+        "hp64",
+        2,
+        "i64",
+        [
+            (0, 0),
+            (1, 2),
+            (3000, 50),
+            (0x7FFFFFFF, 1),
+            (0xFFFFFFFF, 0x80000000),
+            (12345, 0xDEADBEEF),
+            (7, 3),
+            (0x12345678, 0x9ABCDEF0),
+        ],
+    ),
+    (
+        "i64_spill_pool_587.wat",
+        "hp20",
+        1,
+        "i64",
+        [(0,), (1,), (3000,), (0x7FFFFFFF,), (0xFFFFFFFF,), (12345,)],
+    ),
+]
+
+CODE, STK = 0x10000, 0x90000
+PARAM_REGS = [UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2]
+
+
+def compile_fixture(src: Path, flag_on: bool) -> bytes:
+    env = dict(os.environ)
+    env.pop("SYNTH_SPILL_ON_EXHAUST", None)
+    if flag_on:
+        env["SYNTH_SPILL_ON_EXHAUST"] = "1"
+    with tempfile.NamedTemporaryFile(suffix=".elf") as f:
+        subprocess.run(
+            [
+                SYNTH,
+                "compile",
+                str(src),
+                "-o",
+                f.name,
+                "--target",
+                "cortex-m4",
+                "--all-exports",
+            ],
+            check=True,
+            capture_output=True,
+            env=env,
+        )
+        return Path(f.name).read_bytes()
+
+
+def measure(elf_bytes: bytes, export: str, nparams: int, kind: str, vectors):
+    """(total proxy, total insns, total accesses); asserts wasmtime match."""
+    import io
+
+    e = ELFFile(io.BytesIO(elf_bytes))
+    text_sec = e.get_section_by_name(".text")
+    text = text_sec.data()
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: s["st_value"] for s in symtab.iter_symbols()}
+    entry_off = (syms[export] & ~1) - text_sec["sh_addr"]
+
+    total_insns = total_acc = 0
+    for vec in vectors:
+        mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+        mu.mem_map(CODE, 0x10000)
+        mu.mem_write(CODE, text)
+        mu.mem_map(STK, 0x10000)
+        ret = CODE + 0xFF00
+        mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+        counts = [0, 0]  # insns, data accesses
+        mu.hook_add(UC_HOOK_CODE, lambda u, a, s, d: counts.__setitem__(0, counts[0] + 1))
+        mu.hook_add(
+            UC_HOOK_MEM_READ | UC_HOOK_MEM_WRITE,
+            lambda u, t, a, s, v, d: counts.__setitem__(1, counts[1] + 1),
+        )
+        for r, v in zip(PARAM_REGS, vec):
+            mu.reg_write(r, v)
+        mu.reg_write(UC_ARM_REG_SP, STK + 0x8000)
+        mu.reg_write(UC_ARM_REG_LR, ret | 1)
+        mu.emu_start((CODE + entry_off) | 1, ret, timeout=5_000_000)
+        got = mu.reg_read(UC_ARM_REG_R0)
+        if kind == "i64":
+            got |= mu.reg_read(UC_ARM_REG_R1) << 32
+        yield_check(export, vec, got, kind)
+        total_insns += counts[0]
+        total_acc += counts[1]
+    return total_insns + total_acc, total_insns, total_acc
+
+
+_GT_CACHE = {}
+
+
+def yield_check(export, vec, got, kind):
+    src, gt_export = _GT_CACHE["src"], _GT_CACHE["export"]
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module.from_file(eng, str(src))
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    fn = inst.exports(st)[gt_export]
+    sargs = [a - (1 << 32) if a >= 1 << 31 else a for a in vec]
+    exp = fn(st, *sargs)
+    exp &= (1 << 64) - 1 if kind == "i64" else 0xFFFFFFFF
+    if got != exp:
+        print(f"FAIL {export}{vec}: got {got:#x} expect {exp:#x}")
+        sys.exit(1)
+
+
+def main():
+    print(f"{'fixture':30s} {'off (i+m)':>14s} {'on (i+m)':>14s} {'delta':>8s}")
+    worst = []
+    for name, export, nparams, kind, vectors in FIXTURES:
+        src = HERE / name
+        _GT_CACHE["src"], _GT_CACHE["export"] = src, export
+        off = compile_fixture(src, False)
+        on = compile_fixture(src, True)
+        p_off, i_off, m_off = measure(off, export, nparams, kind, vectors)
+        p_on, i_on, m_on = measure(on, export, nparams, kind, vectors)
+        d = 100.0 * (p_on - p_off) / p_off
+        worst.append((name, d))
+        print(
+            f"{name:30s} {p_off:5d} ({i_off}+{m_off}) {p_on:5d} ({i_on}+{m_on}) {d:+7.1f}%"
+        )
+    print("EXECUTION: all vectors matched wasmtime in both flag states")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repro/vcr_ver_001_gate.md
+++ b/scripts/repro/vcr_ver_001_gate.md
@@ -126,3 +126,100 @@ SYNTH_SPILL_ON_EXHAUST=1 target/debug/synth compile \
     scripts/repro/spill_on_exhaust_242.wat -o /tmp/soe.elf --target cortex-m4
 python scripts/repro/spill_on_exhaust_242_differential.py /tmp/soe.elf
 ```
+
+## Post-exhaustion code quality — the named capability, built (follow-up PR)
+
+The missing capability named above ("post-exhaustion code quality on the
+optimized path") is now partially closed. Root cause of the unreached slots,
+found by construction analysis + disassembly of the flag-on streams:
+
+1. **`eliminate_dead_frame_stores` structurally cannot fire** on allocation-
+   time slots: `next_spill_offset` is fresh-monotonic (every eviction gets a
+   new slot), and the pass proves deadness ONLY via a later same-slot
+   overwrite (#515's overwrite-only discipline). No overwrite can exist.
+2. **`forward_stack_reloads` structurally cannot fire**: the Belady eviction
+   store's source register is redefined immediately after the store (that is
+   WHY the value was evicted), so the forwarding shape never survives.
+3. **`spill_rechoice_segment` declined every rename**: the bridge draws
+   scratch from R4-R8 only, so R2/R3 are never touched again after a
+   segment — and `rename_kill_def`'s segment-local deadness proof rejects a
+   register with no later in-segment def as "possibly live-out". The one
+   fact that resolves it (nothing past `bx lr` can read R2/R3) is function-
+   level, invisible to the segment pass. A second blocker hid behind the
+   first: guard (a)'s exact `SegmentTrace` equality rejects any rename onto a
+   fresh register (its exit entry differs), and guard (b) rejected
+   count-neutral `ldr`→`mov` folds.
+4. **`signed_div_const` was a different bug**: the optimized path emitted the
+   div-by-zero + INT_MIN/−1 trap guards even for a constant divisor (the
+   direct selector elides them since v0.11.17), plus a dead spill store the
+   unread-store sweep could not reach past the guards' resolved branches.
+
+Extensions, ALL scoped to functions the #580 machinery actually shaped
+(`OptimizerBridge::spill_on_exhaust_fired`, so a flag-on compile leaves every
+untouched function byte-identical — locked by `vcr_ver_001_gate_242` and the
+frozen suite run in BOTH flag states):
+
+- `scratch_dead_at` (function-level R2/R3 exit-deadness, conservative at any
+  branch/call/unmodeled op) feeding `rename_kill_def`; trace equality taken
+  modulo provably-dead-at-exit exit entries; per-pair pool-pressure commit;
+  count-neutral folds accepted when bytes strictly shrink.
+- Constant REMATERIALIZATION in `spill_forward_segment`: a reload of a slot
+  provably holding a single-instruction constant (`mov`/`movw`; `movt`'s RMW
+  kills the shape — the #582-class discipline) becomes the retargeted
+  materialization; the store then dies in the unread sweep.
+- Bounded fixpoint (≤4 rounds) of the cleanup triple, post-exhaustion only.
+- Terminal-segment RELAXED live-out pinning in range-realloc (only R0/R1
+  observable past `bx lr` pre-prologue; VCR-RA-003 validator run with the
+  same exemptions) — restricted to reload-free segments so R2/R3 stay free
+  for the rechoice pass; late `elide_dead_frame` re-run once cleanup empties
+  the frame.
+- Constant-divisor trap-guard elision in the bridge's DivS/DivU/RemS/RemU
+  (single-def `Const` scan, total-or-disabled def enumeration; c=0 keeps
+  everything, DivS c=−1 keeps the overflow guard).
+
+### Cycle proxy, re-measured (`scripts/repro/postex_cycle_proxy.py`)
+
+Weighted proxy = dynamic instructions + data-memory accesses under unicorn,
+summed over the differential vectors, every run execution-matched against
+wasmtime in both flag states.
+
+| fixture (default path) | off | on (PR #659) | on (now) | target ≤ +5% |
+|---|---|---|---|---|
+| `spill_on_exhaust_242.wat` | 368 | +30.4 % | 432 (**+17.4 %**) | missed |
+| `spill_rung_581.wat` | 204 | +32.4 % | 222 (**+8.8 %**) | missed |
+| `high_pressure_i32.wat` | 300 | +8.0 % | 228 (**−24.0 %**) | ✓ (now faster than the decline) |
+| `signed_div_const.wasm` | 75 | +120 % | 50 (**−33.3 %**) | ✓ (now faster than the decline) |
+| `i64_pair_exhaust_587.wat` | 584 | −5.5 % | 488 (**−16.4 %**) | ✓ |
+| `i64_spill_pool_587.wat` | 1656 | −1.4 % | 1608 (**−2.9 %**) | ✓ |
+
+(PR #659 percentages were derived on slightly different vector sets for two
+fixtures; each column is internally consistent — off and on always share
+vectors.)
+
+### The residual, named
+
+`spill_on_exhaust_242` (+17.4 %) and `spill_rung_581` (+8.8 %) still miss the
+≤ +5 % bar. The residual cause is the allocation itself, not the cleanup:
+`alloc_i32_scratch` draws destinations from a FIXED R4-R8 pool (5 registers)
+while the direct selector allocates over all nine of R0-R8 — so the bridge
+evicts 5 values where Belady over 9 registers needs 1. The post-hoc renamer
+recovers only what fits through the two forever-free caller-saved registers
+(R2/R3, serially reusable across disjoint live windows); the surviving pairs'
+windows overlap every candidate. Widening the RELOAD pool with R2/R3 at
+allocation time was tried and reverted (it starves the renamer of exactly
+those registers: rung +8.8 % → +14.7 %). Closing the last gap needs dest
+allocation over the full pool — the hand-written single-pass allocator itself,
+i.e. the Track-A VCR-RA/VCR-SEL replacement, exactly the North-Star claim.
+The `SYNTH_SPILL_ON_EXHAUST` default-on flip stays HELD (#580) on that gap +
+gale G474RE cycles.
+
+Reproduce:
+
+```sh
+cargo test -p synth-cli --test frozen_codegen_bytes --test vcr_ver_001_gate_242   # off
+SYNTH_SPILL_ON_EXHAUST=1 cargo test -p synth-cli \
+    --test frozen_codegen_bytes --test vcr_ver_001_gate_242                        # on
+SYNTH=target/debug/synth python scripts/repro/postex_cycle_proxy.py
+SYNTH=target/debug/synth SYNTH_SPILL_ON_EXHAUST=1 \
+    python scripts/repro/r12_spill_496_differential.py
+```


### PR DESCRIPTION
## What this is

PR #659 demonstrated the VCR-VER-001 gate but held the `SYNTH_SPILL_ON_EXHAUST` flip on a measured i32-shape cycle regression, naming the missing capability: **post-exhaustion code quality on the optimized path** — allocation-time Belady spill slots (#580) were not reached by the existing cleanup passes. This PR diagnoses why, extends the passes' reach, and re-measures PR #659's cycle-proxy table. Full evidence appended to `scripts/repro/vcr_ver_001_gate.md`.

## Root cause of the unreached slots

1. `eliminate_dead_frame_stores` **structurally cannot fire**: `next_spill_offset` is fresh-monotonic, and the pass proves deadness only via a later same-slot overwrite (the #515 overwrite-only discipline) — no overwrite can exist.
2. `forward_stack_reloads` **structurally cannot fire**: the eviction store's source register is redefined immediately after the store (that is *why* the value was evicted).
3. `spill_rechoice_segment` declined every rename: the bridge draws scratch from **R4-R8 only**, so R2/R3 are never touched again — and the segment-local deadness proof rejects "never touched again" as possibly-live-out. Behind that, exact `SegmentTrace` equality rejected any rename onto a fresh register, and guard (b) rejected count-neutral `ldr`→`mov` folds.
4. `signed_div_const` (the +120% outlier) was a different gap: the optimized path emitted div-by-zero + INT_MIN/−1 trap guards even for constant divisors (the direct selector elides them since v0.11.17, #209 Opt 1a), plus a dead spill store the unread sweep couldn't reach past the guards' resolved branches (#604/#606 discipline).

## Pass changes (all scoped, flag-off bit-identical)

Everything is reachable **only** on functions the #580 machinery actually shaped, via the new `OptimizerBridge::spill_on_exhaust_fired` scoping — a flag-on compile leaves every untouched function byte-identical (guard elision on a non-spilling function triggers a rebuild with guards reinstated). Locked by `vcr_ver_001_gate_242` + the frozen suite run in **both** flag states.

- **`scratch_dead_at`**: function-level R2/R3 exit-deadness (caller-saved, never return-carrying; conservative at any branch/call/unmodeled op), feeding `rename_kill_def`; trace equality taken modulo provably-dead exit entries; per-pair pool-pressure commit; count-neutral folds admitted when bytes strictly shrink.
- **Constant rematerialization** in `spill_forward_segment`: a reload of a slot provably holding a single-instruction constant becomes the retargeted `mov`/`movw`; `movt`'s RMW kills the tracked shape (the #581/#582 discipline — a non-reproducible value is never treated as reproducible; the store-before-reload/`is_const_materialization` machinery on the direct path is untouched).
- **Bounded fixpoint** (≤4 rounds) of the cleanup triple + a late `elide_dead_frame` once cleanup empties the frame.
- **Terminal-segment relaxed live-out pinning** in range-realloc: only R0/R1 are observable past `bx lr` at the pre-prologue position; the VCR-RA-003 validator runs with the same exemptions (`validate_segment_rewrite_exempting`); restricted to reload-free segments so R2/R3 stay free for the rechoice pass.
- **Const-divisor trap-guard elision** in the bridge's DivS/DivU/RemS/RemU: single-def `Const` scan with total-or-disabled def enumeration (a redefined vreg poisons; any unenumerable op disables the map); c=0 keeps every guard, DivS c=−1 keeps the overflow guard.

## Before/after cycle proxy (`scripts/repro/postex_cycle_proxy.py`, new)

Dynamic instructions + data-memory accesses under unicorn, summed over the differential vectors; **every run execution-matched wasmtime in both flag states**.

| fixture (default path) | off | on @ PR #659 | on now | ≤ +5% target |
|---|---|---|---|---|
| `spill_on_exhaust_242` | 368 | +30.4 % | 432 (**+17.4 %**) | missed |
| `spill_rung_581` | 204 | +32.4 % | 222 (**+8.8 %**) | missed |
| `high_pressure_i32` | 300 | +8.0 % | 228 (**−24.0 %**) | ✓ (beats the decline) |
| `signed_div_const` | 75 | +120 % | 50 (**−33.3 %**) | ✓ (beats the decline; fn 76 → 46 B) |
| `i64_pair_exhaust_587` | 584 | −5.5 % | 488 (**−16.4 %**) | ✓ |
| `i64_spill_pool_587` | 1656 | −1.4 % | 1608 (**−2.9 %**) | ✓ |

## The residual, named honestly

Two fixtures miss the bar. The residual is the **allocation itself**, not the cleanup: `alloc_i32_scratch` draws destinations from a fixed R4-R8 pool (5 regs) while the direct selector allocates over all nine of R0-R8 — the bridge evicts 5 values where Belady over 9 registers needs 1, and the post-hoc renamer recovers only what fits through the two forever-free caller-saved registers. A reload-pool widening was tried and **reverted** (measured strictly worse: rung +8.8 % → +14.7 % — it starves the renamer). Closing the last gap is dest allocation over the full pool, i.e. the Track-A VCR-RA/VCR-SEL allocator replacement — exactly the North-Star claim. The default-on flip stays **HELD** (#580) on that + gale G474RE cycles.

## Gates run

- `cargo test --workspace` green (574 synthesis unit tests incl. 10 new; all suites)
- frozen anchors **10/10 + `vcr_ver_001_gate_242` lock in BOTH flag states** (flag-off bit-identical by construction — every extension is behind the bridge-scoped `post_exhaust` bool)
- flag-on differentials PASS: `r12_spill_496` (both silicon victims, `flight_algo = 0x07FDF307`), `spill_on_exhaust_242` (8/8), `i64_pair_exhaust_587` (8/8), `i64_spill_pool_587`, `spill_rung_581`; `high_pressure_i32` + `signed_div_const` execution-verified inside the proxy harness
- `cargo fmt --check` + `clippy --workspace --all-targets -- -D warnings` clean

Refs #242, #580, #496; the verdict this implements is PR #659's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)