### PR TITLE
feat(npm): @pulseengine/synth CLI wrapper with checksum-verified install (#426)

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,119 @@
+name: Release NPM
+
+# Publishes the @pulseengine/synth npm wrapper after the main Release
+# workflow (release.yml) has created the GitHub Release with the per-target
+# binary archives + SHA256SUMS.txt.
+#
+# Unlike rivet (which ships one npm package per platform with the binaries
+# bundled), synth's wrapper is a SINGLE package that downloads and
+# checksum-verifies the matching release tarball at install time. So there is
+# exactly one package to publish, and it does not need the binaries present at
+# publish time — only at first install, which is always after the Release page
+# exists. workflow_run on Release completion satisfies that ordering.
+#
+# Trigger rationale: release.yml creates the Release using GITHUB_TOKEN, and
+# GitHub suppresses downstream `release: published` triggers from
+# GITHUB_TOKEN-authenticated runs (loop-prevention). workflow_run is the
+# documented escape hatch. Note: workflow_run only fires when this file is on
+# the default branch.
+
+concurrency:
+  group: release-npm-${{ github.event.workflow_run.head_branch || github.event.inputs.version || github.ref }}
+  cancel-in-progress: false
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag to publish (e.g. v0.38.0)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish @pulseengine/synth
+    # Skip on failed/cancelled upstream Release runs; always run for manual
+    # workflow_dispatch (backfills).
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      # Preflight: fail loud + early if NPM_TOKEN can't authenticate, instead
+      # of letting `npm publish` crash with a cryptic E404 (expired/no-access)
+      # or EOTP (a classic *Publish* token, which the org's 2FA-on-publish
+      # rejects in CI). npm publish needs a classic *Automation* token or a
+      # granular token with read-write on @pulseengine/*.
+      - name: Preflight — verify npm auth
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if ! who=$(npm whoami 2>/dev/null); then
+            echo "::error title=npm auth failed::NPM_TOKEN is invalid, expired, or the wrong type. npm publish needs a classic *Automation* token (or a granular token with read-write on @pulseengine/*); a classic *Publish* token fails under 2FA with EOTP. Regenerate at npmjs.com -> Access Tokens and update the NPM_TOKEN secret."
+            exit 1
+          fi
+          echo "npm auth OK as: $who"
+
+      - name: Resolve version
+        id: version
+        env:
+          # workflow_run: head_branch is the tag name (e.g. v0.38.0).
+          # workflow_dispatch: the user-supplied tag input.
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          INPUT_TAG: ${{ github.event.inputs.version }}
+        run: |
+          TAG="${INPUT_TAG:-$RUN_BRANCH}"
+          if [ -z "$TAG" ]; then
+            echo "No tag provided" >&2
+            exit 1
+          fi
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Tag '$TAG' is not a release tag (expected vX.Y.Z); skipping" >&2
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # Pin the package version to the tag at publish time so the download URL
+      # (v${version}) resolves to this exact release. Avoids a manual npm
+      # version bump in the release commit and keeps the two from drifting.
+      - name: Set package version
+        working-directory: npm
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          cat package.json
+
+      - name: Publish to npm
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "## NPM package published";
+            echo "";
+            echo "- \`@pulseengine/synth@$VERSION\`";
+            echo "";
+            echo "### Usage";
+            echo '```bash';
+            echo "npx @pulseengine/synth@$VERSION --version";
+            echo '```';
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -61,6 +61,10 @@ an existing tag).
    — see Phase 4 below. Pushes the publishable workspace crates to
    crates.io via OIDC trusted publishing.
 
+4. **`release-npm.yml`** (chained via `workflow_run` after `release.yml`
+   completes) — publishes the `@pulseengine/synth` npm wrapper. See the
+   "npm distribution channel" section below.
+
 ## Provenance and signing model
 
 synth uses **two complementary mechanisms**, matching the sibling repos:
@@ -148,6 +152,76 @@ After the workflow finishes:
 - [ ] `publish-to-crates-io.yml` ran green: confirm
       `cargo install synth-cli` works on a clean machine, or check
       <https://crates.io/crates/synth-cli> shows the new version.
+
+## npm distribution channel
+
+Alongside crates.io, synth publishes an npm CLI wrapper — `@pulseengine/synth`
+— so the compiler can be installed with `npm install -g @pulseengine/synth` or
+run one-shot with `npx @pulseengine/synth --version`. The package lives in
+`npm/`.
+
+### How the wrapper works
+
+The package ships **no binaries**. It has no third-party dependencies. On
+install, its `postinstall` hook (`npm/install.js`):
+
+1. Detects the platform + arch and maps them to the Rust target triple
+   (`npm/index.js` — the single source of truth, mirroring the four targets
+   `release.yml` builds; there is no Windows build).
+2. Downloads the matching `synth-v<version>-<triple>.tar.gz` from the GitHub
+   Release whose tag equals the package version.
+3. Fetches `SHA256SUMS.txt` from the same release and **verifies** the
+   tarball's SHA-256 against it *before* extracting — a mismatch aborts the
+   install. This reuses the release's existing signed checksum manifest (the
+   same one covered by the cosign signature above) as the trust anchor.
+4. Extracts `synth` into `npm/bin/` and `run.js` execs it.
+
+Because the wrapper downloads at install time, publishing it does not require
+the binaries to exist at publish time — only at first user install, which is
+always after the Release page exists. That ordering is why `release-npm.yml`
+triggers on `workflow_run` after `release.yml`, not on tag push.
+
+This is a deliberate deviation from rivet's npm layout (one bundled binary
+package per platform, no checksum check). synth uses a single
+download-and-verify package because (a) checksum verification is a first-class
+requirement for the canonical Track-A supply-chain reference, (b) synth ships
+four targets and no Windows build, and (c) it keeps the maintainer surface to
+one package.
+
+### Publishing (automated)
+
+`release-npm.yml` runs after `release.yml` succeeds, resolves the version from
+the tag, pins `npm/package.json`'s `version` to it (so no manual bump is
+needed in the release commit), and runs `npm publish`. It requires the
+`NPM_TOKEN` repo secret to be a classic **Automation** token (or a granular
+token with read-write on `@pulseengine/*`); a classic *Publish* token fails
+under the org's 2FA-on-publish with `EOTP`. A preflight `npm whoami` step fails
+loud + early if the token is wrong. Backfill a missed release with the manual
+`workflow_dispatch` (pass the existing tag).
+
+### Publishing (manual fallback)
+
+If the workflow is unavailable, a maintainer with publish rights can release
+the wrapper by hand from a clean checkout of the tag:
+
+```bash
+cd npm
+npm version 0.3.1 --no-git-tag-version   # match the release tag (bare semver)
+npm test                                 # platform->tarball mapping unit tests
+npm pack --dry-run                        # sanity-check the file list
+npm publish --access public               # requires NPM_TOKEN / npm login
+```
+
+Then smoke-test: `npx @pulseengine/synth@0.3.1 --version` on macOS and Linux.
+
+### Release-checklist additions
+
+Add to the post-workflow checks below:
+
+- [ ] `release-npm.yml` ran green (or was backfilled via `workflow_dispatch`);
+      <https://www.npmjs.com/package/@pulseengine/synth> shows the new version.
+- [ ] `npx @pulseengine/synth@<version> --version` prints the matching version
+      on a clean machine (verifies the download + checksum path end-to-end).
 
 ## CHANGELOG.md mapping
 

--- a/npm/.npmignore
+++ b/npm/.npmignore
@@ -1,0 +1,6 @@
+bin/
+test/
+*.tmp
+*.tgz
+.DS_Store
+Thumbs.db

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,59 @@
+# @pulseengine/synth
+
+`synth` — a WebAssembly-to-native compiler with mechanized correctness proofs
+in Rocq. It compiles WebAssembly to bare-metal ELF binaries for ARM Cortex-M
+(Thumb-2), Cortex-R5 (A32), RISC-V (RV32IMAC), and host-native AArch64.
+
+This npm package distributes the `synth` CLI binary so it can be installed and
+invoked from any Node.js environment. It complements the crates.io
+distribution (`cargo install synth-cli`).
+
+## Install
+
+```bash
+# One-shot (no install)
+npx @pulseengine/synth --version
+
+# Global install
+npm install -g @pulseengine/synth
+synth --version
+```
+
+## How it works
+
+There are no third-party dependencies. On install, the `postinstall` hook:
+
+1. Detects your platform and architecture.
+2. Downloads the matching `synth-v<version>-<triple>.tar.gz` from the GitHub
+   Release whose tag equals this package's version.
+3. **Verifies** the tarball's SHA-256 against the release's signed
+   `SHA256SUMS.txt` manifest — a mismatch aborts the install.
+4. Extracts the `synth` binary into the package's `bin/` directory.
+
+The package version tracks the synth release version, so
+`npm install @pulseengine/synth@0.38.0` fetches the `v0.38.0` binaries.
+
+Set `SYNTH_NPM_SKIP_DOWNLOAD=1` to skip the download (e.g. air-gapped CI where
+the binary is provided out of band).
+
+## Supported platforms
+
+Mirrors the release build matrix (no Windows build):
+
+- `darwin-arm64` — `aarch64-apple-darwin`
+- `darwin-x64` — `x86_64-apple-darwin`
+- `linux-arm64` — `aarch64-unknown-linux-gnu`
+- `linux-x64` — `x86_64-unknown-linux-gnu`
+
+Binaries are pre-built and published alongside each GitHub release at
+<https://github.com/pulseengine/synth/releases>. On an unsupported platform,
+install from source:
+
+```bash
+cargo install --git https://github.com/pulseengine/synth synth-cli
+```
+
+## License
+
+Apache-2.0. See the [repository](https://github.com/pulseengine/synth) for
+source, documentation, and issues.

--- a/npm/index.js
+++ b/npm/index.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+// Platform detection and release-asset naming for @pulseengine/synth.
+//
+// synth is distributed as a single npm package: install.js (postinstall)
+// downloads the matching pre-built binary from the GitHub Release whose tag
+// equals this package's version, verifies it against the release's signed
+// SHA256SUMS manifest, and extracts it into ./bin. This module owns the
+// platform -> Rust-target-triple mapping shared by install.js and run.js and
+// is the single source of truth for asset names.
+//
+// Supported targets mirror .github/workflows/release.yml exactly — four
+// tarballs, no Windows build:
+//   - aarch64-apple-darwin      (macOS arm64)
+//   - x86_64-apple-darwin       (macOS x64)
+//   - aarch64-unknown-linux-gnu (Linux arm64)
+//   - x86_64-unknown-linux-gnu  (Linux x64)
+
+const os = require("os");
+const path = require("path");
+
+const REPO = "pulseengine/synth";
+
+/**
+ * Map (process.platform, process.arch) to the Rust target triple that
+ * release.yml builds and uploads. Throws with a clear message for any
+ * combination synth does not ship a binary for (notably Windows, which has
+ * no release build — do NOT synthesize a 404 URL for it).
+ *
+ * @param {string} [platform=os.platform()] node platform id
+ * @param {string} [arch=os.arch()] node arch id
+ * @returns {string} e.g. "aarch64-apple-darwin"
+ */
+function getRustTarget(platform = os.platform(), arch = os.arch()) {
+  let osTriple;
+  switch (platform) {
+    case "darwin":
+      osTriple = "apple-darwin";
+      break;
+    case "linux":
+      osTriple = "unknown-linux-gnu";
+      break;
+    default:
+      throw new Error(
+        `Unsupported platform: ${platform}. synth ships binaries for ` +
+          "macOS (darwin) and Linux only. Build from source with " +
+          "`cargo install --git https://github.com/pulseengine/synth synth-cli`.",
+      );
+  }
+
+  let archTriple;
+  switch (arch) {
+    case "x64":
+      archTriple = "x86_64";
+      break;
+    case "arm64":
+      archTriple = "aarch64";
+      break;
+    default:
+      throw new Error(
+        `Unsupported architecture: ${arch}. synth ships x86_64 (x64) and ` +
+          "aarch64 (arm64) binaries only.",
+      );
+  }
+
+  return `${archTriple}-${osTriple}`;
+}
+
+/**
+ * The release-asset tarball name for a given version + platform. Matches the
+ * `synth-${VERSION}-${TARGET}.tar.gz` name produced by release.yml, where
+ * VERSION is the tag *with* its leading `v` (e.g. v0.38.0).
+ *
+ * @param {string} version bare semver, e.g. "0.38.0"
+ * @param {string} [platform]
+ * @param {string} [arch]
+ * @returns {string} e.g. "synth-v0.38.0-aarch64-apple-darwin.tar.gz"
+ */
+function getTarballName(version, platform = os.platform(), arch = os.arch()) {
+  const target = getRustTarget(platform, arch);
+  return `synth-v${version}-${target}.tar.gz`;
+}
+
+/** The binary name inside the tarball / on disk. synth has no Windows build,
+ * so there is never a `.exe`. */
+function getBinaryName() {
+  return "synth";
+}
+
+/**
+ * Absolute path to the extracted synth binary (populated by install.js).
+ */
+function getBinaryPath() {
+  return path.join(__dirname, "bin", getBinaryName());
+}
+
+/**
+ * GitHub Release download URL for the platform tarball at this version.
+ */
+function getTarballUrl(version, platform = os.platform(), arch = os.arch()) {
+  const name = getTarballName(version, platform, arch);
+  return `https://github.com/${REPO}/releases/download/v${version}/${name}`;
+}
+
+/**
+ * GitHub Release download URL for the signed SHA256SUMS manifest.
+ */
+function getChecksumsUrl(version) {
+  return `https://github.com/${REPO}/releases/download/v${version}/SHA256SUMS.txt`;
+}
+
+/**
+ * Parse a SHA256SUMS.txt manifest (as produced by `sha256sum ./*`) into a
+ * { basename: hash } map. Each line is `<64-hex-hash>  ./<name>` — note the
+ * two-space separator and the `./` path prefix; we key by basename so a
+ * caller can look up `synth-v0.38.0-<triple>.tar.gz` directly.
+ *
+ * @param {string} text raw manifest contents
+ * @returns {Map<string,string>}
+ */
+function parseChecksums(text) {
+  const map = new Map();
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const m = line.match(/^([0-9a-fA-F]{64})\s+(.+)$/);
+    if (!m) continue;
+    const hash = m[1].toLowerCase();
+    const name = path.basename(m[2].trim());
+    map.set(name, hash);
+  }
+  return map;
+}
+
+/**
+ * Look up the expected sha256 for a tarball in a parsed manifest.
+ * @returns {string} lowercase hex hash
+ * @throws if the tarball is absent from the manifest
+ */
+function expectedHashFor(tarballName, checksumsText) {
+  const map =
+    checksumsText instanceof Map ? checksumsText : parseChecksums(checksumsText);
+  const hash = map.get(tarballName);
+  if (!hash) {
+    throw new Error(
+      `SHA256SUMS.txt has no entry for ${tarballName} — refusing to install ` +
+        "an unverifiable binary.",
+    );
+  }
+  return hash;
+}
+
+module.exports = {
+  REPO,
+  getRustTarget,
+  getTarballName,
+  getBinaryName,
+  getBinaryPath,
+  getTarballUrl,
+  getChecksumsUrl,
+  parseChecksums,
+  expectedHashFor,
+};
+
+// When invoked directly, print platform info (useful for debugging installs).
+if (require.main === module) {
+  try {
+    const version = require("./package.json").version;
+    console.log("synth npm — platform information:");
+    console.log(`  Platform:     ${os.platform()}`);
+    console.log(`  Architecture: ${os.arch()}`);
+    console.log(`  Rust target:  ${getRustTarget()}`);
+    console.log(`  Tarball:      ${getTarballName(version)}`);
+    console.log(`  Download URL: ${getTarballUrl(version)}`);
+    console.log(`  Binary path:  ${getBinaryPath()}`);
+  } catch (err) {
+    console.error("Error:", err.message);
+    process.exit(1);
+  }
+}

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+// Post-install hook for @pulseengine/synth.
+//
+// Downloads the pre-built `synth` binary for the current platform from the
+// GitHub Release whose tag matches this package's version, VERIFIES the
+// tarball against the release's SHA256SUMS.txt manifest, then extracts the
+// binary into ./bin so run.js can spawn it.
+//
+// The checksum step is mandatory: an install that cannot verify the archive
+// against the published manifest aborts rather than run an unverified binary.
+//
+// Uses only Node built-ins (https, node:crypto, fs, node:child_process) plus
+// the system `tar` — no third-party dependencies.
+
+const os = require("os");
+const path = require("path");
+const fs = require("fs");
+const https = require("https");
+const crypto = require("crypto");
+const { execFileSync } = require("child_process");
+
+const {
+  getRustTarget,
+  getBinaryName,
+  getBinaryPath,
+  getTarballName,
+  getTarballUrl,
+  getChecksumsUrl,
+  expectedHashFor,
+} = require("./index.js");
+
+const VERSION = require("./package.json").version;
+
+// Allow air-gapped / offline installs to skip the network fetch (e.g. when a
+// binary was pre-placed or is provided by another mechanism).
+if (process.env.SYNTH_NPM_SKIP_DOWNLOAD === "1") {
+  console.log(
+    "SYNTH_NPM_SKIP_DOWNLOAD=1 set — skipping synth binary download.",
+  );
+  process.exit(0);
+}
+
+function download(url, { asBuffer = false, dest = null } = {}, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    if (redirects > 5) {
+      return reject(new Error(`Too many redirects fetching ${url}`));
+    }
+    https
+      .get(url, { headers: { "User-Agent": "pulseengine-synth-npm" } }, (res) => {
+        if (
+          res.statusCode >= 300 &&
+          res.statusCode < 400 &&
+          res.headers.location
+        ) {
+          res.resume();
+          return download(res.headers.location, { asBuffer, dest }, redirects + 1)
+            .then(resolve)
+            .catch(reject);
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          return reject(
+            new Error(`HTTP ${res.statusCode} ${res.statusMessage} for ${url}`),
+          );
+        }
+        if (asBuffer) {
+          const chunks = [];
+          res.on("data", (c) => chunks.push(c));
+          res.on("end", () => resolve(Buffer.concat(chunks)));
+          res.on("error", reject);
+        } else {
+          const file = fs.createWriteStream(dest);
+          res.pipe(file);
+          file.on("finish", () => file.close(() => resolve(dest)));
+          file.on("error", (err) => {
+            fs.unlink(dest, () => {});
+            reject(err);
+          });
+        }
+      })
+      .on("error", reject);
+  });
+}
+
+function sha256(buffer) {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+// Extract via execFile (no shell) — inputs are paths we constructed, but the
+// argv form is the correct idiom regardless.
+function extractTarball(archivePath, destDir) {
+  execFileSync("tar", ["-xzf", archivePath, "-C", destDir], {
+    stdio: "inherit",
+  });
+}
+
+async function main() {
+  const target = getRustTarget();
+  const tarballName = getTarballName(VERSION);
+  const tarballUrl = getTarballUrl(VERSION);
+  const checksumsUrl = getChecksumsUrl(VERSION);
+  const binaryName = getBinaryName();
+
+  console.log(`synth npm installer — v${VERSION}`);
+  console.log(`  Platform: ${os.type()} ${os.arch()} (${target})`);
+  console.log(`  Tarball:  ${tarballName}`);
+
+  const binDir = path.join(__dirname, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  const archivePath = path.join(binDir, tarballName);
+
+  // 1. Fetch the signed checksum manifest first, so we know what to expect.
+  console.log("  Fetching SHA256SUMS.txt ...");
+  const checksumsText = (await download(checksumsUrl, { asBuffer: true })).toString(
+    "utf8",
+  );
+  const expected = expectedHashFor(tarballName, checksumsText);
+
+  // 2. Download the tarball.
+  console.log(`  Downloading ${tarballUrl} ...`);
+  await download(tarballUrl, { dest: archivePath });
+
+  // 3. Verify BEFORE extracting.
+  const actual = sha256(fs.readFileSync(archivePath));
+  if (actual !== expected) {
+    fs.unlinkSync(archivePath);
+    throw new Error(
+      `Checksum mismatch for ${tarballName}\n` +
+        `  expected: ${expected}\n` +
+        `  actual:   ${actual}\n` +
+        "The download may be corrupted or tampered with. Aborting.",
+    );
+  }
+  console.log(`  Checksum OK (sha256 ${actual}).`);
+
+  // 4. Extract and expose the binary.
+  console.log("  Extracting ...");
+  extractTarball(archivePath, binDir);
+  fs.unlinkSync(archivePath);
+
+  const binaryPath = getBinaryPath();
+  if (!fs.existsSync(binaryPath)) {
+    throw new Error(
+      `Extraction succeeded but ${binaryName} was not found at ${binaryPath}.`,
+    );
+  }
+  fs.chmodSync(binaryPath, 0o755);
+  console.log(`  Installed synth -> ${binaryPath}`);
+}
+
+main().catch((err) => {
+  console.error("");
+  console.error("Failed to install the synth binary:", err.message);
+  console.error("");
+  console.error("Alternatives:");
+  console.error(
+    "  1. Build from source: cargo install --git " +
+      "https://github.com/pulseengine/synth synth-cli",
+  );
+  console.error(
+    "  2. Download a release manually: " +
+      "https://github.com/pulseengine/synth/releases",
+  );
+  // A failed binary install is a hard error: unlike rivet (which has a
+  // platform-package primary path and treats the download as a fallback),
+  // this package's ONLY delivery mechanism is the verified download. If it
+  // fails, `synth` would not exist — surface that loudly.
+  process.exit(1);
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@pulseengine/synth",
+  "version": "0.38.0",
+  "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
+  "bin": {
+    "synth": "./run.js"
+  },
+  "scripts": {
+    "postinstall": "node install.js",
+    "preuninstall": "node uninstall.js",
+    "test": "node --test"
+  },
+  "keywords": [
+    "webassembly",
+    "wasm",
+    "compiler",
+    "arm",
+    "cortex-m",
+    "riscv",
+    "aarch64",
+    "embedded",
+    "bare-metal",
+    "verified",
+    "rocq",
+    "coq",
+    "rust",
+    "cli"
+  ],
+  "author": "PulseEngine <https://github.com/pulseengine>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pulseengine/synth.git"
+  },
+  "homepage": "https://github.com/pulseengine/synth#readme",
+  "bugs": {
+    "url": "https://github.com/pulseengine/synth/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "files": [
+    "index.js",
+    "install.js",
+    "run.js",
+    "uninstall.js",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/npm/run.js
+++ b/npm/run.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+// Thin launcher that spawns the synth binary extracted by install.js.
+// Forwards argv, stdio, and exit code; propagates signals to the child.
+
+const { spawn } = require("child_process");
+const fs = require("fs");
+const { getBinaryPath } = require("./index.js");
+
+const binaryPath = getBinaryPath();
+
+if (!fs.existsSync(binaryPath)) {
+  console.error("synth binary not found at:", binaryPath);
+  console.error("");
+  console.error("This usually means the postinstall download did not run or");
+  console.error("failed. Try reinstalling:");
+  console.error("  npm install --force @pulseengine/synth");
+  console.error("");
+  console.error(
+    "Or build from source: cargo install --git " +
+      "https://github.com/pulseengine/synth synth-cli",
+  );
+  process.exit(1);
+}
+
+const child = spawn(binaryPath, process.argv.slice(2), {
+  stdio: "inherit",
+  env: process.env,
+});
+
+child.on("error", (err) => {
+  console.error("Failed to start synth:", err.message);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code == null ? 0 : code);
+  }
+});
+
+process.on("SIGINT", () => child.kill("SIGINT"));
+process.on("SIGTERM", () => child.kill("SIGTERM"));

--- a/npm/test/mapping.test.js
+++ b/npm/test/mapping.test.js
@@ -1,0 +1,92 @@
+"use strict";
+
+// Unit tests for @pulseengine/synth's platform -> release-asset mapping and
+// the SHA256SUMS parser. Node built-in test runner only (no dev deps):
+//   npm test          (package.json runs `node --test`)
+//   node --test test/mapping.test.js
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  getRustTarget,
+  getTarballName,
+  getTarballUrl,
+  getChecksumsUrl,
+  getBinaryName,
+  parseChecksums,
+  expectedHashFor,
+} = require("../index.js");
+
+test("platform x arch -> Rust target triple (the four shipped targets)", () => {
+  assert.equal(getRustTarget("darwin", "arm64"), "aarch64-apple-darwin");
+  assert.equal(getRustTarget("darwin", "x64"), "x86_64-apple-darwin");
+  assert.equal(getRustTarget("linux", "arm64"), "aarch64-unknown-linux-gnu");
+  assert.equal(getRustTarget("linux", "x64"), "x86_64-unknown-linux-gnu");
+});
+
+test("darwin/arm64 maps to the exact v0.38.0 tarball name", () => {
+  assert.equal(
+    getTarballName("0.38.0", "darwin", "arm64"),
+    "synth-v0.38.0-aarch64-apple-darwin.tar.gz",
+  );
+});
+
+test("tarball URL points at the versioned GitHub release asset", () => {
+  assert.equal(
+    getTarballUrl("0.38.0", "linux", "x64"),
+    "https://github.com/pulseengine/synth/releases/download/v0.38.0/" +
+      "synth-v0.38.0-x86_64-unknown-linux-gnu.tar.gz",
+  );
+  assert.equal(
+    getChecksumsUrl("0.38.0"),
+    "https://github.com/pulseengine/synth/releases/download/v0.38.0/SHA256SUMS.txt",
+  );
+});
+
+test("binary name is always 'synth' (no Windows build)", () => {
+  assert.equal(getBinaryName(), "synth");
+});
+
+test("unsupported platforms/arches throw a clear error (no 404 URL)", () => {
+  assert.throws(() => getRustTarget("win32", "x64"), /Unsupported platform: win32/);
+  assert.throws(() => getRustTarget("freebsd", "x64"), /Unsupported platform/);
+  assert.throws(() => getRustTarget("linux", "ia32"), /Unsupported architecture: ia32/);
+  assert.throws(() => getRustTarget("darwin", "riscv64"), /Unsupported architecture/);
+});
+
+// The real v0.38.0 manifest is produced by `sha256sum ./*`: two-space
+// separator, a `./` path prefix, one entry per asset. Parsing must key by
+// basename so a lookup by tarball name succeeds.
+const REAL_SHA256SUMS = [
+  "6e280e09614026ae9ca8378d3f5d9c038ea5f9bb0a43cdfaff9d3f60bbbaf437  ./synth-0.38.0.cdx.json",
+  "c2208c039c0b646de3c1dec02b6dc5c26271fce338be58012859528eaf7d1601  ./synth-v0.38.0-aarch64-apple-darwin.tar.gz",
+  "77c123b8bc663c0fd91521d7874a8521ae29b3f1b61f761c1b059b3ea29cb410  ./synth-v0.38.0-aarch64-unknown-linux-gnu.tar.gz",
+  "b1750e5a5cfc2306ca79e5bfeb250f93e518f9ff8539465286e9e50580f369f0  ./synth-v0.38.0-x86_64-apple-darwin.tar.gz",
+  "69e0327d566ab4e767b386019c395457fc261e3ff2f0d85587f71ddd738f95d5  ./synth-v0.38.0-x86_64-unknown-linux-gnu.tar.gz",
+  "",
+].join("\n");
+
+test("parseChecksums keys by basename, strips the ./ prefix", () => {
+  const map = parseChecksums(REAL_SHA256SUMS);
+  assert.equal(map.size, 5);
+  assert.equal(
+    map.get("synth-v0.38.0-aarch64-apple-darwin.tar.gz"),
+    "c2208c039c0b646de3c1dec02b6dc5c26271fce338be58012859528eaf7d1601",
+  );
+});
+
+test("expectedHashFor resolves the darwin/arm64 tarball from the real manifest", () => {
+  const name = getTarballName("0.38.0", "darwin", "arm64");
+  assert.equal(
+    expectedHashFor(name, REAL_SHA256SUMS),
+    "c2208c039c0b646de3c1dec02b6dc5c26271fce338be58012859528eaf7d1601",
+  );
+});
+
+test("expectedHashFor throws when a tarball is absent from the manifest", () => {
+  assert.throws(
+    () => expectedHashFor("synth-v9.9.9-x86_64-apple-darwin.tar.gz", REAL_SHA256SUMS),
+    /no entry for/,
+  );
+});

--- a/npm/uninstall.js
+++ b/npm/uninstall.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+// Pre-uninstall hook: remove the binary downloaded into ./bin by install.js.
+
+const fs = require("fs");
+const path = require("path");
+
+const binDir = path.join(__dirname, "bin");
+
+if (fs.existsSync(binDir)) {
+  try {
+    fs.rmSync(binDir, { recursive: true, force: true });
+  } catch (err) {
+    console.error("Failed to clean synth bin/:", err.message);
+  }
+}


### PR DESCRIPTION
Closes #426 — adds the npm CLI distribution channel (crates.io was already covered), the one remaining gap in synth's Track-A release standard.

## Package layout (`npm/`)

A **single, dependency-free** package (Node built-ins only: `https`, `node:crypto`, `fs`, `node:child_process` + system `tar`):

- `package.json` — `@pulseengine/synth`, version tracks the synth release, `bin: { synth }`, `postinstall`/`preuninstall` hooks.
- `index.js` — single source of truth for the platform → Rust-target-triple mapping (the four targets `release.yml` builds; **no Windows build** → clear throw, never a 404 URL) + the `SHA256SUMS.txt` parser.
- `install.js` — postinstall: download tarball → verify SHA-256 against the release manifest → extract → chmod.
- `run.js` — thin launcher (forwards argv/stdio/exit code, propagates signals).
- `uninstall.js` — removes downloaded `bin/`.
- `README.md`, `.npmignore`, `test/mapping.test.js`.

## Checksum-verify approach

On install: fetch the release's `SHA256SUMS.txt`, look up the tarball by basename (the manifest is generated with `sha256sum ./*`, so entries are `<hash>␠␠./synth-v…tar.gz` — two spaces, `./` prefix), download the tarball, and compare its SHA-256 **before** extracting. A mismatch aborts. This reuses the release's existing cosign-signed checksum manifest as the trust anchor. A failed install is a hard error (the verified download is the package's only delivery mechanism).

## Deviation from rivet (stated in the open, per the issue)

rivet ships one bundled-binary package per platform via `optionalDependencies` and its fallback download does **no** checksum check. synth instead uses a single download-and-verify package because: (a) checksum verification is a first-class requirement for the canonical Track-A supply-chain reference; (b) synth ships four targets and no Windows build; (c) it keeps the maintainer surface to one package. Documented in `docs/release-process.md`.

## Verification

- **Unit tests (8, `node --test`)** — platform→triple mapping for all four targets, exact v0.38.0 tarball name for darwin/arm64, URL construction, unsupported-platform/arch throws, and the parser/`expectedHashFor` fixtured on the **real v0.38.0 manifest**. All pass.
- **`npm pack`** — succeeds; 6 files, `test/` and `bin/` excluded.
- **Real-release smoke test (v0.38.0, on darwin/arm64)** — `node install.js` downloaded `synth-v0.38.0-aarch64-apple-darwin.tar.gz`, checksum matched the manifest (`c2208c03…d1601`), extracted, and `node run.js --version` printed `synth 0.38.0`. End-to-end download + verify path confirmed against the shipped release.

## Publish step (maintainer)

`release-npm.yml` (chained via `workflow_run` after `release.yml`) resolves the version from the tag, pins `npm/package.json`'s version to it, and `npm publish`es — gated on the `NPM_TOKEN` repo secret (classic **Automation** token; a preflight `npm whoami` fails loud if the token is wrong type/expired). Manual `workflow_dispatch` backfills a missed release. A by-hand fallback is documented in `docs/release-process.md`. **Not published here** — the maintainer holds the token.

No Rust or frozen anchors touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)