### PR TITLE
chore(release): v0.39.0 — f32 hard-float, verified-DSL shipped by default, +2 div admits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.0] - 2026-07-10
+
+**A seven-lane feature hub — scalar f32 hard-float becomes reachable on
+Cortex-M4F, the verified selector DSL ships as the DEFAULT selection path,
+two more #73 division admits fall, wit-bindgen buffers unblock, an npm
+distribution lands, and the flaky Z3 release-blocker is killed. Gated by the
+claim-check gate (17/17) plus an independent cold-agent review.**
+
+### Added
+
+- **f32 hard-float reachable on thumb-2 (#619/#369, GI-FPU-002 phase 1).**
+  The existing VFP encoder was unreachable — the direct selector had no float
+  arms and `select_default`'s VFP allocator was a blind round-robin over
+  garbage. Now a real VFP value stack (`StackVal::Float` + an S0–S15
+  allocator), AAPCS-VFP param homing, `.ARM.attributes` FP tags, and CPACR
+  enable in startup — FPU-gated (cortex-m4f/m7/m7dp), honest-reject on M0/M3.
+  Covered: f32 add/sub/mul/div, the six compares, i32.trunc_f32_s/u,
+  f32.convert_i32_s/u, f32 const/param. **48/48 bit-exact vs wasmtime**;
+  surfaced and fixed two latent VCVT/CPACR-mask bugs. f64 held for phase 2.
+- **npm CLI wrapper (#426):** dependency-free `@pulseengine/synth` — postinstall
+  fetches the release tarball for the host triple and verifies it against the
+  cosign-signed SHA256SUMS before extract; publish workflow chains after the
+  release. Closes the last release-standard gap.
+
+### Changed
+
+- **`SYNTH_SEL_DSL` default-ON (#242) — the verified selector DSL is now the
+  SHIPPED selection path for its 40 Rocq-proved ops** (i32/i64 arithmetic,
+  bitwise, shifts, comparisons, clz/ctz/popcnt). Byte-invisible by
+  construction: frozen anchors 10/10 unchanged, 88/88 fixtures bit-identical
+  default-vs-`SYNTH_NO_SEL_DSL`. A North-Star milestone — the DSL stops being
+  a shadow path and becomes what synth emits.
+- **Z3 differential CI job links system libz3 (#553):** kills the flaky
+  `build.rs` prebuilt download (HTTP 403/502) that blocked releases twice.
+  Job now runs in ~1m41s vs ~16 min; the default build stays z3-free (ordeal).
+
+### Fixed
+
+- **Two more #73 i32 division admits discharged (#242):** i32.rem_s and
+  i32.rem_u proven against the fuel-bounded `exec_program_br` executor (the
+  #697 vehicle); i32.div_s held honestly (needs the INT_MIN/-1 overflow
+  restatement). Proofs now **472 Qed / 6 Admitted** (was 470/8).
+- **--native-pointer-abi statics down-shift (#678, VCR-MEM-001 layer-2):**
+  zero-init BSS statics (wit-bindgen realloc/scratch) now rebase into the
+  shrunk reservation instead of a blanket refusal; three sound-decline
+  sub-cases kept precise. Unblocks wit-bindgen buffer nodes.
+- **Estimator gap allowlist verified empty (#498):** the remaining gaps were
+  closed by #555/#641; added the acceptance-criterion regression test (a
+  br_if displacement across a popcnt body, with proven teeth).
+
+### Verification
+
+**Falsification (kill-criterion):** wrong if any shipped .text diverges from
+wasmtime on exercised inputs, if a frozen anchor drifts without a refreeze,
+if `claim_check.py` derives counts differing from the docs, or if the f32
+differential diverges on the covered FPU targets. All CI-gated.
+
 ## [0.38.0] - 2026-07-10
 
 **The largest release: a ten-lane feature hub — five miscompile classes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,14 +1805,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1871,11 +1871,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.38.0"
+version = "0.39.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1930,14 +1930,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1945,11 +1945,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.38.0"
+version = "0.39.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.38.0"
+version = "0.39.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.38.0"
+version = "0.39.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.38.0",
+    version = "0.39.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.38.0" }
+synth-core = { path = "../synth-core", version = "0.39.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.38.0" }
+synth-core = { path = "../synth-core", version = "0.39.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.38.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.38.0" }
+synth-core = { path = "../synth-core", version = "0.39.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.39.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.38.0" }
+synth-core = { path = "../synth-core", version = "0.39.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.38.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.38.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.39.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.39.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.38.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.39.0", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -44,23 +44,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.38.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.38.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.38.0" }
-synth-backend = { path = "../synth-backend", version = "0.38.0" }
+synth-core = { path = "../synth-core", version = "0.39.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.39.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.39.0" }
+synth-backend = { path = "../synth-backend", version = "0.39.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.38.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.39.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.38.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.38.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.38.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.39.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.39.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.39.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.38.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.39.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.38.0" }
+synth-core = { path = "../synth-core", version = "0.39.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.38.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.39.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.38.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.38.0" }
-synth-opt = { path = "../synth-opt", version = "0.38.0" }
+synth-core = { path = "../synth-core", version = "0.39.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.39.0" }
+synth-opt = { path = "../synth-opt", version = "0.39.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-synthesis/src/sel_dsl/mod.rs
+++ b/crates/synth-synthesis/src/sel_dsl/mod.rs
@@ -41,7 +41,7 @@
 //! [`generate_lowering_source`] and the output is **committed to the tree** at
 //! [`generated`] (reviewable diffs, no build-time codegen). `select_default`
 //! keeps dispatch ownership: a migrated arm delegates to the generated rule
-//! behind `SYNTH_SEL_DSL` (default OFF), so OFF ≡ baseline byte-identical by
+//! behind `SYNTH_SEL_DSL` (default ON since v0.39.0; opt out with SYNTH_NO_SEL_DSL), so OFF ≡ baseline byte-identical by
 //! construction.
 //!
 //! Every rule carries a **1:1 Rocq obligation**: rule `rule_i32_add` ↔ theorem

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.38.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.38.0" }
-synth-opt = { path = "../synth-opt", version = "0.38.0" }
+synth-core = { path = "../synth-core", version = "0.39.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.39.0" }
+synth-opt = { path = "../synth-opt", version = "0.39.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.38.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.39.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"

--- a/npm/test.js
+++ b/npm/test.js
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+
+// Unit tests for @pulseengine/synth's platform detection, release-URL
+// construction, and SHA256SUMS parsing. No test framework — a tiny runner
+// over node:assert so it runs on any Node >=14 with zero dependencies.
+//
+// An optional network smoke test at the end downloads the REAL v0.38.0
+// tarball + SHA256SUMS and verifies the checksum end-to-end. It is skipped
+// (not failed) when the network is unavailable or SYNTH_NPM_SKIP_NETWORK=1.
+
+const assert = require("assert");
+const os = require("os");
+const path = require("path");
+const fs = require("fs");
+const https = require("https");
+const crypto = require("crypto");
+const { execFileSync } = require("child_process");
+
+const {
+  getRustTarget,
+  getArchiveName,
+  getDownloadUrl,
+  getChecksumsUrl,
+  expectedChecksum,
+  getBinaryName,
+  SUPPORTED_TARGETS,
+} = require("./index.js");
+
+let passed = 0;
+let failed = 0;
+let skipped = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failed++;
+    console.log(`  FAIL ${name}`);
+    console.log(`       ${err.message}`);
+  }
+}
+
+console.log("platform / arch -> rust target");
+test("darwin/arm64 -> aarch64-apple-darwin", () => {
+  assert.strictEqual(getRustTarget("darwin", "arm64"), "aarch64-apple-darwin");
+});
+test("darwin/x64 -> x86_64-apple-darwin", () => {
+  assert.strictEqual(getRustTarget("darwin", "x64"), "x86_64-apple-darwin");
+});
+test("linux/arm64 -> aarch64-unknown-linux-gnu", () => {
+  assert.strictEqual(getRustTarget("linux", "arm64"), "aarch64-unknown-linux-gnu");
+});
+test("linux/x64 -> x86_64-unknown-linux-gnu", () => {
+  assert.strictEqual(getRustTarget("linux", "x64"), "x86_64-unknown-linux-gnu");
+});
+test("every mapped target is one the release workflow builds", () => {
+  for (const [plat, arch] of [
+    ["darwin", "arm64"],
+    ["darwin", "x64"],
+    ["linux", "arm64"],
+    ["linux", "x64"],
+  ]) {
+    assert.ok(
+      SUPPORTED_TARGETS.includes(getRustTarget(plat, arch)),
+      `${plat}/${arch} not in SUPPORTED_TARGETS`,
+    );
+  }
+});
+test("win32 host errors cleanly (no Windows build)", () => {
+  assert.throws(() => getRustTarget("win32", "x64"), /Unsupported platform/);
+});
+test("unsupported arch errors cleanly", () => {
+  assert.throws(() => getRustTarget("linux", "ia32"), /Unsupported architecture/);
+});
+
+console.log("archive name + URL construction");
+test("archive name: darwin/arm64 @ 0.38.0", () => {
+  assert.strictEqual(
+    getArchiveName("0.38.0", "darwin", "arm64"),
+    "synth-v0.38.0-aarch64-apple-darwin.tar.gz",
+  );
+});
+test("download URL embeds the v-prefixed tag and asset", () => {
+  assert.strictEqual(
+    getDownloadUrl("0.38.0", "linux", "x64"),
+    "https://github.com/pulseengine/synth/releases/download/v0.38.0/" +
+      "synth-v0.38.0-x86_64-unknown-linux-gnu.tar.gz",
+  );
+});
+test("checksums URL points at the release SHA256SUMS.txt", () => {
+  assert.strictEqual(
+    getChecksumsUrl("0.38.0"),
+    "https://github.com/pulseengine/synth/releases/download/v0.38.0/SHA256SUMS.txt",
+  );
+});
+test("binary name is synth", () => {
+  assert.strictEqual(getBinaryName(), "synth");
+});
+test("package.json version has no v prefix; URL adds it", () => {
+  const version = require("./package.json").version;
+  assert.ok(/^\d+\.\d+\.\d+/.test(version), `bad version: ${version}`);
+  assert.ok(getDownloadUrl(version).includes(`/download/v${version}/`));
+});
+
+console.log("SHA256SUMS parsing");
+const SAMPLE_SUMS = [
+  "6e280e09614026ae9ca8378d3f5d9c038ea5f9bb0a43cdfaff9d3f60bbbaf437  ./synth-0.38.0.cdx.json",
+  "c2208c039c0b646de3c1dec02b6dc5c26271fce338be58012859528eaf7d1601  ./synth-v0.38.0-aarch64-apple-darwin.tar.gz",
+  "77c123b8bc663c0fd91521d7874a8521ae29b3f1b61f761c1b059b3ea29cb410  ./synth-v0.38.0-aarch64-unknown-linux-gnu.tar.gz",
+  "b1750e5a5cfc2306ca79e5bfeb250f93e518f9ff8539465286e9e50580f369f0  ./synth-v0.38.0-x86_64-apple-darwin.tar.gz",
+  "69e0327d566ab4e767b386019c395457fc261e3ff2f0d85587f71ddd738f95d5  ./synth-v0.38.0-x86_64-unknown-linux-gnu.tar.gz",
+  "",
+].join("\n");
+
+test("resolves the ./-prefixed entry by basename", () => {
+  assert.strictEqual(
+    expectedChecksum(SAMPLE_SUMS, "synth-v0.38.0-aarch64-apple-darwin.tar.gz"),
+    "c2208c039c0b646de3c1dec02b6dc5c26271fce338be58012859528eaf7d1601",
+  );
+});
+test("resolves the linux x64 entry", () => {
+  assert.strictEqual(
+    expectedChecksum(SAMPLE_SUMS, "synth-v0.38.0-x86_64-unknown-linux-gnu.tar.gz"),
+    "69e0327d566ab4e767b386019c395457fc261e3ff2f0d85587f71ddd738f95d5",
+  );
+});
+test("missing archive throws", () => {
+  assert.throws(
+    () => expectedChecksum(SAMPLE_SUMS, "synth-v9.9.9-aarch64-apple-darwin.tar.gz"),
+    /No checksum entry/,
+  );
+});
+test("end-to-end: derived archive name resolves in the manifest", () => {
+  const archive = getArchiveName("0.38.0", "darwin", "arm64");
+  const hash = expectedChecksum(SAMPLE_SUMS, archive);
+  assert.strictEqual(hash, "c2208c039c0b646de3c1dec02b6dc5c26271fce338be58012859528eaf7d1601");
+});
+
+// ── Optional network smoke test against the real v0.38.0 release ────────────
+function httpGetBuffer(url, redirectsLeft = 5) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, { headers: { "User-Agent": "pulseengine-synth-npm-test" } }, (res) => {
+        if ([301, 302, 307, 308].includes(res.statusCode) && redirectsLeft > 0) {
+          return httpGetBuffer(res.headers.location, redirectsLeft - 1)
+            .then(resolve)
+            .catch(reject);
+        }
+        if (res.statusCode !== 200) {
+          return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+        }
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve(Buffer.concat(chunks)));
+        res.on("error", reject);
+      })
+      .on("error", reject);
+  });
+}
+
+async function smokeTest() {
+  console.log("network smoke test (real v0.38.0 download + checksum)");
+  if (process.env.SYNTH_NPM_SKIP_NETWORK === "1") {
+    skipped++;
+    console.log("  skip SYNTH_NPM_SKIP_NETWORK=1");
+    return;
+  }
+  // Exercise the true host mapping so the smoke test tracks whatever runner
+  // it lands on; fall back to darwin/arm64 for unsupported CI hosts.
+  let plat = os.platform();
+  let arch = os.arch();
+  try {
+    getRustTarget(plat, arch);
+  } catch {
+    plat = "darwin";
+    arch = "arm64";
+  }
+
+  const version = "0.38.0";
+  const archive = getArchiveName(version, plat, arch);
+  const url = getDownloadUrl(version, plat, arch);
+  const sumsUrl = getChecksumsUrl(version);
+
+  try {
+    const sumsText = (await httpGetBuffer(sumsUrl)).toString("utf8");
+    const expected = expectedChecksum(sumsText, archive);
+    const tarball = await httpGetBuffer(url);
+    const actual = crypto.createHash("sha256").update(tarball).digest("hex");
+    assert.strictEqual(actual, expected, `checksum mismatch for ${archive}`);
+
+    // Extract and confirm the tarball actually contains a `synth` binary.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "synth-npm-smoke-"));
+    const tarPath = path.join(tmp, archive);
+    fs.writeFileSync(tarPath, tarball);
+    execFileSync("tar", ["-xzf", tarPath, "-C", tmp], { stdio: "ignore" });
+    assert.ok(fs.existsSync(path.join(tmp, "synth")), "tarball missing synth binary");
+    fs.rmSync(tmp, { recursive: true, force: true });
+
+    passed++;
+    console.log(`  ok   downloaded + verified ${archive} (sha256 ${actual.slice(0, 16)}...)`);
+  } catch (err) {
+    // Network / offline / rate-limit -> skip, don't fail the suite.
+    skipped++;
+    console.log(`  skip network unavailable: ${err.message}`);
+  }
+}
+
+smokeTest().then(() => {
+  console.log("");
+  console.log(`${passed} passed, ${failed} failed, ${skipped} skipped`);
+  process.exit(failed === 0 ? 0 : 1);
+});


### PR DESCRIPTION
Release PR: pin sweep + CHANGELOG for v0.39.0 — a seven-lane feature hub.

**Pre-release verification (feature-loop close):** claim-check gate 17/17 on main + independent cold-agent claim review (re-derived 472 Qed / 6 Admitted, three vacuity spot-checks non-vacuous, no flat 'verified' badge, roadmap statuses honest) — cleared, one cosmetic internal comment fixed here.

Scope: #619/#369 f32 hard-float reachable (48/48 vs wasmtime, FPU-gated) · #242 SYNTH_SEL_DSL default-ON (verified DSL is the shipped path, byte-invisible) · #73 two more div admits discharged (472 Qed / 6 Admitted) · #678 wit-bindgen statics down-shift · #426 npm wrapper · #553 system-libz3 (flaky blocker killed) · #498 estimator close-verify.

Tag v0.39.0 on green merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)