### PR TITLE
feat(claims): claim-verification gate — README/CLAUDE.md claims marked, bound, and CI-gated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,21 @@ jobs:
       - name: Check intra-workspace version pins
         run: python3 scripts/check_version_pins.py
 
+  claim-check:
+    name: Claim Check
+    # claim-verification gate: README/CLAUDE.md/coq/STATUS.md load-bearing
+    # claims (proof counts, "verified" wording, DSL rule coverage, trusted-base
+    # sizes) are pinned in claims.yaml and RE-DERIVED from source here — a
+    # hand-maintained number that drifts from the tree fails the build.
+    # When a proof/rule lands, update the docs AND claims.yaml together.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Ensure PyYAML
+        run: python3 -c "import yaml" || python3 -m pip install --user pyyaml
+      - name: Re-derive documentation claims
+        run: python3 scripts/claim_check.py claims.yaml
+
   verify:
     name: Z3 Verification
     # #553 steps 3/4: this is now the ONLY job that builds z3 (feature

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,13 +89,22 @@ cd coq && make proofs
 
 ### Proof Status
 
-See `coq/STATUS.md` for the complete coverage matrix. Current: 298 Qed / 9 Admitted
-(+2 `admit.` tactics) across `coq/Synth/` — STATUS.md's 291 headline recount predates
-the 7 Qed VCR-SEL-001 pilot lemmas in `Synth/VcrSelPilot.v` (#386). Proofs are tiered:
+See `coq/STATUS.md` for the complete coverage matrix. Current: 423 Qed / 9 Admitted
+(+2 `admit.` tactics) across `coq/Synth/`. This count is CI-gated: `claims.yaml` +
+`scripts/claim_check.py` re-derive it on every commit — when a proof lands, update
+the docs AND `claims.yaml` in the same PR. Proofs are tiered:
 T1 (result-correspondence), T2 (existence-only), T3 (admitted). Remaining admits:
 4 i32 division trap guards (exec_program model gap, #73), 2 Compilation.v,
 1 CorrectnessSimple.v, 2 ArmRefinement.v — 0 i64 admits.
 All i32 AND i64 operations have T1 proofs (i64 T1 parity since v0.11.0).
+
+### Claim-verification gate
+
+Load-bearing doc claims (proof counts, "verified" wording, DSL rule coverage,
+trusted-base sizes) are pinned in `claims.yaml` and re-derived by
+`python3 scripts/claim_check.py claims.yaml` (CI job `claim-check`). Never fix a
+red gate by loosening the ledger — when evidence genuinely weakened, change the
+public claim; when a proof/rule landed, bump doc + ledger together.
 
 ## North Star (roadmap)
 
@@ -112,11 +121,12 @@ frozen and oracle-gated every step:
 - **Track A (core):** `VCR-RA-001` allocator with Belady spilling — **verified,
   default-on since v0.24.0** (`SYNTH_SPILL_REALLOC`; `SYNTH_SPILL_ON_EXHAUST`
   built flag-off, silicon-gated #580). Next: `VCR-SEL-001` Rocq-discharged
-  verified selector DSL (increment 1 in review, PR #623, `SYNTH_SEL_DSL`) and
-  `VCR-PERF-002` proof-carrying specialization (#494, 0.45× floor; phase 1 in
-  review, PR #624).
-- **Track B (semantics):** `VCR-ISA-001` Sail-generated Rocq ISA model;
-  `VCR-WASM-001` WasmCert-Coq source semantics — both still proposed.
+  verified selector DSL (increments 1–4 landed flag-off, 40 rules / 40 Qed,
+  `SYNTH_SEL_DSL`) and `VCR-PERF-002` proof-carrying specialization (#494,
+  0.45× floor; phase 1 facts ingestion landed, PR #624).
+- **Track B (semantics):** `VCR-ISA-001` Sail-generated Rocq ISA model —
+  approved, Sail/ASL bridge spike landed (81 Qed, `coq/Synth/ARM/SailArmBridge.v`);
+  `VCR-WASM-001` WasmCert-Coq source semantics — proposed.
 - **Track C (validation):** the differential oracles are CI-gated jobs
   (cmp-select, RV32 shift-fold/const-addr-fold, callee-saved, spill-frame,
   symtab-based frozen-fixture differentials).

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 | ELF output with vector table | Implemented | Thumb bit set on symbols; not linked on real hardware |
 | Linker scripts (STM32, nRF52840, generic) | Implemented | Generated, not tested with real boards |
 | Cross-compilation (`--link` flag) | Implemented | Requires `arm-none-eabi-gcc` in PATH; not CI-tested |
-| Rocq mechanized proofs | 298 Qed / 9 Admitted | i32 + i64 T1 proofs; division proofs re-admitted for trap guard alignment |
+| Rocq mechanized proofs | 423 Qed / 9 Admitted | i32 + i64 T1 proofs; division proofs re-admitted for trap guard alignment |
 | SMT translation validation | ordeal (pure-Rust QF_BV) default | v0.27.0 (#553); Z3 demoted to feature-gated differential oracle — 141/141 agreement |
 | WebAssembly spec test suite | 227/257 compile | Compilation only — not executed on emulator |
 
@@ -194,7 +194,7 @@ Per the [PulseEngine Verification Guide](https://pulseengine.eu/guides/VERIFICAT
 
 | Track | Status | Coverage |
 |-------|--------|----------|
-| **Rocq** | Partial | 298 Qed / 9 Admitted — division proofs re-admitted for trap guard alignment |
+| **Rocq** | Partial | 423 Qed / 9 Admitted — division proofs re-admitted for trap guard alignment |
 | **Kani** | Starting | 18 bounded model checking harnesses for ARM encoder |
 | **Verus** | Starting | 8 spec functions in `synth-synthesis/src/contracts.rs`; Bazel integration via `rules_verus` |
 | **Lean** | Not started | — |
@@ -206,13 +206,16 @@ See `artifacts/verification-gaps.yaml` for the detailed gap analysis (VG-001 thr
 Mechanized proofs in Rocq 9 show that `compile_wasm_to_arm` preserves WASM semantics for each operation. The proof suite lives in `coq/Synth/` and covers ARM instruction semantics, WASM stack-machine semantics, and per-operation correctness theorems.
 
 ```
-298 Qed / 9 Admitted (+2 admit. tactics)
+423 Qed / 9 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
   T1 result-correspondence (ARM output = WASM result): all i32 ops and all
      i64 ops — i64 T1 parity since v0.11.0, 0 i64 admits (coq/STATUS.md)
   T2 existence-only: f32/f64 and remaining categories
   T3 admitted (9): 4 i32 division trap guards (exec_program model gap, #73),
      2 Compilation.v, 1 CorrectnessSimple.v, 2 ArmRefinement.v
-  + 7 Qed VCR-SEL-001 pilot lemmas (Synth/VcrSelPilot.v, #386)
+  incl. 40 Qed selector-DSL rule theorems (Synth/VcrSelRules.v, 1:1 with
+     coq/vcr_sel_rules.manifest), 7 Qed VCR-SEL-001 pilot lemmas
+     (Synth/VcrSelPilot.v, #386), 81 Qed Sail/ASL bridge lemmas
+     (ARM/SailArmBridge.v, VCR-ISA-001)
 ```
 
 i32 and i64 operations have full T1 (result-correspondence) proofs; i64 parity landed in v0.11.0. Division proofs were re-admitted after updating Compilation.v to emit trap guard sequences (CMP+BCondOffset+UDF) matching the actual compiler — the sequential exec_program model needs PC-relative branching support to verify these. The f32, f64, and SIMD instruction selection has T2 existence proofs but not T1 result-correspondence.
@@ -255,10 +258,10 @@ The one-sentence version: moving synth's correctness from *"we patched every bug
 
 | Track | Item | What it does | Status |
 |-------|------|--------------|--------|
-| **A — codegen core** | `VCR-SEL-001` | Rocq-discharged verified selector DSL — *"ISLE with a proof-assistant backend"*; a missing lowering rule becomes an enumerable coverage gap, not a silent miscompile | increment 1 in review ([PR #623](https://github.com/pulseengine/synth/pull/623): 6-op i32 ALU class + `rotl` behind `SYNTH_SEL_DSL`); 7 Qed pilot lemmas in `coq/Synth/Synth/VcrSelPilot.v` |
-| | `VCR-PERF-002` | Proof-carrying specialization (#494): loom's `wsc.facts` invariants become premises for per-elision proof obligations, certificate-checked by the ordeal-backed validator — toward gale's measured **0.45× (below-native) floor** | design traced (v0.30.0); phase 1 (facts ingestion) in review ([PR #624](https://github.com/pulseengine/synth/pull/624)) |
+| **A — codegen core** | `VCR-SEL-001` | Rocq-discharged verified selector DSL — *"ISLE with a proof-assistant backend"*; a missing lowering rule becomes an enumerable coverage gap, not a silent miscompile | increments 1–4 landed flag-off (`SYNTH_SEL_DSL`): 40 rules / 40 Qed theorems in `coq/Synth/Synth/VcrSelRules.v` (1:1 with `coq/vcr_sel_rules.manifest`, coverage-gated), plus 7 Qed pilot lemmas in `coq/Synth/Synth/VcrSelPilot.v`; default-on flip pending |
+| | `VCR-PERF-002` | Proof-carrying specialization (#494): loom's `wsc.facts` invariants become premises for per-elision proof obligations, certificate-checked by the ordeal-backed validator — toward gale's measured **0.45× (below-native) floor** | design traced (v0.30.0); phase 1 (facts ingestion) landed ([PR #624](https://github.com/pulseengine/synth/pull/624), v0.31.0) |
 | | `SYNTH_SPILL_ON_EXHAUST` | Replace the register-exhaustion decline with allocation-time Belady spilling (#580) — the last piece of the exhaustion hard-fail | built, flag-off; default-on held for silicon cycle numbers |
-| **B — authoritative semantics** | `VCR-ISA-001` | Re-base ARM/RISC-V semantics on Sail-generated Rocq (the official ISA spec) | proposed |
+| **B — authoritative semantics** | `VCR-ISA-001` | Re-base ARM/RISC-V semantics on Sail-generated Rocq (the official ISA spec) | approved — Sail/ASL bridge spike landed (81 Qed, `coq/Synth/ARM/SailArmBridge.v`) |
 | | `VCR-WASM-001` | Anchor WASM source semantics on WasmCert-Coq | proposed |
 | **Gate** | `VCR-VER-001` | Success = a previously load-bearing greedy-fix becomes *revertable*, with the full differential bit-identical and cycles equal-or-better | **demonstrated** (implemented; [evidence](scripts/repro/vcr_ver_001_gate.md)): the v0.11.20 reciprocal-mult cost-gate deleted outright (PR #322, bit-identical); the #496 exhaustion decline revertable behind `SYNTH_SPILL_ON_EXHAUST` — red case green, anchors byte-identical, declines 14→8; flip held on a measured i32-shape cycle regression |
 

--- a/claims.yaml
+++ b/claims.yaml
@@ -1,0 +1,262 @@
+# claims.yaml — synth's load-bearing documentation claims, bound to evidence.
+#
+# Per the pulseengine-claude `claim-verification` skill: a README is a claim
+# about the system — the same species as a requirement, pointing the other way.
+# Each entry pins (a) the verbatim string as it appears in the doc, (b) evidence
+# a machine RE-DERIVES from source (never a number typed only in prose), and
+# (c) thereby the honest wording. CI runs `scripts/claim_check.py claims.yaml`;
+# drift = red.
+#
+# When a proof lands / a rule lands / a roadmap status changes: update the doc
+# AND this ledger in the same PR. Never "fix" a red gate by loosening the
+# ledger while leaving the prose overclaim in place.
+#
+# Not bound here (deliberately — narrative or runtime-derived, gated elsewhere):
+# the 141/141 ordeal-vs-Z3 agreement and 139/139 validator counts (re-derived
+# by the CI `verify` job that actually runs them), the wasm spec-suite 227/257
+# compile rate, and cycle/size numbers (gale silicon + differential jobs).
+
+claims:
+  # ---------------------------------------------------------------------------
+  # Headline Rocq proof counts — the number that drifts fastest.
+  # Was "298 Qed / 9 Admitted" in README/CLAUDE.md and "291" in coq/STATUS.md
+  # while the tree held 423 (v0.31–v0.37 churn: VcrSelRules increments 2–4,
+  # SailArmBridge, i64/flag lemmas). Fixed to derived truth in this PR.
+  # ---------------------------------------------------------------------------
+  - id: SYNTH-PROOF-COUNT-README
+    doc: README.md
+    text: "423 Qed / 9 Admitted"
+    evidence:
+      - kind: count-eq                       # ALL THREE README spots must agree —
+        pattern: '423 Qed / 9 Admitted'      # a verbatim check alone greens if one
+        glob: ['README.md']                  # of them drifts while another matches
+        expect: 3
+      - kind: count-eq
+        pattern: 'Qed\.'
+        glob: ['coq/Synth/**/*.v']
+        expect: 423
+      - kind: count-eq
+        pattern: 'Admitted\.'
+        glob: ['coq/Synth/**/*.v']
+        expect: 9
+      - kind: count-eq                       # the "+2 admit. tactics" disclosure
+        pattern: '^\s*admit\.'
+        glob: ['coq/Synth/**/*.v']
+        expect: 2
+
+  - id: SYNTH-PROOF-COUNT-CLAUDE-MD
+    doc: CLAUDE.md
+    text: "423 Qed / 9 Admitted"
+    evidence:
+      - kind: count-eq
+        pattern: 'Qed\.'
+        glob: ['coq/Synth/**/*.v']
+        expect: 423
+      - kind: count-eq
+        pattern: 'Admitted\.'
+        glob: ['coq/Synth/**/*.v']
+        expect: 9
+
+  - id: SYNTH-PROOF-COUNT-STATUS-MD
+    doc: coq/STATUS.md
+    text: "423 Qed / 9 Admitted"
+    evidence:
+      - kind: count-eq                       # headline + Total line must both agree
+        pattern: '423 Qed / 9 Admitted'
+        glob: ['coq/STATUS.md']
+        expect: 2
+      - kind: count-eq
+        pattern: 'Qed\.'
+        glob: ['coq/Synth/**/*.v']
+        expect: 423
+      - kind: count-eq
+        pattern: 'Admitted\.'
+        glob: ['coq/Synth/**/*.v']
+        expect: 9
+
+  # ---------------------------------------------------------------------------
+  # The admit breakdown the docs disclose — per-file, so a new admit anywhere
+  # (or a silent move between files) is visible, not just the total.
+  # ---------------------------------------------------------------------------
+  - id: SYNTH-ADMIT-BREAKDOWN
+    doc: README.md
+    text: "4 i32 division trap guards"
+    evidence:
+      - kind: count-eq
+        pattern: 'Admitted\.'
+        glob: ['coq/Synth/Synth/CorrectnessI32.v']
+        expect: 4
+      - kind: count-eq
+        pattern: 'Admitted\.'
+        glob: ['coq/Synth/Synth/Compilation.v']
+        expect: 2
+      - kind: count-eq
+        pattern: 'Admitted\.'
+        glob: ['coq/Synth/Synth/CorrectnessSimple.v']
+        expect: 1
+      - kind: count-eq
+        pattern: 'Admitted\.'
+        glob: ['coq/Synth/ARM/ArmRefinement.v']
+        expect: 2
+      - kind: no-new                         # both admit. tactics live here
+        pattern: '^\s*admit\.'
+        glob: ['coq/Synth/ARM/ArmRefinement.v']
+        recorded: 2
+
+  # "0 i64 admits" (README + CLAUDE.md) — i64 T1 parity must not regress.
+  - id: SYNTH-I64-ZERO-ADMITS
+    doc: README.md
+    text: "0 i64 admits"
+    evidence:
+      - kind: count-max
+        pattern: 'Admitted\.'
+        glob: ['coq/Synth/Synth/CorrectnessI64*.v']
+        max: 0
+
+  # The intro's scope claim: T1 for i32+i64 selection, T2-only for float/SIMD.
+  - id: SYNTH-T1-SCOPE
+    doc: README.md
+    text: "cover the i32 and i64 instruction selection with result-correspondence (T1) proofs"
+    evidence:
+      - kind: file-exists
+        path: coq/Synth/Synth/CorrectnessI32.v
+      - kind: file-exists
+        path: coq/Synth/Synth/CorrectnessI64.v
+      - kind: verbatim                       # the honest scoping must stay next to it
+        text: "float/SIMD selection has existence-only (T2) proofs"
+
+  # ---------------------------------------------------------------------------
+  # "verified"/"implemented" wording — bound to the roadmap yaml's status
+  # field, never free-floating prose. rivet's status lifecycle is the source.
+  # ---------------------------------------------------------------------------
+  - id: SYNTH-VCR-RA-001-VERIFIED
+    doc: README.md
+    text: "allocator with liveness-based Belady spilling: `verified`"
+    evidence:
+      - kind: yaml-field
+        path: artifacts/verified-codegen-roadmap.yaml
+        id: VCR-RA-001
+        field: status
+        equals: verified
+
+  - id: SYNTH-VCR-RA-001-VERIFIED-CLAUDE-MD
+    doc: CLAUDE.md
+    text: "`VCR-RA-001` allocator with Belady spilling — **verified,"
+    evidence:
+      - kind: yaml-field
+        path: artifacts/verified-codegen-roadmap.yaml
+        id: VCR-RA-001
+        field: status
+        equals: verified
+
+  - id: SYNTH-VCR-VER-001-DEMONSTRATED
+    doc: README.md
+    text: "**demonstrated** (implemented; [evidence](scripts/repro/vcr_ver_001_gate.md))"
+    evidence:
+      - kind: yaml-field
+        path: artifacts/verified-codegen-roadmap.yaml
+        id: VCR-VER-001
+        field: status
+        equals: implemented
+      - kind: file-exists
+        path: scripts/repro/vcr_ver_001_gate.md
+
+  - id: SYNTH-VCR-SEL-001-STATUS
+    doc: README.md
+    text: "increments 1–4 landed flag-off (`SYNTH_SEL_DSL`)"
+    evidence:
+      - kind: yaml-field
+        path: artifacts/verified-codegen-roadmap.yaml
+        id: VCR-SEL-001
+        field: status
+        equals: implemented
+
+  - id: SYNTH-VCR-ISA-001-STATUS
+    doc: README.md
+    text: "approved — Sail/ASL bridge spike landed"
+    evidence:
+      - kind: yaml-field
+        path: artifacts/verified-codegen-roadmap.yaml
+        id: VCR-ISA-001
+        field: status
+        equals: approved
+      - kind: count-eq                       # "81 Qed" bridge lemmas
+        pattern: 'Qed\.'
+        glob: ['coq/Synth/ARM/SailArmBridge.v']
+        expect: 81
+
+  # ---------------------------------------------------------------------------
+  # Verified selector DSL coverage — the rule table, its manifest, and the
+  # Qed theorems must stay 1:1. The STATUS.md coverage percentage's numerator
+  # is the manifest rule count, never a prose number.
+  # ---------------------------------------------------------------------------
+  - id: SYNTH-SEL-DSL-RULES
+    doc: README.md
+    text: "40 rules / 40 Qed theorems"
+    evidence:
+      - kind: count-eq                       # rules in the manifest
+        pattern: '^rule_'
+        glob: ['coq/vcr_sel_rules.manifest']
+        expect: 40
+      - kind: count-eq                       # 1:1 Qed theorems in VcrSelRules.v
+        pattern: '^(?:Theorem|Lemma) rule_\w+_correct'
+        glob: ['coq/Synth/Synth/VcrSelRules.v']
+        expect: 40
+      - kind: count-max                      # the rule table carries no admits
+        pattern: 'Admitted\.'
+        glob: ['coq/Synth/Synth/VcrSelRules.v']
+        max: 0
+
+  - id: SYNTH-SEL-DSL-COVERAGE-STATUS-MD
+    doc: coq/STATUS.md
+    text: "**40 (26%)**"                     # DSL-served column total, per-op-family table (#667)
+    evidence:
+      - kind: count-eq
+        pattern: '^rule_'
+        glob: ['coq/vcr_sel_rules.manifest']
+        expect: 40
+      - kind: verbatim
+        text: "**40 Qed / 0 Admitted**"
+
+  - id: SYNTH-SEL-DSL-PILOT
+    doc: README.md
+    text: "7 Qed pilot lemmas"
+    evidence:
+      - kind: count-eq
+        pattern: 'Qed\.'
+        glob: ['coq/Synth/Synth/VcrSelPilot.v']
+        expect: 7
+
+  # ---------------------------------------------------------------------------
+  # Trusted base — the axioms the Rocq suite rests on, re-counted, never
+  # hand-maintained (STATUS.md said "41 axioms" while the tree held 93).
+  # ---------------------------------------------------------------------------
+  - id: SYNTH-AXIOM-BASE
+    doc: coq/STATUS.md
+    text: "**Total: 93 Axiom/Parameter declarations**"
+    evidence:
+      - kind: count-eq
+        pattern: '^\s*(?:Axiom|Parameter) '
+        glob: ['coq/Synth/**/*.v']
+        expect: 93
+
+  # ---------------------------------------------------------------------------
+  # Other verification-track counts stated in the README.
+  # ---------------------------------------------------------------------------
+  - id: SYNTH-KANI-HARNESSES
+    doc: README.md
+    text: "18 bounded model checking harnesses for ARM encoder"
+    evidence:
+      - kind: count-eq
+        pattern: '#\[kani::proof\]'
+        glob: ['crates/**/*.rs']
+        expect: 18
+
+  - id: SYNTH-VERUS-SPECS
+    doc: README.md
+    text: "8 spec functions in `synth-synthesis/src/contracts.rs`"
+    evidence:
+      - kind: count-eq
+        pattern: '^pub open spec fn '
+        glob: ['crates/synth-synthesis/src/contracts.rs']
+        expect: 8

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -1,6 +1,11 @@
 # Rocq Proof Suite — Honest Status
 
-**Last Updated: 2026-06-04 (v0.11.x; recount: 291 Qed / 9 Admitted, +2 admit.)
+**Last Updated: 2026-07-10 (v0.37.x; recount: 423 Qed / 9 Admitted, +2 admit.)**
+
+The headline count is CI-gated: `claims.yaml` + `scripts/claim_check.py`
+re-derive `Qed.`/`Admitted.`/`admit.` counts from `coq/Synth/**/*.v` on every
+commit. When a proof lands, update this file, README.md, CLAUDE.md AND
+`claims.yaml` in the same PR.
 
 ## v0.11.0 outcome: true i64 T1 parity
 
@@ -107,12 +112,17 @@ umbrella #147).
 
 | Tier | Meaning | Count |
 |------|---------|-------|
-| **T1: Result Correspondence** | ARM output register = WASM result value | 37 |
-| **T2: Existence-Only** | ARM execution succeeds (no result claim) | 139 |
-| **T3: Admitted** | Not yet proven | 13 |
-| **Infrastructure** | Properties of integers, states, flag lemmas | 65 |
+| **T1: Result Correspondence** | ARM output register = WASM result value | 37¹ |
+| **T2: Existence-Only** | ARM execution succeeds (no result claim) | 139¹ |
+| **T3: Admitted / admit.** | Not yet proven | 11 (9 Admitted + 2 admit.) |
+| **Infrastructure** | Properties of integers, states, flag lemmas | 65¹ |
 
-**Total: 291 Qed / 9 Admitted (+2 admit.) across all files** (recount 2026-06-04)
+¹ T1/T2/Infrastructure tier classification is the 2026-06-04 semantic recount
+and predates the VcrSelRules (42), VcrSelPilot (7) and SailArmBridge (81) Qed;
+see the per-file breakdown below for current per-file counts. The T3 row and
+the headline total are re-derived by the claim gate.
+
+**Total: 423 Qed / 9 Admitted (+2 admit.) across all files** (recount 2026-07-10, CI-gated via `claims.yaml`)
 
 v0.10.0 PR 1: +2 T1 Qed (i64_add_correct, i64_sub_correct) and +9
 infrastructure Qed (combine_i32_unsigned, carry_split_add,
@@ -320,7 +330,14 @@ IEEE 754 definitions and prove correspondence with WASM float semantics.
 |-------|---------|
 | `sail_exec_instr` | Placeholder for Sail ARM specification (not yet imported) |
 
-**Total: 41 axioms** (13 I32 + 6 I64 + 20 VFP + 1 flag + 1 refinement)
+**Total: 93 Axiom/Parameter declarations** (recount 2026-07-10,
+`grep -E '^\s*(Axiom|Parameter) '` over `coq/Synth/**/*.v`; CI-gated via
+`claims.yaml`): 19 Integers.v (13 I32 + 6 I64), 72 ArmSemantics.v (the 21 VFP
+bit-pattern axioms tabled above + the i64 pseudo-op `_spec` result axioms +
+abstract operation parameters), 1 ArmFlagLemmas.v (`nv_flag_sub_lts`),
+1 ArmRefinement.v (`sail_exec_instr`). The tables above enumerate the
+originally-documented subset; the grep count is the authoritative trusted-base
+size.
 
 ## Flag-Correspondence Lemmas (ArmFlagLemmas.v)
 
@@ -354,31 +371,35 @@ All fully proved (Qed); no new axioms.
 
 ## Per-File Breakdown
 
+Recount 2026-07-10 (`grep -oE 'Qed\.'` / `'Admitted\.'` per file):
+
 | File | Qed | Admitted | Tier |
 |------|-----|----------|------|
 | Correctness.v | 6 | 0 | T1 |
 | CorrectnessSimple.v | 28 | 1 | T2 + 1 admitted (i64_const_correct) |
-| CorrectnessI32.v | 29 | 0 | T1 |
-| CorrectnessI64.v | 26 | 3 | T1 (add+sub+mul+div+rem) + T2 (shifts/cmps/bit-manip) + 3 admitted (And, Or, Xor — restated to T1 shape, pending Z.mod_mod halves-distribute rework) |
+| CorrectnessI32.v | 27 | 4 | T1 + 4 admitted (i32 div/rem trap guards — exec_program model gap, #73) |
+| CorrectnessI64.v | 46 | 0 | T1 (arith/bitwise/div/rem) + T2 (shifts/cmps/bit-manip) — 0 i64 admits since v0.11.0 |
 | CorrectnessI64Comparisons.v | 19 | 0 | T2 |
 | CorrectnessF32.v | 20 | 0 | T2 |
 | CorrectnessF64.v | 20 | 0 | T2 |
 | CorrectnessConversions.v | 21 | 0 | T2 |
 | CorrectnessMemory.v | 8 | 0 | T2 |
-| CorrectnessComplete.v | 1 | 0 | T2 |
-| ArmRefinement.v | 0 | 2 | T3 |
-| Integers.v | 10 | 1 | Infra/T3 |
-| ArmFlagLemmas.v | 15 | 0 | Infra (+5: combine_i32_unsigned, carry_split_add, borrow_split_sub, i64_add_via_adds_adc, i64_sub_via_subs_sbc) |
+| CorrectnessComplete.v | 0 | 0 | commentary only (tier taxonomy) |
+| ArmRefinement.v | 0 | 2 | T3 (+ the 2 `admit.` tactics) |
+| Integers.v | 11 | 0 | Infra (i64_to_i32_to_i64_wrap closed v0.10.0 PR 2) |
+| ArmFlagLemmas.v | 46 | 0 | Infra (flag correspondence + i64 carry/borrow/shift lemmas) |
 | Tactics.v | 1 | 0 | Infra |
-| ArmState.v | 14 | 0 | Infra (+3: get_reg_set_flags, flags_set_flags, flags_set_flags_set_reg) |
-| ArmSemantics.v | 8 | 0 | Infra (+1: flag_c_update_flags_arith) |
+| ArmState.v | 14 | 0 | Infra |
+| ArmSemantics.v | 8 | 0 | Infra |
+| SailArmBridge.v | 81 | 0 | Infra (VCR-ISA-001 Sail/ASL bridge: AddWithCarry family + ALU + shifts + moves) |
 | WasmSemantics.v | 6 | 0 | Infra |
-| Compilation.v | 5 | 0 | Infra |
+| Compilation.v | 3 | 2 | Infra + 2 admitted (`ex_compile_*` examples — Z.leb reduction) |
 | Base.v | 4 | 0 | Infra |
 | StateMonad.v | 3 | 0 | Infra |
 | WasmValues.v | 2 | 0 | Infra |
-| VcrSelPilot.v | 7 | 0 | T1 (register-polymorphic; VCR-SEL-001 go/abandon measurement, post-recount) |
-| VcrSelRules.v | 40 | 0 | T1 (register-polymorphic; the WIRED VCR-SEL-001 increment-1+2+3+4 rule table, 1:1 rule<->theorem, coverage-gated by `//coq:vcr_sel_rules_coverage`, post-recount) |
+| VcrSelPilot.v | 7 | 0 | T1 (register-polymorphic; VCR-SEL-001 go/abandon measurement) |
+| VcrSelRules.v | 42 | 0 | T1 (register-polymorphic; the WIRED VCR-SEL-001 increment-1+2+3+4 rule table — 40 rule theorems 1:1 with `coq/vcr_sel_rules.manifest`, coverage-gated by `//coq:vcr_sel_rules_coverage`, + 2 mod-32 helper lemmas #683) |
+| **Total** | **423** | **9** | (+2 `admit.`) |
 
 ## VCR-SEL-001 increments 1 (2026-07-07) + 2 + 3 + 4 (2026-07-08): VcrSelRules.v
 
@@ -421,7 +442,7 @@ see `docs/design/vcr-sel-001-increment-4.md`).
 
 **40 Qed / 0 Admitted**, same T1 bound as the pilot ("the ARM sequence
 computes the named result", not WASM refinement). These 47 Qed (pilot +
-rules) post-date and are NOT in the 2026-06-04 recount above.
+rules) are included in the 2026-07-10 recount above.
 
 ## DSL coverage vs model relevance (per-op-family metric, #667)
 

--- a/scripts/claim_check.py
+++ b/scripts/claim_check.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""claim_check — gate synth's documentation claims against live evidence.
+
+Adapted from the pulseengine-claude `claim-verification` skill's reference
+implementation. The repo's load-bearing doc claims (proof counts, "verified"
+wording, DSL rule coverage, trusted-base sizes) live in `claims.yaml`; CI runs
+this script; drift between a claim, its recorded ledger, and the *actual
+source* fails the build. Truth-over-time becomes a property of the gate, not
+the author.
+
+Usage:  scripts/claim_check.py [claims.yaml]     (default: ./claims.yaml)
+Exit:   0 = all claims hold · 1 = one or more drifted
+
+Evidence predicates re-derive from source — never a number typed only in prose:
+
+  verbatim     the honest wording appears VERBATIM in the doc
+  file-exists  the proof/harness the claim rests on is present
+  count-eq     re-count a pattern from source; fail unless it EQUALS the doc's
+               stated number (for headline counts: a new proof landing must
+               update the doc + ledger together)
+  count-max    re-count from source; fail if it exceeds the recorded trusted-
+               base size (for things that must not grow)
+  no-new       no new sorry/admit/Admitted since the ledger's recorded count
+  yaml-field   a field of a list item in a YAML artifact file (e.g. the rivet
+               roadmap's `status:`) equals the recorded value — "verified"
+               wording in prose is bound to the roadmap's status field
+"""
+
+import glob
+import pathlib
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("claim_check: needs PyYAML  (pip install pyyaml)")
+
+
+def _count(pattern, globs, root):
+    rx = re.compile(pattern, re.MULTILINE)
+    globs = [globs] if isinstance(globs, str) else globs
+    total = 0
+    matched_any = False
+    for g in globs:
+        # Resolve globs relative to the claims file's directory, NOT the CWD —
+        # otherwise the predicate silently matches nothing and greens a claim
+        # it never checked (the "oracle that measures nothing" failure).
+        for f in glob.glob(str(root / g), recursive=True):
+            p = pathlib.Path(f)
+            if p.is_file():
+                matched_any = True
+                total += len(rx.findall(p.read_text(errors="ignore")))
+    return total, matched_any
+
+
+def _yaml_field(ev, root):
+    """Look up `field` of the list item whose `id` matches, in `path`."""
+    path = root / ev["path"]
+    if not path.exists():
+        return None, f'yaml file missing: {ev["path"]}'
+    data = yaml.safe_load(path.read_text(errors="ignore")) or {}
+    items = data.get(ev.get("list", "artifacts"), [])
+    for item in items:
+        if isinstance(item, dict) and item.get("id") == ev["id"]:
+            return item.get(ev["field"]), None
+    return None, f'id {ev["id"]!r} not found in {ev["path"]}'
+
+
+def check_claim(c, root):
+    fails = []
+    doc_path = root / c["doc"]
+    if not doc_path.exists():
+        return [f'doc not found: {c["doc"]}']
+    doc = doc_path.read_text(errors="ignore")
+
+    text = c.get("text")
+    if text and text not in doc:
+        fails.append(f'claim text not found verbatim in {c["doc"]}: "{text}"')
+
+    for ev in c.get("evidence", []):
+        kind = ev.get("kind")
+        if kind == "verbatim":
+            s = ev.get("text", text)
+            if s and s not in doc:
+                fails.append(f'verbatim string absent from {c["doc"]}: "{s}"')
+        elif kind == "file-exists":
+            if not (root / ev["path"]).exists():
+                fails.append(f'evidence file missing: {ev["path"]}')
+        elif kind == "count-eq":
+            n, matched = _count(ev["pattern"], ev["glob"], root)
+            if not matched:
+                fails.append(
+                    f'predicate matched NO files (measures nothing): glob {ev["glob"]}'
+                )
+            elif n != ev["expect"]:
+                fails.append(
+                    f'count drifted: derived {n} != documented {ev["expect"]}  '
+                    f'[/{ev["pattern"]}/ over {ev["glob"]}]  '
+                    f'— update the doc AND claims.yaml together'
+                )
+        elif kind == "count-max":
+            n, matched = _count(ev["pattern"], ev["glob"], root)
+            if not matched:
+                fails.append(
+                    f'predicate matched NO files (measures nothing): glob {ev["glob"]}'
+                )
+            elif n > ev["max"]:
+                fails.append(
+                    f'trusted base grew: {n} > recorded max {ev["max"]}  '
+                    f'[/{ev["pattern"]}/]  — update the claim, not just the number'
+                )
+        elif kind == "no-new":
+            n, matched = _count(ev["pattern"], ev["glob"], root)
+            if not matched:
+                fails.append(
+                    f'predicate matched NO files (measures nothing): glob {ev["glob"]}'
+                )
+            elif n > ev.get("recorded", 0):
+                fails.append(
+                    f'new unproven obligations: {n} > recorded {ev.get("recorded", 0)}  '
+                    f'[/{ev["pattern"]}/]'
+                )
+        elif kind == "yaml-field":
+            val, err = _yaml_field(ev, root)
+            if err:
+                fails.append(err)
+            elif val != ev["equals"]:
+                fails.append(
+                    f'{ev["path"]}: {ev["id"]}.{ev["field"]} is {val!r}, '
+                    f'claim requires {ev["equals"]!r} — fix the PROSE to match '
+                    f'the roadmap, or land the status change first'
+                )
+        else:
+            fails.append(f"unknown evidence kind: {kind!r}")
+    return fails
+
+
+def main():
+    path = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "claims.yaml")
+    if not path.exists():
+        sys.exit(f"claim_check: {path} not found")
+    root = path.parent
+    data = yaml.safe_load(path.read_text()) or {}
+    claims = data.get("claims", [])
+    if not claims:
+        print("claim_check: no claims declared — nothing to gate.")
+        return
+
+    bad = 0
+    for c in claims:
+        fails = check_claim(c, root)
+        if fails:
+            bad += 1
+            print(f"FAIL {c['id']}")
+            for f in fails:
+                print(f"    {f}")
+        else:
+            print(f"ok   {c['id']}")
+
+    print(f"\n{len(claims) - bad}/{len(claims)} claims hold.")
+    sys.exit(1 if bad else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Stands up the CLAIM-VERIFICATION gate per the pulseengine-claude `claim-verification` skill: the load-bearing claims in README.md / CLAUDE.md / coq/STATUS.md are **marked** in a `claims.yaml` ledger, **bound** to evidence a machine re-derives from source, and **gated** in CI so drift fails the build. Docs + CI only — no code, no frozen anchors touched.

## Mark — 17 claims pinned in `claims.yaml`

- Headline Rocq proof counts (README ×3 spots, CLAUDE.md, coq/STATUS.md ×2 — occurrence-pinned per doc)
- The T3 admit breakdown, per file (4 CorrectnessI32 + 2 Compilation + 1 CorrectnessSimple + 2 ArmRefinement, +2 `admit.` in ArmRefinement)
- "0 i64 admits" (count-max 0 over `CorrectnessI64*.v`)
- The intro's T1-scope claim (i32+i64 T1, float/SIMD T2-only wording must stay adjacent)
- `VCR-RA-001` "verified", `VCR-VER-001` "demonstrated (implemented)", `VCR-SEL-001` "landed", `VCR-ISA-001` "approved" — each bound to the roadmap yaml's `status:` field
- Selector-DSL coverage: 40 manifest rules ↔ 40 `rule_*_correct` Qed theorems (1:1), 0 admits; STATUS.md's "40 (26%)" numerator bound to the manifest; 7 pilot lemmas
- Trusted base: 93 Axiom/Parameter declarations (grep-derived)
- 18 Kani harnesses, 8 Verus spec fns

Deliberately NOT bound (runtime-derived, gated by the CI jobs that run them): 141/141 ordeal-vs-Z3, 139/139 validator, 227/257 spec-suite, cycle/size numbers.

## Audit — drift found and fixed to derived truth

| Claim | Doc said | Tree holds |
|---|---|---|
| Qed count | 298 (README, CLAUDE.md) / 291 (STATUS.md) | **423** (v0.31–v0.37 churn: VcrSelRules increments 2–4, SailArmBridge 81 Qed, flag lemmas) |
| Axiom trusted base | "Total: 41 axioms" | **93** Axiom/Parameter declarations |
| STATUS.md per-file table | stale (no SailArmBridge row; CorrectnessI32 29/0 vs actual 27/4; CorrectnessI64 26/3 vs actual 46/0; ArmFlagLemmas 15 vs 46; Compilation 5/0 vs 3/2; Integers 10/1 vs 11/0) | recounted 2026-07-10, sums to 423/9 |
| VCR-SEL-001 | "increment 1 in review (PR #623)" | increments 1–4 landed, 40 rules / 40 Qed |
| VCR-PERF-002 | "phase 1 in review (PR #624)" | landed (v0.31.0) |
| VCR-ISA-001 | "proposed" | approved — Sail/ASL bridge spike landed |

## Bind — predicate types

`count-eq` (stated counts must EQUAL the recount — a landing proof forces doc+ledger bump together), `count-max` (must-not-grow: admits in i64/DSL files), `no-new` (`admit.` tactics), `file-exists`, `verbatim`, and `yaml-field` (prose "verified" wording ↔ the rivet roadmap's `status:` — new kind, needed because the skill says never free-float lifecycle words).

## Gate — red → green evidence

`scripts/claim_check.py claims.yaml` (stdlib + PyYAML), CI job `claim-check` on ubuntu-latest. Verified locally, three drift modes, each exit 1, then green (exit 0, 17/17) on the reverted tree:

1. **Doc-side**: README Features row edited to `500 Qed / 0 Admitted` →
   `FAIL SYNTH-PROOF-COUNT-README — count drifted: derived 2 != documented 3 [/423 Qed \/ 9 Admitted/ over README.md]`
   (occurrence pinning; a plain verbatim check greened this because the string still matched at two other spots — caught and fixed during the build)
2. **Source-side**: a fake `Admitted.` appended to Base.v →
   `FAIL ×3 — count drifted: derived 10 != documented 9 [/Admitted\./ over coq/Synth/**/*.v]`
3. **Roadmap-side**: VCR-RA-001 `status: verified` → `implemented` with prose unchanged →
   `FAIL SYNTH-VCR-RA-001-VERIFIED — VCR-RA-001.status is 'implemented', claim requires 'verified'`

fmt/clippy: no-ops (python + yaml + md only). Frozen fixtures untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)