### PR TITLE
fix(encoder): T3 ADD.W raw-imm packing — ADDW (T4) for static offsets 0x100..0xFFF (#681)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,8 @@ jobs:
         run: SYNTH=./target/debug/synth python scripts/repro/rem_s_666_differential.py
       - name: Run i32 shift-mask oracle (#682)
         run: SYNTH=./target/debug/synth python scripts/repro/i32_shift_mask_682_differential.py
+      - name: Run ADDW static-offset oracle (#681, incl. software-bounds bypass)
+        run: SYNTH=./target/debug/synth python scripts/repro/addw_offset_681_differential.py
 
   fact-spec-oracle:
     name: fact-spec elision oracle (#494 phases 2 + 2b)

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -1460,6 +1460,17 @@ impl ArmEncoder {
                 let rn_bits = reg_to_bits(rn);
                 // RSB encoding: cond(4) | 00 1 0011 S | Rn(4) | Rd(4) | imm12
                 // Opcode for RSB = 0011, I=1 (immediate), S=0
+                //
+                // #681 class audit: the A32 imm12 is a rotate(4):imm8 modified
+                // immediate; `*imm & 0xFF` silently encoded a WRONG constant
+                // for imm > 0xFF (#378 masking class). All current emitters use
+                // imm 32, so erroring here is byte-identical for real codegen.
+                if *imm > 0xFF {
+                    return Err(synth_core::Error::synthesis(
+                        "A32 RSB immediate > 0xFF requires a rotated-immediate encoding \
+                         (not supported) — materialize into a register",
+                    ));
+                }
                 0xE2600000 | (rn_bits << 16) | (rd_bits << 12) | (*imm & 0xFF)
             }
 
@@ -3206,11 +3217,21 @@ impl ArmEncoder {
             ArmOp::Rsb { rd, rn, imm } => {
                 let rd_bits = reg_to_bits(rd);
                 let rn_bits = reg_to_bits(rn);
-                let imm_val = *imm;
 
-                let i_bit = (imm_val >> 11) & 1;
-                let imm3 = (imm_val >> 8) & 0x7;
-                let imm8 = imm_val & 0xFF;
+                // #681 class audit: the T2 `i:imm3:imm8` field is a
+                // ThumbExpandImm modified immediate and RSB has NO plain-imm12
+                // (T4-style) form — packing a raw value > 0xFF silently encodes
+                // a different constant (#253/#255 class). All current emitters
+                // use imm 32 (shift complement), which expands to itself, so
+                // this gate is byte-identical for existing codegen.
+                let field = try_thumb_expand_imm(*imm).ok_or_else(|| {
+                    synth_core::Error::synthesis(
+                        "RSB immediate is not a valid ThumbExpandImm — materialize into a register",
+                    )
+                })?;
+                let i_bit = (field >> 11) & 1;
+                let imm3 = (field >> 8) & 0x7;
+                let imm8 = field & 0xFF;
 
                 // hw1: 11110 i 01110 0 Rn  (S=0)
                 let hw1: u16 = (0xF1C0 | (i_bit << 10) | rn_bits) as u16;
@@ -7768,22 +7789,21 @@ impl ArmEncoder {
         let rd_bits = reg_to_bits(rd);
         let rn_bits = reg_to_bits(rn);
 
-        // For small immediates, use ADD.W Rd, Rn, #imm12
-        // Encoding: 1111 0 i 0 1 0 0 0 S Rn | 0 imm3 Rd imm8
-        // S = 0 (don't update flags)
-        // The 12-bit immediate is encoded as: i:imm3:imm8
-        // For simplicity, we only support imm <= 0xFFF (direct encoding)
+        // In-range immediates (<= 0xFFF) delegate to `encode_thumb32_add`,
+        // which picks the correct form per value:
+        //   - imm <= 0xFF  -> ADD.W (T3). Its `i:imm3:imm8` field is a
+        //     ThumbExpandImm MODIFIED immediate — raw == expanded only here.
+        //   - 0x100..=0xFFF -> ADDW (T4, 0xF200): a PLAIN 12-bit immediate.
+        //
+        // #681: this function used to pack the raw value into the T3 field for
+        // ALL imm <= 0xFFF. ThumbExpandImm(0x200) = 0 and ThumbExpandImm(0x400)
+        // = 0x8000_0000, so every dynamic-address load/store with a static
+        // offset in 0x100..=0xFFF silently computed a WRONG address — and in
+        // --safety-bounds software the guard checked the intended address while
+        // the access used the mis-encoded one (bounds bypass). Same
+        // ThumbExpandImm raw-packing class as #253/#255, reached via #382.
         if imm <= 0xFFF {
-            let i_bit = (imm >> 11) & 1;
-            let imm3 = (imm >> 8) & 0x7;
-            let imm8 = imm & 0xFF;
-
-            let hw1: u16 = (0xF100 | (i_bit << 10) | rn_bits) as u16;
-            let hw2: u16 = ((imm3 << 12) | (rd_bits << 8) | imm8) as u16;
-
-            let mut bytes = hw1.to_le_bytes().to_vec();
-            bytes.extend_from_slice(&hw2.to_le_bytes());
-            Ok(bytes)
+            self.encode_thumb32_add(rd, rn, imm)
         } else {
             // Out-of-range immediate (> 0xFFF): materialize it into a scratch
             // register, then ADD.W Rd, Rn, scratch. This is the #180/#185
@@ -7916,11 +7936,20 @@ impl ArmEncoder {
     /// Encode Thumb-2 32-bit AND with immediate - raw version
     fn encode_thumb32_and_imm_raw(&self, rd: u32, rn: u32, imm: u32) -> Result<Vec<u8>> {
         // AND.W Rd, Rn, #<modified_immediate>
-        // For small immediates (0-255), the encoding is simpler
         // F0 00 Rn | 0 imm3 Rd imm8
-        let i_bit = (imm >> 11) & 1;
-        let imm3 = (imm >> 8) & 0x7;
-        let imm8 = imm & 0xFF;
+        //
+        // #681 class audit: the field is a ThumbExpandImm modified immediate,
+        // not a raw value. The only current caller (POPCNT final mask) passes
+        // 0x3F, which expands to itself — the gate is byte-identical today and
+        // closes the raw-packing landmine for any future caller.
+        let field = try_thumb_expand_imm(imm).ok_or_else(|| {
+            synth_core::Error::synthesis(
+                "AND immediate is not a valid ThumbExpandImm — materialize into a register",
+            )
+        })?;
+        let i_bit = (field >> 11) & 1;
+        let imm3 = (field >> 8) & 0x7;
+        let imm8 = field & 0xFF;
 
         let hw1: u16 = (0xF000 | (i_bit << 10) | rn) as u16;
         let hw2: u16 = ((imm3 << 12) | (rd << 8) | imm8) as u16;
@@ -9496,11 +9525,15 @@ mod tests {
     fn test_encode_add_imm_large_350() {
         let enc = ArmEncoder::new_thumb2();
 
-        // --- Fast path unchanged: imm <= 0xFFF is a single 4-byte ADD.W ---
+        // --- Fast path: imm <= 0xFFF is a single 4-byte instruction, and the
+        // VALUE must be right (#681: this test used to assert only the length,
+        // letting the raw-packed T3 mis-encoding of 0x123 pass CI). 0x123 is
+        // not ThumbExpandImm-representable, so it must be ADDW (T4, plain
+        // imm12): clang `addw r0, r1, #0x123` = f201 0023.
         let small = enc
             .encode_thumb32_add_imm(&Reg::R0, &Reg::R1, 0x123)
             .unwrap();
-        assert_eq!(small.len(), 4, "small imm must stay a single instruction");
+        assert_eq!(small, vec![0x01, 0xF2, 0x23, 0x10], "ADDW r0, r1, #0x123");
 
         // helper: decode a Thumb-2 MOVW/MOVT halfword pair back to its imm16
         fn movx_imm16(b: &[u8]) -> u32 {
@@ -9566,6 +9599,125 @@ mod tests {
         let ip_add2 = u16::from_le_bytes([inplace[10], inplace[11]]) as u32;
         assert_eq!(ip_add2 & 0xF, 12);
         assert_eq!((ip_add2 >> 8) & 0xF, 5);
+    }
+
+    /// #681 — `encode_thumb32_add_imm` packed a RAW immediate into the T3
+    /// ADD.W `i:imm3:imm8` field, which is a ThumbExpandImm MODIFIED immediate:
+    /// ThumbExpandImm(0x200) = 0, ThumbExpandImm(0x400) = 0x8000_0000. Every
+    /// dynamic-address load/store with a static offset in 0x100..=0xFFF
+    /// computed a wrong address (and bypassed --safety-bounds software: the
+    /// guard checked the intended address, the access used the mis-encoded
+    /// one). Fix: imm <= 0xFF keeps T3 (raw == expanded there, bit-identical);
+    /// 0x100..=0xFFF uses ADDW (T4, plain imm12) — same lowering
+    /// `encode_thumb32_add` already uses per #253.
+    ///
+    /// Every expected byte sequence below is pinned against clang
+    /// (`-target thumbv7m-none-eabi`) output, bit-for-bit (#544 pattern).
+    #[test]
+    fn test_encode_add_imm_thumb_expand_681() {
+        let enc = ArmEncoder::new_thumb2();
+        let add = |rd: &Reg, rn: &Reg, imm: u32| enc.encode_thumb32_add_imm(rd, rn, imm).unwrap();
+
+        // imm <= 0xFF stays T3 ADD.W (raw == ThumbExpandImm-expanded):
+        // clang: add.w r12, r0, #0xff  = f100 0cff
+        assert_eq!(add(&Reg::R12, &Reg::R0, 0xFF), vec![0x00, 0xF1, 0xFF, 0x0C]);
+
+        // 0x100..=0xFFF must be ADDW (T4, plain imm12). The old T3 raw packing
+        // decoded as +0 (0x100/0x200), +0x80000000 (0x400), etc.
+        // clang: addw r12, r0, #0x100 = f200 1c00
+        assert_eq!(
+            add(&Reg::R12, &Reg::R0, 0x100),
+            vec![0x00, 0xF2, 0x00, 0x1C]
+        );
+        // clang: addw r12, r0, #0x104 = f200 1c04
+        assert_eq!(
+            add(&Reg::R12, &Reg::R0, 0x104),
+            vec![0x00, 0xF2, 0x04, 0x1C]
+        );
+        // clang: addw r12, r0, #0x200 = f200 2c00
+        assert_eq!(
+            add(&Reg::R12, &Reg::R0, 0x200),
+            vec![0x00, 0xF2, 0x00, 0x2C]
+        );
+        // clang: addw r12, r0, #0x3fc = f200 3cfc
+        assert_eq!(
+            add(&Reg::R12, &Reg::R0, 0x3FC),
+            vec![0x00, 0xF2, 0xFC, 0x3C]
+        );
+        // clang: addw r12, r0, #0x400 = f200 4c00
+        assert_eq!(
+            add(&Reg::R12, &Reg::R0, 0x400),
+            vec![0x00, 0xF2, 0x00, 0x4C]
+        );
+        // clang: addw r12, r0, #0xfff = f600 7cff
+        assert_eq!(
+            add(&Reg::R12, &Reg::R0, 0xFFF),
+            vec![0x00, 0xF6, 0xFF, 0x7C]
+        );
+        // Non-scratch rd/rn — clang: addw r1, r2, #0x104 = f202 1104
+        assert_eq!(add(&Reg::R1, &Reg::R2, 0x104), vec![0x02, 0xF2, 0x04, 0x11]);
+    }
+
+    /// #681 class audit — the T2 RSB and AND.W immediate fields are also
+    /// ThumbExpandImm-coded and were raw-packed. Neither has a plain-imm12
+    /// (T4-style) form, so a non-representable immediate must Err loudly
+    /// (#253/#255/#378 class: never silently encode a different constant).
+    /// Existing emitters only use representable values (RSB #32, AND #0x3F),
+    /// pinned here bit-for-bit against clang.
+    #[test]
+    fn test_rsb_and_imm_thumb_expand_gate_681() {
+        let enc = ArmEncoder::new_thumb2();
+
+        // clang: rsb.w r3, r2, #0x20 = f1c2 0320 — byte-identical to before.
+        let rsb = enc
+            .encode(&ArmOp::Rsb {
+                rd: Reg::R3,
+                rn: Reg::R2,
+                imm: 32,
+            })
+            .unwrap();
+        assert_eq!(rsb, vec![0xC2, 0xF1, 0x20, 0x03]);
+
+        // 0x101 is not ThumbExpandImm-representable -> must Err, not mis-encode.
+        assert!(
+            enc.encode(&ArmOp::Rsb {
+                rd: Reg::R3,
+                rn: Reg::R2,
+                imm: 0x101,
+            })
+            .is_err(),
+            "non-ThumbExpandImm RSB immediate must Err"
+        );
+
+        // clang: and r4, r4, #0x3f = f004 043f — byte-identical to before.
+        let and = enc.encode_thumb32_and_imm_raw(4, 4, 0x3F).unwrap();
+        assert_eq!(and, vec![0x04, 0xF0, 0x3F, 0x04]);
+        assert!(
+            enc.encode_thumb32_and_imm_raw(4, 4, 0x101).is_err(),
+            "non-ThumbExpandImm AND immediate must Err"
+        );
+
+        // A32 RSB: imm12 is a rotate:imm8 modified immediate; > 0xFF used to be
+        // silently masked to `imm & 0xFF` (#378 masking class) -> must Err.
+        let a32 = ArmEncoder::new_arm32();
+        assert!(
+            a32.encode(&ArmOp::Rsb {
+                rd: Reg::R3,
+                rn: Reg::R2,
+                imm: 0x120,
+            })
+            .is_err(),
+            "A32 RSB immediate > 0xFF must Err, not mask"
+        );
+        // imm 32 (the only value real codegen emits) still encodes.
+        assert!(
+            a32.encode(&ArmOp::Rsb {
+                rd: Reg::R3,
+                rn: Reg::R2,
+                imm: 32,
+            })
+            .is_ok()
+        );
     }
 
     /// #350 follow-up — the `encoder_no_panic` fuzz harness drives the encoder

--- a/scripts/repro/addw_offset_681.wat
+++ b/scripts/repro/addw_offset_681.wat
@@ -1,0 +1,63 @@
+;; #681 — dynamic-address load/store with static offset 0x100..=0xFFF.
+;;
+;; `encode_thumb32_add_imm` packed the RAW offset into the T3 ADD.W
+;; ThumbExpandImm field. That field is a MODIFIED immediate, correct only for
+;; imm <= 0xFF: ThumbExpandImm(0x100) = 0, ThumbExpandImm(0x200) = 0,
+;; ThumbExpandImm(0x400) = 0x8000_0000. Every dynamic-base access with a
+;; static offset in [256, 4095] silently computed a WRONG address — and in
+;; --safety-bounds software the guard (correct T4 ADDW) checked the intended
+;; address while the access used the mis-encoded one (bounds bypass).
+;;
+;; Differential: scripts/repro/addw_offset_681_differential.py (wasmtime is
+;; ground truth; unicorn runs synth's Thumb-2 with R11 = linear-memory base).
+(module
+  (memory (export "mem") 1)
+
+  ;; Store distinct sentinels at base+{0,256,512,1020,1024,4092}, read them
+  ;; all back and sum. Pre-fix, the 256/512/1024 stores land at base+0
+  ;; (clobbering each other) and the 1024 access faults 2 GiB past the base.
+  (func (export "probe") (param i32) (result i32)
+    local.get 0 i32.const 111 i32.store
+    local.get 0 i32.const 0x1111 i32.store offset=256
+    local.get 0 i32.const 0x2222 i32.store offset=512
+    local.get 0 i32.const 0x3333 i32.store offset=1020
+    local.get 0 i32.const 0x4444 i32.store offset=1024
+    local.get 0 i32.const 0x5555 i32.store offset=4092
+    local.get 0 i32.load
+    local.get 0 i32.load offset=256
+    i32.add
+    local.get 0 i32.load offset=512
+    i32.add
+    local.get 0 i32.load offset=1020
+    i32.add
+    local.get 0 i32.load offset=1024
+    i32.add
+    local.get 0 i32.load offset=4092
+    i32.add)
+
+  ;; gale's exact #681 repro: the offset=512 store must not clobber base+0.
+  ;; Pre-fix returns 4660; correct result is 111.
+  (func (export "clobber") (param i32) (result i32)
+    local.get 0 i32.const 111 i32.store
+    local.get 0 i32.const 4660 i32.store offset=512
+    local.get 0 i32.load)
+
+  ;; Sub-word paths (i8/i16) with big static offsets — same helper, scalar
+  ;; sub-word arms.
+  (func (export "subword") (param i32) (result i32)
+    local.get 0 i32.const 0xAB i32.store8 offset=257
+    local.get 0 i32.const 0xBEEF i32.store16 offset=770
+    local.get 0 i32.load8_u offset=257
+    local.get 0 i32.load16_u offset=770
+    i32.add)
+
+  ;; i64 path (i64_effective_base): store/load a 64-bit value at base+768.
+  (func (export "wide") (param i32) (result i32)
+    local.get 0 i64.const 0x1122334455667788 i64.store offset=768
+    local.get 0 i64.load offset=768
+    i32.wrap_i64
+    local.get 0 i64.load offset=768
+    i64.const 32
+    i64.shr_u
+    i32.wrap_i64
+    i32.add))

--- a/scripts/repro/addw_offset_681_differential.py
+++ b/scripts/repro/addw_offset_681_differential.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""#681 — T3 ADD.W raw-immediate packing: dynamic base + static offset 0x100..0xFFF.
+
+`encode_thumb32_add_imm` packed the raw offset into the T3 ADD.W ThumbExpandImm
+field (a MODIFIED immediate, correct only for imm <= 0xFF). Dynamic-address
+load/store with a static offset in [256, 4095] silently accessed the wrong
+address: ThumbExpandImm(0x100)=0, ThumbExpandImm(0x200)=0,
+ThumbExpandImm(0x400)=0x8000_0000. Fix: ADDW (T4, plain imm12) for
+0x100..=0xFFF — the lowering `encode_thumb32_add` already used per #253.
+
+Cases (wasmtime ground truth, unicorn Thumb-2 with R11 = linmem base,
+R10 = mem size in bytes):
+
+  probe(base)   — store+load-back at offsets {0,256,512,1020,1024,4092}
+                  RED pre-fix: 256/512/1024 stores land at base+0; the
+                  offset-1024 access faults 2 GiB past the base (UC_ERR).
+  clobber(base) — gale's exact repro: offset=512 store must not clobber
+                  base+0 (pre-fix returns 4660, correct 111).
+  subword(base) — i8/i16 store+load at offsets 257/770 (scalar sub-word arms).
+  wide(base)    — i64 store+load at offset 768 (i64_effective_base path).
+
+Variants: --safety-bounds none and software, both --relocatable (the direct
+selector emits reg-offset Ldr/Str with a static offset — the #382 paths that
+call encode_thumb32_add_imm). The software variant is the BOUNDS-BYPASS pin:
+pre-fix the guard (correct T4 ADDW) checks the intended address while the
+access uses the mis-encoded one, so an in-bounds base passes the check yet the
+access escapes the checked region. An OOB base must trap in BOTH wasmtime and
+synth (guard UDF) — trap-to-trap counts as a match.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/addw_offset_681_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R10,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("addw_offset_681.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+
+CODE = 0x1000
+LIN = 0x200000  # linear memory base (R11)
+MEM_BYTES = 0x10000  # 1 wasm page
+STK = 0x3F000
+RET = 0x30000
+
+FUNCS = ["probe", "clobber", "subword", "wide"]
+# In-bounds bases (max static offset is 4092+4 -> base <= 0xEF00 is safe).
+BASES = [0, 4, 256, 0x1000, 0x8000, 0xEF00]
+# OOB base: 0xFC00 + 4092 + 4 > 0x10000 -> wasmtime traps; synth software
+# mode must UDF (trap-to-trap match). Only meaningful for `probe`.
+OOB_BASES = [0xFC00]
+
+VARIANTS = [
+    ("none", ["-t", "cortex-m3", "--relocatable", "--safety-bounds", "none"]),
+    ("software", ["-t", "cortex-m3", "--relocatable", "--safety-bounds", "software"]),
+]
+
+TRAP = "TRAP"
+
+
+def compile_elf(out, extra):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, *extra, "--all-exports"],
+        capture_output=True,
+        text=True,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({extra}): {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"] - base
+    return code, syms
+
+
+def wasm_expected(func, base):
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    try:
+        return inst.exports(st)[func](st, base) & 0xFFFFFFFF
+    except wasmtime.Trap:
+        return TRAP
+
+
+def run_arm(code, off, base):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(0, 0x40000)
+    mu.mem_map(LIN, MEM_BYTES)
+    mu.mem_write(CODE, code)
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+    mu.reg_write(UC_ARM_REG_R0, base & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_R11, LIN)
+    mu.reg_write(UC_ARM_REG_R10, MEM_BYTES)
+    mu.reg_write(UC_ARM_REG_SP, STK)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    try:
+        mu.emu_start((CODE + off) | 1, RET, timeout=5_000_000, count=100_000)
+    except UcError as e:
+        # A UDF-triggered stop is the software-mode bounds trap; any other
+        # fault (e.g. unmapped 2 GiB-away access) is a miscompile signal.
+        # Unicorn reports both as UcError — disambiguate via PC: inside the
+        # code region == deliberate trap instruction reached.
+        return f"UC_ERR:{e}"
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def main():
+    fails = 0
+    for vname, extra in VARIANTS:
+        with tempfile.NamedTemporaryFile(suffix=".o") as tf:
+            compile_elf(tf.name, extra)
+            code, syms = load(tf.name)
+            cases = [(f, b) for f in FUNCS for b in BASES]
+            if vname == "software":
+                cases += [("probe", b) for b in OOB_BASES]
+            for func, base in cases:
+                want = wasm_expected(func, base)
+                if func not in syms:
+                    print(f"[{vname}] SYMBOL MISSING: {func}")
+                    fails += 1
+                    continue
+                got = run_arm(code, syms[func], base)
+                if want == TRAP:
+                    # trap-to-trap: synth's software guard hits UDF -> UcError
+                    ok = isinstance(got, str) and got.startswith("UC_ERR")
+                else:
+                    ok = got == want
+                fails += 0 if ok else 1
+                mark = "ok  " if ok else "FAIL"
+                gs = f"{got:#010x}" if isinstance(got, int) else got
+                ws = f"{want:#010x}" if isinstance(want, int) else want
+                print(f"[{vname}] {mark} {func}(base={base:#07x}): synth={gs} wasmtime={ws}")
+    if fails:
+        sys.exit(f"\n#681 differential: {fails} mismatches")
+    print("\n#681 differential: all green (T4 ADDW static offsets, bounds honored)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #681.

## Bug

`encode_thumb32_add_imm` packed a **raw** immediate into the T3 `ADD.W` `i:imm3:imm8` field. That field is a **ThumbExpandImm modified immediate** (raw == expanded only for `imm <= 0xFF`): `ThumbExpandImm(0x200) = 0`, `ThumbExpandImm(0x400) = 0x8000_0000`. Every dynamic-address `i32/i64/i8/i16` load/store with a static `offset ∈ [0x100, 0xFFF]` silently accessed the **wrong address** — and in `--safety-bounds software` the guard (correct T4 `ADDW`) checked the *intended* address while the access used the *mis-encoded* one: a bounds-check bypass. Exact #253/#255 ThumbExpandImm class, in a helper #255's audit didn't cover, reached via the #382 paths.

## Fix

`imm <= 0xFFF` now delegates to `encode_thumb32_add`, which already implements the correct split per #253:
- `imm <= 0xFF` → T3 `ADD.W` (raw == expanded — **bit-identical** to before)
- `0x100..=0xFFF` → **ADDW (T4, `0xF200`, plain imm12)**
- `> 0xFFF` → unchanged MOVW/MOVT + ADD.W-register path (#350)

Byte **sizes are unchanged** everywhere, so the #511 estimator↔encoder agreement oracle stays green as-is.

## Class audit (no wildcard survives)

| Site | Finding | Action |
|---|---|---|
| `encode_thumb32_add_imm` | the #681 bug | T3/T4 split via `encode_thumb32_add` |
| `ArmOp::Rsb` (Thumb T2) | raw-packed ThumbExpandImm field; **no** plain-imm12 form exists | gated on `try_thumb_expand_imm`, `Err` on non-representable. All emitters use `#32` → byte-identical |
| `ArmOp::Rsb` (A32) | `*imm & 0xFF` silent masking (#378 class) | `Err` for `imm > 0xFF` |
| `encode_thumb32_and_imm_raw` | raw-packed ThumbExpandImm field | gated; only caller (POPCNT `#0x3F`) byte-identical |
| `encode_thumb32_sub` / `adds` / `subs` / `cmp` / orr / eor / cmn | already T4-split or expand-gated (#253/#255) | pinned, no change |

## Oracles

- **Clang cross-check (#544 pattern)**: `test_encode_add_imm_thumb_expand_681` pins `0xFF / 0x100 / 0x104 / 0x200 / 0x3FC / 0x400 / 0xFFF` (+ a non-scratch rd/rn permutation) **bit-for-bit** against `clang -target thumbv7m-none-eabi`. `test_encode_add_imm_large_350`'s `0x123` assertion upgraded from length-only (which let the mis-encoding pass CI, as the issue notes) to exact ADDW bytes.
- **Red→green differential** (`scripts/repro/addw_offset_681_differential.py`, unicorn-vs-wasmtime, symtab-based per #489): dynamic base + static offsets `{256,512,1020,1024,4092}` over i32/i8/i16/i64 load+store, `--safety-bounds none` and `software` — including the **bypass pin** (in-bounds base, guard passes, pre-fix access escapes 2 GiB past base) and OOB **trap-to-trap**.
  - **RED on pre-fix main**: 36/49 mismatches (gale's `clobber` returns 4660 instead of 111; offset-1024 access faults `UC_ERR_WRITE_UNMAPPED` 2 GiB away)
  - **GREEN on this branch**: 49/49; the OOB software case now stops at the guard's UDF
  - CI-wired into the trap-semantics oracle job next to #682.
- **Frozen anchors**: `frozen_codegen_bytes` 10/10, `.text` bit-identical (fixtures never hit the dynamic-base + big-offset shape).
- **Estimator agreement (#511)**: green, no size deltas.
- Workspace tests green, `cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)