### PR TITLE
chore(release): v0.37.1 — i32 shift mod-32 semantics fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.1] - 2026-07-10
+
+**i32 register shifts finally obey WASM's mod-32 semantics (#682) — a latent
+hand-written bug the DSL had faithfully mirrored, whose Rocq proof was
+vacuous against real hardware: exactly the model-divergence class the
+Sail/ASL bridge documented as gaps 6–7 and judged unreachable.**
+
+### Fixed
+
+- **i32.shl/shr_s/shr_u with amounts >= 32 silently compiled to 0/sign on
+  both direct selectors (#682, PR #683).** ARMv7-M register shifts consume
+  Rm[7:0]; WASM requires amount mod 32. Both direct selectors now emit
+  `AND R12, rm, #31` before the shift (the optimized bridge's own pattern —
+  that path was never affected); the DSL rules gain the mask + an rs != rn
+  scratch side condition with re-proved theorems; Compilation.v aligned.
+  ROR is exempt (cyclic) and pinned. Red→green: 8 mismatches on v0.37.0's
+  relocatable path → 0 across gale's repro table + variable amounts;
+  CI-gated as a new oracle. Deliberate byte change (+4 B per
+  register-controlled shift; constant amounts imm-fold — unaffected):
+  refreeze ritual honored, 23 differentials green before 13 re-pins, RV32
+  untouched. The gate gains a documented SYNTH_REFREEZE_PRINT repin aid.
+  The honest model-semantics fix (Rm[7:0] in ArmSemantics) rides the
+  flat-executor follow-up.
+- **rust-1.97 clippy drift (PR #684):** three unneeded-wildcard patterns +
+  a question-mark/counter-loop pair on pre-existing code — unreds CI after
+  the toolchain bump.
+
 ## [0.37.0] - 2026-07-09
 
 **The certifying validator reaches the shipped bytes: expansion-level

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,14 +2060,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2126,11 +2126,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.37.0"
+version = "0.37.1"
 
 [[package]]
 name = "synth-cli"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2185,14 +2185,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2200,11 +2200,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.37.0"
+version = "0.37.1"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.37.0"
+version = "0.37.1"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.37.0"
+version = "0.37.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.37.0",
+    version = "0.37.1",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.37.0" }
+synth-core = { path = "../synth-core", version = "0.37.1" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.37.0" }
+synth-core = { path = "../synth-core", version = "0.37.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.37.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.37.0" }
+synth-core = { path = "../synth-core", version = "0.37.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.37.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.37.0" }
+synth-core = { path = "../synth-core", version = "0.37.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.37.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.37.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.37.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.37.1", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.37.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.37.1", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -44,23 +44,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.37.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.37.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.37.0" }
-synth-backend = { path = "../synth-backend", version = "0.37.0" }
+synth-core = { path = "../synth-core", version = "0.37.1" }
+synth-frontend = { path = "../synth-frontend", version = "0.37.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.37.1" }
+synth-backend = { path = "../synth-backend", version = "0.37.1" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.37.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.37.1" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.37.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.37.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.37.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.37.1", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.37.1", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.37.1", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.37.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.37.1", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.37.0" }
+synth-core = { path = "../synth-core", version = "0.37.1" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.37.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.37.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.37.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.37.0" }
-synth-opt = { path = "../synth-opt", version = "0.37.0" }
+synth-core = { path = "../synth-core", version = "0.37.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.37.1" }
+synth-opt = { path = "../synth-opt", version = "0.37.1" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -20,12 +20,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.37.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.37.0" }
-synth-opt = { path = "../synth-opt", version = "0.37.0" }
+synth-core = { path = "../synth-core", version = "0.37.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.37.1" }
+synth-opt = { path = "../synth-opt", version = "0.37.1" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.37.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.37.1", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"


### PR DESCRIPTION
Release PR: pin sweep + CHANGELOG for v0.37.1.

Scope: #683 (#682 — i32 register shifts mask mod 32 on both direct selectors + re-proved DSL rules; refreeze ritual honored) · #684 (rust-1.97 clippy unred).

Tag v0.37.1 on green merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)