### PR TITLE
feat(vcr-isa): generate the Rocq lowering model from the shipped selector (#667)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ cd coq && make proofs
 
 ### Proof Status
 
-See `coq/STATUS.md` for the complete coverage matrix. Current: 472 Qed / 6 Admitted
+See `coq/STATUS.md` for the complete coverage matrix. Current: 512 Qed / 6 Admitted
 (+2 `admit.` tactics) across `coq/Synth/`. This count is CI-gated: `claims.yaml` +
 `scripts/claim_check.py` re-derive it on every commit — when a proof lands, update
 the docs AND `claims.yaml` in the same PR. Proofs are tiered:
@@ -129,7 +129,13 @@ frozen and oracle-gated every step:
   0.45× floor; phase 1 facts ingestion landed, PR #624).
 - **Track B (semantics):** `VCR-ISA-001` Sail-generated Rocq ISA model —
   approved, Sail/ASL bridge spike landed (92 Qed, `coq/Synth/ARM/SailArmBridge.v`);
-  `VCR-WASM-001` WasmCert-Coq source semantics — proposed.
+  first "generate the model from the shipped selector" increment landed (#667):
+  the shipped `sel_dsl::RULES` table now EMITS the 40 covered ops' Rocq lowerings
+  (`coq/Synth/Synth/VcrSelRulesGenerated.v`, `Module Gen`), each proven equal to
+  the hand-written `VcrSelRules.rule_X` by a `reflexivity` Qed
+  (`VcrSelRulesGenCheck.v`, 40 Qed) — Coq's kernel is the divergence gate, so the
+  #682 model↔selector drift is unrepresentable at the instruction-sequence level
+  for those ops. `VCR-WASM-001` WasmCert-Coq source semantics — proposed.
 - **Track C (validation):** the differential oracles are CI-gated jobs
   (cmp-select, RV32 shift-fold/const-addr-fold, callee-saved, spill-frame,
   symtab-based frozen-fixture differentials).

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 | ELF output with vector table | Implemented | Thumb bit set on symbols; not linked on real hardware |
 | Linker scripts (STM32, nRF52840, generic) | Implemented | Generated, not tested with real boards |
 | Cross-compilation (`--link` flag) | Implemented | Requires `arm-none-eabi-gcc` in PATH; not CI-tested |
-| Rocq mechanized proofs | 512 Qed / 6 Admitted | i32 + i64 T1 proofs; div_s trap guard re-admitted (div_u/rem_s/rem_u discharged) |
+| Rocq mechanized proofs | 512 Qed / 6 Admitted | i32 + i64 T1 correctness proofs + 40 VCR-ISA-001 (#667) generated-vs-model reflexivity gate lemmas; div_s trap guard re-admitted (div_u/rem_s/rem_u discharged) |
 | SMT translation validation | ordeal (pure-Rust QF_BV) default | v0.27.0 (#553); Z3 demoted to feature-gated differential oracle — 141/141 agreement |
 | WebAssembly spec test suite | 227/257 compile | Compilation only — not executed on emulator |
 
@@ -194,7 +194,7 @@ Per the [PulseEngine Verification Guide](https://pulseengine.eu/guides/VERIFICAT
 
 | Track | Status | Coverage |
 |-------|--------|----------|
-| **Rocq** | Partial | 512 Qed / 6 Admitted — div_s trap guard re-admitted (div_u/rem_s/rem_u discharged) |
+| **Rocq** | Partial | 512 Qed / 6 Admitted (incl. 40 VCR-ISA-001 #667 generated-vs-model gate lemmas) — div_s trap guard re-admitted (div_u/rem_s/rem_u discharged) |
 | **Kani** | Starting | 18 bounded model checking harnesses for ARM encoder |
 | **Verus** | Starting | 8 spec functions in `synth-synthesis/src/contracts.rs`; Bazel integration via `rules_verus` |
 | **Lean** | Not started | — |

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 | ELF output with vector table | Implemented | Thumb bit set on symbols; not linked on real hardware |
 | Linker scripts (STM32, nRF52840, generic) | Implemented | Generated, not tested with real boards |
 | Cross-compilation (`--link` flag) | Implemented | Requires `arm-none-eabi-gcc` in PATH; not CI-tested |
-| Rocq mechanized proofs | 472 Qed / 6 Admitted | i32 + i64 T1 proofs; div_s trap guard re-admitted (div_u/rem_s/rem_u discharged) |
+| Rocq mechanized proofs | 512 Qed / 6 Admitted | i32 + i64 T1 proofs; div_s trap guard re-admitted (div_u/rem_s/rem_u discharged) |
 | SMT translation validation | ordeal (pure-Rust QF_BV) default | v0.27.0 (#553); Z3 demoted to feature-gated differential oracle — 141/141 agreement |
 | WebAssembly spec test suite | 227/257 compile | Compilation only — not executed on emulator |
 
@@ -194,7 +194,7 @@ Per the [PulseEngine Verification Guide](https://pulseengine.eu/guides/VERIFICAT
 
 | Track | Status | Coverage |
 |-------|--------|----------|
-| **Rocq** | Partial | 472 Qed / 6 Admitted — div_s trap guard re-admitted (div_u/rem_s/rem_u discharged) |
+| **Rocq** | Partial | 512 Qed / 6 Admitted — div_s trap guard re-admitted (div_u/rem_s/rem_u discharged) |
 | **Kani** | Starting | 18 bounded model checking harnesses for ARM encoder |
 | **Verus** | Starting | 8 spec functions in `synth-synthesis/src/contracts.rs`; Bazel integration via `rules_verus` |
 | **Lean** | Not started | — |
@@ -206,7 +206,7 @@ See `artifacts/verification-gaps.yaml` for the detailed gap analysis (VG-001 thr
 Mechanized proofs in Rocq 9 show that `compile_wasm_to_arm` preserves WASM semantics for each operation. The proof suite lives in `coq/Synth/` and covers ARM instruction semantics, WASM stack-machine semantics, and per-operation correctness theorems.
 
 ```
-472 Qed / 6 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
+512 Qed / 6 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
   T1 result-correspondence (ARM output = WASM result): all i32 ops and all
      i64 ops — i64 T1 parity since v0.11.0, 0 i64 admits (coq/STATUS.md)
   T2 existence-only: f32/f64 and remaining categories

--- a/claims.yaml
+++ b/claims.yaml
@@ -25,16 +25,16 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-PROOF-COUNT-README
     doc: README.md
-    text: "472 Qed / 6 Admitted"
+    text: "512 Qed / 6 Admitted"
     evidence:
       - kind: count-eq                       # ALL THREE README spots must agree —
-        pattern: '472 Qed / 6 Admitted'      # a verbatim check alone greens if one
+        pattern: '512 Qed / 6 Admitted'      # a verbatim check alone greens if one
         glob: ['README.md']                  # of them drifts while another matches
         expect: 3
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 472
+        expect: 512
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -46,12 +46,12 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-CLAUDE-MD
     doc: CLAUDE.md
-    text: "472 Qed / 6 Admitted"
+    text: "512 Qed / 6 Admitted"
     evidence:
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 472
+        expect: 512
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -59,16 +59,16 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-STATUS-MD
     doc: coq/STATUS.md
-    text: "472 Qed / 6 Admitted"
+    text: "512 Qed / 6 Admitted"
     evidence:
       - kind: count-eq                       # headline + Total line must both agree
-        pattern: '472 Qed / 6 Admitted'
+        pattern: '512 Qed / 6 Admitted'
         glob: ['coq/STATUS.md']
         expect: 2
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 472
+        expect: 512
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']

--- a/coq/BUILD.bazel
+++ b/coq/BUILD.bazel
@@ -246,6 +246,47 @@ rocq_library(
     ],
 )
 
+# VCR-ISA-001 (#667): the selector rule table's Rocq lowerings GENERATED from
+# the shipped sel_dsl::RULES (crates/synth-synthesis) — the same table that
+# emits the shipped Rust lowering. Wrapped in `Module Gen` so the cross-check
+# below can name both `Gen.rule_X` and the hand-written `rule_X`. Committed +
+# pinned up-to-date by the cargo test `rocq_generated_lowering_is_up_to_date`.
+rocq_library(
+    name = "vcr_sel_rules_generated",
+    srcs = ["Synth/Synth/VcrSelRulesGenerated.v"],
+    include_path = "Synth",
+    deps = [
+        ":base",
+        ":common",
+        ":arm_state",
+        ":arm_instructions",
+    ],
+)
+
+# VCR-ISA-001 (#667) divergence GATE: one `reflexivity` Qed per rule proving the
+# GENERATED lowering (Gen.rule_X) equals the HAND-WRITTEN VcrSelRules.rule_X the
+# correctness theorems are about. If the shipped selector's sequence for a
+# covered op ever drifts from the model, the matching reflexivity stops
+# type-checking and this target (part of :verify_proofs) goes red — Coq's kernel
+# is the oracle, closing the #682 model-vs-selector divergence at the
+# instruction-sequence level. Committed + pinned by the cargo test
+# `rocq_gencheck_is_up_to_date`.
+rocq_library(
+    name = "vcr_sel_rules_gencheck",
+    srcs = ["Synth/Synth/VcrSelRulesGenCheck.v"],
+    include_path = "Synth",
+    # Requiring VcrSelRules pulls its whole transitive loadpath (the rocq rules
+    # do not propagate deps automatically), so list the same set vcr_sel_rules
+    # carries plus the two new libraries this file names.
+    deps = _CORRECTNESS_FULL_DEPS + [
+        ":tactics",
+        ":arm_flag_lemmas",
+        ":correctness_tactics",
+        ":vcr_sel_rules",
+        ":vcr_sel_rules_generated",
+    ],
+)
+
 # Master index: imports all correctness proofs
 rocq_library(
     name = "correctness_complete",
@@ -274,6 +315,8 @@ rocq_proof_test(
         ":sail_arm_bridge",
         ":vcr_sel_pilot",
         ":vcr_sel_rules",
+        ":vcr_sel_rules_generated",
+        ":vcr_sel_rules_gencheck",
         ":vcr_sel_expansion",
     ],
 )

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -1,7 +1,9 @@
 # Rocq Proof Suite — Honest Status
 
-**Last Updated: 2026-07-10 (recount: 472 Qed / 6 Admitted, +2 admit., crude
-`grep "Qed\."` over `coq/Synth/**/*.v` — same method as prior recounts)
+**Last Updated: 2026-07-11 (recount: 512 Qed / 6 Admitted, +2 admit., crude
+`grep "Qed\."` over `coq/Synth/**/*.v` — same method as prior recounts; the
++40 vs the prior 472 are the VCR-ISA-001 #667 generated-vs-model cross-check
+lemmas in `VcrSelRulesGenCheck.v`, one `reflexivity` Qed per shipped rule)
 
 The headline count is CI-gated: `claims.yaml` + `scripts/claim_check.py`
 re-derive `Qed.`/`Admitted.`/`admit.` counts from `coq/Synth/**/*.v` on every
@@ -158,7 +160,7 @@ and predates the VcrSelRules (42), VcrSelPilot (7) and SailArmBridge (92) Qed;
 see the per-file breakdown below for current per-file counts. The T3 row and
 the headline total are re-derived by the claim gate.
 
-**Total: 472 Qed / 6 Admitted (+2 admit.) across all files** (recount 2026-07-10, CI-gated via `claims.yaml`)
+**Total: 512 Qed / 6 Admitted (+2 admit.) across all files** (recount 2026-07-10, CI-gated via `claims.yaml`)
 
 v0.10.0 PR 1: +2 T1 Qed (i64_add_correct, i64_sub_correct) and +9
 infrastructure Qed (combine_i32_unsigned, carry_split_add,
@@ -435,7 +437,8 @@ Recount 2026-07-10 (`grep -oE 'Qed\.'` / `'Admitted\.'` per file):
 | WasmValues.v | 2 | 0 | Infra |
 | VcrSelPilot.v | 7 | 0 | T1 (register-polymorphic; VCR-SEL-001 go/abandon measurement) |
 | VcrSelRules.v | 42 | 0 | T1 (register-polymorphic; the WIRED VCR-SEL-001 increment-1+2+3+4 rule table — 40 rule theorems 1:1 with `coq/vcr_sel_rules.manifest`, coverage-gated by `//coq:vcr_sel_rules_coverage`, + 2 mod-32 helper lemmas #683) |
-| **Total** | **472** | **6** | (+2 `admit.`) |
+| VcrSelRulesGenCheck.v | 40 | 0 | Gate (VCR-ISA-001 #667: one `reflexivity` Qed per rule proving the GENERATED lowering `Gen.rule_X` — emitted from the shipped `sel_dsl::RULES` into `VcrSelRulesGenerated.v` — equals the hand-written `VcrSelRules.rule_X`; closes model↔selector divergence at the instruction-sequence level) |
+| **Total** | **512** | **6** | (+2 `admit.`) |
 
 ## VCR-SEL-001 increments 1 (2026-07-07) + 2 + 3 + 4 (2026-07-08): VcrSelRules.v
 

--- a/coq/Synth/Synth/VcrSelRulesGenCheck.v
+++ b/coq/Synth/Synth/VcrSelRulesGenCheck.v
@@ -1,0 +1,141 @@
+(** * VCR-ISA-001 (#667): generated-vs-hand-written lowering cross-check.
+
+GENERATED FILE — DO NOT EDIT BY HAND.
+
+Emitted by [crate::sel_dsl::generate_rocq_gencheck_source]. One
+[reflexivity] Qed per rule proving the GENERATED lowering
+([VcrSelRulesGenerated.Gen.rule_X], emitted straight from the shipped
+[sel_dsl::RULES] table) is definitionally equal to the HAND-WRITTEN
+[VcrSelRules.rule_X] the correctness theorems are stated about. If the
+shipped selector's sequence for a covered op ever diverges from the
+model, the matching [reflexivity] stops type-checking — the gate goes
+red under [//coq:verify_proofs]. Coq's kernel is the oracle; there is no
+text normalizer to get wrong (the #682 lesson).
+
+Pinned up-to-date by the [rocq_gencheck_is_up_to_date] cargo test;
+regenerate with
+[SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl]. *)
+
+Require Import Synth.ARM.ArmInstructions.
+Require Import Synth.Synth.VcrSelRules.
+Require Import Synth.Synth.VcrSelRulesGenerated.
+
+Lemma check_rule_i32_add : Gen.rule_i32_add = rule_i32_add.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_sub : Gen.rule_i32_sub = rule_i32_sub.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_mul : Gen.rule_i32_mul = rule_i32_mul.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_and : Gen.rule_i32_and = rule_i32_and.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_or : Gen.rule_i32_or = rule_i32_or.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_xor : Gen.rule_i32_xor = rule_i32_xor.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_rotl : Gen.rule_i32_rotl = rule_i32_rotl.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_shl : Gen.rule_i32_shl = rule_i32_shl.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_shr_s : Gen.rule_i32_shr_s = rule_i32_shr_s.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_shr_u : Gen.rule_i32_shr_u = rule_i32_shr_u.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_rotr : Gen.rule_i32_rotr = rule_i32_rotr.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_eq : Gen.rule_i32_eq = rule_i32_eq.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_ne : Gen.rule_i32_ne = rule_i32_ne.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_lt_s : Gen.rule_i32_lt_s = rule_i32_lt_s.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_lt_u : Gen.rule_i32_lt_u = rule_i32_lt_u.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_gt_s : Gen.rule_i32_gt_s = rule_i32_gt_s.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_gt_u : Gen.rule_i32_gt_u = rule_i32_gt_u.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_le_s : Gen.rule_i32_le_s = rule_i32_le_s.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_le_u : Gen.rule_i32_le_u = rule_i32_le_u.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_ge_s : Gen.rule_i32_ge_s = rule_i32_ge_s.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_ge_u : Gen.rule_i32_ge_u = rule_i32_ge_u.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_add : Gen.rule_i64_add = rule_i64_add.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_sub : Gen.rule_i64_sub = rule_i64_sub.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_and : Gen.rule_i64_and = rule_i64_and.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_or : Gen.rule_i64_or = rule_i64_or.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_xor : Gen.rule_i64_xor = rule_i64_xor.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_eqz : Gen.rule_i64_eqz = rule_i64_eqz.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_clz : Gen.rule_i32_clz = rule_i32_clz.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_ctz : Gen.rule_i32_ctz = rule_i32_ctz.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i32_popcnt : Gen.rule_i32_popcnt = rule_i32_popcnt.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_eq : Gen.rule_i64_eq = rule_i64_eq.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_ne : Gen.rule_i64_ne = rule_i64_ne.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_lt_s : Gen.rule_i64_lt_s = rule_i64_lt_s.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_lt_u : Gen.rule_i64_lt_u = rule_i64_lt_u.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_gt_s : Gen.rule_i64_gt_s = rule_i64_gt_s.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_gt_u : Gen.rule_i64_gt_u = rule_i64_gt_u.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_le_s : Gen.rule_i64_le_s = rule_i64_le_s.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_le_u : Gen.rule_i64_le_u = rule_i64_le_u.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_ge_s : Gen.rule_i64_ge_s = rule_i64_ge_s.
+Proof. reflexivity. Qed.
+
+Lemma check_rule_i64_ge_u : Gen.rule_i64_ge_u = rule_i64_ge_u.
+Proof. reflexivity. Qed.

--- a/coq/Synth/Synth/VcrSelRulesGenerated.v
+++ b/coq/Synth/Synth/VcrSelRulesGenerated.v
@@ -1,0 +1,149 @@
+(** * VCR-ISA-001 (#667): the selector rule table's Rocq lowerings, GENERATED.
+
+GENERATED FILE — DO NOT EDIT BY HAND.
+
+Emitted by [crate::sel_dsl::generate_rocq_lowering_source] from the
+shipped rule table [crates/synth-synthesis/src/sel_dsl/mod.rs] (RULES),
+the SAME table that produces the shipped Rust lowering
+([sel_dsl/generated.rs]). Each [Gen.rule_X] below is proven equal to the
+hand-written [rule_X] of [VcrSelRules.v] by a [reflexivity] Qed in
+[VcrSelRulesGenCheck.v] — so the Rocq model the theorems are ABOUT cannot
+silently diverge from the shipped selector for the covered ops (the #682
+vacuous-proof failure mode, closed at the instruction-sequence level).
+
+Pinned up-to-date by the [rocq_generated_lowering_is_up_to_date] cargo
+test; regenerate with
+[SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl]. *)
+
+From Stdlib Require Import List.
+From Stdlib Require Import ZArith.
+Require Import Synth.Common.Base.
+Require Import Synth.Common.Integers.
+Require Import Synth.ARM.ArmState.
+Require Import Synth.ARM.ArmInstructions.
+Import ListNotations.
+Open Scope Z_scope.
+
+Module Gen.
+
+Definition rule_i32_add (rd rn rm : arm_reg) : arm_program :=
+  [ADD rd rn (Reg rm)].
+
+Definition rule_i32_sub (rd rn rm : arm_reg) : arm_program :=
+  [SUB rd rn (Reg rm)].
+
+Definition rule_i32_mul (rd rn rm : arm_reg) : arm_program :=
+  [MUL rd rn rm].
+
+Definition rule_i32_and (rd rn rm : arm_reg) : arm_program :=
+  [AND rd rn (Reg rm)].
+
+Definition rule_i32_or (rd rn rm : arm_reg) : arm_program :=
+  [ORR rd rn (Reg rm)].
+
+Definition rule_i32_xor (rd rn rm : arm_reg) : arm_program :=
+  [EOR rd rn (Reg rm)].
+
+Definition rule_i32_rotl (rd rn rm rs : arm_reg) : arm_program :=
+  [RSB rs rm (Imm (I32.repr 32)); ROR_reg rd rn rs].
+
+Definition rule_i32_shl (rd rn rm rs : arm_reg) : arm_program :=
+  [AND rs rm (Imm (I32.repr 31)); LSL_reg rd rn rs].
+
+Definition rule_i32_shr_s (rd rn rm rs : arm_reg) : arm_program :=
+  [AND rs rm (Imm (I32.repr 31)); ASR_reg rd rn rs].
+
+Definition rule_i32_shr_u (rd rn rm rs : arm_reg) : arm_program :=
+  [AND rs rm (Imm (I32.repr 31)); LSR_reg rd rn rs].
+
+Definition rule_i32_rotr (rd rn rm : arm_reg) : arm_program :=
+  [ROR_reg rd rn rm].
+
+Definition rule_i32_eq (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVEQ rd (Imm I32.one)].
+
+Definition rule_i32_ne (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVNE rd (Imm I32.one)].
+
+Definition rule_i32_lt_s (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVLT rd (Imm I32.one)].
+
+Definition rule_i32_lt_u (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVLO rd (Imm I32.one)].
+
+Definition rule_i32_gt_s (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVGT rd (Imm I32.one)].
+
+Definition rule_i32_gt_u (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVHI rd (Imm I32.one)].
+
+Definition rule_i32_le_s (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVLE rd (Imm I32.one)].
+
+Definition rule_i32_le_u (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVLS rd (Imm I32.one)].
+
+Definition rule_i32_ge_s (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVGE rd (Imm I32.one)].
+
+Definition rule_i32_ge_u (rd rn rm : arm_reg) : arm_program :=
+  [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVHS rd (Imm I32.one)].
+
+Definition rule_i64_add (rdlo rdhi rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [ADDS rdlo rnlo (Reg rmlo); ADC rdhi rnhi (Reg rmhi)].
+
+Definition rule_i64_sub (rdlo rdhi rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [SUBS rdlo rnlo (Reg rmlo); SBC rdhi rnhi (Reg rmhi)].
+
+Definition rule_i64_and (rdlo rdhi rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [AND rdlo rnlo (Reg rmlo); AND rdhi rnhi (Reg rmhi)].
+
+Definition rule_i64_or (rdlo rdhi rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [ORR rdlo rnlo (Reg rmlo); ORR rdhi rnhi (Reg rmhi)].
+
+Definition rule_i64_xor (rdlo rdhi rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [EOR rdlo rnlo (Reg rmlo); EOR rdhi rnhi (Reg rmhi)].
+
+Definition rule_i64_eqz (rd rnlo rnhi : arm_reg) : arm_program :=
+  [I64SetCondZ rd rnlo rnhi].
+
+Definition rule_i32_clz (rd rm : arm_reg) : arm_program :=
+  [CLZ rd rm].
+
+Definition rule_i32_ctz (rd rm : arm_reg) : arm_program :=
+  [RBIT rd rm; CLZ rd rd].
+
+Definition rule_i32_popcnt (rd rm : arm_reg) : arm_program :=
+  [POPCNT rd rm].
+
+Definition rule_i64_eq (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_EQ].
+
+Definition rule_i64_ne (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_NE].
+
+Definition rule_i64_lt_s (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_LT].
+
+Definition rule_i64_lt_u (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_CC].
+
+Definition rule_i64_gt_s (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_GT].
+
+Definition rule_i64_gt_u (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_HI].
+
+Definition rule_i64_le_s (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_LE].
+
+Definition rule_i64_le_u (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_LS].
+
+Definition rule_i64_ge_s (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_GE].
+
+Definition rule_i64_ge_u (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64SetCond rd rnlo rnhi rmlo rmhi Cond_CS].
+
+End Gen.

--- a/crates/synth-synthesis/src/sel_dsl/mod.rs
+++ b/crates/synth-synthesis/src/sel_dsl/mod.rs
@@ -105,6 +105,25 @@ impl RegVar {
             RegVar::RmHi => "rm_hi",
         }
     }
+
+    /// The Coq binder name this variable uses in `VcrSelRules.v`. Identical to
+    /// [`RegVar::rust_name`] for the i32 shapes, but the i64 pair binders drop
+    /// the underscore (`rd_lo` in Rust is `rdlo` in Coq) — this is the one
+    /// spelling difference the Rocq generator must bridge.
+    pub const fn coq_name(self) -> &'static str {
+        match self {
+            RegVar::Rd => "rd",
+            RegVar::Rn => "rn",
+            RegVar::Rm => "rm",
+            RegVar::Rs => "rs",
+            RegVar::RdLo => "rdlo",
+            RegVar::RdHi => "rdhi",
+            RegVar::RnLo => "rnlo",
+            RegVar::RnHi => "rnhi",
+            RegVar::RmLo => "rmlo",
+            RegVar::RmHi => "rmhi",
+        }
+    }
 }
 
 /// An explicit side condition a rule's register assignment must satisfy.
@@ -185,6 +204,42 @@ impl CondCode {
             CondCode::Ls => "Condition::LS",
             CondCode::Ge => "Condition::GE",
             CondCode::Hs => "Condition::HS",
+        }
+    }
+
+    /// The conditional-`MOV` constructor the i32 `SetCond` shape expands to in
+    /// the flat Rocq model (`ArmOp::SetCond` is modeled as
+    /// `MOV rd #0; MOV<cc> rd #1`, following the Compilation.v convention).
+    const fn coq_movcc(self) -> &'static str {
+        match self {
+            CondCode::Eq => "MOVEQ",
+            CondCode::Ne => "MOVNE",
+            CondCode::Lt => "MOVLT",
+            CondCode::Lo => "MOVLO",
+            CondCode::Gt => "MOVGT",
+            CondCode::Hi => "MOVHI",
+            CondCode::Le => "MOVLE",
+            CondCode::Ls => "MOVLS",
+            CondCode::Ge => "MOVGE",
+            CondCode::Hs => "MOVHS",
+        }
+    }
+
+    /// The `condition` constructor the i64 `I64SetCond` pseudo-op carries in
+    /// the Rocq model. Note the unsigned codes map to the carry-flag names the
+    /// ARM model uses: `Lo` (LO) is `Cond_CC`, `Hs` (HS) is `Cond_CS`.
+    const fn coq_condition(self) -> &'static str {
+        match self {
+            CondCode::Eq => "Cond_EQ",
+            CondCode::Ne => "Cond_NE",
+            CondCode::Lt => "Cond_LT",
+            CondCode::Lo => "Cond_CC",
+            CondCode::Gt => "Cond_GT",
+            CondCode::Hi => "Cond_HI",
+            CondCode::Le => "Cond_LE",
+            CondCode::Ls => "Cond_LS",
+            CondCode::Ge => "Cond_GE",
+            CondCode::Hs => "Cond_CS",
         }
     }
 }
@@ -1361,6 +1416,209 @@ pub fn generate_lowering_source() -> String {
     out
 }
 
+// ─── VCR-ISA-001 (#667): generate the Rocq model from the shipped selector ────
+//
+// The functions below turn the SAME [`RULES`] table into the Rocq lowering
+// `Definition`s that `coq/Synth/Synth/VcrSelRules.v` proves correct. Today those
+// definitions are HAND-WRITTEN in `VcrSelRules.v` and can silently diverge from
+// the shipped selector (the #682 vacuous-proof incident: a Qed certified a
+// hardware-wrong program because the model had drifted). Generating them from
+// `RULES` closes that divergence at the *instruction-sequence* level (the
+// existing `//coq:vcr_sel_rules_coverage` gate only pins the rule NAMES).
+//
+// The emitted `Gen.<rule>` module is checked against the hand-written
+// `<rule>` by a Coq `reflexivity` proof per rule (see
+// `coq/Synth/Synth/VcrSelRulesGenCheck.v`): Coq's kernel — not a Rust text
+// normalizer — is the oracle, so the fiddly spots (the `SetCond` →
+// two-instruction expansion, the i32 `MOV<cc>` vs i64 `Cond_*` mapping) cannot
+// hide a false green. The `.v` artifacts are committed and pinned up-to-date by
+// the tests below.
+
+/// Render one [`TemplateOp`] as the Coq `arm_instr` term(s) it denotes. A
+/// `SetCond` expands to the TWO-instruction `MOV rd #0; MOV<cc> rd #1` shape
+/// the flat model uses; every other shape is a single instruction.
+fn coq_instrs(t: &TemplateOp) -> Vec<String> {
+    let r = |v: RegVar| v.coq_name();
+    match *t {
+        TemplateOp::AddReg { rd, rn, rm } => {
+            vec![format!("ADD {} {} (Reg {})", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::SubReg { rd, rn, rm } => {
+            vec![format!("SUB {} {} (Reg {})", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::Mul { rd, rn, rm } => vec![format!("MUL {} {} {}", r(rd), r(rn), r(rm))],
+        TemplateOp::AndReg { rd, rn, rm } => {
+            vec![format!("AND {} {} (Reg {})", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::OrrReg { rd, rn, rm } => {
+            vec![format!("ORR {} {} (Reg {})", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::EorReg { rd, rn, rm } => {
+            vec![format!("EOR {} {} (Reg {})", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::RsbImm { rd, rn, imm } => {
+            vec![format!("RSB {} {} (Imm (I32.repr {}))", r(rd), r(rn), imm)]
+        }
+        TemplateOp::AndImm { rd, rn, imm } => {
+            vec![format!("AND {} {} (Imm (I32.repr {}))", r(rd), r(rn), imm)]
+        }
+        TemplateOp::RorReg { rd, rn, rm } => {
+            vec![format!("ROR_reg {} {} {}", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::LslReg { rd, rn, rm } => {
+            vec![format!("LSL_reg {} {} {}", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::LsrReg { rd, rn, rm } => {
+            vec![format!("LSR_reg {} {} {}", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::AsrReg { rd, rn, rm } => {
+            vec![format!("ASR_reg {} {} {}", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::CmpReg { rn, rm } => vec![format!("CMP {} (Reg {})", r(rn), r(rm))],
+        TemplateOp::SetCond { rd, cond } => vec![
+            format!("MOV {} (Imm I32.zero)", r(rd)),
+            format!("{} {} (Imm I32.one)", cond.coq_movcc(), r(rd)),
+        ],
+        TemplateOp::AddsReg { rd, rn, rm } => {
+            vec![format!("ADDS {} {} (Reg {})", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::AdcReg { rd, rn, rm } => {
+            vec![format!("ADC {} {} (Reg {})", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::SubsReg { rd, rn, rm } => {
+            vec![format!("SUBS {} {} (Reg {})", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::SbcReg { rd, rn, rm } => {
+            vec![format!("SBC {} {} (Reg {})", r(rd), r(rn), r(rm))]
+        }
+        TemplateOp::I64SetCondZ { rd, rn_lo, rn_hi } => {
+            vec![format!("I64SetCondZ {} {} {}", r(rd), r(rn_lo), r(rn_hi))]
+        }
+        TemplateOp::Clz { rd, rm } => vec![format!("CLZ {} {}", r(rd), r(rm))],
+        TemplateOp::Rbit { rd, rm } => vec![format!("RBIT {} {}", r(rd), r(rm))],
+        TemplateOp::Popcnt { rd, rm } => vec![format!("POPCNT {} {}", r(rd), r(rm))],
+        TemplateOp::I64SetCond {
+            rd,
+            rn_lo,
+            rn_hi,
+            rm_lo,
+            rm_hi,
+            cond,
+        } => vec![format!(
+            "I64SetCond {} {} {} {} {} {}",
+            r(rd),
+            r(rn_lo),
+            r(rn_hi),
+            r(rm_lo),
+            r(rm_hi),
+            cond.coq_condition()
+        )],
+    }
+}
+
+/// Emit the Coq `Definition <name> (<binders> : arm_reg) : arm_program := [..].`
+/// for one rule — the register-polymorphic ARM sequence the shipped selector
+/// emits, in the exact surface syntax `VcrSelRules.v` hand-writes.
+pub fn emit_rocq_definition(rule: &SelRule) -> String {
+    let binders: Vec<&str> = rule.params.iter().map(|p| p.coq_name()).collect();
+    let instrs: Vec<String> = rule.seq.iter().flat_map(coq_instrs).collect();
+    format!(
+        "Definition {} ({} : arm_reg) : arm_program :=\n  [{}].",
+        rule.name,
+        binders.join(" "),
+        instrs.join("; "),
+    )
+}
+
+/// Generate `coq/Synth/Synth/VcrSelRulesGenerated.v` from [`RULES`] — the whole
+/// rule table's lowerings wrapped in a `Module Gen`, so the cross-check file can
+/// state `Gen.<rule> = <rule>` without a name collision.
+///
+/// Committed to the tree and pinned by
+/// [`tests::rocq_generated_lowering_is_up_to_date`]; regenerate with
+/// `SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl`.
+pub fn generate_rocq_lowering_source() -> String {
+    let mut out = String::new();
+    out.push_str(
+        "(** * VCR-ISA-001 (#667): the selector rule table's Rocq lowerings, GENERATED.\n\
+         \n\
+         GENERATED FILE — DO NOT EDIT BY HAND.\n\
+         \n\
+         Emitted by [crate::sel_dsl::generate_rocq_lowering_source] from the\n\
+         shipped rule table [crates/synth-synthesis/src/sel_dsl/mod.rs] (RULES),\n\
+         the SAME table that produces the shipped Rust lowering\n\
+         ([sel_dsl/generated.rs]). Each [Gen.rule_X] below is proven equal to the\n\
+         hand-written [rule_X] of [VcrSelRules.v] by a [reflexivity] Qed in\n\
+         [VcrSelRulesGenCheck.v] — so the Rocq model the theorems are ABOUT cannot\n\
+         silently diverge from the shipped selector for the covered ops (the #682\n\
+         vacuous-proof failure mode, closed at the instruction-sequence level).\n\
+         \n\
+         Pinned up-to-date by the [rocq_generated_lowering_is_up_to_date] cargo\n\
+         test; regenerate with\n\
+         [SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl]. *)\n\
+         \n\
+         From Stdlib Require Import List.\n\
+         From Stdlib Require Import ZArith.\n\
+         Require Import Synth.Common.Base.\n\
+         Require Import Synth.Common.Integers.\n\
+         Require Import Synth.ARM.ArmState.\n\
+         Require Import Synth.ARM.ArmInstructions.\n\
+         Import ListNotations.\n\
+         Open Scope Z_scope.\n\
+         \n\
+         Module Gen.\n",
+    );
+    for rule in RULES {
+        out.push('\n');
+        out.push_str(&emit_rocq_definition(rule));
+        out.push('\n');
+    }
+    out.push_str("\nEnd Gen.\n");
+    out
+}
+
+/// Generate `coq/Synth/Synth/VcrSelRulesGenCheck.v` — one `reflexivity` Qed per
+/// rule asserting the generated `Gen.<rule>` equals the hand-written `<rule>` of
+/// `VcrSelRules.v`. This is the divergence GATE: Coq's kernel checks the two
+/// lowerings are convertible, so any edit to either side that changes the
+/// emitted sequence fails to compile under `//coq:verify_proofs`.
+///
+/// Committed and pinned by [`tests::rocq_gencheck_is_up_to_date`].
+pub fn generate_rocq_gencheck_source() -> String {
+    let mut out = String::new();
+    out.push_str(
+        "(** * VCR-ISA-001 (#667): generated-vs-hand-written lowering cross-check.\n\
+         \n\
+         GENERATED FILE — DO NOT EDIT BY HAND.\n\
+         \n\
+         Emitted by [crate::sel_dsl::generate_rocq_gencheck_source]. One\n\
+         [reflexivity] Qed per rule proving the GENERATED lowering\n\
+         ([VcrSelRulesGenerated.Gen.rule_X], emitted straight from the shipped\n\
+         [sel_dsl::RULES] table) is definitionally equal to the HAND-WRITTEN\n\
+         [VcrSelRules.rule_X] the correctness theorems are stated about. If the\n\
+         shipped selector's sequence for a covered op ever diverges from the\n\
+         model, the matching [reflexivity] stops type-checking — the gate goes\n\
+         red under [//coq:verify_proofs]. Coq's kernel is the oracle; there is no\n\
+         text normalizer to get wrong (the #682 lesson).\n\
+         \n\
+         Pinned up-to-date by the [rocq_gencheck_is_up_to_date] cargo test;\n\
+         regenerate with\n\
+         [SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl]. *)\n\
+         \n\
+         Require Import Synth.ARM.ArmInstructions.\n\
+         Require Import Synth.Synth.VcrSelRules.\n\
+         Require Import Synth.Synth.VcrSelRulesGenerated.\n",
+    );
+    for rule in RULES {
+        out.push('\n');
+        out.push_str(&format!(
+            "Lemma check_{name} : Gen.{name} = {name}.\nProof. reflexivity. Qed.\n",
+            name = rule.name
+        ));
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1386,6 +1644,83 @@ mod tests {
             "src/sel_dsl/generated.rs is stale relative to the RULES table — \
              regenerate with SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl"
         );
+    }
+
+    /// VCR-ISA-001 (#667): the generated Rocq lowerings
+    /// (`coq/Synth/Synth/VcrSelRulesGenerated.v`) are the committed output of
+    /// the SAME rule table, emitted straight from `RULES`. Any edit to the
+    /// table (or the file) without regenerating fails here; the Coq
+    /// `reflexivity` cross-check (`VcrSelRulesGenCheck.v`) then proves the
+    /// generated lowerings equal the hand-written model. Regenerate with
+    /// `SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl`.
+    #[test]
+    fn rocq_generated_lowering_is_up_to_date() {
+        let path = crate_root().join("../../coq/Synth/Synth/VcrSelRulesGenerated.v");
+        let expected = generate_rocq_lowering_source();
+        if std::env::var("SYNTH_SEL_DSL_REGEN").is_ok() {
+            std::fs::write(&path, &expected).expect("write VcrSelRulesGenerated.v");
+        }
+        let actual = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        assert_eq!(
+            actual, expected,
+            "coq/Synth/Synth/VcrSelRulesGenerated.v is stale relative to the RULES \
+             table — regenerate with SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl"
+        );
+    }
+
+    /// VCR-ISA-001 (#667): the generated cross-check file
+    /// (`coq/Synth/Synth/VcrSelRulesGenCheck.v`, one `reflexivity` Qed per
+    /// rule) is the committed output of `RULES`. Regenerate with
+    /// `SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl`.
+    #[test]
+    fn rocq_gencheck_is_up_to_date() {
+        let path = crate_root().join("../../coq/Synth/Synth/VcrSelRulesGenCheck.v");
+        let expected = generate_rocq_gencheck_source();
+        if std::env::var("SYNTH_SEL_DSL_REGEN").is_ok() {
+            std::fs::write(&path, &expected).expect("write VcrSelRulesGenCheck.v");
+        }
+        let actual = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        assert_eq!(
+            actual, expected,
+            "coq/Synth/Synth/VcrSelRulesGenCheck.v is stale relative to the RULES \
+             table — regenerate with SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl"
+        );
+    }
+
+    /// The generated Rocq `Definition` bodies must match the hand-written
+    /// `VcrSelRules.v` lowerings verbatim (whitespace-normalized). This is the
+    /// fast Rust-side smoke of the same property the Coq `reflexivity` gate
+    /// proves definitionally — it catches a drift even without a Coq build.
+    #[test]
+    fn generated_definitions_match_handwritten_vcr_sel_rules() {
+        let v_path = crate_root().join("../../coq/Synth/Synth/VcrSelRules.v");
+        let v = std::fs::read_to_string(&v_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", v_path.display()));
+        // Collapse all runs of whitespace to a single space for comparison.
+        let norm = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
+        for rule in RULES {
+            let generated = norm(&emit_rocq_definition(rule));
+            // Find `Definition <name> ` ... up to the terminating `.` that ends
+            // the definition (the body is a `[..]` list, no interior periods).
+            let needle = format!("Definition {} ", rule.name);
+            let start = v
+                .find(&needle)
+                .unwrap_or_else(|| panic!("no `{needle}` in VcrSelRules.v"));
+            let rest = &v[start..];
+            let end = rest
+                .find(".\n")
+                .or_else(|| rest.find(".\r\n"))
+                .unwrap_or_else(|| panic!("unterminated Definition {}", rule.name));
+            let handwritten = norm(&rest[..=end]);
+            assert_eq!(
+                generated, handwritten,
+                "generated Rocq lowering for {} diverges from the hand-written \
+                 VcrSelRules.v Definition (VCR-ISA-001 divergence)",
+                rule.name
+            );
+        }
     }
 
     /// Rule names are unique and follow the `rule_` prefix the 1:1 theorem


### PR DESCRIPTION
## What this is

Part of **VCR-ISA-001** (epic #242) — the first bounded increment of "generate the Rocq model from the shipped selector" from issue #667.

Today `coq/Synth/Synth/VcrSelRules.v` **hand-writes** the Rocq lowering `Definition rule_X` that its 40 correctness theorems are stated about — maintained *separately* from the shipped `sel_dsl::RULES` selector table. The two can silently diverge: the #682 vacuous-proof incident was a Qed certifying a hardware-wrong program because the model had drifted from what ships. The existing `//coq:vcr_sel_rules_coverage` gate only pins the rule **names**, not the emitted ARM **sequence**.

## What landed

A **generator** that emits the Rocq lowerings straight from the shipped `RULES` table, and a **Coq `reflexivity` gate** that proves generated == model:

- `sel_dsl::generate_rocq_lowering_source()` → `coq/Synth/Synth/VcrSelRulesGenerated.v` (`Module Gen`, 40 `Definition`s) — emitted from the **same** `RULES` table that produces the shipped Rust lowering (`generated.rs`).
- `sel_dsl::generate_rocq_gencheck_source()` → `coq/Synth/Synth/VcrSelRulesGenCheck.v` — one `reflexivity` Qed per rule asserting `Gen.rule_X = rule_X`. **Coq's kernel is the oracle** — no Rust text normalizer in the trusted base (the #682 lesson). If the shipped selector's sequence for a covered op ever diverges from the model, the matching `reflexivity` stops type-checking and the gate goes red.
- Both `.v` files are committed and pinned up-to-date by cargo tests (`rocq_generated_lowering_is_up_to_date`, `rocq_gencheck_is_up_to_date`); regenerate with `SYNTH_SEL_DSL_REGEN=1 cargo test -p synth-synthesis sel_dsl`.
- Fast Rust smoke test (`generated_definitions_match_handwritten_vcr_sel_rules`) catches drift even without a Coq build (belt-and-suspenders; the Coq reflexivity is the real gate).

The generator bridges the two fiddly spots where a lenient checker would hide a divergence: the `SetCond` → two-instruction `MOV rd #0; MOV<cc> rd #1` expansion, and the dual condition mapping (i32 `MOV<suffix>` vs i64 `Cond_*` constructor, incl. unsigned `LO→CC`/`HS→CS`).

## The gate (CI command)

```
bazel test //coq:verify_proofs      # rocq_proofs now includes :vcr_sel_rules_gencheck
```

**Non-vacuity verified**: perturbing one generated `Definition` (`ADD`→`SUB`) makes `bazel build //coq:vcr_sel_rules_gencheck` fail with `Error: Unable to unify "rule_i32_add" with "Gen.rule_i32_add"`. Restored by regenerating.

Local runs: `bazel test //coq:verify_proofs` 2/2 pass · `python3 scripts/claim_check.py` 17/17 · `cargo clippy --workspace --all-targets -D warnings` clean · `cargo fmt --check` clean.

## Count decision (please confirm)

Proof count **472 → 512** (+40 `reflexivity` Qed). I chose the transparent option — bump the headline everywhere + a separate **"Gate" tier row** in `coq/STATUS.md` + README description cells that call the 40 out as generation-gate lemmas (not T1 correctness) — over quietly excluding the file from the `Qed\.` glob. `claims.yaml` + `STATUS.md` + `CLAUDE.md` + `README.md` reconciled together. **Judgment call for the maintainer**: if you'd rather account these separately (e.g. "472 correctness + 40 gen-gate"), say so and I'll re-split.

## What remains for full VCR-ISA-001 closure

- Replace the hand-written `VcrSelRules.v` `Definition`s with a `Require Import` of the generated `Gen` module, so the model is **generated, not mirrored** (this PR proves the generated definitions are convertible-equal; the next step makes them the single source).
- Extend generation past the 40 covered ops (the rest of the selector still rides the hand-written / whole-compiler model).
- The Sail-generated ISA-model **semantics** (Track B, `SailArmBridge.v`) remains the separate, larger half of VCR-ISA-001.
- Note: the VcrSel family (incl. pre-existing `VcrSelRules.v`) is not in `_CoqProject`, so these files gate on the **Bazel** path (`bazel test //coq:verify_proofs`), not `make proofs` — consistent with the existing convention.

Refs #667, #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)