### PR TITLE
GI-FPU-002 phase 1: scalar f32 hard-float reachable on thumb-2 (#619, #369)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -2780,3 +2780,74 @@ artifacts:
         verbatim in program order (no pass deletes/forwards/reorders linmem
         accesses). No frozen fixture uses the flag, so no re-freeze was needed
         (frozen anchors pass untouched).
+
+  # ---------------------------------------------------------------------------
+  # Scalar f32 hard-float reachability (GI-FPU-002, #619/#369)
+  # ---------------------------------------------------------------------------
+
+  - id: GI-FPU-002
+    type: sw-req
+    title: "Scalar f32 hard-float (VFP) reachable on the thumb-2 CLI path — phase 1 (synth #619/#369)"
+    description: >
+      synth had a working VFP encoder (f32_vfp_encoding_test.rs) and selector
+      VFP arms, but the decoder DROPPED every scalar float op
+      (wasm_decoder.rs `_ => None`), so `synth compile -t cortex-m4f`
+      HONEST-REJECTED f32 on every CLI path (GI-FPU-001 loud-skip). Worse, the
+      "existing" selector VFP lowering was a NON-FUNCTIONAL prototype: the
+      direct `select_with_stack` fell through to `select_default`, whose
+      `alloc_vfp_reg` is a blind `%16` round-robin with no operand-stack
+      integration, so `f32.const;f32.const;f32.add` emitted `VADD S2,S3,S4` over
+      garbage. Phase 1 builds the real bridge.
+
+      DELIVERED (phase 1, implemented):
+        (1) Decoder un-drops the in-scope scalar f32 ops (add/sub/mul/div, the
+            six comparisons, i32.trunc_f32_s/u, f32.convert_i32_s/u, f32.const);
+            f64 and the rest of the f32 surface (abs/neg/sqrt/min/max, load/store,
+            local.set/tee) stay dropped → phase 1b/2.
+        (2) A real VFP value stack in `select_with_stack`: `StackVal::Float`,
+            an S0..S15 allocator (no VFP spilling — loud-bail on exhaustion),
+            and f32 arms that pop/push S-register operands. Integer modules never
+            construct a Float entry, so the frozen integer path is byte-identical.
+        (3) AAPCS-VFP calling convention: f32 params homed in S0..S15 (threaded
+            `params_f32`, decoder → CompileConfig → selector), f32 result in S0.
+        (4) FPU gate: only FPU targets (cortex-m4f/m7/m7dp) lower f32; m0/m3/r5
+            keep the honest reject with a clear GI-FPU-002 message.
+        (5) `.ARM.attributes`: Tag_FP_arch=VFPv4-D16 + Tag_ABI_VFP_args=VFP
+            registers on FPU targets (non-FPU byte-identical), and the reset
+            handler enables CP10/CP11 in SCB->CPACR (the M4F FPU is off at reset).
+        (6) Encoder bug fixed: the signed/unsigned VCVT constants in
+            encode_{arm,thumb}_f32_convert_i32 were SWAPPED (0xEEB80A40 is U32),
+            silently making convert_i32_s an unsigned conversion; and the CPACR
+            ORR mask (main.rs / cortex_m.rs) encoded #0x07800000 instead of
+            #0x00F00000. Both corrected.
+
+      HELD (honest-subset boundary, chosen not missed): f64 (phase 2 — M7DP
+      D-registers), f32 load/store (VLDR/VSTR address materialization — 1b),
+      f32 local.set/tee and non-param f32 locals (VFP home write-back — 1b),
+      mixed f32/integer parameter lists and f32-in-functions-with-calls (both
+      loud-decline: AAPCS-VFP independent register pools / S0..S15 caller-saved).
+    status: implemented
+    tags: [codegen, f32, vfp, hard-float, aapcs-vfp, cortex-m4f, decoder, selector, synth-619, synth-369, gi-fpu-002]
+    links:
+      - type: derives-from
+        target: VCR-001
+    fields:
+      req-type: functional
+      priority: should
+      verification-criteria: >
+        Tracks GitHub issues #619 / #369. RED→GREEN execution differential
+        (scripts/repro/f32_vfp_619_differential.py): compiles f32.add/sub/mul/div
+        + i32.trunc_f32_s + f32.convert_i32_s/u for cortex-m4f, reads each symbol
+        from the ELF SYMTAB (#489), runs it under unicorn (ARM/Thumb, FPU enabled
+        via CPACR CP10/CP11 + FPEXC.EN) with f32 args in S0/S1 (hard-float), and
+        asserts the result is bit-exact (`to_bits`) vs wasmtime on boundary
+        values (0.0, 1.5, -2.25, large, subnormal). RED on origin/main (compile
+        REJECTS → exit 1); GREEN after (48/48 bit-exact → exit 0). Honest-reject:
+        the same harness asserts cortex-m3 REJECTS f32. CI-gateable Rust test
+        crates/synth-backend/tests/f32_hardfloat_619.rs locks the AAPCS-VFP S0/S1
+        homing, the honest reject, and the convert-signedness fix without
+        unicorn. Frozen anchors 10/10 and the #511 estimator oracle pass
+        untouched (float declines the optimized path → the estimator never sees
+        VFP ops). The f32 comparisons compile + are byte-pinned in
+        f32_vfp_encoding_test.rs but are not execution-differentiated (unicorn
+        does not model the VMRS FPSCR→APSR flag transfer — an emulator gap).

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -91,17 +91,26 @@ impl Backend for ArmBackend {
             // mistook a read-before-write local for a param. `None` when the
             // driver supplied no arg-count table (hand-built modules).
             let declared_params = config.func_arg_counts.get(func.index as usize).copied();
-            let func_config =
-                if params.is_some() || !func.block_arity.is_empty() || declared_params.is_some() {
-                    Some(CompileConfig {
-                        current_func_params_i64: params.cloned().unwrap_or_default(),
-                        current_func_block_arity: func.block_arity.clone(),
-                        current_func_param_count: declared_params,
-                        ..config.clone()
-                    })
-                } else {
-                    None
-                };
+            // GI-FPU-002 (#619/#369): THIS function's declared f32-param mask.
+            let params_f32 = config
+                .func_params_f32
+                .get(func.index as usize)
+                .filter(|p| !p.is_empty());
+            let func_config = if params.is_some()
+                || params_f32.is_some()
+                || !func.block_arity.is_empty()
+                || declared_params.is_some()
+            {
+                Some(CompileConfig {
+                    current_func_params_i64: params.cloned().unwrap_or_default(),
+                    current_func_params_f32: params_f32.cloned().unwrap_or_default(),
+                    current_func_block_arity: func.block_arity.clone(),
+                    current_func_param_count: declared_params,
+                    ..config.clone()
+                })
+            } else {
+                None
+            };
             let cfg = func_config.as_ref().unwrap_or(config);
             let compiled = self.compile_function(&name, &func.ops, cfg)?;
             functions.push(compiled);
@@ -379,6 +388,9 @@ fn compile_wasm_to_arm(
         // #359: declared param widths of THIS function, so the AAPCS stack-arg
         // path can refuse 64-bit params (Ok-or-Err). Empty ⇒ assume i32.
         selector.set_params_i64(config.current_func_params_i64.clone());
+        // GI-FPU-002 (#619/#369): declared f32-param mask — home hard-float f32
+        // args in S0..S15 (AAPCS-VFP) instead of the R0..R3 integer path.
+        selector.set_params_f32(config.current_func_params_f32.clone());
         // #509: blocktype-arity side-table of THIS function, so value-carrying
         // br/br_if/br_table land the carried value in the target block's
         // designated result register instead of dropping it. Empty ⇒ legacy
@@ -2026,6 +2038,9 @@ mod tests {
             target: TargetSpec::cortex_m4f(),
             // no_optimize NOT set — this exercises the optimized path that
             // panicked in issue #120, then the fallback to direct selection.
+            // GI-FPU-002: the f32 params must be declared so the direct
+            // selector homes them in S0/S1 (AAPCS-VFP) rather than declining.
+            current_func_params_f32: vec![true, true],
             ..CompileConfig::default()
         };
 
@@ -2049,6 +2064,8 @@ mod tests {
         let backend = ArmBackend::new();
         let config = CompileConfig {
             target: TargetSpec::cortex_m4f(),
+            // GI-FPU-002: declare the two f32 params for AAPCS-VFP homing.
+            current_func_params_f32: vec![true, true],
             ..CompileConfig::default()
         };
 

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -2237,12 +2237,16 @@ impl ArmEncoder {
         let vmov = encode_vmov_core_sreg(true, sd, rm)?;
         bytes.extend_from_slice(&vmov.to_le_bytes());
 
-        // VCVT.F32.S32 Sd, Sd (signed) or VCVT.F32.U32 Sd, Sd (unsigned)
-        // Base: 0xEEB80A40 (signed) or 0xEEB80AC0 (unsigned)
+        // VCVT.F32.S32 Sd, Sd (signed) or VCVT.F32.U32 Sd, Sd (unsigned).
+        // The "op" bit (bit 7) selects signedness: 1 = signed (S32), 0 =
+        // unsigned (U32). So signed = 0xEEB80AC0, unsigned = 0xEEB80A40 —
+        // objdump confirms 0xEEB80A40 decodes to `vcvt.f32.u32` (GI-FPU-002:
+        // the two were previously swapped, silently making `convert_i32_s`
+        // an unsigned conversion).
         let sd_num = vfp_sreg_to_num(sd)?;
         let (vd, d) = encode_sreg(sd_num);
         let (vm, m) = encode_sreg(sd_num); // same register as source
-        let base = if signed { 0xEEB80A40 } else { 0xEEB80AC0 };
+        let base = if signed { 0xEEB80AC0 } else { 0xEEB80A40 };
         let vcvt = base | (d << 22) | (vd << 12) | (m << 5) | vm;
         bytes.extend_from_slice(&vcvt.to_le_bytes());
 
@@ -6898,11 +6902,13 @@ impl ArmEncoder {
         let vmov = encode_vmov_core_sreg(true, sd, rm)?;
         bytes.extend_from_slice(&vfp_to_thumb_bytes(vmov));
 
-        // VCVT.F32.S32/U32 Sd, Sd
+        // VCVT.F32.S32/U32 Sd, Sd. Bit 7 (op) = 1 for signed (S32), 0 for
+        // unsigned (U32): signed = 0xEEB80AC0, unsigned = 0xEEB80A40
+        // (GI-FPU-002: previously swapped — see the ARM32 twin).
         let sd_num = vfp_sreg_to_num(sd)?;
         let (vd, d) = encode_sreg(sd_num);
         let (vm, m) = encode_sreg(sd_num);
-        let base = if signed { 0xEEB80A40 } else { 0xEEB80AC0 };
+        let base = if signed { 0xEEB80AC0 } else { 0xEEB80A40 };
         let vcvt = base | (d << 22) | (vd << 12) | (m << 5) | vm;
         bytes.extend_from_slice(&vfp_to_thumb_bytes(vcvt));
 

--- a/crates/synth-backend/src/cortex_m.rs
+++ b/crates/synth-backend/src/cortex_m.rs
@@ -120,9 +120,11 @@ impl StartupCode {
             // LDR R1, [R0]
             code.extend_from_slice(&[0xD0, 0xF8, 0x00, 0x10]); // LDR R1, [R0, #0]
 
-            // ORR R1, R1, #0x00F00000 (enable CP10+CP11 full access)
-            // Thumb-2 ORR with modified immediate: 0x00F00000
-            code.extend_from_slice(&[0x41, 0xF0, 0xF0, 0x61]); // ORR R1, R1, #0x00F00000
+            // ORR R1, R1, #0x00F00000 (enable CP10+CP11 full access). GI-FPU-002:
+            // the previous bytes [0x41,0xF0,0xF0,0x61] decode to #0x07800000 (a
+            // wrong mask that does NOT enable CP10/CP11); the correct Thumb-2
+            // modified-immediate encoding of #0x00F00000 is [0x41,0xF4,0x70,0x01].
+            code.extend_from_slice(&[0x41, 0xF4, 0x70, 0x01]); // ORR R1, R1, #0x00F00000
 
             // STR R1, [R0]
             code.extend_from_slice(&[0xC0, 0xF8, 0x00, 0x10]); // STR R1, [R0, #0]

--- a/crates/synth-backend/src/elf_builder.rs
+++ b/crates/synth-backend/src/elf_builder.rs
@@ -396,6 +396,21 @@ pub mod aeabi {
     pub const PROFILE_M: u32 = b'M' as u32;
     /// Tag_CPU_arch_profile value: real-time
     pub const PROFILE_R: u32 = b'R' as u32;
+
+    /// Tag_ABI_VFP_args (GI-FPU-002, #619): 0 = base (soft-float) variant,
+    /// 1 = FP args passed in VFP registers (AAPCS-VFP / hard-float).
+    pub const TAG_ABI_VFP_ARGS: u32 = 28;
+    /// Tag_FP_arch (GI-FPU-002, #619): the floating-point hardware the object
+    /// requires (tag 10 — NOT 36, which is Tag_FP_HP_extension). Value 0 = none
+    /// (soft-float; omitted by the writer).
+    pub const TAG_FP_ARCH: u32 = 10;
+    /// Tag_ABI_VFP_args value: FP args passed in VFP registers (hard-float).
+    pub const VFP_ARGS_VFP_REGS: u32 = 1;
+    /// Tag_FP_arch value: VFPv4-D16. synth's phase-1 f32 codegen uses only the
+    /// single-precision VADD/VMUL/VCVT subset shared by every Cortex-M FPU
+    /// (FPv4-SP through FPv5), so this conservative value describes the required
+    /// hardware without over-claiming (#619/#369).
+    pub const FP_ARCH_VFPV4_D16: u32 = 6;
 }
 
 /// Encode a u32 as ULEB128 (build-attribute value encoding).
@@ -422,14 +437,22 @@ pub fn arm_attributes_section(
     cpu_arch_profile: u32,
     arm_isa_use: u32,
     thumb_isa_use: u32,
+    fp_arch: u32,
+    vfp_args: u32,
 ) -> Section {
-    // File-scope attribute pairs (uleb tag, uleb value).
+    // File-scope attribute pairs (uleb tag, uleb value). Emitted in ascending
+    // tag order: CPU_arch(6), profile(7), ARM_ISA(8), THUMB_ISA(9),
+    // FP_arch(10), ABI_VFP_args(28). Tags with value 0 are omitted (spec
+    // default), so a soft-float (no-FPU) object is byte-identical to before
+    // GI-FPU-002.
     let mut attrs = Vec::new();
     for (tag, value) in [
         (aeabi::TAG_CPU_ARCH, cpu_arch),
         (aeabi::TAG_CPU_ARCH_PROFILE, cpu_arch_profile),
         (aeabi::TAG_ARM_ISA_USE, arm_isa_use),
         (aeabi::TAG_THUMB_ISA_USE, thumb_isa_use),
+        (aeabi::TAG_FP_ARCH, fp_arch),
+        (aeabi::TAG_ABI_VFP_ARGS, vfp_args),
     ] {
         if value != 0 {
             push_uleb128(&mut attrs, tag);
@@ -1788,7 +1811,7 @@ mod tests {
     #[test]
     fn test_arm_attributes_section_bytes_637() {
         // Cortex-M3: v7, profile M, no A32, Thumb-2.
-        let sec = arm_attributes_section(aeabi::CPU_ARCH_V7, aeabi::PROFILE_M, 0, 2);
+        let sec = arm_attributes_section(aeabi::CPU_ARCH_V7, aeabi::PROFILE_M, 0, 2, 0, 0);
         assert_eq!(sec.name, ".ARM.attributes");
         assert_eq!(sec.section_type, SectionType::ArmAttributes);
         let d = &sec.data;
@@ -1811,7 +1834,19 @@ mod tests {
         );
 
         // Cortex-R5: v7, profile R, A32 permitted, Thumb-2 permitted.
-        let sec = arm_attributes_section(aeabi::CPU_ARCH_V7, aeabi::PROFILE_R, 1, 2);
+        let sec = arm_attributes_section(aeabi::CPU_ARCH_V7, aeabi::PROFILE_R, 1, 2, 0, 0);
         assert_eq!(&sec.data[16..], &[6, 10, 7, b'R', 8, 1, 9, 2]);
+
+        // GI-FPU-002: a hard-float FPU target adds Tag_FP_arch(10)=VFPv4-D16(6)
+        // and Tag_ABI_VFP_args(28)=1, in ascending tag order.
+        let sec = arm_attributes_section(
+            aeabi::CPU_ARCH_V7EM,
+            aeabi::PROFILE_M,
+            0,
+            2,
+            aeabi::FP_ARCH_VFPV4_D16,
+            aeabi::VFP_ARGS_VFP_REGS,
+        );
+        assert_eq!(&sec.data[16..], &[6, 13, 7, b'M', 9, 2, 10, 6, 28, 1]);
     }
 }

--- a/crates/synth-backend/tests/f32_hardfloat_619.rs
+++ b/crates/synth-backend/tests/f32_hardfloat_619.rs
@@ -1,0 +1,103 @@
+//! GI-FPU-002 (#619/#369) phase-1: scalar f32 hard-float reachability on the
+//! direct (`select_with_stack`) selector.
+//!
+//! Locks the pieces the Python execution differential
+//! (`scripts/repro/f32_vfp_619_differential.py`) validates end-to-end, but that
+//! CI can gate without unicorn/wasmtime:
+//!   * f32 params are homed in AAPCS-VFP argument S-registers (S0, S1, …), and
+//!     `f32.add` routes through the real VFP value stack (not the old blind
+//!     round-robin `select_default`);
+//!   * a non-FPU target honest-rejects f32 (never a soft-float miscompile);
+//!   * `f32.convert_i32_s` encodes to the SIGNED VCVT (the previously-swapped
+//!     signed/unsigned constant is fixed).
+
+use synth_backend::ArmEncoder;
+use synth_core::target::FPUPrecision;
+use synth_synthesis::{ArmOp, InstructionSelector, Reg, RuleDatabase, VfpReg, WasmOp};
+
+fn m4f_selector() -> InstructionSelector {
+    let db = RuleDatabase::with_standard_rules();
+    let mut s = InstructionSelector::new(db.rules().to_vec());
+    s.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+    s
+}
+
+#[test]
+fn f32_params_home_in_s0_s1_and_add_uses_vfp_stack() {
+    // (param f32 f32) f32.add — the differential's `fadd`.
+    let ops = vec![WasmOp::LocalGet(0), WasmOp::LocalGet(1), WasmOp::F32Add];
+    let mut sel = m4f_selector();
+    sel.set_params_f32(vec![true, true]);
+    let instrs = sel
+        .select_with_stack(&ops, 2)
+        .expect("f32.add must compile on cortex-m4f via the VFP value stack");
+
+    // The add must be a real VADD.F32 whose operands are the two AAPCS-VFP
+    // param homes S0 (param 0) and S1 (param 1) — proving the value stack, not
+    // the blind round-robin allocator, chose the registers.
+    let add = instrs
+        .iter()
+        .find_map(|i| match &i.op {
+            ArmOp::F32Add { sd, sn, sm } => Some((*sd, *sn, *sm)),
+            _ => None,
+        })
+        .expect("must emit an ArmOp::F32Add");
+    let (_sd, sn, sm) = add;
+    assert!(
+        (sn == VfpReg::S0 && sm == VfpReg::S1) || (sn == VfpReg::S1 && sm == VfpReg::S0),
+        "f32.add operands must be the param homes S0/S1, got sn={sn:?} sm={sm:?}"
+    );
+}
+
+#[test]
+fn f32_honest_rejects_on_non_fpu_target() {
+    let ops = vec![WasmOp::LocalGet(0), WasmOp::LocalGet(1), WasmOp::F32Add];
+    let db = RuleDatabase::with_standard_rules();
+    let mut sel = InstructionSelector::new(db.rules().to_vec()); // no FPU (cortex-m3 default)
+    sel.set_params_f32(vec![true, true]);
+    let err = sel
+        .select_with_stack(&ops, 2)
+        .expect_err("f32 must be rejected on a non-FPU target");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("GI-FPU-002") && msg.to_lowercase().contains("fpu"),
+        "reject message must name the FPU requirement: {msg}"
+    );
+}
+
+#[test]
+fn f32_convert_i32_s_encodes_signed_vcvt() {
+    // The signed convert must be VCVT.F32.S32 (op bit set): base 0xEEB80AC0,
+    // whose Thumb-2 second halfword is 0x0AC0. The unsigned convert is 0x0A40.
+    let enc = ArmEncoder::new_thumb2_with_fpu(Some(FPUPrecision::Single));
+    let signed = enc
+        .encode(&ArmOp::F32ConvertI32S {
+            sd: VfpReg::S0,
+            rm: Reg::R0,
+        })
+        .expect("encode F32ConvertI32S");
+    let unsigned = enc
+        .encode(&ArmOp::F32ConvertI32U {
+            sd: VfpReg::S0,
+            rm: Reg::R0,
+        })
+        .expect("encode F32ConvertI32U");
+    assert_ne!(
+        signed, unsigned,
+        "signed and unsigned f32 convert must differ (they were swapped/aliased)"
+    );
+    // VCVT is the second instruction (after VMOV Sd, Rm); its low halfword-pair
+    // is the 4 trailing bytes. Signed = ...0AC0, unsigned = ...0A40 (LE).
+    assert_eq!(
+        &signed[6..8],
+        &[0xC0, 0x0A],
+        "F32ConvertI32S must be VCVT.F32.S32 (0x0AC0), got {:02x?}",
+        &signed[6..8]
+    );
+    assert_eq!(
+        &unsigned[6..8],
+        &[0x40, 0x0A],
+        "F32ConvertI32U must be VCVT.F32.U32 (0x0A40), got {:02x?}",
+        &unsigned[6..8]
+    );
+}

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1390,6 +1390,11 @@ fn compile_command(
     // `i64.shr_u x 32` returned 32 (the shift amount) instead of the high word.
     // Empty for the demo path (all-i32 demos).
     let mut current_func_params_i64: Vec<bool> = Vec::new(); // #359/#518/#599
+    // GI-FPU-002 (#619/#369): declared f32-param mask of THIS function (and the
+    // per-module table) — home hard-float f32 args in S0..S15 (AAPCS-VFP).
+    // Empty for the demo path (no module signature).
+    let mut current_func_params_f32: Vec<bool> = Vec::new();
+    let mut func_params_f32_all: Vec<Vec<bool>> = Vec::new();
     // #457: declared param count of THIS function — caps the access-pattern
     // param inference (a read-before-write local is otherwise indistinguishable
     // from a param). None for the demo path (no module signature).
@@ -1460,6 +1465,7 @@ fn compile_command(
             startup_globals_words = globals_table_words(&module.globals);
             let module_func_params_i64 = module.func_params_i64;
             let module_func_arg_counts = module.func_arg_counts;
+            func_params_f32_all = module.func_params_f32.clone();
             // VCR-PERF-002 Phase 1 (#494): whatever facts loom forwarded
             // (empty for a section-less module — the overwhelmingly common
             // case — and for any malformed section, per the fail-safe rule).
@@ -1506,6 +1512,10 @@ fn compile_command(
             // all-exports compile loop (#359/#509/#518).
             if let Some(p) = module_func_params_i64.get(func.index as usize) {
                 current_func_params_i64 = p.clone();
+            }
+            // GI-FPU-002 (#619/#369): THIS function's declared f32-param mask.
+            if let Some(p) = func_params_f32_all.get(func.index as usize) {
+                current_func_params_f32 = p.clone();
             }
             // #457: THIS function's declared param count from the type section.
             current_func_param_count = module_func_arg_counts.get(func.index as usize).copied();
@@ -1611,6 +1621,9 @@ fn compile_command(
         // Without these the selector materialized constants into the param's
         // live high register (i64.shr_u/shr_s returned the shift amount).
         current_func_params_i64,
+        // GI-FPU-002 (#619/#369): AAPCS-VFP f32-param homing.
+        current_func_params_f32,
+        func_params_f32: func_params_f32_all,
         // #457: declared param count — caps the param-count inference so a
         // read-before-write local lands in a zero-inited frame slot.
         current_func_param_count,
@@ -2357,6 +2370,7 @@ fn compile_all_exports(
         all_func_ret_i64,  // #311: per-function returns-i64 (pair tagging)
         all_type_ret_i64,  // #311: per-type returns-i64 (call_indirect)
         all_func_params_i64, // #359: per-function declared param widths (stack-arg ABI)
+        all_func_params_f32, // GI-FPU-002: per-function declared f32-param mask (AAPCS-VFP)
         all_wsc_facts,     // VCR-PERF-002 Phase 1 (#494): loom wsc.facts premises
         all_call_indirect_guards, // #642: table size + closed-world type verdicts
     ) = if path.extension().is_some_and(|ext| ext == "wast") {
@@ -2456,6 +2470,7 @@ fn compile_all_exports(
             Vec::new(), // #311: WAST runs the fixture suite; i32-only
             Vec::new(),
             Vec::new(), // #359: WAST fixture suite is i32-only — no stack params
+            Vec::new(), // GI-FPU-002: WAST fixture suite is i32-only — no f32 params
             Vec::new(), // #494: facts are a loom-emitted-.wasm channel; WAST fixtures carry none
             // #642: the multi-module WAST merge has no single table image to
             // verify — the default guards DECLINE any call_indirect (the WAST
@@ -2551,6 +2566,7 @@ fn compile_all_exports(
             module.func_ret_i64,
             module.type_ret_i64,
             module.func_params_i64,
+            module.func_params_f32,
             module.wsc_facts,
             guards, // #642
         )
@@ -2629,6 +2645,9 @@ fn compile_all_exports(
         // source of truth for the AAPCS stack-argument refusal. The per-function
         // `current_func_params_i64` is derived from this in the compile loop.
         func_params_i64: all_func_params_i64.clone(),
+        // GI-FPU-002 (#619/#369): per-function AAPCS-VFP f32-param homing.
+        func_params_f32: all_func_params_f32.clone(),
+        current_func_params_f32: Vec::new(),
         // #543 Phase 1: threaded but not yet consumed (inert plumbing). The
         // Phase-2 back-off (const-CSE + #468 base-CSE decline inside these ranges)
         // lives on the optimized path this config feeds. See VCR-DMA-001.
@@ -2688,6 +2707,12 @@ fn compile_all_exports(
                 && !p.is_empty()
             {
                 fc.current_func_params_i64 = p.clone();
+            }
+            // GI-FPU-002 (#619/#369): THIS function's declared f32-param mask.
+            if let Some(p) = all_func_params_f32.get(func.index as usize)
+                && !p.is_empty()
+            {
+                fc.current_func_params_f32 = p.clone();
             }
             fc.current_func_block_arity = func.block_arity.clone();
             // #457: THIS function's DECLARED param count, so the backends can
@@ -3076,9 +3101,13 @@ fn arm_build_attributes(target: &TargetSpec) -> Section {
         // architecturally permitted on v7-R, but synth emits pure A32 here and
         // the STT_FUNC symbols carry no Thumb bit (#598) — advertise A32 only
         // so ISA auto-detection picks the A32 decoder.
-        IsaVariant::Arm32 => arm_attributes_section(aeabi::CPU_ARCH_V7, aeabi::PROFILE_R, 1, 0),
+        IsaVariant::Arm32 => {
+            arm_attributes_section(aeabi::CPU_ARCH_V7, aeabi::PROFILE_R, 1, 0, 0, 0)
+        }
         // Cortex-M0 (Thumb-1 only): v6-M, 16-bit Thumb.
-        IsaVariant::Thumb => arm_attributes_section(aeabi::CPU_ARCH_V6M, aeabi::PROFILE_M, 0, 1),
+        IsaVariant::Thumb => {
+            arm_attributes_section(aeabi::CPU_ARCH_V6M, aeabi::PROFILE_M, 0, 1, 0, 0)
+        }
         // Cortex-M Thumb-2 family: arch from the triple (M3 = v7-M,
         // M4/M4F/M7 = v7E-M, M55 = v8.1-M.mainline), profile M, Thumb-2.
         _ => {
@@ -3089,7 +3118,16 @@ fn arm_build_attributes(target: &TargetSpec) -> Section {
             } else {
                 aeabi::CPU_ARCH_V7
             };
-            arm_attributes_section(cpu_arch, aeabi::PROFILE_M, 0, 2)
+            // GI-FPU-002 (#619/#369): an FPU target advertises hard-float —
+            // Tag_FP_arch = VFPv4-D16 and Tag_ABI_VFP_args = VFP registers — so
+            // a consumer can tell the FP mode from the artifact. Non-FPU M-profile
+            // targets keep 0/0 (omitted) and stay byte-identical.
+            let (fp_arch, vfp_args) = if target.has_fpu() {
+                (aeabi::FP_ARCH_VFPV4_D16, aeabi::VFP_ARGS_VFP_REGS)
+            } else {
+                (0, 0)
+            };
+            arm_attributes_section(cpu_arch, aeabi::PROFILE_M, 0, 2, fp_arch, vfp_args)
         }
     }
 }
@@ -4278,7 +4316,12 @@ fn build_multi_func_cortex_m_elf(
     let vector_table_size: u32 = 128;
 
     let startup_addr = flash_base + vector_table_size;
-    let startup_code = generate_minimal_startup(linear_memory_size, globals_words, linmem_base);
+    let startup_code = generate_minimal_startup(
+        linear_memory_size,
+        globals_words,
+        linmem_base,
+        target.has_fpu(),
+    );
     let startup_size = startup_code.len() as u32;
 
     let default_handler_addr = startup_addr + startup_size;
@@ -5156,7 +5199,12 @@ fn build_cortex_m_elf(
     let vector_table_size: u32 = 128; // 32 entries * 4 bytes
 
     let startup_addr = flash_base + vector_table_size;
-    let startup_code = generate_minimal_startup(linear_memory_size, globals_words, linmem_base);
+    let startup_code = generate_minimal_startup(
+        linear_memory_size,
+        globals_words,
+        linmem_base,
+        target.has_fpu(),
+    );
     let startup_size = startup_code.len() as u32;
 
     let default_handler_addr = startup_addr + startup_size;
@@ -5326,8 +5374,15 @@ fn build_cortex_m_elf(
 ///   high stack layout; `0x20000000 + stack_size` under `--stack-layout=low`,
 ///   #687)
 /// * R9  = `linmem_base` + memory_size (globals table; only when globals exist)
-fn generate_minimal_startup(memory_size: u32, globals_words: &[u32], linmem_base: u32) -> Vec<u8> {
+fn generate_minimal_startup(
+    memory_size: u32,
+    globals_words: &[u32],
+    linmem_base: u32,
+    enable_fpu: bool,
+) -> Vec<u8> {
     // This startup code:
+    // 0. (GI-FPU-002, #619) On an FPU target, enables CP10/CP11 in SCB->CPACR
+    //    so VFP instructions don't fault (the FPU is disabled at reset).
     // 1. Initializes R10 with memory size (for bounds checking)
     // 2. Initializes R11 with the linear memory base for WASM memory access
     // 3. Loads the address of the user function
@@ -5349,6 +5404,21 @@ fn generate_minimal_startup(memory_size: u32, globals_words: &[u32], linmem_base
     let r10_movt = encode_thumb2_movt(10, (memory_size >> 16) as u16);
 
     let mut code: Vec<u8> = Vec::new();
+    // GI-FPU-002 (#619/#369): enable the FPU before any VFP instruction runs.
+    // SCB->CPACR (0xE000ED88) |= 0x00F00000 sets CP10+CP11 to full access, then
+    // DSB+ISB. Seven 4-byte Thumb-2 instructions (28 bytes, a multiple of 4) so
+    // the later 16-bit `LDR r0,[pc,#4]` literal load stays 4-byte aligned and
+    // its relative offset is unchanged. Emitted ONLY on FPU targets — a
+    // non-FPU startup is byte-identical to before.
+    if enable_fpu {
+        code.extend_from_slice(&[0x4E, 0xF6, 0x88, 0x50]); // MOVW R0, #0xED88
+        code.extend_from_slice(&[0xCE, 0xF2, 0x00, 0x00]); // MOVT R0, #0xE000
+        code.extend_from_slice(&[0xD0, 0xF8, 0x00, 0x10]); // LDR  R1, [R0]
+        code.extend_from_slice(&[0x41, 0xF4, 0x70, 0x01]); // ORR  R1, R1, #0x00F00000
+        code.extend_from_slice(&[0xC0, 0xF8, 0x00, 0x10]); // STR  R1, [R0]
+        code.extend_from_slice(&[0xBF, 0xF3, 0x4F, 0x8F]); // DSB SY
+        code.extend_from_slice(&[0xBF, 0xF3, 0x6F, 0x8F]); // ISB SY
+    }
     // MOVW R10, #(memory_size & 0xFFFF) / MOVT R10, #(memory_size >> 16)
     code.extend_from_slice(&r10_movw);
     code.extend_from_slice(&r10_movt);
@@ -6420,7 +6490,7 @@ mod tests {
     fn test_minimal_startup_generation() {
         // Test with 64KB memory size (0x10000)
         let memory_size: u32 = 64 * 1024;
-        let startup = generate_minimal_startup(memory_size, &[], 0x2000_0000);
+        let startup = generate_minimal_startup(memory_size, &[], 0x2000_0000, false);
 
         // Should be 28 bytes:
         // MOVW R10 + MOVT R10 + MOVW R11 + MOVT R11 + LDR + BLX + B + padding + literal
@@ -6460,8 +6530,8 @@ mod tests {
         let memory_size: u32 = 64 * 1024;
         // i64 0x123456789ABCDEF0 (lo, hi) followed by an i32 canary.
         let words = [0x9ABCDEF0u32, 0x12345678, 0x0C0FFEE1];
-        let startup = generate_minimal_startup(memory_size, &words, 0x2000_0000);
-        let empty = generate_minimal_startup(memory_size, &[], 0x2000_0000);
+        let startup = generate_minimal_startup(memory_size, &words, 0x2000_0000, false);
+        let empty = generate_minimal_startup(memory_size, &[], 0x2000_0000, false);
 
         // 16 scaffold + 8 (R9 movw/movt) + 3 * 12 (movw/movt/str) + 12 tail
         assert_eq!(startup.len(), 16 + 8 + 36 + 12, "materializer size");
@@ -6496,8 +6566,8 @@ mod tests {
         let base_low = base_high + DEFAULT_LOW_STACK_SIZE; // 0x2000_1000
         let words = [0x0C0FFEE1u32];
 
-        let low = generate_minimal_startup(memory_size, &words, base_low);
-        let high = generate_minimal_startup(memory_size, &words, base_high);
+        let low = generate_minimal_startup(memory_size, &words, base_low, false);
+        let high = generate_minimal_startup(memory_size, &words, base_high, false);
         assert_eq!(low.len(), high.len(), "same shape, shifted constants");
 
         // R10 (memory size) identical.

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -183,6 +183,16 @@ pub struct CompileConfig {
     /// driver loop, because `compile_function` is shared across backends and
     /// carries no function index. Empty → assume i32.
     pub current_func_params_i64: Vec<bool>,
+    /// GI-FPU-002 (#619/#369): per-function declared f32-param mask (full index,
+    /// imports first). The driver copies `func_params_f32[f]` into
+    /// [`current_func_params_f32`] before each `compile_function`. Empty ⇒
+    /// all-non-f32 (byte-identical to before).
+    pub func_params_f32: Vec<Vec<bool>>,
+    /// GI-FPU-002: declared f32-param mask of the function CURRENTLY being
+    /// compiled — `current_func_params_f32[k]` is true when param `k` is f32.
+    /// Set per function from [`func_params_f32`], mirroring
+    /// [`current_func_params_i64`]. Empty ⇒ no f32 params.
+    pub current_func_params_f32: Vec<bool>,
     /// #457: DECLARED parameter count of the function CURRENTLY being compiled,
     /// from the module's type section (`func_arg_counts[func.index]`). Set per
     /// function by the driver loops like [`current_func_params_i64`].
@@ -350,6 +360,8 @@ impl Default for CompileConfig {
             global_widths: Vec::new(),
             func_params_i64: Vec::new(),
             current_func_params_i64: Vec::new(),
+            func_params_f32: Vec::new(),
+            current_func_params_f32: Vec::new(),
             // #457: None ⇒ declared signature unknown ⇒ param-count inference
             // only (unit tests / hand-built op streams); driver loops fill it.
             current_func_param_count: None,

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -305,6 +305,11 @@ pub struct DecodedModule {
     /// AAPCS stack-argument path needs the declared widths — op-stream inference
     /// can't see an unused i64 param that still shifts the incoming-stack layout.
     pub func_params_i64: Vec<Vec<bool>>,
+    /// GI-FPU-002 (#619/#369): declared f32-param mask per *function* (full
+    /// index, imports first): `func_params_f32[f][k]` is true when param `k` is
+    /// f32. The direct selector homes hard-float f32 args in S0..S15 (AAPCS-VFP),
+    /// which op-stream inference cannot recover for a pure-passthrough f32 param.
+    pub func_params_f32: Vec<Vec<bool>>,
     /// Defined globals with their initializers (#237). Empty if the module has
     /// no global section. Used by the native-pointer ABI to make a global whose
     /// initializer is a linear-memory address (e.g. `$__stack_pointer`)
@@ -589,6 +594,12 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     // #359: declared param widths per type / per function (full index).
     let mut type_params_i64: Vec<Vec<bool>> = Vec::new();
     let mut func_params_i64: Vec<Vec<bool>> = Vec::new();
+    // GI-FPU-002 (#619/#369): per-type / per-function declared f32-param mask,
+    // so the direct selector can home hard-float (AAPCS-VFP) f32 args in S0..S15
+    // instead of the core-register (R0..R3) integer path. Independent of
+    // `params_i64` (which lumps f64 with i64): an f32 param is neither.
+    let mut type_params_f32: Vec<Vec<bool>> = Vec::new();
+    let mut func_params_f32: Vec<Vec<bool>> = Vec::new();
     // #509: (param_count, result_count) per type index, for FuncType blocktypes.
     let mut type_block_arity: Vec<(u8, u8)> = Vec::new();
     let mut elem_func_indices: Vec<u32> = Vec::new();
@@ -672,9 +683,19 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                             ),
                             _ => (0, false, Vec::new()),
                         };
+                        // GI-FPU-002: declared f32-param mask for this type.
+                        let params_f32 = match &sub_ty.composite_type.inner {
+                            wasmparser::CompositeInnerType::Func(func_ty) => func_ty
+                                .params()
+                                .iter()
+                                .map(|t| matches!(t, wasmparser::ValType::F32))
+                                .collect::<Vec<bool>>(),
+                            _ => Vec::new(),
+                        };
                         type_arg_counts.push(count);
                         type_ret_i64.push(ret_i64);
                         type_params_i64.push(params_i64);
+                        type_params_f32.push(params_f32);
                         // #680: v128 anywhere in the signature.
                         type_has_v128.push(match &sub_ty.composite_type.inner {
                             wasmparser::CompositeInnerType::Func(f) => f
@@ -721,6 +742,12 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                             );
                             func_params_i64.push(
                                 type_params_i64
+                                    .get(type_idx as usize)
+                                    .cloned()
+                                    .unwrap_or_default(),
+                            );
+                            func_params_f32.push(
+                                type_params_f32
                                     .get(type_idx as usize)
                                     .cloned()
                                     .unwrap_or_default(),
@@ -787,6 +814,12 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                     );
                     func_params_i64.push(
                         type_params_i64
+                            .get(type_idx as usize)
+                            .cloned()
+                            .unwrap_or_default(),
+                    );
+                    func_params_f32.push(
+                        type_params_f32
                             .get(type_idx as usize)
                             .cloned()
                             .unwrap_or_default(),
@@ -1062,6 +1095,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
         func_ret_i64,
         type_ret_i64,
         func_params_i64,
+        func_params_f32,
         globals,
         elem_func_indices,
         table_size: table_sizes.first().copied().flatten(),
@@ -1853,6 +1887,34 @@ fn convert_operator(op: &wasmparser::Operator) -> Option<WasmOp> {
         I64x2ExtractLane { lane } => Some(WasmOp::I64x2ExtractLane(*lane)),
         I64x2ReplaceLane { lane } => Some(WasmOp::I64x2ReplaceLane(*lane)),
 
+        // === Scalar f32 (GI-FPU-002 phase 1, #619/#369) ===
+        // Un-dropped so the FPU targets (cortex-m4f/m7/m7dp) can route these to
+        // the VFP selector arms in `select_with_stack`. The FPU gate lives at
+        // the selector/validate layer (`requires_fpu()` + `set_target`): on a
+        // non-FPU target (m0/m3/r5) these still honest-reject. f64 stays dropped
+        // (phase 2 — M7DP D-registers). Only the wired scope is un-dropped; the
+        // rest of the scalar f32 surface (abs/neg/sqrt/min/max/…) still falls to
+        // `_ => None` and loud-skips its function until phase 1b wires it.
+        F32Add => Some(WasmOp::F32Add),
+        F32Sub => Some(WasmOp::F32Sub),
+        F32Mul => Some(WasmOp::F32Mul),
+        F32Div => Some(WasmOp::F32Div),
+        F32Eq => Some(WasmOp::F32Eq),
+        F32Ne => Some(WasmOp::F32Ne),
+        F32Lt => Some(WasmOp::F32Lt),
+        F32Le => Some(WasmOp::F32Le),
+        F32Gt => Some(WasmOp::F32Gt),
+        F32Ge => Some(WasmOp::F32Ge),
+        F32Const { value } => Some(WasmOp::F32Const(f32::from_bits(value.bits()))),
+        // F32Load / F32Store (linear-memory f32 access) stay dropped in phase 1
+        // — VFP VLDR/VSTR take a [Rn,#imm] address, so the computed base+offset
+        // needs an extra materialization the phase-1 selector does not yet emit.
+        // They loud-skip at decode (phase 1b).
+        F32ConvertI32S => Some(WasmOp::F32ConvertI32S),
+        F32ConvertI32U => Some(WasmOp::F32ConvertI32U),
+        I32TruncF32S => Some(WasmOp::I32TruncF32S),
+        I32TruncF32U => Some(WasmOp::I32TruncF32U),
+
         // f32x4
         F32x4Add => Some(WasmOp::F32x4Add),
         F32x4Sub => Some(WasmOp::F32x4Sub),
@@ -2471,13 +2533,19 @@ mod tests {
 
     #[test]
     fn test_369_scalar_float_op_flags_function_unsupported_not_dropped() {
-        // #369: a scalar f32/f64 op the decoder can't lower must FLAG the
-        // function (-> loud skip), never be silently dropped (which left a
-        // `mov r0,r1` wrong-value stub). A pure-integer function stays clean.
+        // GI-FPU-002 (#619): the in-scope scalar f32 ops (add/sub/mul/div,
+        // comparisons, i32.trunc_f32_s/u, f32.convert_i32_s/u, f32.const) are
+        // now DECODED (routed to the VFP selector on FPU targets), so `f32.add`
+        // is no longer flagged. An out-of-scope scalar float op (`f64.add`,
+        // phase 2) is STILL flagged (loud-skip), never silently dropped — the
+        // #369 honesty contract holds for the not-yet-lowered surface. A
+        // pure-integer function stays clean.
         let wat = r#"
             (module
                 (func (export "fadd") (param f32 f32) (result f32)
                     local.get 0 local.get 1 f32.add)
+                (func (export "dadd") (param f64 f64) (result f64)
+                    local.get 0 local.get 1 f64.add)
                 (func (export "iadd") (param i32 i32) (result i32)
                     local.get 0 local.get 1 i32.add))
         "#;
@@ -2487,19 +2555,30 @@ mod tests {
             .iter()
             .find(|f| f.export_name.as_deref() == Some("fadd"))
             .unwrap();
+        let dadd = functions
+            .iter()
+            .find(|f| f.export_name.as_deref() == Some("dadd"))
+            .unwrap();
         let iadd = functions
             .iter()
             .find(|f| f.export_name.as_deref() == Some("iadd"))
             .unwrap();
+        // In-scope f32 op: now decoded (reachable), not flagged.
         assert!(
-            fadd.unsupported.is_some(),
-            "f32.add must flag the function unsupported (loud-skip), got {:?}",
+            fadd.unsupported.is_none(),
+            "GI-FPU-002: f32.add must now decode (not be flagged), got {:?}",
             fadd.unsupported
         );
         assert!(
-            fadd.unsupported.as_deref().unwrap().contains("F32Add"),
-            "diagnostic should name the op: {:?}",
-            fadd.unsupported
+            fadd.ops.contains(&WasmOp::F32Add),
+            "f32.add must decode to WasmOp::F32Add: {:?}",
+            fadd.ops
+        );
+        // Out-of-scope scalar double op: still flagged (phase 2), never dropped.
+        assert!(
+            dadd.unsupported.is_some(),
+            "f64.add must still flag the function unsupported (phase 2), got {:?}",
+            dadd.unsupported
         );
         assert!(
             iadd.unsupported.is_none(),

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -232,6 +232,13 @@ enum StackVal {
     /// Spilled to the frame: i32 at `[sp, lo_slot]`; i64 lo at `[sp, lo_slot]`,
     /// hi at `[sp, lo_slot+4]`.
     Spilled { lo_slot: i32, is_i64: bool },
+    /// GI-FPU-002 (#619/#369): an f32 value in VFP single-precision register
+    /// `sreg`. Distinct from the integer/`Reg` entries — the hard-float value
+    /// lives in the S-register file, never a core register or a frame slot.
+    /// The integer pop/peek/spill helpers never see one in well-typed wasm (an
+    /// integer op only pops integer entries); they reject it defensively rather
+    /// than misread it. f32 ops manage these via the dedicated VFP allocator.
+    Float { sreg: VfpReg },
 }
 
 impl StackVal {
@@ -250,6 +257,16 @@ impl StackVal {
     fn is_i64(&self) -> bool {
         match self {
             StackVal::Reg { is_i64, .. } | StackVal::Spilled { is_i64, .. } => *is_i64,
+            // GI-FPU-002: an f32 is a single 32-bit S-register value.
+            StackVal::Float { .. } => false,
+        }
+    }
+    /// GI-FPU-002: the S-register of an f32 stack value, if this is one.
+    #[inline]
+    fn as_float(&self) -> Option<VfpReg> {
+        match self {
+            StackVal::Float { sreg } => Some(*sreg),
+            _ => None,
         }
     }
 }
@@ -873,6 +890,15 @@ fn pop_operand(
     };
     match v {
         StackVal::Reg { reg, .. } => Ok(reg),
+        // GI-FPU-002: an integer op tried to pop an f32 value. Well-typed wasm
+        // never does this (an f32 stack entry is only consumed by an f32 op,
+        // which uses the VFP path); reject loudly rather than misread S-reg
+        // bits as a core register.
+        StackVal::Float { .. } => Err(synth_core::Error::synthesis(
+            "GI-FPU-002: an integer operation popped an f32 (VFP) stack value — \
+             invalid wasm or an unlowered float op reached the integer path"
+                .to_string(),
+        )),
         StackVal::Spilled { lo_slot, is_i64 } => {
             // Reload against the *remaining* stack (this entry already popped).
             // i32: one temp + one LDR. i64: a consecutive pair + LDR lo/hi.
@@ -936,6 +962,12 @@ fn peek_operand(
             "stack underflow: malformed WASM or compiler bug".to_string(),
         )),
         Some(StackVal::Reg { reg, .. }) => Ok(reg),
+        // GI-FPU-002: see `pop_operand` — an integer peek never targets an f32.
+        Some(StackVal::Float { .. }) => Err(synth_core::Error::synthesis(
+            "GI-FPU-002: an integer operation peeked an f32 (VFP) stack value — \
+             invalid wasm or an unlowered float op reached the integer path"
+                .to_string(),
+        )),
         Some(StackVal::Spilled { lo_slot, is_i64 }) => {
             let lo = if is_i64 {
                 let (lo, hi) = alloc_consecutive_pair(
@@ -1882,6 +1914,242 @@ fn index_to_vfp_dreg(index: u8) -> VfpReg {
     }
 }
 
+// ============================================================================
+// GI-FPU-002 (#619/#369): scalar f32 (hard-float / VFP) lowering for the direct
+// `select_with_stack` selector. The encoder + ArmOp VFP variants already exist;
+// this bridges the operand stack to them with a real S-register value stack and
+// AAPCS-VFP param/return homing. Phase-1 honest-subset: f32 add/sub/mul/div,
+// the six comparisons, i32.trunc_f32_s/u, f32.convert_i32_s/u, f32 const, and
+// f32 param `local.get`. f64, f32 load/store, f32 local.set/tee, and mixed
+// int/f32 parameter lists loud-decline (never miscompile). FPU-gated by the
+// caller; f64 stays dropped at decode. See CLAUDE.md North Star / #369.
+// ============================================================================
+
+/// The 0..15 file index of a single-precision VFP register `S0..S15`, or `None`
+/// for a double-precision (`D`) register (never used on the f32 path).
+fn vfp_s_index(r: VfpReg) -> Option<usize> {
+    use VfpReg::*;
+    Some(match r {
+        S0 => 0,
+        S1 => 1,
+        S2 => 2,
+        S3 => 3,
+        S4 => 4,
+        S5 => 5,
+        S6 => 6,
+        S7 => 7,
+        S8 => 8,
+        S9 => 9,
+        S10 => 10,
+        S11 => 11,
+        S12 => 12,
+        S13 => 13,
+        S14 => 14,
+        S15 => 15,
+        _ => return None,
+    })
+}
+
+/// Allocate the lowest-numbered free single-precision S-register (S0..S15).
+/// Errs (honest decline) when all 16 are live — phase 1 has no VFP spilling, so
+/// an f32 expression deeper than the register file loud-skips its function.
+fn alloc_vfp_temp(used: &mut [bool; 16]) -> Result<VfpReg> {
+    for (i, slot) in used.iter_mut().enumerate() {
+        if !*slot {
+            *slot = true;
+            return Ok(index_to_vfp_reg(i as u8));
+        }
+    }
+    Err(synth_core::Error::synthesis(
+        "GI-FPU-002: VFP register file exhausted (S0..S15 all live) — f32 \
+         expression too deep for phase 1 (no VFP spilling yet)"
+            .to_string(),
+    ))
+}
+
+/// Free a VFP temp unless it is a permanent param/local home register.
+fn free_vfp_temp(used: &mut [bool; 16], home: &[bool; 16], r: VfpReg) {
+    if let Some(i) = vfp_s_index(r)
+        && !home[i]
+    {
+        used[i] = false;
+    }
+}
+
+/// Pop the top operand as an f32 (VFP) value; err if it is not one (an
+/// unlowered mixed int/float sequence, or invalid wasm).
+fn pop_float(stack: &mut Vec<StackVal>) -> Result<VfpReg> {
+    match stack.pop() {
+        Some(StackVal::Float { sreg }) => Ok(sreg),
+        Some(_) => Err(synth_core::Error::synthesis(
+            "GI-FPU-002: an f32 operation expected an f32 (VFP) operand but the \
+             stack top was an integer value — invalid wasm or an unlowered \
+             mixed int/float sequence"
+                .to_string(),
+        )),
+        None => Err(synth_core::Error::synthesis(
+            "stack underflow: malformed WASM or compiler bug".to_string(),
+        )),
+    }
+}
+
+/// True if `op` is one of the in-scope scalar f32 ops the phase-1 VFP path
+/// lowers (mirrors the decoder's un-dropped set). `LocalGet`/`LocalSet` of an
+/// f32 local are handled separately (they need the f32-local map to classify).
+fn is_scope_f32_op(op: &WasmOp) -> bool {
+    use WasmOp::*;
+    matches!(
+        op,
+        F32Add
+            | F32Sub
+            | F32Mul
+            | F32Div
+            | F32Eq
+            | F32Ne
+            | F32Lt
+            | F32Le
+            | F32Gt
+            | F32Ge
+            | F32Const(_)
+            | F32ConvertI32S
+            | F32ConvertI32U
+            | I32TruncF32S
+            | I32TruncF32U
+    )
+}
+
+/// Lower an in-scope scalar f32 op (or f32-param `local.get`) onto the VFP
+/// register file. Returns `Ok(true)` when it handled `op` (caller `continue`s),
+/// `Ok(false)` when `op` is not an f32 op (fall through to the integer match),
+/// and `Err` on an honest phase-1 decline (the function loud-skips).
+#[allow(clippy::too_many_arguments)]
+fn try_lower_f32(
+    op: &WasmOp,
+    idx: usize,
+    params_f32: &[bool],
+    f32_home: &std::collections::HashMap<u32, VfpReg>,
+    vfp_used: &mut [bool; 16],
+    vfp_home: &[bool; 16],
+    stack: &mut Vec<StackVal>,
+    next_temp: &mut u8,
+    spill: &mut SpillState,
+    instructions: &mut Vec<ArmInstruction>,
+    reserved: &[Reg],
+) -> Result<bool> {
+    use WasmOp::*;
+    match op {
+        F32Const(v) => {
+            let sd = alloc_vfp_temp(vfp_used)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::F32Const { sd, value: *v },
+                source_line: Some(idx),
+            });
+            stack.push(StackVal::Float { sreg: sd });
+            Ok(true)
+        }
+        LocalGet(i) => {
+            if let Some(&home) = f32_home.get(i) {
+                // Read-only reference to the home S-register. Phase 1 never
+                // rewrites a home while referenced (f32 local.set declines), so
+                // no copy is needed to defend against aliasing.
+                stack.push(StackVal::Float { sreg: home });
+                Ok(true)
+            } else {
+                // Not a known f32 local — let the integer LocalGet handle it.
+                Ok(false)
+            }
+        }
+        LocalSet(i) | LocalTee(i) => {
+            let top_is_float = stack.last().and_then(|v| v.as_float()).is_some();
+            let target_is_f32 =
+                f32_home.contains_key(i) || params_f32.get(*i as usize).copied().unwrap_or(false);
+            if top_is_float || target_is_f32 {
+                Err(synth_core::Error::synthesis(
+                    "GI-FPU-002 phase 1: f32 local.set/local.tee is not yet \
+                     lowered (VFP home write-back) — declining the function"
+                        .to_string(),
+                ))
+            } else {
+                Ok(false)
+            }
+        }
+        F32Add | F32Sub | F32Mul | F32Div => {
+            let sm = pop_float(stack)?;
+            let sn = pop_float(stack)?;
+            let sd = alloc_vfp_temp(vfp_used)?;
+            let arm = match op {
+                F32Add => ArmOp::F32Add { sd, sn, sm },
+                F32Sub => ArmOp::F32Sub { sd, sn, sm },
+                F32Mul => ArmOp::F32Mul { sd, sn, sm },
+                _ => ArmOp::F32Div { sd, sn, sm },
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_temp(vfp_used, vfp_home, sm);
+            free_vfp_temp(vfp_used, vfp_home, sn);
+            stack.push(StackVal::Float { sreg: sd });
+            Ok(true)
+        }
+        F32Eq | F32Ne | F32Lt | F32Le | F32Gt | F32Ge => {
+            let sm = pop_float(stack)?;
+            let sn = pop_float(stack)?;
+            // The comparison result is an i32 (0/1) in a core register.
+            let rd = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+            let arm = match op {
+                F32Eq => ArmOp::F32Eq { rd, sn, sm },
+                F32Ne => ArmOp::F32Ne { rd, sn, sm },
+                F32Lt => ArmOp::F32Lt { rd, sn, sm },
+                F32Le => ArmOp::F32Le { rd, sn, sm },
+                F32Gt => ArmOp::F32Gt { rd, sn, sm },
+                _ => ArmOp::F32Ge { rd, sn, sm },
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_temp(vfp_used, vfp_home, sm);
+            free_vfp_temp(vfp_used, vfp_home, sn);
+            stack.push(StackVal::i32(rd));
+            Ok(true)
+        }
+        F32ConvertI32S | F32ConvertI32U => {
+            // Pop the i32 operand from the integer stack (reloads if spilled).
+            let rm = pop_operand(stack, next_temp, instructions, spill, reserved, idx)?;
+            let sd = alloc_vfp_temp(vfp_used)?;
+            let arm = if matches!(op, F32ConvertI32S) {
+                ArmOp::F32ConvertI32S { sd, rm }
+            } else {
+                ArmOp::F32ConvertI32U { sd, rm }
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            stack.push(StackVal::Float { sreg: sd });
+            Ok(true)
+        }
+        I32TruncF32S | I32TruncF32U => {
+            let sm = pop_float(stack)?;
+            let rd = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+            let arm = if matches!(op, I32TruncF32S) {
+                ArmOp::I32TruncF32S { rd, sm }
+            } else {
+                ArmOp::I32TruncF32U { rd, sm }
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_temp(vfp_used, vfp_home, sm);
+            stack.push(StackVal::i32(rd));
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
 /// Convert Q-register index to QReg enum (Q0-Q7, wrapping)
 fn index_to_qreg(index: u8) -> QReg {
     match index % 8 {
@@ -1941,6 +2209,10 @@ pub struct InstructionSelector {
     /// path refuses (Ok-or-Err) when any param is 64-bit. Empty ⇒ assume i32
     /// (the legacy path; every function with <=4 i32 params is byte-identical).
     params_i64: Vec<bool>,
+    /// GI-FPU-002 (#619/#369): `params_f32[k]` true ⇒ param `k` is an f32,
+    /// homed in an AAPCS-VFP argument S-register (S0..S15) rather than the
+    /// R0..R3 integer path. Empty ⇒ no f32 params (byte-identical legacy path).
+    params_f32: Vec<bool>,
     /// #643: byte width of each defined global's storage slot, indexed by
     /// global index — 4 for i32/f32, 8 for i64/f64, 16 for v128. The globals
     /// table (R9-relative) is laid out by SUMMING these widths, NOT `idx * 4`:
@@ -2103,6 +2375,7 @@ impl InstructionSelector {
             func_ret_i64: Vec::new(),
             type_ret_i64: Vec::new(),
             params_i64: Vec::new(),
+            params_f32: Vec::new(),
             global_widths: Vec::new(),
             block_arity: Vec::new(),
             func_arg_counts: Vec::new(),
@@ -2140,6 +2413,7 @@ impl InstructionSelector {
             func_ret_i64: Vec::new(),
             type_ret_i64: Vec::new(),
             params_i64: Vec::new(),
+            params_f32: Vec::new(),
             global_widths: Vec::new(),
             block_arity: Vec::new(),
             func_arg_counts: Vec::new(),
@@ -2445,6 +2719,13 @@ impl InstructionSelector {
     /// (Ok-or-Err). Empty ⇒ all params assumed i32 (the legacy path).
     pub fn set_params_i64(&mut self, params_i64: Vec<bool>) {
         self.params_i64 = params_i64;
+    }
+
+    /// GI-FPU-002 (#619/#369): register the declared f32-param mask of the
+    /// function about to be compiled, so `select_with_stack` homes hard-float
+    /// f32 args in their AAPCS-VFP argument S-registers (S0..S15).
+    pub fn set_params_f32(&mut self, params_f32: Vec<bool>) {
+        self.params_f32 = params_f32;
     }
 
     /// #509: register the blocktype-arity side-table of the function about to
@@ -6963,6 +7244,81 @@ impl InstructionSelector {
             out
         };
 
+        // GI-FPU-002 (#619/#369): hard-float (AAPCS-VFP) f32 setup. Snapshot the
+        // FPU capability + f32-param mask, seed each f32 param's home S-register,
+        // and apply the phase-1 honest decline guards. Inert (all-false / empty)
+        // for every function without an f32 param or f32 op — the integer path
+        // is byte-identical.
+        let fpu = self.fpu;
+        let params_f32 = self.params_f32.clone();
+        let mut vfp_used = [false; 16];
+        let mut vfp_home = [false; 16];
+        let mut f32_home: std::collections::HashMap<u32, VfpReg> = std::collections::HashMap::new();
+        {
+            let has_f32_param =
+                (0..num_params).any(|i| params_f32.get(i as usize).copied().unwrap_or(false));
+            let has_f32_op = wasm_ops.iter().any(is_scope_f32_op);
+            let has_any_f32 = has_f32_param || has_f32_op;
+            if has_any_f32 {
+                // Honest reject on a non-FPU target (m0/m3/r5) — GI-FPU-001
+                // capability contract. `fpu.is_none()` ⇒ no VFP.
+                if fpu.is_none() {
+                    return Err(synth_core::Error::synthesis(format!(
+                        "GI-FPU-002: scalar f32 requires a hardware FPU target \
+                         (cortex-m4f/m7/m7dp); '{}' has none — refusing to emit \
+                         soft-float f32 (declining the function, #619/#369)",
+                        self.target_name
+                    )));
+                }
+                // Phase-1 honest declines (never a miscompile):
+                //  * mixed f32 + integer params — AAPCS-VFP uses independent
+                //    core (R0..R3) and VFP (S0..S15) argument pools, so an f32
+                //    param must not consume a core slot; the phase-1 core-reg
+                //    layout is not yet VFP-aware.
+                let has_int_param =
+                    (0..num_params).any(|i| !params_f32.get(i as usize).copied().unwrap_or(false));
+                if has_f32_param && has_int_param {
+                    return Err(synth_core::Error::synthesis(
+                        "GI-FPU-002 phase 1: mixed f32/integer parameter lists \
+                         are not yet lowered (AAPCS-VFP independent register \
+                         pools) — declining the function"
+                            .to_string(),
+                    ));
+                }
+                //  * any call — S0..S15 are caller-saved, so an f32 value or
+                //    param home would be clobbered across a bl (phase 1b).
+                if wasm_ops
+                    .iter()
+                    .any(|o| matches!(o, WasmOp::Call(_) | WasmOp::CallIndirect { .. }))
+                {
+                    return Err(synth_core::Error::synthesis(
+                        "GI-FPU-002 phase 1: f32 in a function with a call is \
+                         not yet lowered (S0..S15 are caller-saved) — declining"
+                            .to_string(),
+                    ));
+                }
+                // Seed f32-param homes. With no mixed params, the k-th param is
+                // the k-th f32 param, homed in AAPCS-VFP arg register S(k).
+                let mut vfp_arg: u8 = 0;
+                for i in 0..num_params {
+                    if params_f32.get(i as usize).copied().unwrap_or(false) {
+                        if vfp_arg >= 16 {
+                            return Err(synth_core::Error::synthesis(
+                                "GI-FPU-002 phase 1: more than 16 f32 params \
+                                 (VFP arg registers exhausted) — declining"
+                                    .to_string(),
+                            ));
+                        }
+                        let home = index_to_vfp_reg(vfp_arg);
+                        vfp_used[vfp_arg as usize] = true;
+                        vfp_home[vfp_arg as usize] = true;
+                        f32_home.insert(i, home);
+                        vfp_arg += 1;
+                    }
+                }
+            }
+        }
+
         for (idx, op) in wasm_ops.iter().enumerate() {
             // Param registers still live at this op — reserved from temp/pair/
             // reload allocation so a constant/result/reload never clobbers a live
@@ -6993,6 +7349,27 @@ impl InstructionSelector {
                 if let Some(r) = bl.result_reg {
                     live_params.push(r);
                 }
+            }
+            // GI-FPU-002 (#619/#369): intercept in-scope scalar f32 ops (and f32
+            // param local.get) before the integer match. Gated on FPU presence;
+            // integer modules never construct an f32 stack entry, so this is
+            // inert for them (byte-identical). `Ok(false)` ⇒ not an f32 op.
+            if fpu.is_some()
+                && try_lower_f32(
+                    op,
+                    idx,
+                    &params_f32,
+                    &f32_home,
+                    &mut vfp_used,
+                    &vfp_home,
+                    &mut stack,
+                    &mut next_temp,
+                    &mut spill,
+                    &mut instructions,
+                    &live_params,
+                )?
+            {
+                continue;
             }
             match op {
                 LocalGet(local_idx) => {
@@ -12575,49 +12952,74 @@ impl InstructionSelector {
         // the hi whenever the final value transited registers other than
         // r0/r1 (decide() returned (0,0) where the contract says (0,1)).
         // Capture the width BEFORE peek (which returns only the lo register).
-        let result_is_i64 = matches!(
-            stack.last(),
-            Some(StackVal::Reg { is_i64: true, .. }) | Some(StackVal::Spilled { is_i64: true, .. })
-        );
-        let result_reg = if stack.is_empty() {
-            None
-        } else {
-            Some(peek_operand(
-                &mut stack,
-                &mut next_temp,
-                &mut instructions,
-                &mut spill,
-                &[],
-                wasm_ops.len(),
-            )?)
-        };
-        if let Some(result_reg) = result_reg {
-            // lo move FIRST: for a consecutive pair (hi = lo+1) the only
-            // overlap case is lo == R1 (hi == R2), where r1 must be READ by
-            // the lo move before the hi move WRITES it — lo-first is safe for
-            // every possible pair (hi == R0 would require lo == "R-1").
-            if result_reg != Reg::R0 {
+        // GI-FPU-002 (#619/#369): an f32 result is returned in S0 (AAPCS-VFP).
+        // If the producing S-register is not already S0, copy it there via a
+        // core scratch (phase 1 has no VMOV Sd,Sm op; R12/IP is caller-saved,
+        // safe to clobber at the epilogue). Skip the integer return-value move.
+        let f32_result = stack.last().and_then(|v| v.as_float());
+        if let Some(sreg) = f32_result {
+            if vfp_s_index(sreg) != Some(0) {
                 instructions.push(ArmInstruction {
-                    op: ArmOp::Mov {
-                        rd: Reg::R0,
-                        op2: Operand2::Reg(result_reg),
+                    op: ArmOp::I32ReinterpretF32 {
+                        rd: Reg::R12,
+                        sm: sreg,
+                    },
+                    source_line: None,
+                });
+                instructions.push(ArmInstruction {
+                    op: ArmOp::F32ReinterpretI32 {
+                        sd: VfpReg::S0,
+                        rm: Reg::R12,
                     },
                     source_line: None,
                 });
             }
-            if result_is_i64 {
-                let hi = i64_pair_hi(result_reg)?;
-                if hi != Reg::R1 {
+        } else {
+            let result_is_i64 = matches!(
+                stack.last(),
+                Some(StackVal::Reg { is_i64: true, .. })
+                    | Some(StackVal::Spilled { is_i64: true, .. })
+            );
+            let result_reg = if stack.is_empty() {
+                None
+            } else {
+                Some(peek_operand(
+                    &mut stack,
+                    &mut next_temp,
+                    &mut instructions,
+                    &mut spill,
+                    &[],
+                    wasm_ops.len(),
+                )?)
+            };
+            if let Some(result_reg) = result_reg {
+                // lo move FIRST: for a consecutive pair (hi = lo+1) the only
+                // overlap case is lo == R1 (hi == R2), where r1 must be READ by
+                // the lo move before the hi move WRITES it — lo-first is safe for
+                // every possible pair (hi == R0 would require lo == "R-1").
+                if result_reg != Reg::R0 {
                     instructions.push(ArmInstruction {
                         op: ArmOp::Mov {
-                            rd: Reg::R1,
-                            op2: Operand2::Reg(hi),
+                            rd: Reg::R0,
+                            op2: Operand2::Reg(result_reg),
                         },
                         source_line: None,
                     });
                 }
+                if result_is_i64 {
+                    let hi = i64_pair_hi(result_reg)?;
+                    if hi != Reg::R1 {
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Mov {
+                                rd: Reg::R1,
+                                op2: Operand2::Reg(hi),
+                            },
+                            source_line: None,
+                        });
+                    }
+                }
             }
-        }
+        } // GI-FPU-002: end of the integer-result `else` branch
         if layout.frame_size > 0 {
             instructions.push(ArmInstruction {
                 op: ArmOp::Add {

--- a/scripts/repro/f32_vfp_619.wat
+++ b/scripts/repro/f32_vfp_619.wat
@@ -1,0 +1,14 @@
+(module
+  ;; GI-FPU-002 (#619/#369) phase-1 f32 hard-float differential fixture.
+  ;; All functions take hard-float (AAPCS-VFP) f32 args in S0/S1 and return in
+  ;; S0 (or R0 for the i32-result trunc/compare). Exercised on FPU-boundary
+  ;; values (0.0, 1.5, -2.25, large, denormal-ish) against wasmtime.
+  (func (export "fadd") (param f32 f32) (result f32) local.get 0 local.get 1 f32.add)
+  (func (export "fsub") (param f32 f32) (result f32) local.get 0 local.get 1 f32.sub)
+  (func (export "fmul") (param f32 f32) (result f32) local.get 0 local.get 1 f32.mul)
+  (func (export "fdiv") (param f32 f32) (result f32) local.get 0 local.get 1 f32.div)
+  (func (export "flt")  (param f32 f32) (result i32) local.get 0 local.get 1 f32.lt)
+  (func (export "fgt")  (param f32 f32) (result i32) local.get 0 local.get 1 f32.gt)
+  (func (export "trunc_s") (param f32) (result i32) local.get 0 i32.trunc_f32_s)
+  (func (export "conv_s")  (param i32) (result f32) local.get 0 f32.convert_i32_s)
+  (func (export "conv_u")  (param i32) (result f32) local.get 0 f32.convert_i32_u))

--- a/scripts/repro/f32_vfp_619_differential.py
+++ b/scripts/repro/f32_vfp_619_differential.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""GI-FPU-002 (#619/#369) — EXECUTION-validate scalar f32 hard-float codegen.
+
+synth has a working VFP encoder + selector VFP lowering, but the decoder dropped
+every scalar float op, so `synth compile f32.wat -t cortex-m4f` HONESTLY REJECTED
+f32 on every CLI path. Phase 1 wires decode -> the direct selector's VFP arms
+(add/sub/mul/div, the six comparisons, i32.trunc_f32_s/u, f32.convert_i32_s/u,
+f32.const, f32-param local.get) with AAPCS-VFP homing (args in S0..S15, result in
+S0), gated on FPU presence (m0/m3 keep the honest reject).
+
+This harness compiles the fixture for cortex-m4f, reads each function's address
+from the ELF SYMTAB (#489 — never `synth disasm` text), runs it under unicorn
+(UC_ARCH_ARM / Thumb) with the FPU ENABLED (CPACR CP10/CP11 + FPEXC.EN, since the
+M4F FPU is off at reset), passing the f32 args in S0/S1 per hard-float, and
+asserts the result is BIT-EXACT (`to_bits`, so signed-zero / NaN can't slip) to
+wasmtime ground truth on FPU-boundary values.
+
+RED / GREEN: on origin/main the compile step REJECTS (capability gap) -> this
+script exits nonzero (RED, "compile rejected"). After phase 1 it compiles and
+matches wasmtime -> exits 0 (GREEN). One harness, run against both trees.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=/path/to/synth python scripts/repro/f32_vfp_619_differential.py
+Exits nonzero on any mismatch or on a compile rejection.
+"""
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_PC,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_S0,
+    UC_ARM_REG_S1,
+    UC_ARM_REG_SP,
+)
+
+# Unicorn exposes CPACR as coprocessor reg C1_C0_2 and FPEXC for VFP enable.
+try:
+    from unicorn.arm_const import UC_ARM_REG_C1_C0_2, UC_ARM_REG_FPEXC
+except ImportError:  # older unicorn naming
+    UC_ARM_REG_C1_C0_2 = None
+    UC_ARM_REG_FPEXC = None
+
+WAT = Path(__file__).with_name("f32_vfp_619.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+CODE_BASE = 0x1000
+STACK_TOP = 0x40000
+STACK_MEM = 0x30000
+
+# FPU-boundary inputs: 0.0, 1.5, -2.25, a large magnitude, a denormal-ish tiny.
+F32_PAIRS = [
+    (0.0, 1.5),
+    (1.5, 2.5),
+    (-2.25, 4.0),
+    (1.0e30, 3.0),
+    (1.0e-40, 2.0),  # 1e-40 is subnormal in f32
+    (-0.0, 0.0),
+]
+# i32 inputs for convert; f32 inputs for trunc (all in i32 range — an
+# out-of-range trunc TRAPS in wasm, which is a control-flow property, not a
+# value differential).
+I32_INPUTS = [0, 1, -1, 7, -7, 2147483647, -2147483648, 100000]
+TRUNC_INPUTS = [0.0, 1.9, -1.9, 2.5, -2.5, 123.75, -123.75, 2000000.5]
+
+BINOP_F32 = ["fadd", "fsub", "fmul", "fdiv"]
+# NOTE: the f32 comparisons (flt/fgt/…) compile to VCMP.F32 + VMRS APSR_nzcv,
+# FPSCR + IT + MOV. unicorn does NOT model the VMRS FPSCR->APSR flag transfer
+# (the APSR flags stay 0, so every predicated set reads false and the result is
+# uniformly 0) — an EMULATOR gap, not a synth defect. The compare ENCODING is
+# byte-pinned in crates/synth-backend/tests/f32_vfp_encoding_test.rs and the MI
+# (a<b) / GT (a>b) condition selection is verified by inspection, so we exercise
+# the compares at COMPILE time (they are in the fixture) but do not execution-
+# differentiate them here. Arithmetic, convert, and trunc use no flag transfer
+# and are fully validated below.
+
+
+def compile_elf(out, target):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+         "--target", target, "--all-exports"],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"},
+    )
+    return r.returncode == 0, (r.stderr + r.stdout)
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+    return data, base, syms
+
+
+def f32_bits(x):
+    return struct.unpack("<I", struct.pack("<f", x))[0]
+
+
+def bits_f32(b):
+    return struct.unpack("<f", struct.pack("<I", b & 0xFFFFFFFF))[0]
+
+
+def run_unicorn(text, text_base, addr, s0_bits=None, s1_bits=None, r0=None):
+    uc = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    map_base = text_base & ~0xFFF
+    size = ((len(text) + (text_base - map_base)) + 0xFFF) & ~0xFFF
+    uc.mem_map(map_base, max(size, 0x1000))
+    uc.mem_write(text_base, text)
+    uc.mem_map(STACK_MEM, 0x10000)
+    uc.reg_write(UC_ARM_REG_SP, STACK_TOP)
+    # Enable the FPU (M4F FPU is disabled at reset): CPACR CP10/CP11 + FPEXC.EN.
+    if UC_ARM_REG_C1_C0_2 is not None:
+        uc.reg_write(UC_ARM_REG_C1_C0_2, 0x00F00000)
+    if UC_ARM_REG_FPEXC is not None:
+        uc.reg_write(UC_ARM_REG_FPEXC, 0x40000000)
+    if s0_bits is not None:
+        uc.reg_write(UC_ARM_REG_S0, s0_bits)
+    if s1_bits is not None:
+        uc.reg_write(UC_ARM_REG_S1, s1_bits)
+    if r0 is not None:
+        uc.reg_write(UC_ARM_REG_R0, r0 & 0xFFFFFFFF)
+    ret = STACK_TOP | 1
+    uc.reg_write(UC_ARM_REG_LR, ret)
+    uc.emu_start(addr | 1, ret & ~1, count=200)
+    return uc
+
+
+def wasm_instance():
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    store = wasmtime.Store(eng)
+    inst = wasmtime.Instance(store, mod, [])
+    return store, inst
+
+
+def main():
+    elf = "/tmp/f32_vfp_619.elf"
+
+    # Honest-reject check: f32 must be rejected on a no-FPU target (m3).
+    ok_m3, _ = compile_elf("/tmp/f32_vfp_619_m3.elf", "cortex-m3")
+    if ok_m3:
+        sys.exit("FAIL: f32 must be REJECTED on cortex-m3 (no FPU), but compiled")
+
+    ok, log = compile_elf(elf, "cortex-m4f")
+    if not ok:
+        print("RED: `synth compile -t cortex-m4f` REJECTED f32 (capability gap).")
+        print(log.strip()[:400])
+        sys.exit(1)
+
+    text, base, syms = load(elf)
+    store, inst = wasm_instance()
+
+    fails = 0
+    checked = 0
+
+    def bit_result_f32(fn, uc):
+        return uc.reg_read(UC_ARM_REG_S0) & 0xFFFFFFFF
+
+    for fn in BINOP_F32:
+        wf = inst.exports(store)[fn]
+        for a, b in F32_PAIRS:
+            uc = run_unicorn(text, base, syms[fn], s0_bits=f32_bits(a), s1_bits=f32_bits(b))
+            got = uc.reg_read(UC_ARM_REG_S0) & 0xFFFFFFFF
+            want = f32_bits(wf(store, a, b))
+            checked += 1
+            if got != want:
+                fails += 1
+                print(f"MISMATCH {fn}({a},{b}): synth 0x{got:08x} ({bits_f32(got)}) "
+                      f"!= wasmtime 0x{want:08x} ({bits_f32(want)})")
+
+    wf = inst.exports(store)["trunc_s"]
+    for a in TRUNC_INPUTS:
+        uc = run_unicorn(text, base, syms["trunc_s"], s0_bits=f32_bits(a))
+        got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+        want = wf(store, a) & 0xFFFFFFFF
+        checked += 1
+        if got != want:
+            fails += 1
+            print(f"MISMATCH trunc_s({a}): synth 0x{got:08x} != wasmtime 0x{want:08x}")
+
+    for fn in ("conv_s", "conv_u"):
+        wf = inst.exports(store)[fn]
+        for a in I32_INPUTS:
+            uc = run_unicorn(text, base, syms[fn], r0=a)
+            got = uc.reg_read(UC_ARM_REG_S0) & 0xFFFFFFFF
+            want = f32_bits(wf(store, a))
+            checked += 1
+            if got != want:
+                fails += 1
+                print(f"MISMATCH {fn}({a}): synth 0x{got:08x} ({bits_f32(got)}) "
+                      f"!= wasmtime 0x{want:08x} ({bits_f32(want)})")
+
+    if fails:
+        sys.exit(f"\nFAIL: {fails}/{checked} f32 results diverged from wasmtime")
+    print(f"GREEN: {checked}/{checked} f32 results bit-exact vs wasmtime "
+          f"(m3 honest-reject confirmed).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/i64_global_init_649_differential.py
+++ b/scripts/repro/i64_global_init_649_differential.py
@@ -92,6 +92,10 @@ class ImageRunner:
         self.mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
         self.mu.mem_map(FLASH, 0x100000)
         self.mu.mem_map(RAM, RAM_SIZE)  # zeroed RAM: inits must come from startup
+        # GI-FPU-002 (#619): FPU-target startup writes SCB->CPACR (0xE000ED88)
+        # to enable CP10/CP11 — map the System Control Space page so the
+        # reset-path replay does not fault on it (real silicon has this reg).
+        self.mu.mem_map(0xE000E000, 0x1000)
         self.mu.mem_write(base, code)
         # Initial SP from vector table word 0 (the image's own stack top).
         self.sp = int.from_bytes(code[0:4], "little")

--- a/scripts/repro/stack_layout_687_differential.py
+++ b/scripts/repro/stack_layout_687_differential.py
@@ -89,6 +89,10 @@ class ImageRunner:
         self.mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
         self.mu.mem_map(FLASH, 0x100000)
         self.mu.mem_map(RAM, RAM_SIZE)  # NOTHING below RAM is mapped (#687)
+        # GI-FPU-002 (#619): FPU-target startup writes SCB->CPACR (0xE000ED88)
+        # to enable CP10/CP11 — map the System Control Space page so the
+        # reset-path replay does not fault on it (real silicon has this reg).
+        self.mu.mem_map(0xE000E000, 0x1000)
         self.mu.mem_write(base, code)
         # Initial SP from vector table word 0 (layout-dependent under #687).
         self.sp = int.from_bytes(code[0:4], "little")


### PR DESCRIPTION
## Summary

Makes scalar **f32 reachable end-to-end on the thumb-2 CLI path for FPU targets** (cortex-m4f/m7/m7dp), routing through the existing VFP encoder + selector, with honest reject on non-FPU (m0/m3/r5). Closes the "M4F float frontier" gap from #619 and the hard-float half of #369.

### Infra found (premise correction)
The issue's premise was half-true: the VFP encoder (`f32_vfp_encoding_test.rs`) and `ArmOp` VFP variants exist, and `select_default` has VFP arms — but the **direct `select_with_stack` selector had no float arms**; it fell through to `select_default`, whose `alloc_vfp_reg` is a blind `%16` round-robin with **no operand-stack integration**. So `f32.const;f32.const;f32.add` emitted `VADD S2,S3,S4` over garbage. Building the real VFP value stack *is* phase 1.

### f32 ops wired (phase-1 honest subset)
`f32.add/sub/mul/div`, the six comparisons, `i32.trunc_f32_s/u`, `f32.convert_i32_s/u`, `f32.const`, and f32-param `local.get`. Decoder un-drops exactly these; the selector lowers them onto a real S0–S15 value stack (`StackVal::Float`, no VFP spilling — loud-bail on exhaustion). Integer modules never construct a `Float` entry → frozen path byte-identical.

### AAPCS-VFP handling
f32 params homed in S0..S15 (a `params_f32` mask threaded decoder → `CompileConfig` → selector), f32 result returned in S0. Mixed f32/integer param lists and f32-in-functions-with-calls **loud-decline** (independent core/VFP arg pools; S0–S15 caller-saved). `.ARM.attributes` gains `Tag_FP_arch=VFPv4-D16` + `Tag_ABI_VFP_args` on FPU targets, and the reset handler now enables CP10/CP11 in `SCB->CPACR` (the M4F FPU is disabled at reset).

### f64 verdict
**Held for phase 2** (M7DP double-FPU) — loud-skipped at decode with a phase-2 reason. `StackVal::Float` holds only an S-register, so f64 never touches the value-stack model. Also held for 1b: f32 load/store and f32 `local.set/tee`.

### Two latent encoder bugs fixed (surfaced by making float reachable)
- `encode_{arm,thumb}_f32_convert_i32`: signed/unsigned VCVT constants were **swapped** (`0xEEB80A40` is U32), silently making `convert_i32_s` an *unsigned* conversion. objdump-confirmed.
- CPACR `ORR` mask (main.rs / cortex_m.rs) encoded `#0x07800000` instead of `#0x00F00000` (did not actually enable CP10/CP11).

### Red→green evidence
`scripts/repro/f32_vfp_619_differential.py` — compiles the fixture for cortex-m4f, reads each symbol from the ELF **SYMTAB** (#489), runs it under **unicorn** (ARM/Thumb, FPU enabled via CPACR + FPEXC) with f32 args in S0/S1 per hard-float, and asserts **bit-exact** (`to_bits`) vs wasmtime on boundary values (0.0, 1.5, -2.25, 1e30, subnormal).
- **RED** on `origin/main`: compile rejects → exit 1.
- **GREEN** here: **48/48** bit-exact → exit 0.

The f32 comparisons compile and are byte-pinned in `f32_vfp_encoding_test.rs` but are **not** execution-differentiated — unicorn does not model the `VMRS APSR_nzcv, FPSCR` flag transfer (emulator gap, not a synth defect; documented in the harness).

### Honest-reject confirmation
The same harness asserts **cortex-m3 rejects f32**. `crates/synth-backend/tests/f32_hardfloat_619.rs` locks the AAPCS-VFP S0/S1 homing, the honest reject, and the convert-signedness fix in CI without unicorn.

### Gates
Frozen anchors **10/10**, the #511 estimator↔encoder oracle, and the claim gate **17/17** all pass untouched (float declines the optimized path → the estimator never sees VFP ops). `cargo test --workspace` green; fmt + chunked clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)