### PR TITLE
fix(selector): param liveness extends across loop back-edges — loop bound survives the induction increment (#663)

### DIFF
--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -6736,6 +6736,55 @@ impl InstructionSelector {
                 param_last_read.insert(*p, i);
             }
         }
+        // #663: the linear scan above is blind to loop BACK-EDGES — a param
+        // read inside a `Loop..End` span is re-executed every iteration, so
+        // its value is live until the loop exits, not until the (linearly)
+        // last read. Pre-fix, a parameter-bounded counting loop lost the
+        // bound's reservation right after the loop-top compare, and the
+        // induction increment was allocated into the bound's home register
+        // (`adds r0, r7, #1` clobbered n in r0 → loop exited after one
+        // iteration). Extend each last read to the End of every enclosing
+        // loop, iterating to fixpoint so a read in an inner loop extends to
+        // the outermost enclosing loop's End (its back-edge re-executes the
+        // read too). Spans are contiguous and properly nested, so extending
+        // only the maximum read index is sound: any earlier read's enclosing
+        // loop that ends after the max read must also contain the max read.
+        let loop_spans: Vec<(usize, usize)> = {
+            let mut spans = Vec::new();
+            let mut open: Vec<(bool, usize)> = Vec::new(); // (is_loop, start)
+            for (i, op) in wasm_ops.iter().enumerate() {
+                match op {
+                    WasmOp::Loop => open.push((true, i)),
+                    WasmOp::Block | WasmOp::If => open.push((false, i)),
+                    WasmOp::End => {
+                        if let Some((true, start)) = open.pop() {
+                            spans.push((start, i));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            // A loop left open at stream end (implicit function-body End)
+            // conservatively extends to the last op.
+            for (is_loop, start) in open {
+                if is_loop {
+                    spans.push((start, wasm_ops.len().saturating_sub(1)));
+                }
+            }
+            spans
+        };
+        for last in param_last_read.values_mut() {
+            let mut changed = true;
+            while changed {
+                changed = false;
+                for &(start, end) in &loop_spans {
+                    if *last > start && *last < end {
+                        *last = end;
+                        changed = true;
+                    }
+                }
+            }
+        }
         let live_param_regs = |at: usize| -> Vec<Reg> {
             let mut out = Vec::new();
             for (p, r) in &param_regs {
@@ -13774,6 +13823,122 @@ mod tests {
                 .any(|i| matches!(&i.op, ArmOp::Movw { rd: Reg::R0, .. })),
             "a constant clobbered param0 (r0) while it was still live (#193): {arm:#?}"
         );
+    }
+
+    /// #663 regression: a param read inside a loop body is re-read every
+    /// iteration via the back-edge, so its reservation must extend to the
+    /// loop's End — linear last-read liveness ended it at the first
+    /// iteration's read, and the induction increment `$i + 1` was allocated
+    /// into r0 (the live bound n): `adds r0, r7, #1` → the loop exited after
+    /// one iteration. Reproducer is gale's `sum_below` (sum of 0..n-1 with
+    /// n = param 0). Pin: no instruction up to and including the loop
+    /// back-edge (the last `B`) may define r0.
+    #[test]
+    fn test_663_loop_body_defs_avoid_live_param_bound() {
+        use WasmOp::*;
+        let mut selector = InstructionSelector::new(RuleDatabase::new().rules().to_vec());
+        // (param i32 i32) (local $i i32) (local $acc i32) — locals 2, 3
+        let ops = vec![
+            Block,
+            Loop,
+            LocalGet(2), // $i
+            LocalGet(0), // n — the bound, re-read EVERY iteration
+            I32GeS,
+            BrIf(1), // exit to $d
+            LocalGet(3),
+            LocalGet(2),
+            I32Add,
+            LocalSet(3), // $acc += $i
+            LocalGet(2),
+            I32Const(1),
+            I32Add,
+            LocalSet(2), // $i += 1 — pre-fix this landed in r0
+            Br(0),       // back-edge
+            End,
+            End,
+            LocalGet(3),
+        ];
+        let arm = selector.select_with_stack(&ops, 2).unwrap();
+        let back_edge = arm
+            .iter()
+            .rposition(|i| matches!(&i.op, ArmOp::B { .. }))
+            .expect("the loop back-edge B must be emitted");
+        for (i, instr) in arm[..=back_edge].iter().enumerate() {
+            if let Some(effect) = crate::liveness::reg_effect(&instr.op) {
+                assert!(
+                    !effect.defs.contains(&Reg::R0),
+                    "instruction {i} ({:?}) defines r0 while the loop bound \
+                     (param0) is still live across the back-edge (#663): {arm:#?}",
+                    instr.op
+                );
+            }
+        }
+    }
+
+    /// #663 nested-loop variant: a param read only in the INNER loop is
+    /// still re-executed by the OUTER back-edge, so the reservation must
+    /// extend to the outermost enclosing loop's End (fixpoint extension),
+    /// not just the inner one's.
+    #[test]
+    fn test_663_nested_loop_extends_reservation_to_outer_end() {
+        use WasmOp::*;
+        let mut selector = InstructionSelector::new(RuleDatabase::new().rules().to_vec());
+        // (param i32 i32) (local $i i32) (local $j i32) (local $acc i32)
+        // outer bound = param 1 (r1), inner bound = param 0 (r0, read only
+        // inside the inner loop).
+        let ops = vec![
+            Block,
+            Loop, // outer
+            LocalGet(2),
+            LocalGet(1),
+            I32GeS,
+            BrIf(1),
+            I32Const(0),
+            LocalSet(3), // $j = 0
+            Block,
+            Loop, // inner
+            LocalGet(3),
+            LocalGet(0), // inner bound — deepest read of param 0
+            I32GeS,
+            BrIf(1),
+            LocalGet(4),
+            I32Const(1),
+            I32Add,
+            LocalSet(4),
+            LocalGet(3),
+            I32Const(1),
+            I32Add,
+            LocalSet(3),
+            Br(0), // inner back-edge
+            End,
+            End,
+            LocalGet(2),
+            I32Const(1),
+            I32Add,
+            LocalSet(2), // outer increment — after param 0's linear last read
+            Br(0),       // outer back-edge
+            End,
+            End,
+            LocalGet(4),
+        ];
+        let arm = selector.select_with_stack(&ops, 2).unwrap();
+        let outer_back_edge = arm
+            .iter()
+            .rposition(|i| matches!(&i.op, ArmOp::B { .. }))
+            .expect("the outer back-edge B must be emitted");
+        for (i, instr) in arm[..=outer_back_edge].iter().enumerate() {
+            if let Some(effect) = crate::liveness::reg_effect(&instr.op) {
+                for r in [Reg::R0, Reg::R1] {
+                    assert!(
+                        !effect.defs.contains(&r),
+                        "instruction {i} ({:?}) defines {r:?} while a loop \
+                         bound param is live across an enclosing back-edge \
+                         (#663 nested): {arm:#?}",
+                        instr.op
+                    );
+                }
+            }
+        }
     }
 
     /// #195 regression: a single i32 argument to a local call must be placed in

--- a/scripts/repro/loop_param_bound_663.wat
+++ b/scripts/repro/loop_param_bound_663.wat
@@ -1,0 +1,54 @@
+(module
+  ;; #663 — parameter-bounded counting loop: sum of 0..n-1.
+  ;; The bound n lives in a param register (r0) and is re-read by the loop
+  ;; condition EVERY iteration; linear last-read liveness ended its
+  ;; reservation at the first read, so the induction increment was
+  ;; allocated into r0 and the loop exited after one iteration.
+  (func (export "sum_below") (param i32 i32) (result i32)
+    (local $i i32) (local $acc i32)
+    (block $d (loop $l
+      (br_if $d (i32.ge_s (local.get $i) (local.get 0)))
+      (local.set $acc (i32.add (local.get $acc) (local.get $i)))
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (br $l)))
+    (local.get $acc))
+
+  ;; second param as the bound (param reg r1), first param as a stride —
+  ;; both params live across the back-edge.
+  (func (export "sum_stride") (param i32 i32) (result i32)
+    (local $i i32) (local $acc i32)
+    (block $d (loop $l
+      (br_if $d (i32.ge_s (local.get $i) (local.get 1)))
+      (local.set $acc (i32.add (local.get $acc) (local.get 0)))
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (br $l)))
+    (local.get $acc))
+
+  ;; nested loops, bound read only in the INNER loop — the OUTER back-edge
+  ;; also re-executes the read, so the reservation must extend to the
+  ;; outermost enclosing loop end.
+  (func (export "sum_nested") (param i32 i32) (result i32)
+    (local $i i32) (local $j i32) (local $acc i32)
+    (block $do (loop $lo
+      (br_if $do (i32.ge_s (local.get $i) (local.get 1)))
+      (local.set $j (i32.const 0))
+      (block $di (loop $li
+        (br_if $di (i32.ge_s (local.get $j) (local.get 0)))
+        (local.set $acc (i32.add (local.get $acc) (i32.const 1)))
+        (local.set $j (i32.add (local.get $j) (i32.const 1)))
+        (br $li)))
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (br $lo)))
+    (local.get $acc))
+
+  ;; constant-bound control: was already correct pre-fix (pins that the
+  ;; loop lowering itself is fine).
+  (func (export "sum_const") (param i32 i32) (result i32)
+    (local $i i32) (local $acc i32)
+    (block $d (loop $l
+      (br_if $d (i32.ge_s (local.get $i) (i32.const 10)))
+      (local.set $acc (i32.add (local.get $acc) (local.get $i)))
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (br $l)))
+    (local.get $acc))
+)

--- a/scripts/repro/loop_param_bound_663_differential.py
+++ b/scripts/repro/loop_param_bound_663_differential.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""#663 — thumb-2 parameter-bounded loop: live param bound clobbered by the
+induction increment (loop exits after 1 iteration).
+
+The direct selector's #193 param reservation computes each register-backed
+param's LAST READ with a linear scan — but a loop back-edge re-executes every
+read inside the Loop..End span, so a param whose (linearly) last read sits
+inside a loop body lost its reservation before the loop finished. The
+induction update `$i + 1` was then allocated into r0 (the live bound n):
+`adds r0, r7, #1` — iteration 2's `cmp r2, r0` compares $i against $i+1 and
+exits. Fix: extend the last-read horizon of any param read inside a
+Loop..End span to the span's End (transitively, so nested loops extend to
+the outermost enclosing loop).
+
+Table (each row cross-checked against wasmtime ground truth under unicorn
+Thumb; pre-fix synth returns 0 for every param-bounded row):
+
+  sum_below(3, _)    -> 3       <- RED pre-fix (0)
+  sum_below(10, _)   -> 45      <- RED pre-fix (0)  (gale's #663 table row)
+  sum_below(100, _)  -> 4950    <- RED pre-fix (0)
+  sum_below(1000, _) -> 499500  <- RED pre-fix (0)
+  sum_stride(7, 5)   -> 35      (bound in r1, stride param also live)
+  sum_nested(4, 3)   -> 12      (bound read only in the INNER loop)
+  sum_const(_, _)    -> 45      (constant bound — correct pre-fix, pins
+                                 the loop lowering itself)
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/loop_param_bound_663_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("loop_param_bound_663.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+
+CASES = [
+    ("sum_below", (3, 0)),
+    ("sum_below", (10, 0)),
+    ("sum_below", (100, 0)),
+    ("sum_below", (1000, 0)),
+    ("sum_below", (0, 0)),  # zero-trip loop
+    ("sum_stride", (7, 5)),
+    ("sum_nested", (4, 3)),
+    ("sum_const", (0, 0)),
+]
+
+# Both direct-selector paths exercise the #193 reservation machinery.
+VARIANTS = [
+    ("relocatable", ["-t", "cortex-m3", "--relocatable"]),
+    ("default", ["-t", "cortex-m3"]),
+]
+
+
+def compile_elf(out, extra):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, *extra, "--all-exports"],
+        capture_output=True,
+        text=True,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({extra}): {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"] - base
+    return code, syms
+
+
+def wasm_expected(func, args):
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    sargs = [a - 2**32 if a >= 2**31 else a for a in args]
+    return inst.exports(st)[func](st, *sargs) & 0xFFFFFFFF
+
+
+def run_arm(code, off, args):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(0, 0x40000)
+    mu.mem_write(0x1000, code)
+    ret = 0x30000
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    for reg, val in zip((UC_ARM_REG_R0, UC_ARM_REG_R1), args):
+        mu.reg_write(reg, val & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_SP, 0x3F000)
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    try:
+        mu.emu_start((0x1000 + off) | 1, ret, timeout=5_000_000, count=100_000)
+    except UcError as e:
+        return f"UC_ERR:{e}"
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def main():
+    fails = 0
+    for vname, extra in VARIANTS:
+        with tempfile.NamedTemporaryFile(suffix=".o") as tf:
+            compile_elf(tf.name, extra)
+            code, syms = load(tf.name)
+            for func, args in CASES:
+                want = wasm_expected(func, args)
+                if func not in syms:
+                    print(f"[{vname}] SYMBOL MISSING: {func}")
+                    fails += 1
+                    continue
+                got = run_arm(code, syms[func], args)
+                ok = got == want
+                fails += 0 if ok else 1
+                mark = "ok  " if ok else "FAIL"
+                print(f"[{vname}] {mark} {func}{args}: synth={got} wasmtime={want}")
+    if fails:
+        sys.exit(f"\n#663 differential: {fails} mismatches")
+    print("\n#663 differential: all green (param bound survives the back-edge)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #663 (thumb-2 parameter-bounded loop exits after 1 iteration — silent miscompile of every `for (i = 0; i < n; i++)` with `n` a parameter).

## Root cause

The direct selector's #193 live-param reservation (`param_last_read` in `crates/synth-synthesis/src/instruction_selector.rs`) computes each register-backed param's last read with a **linear** scan. A loop back-edge re-executes every read inside its `Loop..End` span, so a param whose linearly-last read sits inside a loop body — exactly a loop bound, re-compared every iteration — lost its reservation after the first iteration's read. The induction update `$i + 1` was then allocated into the bound's home register (`adds r0, r7, #1` clobbered `n` in `r0`); iteration 2 compared `$i` against `$i+1` and exited. gale's `sum_below` returned 0 for every `n`.

## Fix

After the linear scan, extend each param's last-read index to the `End` of every enclosing `Loop..End` span, iterated to fixpoint — a read inside an inner loop extends to the outermost enclosing loop's `End`, since the outer back-edge re-executes it too. Spans are contiguous and properly nested, so extending only the maximum read index is sound. Lineage: #193 → #210 → #331 (live param registers vs temp/const/reload allocation); this closes that machinery's back-edge blind spot.

Post-fix disasm of the repro: the increment lands in a genuinely-dead register (`adds r1, r7, #1` — param 1 is never read; `r8` when both params are live), `r0` survives the loop.

## Oracles

- **red→green execution differential** `scripts/repro/loop_param_bound_663_differential.py` (unicorn Thumb vs wasmtime): gale's repro at n = 3/10/100/1000, zero-trip, bound-in-r1 + second live param, nested loops (bound read only in the inner loop), constant-bound control — on **both** `--relocatable` and default paths. Pre-fix: 10 mismatches (all param-bounded rows return 0, incl. `sum_nested`). Post-fix: all green.
- **unit pins** `test_663_loop_body_defs_avoid_live_param_bound` + `test_663_nested_loop_extends_reservation_to_outer_end`: via `liveness::reg_effect`, no instruction up to and including the loop back-edge defines a live bound-param register. Both verified RED with the extension neutered, green with it.
- **frozen anchors**: `frozen_codegen_bytes` **10/10** byte-identical — the extension is byte-neutral on every frozen fixture (no re-pin, no refreeze).
- workspace `cargo test`: **2080 passed / 0 failed**; `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)