### PR TITLE
chore(release): v0.38.0 — ten-lane feature hub + claim-verification gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0] - 2026-07-10
+
+**The largest release: a ten-lane feature hub — five miscompile classes
+closed (several with class-audit spillover), falcon's call_indirect story
+finished end-to-end, a stack-overflow-safety layout, the flat-executor
+verification upgrade discharging a real proof admit, and a
+claim-verification gate that makes doc honesty a build property. Gated by
+the new claim-check gate PLUS an independent cold-agent claim review.**
+
+### Added
+
+- **Claim-verification gate (#688):** README/CLAUDE/STATUS proof-count,
+  admit-breakdown, coverage, and roadmap-status claims are marked → bound to
+  re-derivable evidence → CI-gated (`scripts/claim_check.py` + `claims.yaml`).
+  Drift fails the build. Stood up per the pulseengine-claude
+  claim-verification skill; it immediately caught six stale proof counts.
+- **Heterogeneous funcref tables (#676):** runtime type-id sidecar +
+  per-slot class check — the terminal layer of falcon's dispatch
+  (#642→#650→#664→#676 complete). Homogeneous tables byte-identical.
+- **`--stack-layout=low` (#687, VCR-MEM-003):** stack at the SRAM bottom so
+  overflow BusFaults instead of silently corrupting linmem/globals — proven
+  by an oracle (stack-high clobbered 4/8 canaries pre-fault; stack-low
+  faults with 8/8 intact). No MPU needed. Flag-off byte-identical.
+- **Flat-executor verification upgrade (#697, #242):** SBCS, conditional
+  flags-writers, and a fuel-bounded branch-taking `exec_program_br` — closing
+  the executor gap VCR-SEL-001 named. All ten binary i64 comparisons proven
+  at expansion tier (no axiom); the first #73 division trap-guard admit
+  DISCHARGED. Proofs now 470 Qed / 8 Admitted; SailArmBridge → 92 Qed.
+
+### Fixed
+
+- **Loop bound in a live param register clobbered by the induction
+  increment (#663):** param liveness now extends across loop back-edges;
+  loops ran once, now run fully.
+- **T3 ADD.W raw-immediate packing → wrong address + software-bounds bypass
+  (#681):** ADDW (T4) for offsets 0x100..0xFFF; class audit gated three more
+  raw-packing sites (a store had escaped 2 GiB past base).
+- **memory.copy/fill clobbered reused local operands + mask was a silent
+  no-op while the safety manifest attested it (#677/#679):** operands copied
+  to scratch; mask discipline applied so attestation is backed by emission.
+  (Surfaced a second instance of the #663 liveness class in the allocator's
+  coloring — fixed.)
+- **v128 SIMD ops silently dropped to no-ops on non-SIMD targets (#680):**
+  category-level loud-skip (macro-generated from wasmparser's SIMD markers);
+  the ops were decoded but their selector arms sat behind a test-only flag.
+- **ELF tooling (#637/#656):** `.ARM.attributes` emitted + `synth disasm`
+  auto-detects Thumb; internal `func_N` symbols are STB_LOCAL (co-linkable).
+
+### Changed
+
+- **Shift-mask elision (#686, flag-off `SYNTH_SHIFT_MASK_ELIDE`):** elides the
+  #682 mod-32 mask when the amount is provably < 32 (gust_mix −10 B, the 12%
+  proxy); also recovers the const-shift imm-fold #682 had blocked. Default-on
+  flip deferred (moves anchors — its own refreeze PR).
+
 ## [0.37.1] - 2026-07-10
 
 **i32 register shifts finally obey WASM's mod-32 semantics (#682) — a latent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,14 +2060,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2126,11 +2126,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.37.1"
+version = "0.38.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -2185,14 +2185,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -2200,11 +2200,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.37.1"
+version = "0.38.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.37.1"
+version = "0.38.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.37.1"
+version = "0.38.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.37.1",
+    version = "0.38.0",
 )
 
 # Bazel dependencies

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -410,7 +410,7 @@ Recount 2026-07-10 (`grep -oE 'Qed\.'` / `'Admitted\.'` per file):
 |------|-----|----------|------|
 | Correctness.v | 6 | 0 | T1 |
 | CorrectnessSimple.v | 28 | 1 | T2 + 1 admitted (i64_const_correct) |
-| CorrectnessI32.v | 27 | 4 | T1 + 4 admitted (i32 div/rem trap guards — exec_program model gap, #73) |
+| CorrectnessI32.v | 28 | 3 | T1 + 3 admitted (i32_divu discharged #697) (i32 div/rem trap guards — exec_program model gap, #73) |
 | CorrectnessI64.v | 46 | 0 | T1 (arith/bitwise/div/rem) + T2 (shifts/cmps/bit-manip) — 0 i64 admits since v0.11.0 |
 | CorrectnessI64Comparisons.v | 19 | 0 | T2 |
 | CorrectnessF32.v | 20 | 0 | T2 |

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.37.1" }
+synth-core = { path = "../synth-core", version = "0.38.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.37.1" }
+synth-core = { path = "../synth-core", version = "0.38.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.37.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.37.1" }
+synth-core = { path = "../synth-core", version = "0.38.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.38.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.37.1" }
+synth-core = { path = "../synth-core", version = "0.38.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.37.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.37.1", optional = true }
+synth-core = { path = "../synth-core", version = "0.38.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.38.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.37.1", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.38.0", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -44,23 +44,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.37.1" }
-synth-frontend = { path = "../synth-frontend", version = "0.37.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.37.1" }
-synth-backend = { path = "../synth-backend", version = "0.37.1" }
+synth-core = { path = "../synth-core", version = "0.38.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.38.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.38.0" }
+synth-backend = { path = "../synth-backend", version = "0.38.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.37.1" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.38.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.37.1", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.37.1", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.37.1", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.38.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.38.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.38.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.37.1", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.38.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.37.1" }
+synth-core = { path = "../synth-core", version = "0.38.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.37.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.38.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.37.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.37.1" }
-synth-opt = { path = "../synth-opt", version = "0.37.1" }
+synth-core = { path = "../synth-core", version = "0.38.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.38.0" }
+synth-opt = { path = "../synth-opt", version = "0.38.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -20,12 +20,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.37.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.37.1" }
-synth-opt = { path = "../synth-opt", version = "0.37.1" }
+synth-core = { path = "../synth-core", version = "0.38.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.38.0" }
+synth-opt = { path = "../synth-opt", version = "0.38.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.37.1", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.38.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"

--- a/docs/research/SAIL_FINDINGS_AND_STRATEGY.md
+++ b/docs/research/SAIL_FINDINGS_AND_STRATEGY.md
@@ -255,6 +255,8 @@ For automotive safety certification:
 - ✅ Traceability matrix (WASM ops → ARM instructions → test cases)
 
 **Certification Claim**:
+> **⚠️ DRAFT — DO NOT PUBLISH VERBATIM (claim-verification, #688): the compiler is Partial (8 Admitted, #73 div/rem trap-guard model gap), and the Sail/ASL bridge is a hand-transcribed 92-Qed SPIKE (VCR-ISA-001 status: approved, NOT verified — the ASL side is not machine-generated from official Sail). Any external claim must name the technique + trusted base per the claim-verification skill.**
+
 > "The Synth WASM-to-ARM compiler has been formally verified in the Coq theorem prover and validated against the official ARM Sail architectural specifications. The compiler's correctness has been demonstrated through:
 > 1. Mathematical proofs of semantic preservation (Coq)
 > 2. Validation against official ARM ISA emulator (Sail C backend)


### PR DESCRIPTION
Release PR: pin sweep + CHANGELOG for v0.38.0 — the largest release.

**Pre-release verification (feature-loop close):** claim-check gate 17/17 on main + an independent cold-agent claim review (re-derived 470/8, three non-vacuity spot-checks passed, no flat 'verified' badge on the release surface) — cleared with two notes, both fixed here.

Scope: #688 claim gate · #663 loop-bound · #681 ADDW packing · #680 v128 loud-skip · #677/#679 bulk-memory · #637/#656 ELF tooling · #686 shift-elision (flag-off) · #687 stack-layout-low · #676 heterogeneous tables (falcon dispatch complete) · #697 flat-executor upgrade (470 Qed / 8 Admitted, first #73 admit discharged).

Tag v0.38.0 on green merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)