### PR TITLE
fix(shadow-stack): co-rebase N aliased __stack_pointer globals (#707)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--shadow-stack-size` co-rebases N aliased `__stack_pointer` globals
+  (#707, VCR-MEM-001).** After #701 cleared the buffer-carrying blocker, a
+  multi-provider `meld fuse --memory shared` node (gust:os `app` +
+  `time-provider` + `log-provider`) compiled but the shadow-stack shrink then
+  refused: the fused module carries one `__stack_pointer` global per component,
+  all with `init == sp_init`, and the re-base insisted on a *unique* match.
+  These globals alias the one shared reservation, so #707 re-bases the whole
+  **mutable**-global `init == sp_init` equivalence class to the shrunk budget
+  (an immutable constant that merely coincides with sp_init is never touched —
+  same predicate `identify_stack_pointer_global` selects on). A single-SP module
+  has exactly one match ⇒ byte-identical (the #383/#678 paths are unchanged);
+  only "no mutable global carries sp_init" stays an honest refuse. Gated by
+  `multi_sp_rebase_707.rs` (compile red→green, three mutable slots re-based while
+  the immutable constant stays put, no-flag frozen) + the execution differential
+  `multi_sp_707_differential.py`. Unblocks the gust:os v0.4.0 OS node (the last
+  synth gate before that cut).
+
 ## [0.39.0] - 2026-07-10
 
 **A seven-lane feature hub — scalar f32 hard-float becomes reachable on

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -2179,6 +2179,26 @@ artifacts:
       `--shadow-stack-size auto`) below, which is orthogonal (this fixes the ELF
       mechanics of the down-shift; that computes how big B may safely be).
 
+      MULTI-SP CO-REBASE LANDED (2026-07-11, gale #707). After #701 (#678 tail
+      down-shift) cleared the buffer-carrying blocker, a multi-provider
+      meld-fused gust:os node (`app-tl` = app + time-provider + log-provider)
+      compiled all functions but `--shadow-stack-size` then REFUSED: the fused
+      shared-memory module carries N mutable `__stack_pointer` globals (one per
+      fused component), ALL with `init == sp_init`, and the re-base picked the
+      UNIQUE such global — bailing on ambiguity ("could not uniquely identify the
+      shadow-stack global ... N globals have init == sp_init"). #707 re-bases the
+      whole `init == sp_init` equivalence class: in a `meld fuse --memory shared`
+      module the per-component SP globals all point into the ONE shared
+      reservation, so sliding all of them to the shrunk budget is correct (they
+      alias the same stack). A single-SP module has exactly one match ⇒
+      byte-identical (the #383 tests still pin that path); only the len==0 case
+      remains an honest refuse. Evidence: `multi_sp_rebase_707.rs` (compile
+      red→green + all-slots-rebased + no-flag frozen) + the execution differential
+      `multi_sp_707_differential.py` (each of 3 exports roundtrips through its own
+      co-rebased SP global and restores its own slot to B; faithful — fails when
+      the expected init is wrong). This unblocks the gust:os v0.4.0 buffer-interface
+      OS node (log carries `list<u8>`), the last synth gate before that cut.
+
       LAYER-2 DECISION LOGIC LANDED (2026-06-22, frozen-safe, no dep change):
       `synth-cli/src/shadow_budget.rs` — a pure `budget_from_bound(bound,
       sp_init, fallback) -> BudgetDecision` over a synth-OWNED `StackDepthBound`

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2985,6 +2985,21 @@ fn compile_all_exports(
                         })
                         .collect(),
                     sp_init: stack_pointer_global_opt.map(|(_, v)| v).unwrap_or(0),
+                    // #707: the re-base equivalence class — MUTABLE i32 globals
+                    // whose init == sp_init (mutability preserved here because the
+                    // `globals` slot list above dropped it). Empty when there is
+                    // no SP global, so the shrink honestly refuses rather than
+                    // re-basing nothing silently.
+                    sp_alias_indices: match stack_pointer_global_opt {
+                        Some((_, sp_v)) => all_globals
+                            .iter()
+                            .filter(|g| {
+                                g.mutable && matches!(g.init, Some(GlobalInit::I32(v)) if v == sp_v)
+                            })
+                            .map(|g| g.index)
+                            .collect(),
+                        None => Vec::new(),
+                    },
                     shadow_stack_size,
                 })
             } else {
@@ -3188,6 +3203,15 @@ struct NativeGlobalsLayout {
     globals: Vec<(u32, i32)>,
     /// The shadow-stack top (the SP global's init); the region must cover it.
     sp_init: i32,
+    /// #707: indices of the globals the shadow-stack shrink may re-base — every
+    /// MUTABLE i32 global whose init == sp_init (the same predicate
+    /// `identify_stack_pointer_global` selects on, kept here because `globals`
+    /// above threw the mutability flag away). A single-SP module has one entry;
+    /// a `meld fuse --memory shared` multi-provider node has one per fused
+    /// component, all aliasing the one reservation. Computed from the decoded
+    /// globals so an IMMUTABLE constant that merely coincides with sp_init is
+    /// NEVER re-based.
+    sp_alias_indices: Vec<u32>,
     /// #383 (VCR-MEM-001): integrator-declared shadow-stack budget in bytes. When
     /// `Some(B)`, the caller asked to shrink the [0, sp_init) reservation to `B`
     /// (re-basing the stack top and shifting the high zero-init static relocs
@@ -3620,24 +3644,40 @@ fn build_relocatable_elf(
                     all_code[pos..pos + 4].copy_from_slice(&new_c.to_le_bytes());
                 }
             }
-            // Re-base the SP global slot: the unique global whose init == sp_init.
-            let sp_matches: Vec<usize> = ng
-                .globals
-                .iter()
-                .enumerate()
-                .filter(|(_, (_, v))| *v == ng.sp_init)
-                .map(|(i, _)| i)
-                .collect();
-            if sp_matches.len() != 1 {
+            // Re-base the shadow-stack global slot(s): every MUTABLE global whose
+            // init == sp_init (`ng.sp_alias_indices`, the same predicate
+            // `identify_stack_pointer_global` selects on — an immutable constant
+            // that merely coincides with sp_init is never touched). #707: a
+            // multi-provider meld-fused shared-memory node (`meld fuse --memory
+            // shared`) carries one `__stack_pointer` global PER fused component,
+            // all initialized to the same sp_init — they alias the ONE shadow-stack
+            // reservation, so re-basing the whole equivalence class to the shrunk
+            // top `budget` is correct (they point into the same stack). A single-SP
+            // module (the common case) has exactly one member, so this is
+            // byte-identical to the pre-#707 behaviour there. Only an EMPTY set is a
+            // real failure (no mutable global carries the SP init) — refuse honestly.
+            if ng.sp_alias_indices.is_empty() {
                 anyhow::bail!(
-                    "--shadow-stack-size: could not uniquely identify the shadow-stack global to \
-                     re-base ({} globals have init == sp_init {}); refusing. VCR-MEM-001/#383.",
-                    sp_matches.len(),
+                    "--shadow-stack-size: no mutable global carries init == sp_init {}; cannot \
+                     identify the shadow-stack global to re-base; refusing. VCR-MEM-001/#383.",
+                    ng.sp_init
+                );
+            }
+            if ng.sp_alias_indices.len() > 1 {
+                info!(
+                    "Native-pointer shadow-stack shrink (#707): re-basing {} aliased \
+                     __stack_pointer globals (all init == sp_init {}) to budget {budget} — a \
+                     multi-provider shared-memory fused node shares one reservation.",
+                    ng.sp_alias_indices.len(),
                     ng.sp_init
                 );
             }
             let mut rebased = ng.globals.clone();
-            rebased[sp_matches[0]].1 = budget as i32;
+            for slot in rebased.iter_mut() {
+                if ng.sp_alias_indices.contains(&slot.0) {
+                    slot.1 = budget as i32;
+                }
+            }
             // Reservation now covers [0, B) stack + the preserved static tail that sat
             // above sp_init (the retargeted statics are in `.data`, unaffected).
             // saturating_sub: used_extent is `.min(linear_memory_bytes)`-clamped, so a
@@ -6006,6 +6046,7 @@ mod tests {
         let native = NativeGlobalsLayout {
             globals: vec![(0, 65_536)],
             sp_init: 65_536,
+            sp_alias_indices: vec![0],
             shadow_stack_size: None,
         };
 
@@ -6113,6 +6154,7 @@ mod tests {
         let native = NativeGlobalsLayout {
             globals: vec![(0, 65_536)],
             sp_init: 65_536,
+            sp_alias_indices: vec![0],
             shadow_stack_size: None,
         };
         let elf = build_relocatable_elf(
@@ -6206,6 +6248,7 @@ mod tests {
         let native = NativeGlobalsLayout {
             globals: vec![(0, 65_536)],
             sp_init: 65_536,
+            sp_alias_indices: vec![0],
             shadow_stack_size: None,
         };
 

--- a/crates/synth-cli/tests/multi_sp_rebase_707.rs
+++ b/crates/synth-cli/tests/multi_sp_rebase_707.rs
@@ -1,0 +1,114 @@
+//! VCR-MEM-001 (#707) — co-rebase N aliased `__stack_pointer` globals.
+//!
+//! A `meld fuse --memory shared` multi-provider node keeps each fused component's
+//! own `__stack_pointer` global, so the module carries N mutable i32 globals ALL
+//! initialized to the same stack top (sp_init). They alias the ONE shared
+//! reservation. Layer-1 (#383) re-based the *unique* global whose `init ==
+//! sp_init` and REFUSED when more than one matched ("could not uniquely identify
+//! the shadow-stack global"). That refusal gated the gust:os multi-provider OS
+//! node (app + time-provider + log-provider = 3 SP globals, all init 0x100000).
+//!
+//! #707 re-bases the whole equivalence class: every mutable global with `init ==
+//! sp_init` slides to the shrunk budget (they point into the same stack). A
+//! single-SP module has exactly one match, so this is byte-identical there — the
+//! #383 tests still pin that path. The execution differential
+//! (`scripts/repro/multi_sp_707_differential.py`) confirms each co-rebased stack
+//! roundtrips correctly and restores its own slot to the budget; gale's on-silicon
+//! reflash on the real fused node is the final gate.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use object::{Object, ObjectSection};
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro/mem707_multi_sp.wat")
+}
+
+fn compile(extra: &[&str], out: &str) -> std::process::Output {
+    let fx = fixture();
+    let mut args = vec![
+        "compile",
+        fx.to_str().unwrap(),
+        "--target",
+        "cortex-m3",
+        "--native-pointer-abi",
+        "--all-exports",
+        "--relocatable",
+        "-o",
+        out,
+    ];
+    args.extend_from_slice(extra);
+    Command::new(synth())
+        .args(&args)
+        .output()
+        .expect("run synth")
+}
+
+fn bss_size(path: &str) -> u64 {
+    let data = std::fs::read(path).expect("read .o");
+    let obj = object::File::parse(&*data).expect("parse ELF");
+    obj.sections()
+        .find(|s| s.name() == Ok(".bss"))
+        .expect(".bss present")
+        .size()
+}
+
+/// The materialized global slots in `.data`, decoded as little-endian i32 words.
+/// The fixture has three mutable SP globals + one immutable constant ⇒ four
+/// 4-byte slots (slots 0..2 = sp0/sp1/sp2, slot 3 = the immutable `$konst`).
+fn global_slots(path: &str) -> Vec<i32> {
+    let bytes = std::fs::read(path).expect("read .o");
+    let obj = object::File::parse(&*bytes).expect("parse ELF");
+    let data = obj
+        .section_by_name(".data")
+        .expect(".data present")
+        .data()
+        .expect(".data bytes");
+    data.chunks_exact(4)
+        .map(|w| i32::from_le_bytes(w.try_into().unwrap()))
+        .collect()
+}
+
+/// RED before the fix / GREEN after: the fused node with THREE `__stack_pointer`
+/// globals (all init 4096) was refused ("could not uniquely identify"); #707
+/// co-rebases all three to the budget and shrinks the reservation.
+#[test]
+fn all_aliased_sp_globals_rebase_707() {
+    let out = compile(&["--shadow-stack-size", "512"], "/tmp/mem707_test.o");
+    assert!(
+        out.status.success(),
+        "#707: the 3-SP fused node must now COMPILE (was refused): {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Every MUTABLE global whose init == sp_init (the three SP globals) re-bases
+    // to 512; the immutable `$konst` (slot 3) — which merely COINCIDES with
+    // sp_init — must stay 4096. Re-basing it would corrupt a program constant.
+    assert_eq!(
+        global_slots("/tmp/mem707_test.o"),
+        vec![512, 512, 512, 4096],
+        "the three mutable SP globals co-rebase; the immutable constant is untouched"
+    );
+    // Reservation shrinks 4096 → budget 512 (no static tail above sp_init).
+    assert_eq!(bss_size("/tmp/mem707_test.o"), 512);
+}
+
+/// Opt-in / frozen-safe: WITHOUT the flag the same node keeps all three SP slots
+/// at their declared top and the full reservation (byte-identical to pre-#707).
+#[test]
+fn no_flag_leaves_multi_sp_full_707() {
+    let out = compile(&[], "/tmp/mem707_noflag_test.o");
+    assert!(out.status.success());
+    assert_eq!(
+        global_slots("/tmp/mem707_noflag_test.o"),
+        vec![4096, 4096, 4096, 4096],
+        "no flag must leave every slot at its declared value"
+    );
+    assert_eq!(bss_size("/tmp/mem707_noflag_test.o"), 4096);
+}

--- a/scripts/repro/mem707_multi_sp.wat
+++ b/scripts/repro/mem707_multi_sp.wat
@@ -1,0 +1,40 @@
+(module
+  ;; #707: a multi-provider meld-fused shared-memory node. `meld fuse --memory
+  ;; shared` merges the memories of N components but leaves each component's own
+  ;; `__stack_pointer` global distinct — so the fused module carries N mutable
+  ;; i32 globals ALL initialized to the same stack top (sp_init). They all point
+  ;; into the ONE shared reservation. `--shadow-stack-size` used to refuse
+  ;; ("N globals have init == sp_init; refusing") because it could not pick a
+  ;; unique SP global; #707 re-bases the whole equivalence class (they alias).
+  (memory (export "memory") 1)
+  (global $sp0 (mut i32) (i32.const 4096))
+  (global $sp1 (mut i32) (i32.const 4096))
+  (global $sp2 (mut i32) (i32.const 4096))
+  ;; An IMMUTABLE constant that merely COINCIDES with sp_init (4096). It is NOT a
+  ;; shadow-stack pointer, so the shrink must leave it at 4096 — re-basing it
+  ;; would corrupt a program constant. The re-base predicate keys on `mutable`,
+  ;; not on the value, exactly so this slot is untouched.
+  (global $konst i32 (i32.const 4096))
+  (func (export "f0") (param $v i32) (result i32)
+    (local $s i32)
+    (local.set $s (i32.sub (global.get $sp0) (i32.const 16)))
+    (global.set $sp0 (local.get $s))
+    (i32.store (local.get $s) (local.get $v))
+    (global.set $sp0 (i32.add (local.get $s) (i32.const 16)))
+    (i32.load (local.get $s)))
+  (func (export "f1") (param $v i32) (result i32)
+    (local $s i32)
+    (local.set $s (i32.sub (global.get $sp1) (i32.const 16)))
+    (global.set $sp1 (local.get $s))
+    (i32.store (local.get $s) (local.get $v))
+    (global.set $sp1 (i32.add (local.get $s) (i32.const 16)))
+    (i32.load (local.get $s)))
+  (func (export "f2") (param $v i32) (result i32)
+    (local $s i32)
+    (local.set $s (i32.sub (global.get $sp2) (i32.const 16)))
+    (global.set $sp2 (local.get $s))
+    (i32.store (local.get $s) (local.get $v))
+    (global.set $sp2 (i32.add (local.get $s) (i32.const 16)))
+    (i32.load (local.get $s)))
+  ;; reads the immutable constant so its slot is materialized and reachable.
+  (func (export "getk") (result i32) (global.get $konst)))

--- a/scripts/repro/multi_sp_707_differential.py
+++ b/scripts/repro/multi_sp_707_differential.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""#707 multi-provider shared-memory fused node: N `__stack_pointer` globals all
+init == sp_init, co-rebased by `--shadow-stack-size`.
+
+A `meld fuse --memory shared` node keeps each fused component's own
+`__stack_pointer` global, so the module carries N mutable i32 globals ALL
+initialized to the same stack top. `--shadow-stack-size B` used to REFUSE (could
+not pick a unique SP global); #707 re-bases the whole equivalence class to B
+(they alias the one shared reservation).
+
+This differential validates the co-rebase is runtime-correct: each of the three
+exports f0/f1/f2 does an independent shadow-stack roundtrip through its OWN SP
+global (sp0/sp1/sp2). After the shrink every SP slot inits to B, each roundtrip
+must (a) return its input v (the store landed at the re-based frame and read
+back) and (b) restore its own SP slot to B on return. Run each export on a fresh
+instance — exactly wasmtime's per-call semantics — so the three aliasing stacks
+never overlap in time.
+
+Compile (co-rebased):
+  synth compile scripts/repro/mem707_multi_sp.wat -o /tmp/mem707.o \
+        --target cortex-m3 --native-pointer-abi --all-exports --relocatable \
+        --shadow-stack-size 512
+Run:
+  <venv>/bin/python scripts/repro/multi_sp_707_differential.py /tmp/mem707.o [expected_sp_init]
+"""
+import struct
+import sys
+
+from elftools.elf.elffile import ELFFile
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_THUMB
+from unicorn.arm_const import (
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_LR,
+    UC_ARM_REG_SP,
+)
+
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/mem707.o"
+# The re-based SP init the slots must hold after each roundtrip (budget B, or the
+# original 4096 with no flag). Defaults to the shrunk budget the doc-comment uses.
+EXP_SP = int(sys.argv[2]) if len(sys.argv) > 2 else 512
+ABS32 = 2
+
+# Native-pointer derefs are absolute (R11 = 0). Map a LOW page at 0 to cover the
+# shadow-stack reservation [0, B) the frames live in, plus the usual code/data.
+LOW, CODE, DATA = 0x0, 0x10000, 0x40000
+MAPSZ = 0x10000
+
+e = ELFFile(open(ELF, "rb"))
+text = bytearray(e.get_section_by_name(".text").data())
+data = bytearray(e.get_section_by_name(".data").data())
+
+symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+syms = {s.name: s["st_value"] for s in symtab.iter_symbols()}
+
+# Relocate every R_ARM_ABS32 literal-pool word in place (REL: final = base + sym
+# + in-place addend). `__synth_globals` lives in .data; text/code stay in .text.
+secname_by_idx = {i: s.name for i, s in enumerate(e.iter_sections())}
+for r in e.get_section_by_name(".rel.text").iter_relocations():
+    if r["r_info_type"] != ABS32:
+        continue
+    sym = symtab.get_symbol(r["r_info_sym"])
+    shndx = sym["st_shndx"]
+    base = DATA if secname_by_idx.get(shndx) == ".data" else CODE
+    (add,) = struct.unpack_from("<I", text, r["r_offset"])
+    struct.pack_into("<I", text, r["r_offset"], (base + sym["st_value"] + add) & 0xFFFFFFFF)
+
+mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+for base in (LOW, CODE, DATA):
+    mu.mem_map(base, MAPSZ)
+mu.mem_write(CODE, bytes(text))
+
+RET = CODE + 0xFFF0
+mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+GLOBALS = DATA + syms["__synth_globals"]
+ok = True
+for fn, slot in (("f0", 0), ("f1", 1), ("f2", 2)):
+    entry = CODE + syms[fn]
+    for v in (7, -123456, 0x7FFFFFFF, 0):
+        # Fresh instance per call: re-init the .data global slots + zero the LOW
+        # reservation, exactly as wasmtime instantiates fresh each invocation.
+        mu.mem_write(DATA, bytes(data))
+        mu.mem_write(LOW, b"\x00" * MAPSZ)
+        mu.reg_write(UC_ARM_REG_R0, v & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R11, 0)  # native deref base = 0
+        mu.reg_write(UC_ARM_REG_SP, DATA + 0x8000)  # a real machine SP pad
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        mu.emu_start(entry | 1, RET, timeout=5_000_000)
+        got = mu.reg_read(UC_ARM_REG_R0)
+        exp = v & 0xFFFFFFFF
+        sp_slot = struct.unpack("<i", mu.mem_read(GLOBALS + slot * 4, 4))[0]
+        ok_run = got == exp and sp_slot == EXP_SP
+        ok &= ok_run
+        print(
+            f"{fn}({v}) = {got:#x} (expect {exp:#x}), sp{slot} slot after = "
+            f"{sp_slot} (expect {EXP_SP})  {'OK' if ok_run else 'MISMATCH'}"
+        )
+
+# The immutable `$konst` (slot 3) coincides with sp_init but is NOT a stack
+# pointer — the shrink must leave it at its original 4096, and getk() must
+# still return 4096 (re-basing it would corrupt a program constant).
+mu.mem_write(DATA, bytes(data))
+mu.mem_write(LOW, b"\x00" * MAPSZ)
+mu.reg_write(UC_ARM_REG_R11, 0)
+mu.reg_write(UC_ARM_REG_SP, DATA + 0x8000)
+mu.reg_write(UC_ARM_REG_LR, RET | 1)
+mu.emu_start((CODE + syms["getk"]) | 1, RET, timeout=5_000_000)
+getk = mu.reg_read(UC_ARM_REG_R0)
+konst_slot = struct.unpack("<i", mu.mem_read(GLOBALS + 3 * 4, 4))[0]
+ok_konst = getk == 4096 and konst_slot == 4096
+ok &= ok_konst
+print(
+    f"getk() = {getk} (expect 4096), konst slot = {konst_slot} (expect 4096, "
+    f"immutable — never re-based)  {'OK' if ok_konst else 'MISMATCH'}"
+)
+
+print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+sys.exit(0 if ok else 1)


### PR DESCRIPTION
## What

Closes #707. After #701 cleared the buffer-carrying blocker (#678 tail
down-shift), a multi-provider `meld fuse --memory shared` gust:os node
(`app-tl` = app + time-provider + log-provider) compiled all functions but
`--shadow-stack-size` then **refused**: the fused shared-memory module carries
one `__stack_pointer` global **per fused component**, all with
`init == sp_init`, and the re-base insisted on a *unique* match —

```
Error: --shadow-stack-size: could not uniquely identify the shadow-stack global
to re-base (3 globals have init == sp_init 1048576); refusing. VCR-MEM-001/#383.
```

## Fix (issue Option 1)

They alias the **one** shared reservation, so re-base the whole **mutable**-global
`init == sp_init` equivalence class to the shrunk budget. The candidate index set
is computed from the decoded globals (`NativeGlobalsLayout.sp_alias_indices`) —
the **same** predicate `identify_stack_pointer_global` selects on (`mutable ∧
i32 ∧ init == sp_init`). Crucially this keeps the `mutable` filter, so an
**immutable** constant that merely coincides with sp_init is **never** re-based
(re-basing it would corrupt a program constant).

- A single-SP module has exactly one member ⇒ **byte-identical** to pre-#707;
  the #383/#678 tests still pin that path.
- Only "no mutable global carries sp_init" stays an honest refuse.

## Gate

- **`crates/synth-cli/tests/multi_sp_rebase_707.rs`** — compile red→green on the
  3-SP fixture; asserts the three mutable SP slots re-base to the budget **while
  the immutable `$konst` slot stays 4096**; no-flag path frozen. This
  immutable-coincidence row is the discriminator — the naive value-only predicate
  would move it.
- **`scripts/repro/multi_sp_707_differential.py`** — each of the 3 exports
  roundtrips through its **own** co-rebased SP global and restores its own slot
  to the budget; `getk()` confirms the immutable constant is untouched. Faithful:
  fails when the expected init is wrong (verified against the no-flag object).
- Frozen anchors **10/10**, claim gate **17/17**, clippy/fmt clean.

## Scope note

The differential validates each export on a **fresh instance** (correct for
separate exports, matching wasmtime's per-call semantics). It does **not**
exercise the concurrent case (two component frames live at once, both stacks
based at the same top) — and it shouldn't: synth re-bases **uniformly** and
preserves whatever disjointness/aliasing `meld`'s fusion established. Proving the
shared stack is collision-free is meld's concern, not synth's. gale's on-silicon
reflash on the real fused node is the runtime gate.

Lineage: #383 (layer-1 shrink) → #678/#701 (layer-2 tail down-shift) → #707
(multi-SP co-rebase). VCR-MEM-001, epic #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)