### PR TITLE
fix(vcr-mem): down-shift inline linmem statics into shrunk reservation (#678, VCR-MEM-001 layer-2)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -2135,6 +2135,39 @@ artifacts:
       gale offered on-silicon reflash on this exact gust_kernel.wasm as the final
       gate. A FOCUSED gated step, not an idle-tick increment.
 
+      LAYER-2 DOWN-SHIFT LANDED (2026-07-10, gale #678). The SHIPPED layer-1
+      (#383) was narrower than the layer-1 the roadmap sketched above: it
+      re-based the SP slot + resized the .bss but REFUSED any residual
+      `__synth_wasm_data + C` reloc with C != 0 still pointing into the
+      reservation ("down-shifting inline statics is the deferred general case").
+      That refusal gated EVERY buffer-carrying dissolved node (wit-bindgen
+      `list<u8>` — gale's gust:os `log`/`channel`/`io` capabilities) AND every
+      plain `static mut` array (a `spawn` task table), because the wit-bindgen
+      canonical ABI / any stateful CM node puts data + zero-init scratch in the
+      static tail `[sp_init, used_extent)`. So only pure-stateless-scalar nodes
+      (gale's drivers, the gust:os `time` interface) fit an MCU today; the whole
+      gust:os OS milestone beyond `time` was blocked. #678 completes the
+      down-shift the shipped layer-1 deferred: each residual tail static rebases
+      in place `C -> C - (sp_init - budget)` (Abs32 REL literal word patched like
+      the #354 retarget), landing in the down-shifted `.bss` tail — which is a
+      ZERO byte, exactly wasm's zero-init semantics, because a residual reloc is
+      NEVER inside a `(data)` segment (the split path either has no segments —
+      `split_linmem_bss` — or retargets ALL of them into `.data`). The addend-0
+      region-base pointer (`global.get $sp` base) is stable and left as-is; the
+      SP VALUE rides the re-based `__synth_globals` slot. Sound-decline sub-cases
+      kept LOUD + precise: a load window straddling a `(data)` segment boundary
+      (part in `.data`, part in `.bss` tail), an addend below sp_init (would
+      collide with the live stack), and the one-PROGBITS fallback geometry.
+      Opt-in (only fires with `--shadow-stack-size`) ⇒ frozen fixtures
+      bit-identical (10/10). Evidence: `static_downshift_678.rs` (4 tests:
+      bss-static + buffer+bss down-shift, straddle decline, no-flag frozen) +
+      the execution differential `native_pointer_static_downshift_678.py`
+      (a shadow-stack roundtrip + a `.data` buffer + a down-shifted BSS static,
+      all agreeing with wasmtime `run(p) == 43 + 2p` incl. negative p). NOT to
+      be confused with the roadmap's numbered layer-2 (scry-PROVEN auto-budget,
+      `--shadow-stack-size auto`) below, which is orthogonal (this fixes the ELF
+      mechanics of the down-shift; that computes how big B may safely be).
+
       LAYER-2 DECISION LOGIC LANDED (2026-06-22, frozen-safe, no dep change):
       `synth-cli/src/shadow_budget.rs` — a pure `budget_from_bound(bound,
       sp_init, fallback) -> BudgetDecision` over a synth-OWNED `StackDepthBound`

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -3456,15 +3456,21 @@ fn build_relocatable_elf(
         }
     }
 
-    // #383 (VCR-MEM-001 layer-1): shrink the [0, sp_init) shadow-stack reservation
-    // to the integrator-declared budget B. Correct-by-construction for the verified
-    // gust geometry (stack-first: statics at/above sp_init are retargeted into the
-    // packed `.data`, so the only static relocs still pointing into the `.bss`
-    // reservation are addend-0 region-base pointers — stable because
-    // `__synth_wasm_data` stays at offset 0). The shrink re-bases the SP global slot
-    // sp_init -> B and resizes the `.bss` to B + (used_extent - sp_init). It REFUSES
-    // honestly (typed Err, the #359/#368 lesson) for any geometry it cannot prove
-    // safe; opt-in, so the default (unset) reserves the full page = byte-identical.
+    // #383 (VCR-MEM-001 layer-1 + #678 layer-2): shrink the [0, sp_init)
+    // shadow-stack reservation to the integrator-declared budget B. Layer-1
+    // handled the verified gust geometry where the only static relocs still
+    // pointing into the `.bss` reservation are addend-0 region-base pointers
+    // (stable because `__synth_wasm_data` stays at offset 0); layer-2 (#678)
+    // additionally DOWN-SHIFTS the inline linmem statics that sit in the tail
+    // `[sp_init, used_extent)` (a `static mut` array, a wit-bindgen `list<u8>`
+    // buffer's realloc/scratch) by rebasing their addend `C -> C - (sp_init - B)`,
+    // so a buffer-carrying dissolved node links into an 8-KiB part instead of
+    // being refused. The shrink re-bases the SP global slot sp_init -> B and
+    // resizes the `.bss` to B + (used_extent - sp_init). It still REFUSES honestly
+    // (typed Err, the #359/#368 lesson) for the sub-shapes it cannot down-shift
+    // soundly (segment-straddling access, below-base addend, one-PROGBITS
+    // fallback); opt-in, so the default (unset) reserves the full page =
+    // byte-identical.
     let (reserved_extent, rebased_globals): (u32, Option<Vec<(u32, i32)>>) = match native_layout
         .as_ref()
         .and_then(|ng| ng.shadow_stack_size.map(|b| (ng, b)))
@@ -3488,12 +3494,36 @@ fn build_relocatable_elf(
                      sp_init={sp}; refusing (would enlarge, not shrink)."
                 );
             }
-            // Every `__synth_wasm_data` reloc still pointing into the `.bss` reservation
-            // (i.e. NOT retargeted into `.data`) must be a region-base pointer (addend 0),
-            // which is stable under the shrink. A non-zero addend is a real static inside
-            // the reservation; down-shifting inline statics is the deferred general case ⇒
-            // refuse rather than mis-address. Only the Abs32 literal-pool form is inspected;
-            // any other static-reloc kind into the reservation is refused.
+            // VCR-MEM-001 layer-2 (#678): DOWN-SHIFT the inline linmem statics that
+            // sit in the static tail `[sp_init, used_extent)` so a buffer-carrying
+            // dissolved node (wit-bindgen `list<u8>`, a `static mut` array) links
+            // into a shrunk reservation instead of being refused (the layer-1
+            // "deferred general case").
+            //
+            // Model. Before the shrink the `[0, used_extent)` region maps 1:1 to
+            // wasm linear memory: wasm address A ↦ object offset A via
+            // `__synth_wasm_data + A` (`__synth_wasm_data` = offset 0). Shrinking
+            // `sp_init → budget` removes `[budget, sp_init)` from the stack
+            // reservation, so every static that lived at/above `sp_init` slides
+            // DOWN by `down = sp_init - budget` to `[budget, budget + tail)`. Each
+            // residual (NOT `.data`-retargeted) `__synth_wasm_data + C` reloc is
+            // rebased in place: `C → C - down` (Abs32 is REL — the addend is the
+            // in-place literal word, patched exactly like the #354 retarget).
+            //
+            // Soundness. The affine map is exact and `reserved_extent = budget +
+            // (used_extent - sp_init)` already covers the shifted tail, because
+            // `static_top_abs32` (computed above, pre-patch) is `max(C)+8` over
+            // every Abs32 `__synth_wasm_data` reloc. A residual reloc is NEVER
+            // inside a `(data)` segment (the split path either has no segments —
+            // `split_linmem_bss` — or retargets ALL of them into `.data`), so the
+            // down-shifted target is a ZERO byte in the `.bss` reservation, which
+            // is exactly wasm's zero-init semantics for that address. The only
+            // unsound shape is a load window that STRADDLES a segment boundary
+            // from just below (part in `.data`, part in the `.bss` tail) — declined
+            // loudly rather than mis-addressed. The addend-0 region-base pointer
+            // (`global.get $sp`'s base, `memory.grow`) is stable and left as-is;
+            // the SP VALUE rides the re-based `__synth_globals` slot below.
+            let down = sp.saturating_sub(budget);
             for (i, func) in funcs.iter().enumerate() {
                 for reloc in &func.relocations {
                     if reloc.symbol != "__synth_wasm_data"
@@ -3516,14 +3546,40 @@ fn build_relocatable_elf(
                              into the reservation; refusing. VCR-MEM-001/#383."
                         ),
                     };
-                    if c != 0 {
+                    // Addend-0 region-base pointer: stable under the shrink
+                    // (`__synth_wasm_data` stays at offset 0). No rebase.
+                    if c == 0 {
+                        continue;
+                    }
+                    // A static below sp_init would rebase into the live stack
+                    // region `[0, budget)` (or negative) — the selector never
+                    // emits one (`static_data_addend` requires `C >= wasm_data_base
+                    // = sp_init`), so this is an unexpected shape: decline loudly.
+                    if c < sp {
                         anyhow::bail!(
-                            "--shadow-stack-size: a native-pointer static access addends {c} into \
-                             the [0, sp_init) reservation (not the region base, not retargeted into \
-                             .data); down-shifting inline statics is the deferred general case. \
-                             Refusing rather than mis-addressing. VCR-MEM-001/#383."
+                            "--shadow-stack-size: a native-pointer static access addends {c}, below \
+                             sp_init={sp}; down-shifting it would collide with the live stack \
+                             reservation. Refusing rather than mis-addressing. VCR-MEM-001/#678."
                         );
                     }
+                    // Straddle guard: the (conservative 8-byte, covers i64) access
+                    // window must not overlap an initialized `(data)` segment — those
+                    // bytes live in `.data`, not the zero `.bss` tail, so a
+                    // down-shift would read zero where wasm reads segment data.
+                    const STRADDLE_W: u32 = 8;
+                    if data_segments
+                        .iter()
+                        .any(|(off, d)| c < off + d.len() as u32 && *off < c + STRADDLE_W)
+                    {
+                        anyhow::bail!(
+                            "--shadow-stack-size: a native-pointer static at {c} straddles an \
+                             initialized (data) segment boundary; part of its access window lives \
+                             in .data and part in the .bss tail, so it cannot be down-shifted \
+                             soundly. Refusing rather than mis-addressing. VCR-MEM-001/#678."
+                        );
+                    }
+                    let new_c = c - down;
+                    all_code[pos..pos + 4].copy_from_slice(&new_c.to_le_bytes());
                 }
             }
             // Re-base the SP global slot: the unique global whose init == sp_init.

--- a/crates/synth-cli/tests/static_downshift_678.rs
+++ b/crates/synth-cli/tests/static_downshift_678.rs
@@ -1,0 +1,154 @@
+//! VCR-MEM-001 layer-2 (#678) — down-shift inline linmem statics into the
+//! shrunk native-pointer reservation.
+//!
+//! Layer-1 (#383) refused any `__synth_wasm_data + C` reloc with `C != 0` still
+//! pointing into the `[0, sp_init)` reservation ("down-shifting inline statics is
+//! the deferred general case"). That refusal gated every buffer-carrying dissolved
+//! node (wit-bindgen `list<u8>`) and every plain `static mut` array on a tiny MCU.
+//! Layer-2 rebases those tail statics `C -> C - (sp_init - budget)` so the node
+//! links; the execution differential lives in
+//! `scripts/repro/native_pointer_static_downshift_678.py` (a shadow-stack
+//! roundtrip plus a `.data` buffer plus a down-shifted BSS static, all agreeing
+//! with wasmtime).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use object::{Object, ObjectSection, ObjectSymbol, RelocationTarget};
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn repro(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro")
+        .join(name)
+}
+
+fn compile(fixture: &str, extra: &[&str], out: &str) -> std::process::Output {
+    let fx = repro(fixture);
+    let mut args = vec![
+        "compile",
+        fx.to_str().unwrap(),
+        "--target",
+        "cortex-m3",
+        "--native-pointer-abi",
+        "--all-exports",
+        "--relocatable",
+        "-o",
+        out,
+    ];
+    args.extend_from_slice(extra);
+    Command::new(synth())
+        .args(&args)
+        .output()
+        .expect("run synth")
+}
+
+fn bss_size(path: &str) -> u64 {
+    let data = std::fs::read(path).expect("read .o");
+    let obj = object::File::parse(&*data).expect("parse ELF");
+    obj.sections()
+        .find(|s| s.name() == Ok(".bss"))
+        .expect(".bss present")
+        .size()
+}
+
+/// The in-place REL addend of the (unique) `__synth_wasm_data` R_ARM_ABS32 reloc
+/// whose in-place literal word is non-zero — i.e. the down-shifted static addend.
+fn max_wasm_data_addend(path: &str) -> u32 {
+    let bytes = std::fs::read(path).expect("read .o");
+    let obj = object::File::parse(&*bytes).expect("parse ELF");
+    let text = obj.section_by_name(".text").expect(".text");
+    let text_data = text.data().expect("text data");
+    let mut best = 0u32;
+    for (off, reloc) in text.relocations() {
+        if let RelocationTarget::Symbol(sidx) = reloc.target() {
+            let sym = obj.symbol_by_index(sidx).expect("sym");
+            if sym.name() == Ok("__synth_wasm_data") {
+                let p = off as usize;
+                let word = u32::from_le_bytes(text_data[p..p + 4].try_into().unwrap());
+                best = best.max(word);
+            }
+        }
+    }
+    best
+}
+
+/// RED before the fix / GREEN after: a plain BSS static (`split_linmem_bss`
+/// geometry, no `(data)` segment) at wasm addr 4160 down-shifts by
+/// `sp_init(4096) - budget(512) = 3584` to object offset 576, and the reservation
+/// shrinks to `budget + tail`.
+#[test]
+fn bss_static_downshifts_678() {
+    let out = compile(
+        "mem678_bss.wat",
+        &["--shadow-stack-size", "512"],
+        "/tmp/mem678_bss_test.o",
+    );
+    assert!(
+        out.status.success(),
+        "layer-2 must COMPILE the bss-static node (was refused): {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        max_wasm_data_addend("/tmp/mem678_bss_test.o"),
+        576,
+        "static at 4160 must rebase to 4160 - (4096-512) = 576"
+    );
+    // budget 512 + static tail (used_extent 4168 - sp_init 4096 = 72) = 584.
+    assert_eq!(bss_size("/tmp/mem678_bss_test.o"), 584);
+}
+
+/// Mixed geometry: a `(data)` segment (retargeted to `.data`) AND a BSS static at
+/// 4200 (down-shifted). Both mechanisms coexist — the segment read stays in
+/// `.data`, only the residual BSS reloc is rebased (4200 - 3584 = 616).
+#[test]
+fn buffer_plus_bss_downshifts_678() {
+    let out = compile(
+        "mem678_buf.wat",
+        &["--shadow-stack-size", "512"],
+        "/tmp/mem678_buf_test.o",
+    );
+    assert!(
+        out.status.success(),
+        "layer-2 must COMPILE the buffer node: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        max_wasm_data_addend("/tmp/mem678_buf_test.o"),
+        616,
+        "bss static at 4200 must rebase to 616; the data-seg read stays in .data"
+    );
+}
+
+/// Sound-decline: a load window that straddles a `(data)` segment boundary from
+/// just below has part of its bytes in `.data` and part in the `.bss` tail — it
+/// cannot be down-shifted soundly, so it is refused LOUDLY with a precise reason
+/// (not a blanket refusal).
+#[test]
+fn straddling_static_refused_678() {
+    let out = compile(
+        "mem678_straddle.wat",
+        &["--shadow-stack-size", "512"],
+        "/tmp/mem678_straddle_test.o",
+    );
+    assert!(!out.status.success(), "straddle must be refused");
+    let log = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        log.contains("straddles an initialized (data) segment"),
+        "expected the precise straddle decline; got:\n{log}"
+    );
+}
+
+/// Opt-in / frozen-safe: WITHOUT the flag the same buffer node keeps the full
+/// reservation and no static is rebased (byte-identical to pre-#678).
+#[test]
+fn no_flag_leaves_statics_inline_678() {
+    let out = compile("mem678_buf.wat", &[], "/tmp/mem678_buf_noflag.o");
+    assert!(out.status.success());
+    // Un-shifted: the bss static keeps its full wasm addend 4200.
+    assert_eq!(max_wasm_data_addend("/tmp/mem678_buf_noflag.o"), 4200);
+}

--- a/scripts/repro/mem678_bss.wat
+++ b/scripts/repro/mem678_bss.wat
@@ -1,0 +1,9 @@
+(module
+  (memory (export "memory") 1)
+  (global $sp (mut i32) (i32.const 4096))
+  (func (export "rw") (param i32) (result i32)
+    i32.const 4160
+    local.get 0
+    i32.store
+    i32.const 4160
+    i32.load))

--- a/scripts/repro/mem678_buf.wat
+++ b/scripts/repro/mem678_buf.wat
@@ -1,0 +1,10 @@
+(module
+  (memory (export "memory") 1)
+  (global $sp (mut i32) (i32.const 4096))
+  (data (i32.const 4160) "\2a\00\00\00")
+  (func (export "run") (result i32)
+    i32.const 4160
+    i32.load
+    i32.const 4200
+    i32.load
+    i32.add))

--- a/scripts/repro/mem678_full.wat
+++ b/scripts/repro/mem678_full.wat
@@ -1,0 +1,27 @@
+(module
+  (memory (export "memory") 1)
+  (global $sp (mut i32) (i32.const 4096))
+  (data (i32.const 4160) "\2a\00\00\00")
+  (func (export "run") (param i32) (result i32) (local $slot i32)
+    ;; shadow-stack roundtrip: store param at [sp-4], read back
+    global.get $sp
+    i32.const 4
+    i32.sub
+    local.tee $slot
+    local.get 0
+    i32.store
+    ;; bss static at 4200: store param+1, read back
+    i32.const 4200
+    local.get 0
+    i32.const 1
+    i32.add
+    i32.store
+    ;; sum = data-seg(42) + bss(param+1) + stack(param)
+    i32.const 4160
+    i32.load
+    i32.const 4200
+    i32.load
+    i32.add
+    local.get $slot
+    i32.load
+    i32.add))

--- a/scripts/repro/mem678_straddle.wat
+++ b/scripts/repro/mem678_straddle.wat
@@ -1,0 +1,7 @@
+(module
+  (memory (export "memory") 1)
+  (global $sp (mut i32) (i32.const 4096))
+  (data (i32.const 4160) "\2a\00\00\00")
+  (func (export "run") (result i32)
+    i32.const 4156
+    i32.load))

--- a/scripts/repro/native_pointer_static_downshift_678.py
+++ b/scripts/repro/native_pointer_static_downshift_678.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""VCR-MEM-001 layer-2 (#678) execution differential: inline linmem statics
+down-shifted into `.data`/`.bss` under `--native-pointer-abi --shadow-stack-size`.
+
+A buffer-carrying dissolved node reads THREE kinds of static under the shrunk
+reservation, all in one function:
+  * an initialized `(data)` segment (wit-bindgen `list<u8>` literal) — retargeted
+    to `__synth_wasm_seg_0` in `.data`;
+  * a zero-init BSS static (`static mut` array) at a non-zero addend in the tail —
+    DOWN-SHIFTED `C -> C - (sp_init - budget)` into the `.bss` reservation;
+  * a shadow-stack slot reached through `global.get $sp` (addend-0 region base +
+    the re-based `__synth_globals` SP slot).
+
+Compile:
+  synth compile scripts/repro/mem678_full.wat -o /tmp/mem678_full.o \
+        --target cortex-m3 --native-pointer-abi --all-exports --relocatable \
+        --shadow-stack-size 512
+Run:
+  <venv>/bin/python scripts/repro/native_pointer_static_downshift_678.py /tmp/mem678_full.o
+
+Asserts run(p) == 43 + 2*p (wasmtime ground truth) for several p — i.e. the
+down-shifted BSS read, the retargeted `.data` segment read, and the re-based SP
+slot all land at the correct addresses after the shrink.
+"""
+import struct
+import sys
+
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_THUMB
+from unicorn.arm_const import (
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_LR,
+    UC_ARM_REG_SP,
+)
+
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/mem678_full.o"
+ABS32 = 2
+
+# Distinct bases for each linker-placed region — this is the whole point: the
+# `.bss` reservation and the packed `.data` are SEPARATE sections at separate
+# addresses (the old single-`.data` harness could not express the down-shift).
+BASES = {".text": 0x10000, ".bss": 0x40000, ".data": 0x60000}
+MAPSZ = 0x10000
+
+e = ELFFile(open(ELF, "rb"))
+secname_by_idx = {i: s.name for i, s in enumerate(e.iter_sections())}
+text = bytearray(e.get_section_by_name(".text").data())
+data = bytearray(e.get_section_by_name(".data").data())
+bss_size = e.get_section_by_name(".bss")["sh_size"]
+
+symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+syms = {}
+for s in symtab.iter_symbols():
+    syms[s.name] = (s["st_shndx"], s["st_value"])
+
+# Relocate every R_ARM_ABS32 literal-pool word in place: final address =
+# base(section owning the symbol) + symbol value + in-place addend (REL).
+for r in e.get_section_by_name(".rel.text").iter_relocations():
+    if r["r_info_type"] != ABS32:
+        continue
+    sym = symtab.get_symbol(r["r_info_sym"])
+    shndx, val = syms[sym.name]
+    base = BASES[secname_by_idx[shndx]]
+    (add,) = struct.unpack_from("<I", text, r["r_offset"])
+    struct.pack_into("<I", text, r["r_offset"], (base + val + add) & 0xFFFFFFFF)
+
+mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+for name, base in BASES.items():
+    mu.mem_map(base, MAPSZ)
+mu.mem_write(BASES[".text"], bytes(text))
+mu.mem_write(BASES[".data"], bytes(data))
+# .bss starts zeroed (NOBITS) — exactly wasm's zero-init semantics.
+
+entry = BASES[".text"] + syms["run"][1]
+RET = BASES[".text"] + 0xFF0
+mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+ok = True
+for p in (0, 7, 100, -5):
+    # Re-zero .bss between runs (fresh wasm instance per wasmtime invocation).
+    mu.mem_write(BASES[".bss"], b"\x00" * bss_size)
+    mu.reg_write(UC_ARM_REG_R0, p & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_R11, 0)  # native deref: fp/base = 0
+    mu.reg_write(UC_ARM_REG_SP, BASES[".bss"] + 0x8000)  # a real machine SP pad
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    mu.emu_start(entry | 1, RET, timeout=5_000_000)
+    got = mu.reg_read(UC_ARM_REG_R0)
+    exp = (43 + 2 * p) & 0xFFFFFFFF
+    print(f"run({p}) = {got} (expect {exp})")
+    ok &= got == exp
+
+print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+sys.exit(0 if ok else 1)


### PR DESCRIPTION
## What

Fixes #678. Under `--native-pointer-abi --shadow-stack-size <B>`, the shipped
VCR-MEM-001 layer-1 (#383) **refused** any buffer-carrying dissolved node
(wit-bindgen `list<u8>`) or plain `static mut` array:

```
Error: --shadow-stack-size: a native-pointer static access addends 4200 into the
[0, sp_init) reservation ... down-shifting inline statics is the deferred
general case. Refusing rather than mis-addressing. VCR-MEM-001/#383.
```

Layer-1 re-based the SP slot + resized the `.bss` but refused any residual
`__synth_wasm_data + C` reloc with `C != 0` still pointing into the reservation.
That gated the whole gust:os OS milestone beyond the scalar `time` interface —
`spawn`/`log`/`channel`/`io` all put data + zero-init scratch in the static tail
`[sp_init, used_extent)`.

## Root cause

`static_data_addend` classifies any const address `>= sp_init` (= `wasm_data_base`)
as a static `__synth_wasm_data + C` reloc. The mixed/`split_linmem_bss` shrink
retargets initialized `(data)` segments into `.data`, but a **zero-init BSS
static** (or a wit-bindgen realloc/scratch read) is not in any segment, so it
fell to the residual loop and was refused.

## Fix (layer-2)

Each residual tail static rebases in place `C -> C - (sp_init - budget)` (Abs32
is REL — patch the in-place literal word, exactly like the #354 retarget),
landing in the down-shifted `.bss` tail. That target is a **zero** byte — exactly
wasm's zero-init semantics — because a residual reloc is never inside a `(data)`
segment (the split path has no segments, or retargets them all into `.data`). The
addend-0 region-base pointer (`global.get $sp` base) is stable; the SP *value*
rides the re-based `__synth_globals` slot. `reserved_extent` already covers the
shifted tail (`static_top_abs32 = max(C)+8`, pre-patch).

## Sound-decline sub-cases (loud + precise, not blanket)

- a load window **straddling** a `(data)` segment boundary (part in `.data`, part
  in the `.bss` tail);
- an addend **below `sp_init`** (would collide with the live stack region);
- the **one-PROGBITS fallback** geometry (statics inline, not separable — kept).

## Red -> green

- `mem678_bss` / `mem678_buf` refused on `origin/main`; now compile, statics land
  at the down-shifted addends (4160->576, 4200->616), `.bss` sized `B + tail`.
- Execution differential `native_pointer_static_downshift_678.py` (unicorn):
  a shadow-stack roundtrip + a `.data` buffer + a down-shifted BSS static all
  agree with wasmtime `run(p) == 43 + 2p` (incl. negative `p`).
- 4 durable integration tests (`static_downshift_678.rs`).
- Opt-in ⇒ frozen anchors **10/10** byte-identical; existing #383 tests green.

Roadmap `VCR-MEM-001` updated (layer-2 down-shift note; distinct from the
numbered scry-auto-budget layer-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)