### PR TITLE
chore(release): v0.39.1 — #707 multi-SP co-rebase unblocks gust:os OS node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.1] - 2026-07-11
+
+**A single-fix release that unblocks the gust:os multi-provider OS node — the
+last synth gate before gust:os v0.4.0. Also sweeps the npm wrapper version
+(stale at 0.38.0 from the #703 post-hub merge) up to the release tag.**
+
 ### Fixed
 
 - **`--shadow-stack-size` co-rebases N aliased `__stack_pointer` globals

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,14 +1805,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1871,11 +1871,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.39.0"
+version = "0.39.1"
 
 [[package]]
 name = "synth-cli"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1930,14 +1930,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1945,11 +1945,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.39.0"
+version = "0.39.1"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.39.0"
+version = "0.39.1"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.39.0"
+version = "0.39.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.39.0",
+    version = "0.39.1",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.39.0" }
+synth-core = { path = "../synth-core", version = "0.39.1" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.39.0" }
+synth-core = { path = "../synth-core", version = "0.39.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.39.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.39.0" }
+synth-core = { path = "../synth-core", version = "0.39.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.39.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.39.0" }
+synth-core = { path = "../synth-core", version = "0.39.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.39.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.39.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.39.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.39.1", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.39.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.39.1", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -44,23 +44,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.39.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.39.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.39.0" }
-synth-backend = { path = "../synth-backend", version = "0.39.0" }
+synth-core = { path = "../synth-core", version = "0.39.1" }
+synth-frontend = { path = "../synth-frontend", version = "0.39.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.39.1" }
+synth-backend = { path = "../synth-backend", version = "0.39.1" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.39.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.39.1" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.39.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.39.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.39.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.39.1", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.39.1", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.39.1", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.39.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.39.1", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.39.0" }
+synth-core = { path = "../synth-core", version = "0.39.1" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.39.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.39.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.39.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.39.0" }
-synth-opt = { path = "../synth-opt", version = "0.39.0" }
+synth-core = { path = "../synth-core", version = "0.39.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.39.1" }
+synth-opt = { path = "../synth-opt", version = "0.39.1" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.39.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.39.0" }
-synth-opt = { path = "../synth-opt", version = "0.39.0" }
+synth-core = { path = "../synth-core", version = "0.39.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.39.1" }
+synth-opt = { path = "../synth-opt", version = "0.39.1" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.39.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.39.1", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.38.0",
+  "version": "0.39.1",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"


### PR DESCRIPTION
Single-fix release cutting the merged #707 fix (PR #710).

## Contents
- **#707** — `--shadow-stack-size` co-rebases the whole **mutable** `init == sp_init`
  equivalence class (the per-component `__stack_pointer` globals a `meld fuse
  --memory shared` node carries). Unblocks the gust:os v0.4.0 multi-provider OS
  node — the last synth gate before that cut. An immutable constant coinciding
  with sp_init is never touched (same predicate `identify_stack_pointer_global`
  uses). Gated by `multi_sp_rebase_707.rs` + `multi_sp_707_differential.py`.

## Pin sweep
- workspace + all path-dep `version =` + `MODULE.bazel`: `0.39.0 → 0.39.1`
- npm wrapper `package.json`: `0.38.0 → 0.39.1` (it was **stale** from #703's
  post-hub merge — the npm package version *is* the GitHub-release tag it
  downloads, so it must equal the release).

## Gates
- Claim gate **17/17**, frozen anchors **10/10**, clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)