### PR TITLE
coq(#73): discharge i32 rem_s/rem_u trap-guard admits vs exec_program_br

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,12 +89,13 @@ cd coq && make proofs
 
 ### Proof Status
 
-See `coq/STATUS.md` for the complete coverage matrix. Current: 470 Qed / 8 Admitted
+See `coq/STATUS.md` for the complete coverage matrix. Current: 472 Qed / 6 Admitted
 (+2 `admit.` tactics) across `coq/Synth/`. This count is CI-gated: `claims.yaml` +
 `scripts/claim_check.py` re-derive it on every commit — when a proof lands, update
 the docs AND `claims.yaml` in the same PR. Proofs are tiered:
 T1 (result-correspondence), T2 (existence-only), T3 (admitted). Remaining admits:
-3 i32 division trap guards (exec_program model gap, #73), 2 Compilation.v,
+1 i32 division trap guard (div_s INT_MIN/-1 double guard, #73 — div_u/rem_s/rem_u
+discharged against `exec_program_br`), 2 Compilation.v,
 1 CorrectnessSimple.v, 2 ArmRefinement.v — 0 i64 admits.
 All i32 AND i64 operations have T1 proofs (i64 T1 parity since v0.11.0).
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 | ELF output with vector table | Implemented | Thumb bit set on symbols; not linked on real hardware |
 | Linker scripts (STM32, nRF52840, generic) | Implemented | Generated, not tested with real boards |
 | Cross-compilation (`--link` flag) | Implemented | Requires `arm-none-eabi-gcc` in PATH; not CI-tested |
-| Rocq mechanized proofs | 470 Qed / 8 Admitted | i32 + i64 T1 proofs; division proofs re-admitted for trap guard alignment |
+| Rocq mechanized proofs | 472 Qed / 6 Admitted | i32 + i64 T1 proofs; div_s trap guard re-admitted (div_u/rem_s/rem_u discharged) |
 | SMT translation validation | ordeal (pure-Rust QF_BV) default | v0.27.0 (#553); Z3 demoted to feature-gated differential oracle — 141/141 agreement |
 | WebAssembly spec test suite | 227/257 compile | Compilation only — not executed on emulator |
 
@@ -194,7 +194,7 @@ Per the [PulseEngine Verification Guide](https://pulseengine.eu/guides/VERIFICAT
 
 | Track | Status | Coverage |
 |-------|--------|----------|
-| **Rocq** | Partial | 470 Qed / 8 Admitted — division proofs re-admitted for trap guard alignment |
+| **Rocq** | Partial | 472 Qed / 6 Admitted — div_s trap guard re-admitted (div_u/rem_s/rem_u discharged) |
 | **Kani** | Starting | 18 bounded model checking harnesses for ARM encoder |
 | **Verus** | Starting | 8 spec functions in `synth-synthesis/src/contracts.rs`; Bazel integration via `rules_verus` |
 | **Lean** | Not started | — |
@@ -206,11 +206,12 @@ See `artifacts/verification-gaps.yaml` for the detailed gap analysis (VG-001 thr
 Mechanized proofs in Rocq 9 show that `compile_wasm_to_arm` preserves WASM semantics for each operation. The proof suite lives in `coq/Synth/` and covers ARM instruction semantics, WASM stack-machine semantics, and per-operation correctness theorems.
 
 ```
-470 Qed / 8 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
+472 Qed / 6 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
   T1 result-correspondence (ARM output = WASM result): all i32 ops and all
      i64 ops — i64 T1 parity since v0.11.0, 0 i64 admits (coq/STATUS.md)
   T2 existence-only: f32/f64 and remaining categories
-  T3 admitted (8): 3 i32 division trap guards (exec_program model gap, #73),
+  T3 admitted (6): 1 i32 division trap guard (div_s INT_MIN/-1 double guard, #73;
+     div_u/rem_s/rem_u discharged against exec_program_br),
      2 Compilation.v, 1 CorrectnessSimple.v, 2 ArmRefinement.v
   incl. 40 Qed selector-DSL rule theorems (Synth/VcrSelRules.v, 1:1 with
      coq/vcr_sel_rules.manifest), 7 Qed VCR-SEL-001 pilot lemmas

--- a/claims.yaml
+++ b/claims.yaml
@@ -25,20 +25,20 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-PROOF-COUNT-README
     doc: README.md
-    text: "470 Qed / 8 Admitted"
+    text: "472 Qed / 6 Admitted"
     evidence:
       - kind: count-eq                       # ALL THREE README spots must agree —
-        pattern: '470 Qed / 8 Admitted'      # a verbatim check alone greens if one
+        pattern: '472 Qed / 6 Admitted'      # a verbatim check alone greens if one
         glob: ['README.md']                  # of them drifts while another matches
         expect: 3
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 470
+        expect: 472
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 8
+        expect: 6
       - kind: count-eq                       # the "+2 admit. tactics" disclosure
         pattern: '^\s*admit\.'
         glob: ['coq/Synth/**/*.v']
@@ -46,33 +46,33 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-CLAUDE-MD
     doc: CLAUDE.md
-    text: "470 Qed / 8 Admitted"
+    text: "472 Qed / 6 Admitted"
     evidence:
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 470
+        expect: 472
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 8
+        expect: 6
 
   - id: SYNTH-PROOF-COUNT-STATUS-MD
     doc: coq/STATUS.md
-    text: "470 Qed / 8 Admitted"
+    text: "472 Qed / 6 Admitted"
     evidence:
       - kind: count-eq                       # headline + Total line must both agree
-        pattern: '470 Qed / 8 Admitted'
+        pattern: '472 Qed / 6 Admitted'
         glob: ['coq/STATUS.md']
         expect: 2
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 470
+        expect: 472
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 8
+        expect: 6
 
   # ---------------------------------------------------------------------------
   # The admit breakdown the docs disclose — per-file, so a new admit anywhere
@@ -80,12 +80,12 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-ADMIT-BREAKDOWN
     doc: README.md
-    text: "3 i32 division trap guards"
+    text: "1 i32 division trap guard"
     evidence:
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/Synth/CorrectnessI32.v']
-        expect: 3
+        expect: 1
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/Synth/Compilation.v']

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -1,6 +1,6 @@
 # Rocq Proof Suite — Honest Status
 
-**Last Updated: 2026-07-10 (recount: 470 Qed / 8 Admitted, +2 admit., crude
+**Last Updated: 2026-07-10 (recount: 472 Qed / 6 Admitted, +2 admit., crude
 `grep "Qed\."` over `coq/Synth/**/*.v` — same method as prior recounts)
 
 The headline count is CI-gated: `claims.yaml` + `scripts/claim_check.py`
@@ -27,15 +27,18 @@ The flat-executor capability gap named by VCR-SEL-001 increment 4 is closed:
   I64SetCond rules re-proven at EXPANSION tier — against the encoder's
   actual dual-precision chains (CMP lo,lo; SBCS/CMPEQ hi,hi; MOVcc) —
   with no `i64_setcond_bits` axiom.
-- **`i32_divu_correct`** (CorrectnessI32.v): the first #73 trap-guard
-  admit DISCHARGED, restated against `exec_program_br` (the BNE skips the
-  UDF; extra `I32.valid_unsigned` divisor hypothesis makes the raw-Z
-  divu guard and the mod-2^32 Z-flag agree). Compilation.v's I32DivS
-  guard offsets corrected for real branch semantics (2→3, 0→1).
+- **`i32_divu_correct` + `i32_rems_correct` + `i32_remu_correct`**
+  (CorrectnessI32.v): three of the four #73 trap-guard admits DISCHARGED,
+  each restated against `exec_program_br` (the BNE skips the UDF; extra
+  `I32.valid_unsigned` divisor hypothesis makes the raw-Z guard and the
+  mod-2^32 Z-flag agree; SDIV/UDIV then MLS computes the remainder tail).
+  Compilation.v's I32DivS guard offsets corrected for real branch
+  semantics (2→3, 0→1). Only `i32_divs_correct` — whose model carries the
+  extra INT_MIN/-1 double guard — remains Admitted.
 
-**Total admits: 8** (was 9) — 3 i32 division/remainder trap guards
-(div_s/rem_s/rem_u, #73 — restatement against `exec_program_br` pending,
-no new executor capability needed), 2 Compilation.v, 1 CorrectnessSimple.v,
+**Total admits: 6** (was 8) — 1 i32 division trap guard (div_s only, #73 —
+the INT_MIN/-1 double-guard restatement against `exec_program_br` pending;
+div_u/rem_s/rem_u discharged), 2 Compilation.v, 1 CorrectnessSimple.v,
 2 ArmRefinement.v. The headline count grew 291 → 467 because the recount
 now includes everything landed since 2026-06-04 (SailArmBridge rounds 1–3,
 VcrSelRules increments, VcrSelExpansion, i64 certifying validation lemmas).
@@ -147,7 +150,7 @@ umbrella #147).
 |------|---------|-------|
 | **T1: Result Correspondence** | ARM output register = WASM result value | 37¹ |
 | **T2: Existence-Only** | ARM execution succeeds (no result claim) | 139¹ |
-| **T3: Admitted / admit.** | Not yet proven | 11 (8 Admitted + 2 admit.) |
+| **T3: Admitted / admit.** | Not yet proven | 8 (6 Admitted + 2 admit.) |
 | **Infrastructure** | Properties of integers, states, flag lemmas | 65¹ |
 
 ¹ T1/T2/Infrastructure tier classification is the 2026-06-04 semantic recount
@@ -155,7 +158,7 @@ and predates the VcrSelRules (42), VcrSelPilot (7) and SailArmBridge (92) Qed;
 see the per-file breakdown below for current per-file counts. The T3 row and
 the headline total are re-derived by the claim gate.
 
-**Total: 470 Qed / 8 Admitted (+2 admit.) across all files** (recount 2026-07-10, CI-gated via `claims.yaml`)
+**Total: 472 Qed / 6 Admitted (+2 admit.) across all files** (recount 2026-07-10, CI-gated via `claims.yaml`)
 
 v0.10.0 PR 1: +2 T1 Qed (i64_add_correct, i64_sub_correct) and +9
 infrastructure Qed (combine_i32_unsigned, carry_split_add,
@@ -279,7 +282,7 @@ Named `*_executes` to distinguish from T1 `*_correct` proofs.
 |------|-------|------------|---------------------|
 | ArmRefinement.v | 2 | Needs Sail-generated ARM semantics | Phase 2: Import Sail specifications |
 | Integers.v | 1 | `i64_to_i32_to_i64_wrap` — Rocq 9 `Z.mod_mod` signature changed | Rework proof for new Z.mod_mod API |
-| CorrectnessI32.v | 3 | `i32_divs/divu/rems/remu_correct` — trap guard sequences (CMP+BCondOffset+UDF) cannot be verified in the sequential exec_program model | Extend exec_program to support PC-relative branching |
+| CorrectnessI32.v | 1 | `i32_divs_correct` — the INT_MIN/-1 double-guard trap sequence; div_u/rem_s/rem_u discharged against `exec_program_br` (#697/#73) | Restate against `exec_program_br` (as div_u/rem_s/rem_u) with the second (INT_MIN/-1) guard |
 | CorrectnessSimple.v | 1 | `i32_const_correct` — compilation now branches on `I32.unsigned n <= 65535`; large-constant case requires Z.land/Z.shiftr lemmas | Prove MOVW+MOVT reconstruction lemma |
 | CorrectnessSimple.v | 1 | `i64_const_correct` — v0.8.0 PR 1a aligned codegen to `I64ConstPseudo` (loads both halves); proof claimed R0 = low 16 bits via stale MOVW model | v0.8.0 PR 5: concrete `i64_const_lo`/`i64_const_hi` definitions |
 | CorrectnessI64.v | 3 | `i64_and/or/xor_correct` — halves-distribute-over-bitwise decomposition blocked by the same Rocq 9 `Z.mod_mod` rewrite issue as `i64_to_i32_to_i64_wrap` | Rework with new Z.mod_mod API (separate PR) |
@@ -410,7 +413,7 @@ Recount 2026-07-10 (`grep -oE 'Qed\.'` / `'Admitted\.'` per file):
 |------|-----|----------|------|
 | Correctness.v | 6 | 0 | T1 |
 | CorrectnessSimple.v | 28 | 1 | T2 + 1 admitted (i64_const_correct) |
-| CorrectnessI32.v | 28 | 3 | T1 + 3 admitted (i32_divu discharged #697) (i32 div/rem trap guards — exec_program model gap, #73) |
+| CorrectnessI32.v | 30 | 1 | T1 + 1 admitted (div_u/rem_s/rem_u discharged against `exec_program_br` #697/#73; only i32_divs_correct — INT_MIN/-1 double guard — remains) |
 | CorrectnessI64.v | 46 | 0 | T1 (arith/bitwise/div/rem) + T2 (shifts/cmps/bit-manip) — 0 i64 admits since v0.11.0 |
 | CorrectnessI64Comparisons.v | 19 | 0 | T2 |
 | CorrectnessF32.v | 20 | 0 | T2 |
@@ -432,7 +435,7 @@ Recount 2026-07-10 (`grep -oE 'Qed\.'` / `'Admitted\.'` per file):
 | WasmValues.v | 2 | 0 | Infra |
 | VcrSelPilot.v | 7 | 0 | T1 (register-polymorphic; VCR-SEL-001 go/abandon measurement) |
 | VcrSelRules.v | 42 | 0 | T1 (register-polymorphic; the WIRED VCR-SEL-001 increment-1+2+3+4 rule table — 40 rule theorems 1:1 with `coq/vcr_sel_rules.manifest`, coverage-gated by `//coq:vcr_sel_rules_coverage`, + 2 mod-32 helper lemmas #683) |
-| **Total** | **470** | **9** | (+2 `admit.`) |
+| **Total** | **472** | **6** | (+2 `admit.`) |
 
 ## VCR-SEL-001 increments 1 (2026-07-07) + 2 + 3 + 4 (2026-07-08): VcrSelRules.v
 

--- a/coq/Synth/Synth/CorrectnessI32.v
+++ b/coq/Synth/Synth/CorrectnessI32.v
@@ -1,16 +1,16 @@
 (** * I32 Operations Correctness
 
     This file contains correctness proofs for all i32 WebAssembly operations.
-    Total: 29 theorems — 26 Qed, 3 Admitted
+    Total: 29 theorems — 28 Qed, 1 Admitted
 
     Strategy:
     - Arithmetic (add, sub, mul, and, or, xor): synth_binop_proof tactic
-    - Division (divu): Qed against the branch-taking executor
-      exec_program_br — the trap guard's BCondOffset actually skips the
-      UDF (#73)
-    - Division (divs) + remainder (rems, remu): Admitted — same
-      trap-guard restatement pending (longer guard chains, no new
-      executor capability needed)
+    - Division (divu) + remainder (rems, remu): Qed against the
+      branch-taking executor exec_program_br — the trap guard's BCondOffset
+      actually skips the UDF (#73)
+    - Division (divs): Admitted — same trap-guard restatement pending, but
+      the divs model carries the extra INT_MIN/-1 (overflow) guard on top
+      of the divide-by-zero guard (no new executor capability needed)
     - Comparisons: flag-correspondence lemmas from ArmFlagLemmas.v
     - Bit manipulation: axiom-based (I32.clz/rbit/popcnt)
     - Shifts: Qed — mod-32 mask + register shift (#682)
@@ -80,11 +80,11 @@ Proof. synth_binop_proof. Qed.
     [exec_program_br] (ArmSemantics.v) is the model that can take the
     guard's skip.
 
-    Status: [i32_divu_correct] is DISCHARGED against [exec_program_br]
-    below. [i32_divs_correct] (the INT_MIN/-1 double guard),
-    [i32_rems_correct] and [i32_remu_correct] (guard + SDIV/UDIV + MLS
-    tail) remain Admitted pending the same restatement — their guard
-    chains are longer but need no new executor capability. *)
+    Status: [i32_divu_correct], [i32_rems_correct] and [i32_remu_correct]
+    are DISCHARGED against [exec_program_br] below (guard + UDIV/SDIV + MLS
+    tail). Only [i32_divs_correct] remains Admitted — its model carries the
+    extra INT_MIN/-1 (overflow) guard on top of the divide-by-zero guard;
+    the same restatement applies but needs no new executor capability. *)
 
 Theorem i32_divs_correct : forall wstate astate v1 v2 stack' result,
   wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
@@ -170,10 +170,18 @@ Proof.
   - apply get_set_reg_eq.
 Qed.
 
+(** i32.rem_s — trap-guard restatement against [exec_program_br] (#73).
+    Identical shape to [i32_remu_correct] but with SDIV: CMP R1,#0; BNE +1;
+    UDF; SDIV R2,R0,R1; MLS R0,R2,R1,R0. The single divide-by-zero guard
+    is the only trap in both the code and the [I32.rems] model — signed
+    remainder does not trap on INT_MIN/-1 (and neither does this sequence).
+    [I32.divs v1 v2 = Some quotient] gives both [v2 <> 0] and the SDIV
+    result; MLS then computes v1 - quotient*v2. *)
 Theorem i32_rems_correct : forall wstate astate v1 v2 stack' result quotient,
   wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
   get_reg astate R0 = v1 ->
   get_reg astate R1 = v2 ->
+  I32.valid_unsigned v2 ->
   I32.divs v1 v2 = Some quotient ->
   result = I32.sub v1 (I32.mul quotient v2) ->
   I32.rems v1 v2 = Some result ->
@@ -181,16 +189,73 @@ Theorem i32_rems_correct : forall wstate astate v1 v2 stack' result quotient,
     Some (mkWasmState (VI32 result :: stack')
             wstate.(locals) wstate.(globals) wstate.(memory)) ->
   exists astate',
-    exec_program (compile_wasm_to_arm I32RemS) astate = Some astate' /\
+    exec_program_br (compile_wasm_to_arm I32RemS) astate = Some astate' /\
     get_reg astate' R0 = result.
 Proof.
-  (* Admitted: requires PC-relative branching model to skip UDF trap guard *)
-Admitted.
+  intros wstate astate v1 v2 stack' result quotient
+    Hstack HR0 HR1 Hval Hdivs Hresult Hrems Hwasm.
+  (* The divisor is non-zero — otherwise divs would have trapped. *)
+  assert (Hnz : v2 <> 0).
+  { unfold I32.divs in Hdivs.
+    destruct (Z.eqb_spec v2 0); [discriminate | assumption]. }
+  assert (Hz : compute_z_flag (I32.sub v2 I32.zero) = false).
+  { rewrite z_flag_sub_eq.
+    unfold I32.eq.
+    replace (I32.unsigned I32.zero) with 0 by reflexivity.
+    apply Z.eqb_neq.
+    unfold I32.unsigned.
+    rewrite Z.mod_small; [exact Hnz |].
+    unfold I32.valid_unsigned, I32.max_unsigned, I32.modulus in *. lia. }
+  unfold exec_program_br.
+  change (length (compile_wasm_to_arm I32RemS)) with 5%nat.
+  (* pc = 0: CMP R1,#0 latches the flags. *)
+  erewrite (exec_program_pc_instr _ _ _ _ (CMP R1 (Imm I32.zero)));
+    [| reflexivity | exact I].
+  cbn [exec_instr eval_operand2].
+  (* pc = 1: BNE +1 — Z=0, branch TAKEN, skips the UDF. *)
+  erewrite (exec_program_pc_bcond _ _ _ _ Cond_NE 1); [| reflexivity].
+  rewrite flags_set_flags.
+  cbn [eval_condition].
+  rewrite flag_z_update_flags_arith.
+  rewrite HR1, Hz.
+  cbn [negb].
+  (* pc = 3: SDIV R2,R0,R1 -> R2 = quotient. *)
+  erewrite (exec_program_pc_instr _ _ _ _ (SDIV R2 R0 R1));
+    [| reflexivity | exact I].
+  cbn [exec_instr].
+  rewrite !get_reg_set_flags.
+  rewrite HR0, HR1, Hdivs.
+  cbn beta iota.
+  (* pc = 4: MLS R0,R2,R1,R0 -> R0 = v1 - quotient*v2. *)
+  erewrite (exec_program_pc_instr _ _ _ _ (MLS R0 R2 R1 R0));
+    [| reflexivity | exact I].
+  cbn [exec_instr].
+  rewrite (get_set_reg_eq _ R2).
+  rewrite (get_set_reg_neq _ R2 R1) by discriminate.
+  rewrite (get_set_reg_neq _ R2 R0) by discriminate.
+  rewrite !get_reg_set_flags.
+  rewrite HR0, HR1.
+  cbn beta iota.
+  (* pc = 5: off the end. *)
+  rewrite exec_program_pc_done; [| reflexivity].
+  eexists. split.
+  - reflexivity.
+  - rewrite get_set_reg_eq. symmetry. exact Hresult.
+Qed.
 
+(** i32.rem_u — trap-guard restatement against [exec_program_br] (#73),
+    the same vehicle that discharged [i32_divu_correct]. The compiled
+    sequence is CMP R1,#0; BNE +1; UDF; UDIV R2,R0,R1; MLS R0,R2,R1,R0:
+    with a non-zero divisor the CMP latches Z=0, the BNE is TAKEN (pc skips
+    the UDF), UDIV puts the quotient in R2, and MLS computes
+    R0 - R2*R1 = v1 - quotient*v2 = the remainder. The [I32.valid_unsigned v2]
+    hypothesis is the same register-normalization the flat model left
+    implicit (raw [v2 =? 0] guard vs the CMP's [v2 mod 2^32] Z-flag). *)
 Theorem i32_remu_correct : forall wstate astate v1 v2 stack' result quotient,
   wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
   get_reg astate R0 = v1 ->
   get_reg astate R1 = v2 ->
+  I32.valid_unsigned v2 ->
   I32.divu v1 v2 = Some quotient ->
   result = I32.sub v1 (I32.mul quotient v2) ->
   I32.remu v1 v2 = Some result ->
@@ -198,11 +263,60 @@ Theorem i32_remu_correct : forall wstate astate v1 v2 stack' result quotient,
     Some (mkWasmState (VI32 result :: stack')
             wstate.(locals) wstate.(globals) wstate.(memory)) ->
   exists astate',
-    exec_program (compile_wasm_to_arm I32RemU) astate = Some astate' /\
+    exec_program_br (compile_wasm_to_arm I32RemU) astate = Some astate' /\
     get_reg astate' R0 = result.
 Proof.
-  (* Admitted: requires PC-relative branching model to skip UDF trap guard *)
-Admitted.
+  intros wstate astate v1 v2 stack' result quotient
+    Hstack HR0 HR1 Hval Hdivu Hresult Hremu Hwasm.
+  (* The divisor is non-zero — otherwise divu would have trapped. *)
+  assert (Hnz : v2 <> 0).
+  { unfold I32.divu in Hdivu.
+    destruct (Z.eqb_spec v2 0); [discriminate | assumption]. }
+  (* The Z flag latched by CMP R1,#0 is therefore false. *)
+  assert (Hz : compute_z_flag (I32.sub v2 I32.zero) = false).
+  { rewrite z_flag_sub_eq.
+    unfold I32.eq.
+    replace (I32.unsigned I32.zero) with 0 by reflexivity.
+    apply Z.eqb_neq.
+    unfold I32.unsigned.
+    rewrite Z.mod_small; [exact Hnz |].
+    unfold I32.valid_unsigned, I32.max_unsigned, I32.modulus in *. lia. }
+  unfold exec_program_br.
+  change (length (compile_wasm_to_arm I32RemU)) with 5%nat.
+  (* pc = 0: CMP R1,#0 latches the flags, registers untouched. *)
+  erewrite (exec_program_pc_instr _ _ _ _ (CMP R1 (Imm I32.zero)));
+    [| reflexivity | exact I].
+  cbn [exec_instr eval_operand2].
+  (* pc = 1: BNE +1 — Z=0, so the branch is TAKEN, skipping the UDF. *)
+  erewrite (exec_program_pc_bcond _ _ _ _ Cond_NE 1); [| reflexivity].
+  rewrite flags_set_flags.
+  cbn [eval_condition].
+  rewrite flag_z_update_flags_arith.
+  rewrite HR1, Hz.
+  cbn [negb].
+  (* pc = 3: UDIV R2,R0,R1 -> R2 = quotient. *)
+  erewrite (exec_program_pc_instr _ _ _ _ (UDIV R2 R0 R1));
+    [| reflexivity | exact I].
+  cbn [exec_instr].
+  rewrite !get_reg_set_flags.
+  rewrite HR0, HR1, Hdivu.
+  cbn beta iota.
+  (* pc = 4: MLS R0,R2,R1,R0 -> R0 = R0 - R2*R1 = v1 - quotient*v2. *)
+  erewrite (exec_program_pc_instr _ _ _ _ (MLS R0 R2 R1 R0));
+    [| reflexivity | exact I].
+  cbn [exec_instr].
+  rewrite (get_set_reg_eq _ R2).
+  rewrite (get_set_reg_neq _ R2 R1) by discriminate.
+  rewrite (get_set_reg_neq _ R2 R0) by discriminate.
+  rewrite !get_reg_set_flags.
+  rewrite HR0, HR1.
+  cbn beta iota.
+  (* pc = 5: off the end — the program completed. *)
+  rewrite exec_program_pc_done; [| reflexivity].
+  eexists. split.
+  - reflexivity.
+  - rewrite get_set_reg_eq. symmetry. exact Hresult.
+Qed.
 
 (** ** I32 Bitwise Operations (10 total) *)
 
@@ -625,10 +739,11 @@ Qed.
 
 (** ** Summary
 
-    I32 theorems: 29 total — 26 Qed, 3 Admitted
-    - Arithmetic: 4 Qed (Add, Sub, Mul, DivU — DivU against the
-      branch-taking exec_program_br, #73), 3 Admitted (DivS, RemS, RemU —
-      trap-guard restatement against exec_program_br pending)
+    I32 theorems: 29 total — 28 Qed, 1 Admitted
+    - Arithmetic: 6 Qed (Add, Sub, Mul, DivU, RemS, RemU — DivU/RemS/RemU
+      against the branch-taking exec_program_br, #73), 1 Admitted (DivS —
+      trap-guard restatement against exec_program_br pending, extra
+      INT_MIN/-1 overflow guard)
     - Bitwise: 8 Qed (And, Or, Xor, Shl, ShrU, ShrS, Rotl, Rotr)
     - Comparison: 11 Qed (EQZ, EQ, NE, LtS, LtU, GtS, GtU, LeS, LeU, GeS, GeU)
     - Bit manipulation: 3 Qed (CLZ/CTZ/POPCNT using axiomatized I32.clz/ctz/popcnt)


### PR DESCRIPTION
## What

Finishes the #73 i32 div/rem admit-discharge program (epic #242). Two more of the four division/remainder trap-guard admits are now **Qed** against the branch-taking executor `exec_program_br`:

- `i32_rems_correct` — **discharged**
- `i32_remu_correct` — **discharged**

Both build on #697's `i32_divu_correct` discharge, restated the same way: `CMP R1,#0` latches Z=0 for a non-zero divisor, `BNE` is TAKEN (skipping the UDF trap), `UDIV`/`SDIV` puts the quotient in R2, and `MLS` computes `v1 - quotient*v2` = the remainder. Each carries the same `I32.valid_unsigned` divisor hypothesis #697 introduced to reconcile the raw-Z guard with the mod-2^32 Z-flag. Proofs use the `exec_program_pc_{instr,bcond,done}` rewrite lemmas (not raw `simpl`).

## Held (honestly)

- `i32_divs_correct` — **remains Admitted.** Its model carries the extra INT_MIN/-1 overflow guard on top of the divide-by-zero guard. The same `exec_program_br` restatement applies and needs no new executor capability; left as a bounded follow-up. An honest 2-of-3 discharge.

## Admit count

- #73 div/rem trap-guard admits: **4 → 1** (div_u via #697, rem_s + rem_u here, div_s held)
- Repo total: **8 Admitted → 6 Admitted** (+2 `admit.` tactics unchanged)
- `CorrectnessI32.v` breakdown: **3 → 1**

## Verification

- `bazel test //coq:verify_proofs` — **green**. Confirmed the proofs are genuinely `coqc`'d (not stale cache): a deliberate negative-control break of the proof body made the build **fail**, restoring it made it pass. Every pre-existing `Qed` still passes.
- **Non-vacuity:** hypotheses are satisfiable (e.g. v1=6, v2=4 → `divu=Some 1`, `remu=Some 2`); the body derives and consumes `Hnz : v2 <> 0`, so the theorems are not vacuously true.
- Claim gate reconciled to derived truth — `python3 scripts/claim_check.py` = **17/17** (README.md, CLAUDE.md, coq/STATUS.md, claims.yaml all set to 472 Qed / 6 Admitted, breakdown 1).
- `cargo test -p synth-cli --test frozen_codegen_bytes` — 10/10 pass (coq-only change; no codegen bytes move). No Rust touched → fmt/clippy no-ops.

Refs #242 #73 #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)