### PR TITLE
fix(codegen): i32 register shifts mask the amount mod 32 (#682) — direct selectors + DSL rules + Rocq models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,8 @@ jobs:
         run: SYNTH=./target/debug/synth python scripts/repro/unreachable_665_differential.py
       - name: Run rem_s trap-table oracle (#666, rv32)
         run: SYNTH=./target/debug/synth python scripts/repro/rem_s_666_differential.py
+      - name: Run i32 shift-mask oracle (#682)
+        run: SYNTH=./target/debug/synth python scripts/repro/i32_shift_mask_682_differential.py
 
   fact-spec-oracle:
     name: fact-spec elision oracle (#494 phases 2 + 2b)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -129,7 +129,7 @@
     "@@rules_renode~//renode:extensions.bzl%renode": {
       "general": {
         "bzlTransitiveDigest": "7Lnr806jnybahW/j3rYmzxDyIEILjiU3LTCqQKMBTAE=",
-        "usagesDigest": "VE13m5ohDpPqHMhUPkAXl92MiGmqWvXfKy59eIpTLD8=",
+        "usagesDigest": "k09BGJyWOyKalACFBPzTB3sNnounj9NxV9wXo1dYdS0=",
         "recordedFileInputs": {
           "@@rules_renode~//renode/renode.BUILD.bazel": "92dbf0d95a2e56bfda1a31891f4d0b5f262d30b6546afb1b60cc48fdc09effac"
         },

--- a/coq/Synth/Synth/Compilation.v
+++ b/coq/Synth/Synth/Compilation.v
@@ -111,16 +111,18 @@ Definition compile_wasm_to_arm (w : wasm_instr) : arm_program :=
 
   (* i32 shift operations — register-based, matching Rust instruction_selector.rs *)
   | I32Shl =>
-      (* Logical shift left: R0 = R0 << R1 (I32.shl masks mod 32 internally) *)
-      [LSL_reg R0 R0 R1]
+      (* Logical shift left: R0 = R0 << (R1 mod 32). #682: the mask is
+         MATERIALIZED (AND R12) — ARMv7-M register shifts consume Rm[7:0],
+         so relying on I32.shl's internal mod-32 was vacuous vs hardware. *)
+      [AND R12 R1 (Imm (I32.repr 31)); LSL_reg R0 R0 R12]
 
   | I32ShrU =>
-      (* Logical shift right (unsigned): R0 = R0 >> R1 *)
-      [LSR_reg R0 R0 R1]
+      (* #682: amount masked mod 32 via R12 (ARM Rm[7:0] vs WASM mod-32). *)
+      [AND R12 R1 (Imm (I32.repr 31)); LSR_reg R0 R0 R12]
 
   | I32ShrS =>
-      (* Arithmetic shift right (signed): R0 = R0 >> R1 *)
-      [ASR_reg R0 R0 R1]
+      (* #682: amount masked mod 32 via R12 (ARM Rm[7:0] vs WASM mod-32). *)
+      [AND R12 R1 (Imm (I32.repr 31)); ASR_reg R0 R0 R12]
 
   | I32Rotl =>
       (* Rotate left = rotate right by (32 - shift) *)

--- a/coq/Synth/Synth/CorrectnessI32.v
+++ b/coq/Synth/Synth/CorrectnessI32.v
@@ -14,7 +14,7 @@
     - Shifts: Admitted — ARM compilation uses fixed immediate, not register shift
 *)
 
-From Stdlib Require Import ZArith.
+From Stdlib Require Import ZArith Lia Znumtheory.
 Require Import Synth.Common.Base.
 Require Import Synth.Common.Integers.
 Require Import Synth.ARM.ArmState.
@@ -182,7 +182,25 @@ Theorem i32_xor_correct : forall wstate astate v1 v2 stack',
     get_reg astate' R0 = I32.xor v1 v2.
 Proof. synth_binop_proof. Qed.
 
-(** Shift operations — register-based, matching Rust instruction selector *)
+(** Shift operations — register-based, matching the Rust instruction
+    selector. #682: the amount is masked mod 32 through R12 (ARMv7-M
+    register shifts consume Rm[7:0]; WASM requires mod 32 — the old bare
+    single-instruction lowering was wrong on hardware and its proof
+    vacuous, since I32.shl masks internally). Z-level mask lemmas below
+    duplicate VcrSelRules.v pending consolidation into Common/Integers. *)
+
+Lemma land31_mod32' : forall a : Z, (Z.land a 31) mod 32 = a mod 32.
+Proof.
+  intros a. change 31 with (Z.ones 5).
+  rewrite Z.land_ones by lia.
+  change (2 ^ 5) with 32. apply Z.mod_mod. lia.
+Qed.
+
+Lemma mod_modulus_mod32' : forall a : Z, (a mod 4294967296) mod 32 = a mod 32.
+Proof.
+  intros a.
+  symmetry. apply Zmod_div_mod; [lia | lia | exists 134217728; reflexivity].
+Qed.
 
 Theorem i32_shl_correct : forall wstate astate v1 v2 stack',
   wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
@@ -195,8 +213,20 @@ Theorem i32_shl_correct : forall wstate astate v1 v2 stack',
     exec_program (compile_wasm_to_arm I32Shl) astate = Some astate' /\
     get_reg astate' R0 = I32.shl v1 v2.
 Proof.
-  (* Compiles to [LSL_reg R0 R0 R1] *)
-  synth_binop_proof.
+  intros wstate astate v1 v2 stack' Hstack HR0 HR1 Hwasm.
+  unfold compile_wasm_to_arm.
+  set (s1 := set_reg astate R12 (I32.and (get_reg astate R1) (I32.repr 31))).
+  set (s2 := set_reg s1 R0 (I32.shl (get_reg s1 R0) (get_reg s1 R12))).
+  exists s2. split.
+  - subst s2 s1. simpl. reflexivity.
+  - subst s2. rewrite get_set_reg_eq.
+    subst s1. rewrite get_set_reg_neq by discriminate.
+    rewrite get_set_reg_eq.
+    rewrite HR0, HR1.
+    unfold I32.shl, I32.and, I32.repr, I32.unsigned, I32.modulus.
+    change (31 mod 4294967296) with 31.
+    rewrite !mod_modulus_mod32', land31_mod32'.
+    reflexivity.
 Qed.
 
 Theorem i32_shru_correct : forall wstate astate v1 v2 stack',
@@ -210,7 +240,20 @@ Theorem i32_shru_correct : forall wstate astate v1 v2 stack',
     exec_program (compile_wasm_to_arm I32ShrU) astate = Some astate' /\
     get_reg astate' R0 = I32.shru v1 v2.
 Proof.
-  synth_binop_proof.
+  intros wstate astate v1 v2 stack' Hstack HR0 HR1 Hwasm.
+  unfold compile_wasm_to_arm.
+  set (s1 := set_reg astate R12 (I32.and (get_reg astate R1) (I32.repr 31))).
+  set (s2 := set_reg s1 R0 (I32.shru (get_reg s1 R0) (get_reg s1 R12))).
+  exists s2. split.
+  - subst s2 s1. simpl. reflexivity.
+  - subst s2. rewrite get_set_reg_eq.
+    subst s1. rewrite get_set_reg_neq by discriminate.
+    rewrite get_set_reg_eq.
+    rewrite HR0, HR1.
+    unfold I32.shru, I32.and, I32.repr, I32.unsigned, I32.modulus.
+    change (31 mod 4294967296) with 31.
+    rewrite !mod_modulus_mod32', land31_mod32'.
+    reflexivity.
 Qed.
 
 Theorem i32_shrs_correct : forall wstate astate v1 v2 stack',
@@ -224,7 +267,20 @@ Theorem i32_shrs_correct : forall wstate astate v1 v2 stack',
     exec_program (compile_wasm_to_arm I32ShrS) astate = Some astate' /\
     get_reg astate' R0 = I32.shrs v1 v2.
 Proof.
-  synth_binop_proof.
+  intros wstate astate v1 v2 stack' Hstack HR0 HR1 Hwasm.
+  unfold compile_wasm_to_arm.
+  set (s1 := set_reg astate R12 (I32.and (get_reg astate R1) (I32.repr 31))).
+  set (s2 := set_reg s1 R0 (I32.shrs (get_reg s1 R0) (get_reg s1 R12))).
+  exists s2. split.
+  - subst s2 s1. simpl. reflexivity.
+  - subst s2. rewrite get_set_reg_eq.
+    subst s1. rewrite get_set_reg_neq by discriminate.
+    rewrite get_set_reg_eq.
+    rewrite HR0, HR1.
+    unfold I32.shrs, I32.and, I32.repr, I32.unsigned, I32.modulus.
+    change (31 mod 4294967296) with 31.
+    rewrite !mod_modulus_mod32', land31_mod32'.
+    reflexivity.
 Qed.
 
 Theorem i32_rotl_correct : forall wstate astate v1 v2 stack',

--- a/coq/Synth/Synth/VcrSelRules.v
+++ b/coq/Synth/Synth/VcrSelRules.v
@@ -71,6 +71,7 @@
     operands) and the ARM execution result, both halves pinned. *)
 
 From Stdlib Require Import List.
+From Stdlib Require Import Lia ZArith Znumtheory.
 From Stdlib Require Import ZArith.
 Require Import Synth.Common.Base.
 Require Import Synth.Common.Integers.
@@ -107,14 +108,43 @@ Definition rule_i32_xor (rd rn rm : arm_reg) : arm_program := [EOR rd rn (Reg rm
 Definition rule_i32_rotl (rd rn rm rs : arm_reg) : arm_program :=
   [RSB rs rm (Imm (I32.repr 32)); ROR_reg rd rn rs].
 
-(** ** Increment 2: i32 register shifts + rotr — tier A (single instruction,
-    no scratch; the shift amount is masked mod 32 by the I32 semantics of
-    LSL_reg/LSR_reg/ASR_reg/ROR_reg, matching WASM). *)
+(** ** Increment 2: i32 register shifts + rotr.
 
-Definition rule_i32_shl   (rd rn rm : arm_reg) : arm_program := [LSL_reg rd rn rm].
-Definition rule_i32_shr_s (rd rn rm : arm_reg) : arm_program := [ASR_reg rd rn rm].
-Definition rule_i32_shr_u (rd rn rm : arm_reg) : arm_program := [LSR_reg rd rn rm].
+    #682 SOUNDNESS FIX: the single-instruction shift rules were WRONG on
+    hardware — ARMv7-M register shifts consume Rm[7:0] and yield 0 (LSL/LSR)
+    or the sign (ASR) for amounts >= 32, while WASM requires amount mod 32.
+    The model's LSL_reg/LSR_reg/ASR_reg use I32.shl/shru/shrs, which mask
+    mod 32 INTERNALLY (WASM-like) — so the old Qeds were vacuous against
+    real hardware (the exact divergence SailArmBridge.v documents as gaps
+    6-7). The rules now materialize the mask explicitly:
+    [AND rs rm #31; shift rd rn rs] — correct under BOTH the current model
+    semantics and real Rm[7:0] hardware. The scratch [rs] carries the
+    [rs <> rn] non-aliasing side condition (rotl pattern); the Rust side
+    passes R12 (never allocatable, #212), so the condition always holds.
+    ROR is exempt: rotation is cyclic, so Rm[7:0] mod 32 = WASM semantics. *)
+
+Definition rule_i32_shl   (rd rn rm rs : arm_reg) : arm_program :=
+  [AND rs rm (Imm (I32.repr 31)); LSL_reg rd rn rs].
+Definition rule_i32_shr_s (rd rn rm rs : arm_reg) : arm_program :=
+  [AND rs rm (Imm (I32.repr 31)); ASR_reg rd rn rs].
+Definition rule_i32_shr_u (rd rn rm rs : arm_reg) : arm_program :=
+  [AND rs rm (Imm (I32.repr 31)); LSR_reg rd rn rs].
 Definition rule_i32_rotr  (rd rn rm : arm_reg) : arm_program := [ROR_reg rd rn rm].
+
+(** The mask identity: ANDing the amount with 31 does not change the
+    mod-32 shift the I32 semantics performs. Z-level plumbing first. *)
+Lemma land31_mod32 : forall a : Z, (Z.land a 31) mod 32 = a mod 32.
+Proof.
+  intros a. change 31 with (Z.ones 5).
+  rewrite Z.land_ones by lia.
+  change (2 ^ 5) with 32. apply Z.mod_mod. lia.
+Qed.
+
+Lemma mod_modulus_mod32 : forall a : Z, (a mod 4294967296) mod 32 = a mod 32.
+Proof.
+  intros a.
+  symmetry. apply Zmod_div_mod; [lia | lia | exists 134217728; reflexivity].
+Qed.
 
 (** ** Increment 2: i32 comparisons — the Rust rule emits
     [Cmp {rn, Reg(rm)}; SetCond {rd, cond}]; per the established
@@ -269,7 +299,8 @@ Qed.
     rules are single-instruction no-scratch shapes; their fixed-register
     ancestors in CorrectnessI32.v already close with [synth_binop_proof]). *)
 
-Theorem rule_i32_shl_correct : forall wstate astate v1 v2 stack' rd rn rm,
+Theorem rule_i32_shl_correct : forall wstate astate v1 v2 stack' rd rn rm rs,
+  rs <> rn ->        (* mask scratch must not alias the value register *)
   wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
   get_reg astate rn = v1 ->
   get_reg astate rm = v2 ->
@@ -277,11 +308,27 @@ Theorem rule_i32_shl_correct : forall wstate astate v1 v2 stack' rd rn rm,
     Some (mkWasmState (VI32 (I32.shl v1 v2) :: stack')
             wstate.(locals) wstate.(globals) wstate.(memory)) ->
   exists astate',
-    exec_program (rule_i32_shl rd rn rm) astate = Some astate' /\
+    exec_program (rule_i32_shl rd rn rm rs) astate = Some astate' /\
     get_reg astate' rd = I32.shl v1 v2.
-Proof. synth_binop_proof_poly. Qed.
+Proof.
+  intros wstate astate v1 v2 stack' rd rn rm rs Hne Hstack HR0 HR1 Hwasm.
+  unfold rule_i32_shl.
+  set (s1 := set_reg astate rs (I32.and (get_reg astate rm) (I32.repr 31))).
+  set (s2 := set_reg s1 rd (I32.shl (get_reg s1 rn) (get_reg s1 rs))).
+  exists s2. split.
+  - subst s2 s1. simpl. reflexivity.
+  - subst s2. rewrite get_set_reg_eq.
+    subst s1. rewrite get_set_reg_neq by exact Hne.
+    rewrite get_set_reg_eq.
+    rewrite HR0, HR1.
+    unfold I32.shl, I32.and, I32.repr, I32.unsigned, I32.modulus.
+    change (31 mod 4294967296) with 31.
+    rewrite !mod_modulus_mod32, land31_mod32.
+    reflexivity.
+Qed.
 
-Theorem rule_i32_shr_s_correct : forall wstate astate v1 v2 stack' rd rn rm,
+Theorem rule_i32_shr_s_correct : forall wstate astate v1 v2 stack' rd rn rm rs,
+  rs <> rn ->        (* mask scratch must not alias the value register *)
   wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
   get_reg astate rn = v1 ->
   get_reg astate rm = v2 ->
@@ -289,11 +336,27 @@ Theorem rule_i32_shr_s_correct : forall wstate astate v1 v2 stack' rd rn rm,
     Some (mkWasmState (VI32 (I32.shrs v1 v2) :: stack')
             wstate.(locals) wstate.(globals) wstate.(memory)) ->
   exists astate',
-    exec_program (rule_i32_shr_s rd rn rm) astate = Some astate' /\
+    exec_program (rule_i32_shr_s rd rn rm rs) astate = Some astate' /\
     get_reg astate' rd = I32.shrs v1 v2.
-Proof. synth_binop_proof_poly. Qed.
+Proof.
+  intros wstate astate v1 v2 stack' rd rn rm rs Hne Hstack HR0 HR1 Hwasm.
+  unfold rule_i32_shr_s.
+  set (s1 := set_reg astate rs (I32.and (get_reg astate rm) (I32.repr 31))).
+  set (s2 := set_reg s1 rd (I32.shrs (get_reg s1 rn) (get_reg s1 rs))).
+  exists s2. split.
+  - subst s2 s1. simpl. reflexivity.
+  - subst s2. rewrite get_set_reg_eq.
+    subst s1. rewrite get_set_reg_neq by exact Hne.
+    rewrite get_set_reg_eq.
+    rewrite HR0, HR1.
+    unfold I32.shrs, I32.and, I32.repr, I32.unsigned, I32.modulus.
+    change (31 mod 4294967296) with 31.
+    rewrite !mod_modulus_mod32, land31_mod32.
+    reflexivity.
+Qed.
 
-Theorem rule_i32_shr_u_correct : forall wstate astate v1 v2 stack' rd rn rm,
+Theorem rule_i32_shr_u_correct : forall wstate astate v1 v2 stack' rd rn rm rs,
+  rs <> rn ->        (* mask scratch must not alias the value register *)
   wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
   get_reg astate rn = v1 ->
   get_reg astate rm = v2 ->
@@ -301,9 +364,24 @@ Theorem rule_i32_shr_u_correct : forall wstate astate v1 v2 stack' rd rn rm,
     Some (mkWasmState (VI32 (I32.shru v1 v2) :: stack')
             wstate.(locals) wstate.(globals) wstate.(memory)) ->
   exists astate',
-    exec_program (rule_i32_shr_u rd rn rm) astate = Some astate' /\
+    exec_program (rule_i32_shr_u rd rn rm rs) astate = Some astate' /\
     get_reg astate' rd = I32.shru v1 v2.
-Proof. synth_binop_proof_poly. Qed.
+Proof.
+  intros wstate astate v1 v2 stack' rd rn rm rs Hne Hstack HR0 HR1 Hwasm.
+  unfold rule_i32_shr_u.
+  set (s1 := set_reg astate rs (I32.and (get_reg astate rm) (I32.repr 31))).
+  set (s2 := set_reg s1 rd (I32.shru (get_reg s1 rn) (get_reg s1 rs))).
+  exists s2. split.
+  - subst s2 s1. simpl. reflexivity.
+  - subst s2. rewrite get_set_reg_eq.
+    subst s1. rewrite get_set_reg_neq by exact Hne.
+    rewrite get_set_reg_eq.
+    rewrite HR0, HR1.
+    unfold I32.shru, I32.and, I32.repr, I32.unsigned, I32.modulus.
+    change (31 mod 4294967296) with 31.
+    rewrite !mod_modulus_mod32, land31_mod32.
+    reflexivity.
+Qed.
 
 Theorem rule_i32_rotr_correct : forall wstate astate v1 v2 stack' rd rn rm,
   wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->

--- a/crates/synth-cli/tests/frozen_codegen_bytes.rs
+++ b/crates/synth-cli/tests/frozen_codegen_bytes.rs
@@ -123,6 +123,14 @@ fn text_sha256(wasm: &str, backend: &str, target: &str) -> (String, usize) {
 fn assert_frozen(cases: &[(&str, &str, usize)], backend: &str, target: &str) {
     for &(wasm, golden, golden_len) in cases {
         let (got, len) = text_sha256(wasm, backend, target);
+        // Refreeze ritual aid: with SYNTH_REFREEZE_PRINT=1 the gate prints the
+        // NEW golden tuples instead of asserting — paste them over the old
+        // pins ONLY after every scripts/repro/*_differential.py passes on the
+        // new bytes (they move together; see the assert message below).
+        if std::env::var("SYNTH_REFREEZE_PRINT").is_ok() {
+            println!("REPIN ({backend}/{target}): (\"{wasm}\", \"{got}\", {len}),");
+            continue;
+        }
         assert_eq!(
             len, golden_len,
             "{wasm} ({backend}): .text length changed ({len} vs locked {golden_len}) \
@@ -206,18 +214,18 @@ fn frozen_fixtures_text_is_bit_identical_oracle_001() {
     let cases = [
         (
             "control_step.wasm",
-            "d0907e0206e8abd5724dec30eb261f2b9d689c6ec1a3d3b66853691fb532de82",
-            294usize,
+            "f962794f128223b5212fc5cc25bb8393bcae758e89b93c07eb23deb4fffe5c0d",
+            314usize,
         ),
         (
             "flight_seam.wasm",
-            "92fd68638e4074024f54c7744775f44aa88d2f5b36abbd0963d27d62b95e1e97",
-            706,
+            "28642d60533c3fc154dfc7ab27e6a9f4ffe5b0a81adfe4c0fba493d490fc8d2c",
+            870,
         ),
         (
             "flight_seam_flat.wasm",
-            "660c3fbc3a58820b13949412e11f79d47eccfb4de7cfa737a781abe01e4e1b96",
-            846,
+            "643882379d3c25cd1acc34129f5456d54b6864b127184c1f81823daeb267401c",
+            1014,
         ),
         (
             "signed_div_const.wasm",
@@ -247,13 +255,13 @@ fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
     let old = [
         (
             "flight_seam.wasm",
-            "9e73eea3867ba085820329951e84a7d650c38a7fc78d9d03a6a83d02963f9670",
-            774usize,
+            "a11ed21e5fe53cdd3bc45382e7ad4288a53abf7fbdffa42c299cf1d2bc24f1da",
+            938usize,
         ),
         (
             "flight_seam_flat.wasm",
-            "887ea546429a4569112147fdc94b0ba90f02a6ccd2b511aa2ca48dab017dbc2c",
-            910,
+            "973a630e6ed687ec02dc73ce9f79cb8261455fceaca1f373c51279d23943ef8a",
+            1078,
         ),
     ];
     for &(wasm, golden, golden_len) in &old {
@@ -290,6 +298,14 @@ fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
             .expect(".text")
             .data()
             .expect("read .text");
+        if std::env::var("SYNTH_REFREEZE_PRINT").is_ok() {
+            let hex: String = Sha256::digest(data)
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
+            println!("REPIN: (\"{wasm}\", \"{hex}\", {}),", data.len());
+            continue;
+        }
         assert_eq!(
             data.len(),
             golden_len,
@@ -325,13 +341,13 @@ fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
     let old = [
         (
             "flight_seam.wasm",
-            "dce728b48e14aa9187774799c0b268c6ad60be6dc0fa3e7cc9458c17dc65403b",
-            738usize,
+            "b590aea84d62b5dd58702a1a4dd5628683615b0482f1610bdf700509f8c8e360",
+            902usize,
         ),
         (
             "flight_seam_flat.wasm",
-            "0665e623f33457479940046d57a4b7ec02416a61bcc6ec71ea3556ed5b3cb568",
-            878,
+            "49ebf8a1b48d96f66ad4d91f401cd78ce8bcbacc9340941039301a18aba2ec83",
+            1046,
         ),
     ];
     for &(wasm, golden, golden_len) in &old {
@@ -368,6 +384,14 @@ fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
             .expect(".text")
             .data()
             .expect("read .text");
+        if std::env::var("SYNTH_REFREEZE_PRINT").is_ok() {
+            let hex: String = Sha256::digest(data)
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
+            println!("REPIN: (\"{wasm}\", \"{hex}\", {}),", data.len());
+            continue;
+        }
         assert_eq!(
             data.len(),
             golden_len,
@@ -402,13 +426,13 @@ fn frozen_fixtures_const_cse_escape_hatch_restores_old_bytes() {
     let old = [
         (
             "control_step.wasm",
-            "1a97711cfb4754794a8577814388f08b81eff444edcba3de7d3e3d18ff435183",
-            304usize,
+            "93ef2610ce177e30e28767182ceecfa455d4e69968429145c967f16d7b2e22f1",
+            324usize,
         ),
         (
             "flight_seam.wasm",
-            "6872d6f3f00331e9a52e176428fca375a87b9fbe0cf2b3eb0fb657c304a7372d",
-            730,
+            "d8af257f82594e0a41d75c2fba2aaee62041fff54863342f4a9c3aebe39e10f3",
+            894,
         ),
     ];
     for &(wasm, golden, golden_len) in &old {
@@ -445,6 +469,14 @@ fn frozen_fixtures_const_cse_escape_hatch_restores_old_bytes() {
             .expect(".text")
             .data()
             .expect("read .text");
+        if std::env::var("SYNTH_REFREEZE_PRINT").is_ok() {
+            let hex: String = Sha256::digest(data)
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
+            println!("REPIN: (\"{wasm}\", \"{hex}\", {}),", data.len());
+            continue;
+        }
         assert_eq!(
             data.len(),
             golden_len,
@@ -478,13 +510,13 @@ fn frozen_fixtures_dead_frame_elim_escape_hatch_restores_old_bytes() {
     let old = [
         (
             "flight_seam.wasm",
-            "1e1d2b75fe6c4975359c8b1163a6e082a548a0ce1e23d7a360495785bf5e54c2",
-            726usize,
+            "18163e0b37f5932f0e97fe573d9626f53ca1962b823c24e8f5057a34cf8c4318",
+            890usize,
         ),
         (
             "flight_seam_flat.wasm",
-            "d11849db9bef82b77280ee06fdc6f076a7df278b2e5a3213284e569cbf1eccc9",
-            866,
+            "d62bdfa3faed21aef1ad943d824817f3adb04f0f400c1dd498690a437dd2bf43",
+            1034,
         ),
     ];
     for &(wasm, golden, golden_len) in &old {
@@ -521,6 +553,14 @@ fn frozen_fixtures_dead_frame_elim_escape_hatch_restores_old_bytes() {
             .expect(".text")
             .data()
             .expect("read .text");
+        if std::env::var("SYNTH_REFREEZE_PRINT").is_ok() {
+            let hex: String = Sha256::digest(data)
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
+            println!("REPIN: (\"{wasm}\", \"{hex}\", {}),", data.len());
+            continue;
+        }
         assert_eq!(
             data.len(),
             golden_len,
@@ -550,8 +590,8 @@ fn frozen_fixtures_uxth_fold_escape_hatch_restores_old_bytes() {
     // default.
     let old = [(
         "control_step.wasm",
-        "158b036bc678261a6f6ee71450d0af7b23d92415d16d21679347e2a436c25bb2",
-        300usize,
+        "fdcfbac168dcd71ae4a981103f618bb661ffb74c9fd2248c876e5c9b007a65fe",
+        320usize,
     )];
     for &(wasm, golden, golden_len) in &old {
         let elf = format!("/tmp/frozen_nouxth_{wasm}.elf");
@@ -587,6 +627,14 @@ fn frozen_fixtures_uxth_fold_escape_hatch_restores_old_bytes() {
             .expect(".text")
             .data()
             .expect("read .text");
+        if std::env::var("SYNTH_REFREEZE_PRINT").is_ok() {
+            let hex: String = Sha256::digest(data)
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
+            println!("REPIN: (\"{wasm}\", \"{hex}\", {}),", data.len());
+            continue;
+        }
         assert_eq!(
             data.len(),
             golden_len,
@@ -720,6 +768,14 @@ fn frozen_fixtures_rv32_shift_fold_escape_hatch_restores_old_bytes() {
             .expect(".text")
             .data()
             .expect("read .text");
+        if std::env::var("SYNTH_REFREEZE_PRINT").is_ok() {
+            let hex: String = Sha256::digest(data)
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
+            println!("REPIN: (\"{wasm}\", \"{hex}\", {}),", data.len());
+            continue;
+        }
         assert_eq!(
             data.len(),
             golden_len,
@@ -792,6 +848,14 @@ fn frozen_fixtures_rv32_cmp_select_escape_hatch_restores_old_bytes() {
             .expect(".text")
             .data()
             .expect("read .text");
+        if std::env::var("SYNTH_REFREEZE_PRINT").is_ok() {
+            let hex: String = Sha256::digest(data)
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
+            println!("REPIN: (\"{wasm}\", \"{hex}\", {}),", data.len());
+            continue;
+        }
         assert_eq!(
             data.len(),
             golden_len,
@@ -860,6 +924,14 @@ fn frozen_fixtures_rv32_local_promo_escape_hatch_is_noop() {
             .expect(".text")
             .data()
             .expect("read .text");
+        if std::env::var("SYNTH_REFREEZE_PRINT").is_ok() {
+            let hex: String = Sha256::digest(data)
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
+            println!("REPIN: (\"{wasm}\", \"{hex}\", {}),", data.len());
+            continue;
+        }
         assert_eq!(
             data.len(),
             golden_len,

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -2589,28 +2589,66 @@ impl InstructionSelector {
             }
 
             // Shifts: WASM pops both value (rn) and shift amount (rm) from stack.
-            // VCR-SEL-001 increment 2 (#242): delegated to the Rocq-proved rules
-            // behind SYNTH_SEL_DSL, byte-identical by construction (single
-            // identical instruction).
+            // #682: ARMv7-M register shifts use Rm[7:0] (>= 32 yields 0/sign)
+            // while WASM requires amount mod 32 — mask into R12 first (encoder
+            // scratch, never allocatable per #212, so no liveness hazard; the
+            // same pattern the optimized path always used). Flag-on delegates
+            // to the Rocq-proved masked rules, byte-identical by construction.
             I32Shl => {
                 if self.sel_dsl {
-                    crate::sel_dsl::generated::rule_i32_shl(rd, rn, rm)
+                    crate::sel_dsl::generated::rule_i32_shl(rd, rn, rm, Reg::R12)
+                        .map_err(synth_core::Error::synthesis)?
                 } else {
-                    vec![ArmOp::LslReg { rd, rn, rm }]
+                    vec![
+                        ArmOp::And {
+                            rd: Reg::R12,
+                            rn: rm,
+                            op2: Operand2::Imm(31),
+                        },
+                        ArmOp::LslReg {
+                            rd,
+                            rn,
+                            rm: Reg::R12,
+                        },
+                    ]
                 }
             }
             I32ShrS => {
                 if self.sel_dsl {
-                    crate::sel_dsl::generated::rule_i32_shr_s(rd, rn, rm)
+                    crate::sel_dsl::generated::rule_i32_shr_s(rd, rn, rm, Reg::R12)
+                        .map_err(synth_core::Error::synthesis)?
                 } else {
-                    vec![ArmOp::AsrReg { rd, rn, rm }]
+                    vec![
+                        ArmOp::And {
+                            rd: Reg::R12,
+                            rn: rm,
+                            op2: Operand2::Imm(31),
+                        },
+                        ArmOp::AsrReg {
+                            rd,
+                            rn,
+                            rm: Reg::R12,
+                        },
+                    ]
                 }
             }
             I32ShrU => {
                 if self.sel_dsl {
-                    crate::sel_dsl::generated::rule_i32_shr_u(rd, rn, rm)
+                    crate::sel_dsl::generated::rule_i32_shr_u(rd, rn, rm, Reg::R12)
+                        .map_err(synth_core::Error::synthesis)?
                 } else {
-                    vec![ArmOp::LsrReg { rd, rn, rm }]
+                    vec![
+                        ArmOp::And {
+                            rd: Reg::R12,
+                            rn: rm,
+                            op2: Operand2::Imm(31),
+                        },
+                        ArmOp::LsrReg {
+                            rd,
+                            rn,
+                            rm: Reg::R12,
+                        },
+                    ]
                 }
             }
 
@@ -10971,21 +11009,31 @@ impl InstructionSelector {
                             idx,
                         )?
                     };
+                    // #682: LSL/LSR/ASR mask the amount mod 32 through R12
+                    // (ARM uses Rm[7:0]; WASM requires mod 32). ROR is cyclic,
+                    // so Rm[7:0] already agrees with WASM — no mask. The mask
+                    // is emitted in the hand-written branch below; the DSL
+                    // branch's generated rules carry their own.
+                    let masked_amt = if matches!(op, I32Rotr) {
+                        shift_amt
+                    } else {
+                        Reg::R12
+                    };
                     let shift_op = match op {
                         I32Shl => ArmOp::LslReg {
                             rd: dst,
                             rn: value,
-                            rm: shift_amt,
+                            rm: masked_amt,
                         },
                         I32ShrU => ArmOp::LsrReg {
                             rd: dst,
                             rn: value,
-                            rm: shift_amt,
+                            rm: masked_amt,
                         },
                         I32ShrS => ArmOp::AsrReg {
                             rd: dst,
                             rn: value,
-                            rm: shift_amt,
+                            rm: masked_amt,
                         },
                         I32Rotr => ArmOp::RorReg {
                             rd: dst,
@@ -10999,7 +11047,9 @@ impl InstructionSelector {
                     // Rocq-proved rule — the identical ArmOp, byte-identical
                     // by construction (mirror-pinned per op).
                     let dsl_ops = if self.sel_dsl {
-                        crate::sel_dsl::i32_shift_rule(op, dst, value, shift_amt)
+                        crate::sel_dsl::i32_shift_rule(op, dst, value, shift_amt, Reg::R12)
+                            .map(|r| r.map_err(synth_core::Error::synthesis))
+                            .transpose()?
                     } else {
                         None
                     };
@@ -11012,6 +11062,17 @@ impl InstructionSelector {
                             cf.add_instruction();
                         }
                     } else {
+                        if !matches!(op, I32Rotr) {
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::And {
+                                    rd: Reg::R12,
+                                    rn: shift_amt,
+                                    op2: Operand2::Imm(31),
+                                },
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                        }
                         instructions.push(ArmInstruction {
                             op: shift_op,
                             source_line: Some(idx),
@@ -12581,10 +12642,27 @@ mod tests {
                     | ArmOp::RorReg { rd, rn, rm } => (*rd, *rn, *rm),
                     _ => unreachable!(),
                 };
+                // #682: LSL/LSR/ASR windows are two instructions (And #31 into
+                // R12, then the shift by R12); the rule is invoked with the
+                // ORIGINAL amount register (the And's rn). ROR stays unmasked.
+                let is_masked = !matches!(&baseline[i], ArmOp::RorReg { .. });
+                let (window, orig_rm) = if is_masked {
+                    let orig = match &baseline[i - 1] {
+                        ArmOp::And { rn, .. } => *rn,
+                        other => panic!(
+                            "{}: expected the #682 mask before the shift, found {:?}",
+                            rule.name, other
+                        ),
+                    };
+                    (baseline[i - 1..=i].to_vec(), orig)
+                } else {
+                    (baseline[i..i + 1].to_vec(), rm)
+                };
                 (
-                    baseline[i..i + 1].to_vec(),
-                    crate::sel_dsl::i32_shift_rule(&rule.op, rd, rn, rm)
-                        .unwrap_or_else(|| panic!("{}: shift dispatch missing", rule.name)),
+                    window,
+                    crate::sel_dsl::i32_shift_rule(&rule.op, rd, rn, orig_rm, Reg::R12)
+                        .unwrap_or_else(|| panic!("{}: shift dispatch missing", rule.name))
+                        .unwrap_or_else(|e| panic!("{}: side condition: {e}", rule.name)),
                 )
             };
             assert_eq!(
@@ -12974,21 +13052,33 @@ mod tests {
 
         let arm_instrs = selector.select(&wasm_ops).unwrap();
 
-        assert_eq!(arm_instrs.len(), 3);
+        // #682: each register shift is a two-instruction sequence — the
+        // amount mask (AND R12, rm, #31; WASM mod-32 vs ARM Rm[7:0]) then
+        // the shift consuming R12.
+        assert_eq!(arm_instrs.len(), 6);
 
-        match &arm_instrs[0].op {
-            ArmOp::LslReg { .. } => {}
-            _ => panic!("Expected LslReg, got {:?}", arm_instrs[0].op),
-        }
-
+        let expect_mask = |i: usize| match &arm_instrs[i].op {
+            ArmOp::And {
+                rd: Reg::R12,
+                op2: Operand2::Imm(31),
+                ..
+            } => {}
+            other => panic!("Expected #682 mask AND R12,#31 at {i}, got {other:?}"),
+        };
+        expect_mask(0);
         match &arm_instrs[1].op {
-            ArmOp::AsrReg { .. } => {}
-            _ => panic!("Expected AsrReg, got {:?}", arm_instrs[1].op),
+            ArmOp::LslReg { rm: Reg::R12, .. } => {}
+            _ => panic!("Expected LslReg by R12, got {:?}", arm_instrs[1].op),
         }
-
-        match &arm_instrs[2].op {
-            ArmOp::LsrReg { .. } => {}
-            _ => panic!("Expected LsrReg, got {:?}", arm_instrs[2].op),
+        expect_mask(2);
+        match &arm_instrs[3].op {
+            ArmOp::AsrReg { rm: Reg::R12, .. } => {}
+            _ => panic!("Expected AsrReg by R12, got {:?}", arm_instrs[3].op),
+        }
+        expect_mask(4);
+        match &arm_instrs[5].op {
+            ArmOp::LsrReg { rm: Reg::R12, .. } => {}
+            _ => panic!("Expected LsrReg by R12, got {:?}", arm_instrs[5].op),
         }
     }
 
@@ -13055,8 +13145,24 @@ mod tests {
                 _ => None,
             }
         }
-        // No operand-producing instruction targets R12 (it is encoder scratch only).
+        // No operand-producing instruction targets R12 (it is encoder scratch
+        // only) — EXCEPT the #682 shift-amount mask `AND R12, rm, #31`, the
+        // sanctioned define-and-immediately-consume scratch pattern (the next
+        // instruction's register shift reads R12 and nothing else ever does).
+        fn is_682_mask(op: &ArmOp) -> bool {
+            matches!(
+                op,
+                ArmOp::And {
+                    rd: Reg::R12,
+                    op2: Operand2::Imm(31),
+                    ..
+                }
+            )
+        }
         for ins in &instrs {
+            if is_682_mask(&ins.op) {
+                continue;
+            }
             assert_ne!(
                 dest(&ins.op),
                 Some(Reg::R12),

--- a/crates/synth-synthesis/src/sel_dsl/generated.rs
+++ b/crates/synth-synthesis/src/sel_dsl/generated.rs
@@ -99,25 +99,64 @@ pub fn rule_i32_rotl(rd: Reg, rn: Reg, rm: Reg, rs: Reg) -> Result<Vec<ArmOp>, &
     ])
 }
 
-/// `i32.shl`: rd = rn << rm
+/// `i32.shl`: rd = rn << (rm mod 32) — #682 mask via scratch rs
 ///
 /// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_shl_correct` (Qed).
-pub fn rule_i32_shl(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
-    vec![ArmOp::LslReg { rd, rn, rm }]
+///
+/// Side condition: `rs` must not alias `rn` (hypothesis of the theorem;
+/// violation is a loud `Err`, never a silent misassemble).
+pub fn rule_i32_shl(rd: Reg, rn: Reg, rm: Reg, rs: Reg) -> Result<Vec<ArmOp>, &'static str> {
+    if rs == rn {
+        return Err("rule_i32_shl: side condition violated: rs must not alias rn");
+    }
+    Ok(vec![
+        ArmOp::And {
+            rd: rs,
+            rn: rm,
+            op2: Operand2::Imm(31),
+        },
+        ArmOp::LslReg { rd, rn, rm: rs },
+    ])
 }
 
-/// `i32.shr_s`: rd = rn >> rm (arithmetic)
+/// `i32.shr_s`: rd = rn >> (rm mod 32) (arithmetic) — #682 mask via scratch rs
 ///
 /// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_shr_s_correct` (Qed).
-pub fn rule_i32_shr_s(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
-    vec![ArmOp::AsrReg { rd, rn, rm }]
+///
+/// Side condition: `rs` must not alias `rn` (hypothesis of the theorem;
+/// violation is a loud `Err`, never a silent misassemble).
+pub fn rule_i32_shr_s(rd: Reg, rn: Reg, rm: Reg, rs: Reg) -> Result<Vec<ArmOp>, &'static str> {
+    if rs == rn {
+        return Err("rule_i32_shr_s: side condition violated: rs must not alias rn");
+    }
+    Ok(vec![
+        ArmOp::And {
+            rd: rs,
+            rn: rm,
+            op2: Operand2::Imm(31),
+        },
+        ArmOp::AsrReg { rd, rn, rm: rs },
+    ])
 }
 
-/// `i32.shr_u`: rd = rn >> rm (logical)
+/// `i32.shr_u`: rd = rn >> (rm mod 32) (logical) — #682 mask via scratch rs
 ///
 /// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_shr_u_correct` (Qed).
-pub fn rule_i32_shr_u(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
-    vec![ArmOp::LsrReg { rd, rn, rm }]
+///
+/// Side condition: `rs` must not alias `rn` (hypothesis of the theorem;
+/// violation is a loud `Err`, never a silent misassemble).
+pub fn rule_i32_shr_u(rd: Reg, rn: Reg, rm: Reg, rs: Reg) -> Result<Vec<ArmOp>, &'static str> {
+    if rs == rn {
+        return Err("rule_i32_shr_u: side condition violated: rs must not alias rn");
+    }
+    Ok(vec![
+        ArmOp::And {
+            rd: rs,
+            rn: rm,
+            op2: Operand2::Imm(31),
+        },
+        ArmOp::LsrReg { rd, rn, rm: rs },
+    ])
 }
 
 /// `i32.rotr`: rd = rn rotated right by rm

--- a/crates/synth-synthesis/src/sel_dsl/mod.rs
+++ b/crates/synth-synthesis/src/sel_dsl/mod.rs
@@ -208,6 +208,8 @@ pub enum TemplateOp {
     EorReg { rd: RegVar, rn: RegVar, rm: RegVar },
     /// `ArmOp::Rsb { rd, rn, imm }` — `rd = imm - rn`
     RsbImm { rd: RegVar, rn: RegVar, imm: u32 },
+    /// `ArmOp::And { rd, rn, op2: Imm(imm) }` — `rd = rn & imm` (#682 mask)
+    AndImm { rd: RegVar, rn: RegVar, imm: u32 },
     /// `ArmOp::RorReg { rd, rn, rm }`
     RorReg { rd: RegVar, rn: RegVar, rm: RegVar },
     /// `ArmOp::LslReg { rd, rn, rm }`
@@ -425,41 +427,62 @@ pub const RULES: &[SelRule] = &[
     SelRule {
         name: "rule_i32_shl",
         op: WasmOp::I32Shl,
-        params: &[Rd, Rn, Rm],
-        side_conditions: &[],
-        seq: &[TemplateOp::LslReg {
-            rd: Rd,
-            rn: Rn,
-            rm: Rm,
-        }],
+        params: &[Rd, Rn, Rm, Rs],
+        side_conditions: &[SideCondition::NotAlias(Rs, Rn)],
+        seq: &[
+            TemplateOp::AndImm {
+                rd: Rs,
+                rn: Rm,
+                imm: 31,
+            },
+            TemplateOp::LslReg {
+                rd: Rd,
+                rn: Rn,
+                rm: Rs,
+            },
+        ],
         delegation: Delegation::Both,
-        doc: "`i32.shl`: rd = rn << rm",
+        doc: "`i32.shl`: rd = rn << (rm mod 32) — #682 mask via scratch rs",
     },
     SelRule {
         name: "rule_i32_shr_s",
         op: WasmOp::I32ShrS,
-        params: &[Rd, Rn, Rm],
-        side_conditions: &[],
-        seq: &[TemplateOp::AsrReg {
-            rd: Rd,
-            rn: Rn,
-            rm: Rm,
-        }],
+        params: &[Rd, Rn, Rm, Rs],
+        side_conditions: &[SideCondition::NotAlias(Rs, Rn)],
+        seq: &[
+            TemplateOp::AndImm {
+                rd: Rs,
+                rn: Rm,
+                imm: 31,
+            },
+            TemplateOp::AsrReg {
+                rd: Rd,
+                rn: Rn,
+                rm: Rs,
+            },
+        ],
         delegation: Delegation::Both,
-        doc: "`i32.shr_s`: rd = rn >> rm (arithmetic)",
+        doc: "`i32.shr_s`: rd = rn >> (rm mod 32) (arithmetic) — #682 mask via scratch rs",
     },
     SelRule {
         name: "rule_i32_shr_u",
         op: WasmOp::I32ShrU,
-        params: &[Rd, Rn, Rm],
-        side_conditions: &[],
-        seq: &[TemplateOp::LsrReg {
-            rd: Rd,
-            rn: Rn,
-            rm: Rm,
-        }],
+        params: &[Rd, Rn, Rm, Rs],
+        side_conditions: &[SideCondition::NotAlias(Rs, Rn)],
+        seq: &[
+            TemplateOp::AndImm {
+                rd: Rs,
+                rn: Rm,
+                imm: 31,
+            },
+            TemplateOp::LsrReg {
+                rd: Rd,
+                rn: Rn,
+                rm: Rs,
+            },
+        ],
         delegation: Delegation::Both,
-        doc: "`i32.shr_u`: rd = rn >> rm (logical)",
+        doc: "`i32.shr_u`: rd = rn >> (rm mod 32) (logical) — #682 mask via scratch rs",
     },
     SelRule {
         name: "rule_i32_rotr",
@@ -999,12 +1022,13 @@ pub fn i32_shift_rule(
     rd: crate::rules::Reg,
     rn: crate::rules::Reg,
     rm: crate::rules::Reg,
-) -> Option<Vec<crate::rules::ArmOp>> {
+    rs: crate::rules::Reg,
+) -> Option<Result<Vec<crate::rules::ArmOp>, &'static str>> {
     Some(match op {
-        WasmOp::I32Shl => generated::rule_i32_shl(rd, rn, rm),
-        WasmOp::I32ShrS => generated::rule_i32_shr_s(rd, rn, rm),
-        WasmOp::I32ShrU => generated::rule_i32_shr_u(rd, rn, rm),
-        WasmOp::I32Rotr => generated::rule_i32_rotr(rd, rn, rm),
+        WasmOp::I32Shl => generated::rule_i32_shl(rd, rn, rm, rs),
+        WasmOp::I32ShrS => generated::rule_i32_shr_s(rd, rn, rm, rs),
+        WasmOp::I32ShrU => generated::rule_i32_shr_u(rd, rn, rm, rs),
+        WasmOp::I32Rotr => Ok(generated::rule_i32_rotr(rd, rn, rm)),
         _ => return None,
     })
 }
@@ -1167,6 +1191,15 @@ fn template_expr(t: &TemplateOp, indent: usize) -> String {
             let fld = " ".repeat(indent + 4);
             format!(
                 "ArmOp::Rsb {{\n{fld}{},\n{fld}{},\n{fld}imm: {imm},\n{ind}}}",
+                field("rd", rd),
+                field("rn", rn)
+            )
+        }
+        TemplateOp::AndImm { rd, rn, imm } => {
+            let ind = " ".repeat(indent);
+            let fld = " ".repeat(indent + 4);
+            format!(
+                "ArmOp::And {{\n{fld}{},\n{fld}{},\n{fld}op2: Operand2::Imm({imm}),\n{ind}}}",
                 field("rd", rd),
                 field("rn", rn)
             )

--- a/crates/synth-synthesis/tests/rocq_correspondence.rs
+++ b/crates/synth-synthesis/tests/rocq_correspondence.rs
@@ -128,23 +128,23 @@ fn i32_xor_corresponds_to_rocq() {
 
 #[test]
 fn i32_shl_corresponds_to_rocq() {
-    // Rocq: I32Shl => [LSL_reg R0 R0 R1]
+    // Rocq (#682): rule_i32_shl => [AND rs rm #31; LSL_reg rd rn rs]
     let ops = select_single(WasmOp::I32Shl);
-    assert_eq!(opcode_names(&ops), vec!["LSL_reg"]);
+    assert_eq!(opcode_names(&ops), vec!["AND", "LSL_reg"]);
 }
 
 #[test]
 fn i32_shru_corresponds_to_rocq() {
-    // Rocq: I32ShrU => [LSR_reg R0 R0 R1]
+    // Rocq (#682): rule_i32_shr_u => [AND rs rm #31; LSR_reg rd rn rs]
     let ops = select_single(WasmOp::I32ShrU);
-    assert_eq!(opcode_names(&ops), vec!["LSR_reg"]);
+    assert_eq!(opcode_names(&ops), vec!["AND", "LSR_reg"]);
 }
 
 #[test]
 fn i32_shrs_corresponds_to_rocq() {
-    // Rocq: I32ShrS => [ASR_reg R0 R0 R1]
+    // Rocq (#682): rule_i32_shr_s => [AND rs rm #31; ASR_reg rd rn rs]
     let ops = select_single(WasmOp::I32ShrS);
-    assert_eq!(opcode_names(&ops), vec!["ASR_reg"]);
+    assert_eq!(opcode_names(&ops), vec!["AND", "ASR_reg"]);
 }
 
 #[test]
@@ -327,9 +327,10 @@ fn instruction_counts_match_rocq() {
         (WasmOp::I32And, 1),
         (WasmOp::I32Or, 1),
         (WasmOp::I32Xor, 1),
-        (WasmOp::I32Shl, 1),
-        (WasmOp::I32ShrU, 1),
-        (WasmOp::I32ShrS, 1),
+        // #682: register shifts are AND-mask + shift (2 instructions).
+        (WasmOp::I32Shl, 2),
+        (WasmOp::I32ShrU, 2),
+        (WasmOp::I32ShrS, 2),
         (WasmOp::I32Rotr, 1),
         (WasmOp::I32Clz, 1),
         (WasmOp::I32DivS, 4), // CMP + BNE + UDF + SDIV (with trap guard)

--- a/scripts/repro/i32_shift_mask_682.wat
+++ b/scripts/repro/i32_shift_mask_682.wat
@@ -1,0 +1,11 @@
+(module
+  (func (export "shl32")   (param i32) (result i32) (local.get 0) (i32.const 32)  (i32.shl))
+  (func (export "shl33")   (param i32) (result i32) (local.get 0) (i32.const 33)  (i32.shl))
+  (func (export "shl300")  (param i32) (result i32) (local.get 0) (i32.const 300) (i32.shl))
+  (func (export "shr300")  (param i32) (result i32) (local.get 0) (i32.const 300) (i32.shr_u))
+  (func (export "sar300")  (param i32) (result i32) (local.get 0) (i32.const 300) (i32.shr_s))
+  (func (export "shl_var") (param i32 i32) (result i32) (local.get 0) (local.get 1) (i32.shl))
+  (func (export "shr_var") (param i32 i32) (result i32) (local.get 0) (local.get 1) (i32.shr_u))
+  (func (export "sar_var") (param i32 i32) (result i32) (local.get 0) (local.get 1) (i32.shr_s))
+  (func (export "rotr_var") (param i32 i32) (result i32) (local.get 0) (local.get 1) (i32.rotr))
+)

--- a/scripts/repro/i32_shift_mask_682_differential.py
+++ b/scripts/repro/i32_shift_mask_682_differential.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""#682 — thumb-2 i32 shifts must reduce the amount mod 32 (WASM §4.3.2).
+
+ARMv7-M register-controlled shifts consume Rm[7:0] and yield 0 (LSL/LSR) or
+the sign (ASR) for amounts >= 32; WASM requires `amount mod 32`. The bare
+`LSL.W/LSR.W/ASR.W rd, rn, rm` lowering (present since before VCR-SEL inc-2,
+faithfully inherited by the DSL rules whose model-side proof was vacuous —
+ArmSemantics' LSL_reg used I32.shl's internal mod-32) silently miscompiled
+every shift with amount >= 32. Fix: `AND R12, rm, #31` before the shift, on
+both direct selectors and in the Rocq-proved rules (now non-vacuous under
+either shift semantics). ROR is cyclic, so Rm[7:0] agrees with WASM — pinned
+here as the unmasked exemption.
+
+Table (gale's #682 repro + variable-amount and rotr rows, each cross-checked
+against wasmtime ground truth under unicorn Thumb):
+
+  shl32(1)             -> 1        <- RED on pre-fix synth (0)
+  shl33(1)             -> 2        <- RED (0)
+  shl300(1)            -> 4096     <- RED (0)
+  shr300(0x80000000)   -> 0x80000  <- RED (0)
+  sar300(0x40000000)   -> 0x40000  <- RED (0)
+  shl_var(1, 33)       -> 2        <- RED (0)
+  shr_var(-1, 40)      -> 0x00FFFFFF
+  sar_var(0x80000000, 63) -> -1 (mod-32 amount = 31)
+  rotr_var(0x00000001, 33) -> 0x80000000  (cyclic, correct pre-fix too)
+  + in-range sanity rows (amounts < 32 unchanged)
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/i32_shift_mask_682_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("i32_shift_mask_682.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+
+CASES = [
+    ("shl32", (1,)),
+    ("shl33", (1,)),
+    ("shl300", (1,)),
+    ("shr300", (0x80000000,)),
+    ("sar300", (0x40000000,)),
+    ("shl_var", (1, 33)),
+    ("shl_var", (1, 300)),
+    ("shr_var", (0xFFFFFFFF, 40)),
+    ("sar_var", (0x80000000, 63)),
+    ("rotr_var", (1, 33)),
+    # in-range sanity: amounts < 32 must be untouched by the fix
+    ("shl_var", (1, 4)),
+    ("shr_var", (0x100, 4)),
+    ("sar_var", (0x80000000, 4)),
+    ("rotr_var", (0x10, 4)),
+]
+
+# Both direct-selector paths: --relocatable (select_with_stack) and the
+# blind fixed-register path is covered by unit tests; the optimized default
+# path already masked (bridge) — included as a regression pin.
+VARIANTS = [
+    ("relocatable", ["-t", "cortex-m3", "--relocatable"]),
+    ("default", ["-t", "cortex-m3"]),
+]
+
+
+def compile_elf(out, extra):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, *extra, "--all-exports"],
+        capture_output=True,
+        text=True,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({extra}): {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"] - base
+    return code, syms
+
+
+def wasm_expected(func, args):
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    sargs = [a - 2**32 if a >= 2**31 else a for a in args]
+    return inst.exports(st)[func](st, *sargs) & 0xFFFFFFFF
+
+
+def run_arm(code, off, args):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(0, 0x40000)
+    mu.mem_write(0x1000, code)
+    ret = 0x30000
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    for reg, val in zip((UC_ARM_REG_R0, UC_ARM_REG_R1), args):
+        mu.reg_write(reg, val & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_SP, 0x3F000)
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    try:
+        mu.emu_start((0x1000 + off) | 1, ret, timeout=5_000_000, count=10_000)
+    except UcError as e:
+        return f"UC_ERR:{e}"
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def main():
+    fails = 0
+    for vname, extra in VARIANTS:
+        with tempfile.NamedTemporaryFile(suffix=".o") as tf:
+            compile_elf(tf.name, extra)
+            code, syms = load(tf.name)
+            for func, args in CASES:
+                want = wasm_expected(func, args)
+                if func not in syms:
+                    print(f"[{vname}] SYMBOL MISSING: {func}")
+                    fails += 1
+                    continue
+                got = run_arm(code, syms[func], args)
+                ok = got == want
+                fails += 0 if ok else 1
+                mark = "ok  " if ok else "FAIL"
+                print(
+                    f"[{vname}] {mark} {func}{args}: synth={got:#x} wasmtime={want:#x}"
+                    if isinstance(got, int)
+                    else f"[{vname}] {mark} {func}{args}: synth={got} wasmtime={want:#x}"
+                )
+    if fails:
+        sys.exit(f"\n#682 differential: {fails} mismatches")
+    print("\n#682 differential: all green (WASM mod-32 shift semantics hold)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Root cause

ARMv7-M register-controlled shifts consume Rm[7:0] (amounts >= 32 -> 0 or sign); WASM requires `amount mod 32`. Both direct selectors emitted the bare shift — a latent hand-written bug that PREDATES the DSL (verified: pre-inc-2 baseline was already `vec![ArmOp::LslReg]`), which inc-2's rules faithfully mirrored. The Rocq Qed was vacuous: the model's `LSL_reg` uses `I32.shl`'s internal mod-32 (WASM-like) semantics — the exact hand-model divergence `SailArmBridge.v` documented as gaps 6–7, whose 'unreachable via WASM masking' judgment this issue falsifies. The optimized bridge always masked (via R12), which is why only the direct paths (`--relocatable` and blind) miscompiled.

## Fix

- `AND R12, rm, #31` before LSL/LSR/ASR on both direct selectors (R12 = encoder scratch per #212, no liveness hazard — the bridge's own pattern). ROR exempt (cyclic — Rm[7:0] ≡ WASM), pinned.
- DSL rules gain the mask + scratch param with `rs != rn` side condition (rotl pattern); rule table + generator + generated Rust + **re-proved Rocq theorems** (masked sequences, correct under both the current model semantics and real hardware; `bazel test //coq:verify_proofs` green incl. the coverage gate). `Compilation.v` + `CorrectnessI32.v` updated identically. The honest model-semantics fix (Rm[7:0]) stays with the flat-executor follow-up.

## Evidence

- **Red**: `i32_shift_mask_682_differential.py` vs v0.37.0 — 8 mismatches (every amount-≥32 row returns 0), relocatable path; default path green (bridge masked).
- **Green**: all rows both paths, incl. variable amounts, `sar_var(0x80000000, 63) = -1`, the rotr exemption, and in-range sanity. CI-gated as a new oracle job.
- **Refreeze ritual**: all 23 CI-gated differentials PASS on the new bytes before re-pinning; **13 goldens re-pinned** (+20B control_step = 5 masked shifts; signed_div_const unchanged — const amounts imm-fold); RV32 pins untouched. The gate gains a documented `SYNTH_REFREEZE_PRINT` repin aid.
- Workspace tests green, fmt + clippy -D warnings clean.

Closes #682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)