### PR TITLE
fix(bulk-memory): #677 operand clobber + #679 silent-unmasked mask — copy/fill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,10 @@ jobs:
       # elision never fires unsoundly (red-tested at land time).
       - name: Run i32 shift-mask oracle with mask elision ON (#686)
         run: SYNTH_SHIFT_MASK_ELIDE=1 SYNTH=./target/debug/synth python scripts/repro/i32_shift_mask_682_differential.py
+      - name: Run bulk-memory operand-clobber oracle (#677, thumb2)
+        run: SYNTH=./target/debug/synth python scripts/repro/bulk_local_clobber_677_differential.py
+      - name: Run bulk-memory mask-coverage oracle (#679, thumb2)
+        run: SYNTH=./target/debug/synth python scripts/repro/bulk_mask_679_differential.py
 
   fact-spec-oracle:
     name: fact-spec elision oracle (#494 phases 2 + 2b)

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -983,6 +983,58 @@ fn peek_operand(
     }
 }
 
+/// #677: return a register the bulk-memory lowerings may MUTATE in place.
+///
+/// `memory.copy`/`memory.fill` reuse their popped operand registers as the
+/// walking loop pointers / byte buffer (and, under `--safety-bounds mask`,
+/// the clamped length). A popped register is NOT always a dead temp:
+/// `LocalGet` of a register-homed local (AAPCS param in r0-r3, promoted
+/// local in r4-r8) pushes the HOME register itself onto the vstack, so
+/// mutating it in place corrupts every later read of that local — a wild
+/// `mem_base + <loop cursor>` pointer for a dest/src, a wrong value for a
+/// len. The same register can also sit deeper on the remaining vstack
+/// (duplicate `local.get`), be reserved as an if/block result register
+/// (both folded into `live_params` by the op loop), or alias ANOTHER popped
+/// operand of the same op (`memory.fill (local.get 0) (local.get 0) ...`).
+///
+/// Mirror of the #193 reservation discipline: if the popped register is
+/// provably dead — none of the above — it is returned unchanged (byte-
+/// identical to pre-#677 code for the const/dead-temp shapes the #374
+/// differential pins). Otherwise the operand is copied into a fresh scratch
+/// (`MOV scratch, reg`) and the scratch returned; `reserve` (live params +
+/// every popped operand of the op + scratches chosen so far) keeps the
+/// allocator from handing back a register the op still needs, and is grown
+/// with the new scratch so later calls avoid it too.
+#[allow(clippy::too_many_arguments)]
+fn bulk_mutable_operand(
+    reg: Reg,
+    other_operands: &[Reg],
+    live_params: &[Reg],
+    stack: &mut [StackVal],
+    next_temp: &mut u8,
+    instructions: &mut Vec<ArmInstruction>,
+    spill: &mut SpillState,
+    reserve: &mut Vec<Reg>,
+    line: usize,
+) -> Result<Reg> {
+    let live_after = live_params.contains(&reg)
+        || other_operands.contains(&reg)
+        || stack_live_regs(stack).contains(&reg);
+    if !live_after {
+        return Ok(reg);
+    }
+    let scratch = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserve, line)?;
+    reserve.push(scratch);
+    instructions.push(ArmInstruction {
+        op: ArmOp::Mov {
+            rd: scratch,
+            op2: Operand2::Reg(reg),
+        },
+        source_line: Some(line),
+    });
+    Ok(scratch)
+}
+
 /// Allocate a CONSECUTIVE pair `(rN, rN+1)` of registers from ALLOCATABLE_REGS,
 /// neither of which is currently in use.
 ///
@@ -11878,19 +11930,30 @@ impl InstructionSelector {
                 }
 
                 // Bulk memory (#374): memory.fill / memory.copy. Both pop three
-                // i32 operands (dst, val/src, len) and push nothing, so all three
-                // popped registers are DEAD after the op — we reuse them as walking
-                // pointers and the byte buffer, needing only R12 as extra scratch
-                // (no temp allocation). Lowered to a bounds-checked byte loop:
-                //   - bounds (Software mode only, mirroring the store helper): trap
+                // i32 operands (dst, val/src, len) and push nothing. The lowering
+                // reuses (mutates) operand registers as walking pointers / byte
+                // buffer, so any popped register still live past the op — a
+                // register-homed local's HOME register, a duplicate vstack entry,
+                // or an alias of another operand — is first copied into a fresh
+                // scratch via `bulk_mutable_operand` (#677); a provably-dead temp
+                // is used in place (byte-identical to pre-#677 code). Lowered to a
+                // bounds-checked byte loop:
+                //   - bounds (Software mode, mirroring the store helper): trap
                 //     iff `off + len` overflows u32 OR `off + len > size` (R10, in
                 //     bytes). End-EXCLUSIVE, so a zero-length op at `off == size`
                 //     and an access ending exactly at `size` do NOT trap (matches
                 //     wasmtime). Trap target is the established "Trap_Handler".
+                //   - Masking (#679): the same wrap-not-trap discipline as the
+                //     scalar `mask_effective_address` — fold dst (and src) into
+                //     `[0, size)` with `AND (size-1)`, then clamp len to
+                //     `size - dst` (and `size - src`) so the FINAL byte stays in
+                //     bounds; every loop access lands in `[0, size)` and an
+                //     in-bounds op is untouched. Pre-#679 Masking emitted the
+                //     raw loop, byte-identical to None, while the safety
+                //     manifest still attested `mask`.
                 //   - addresses are R11-relative (R11 = linear-memory base);
                 //     R10 = size in bytes.
-                // None/Mpu/Masking emit just the loop (Masking does NOT wrap each
-                // byte address — a documented gap; Software is the safe default).
+                // None/Mpu emit just the loop (MPU faults in hardware).
                 MemoryFill => {
                     let len = pop_operand(
                         &mut stack,
@@ -11919,7 +11982,71 @@ impl InstructionSelector {
                     let loop_label = self.alloc_label("memfill_loop");
                     let done_label = self.alloc_label("memfill_done");
                     let software = matches!(self.bounds_check, BoundsCheckConfig::Software);
+                    let masking = matches!(self.bounds_check, BoundsCheckConfig::Masking);
+                    // #677: the loop mutates `dst` in place (walking pointer) and,
+                    // under Masking, the clamp mutates `len`; copy either into a
+                    // scratch first when it is still live past this op. `val` and
+                    // (non-mask) `len` are only ever read — no copy needed.
+                    let mut reserve: Vec<Reg> = live_params.clone();
+                    reserve.extend([len, val, dst]);
+                    let dst = bulk_mutable_operand(
+                        dst,
+                        &[val, len],
+                        &live_params,
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &mut reserve,
+                        idx,
+                    )?;
+                    let len = if masking {
+                        bulk_mutable_operand(
+                            len,
+                            &[val, dst],
+                            &live_params,
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            &mut reserve,
+                            idx,
+                        )?
+                    } else {
+                        len
+                    };
                     let mut ops: Vec<ArmOp> = Vec::new();
+                    if masking {
+                        // #679: dst &= (size-1); len = min(len, size - dst).
+                        // After this, dst ∈ [0, size) and dst+len <= size, so
+                        // every byte the loop writes is in bounds; an op that was
+                        // already wasm-in-bounds is unchanged (dst < size keeps
+                        // AND a no-op; len <= size-dst keeps the clamp a no-op).
+                        ops.push(ArmOp::Sub {
+                            rd: Reg::R12,
+                            rn: Reg::R10,
+                            op2: Operand2::Imm(1),
+                        });
+                        ops.push(ArmOp::And {
+                            rd: dst,
+                            rn: dst,
+                            op2: Operand2::Reg(Reg::R12),
+                        });
+                        ops.push(ArmOp::Sub {
+                            rd: Reg::R12,
+                            rn: Reg::R10,
+                            op2: Operand2::Reg(dst),
+                        });
+                        ops.push(ArmOp::Cmp {
+                            rn: len,
+                            op2: Operand2::Reg(Reg::R12),
+                        });
+                        ops.push(ArmOp::SelectMove {
+                            rd: len,
+                            rm: Reg::R12,
+                            cond: Condition::HI,
+                        });
+                    }
                     // R12 = dst + len (wasm offset of one-past-end); ADDS sets carry
                     // on u32 overflow.
                     ops.push(ArmOp::Adds {
@@ -12035,7 +12162,89 @@ impl InstructionSelector {
                     let bwd_loop = self.alloc_label("memcpy_bwd_loop");
                     let done_label = self.alloc_label("memcpy_done");
                     let software = matches!(self.bounds_check, BoundsCheckConfig::Software);
+                    let masking = matches!(self.bounds_check, BoundsCheckConfig::Masking);
+                    // #677: the copy mutates ALL THREE operand registers in place
+                    // (dst/src walking pointers, len as the byte buffer — and the
+                    // Masking clamp); copy each into a scratch first when it is
+                    // still live past this op.
+                    let mut reserve: Vec<Reg> = live_params.clone();
+                    reserve.extend([len, src, dst]);
+                    let dst = bulk_mutable_operand(
+                        dst,
+                        &[src, len],
+                        &live_params,
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &mut reserve,
+                        idx,
+                    )?;
+                    let src = bulk_mutable_operand(
+                        src,
+                        &[dst, len],
+                        &live_params,
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &mut reserve,
+                        idx,
+                    )?;
+                    let len = bulk_mutable_operand(
+                        len,
+                        &[dst, src],
+                        &live_params,
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &mut reserve,
+                        idx,
+                    )?;
                     let mut ops: Vec<ArmOp> = Vec::new();
+                    if masking {
+                        // #679: fold BOTH effective addresses into [0, size) and
+                        // clamp len so both ranges end within the bound:
+                        //   dst &= size-1; src &= size-1;
+                        //   len = min(len, size - dst, size - src)
+                        // Every byte the loop touches (read AND write) then lands
+                        // in [0, size); a wasm-in-bounds copy is unchanged. Same
+                        // wrap-not-trap discipline as `mask_effective_address`,
+                        // with the dynamic len taking the place of the static
+                        // access-size clamp (len bounds the FINAL byte).
+                        ops.push(ArmOp::Sub {
+                            rd: Reg::R12,
+                            rn: Reg::R10,
+                            op2: Operand2::Imm(1),
+                        });
+                        ops.push(ArmOp::And {
+                            rd: dst,
+                            rn: dst,
+                            op2: Operand2::Reg(Reg::R12),
+                        });
+                        ops.push(ArmOp::And {
+                            rd: src,
+                            rn: src,
+                            op2: Operand2::Reg(Reg::R12),
+                        });
+                        for range_base in [dst, src] {
+                            ops.push(ArmOp::Sub {
+                                rd: Reg::R12,
+                                rn: Reg::R10,
+                                op2: Operand2::Reg(range_base),
+                            });
+                            ops.push(ArmOp::Cmp {
+                                rn: len,
+                                op2: Operand2::Reg(Reg::R12),
+                            });
+                            ops.push(ArmOp::SelectMove {
+                                rd: len,
+                                rm: Reg::R12,
+                                cond: Condition::HI,
+                            });
+                        }
+                    }
                     if software {
                         // Both `dst+len` and `src+len` must be in bounds
                         // (end-exclusive; overflow or `> size` traps, `== size` is
@@ -18039,6 +18248,279 @@ mod tests {
         assert!(
             labels >= 2,
             "copy must emit forward+backward loop labels, got {labels}"
+        );
+    }
+
+    /// Destination register written by the ArmOps the bulk-memory lowering
+    /// emits (loop pointers, scratch movs, mask/clamp). `Strb`/`Cmp`/branches
+    /// define nothing.
+    fn bulk_def_reg(op: &ArmOp) -> Option<Reg> {
+        match op {
+            ArmOp::Mov { rd, .. }
+            | ArmOp::Add { rd, .. }
+            | ArmOp::Adds { rd, .. }
+            | ArmOp::Sub { rd, .. }
+            | ArmOp::And { rd, .. }
+            | ArmOp::Ldrb { rd, .. }
+            | ArmOp::SelectMove { rd, .. } => Some(*rd),
+            _ => None,
+        }
+    }
+
+    /// All registers written by instructions belonging to wasm op `line`.
+    fn defs_at_line(arm: &[ArmInstruction], line: usize) -> Vec<Reg> {
+        arm.iter()
+            .filter(|i| i.source_line == Some(line))
+            .filter_map(|i| bulk_def_reg(&i.op))
+            .collect()
+    }
+
+    #[test]
+    fn test_677_copy_preserves_live_dst_local_reg() {
+        // #677: `memory.copy` with a param-homed dst (R0) that is READ AFTER
+        // the op. Pre-fix the lowering mutated R0 in place as the walking
+        // pointer (`add r0, r11, r0; adds r0,#1; ...`), so the later
+        // `local.get 0` read a wild loop cursor. Post-fix the operand is
+        // copied into a scratch and R0 is never a destination of any
+        // copy-lowering instruction.
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        let wasm_ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::LocalGet(2),
+            WasmOp::MemoryCopy, // idx 3
+            WasmOp::LocalGet(0),
+            WasmOp::End,
+        ];
+        let arm = selector.select_with_stack(&wasm_ops, 3).unwrap();
+        let defs = defs_at_line(&arm, 3);
+        assert!(
+            !defs.contains(&Reg::R0),
+            "memory.copy must not mutate the still-live dst local's home \
+             register R0 (got defs {defs:?})"
+        );
+        // The scratch copy is the mechanism: at least one MOV off R0.
+        assert!(
+            arm.iter().any(|i| i.source_line == Some(3)
+                && matches!(
+                    &i.op,
+                    ArmOp::Mov {
+                        op2: Operand2::Reg(Reg::R0),
+                        ..
+                    }
+                )),
+            "expected a scratch copy MOV of the live dst operand"
+        );
+    }
+
+    #[test]
+    fn test_677_copy_preserves_live_len_local_reg() {
+        // #677 third reproducer: `len` (param-homed R2) reused after the copy.
+        // Pre-fix `len` was recycled as the byte buffer (`ldrb r2, [src]`),
+        // so the later `local.get 2` returned the last byte copied.
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        let wasm_ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::LocalGet(2),
+            WasmOp::MemoryCopy, // idx 3
+            WasmOp::LocalGet(2),
+            WasmOp::End,
+        ];
+        let arm = selector.select_with_stack(&wasm_ops, 3).unwrap();
+        let defs = defs_at_line(&arm, 3);
+        assert!(
+            !defs.contains(&Reg::R2),
+            "memory.copy must not mutate the still-live len local's home \
+             register R2 (got defs {defs:?})"
+        );
+    }
+
+    #[test]
+    fn test_677_fill_preserves_live_dst_local_reg() {
+        // #677 fill reproducer: dst local read back via i32.load8_u after
+        // the fill — its home register must survive the fill loop.
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        let wasm_ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::LocalGet(2),
+            WasmOp::MemoryFill, // idx 3
+            WasmOp::LocalGet(0),
+            WasmOp::End,
+        ];
+        let arm = selector.select_with_stack(&wasm_ops, 3).unwrap();
+        let defs = defs_at_line(&arm, 3);
+        assert!(
+            !defs.contains(&Reg::R0),
+            "memory.fill must not mutate the still-live dst local's home \
+             register R0 (got defs {defs:?})"
+        );
+    }
+
+    #[test]
+    fn test_677_fill_dst_aliasing_val_gets_scratch() {
+        // #677 aliasing corner: `memory.fill (local.get 0) (local.get 0) ...`
+        // pops the SAME register for dst and val. Mutating dst in place would
+        // change the fill byte mid-loop even though the local is never read
+        // again — the alias check must force the scratch copy.
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        let wasm_ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::MemoryFill, // idx 3
+            WasmOp::End,
+        ];
+        let arm = selector.select_with_stack(&wasm_ops, 2).unwrap();
+        let defs = defs_at_line(&arm, 3);
+        assert!(
+            !defs.contains(&Reg::R0),
+            "aliased dst/val operand register R0 must not be mutated \
+             (got defs {defs:?})"
+        );
+    }
+
+    #[test]
+    fn test_677_dead_const_operands_lower_without_copies() {
+        // Behavior preservation: const operands land in dead round-robin
+        // temps — provably dead, so NO scratch MOVs are inserted and the
+        // lowering stays byte-identical to pre-#677 code (the shape the #374
+        // differential and the frozen anchors pin).
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        let wasm_ops = vec![
+            WasmOp::I32Const(32),
+            WasmOp::I32Const(16),
+            WasmOp::I32Const(4),
+            WasmOp::MemoryCopy, // idx 3
+            WasmOp::End,
+        ];
+        let arm = selector.select_with_stack(&wasm_ops, 0).unwrap();
+        let movs = arm
+            .iter()
+            .filter(|i| {
+                i.source_line == Some(3)
+                    && matches!(
+                        &i.op,
+                        ArmOp::Mov {
+                            op2: Operand2::Reg(_),
+                            ..
+                        }
+                    )
+            })
+            .count();
+        assert_eq!(
+            movs, 0,
+            "dead const operands must not grow scratch copies (#374 shape)"
+        );
+    }
+
+    #[test]
+    fn test_679_fill_mask_emits_fold_and_clamp() {
+        // #679: under `--safety-bounds mask`, memory.fill must fold dst with
+        // AND (size-1) and clamp len with CMP + IT-HI SelectMove — pre-fix it
+        // emitted the raw loop, byte-identical to `none`.
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        selector.set_bounds_check(BoundsCheckConfig::Masking);
+        let wasm_ops = vec![
+            WasmOp::I32Const(32),
+            WasmOp::I32Const(0xAB),
+            WasmOp::I32Const(4),
+            WasmOp::MemoryFill, // idx 3
+            WasmOp::End,
+        ];
+        let arm = selector.select_with_stack(&wasm_ops, 0).unwrap();
+        let at3: Vec<&ArmOp> = arm
+            .iter()
+            .filter(|i| i.source_line == Some(3))
+            .map(|i| &i.op)
+            .collect();
+        assert!(
+            at3.iter().any(|op| matches!(op, ArmOp::And { .. })),
+            "mask profile must fold the fill dst with AND (size-1)"
+        );
+        assert!(
+            at3.iter().any(|op| matches!(
+                op,
+                ArmOp::SelectMove {
+                    cond: Condition::HI,
+                    ..
+                }
+            )),
+            "mask profile must clamp the fill len (CMP + IT-HI move)"
+        );
+    }
+
+    #[test]
+    fn test_679_copy_mask_folds_both_addresses_and_clamps_len() {
+        // #679: memory.copy under mask must fold BOTH effective addresses
+        // (dst AND src) and clamp len against BOTH ranges.
+        let db = RuleDatabase::new();
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        selector.set_bounds_check(BoundsCheckConfig::Masking);
+        let wasm_ops = vec![
+            WasmOp::I32Const(32),
+            WasmOp::I32Const(16),
+            WasmOp::I32Const(4),
+            WasmOp::MemoryCopy, // idx 3
+            WasmOp::End,
+        ];
+        let arm = selector.select_with_stack(&wasm_ops, 0).unwrap();
+        let ands = arm
+            .iter()
+            .filter(|i| i.source_line == Some(3) && matches!(&i.op, ArmOp::And { .. }))
+            .count();
+        let clamps = arm
+            .iter()
+            .filter(|i| {
+                i.source_line == Some(3)
+                    && matches!(
+                        &i.op,
+                        ArmOp::SelectMove {
+                            cond: Condition::HI,
+                            ..
+                        }
+                    )
+            })
+            .count();
+        assert_eq!(ands, 2, "copy under mask must AND-fold dst AND src");
+        assert_eq!(clamps, 2, "copy under mask must clamp len for both ranges");
+    }
+
+    #[test]
+    fn test_679_mask_lowering_differs_from_none() {
+        // #679 attestation integrity: `mask` must NEVER lower bulk memory
+        // identically to `none` (that was the silent no-op the safety
+        // manifest still attested as `mask`). Structural inequality here;
+        // the ELF-level byte-diff proof lives in
+        // scripts/repro/bulk_mask_679_differential.py.
+        let wasm_ops = vec![
+            WasmOp::I32Const(32),
+            WasmOp::I32Const(16),
+            WasmOp::I32Const(4),
+            WasmOp::MemoryCopy,
+            WasmOp::End,
+        ];
+        let db = RuleDatabase::new();
+        let mut masked = InstructionSelector::new(db.rules().to_vec());
+        masked.set_bounds_check(BoundsCheckConfig::Masking);
+        let masked_arm = masked.select_with_stack(&wasm_ops, 0).unwrap();
+        let db = RuleDatabase::new();
+        let mut plain = InstructionSelector::new(db.rules().to_vec());
+        plain.set_bounds_check(BoundsCheckConfig::None);
+        let plain_arm = plain.select_with_stack(&wasm_ops, 0).unwrap();
+        let ops_of =
+            |v: &[ArmInstruction]| v.iter().map(|i| format!("{:?}", i.op)).collect::<Vec<_>>();
+        assert_ne!(
+            ops_of(&masked_arm),
+            ops_of(&plain_arm),
+            "mask bulk-memory lowering must differ from none"
         );
     }
 

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -3612,11 +3612,45 @@ fn try_reallocate_segment(
 
     // Colouring input: pool ranges only (reserved registers cannot collide
     // with pool colours, so their edges are irrelevant to the colouring).
-    let pool_adj: BTreeMap<usize, BTreeSet<usize>> = adj
+    let mut pool_adj: BTreeMap<usize, BTreeSet<usize>> = adj
         .iter()
         .filter(|(n, _)| pool_nodes.contains(n))
         .map(|(n, nbrs)| (*n, nbrs.intersection(&pool_nodes).copied().collect()))
         .collect();
+
+    // #677 (the #663 defect class): a pool register with NO range in this
+    // segment is not thereby FREE — it may be live-through (defined before the
+    // segment, read after it: a param home the segment never touches, a value
+    // live across a loop back-edge). Segment-local analysis cannot prove it
+    // dead, so introducing it as a rename target silently clobbers the live
+    // value — the memory.copy backward path recolored its walking-pointer
+    // intermediate onto R0, the still-live dst local (#677). Block every
+    // ABSENT pool colour with a synthetic pinned node that interferes with all
+    // real pool nodes. This never costs a recoloring the original bytes did
+    // not have: simultaneously-live ranges carry distinct ORIGINAL registers
+    // (a register holds one value at a time), all of which are present, so an
+    // identity-shaped colouring within the present registers always exists.
+    // Relaxed-exit terminal segments (VCR-VER-001 #580) keep their exemptions:
+    // past the `bx lr` only R0/R1 are observable, so only absent R0/R1 are
+    // blocked there — R2-R8/R12 stay introducible, preserving the push-shrink
+    // the post-exhaust pass exists for.
+    let present: BTreeSet<Reg> = ranges.iter().map(|r| r.reg).collect();
+    let mut next_blocker = ranges.len();
+    for (idx, reg) in pool.iter().enumerate() {
+        if present.contains(reg) {
+            continue;
+        }
+        if relaxed_exit && !matches!(reg, Reg::R0 | Reg::R1) {
+            continue;
+        }
+        let blocker = next_blocker;
+        next_blocker += 1;
+        pins.insert(blocker, idx);
+        for (_, nbrs) in pool_adj.iter_mut() {
+            nbrs.insert(blocker);
+        }
+        pool_adj.insert(blocker, pool_nodes.iter().copied().collect());
+    }
 
     // Spill cost: occurrence count per range (1 per def + 1 per use event),
     // replayed with the same numbering.

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -3646,7 +3646,7 @@ fn try_reallocate_segment(
         let blocker = next_blocker;
         next_blocker += 1;
         pins.insert(blocker, idx);
-        for (_, nbrs) in pool_adj.iter_mut() {
+        for nbrs in pool_adj.values_mut() {
             nbrs.insert(blocker);
         }
         pool_adj.insert(blocker, pool_nodes.iter().copied().collect());

--- a/scripts/repro/bulk_local_clobber_677.wat
+++ b/scripts/repro/bulk_local_clobber_677.wat
@@ -1,0 +1,37 @@
+(module
+  ;; #677 — memory.copy/memory.fill clobber a local dest/src/len operand that is
+  ;; reused AFTER the op (the lowering mutated the popped register in place as
+  ;; the loop pointer / byte buffer, with no scratch copy).
+  (memory 1)
+  (export "memory" (memory 0))
+
+  ;; dst is a local, read back after the copy (issue reproducer 1).
+  ;; wasmtime: i32.load([dst]) = the copied word. pre-fix synth: wild pointer.
+  (func (export "cpy_dst") (param i32 i32) (result i32)
+    (i32.store (i32.const 16) (i32.const 67305985))          ;; 0x04030201 at [16]
+    (memory.copy (local.get 0) (i32.const 16) (local.get 1))
+    (i32.load (local.get 0)))
+
+  ;; memory.fill, dst is a local read back after (issue reproducer 2).
+  (func (export "fil_dst") (param i32 i32) (result i32)
+    (memory.fill (local.get 0) (i32.const 66) (local.get 1))
+    (i32.load8_u (local.get 0)))
+
+  ;; len operand reused after the copy (issue reproducer 3).
+  ;; pre-fix synth returned the last byte copied (len recycled as byte buffer).
+  (func (export "cpy_len") (param i32 i32) (result i32)
+    (i32.store (i32.const 16) (i32.const 99))
+    (memory.copy (i32.const 32) (i32.const 16) (local.get 1))
+    (local.get 1))
+
+  ;; src operand reused after the copy.
+  (func (export "cpy_src") (param i32 i32) (result i32)
+    (i32.store (i32.const 16) (i32.const 168496141))         ;; 0x0A0B0C0D at [16]
+    (memory.copy (i32.const 64) (local.get 0) (local.get 1))
+    (local.get 0))
+
+  ;; control: const dest — unaffected pre-fix, isolates the local-operand bug.
+  (func (export "cpy_const") (param i32 i32) (result i32)
+    (i32.store (i32.const 16) (i32.const 67305985))
+    (memory.copy (i32.const 32) (i32.const 16) (local.get 1))
+    (i32.load (i32.const 32))))

--- a/scripts/repro/bulk_local_clobber_677_differential.py
+++ b/scripts/repro/bulk_local_clobber_677_differential.py
@@ -63,11 +63,13 @@ def load_text_and_syms(elf_path):
         text = ef.get_section_by_name(".text")
         code, base = text.data(), text["sh_addr"]
         syms = {}
-        symtab = ef.get_section_by_name(".symtab")
-        if symtab is not None:
-            for s in symtab.iter_symbols():
-                if s.name:
-                    syms[s.name] = s["st_value"]
+        # synth emits .symtab as an unnamed SHT_SYMTAB section, so match by
+        # TYPE not name (#489 pattern — get_section_by_name returns None here).
+        for sec in ef.iter_sections():
+            if sec.header.sh_type == "SHT_SYMTAB":
+                for s in sec.iter_symbols():
+                    if s.name:
+                        syms[s.name] = s["st_value"]
     if not syms:
         # Self-contained images carry no symtab — fall back to `synth disasm`
         # labels (same-arch decode, the established #374-harness pattern).

--- a/scripts/repro/bulk_local_clobber_677_differential.py
+++ b/scripts/repro/bulk_local_clobber_677_differential.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""#677 — bulk-memory operand-register clobber differential (thumb-2).
+
+The #374 memory.copy/memory.fill lowering mutated its popped operand registers
+in place (dst/src as walking loop pointers, len as the byte buffer). A popped
+register is NOT always a dead temp: `local.get` of a register-homed local
+(AAPCS param r0-r3, promoted local r4-r8) pushes the HOME register itself, so
+a local reused AFTER the op read a wild `mem_base + <loop cursor>` pointer (for
+a dest/src) or the last byte copied (for a len). Const operands were unaffected.
+The fix copies any still-live popped operand into a scratch register before the
+loop mutates it (#193 reservation discipline, `bulk_mutable_operand`).
+
+**wasmtime is ground truth**; **unicorn** runs synth's Thumb-2 output. All
+vectors are in-bounds — this gate is about the RETURN VALUE (the reused local)
+and the memory image, not traps. Symbols are read from the ELF symtab
+(pyelftools), not `synth disasm` text (host-dependent — see PR #489).
+
+Run:
+  SYNTH=./target/release/synth python scripts/repro/bulk_local_clobber_677_differential.py
+Exits nonzero on any mismatch. RED on pre-fix main, GREEN post-#677.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_ERR_INSN_INVALID, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R10,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("bulk_local_clobber_677.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+
+MEM_BYTES = 0x10000  # 1 page = 64 KiB (matches the wat `(memory 1)`)
+CODE, LIN, STK, RET = 0x200000, 0x400000, 0x90000, 0x300000
+
+# (fn, arg0, arg1) — arg0 = the local under test (dst/src), arg1 = len.
+VECTORS = [
+    ("cpy_dst", 32, 4),      # dst local read back: expect 67305985
+    ("cpy_dst", 4096, 8),    # different dst, len
+    ("fil_dst", 32, 4),      # fill dst local read back: expect 66
+    ("fil_dst", 100, 1),
+    ("cpy_len", 0, 4),       # len local reused: expect 4
+    ("cpy_len", 0, 0),       # len 0: no-op copy, local must still read 0
+    ("cpy_src", 16, 4),      # src local reused: expect 16
+    ("cpy_const", 0, 4),     # control (const dest): green pre-fix too
+]
+
+
+def load_text_and_syms(elf_path):
+    with open(elf_path, "rb") as f:
+        ef = ELFFile(f)
+        text = ef.get_section_by_name(".text")
+        code, base = text.data(), text["sh_addr"]
+        syms = {}
+        symtab = ef.get_section_by_name(".symtab")
+        if symtab is not None:
+            for s in symtab.iter_symbols():
+                if s.name:
+                    syms[s.name] = s["st_value"]
+    if not syms:
+        # Self-contained images carry no symtab — fall back to `synth disasm`
+        # labels (same-arch decode, the established #374-harness pattern).
+        import re
+        dis = subprocess.run([SYNTH, "disasm", elf_path],
+                             capture_output=True, text=True).stdout
+        syms = {m.group(2): int(m.group(1), 16)
+                for m in re.finditer(r"^([0-9a-f]{8}) <(\w+)>:", dis, re.M)}
+    return code, base, syms
+
+
+def main():
+    elf = tempfile.NamedTemporaryFile(suffix=".elf", delete=False).name
+    subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", elf, "--target", "cortex-m4",
+         "--all-exports", "--safety-bounds", "software"],
+        check=True,
+    )
+    code, base, syms = load_text_and_syms(elf)
+
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+
+    def wasmtime_run(fn, a, b):
+        store = wasmtime.Store(eng)
+        inst = wasmtime.Instance(store, mod, [])
+        ret = inst.exports(store)[fn](store, a, b)
+        mem = inst.exports(store)["memory"]
+        img = bytes(mem.read(store, 0, MEM_BYTES))
+        return ret & 0xFFFFFFFF, img
+
+    def unicorn_run(fn, a, b):
+        fa = syms[fn] & ~1  # thumb bit
+        mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+        mu.mem_map(CODE, 0x10000)
+        mu.mem_map(LIN, MEM_BYTES)
+        mu.mem_map(STK - 0x8000, 0x10000)
+        mu.mem_map(RET, 0x1000)
+        mu.mem_write(CODE, code)
+        mu.mem_write(LIN, b"\x00" * MEM_BYTES)
+        mu.reg_write(UC_ARM_REG_SP, STK)
+        mu.reg_write(UC_ARM_REG_R11, LIN)        # linear-memory base
+        mu.reg_write(UC_ARM_REG_R10, MEM_BYTES)  # memory size (bytes)
+        mu.reg_write(UC_ARM_REG_R0, a & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R1, b & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        try:
+            mu.emu_start((CODE + fa - base) | 1, RET, count=500000)
+        except UcError as e:
+            # No vector here should trap; UDF or an unmapped access both mean
+            # a wild pointer escaped — report as ERR, never a match.
+            return f"ERR:{e}", b""
+        return mu.reg_read(UC_ARM_REG_R0), bytes(mu.mem_read(LIN, MEM_BYTES))
+
+    fails = 0
+    for fn, a, b in VECTORS:
+        gt_ret, gt_img = wasmtime_run(fn, a, b)
+        sy_ret, sy_img = unicorn_run(fn, a, b)
+        if isinstance(sy_ret, str):
+            ok, detail = False, sy_ret
+        else:
+            ok = sy_ret == gt_ret and sy_img == gt_img
+            detail = f"ret synth={sy_ret} wasmtime={gt_ret}"
+            if sy_img != gt_img:
+                diff = next(i for i in range(MEM_BYTES) if sy_img[i] != gt_img[i])
+                detail += (f"; mem differs @{diff}: synth=0x{sy_img[diff]:02x} "
+                           f"wasmtime=0x{gt_img[diff]:02x}")
+        fails += 0 if ok else 1
+        print(f"{fn}({a},{b}): {'OK' if ok else 'MISMATCH'}  [{detail}]")
+    print(f"\n{len(VECTORS) - fails}/{len(VECTORS)} match")
+    print("ORACLE: PASS" if fails == 0 else f"ORACLE: FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/bulk_mask_679.wat
+++ b/scripts/repro/bulk_mask_679.wat
@@ -1,0 +1,37 @@
+(module
+  ;; #679 — `--safety-bounds mask` was a silent no-op for memory.copy /
+  ;; memory.fill: the bulk lowering was emitted byte-identical to `none`
+  ;; (no fold, no clamp) while the safety manifest still attested `mask`.
+  (memory 1)
+  (export "memory" (memory 0))
+
+  ;; issue reproducer: copy 1 byte [100] -> dst=local0, read back [16].
+  ;; With mem_size=4096 and dst=4112: masked dst folds 4112&4095=16 -> 171.
+  ;; Escaped (pre-fix): raw write at 4112, [16] untouched -> 0.
+  (func (export "cpy_esc") (param i32 i32) (result i32)
+    (i32.store8 (i32.const 100) (i32.const 171))
+    (i32.store8 (i32.const 16) (i32.const 0))
+    (memory.copy (local.get 0) (i32.const 100) (i32.const 1))
+    (i32.load8_u (i32.const 16)))
+
+  ;; fill escape: fill 1 byte 238 at dst=local0, read back [24].
+  (func (export "fil_esc") (param i32 i32) (result i32)
+    (i32.store8 (i32.const 24) (i32.const 0))
+    (memory.fill (local.get 0) (i32.const 238) (i32.const 1))
+    (i32.load8_u (i32.const 24)))
+
+  ;; src escape: stage 205 at [40]; copy 1 byte src=local0 -> [8]; read [8].
+  ;; With src=4136: masked src folds 4136&4095=40 -> 205.
+  (func (export "cpy_src_esc") (param i32 i32) (result i32)
+    (i32.store8 (i32.const 40) (i32.const 205))
+    (i32.store8 (i32.const 8) (i32.const 0))
+    (memory.copy (i32.const 8) (local.get 0) (i32.const 1))
+    (i32.load8_u (i32.const 8)))
+
+  ;; len clamp: stage 119 at [3]; copy len=local1 bytes [0..) -> [4092..).
+  ;; With len=400 and mem_size=4096: len clamps to 4096-4092=4 — the copy
+  ;; ends exactly at the bound; read back [4095] (= staged byte [3]).
+  (func (export "cpy_clamp") (param i32 i32) (result i32)
+    (i32.store8 (i32.const 3) (i32.const 119))
+    (memory.copy (i32.const 4092) (i32.const 0) (local.get 1))
+    (i32.load8_u (i32.const 4095))))

--- a/scripts/repro/bulk_mask_679_differential.py
+++ b/scripts/repro/bulk_mask_679_differential.py
@@ -91,11 +91,13 @@ def load_text_and_syms(elf_path):
         text = ef.get_section_by_name(".text")
         code, base = text.data(), text["sh_addr"]
         syms = {}
-        symtab = ef.get_section_by_name(".symtab")
-        if symtab is not None:
-            for s in symtab.iter_symbols():
-                if s.name:
-                    syms[s.name] = s["st_value"]
+        # synth emits .symtab as an unnamed SHT_SYMTAB section, so match by
+        # TYPE not name (#489 pattern — get_section_by_name returns None here).
+        for sec in ef.iter_sections():
+            if sec.header.sh_type == "SHT_SYMTAB":
+                for s in sec.iter_symbols():
+                    if s.name:
+                        syms[s.name] = s["st_value"]
     if not syms:
         # Self-contained images carry no symtab — fall back to `synth disasm`
         # labels (same-arch decode, the established #374-harness pattern).

--- a/scripts/repro/bulk_mask_679_differential.py
+++ b/scripts/repro/bulk_mask_679_differential.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""#679 — `--safety-bounds mask` bulk-memory coverage oracle (thumb-2).
+
+Pre-fix, `memory.copy`/`memory.fill` under `--safety-bounds mask` were emitted
+**byte-identical to `--safety-bounds none`** — no fold, no clamp — while the
+`safety-manifest.json` still attested `"safety_bounds": "mask"` for the whole
+module: an attestation-integrity hole (the mask sandbox was silently absent
+for bulk memory). The fix applies the scalar `mask_effective_address`
+wrap-not-trap discipline to the bulk lowering: dst and src effective addresses
+fold with `AND (size-1)`, and len clamps to `size - dst` / `size - src` so the
+FINAL byte stays in bounds.
+
+Three gates, all RED on pre-fix main:
+
+  1. BYTE-DIFF: the `.text` of a mask build must DIFFER from a `none` build of
+     the same module (pre-fix: `cmp` equal). The manifest must attest `mask`
+     for the mask build — attestation and emission move together.
+  2. ESCAPE/FOLD: run the mask ELF under unicorn with R10 = mem_size = 4096
+     (power of two) and dst/src beyond it. Mask semantics are MODELED in
+     python (wasmtime cannot model a 4 KiB bound — wasm's minimum is one
+     64 KiB page; OOB in wasm traps, mask deliberately wraps instead):
+     escaped operands must fold mod 4096, len must clamp to the bound.
+  3. CONTAINMENT: after every masked run, NO byte outside [0, mem_size) may
+     have changed (the linear map is 64 KiB, so an un-masked escape would
+     write silently — exactly the pre-fix failure, not a fault).
+
+Symbols come from the ELF symtab (pyelftools), not `synth disasm` (PR #489).
+
+Run:
+  SYNTH=./target/release/synth python scripts/repro/bulk_mask_679_differential.py
+Exits nonzero on any failure.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R10,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("bulk_mask_679.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+
+MASK_SIZE = 4096       # R10: the power-of-two mem_size the mask folds into
+MAP_BYTES = 0x10000    # the 64 KiB actually mapped — escapes write, not fault
+CODE, LIN, STK, RET = 0x200000, 0x400000, 0x90000, 0x300000
+
+# (fn, arg0, arg1, expected_return) — mask semantics modeled by hand.
+VECTORS = [
+    # escaped dst 4096+16 folds to 16 -> the byte lands where we read
+    ("cpy_esc", MASK_SIZE + 16, 0, 171),
+    # in-bounds control: same op fully in bounds behaves identically
+    ("cpy_esc", 16, 0, 171),
+    # fill: escaped dst 4096+24 folds to 24
+    ("fil_esc", MASK_SIZE + 24, 0, 238),
+    ("fil_esc", 24, 0, 238),
+    # escaped SRC 4096+40 folds to 40 (read-side masking)
+    ("cpy_src_esc", MASK_SIZE + 40, 0, 205),
+    ("cpy_src_esc", 40, 0, 205),
+    # len clamp: dst=4092, len=400 -> len=4, copy ends AT the bound
+    ("cpy_clamp", 0, 400, 119),
+    # len already in bounds -> clamp is a no-op
+    ("cpy_clamp", 0, 4, 119),
+]
+
+
+def compile_elf(bounds):
+    out = tempfile.NamedTemporaryFile(suffix=f"_{bounds}.elf", delete=False).name
+    subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "--target", "cortex-m4",
+         "--all-exports", "--safety-bounds", bounds],
+        check=True,
+    )
+    return out
+
+
+def load_text_and_syms(elf_path):
+    with open(elf_path, "rb") as f:
+        ef = ELFFile(f)
+        text = ef.get_section_by_name(".text")
+        code, base = text.data(), text["sh_addr"]
+        syms = {}
+        symtab = ef.get_section_by_name(".symtab")
+        if symtab is not None:
+            for s in symtab.iter_symbols():
+                if s.name:
+                    syms[s.name] = s["st_value"]
+    if not syms:
+        # Self-contained images carry no symtab — fall back to `synth disasm`
+        # labels (same-arch decode, the established #374-harness pattern).
+        import re
+        dis = subprocess.run([SYNTH, "disasm", elf_path],
+                             capture_output=True, text=True).stdout
+        syms = {m.group(2): int(m.group(1), 16)
+                for m in re.finditer(r"^([0-9a-f]{8}) <(\w+)>:", dis, re.M)}
+    return code, base, syms
+
+
+# A module whose functions contain ONLY bulk-memory ops (no scalar
+# loads/stores, which mask correctly and would hide the gap): pre-fix, the
+# mask build of THIS module is byte-identical to the none build — the
+# issue's `cmp` evidence.
+PURE_BULK_WAT = """(module (memory 1)
+ (func (export "c") (param i32 i32 i32)
+   (memory.copy (local.get 0) (local.get 1) (local.get 2)))
+ (func (export "f") (param i32 i32 i32)
+   (memory.fill (local.get 0) (local.get 1) (local.get 2))))
+"""
+
+
+def main():
+    fails = 0
+    mask_elf = compile_elf("mask")
+    none_elf = compile_elf("none")
+
+    # ---- gate 1: attestation integrity — the emission of a PURE bulk-memory
+    # module must differ from `none` (pre-fix: byte-identical, while the
+    # manifest attested mask), and the manifest must attest mask.
+    pure = Path(tempfile.NamedTemporaryFile(suffix=".wat", delete=False).name)
+    pure.write_text(PURE_BULK_WAT)
+    pure_elfs = {}
+    for bounds in ("mask", "none"):
+        out = tempfile.NamedTemporaryFile(suffix=f"_pure_{bounds}.elf",
+                                          delete=False).name
+        subprocess.run(
+            [SYNTH, "compile", str(pure), "-o", out, "--target", "cortex-m4",
+             "--all-exports", "--safety-bounds", bounds],
+            check=True,
+        )
+        pure_elfs[bounds], _, _ = load_text_and_syms(out)
+    if pure_elfs["mask"] == pure_elfs["none"]:
+        print("BYTE-DIFF: FAIL — pure-bulk mask .text is byte-identical to "
+              "none (the #679 silent no-op)")
+        fails += 1
+    else:
+        print(f"BYTE-DIFF: OK — pure-bulk mask .text differs from none "
+              f"({len(pure_elfs['mask'])} vs {len(pure_elfs['none'])} bytes)")
+    manifest_path = Path(mask_elf).with_suffix("") .as_posix() + ".safety-manifest.json"
+    candidates = [manifest_path, mask_elf + ".safety-manifest.json",
+                  str(Path(mask_elf).with_name(Path(mask_elf).stem + ".safety-manifest.json"))]
+    manifest = None
+    for c in candidates:
+        if os.path.exists(c):
+            manifest = json.load(open(c))
+            break
+    if manifest is None:
+        print("MANIFEST: WARN — no safety-manifest sidecar found "
+              f"(looked at {candidates})")
+    elif str(manifest.get("safety_bounds", "")).lower() not in ("mask", "masking"):
+        print(f"MANIFEST: FAIL — mask build attests {manifest.get('safety_bounds')!r}")
+        fails += 1
+    else:
+        print("MANIFEST: OK — mask build attests mask (and now emits it)")
+
+    # ---- gates 2+3: execution under unicorn with R10 = 4096.
+    code, base, syms = load_text_and_syms(mask_elf)
+
+    def run(fn, a, b):
+        fa = syms[fn] & ~1
+        mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+        mu.mem_map(CODE, 0x10000)
+        mu.mem_map(LIN, MAP_BYTES)
+        mu.mem_map(STK - 0x8000, 0x10000)
+        mu.mem_map(RET, 0x1000)
+        mu.mem_write(CODE, code)
+        mu.mem_write(LIN, b"\x00" * MAP_BYTES)
+        mu.reg_write(UC_ARM_REG_SP, STK)
+        mu.reg_write(UC_ARM_REG_R11, LIN)
+        mu.reg_write(UC_ARM_REG_R10, MASK_SIZE)  # mem_size the mask folds into
+        mu.reg_write(UC_ARM_REG_R0, a & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R1, b & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        try:
+            mu.emu_start((CODE + fa - base) | 1, RET, count=500000)
+        except UcError as e:
+            return f"ERR:{e}", b""
+        return mu.reg_read(UC_ARM_REG_R0), bytes(mu.mem_read(LIN, MAP_BYTES))
+
+    for fn, a, b, expect in VECTORS:
+        ret, img = run(fn, a, b)
+        if isinstance(ret, str):
+            ok, detail = False, ret
+        else:
+            contained = all(v == 0 for v in img[MASK_SIZE:])
+            ok = ret == expect and contained
+            detail = f"ret={ret} expect={expect}"
+            if not contained:
+                leak = next(i for i in range(MASK_SIZE, MAP_BYTES) if img[i] != 0)
+                detail += f"; ESCAPED write at raw offset {leak} (>= mem_size)"
+        fails += 0 if ok else 1
+        print(f"{fn}({a},{b}): {'OK' if ok else 'MISMATCH'}  [{detail}]")
+
+    print(f"\nORACLE: {'PASS' if fails == 0 else f'FAIL ({fails})'}")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/bulk_memory_374_differential.py
+++ b/scripts/repro/bulk_memory_374_differential.py
@@ -33,6 +33,7 @@ Exits nonzero on any mismatch.
 """
 import re
 import subprocess
+import os
 import sys
 
 import wasmtime
@@ -57,7 +58,7 @@ from unicorn.arm_const import (
 
 WASM = "scripts/repro/bulk_memory_374_diff.wat"
 ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/bmd.elf"
-SYNTH = "./target/release/synth"
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
 
 MEM_BYTES = 0x10000  # 1 page = 64 KiB (matches the wat `(memory 1)`)
 CODE, LIN, STK, RET = 0x200000, 0x400000, 0x90000, 0x300000


### PR DESCRIPTION
Fixes the two bulk-memory defects in the #374 `memory.copy`/`memory.fill` lowering (`select_with_stack`, shared Thumb-2 + A32 direct path). Closes #677, closes #679.

## #677 — copy/fill clobber a local dst/src/len operand reused after the op

The lowering mutated its three popped operand registers in place (dst/src as walking loop pointers, len as the byte buffer). `local.get` of a register-homed local (AAPCS param r0-r3, promoted local r4-r8) pushes the **home register itself**, so a local reused after the op read a wild `mem_base + <cursor>` pointer or the last byte copied.

**Fix** (mirrors the #193 reservation discipline): new `bulk_mutable_operand` helper copies a popped operand into a fresh scratch (`mov scratch, reg`) before the loop mutates it, whenever the register is still live — live param / promoted-local home, duplicate vstack entry, if/block result reg, or **aliased to another popped operand** (`memory.fill (local.get 0) (local.get 0) …`). A provably-dead temp is used in place, so the const-operand shapes the #374 differential pins stay byte-identical.

**The red differential then exposed the #663-class range-realloc hole underneath**: `try_reallocate_segment` treated a pool register with **no range in a segment** as free, but such a register can be live-through (a param home the segment never touches). The memcpy backward path's walking-pointer intermediate got recolored onto R0 — the still-live dst local — re-introducing the clobber the selector fix had just removed. Absent pool colours are now blocked with synthetic pinned interference nodes. Identity colouring within the segment's present registers always exists (simultaneously-live ranges carry distinct original registers), so no recoloring the original bytes had is lost; relaxed-exit terminal segments keep their #580 exemptions (only absent R0/R1 blocked past the `bx lr`). This is a targeted instance-fix of the #663 defect class — #663's loop reproducers remain to be validated separately.

## #679 — `--safety-bounds mask` silent no-op for bulk memory (attestation integrity)

Bulk memory under `mask` was emitted **byte-identical to `none`** — no fold, no clamp — while `safety-manifest.json` still attested `"safety_bounds": "mask"`. Fix applies the scalar #651/#654 `mask_effective_address` wrap-not-trap discipline to the loop setup:

```
dst &= size-1 ; src &= size-1            ; fold both effective addresses
len = min(len, size - dst, size - src)   ; len bounds the FINAL byte
```

Every loop access (read and write) lands in `[0, size)`; a wasm-in-bounds op is unchanged; the manifest's `mask` claim is now backed by the emission — silent-unmasked-while-attested is structurally gone for copy/fill.

## Oracles (all local-run; red on v0.37.1 baseline → green here)

| gate | baseline (origin/main) | this PR |
|---|---|---|
| `bulk_local_clobber_677_differential.py` (unicorn vs wasmtime) | **2/8 FAIL** | 8/8 PASS |
| `bulk_mask_679_differential.py` pure-bulk byte-diff mask≠none | **identical (FAIL)** | differs (300 vs 250 B) |
| `bulk_mask_679_differential.py` escape/fold/clamp + containment (R10=4096) | **FAIL (raw escaped writes)** | 8/8 PASS |
| `bulk_memory_374_differential.py` (#374) | 16/16 | **16/16** |
| `frozen_codegen_bytes` anchors (fixtures lack bulk memory — verified) | 10/10 | **10/10** |
| `safety_bounds_377_differential.py` (both paths) | 13/13 ×2 | 13/13 ×2 |
| `unreachable_665` / `i32_shift_mask_682` | PASS | PASS |
| `cargo test --workspace`, fmt, chunked clippy `-D warnings` | green | green |

Plus 8 new selector unit tests (677 preservation/aliasing/no-copy-when-dead; 679 fold+clamp presence, mask≠none structural). Both new oracles are CI-wired in the trap-semantics job, reading symbols with a symtab-first/disasm-fallback loader (#489 discipline).

Lineage: #374 (bulk-memory lowering), #654/#651 (scalar mask discipline), #193 (reservation discipline), #663 (realloc defect class), #489 (oracle CI-gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)