### PR TITLE
feat(vcr-perf): #494 phase 3 — branchless select-collapse elision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,6 +416,17 @@ jobs:
         run: python scripts/repro/fact_spec_div_494_differential.py --expect-decline
       - name: Run RED force-admit divergence demonstration
         run: python scripts/repro/fact_spec_div_494_differential.py --force-admit
+      # #494 phase 3 — branchless select-collapse: the sibling of the Phase-2
+      # if-elision on the shape LLVM actually emits (min/max clamp via select).
+      # In-bounds differential (specialized ≡ wasmtime ≡ unspecialized over the
+      # proven bound; 2 collapses + gust_mix 50 B -> 14 B shrink required) and
+      # the wrong-bound loud-decline byte-identity leg.
+      - name: Run select-collapse in-bounds differential (proven bound)
+        run: python scripts/repro/fact_spec_select_494_differential.py
+      - name: Run select-collapse wrong-bound loud-decline path
+        run: >
+          python scripts/repro/fact_spec_select_494_differential.py
+          --fact-lo 0 --fact-hi 4000 --expect-decline
 
   rv32-shift-fold-oracle:
     name: rv32 immediate-shift-fold execution oracle

--- a/crates/synth-verify/src/fact_spec.rs
+++ b/crates/synth-verify/src/fact_spec.rs
@@ -585,6 +585,152 @@ impl<'a> Pass<'a> {
         }
     }
 
+    /// Discharge the select-collapse obligation for the branchless `select`
+    /// at op `i`. The operands are `(val1, val2, cond)` in wasm select order
+    /// (`val1` deepest, `cond` on top); the runtime result is
+    /// `(cond != 0) ? val1 : val2`. When a value-range premise pins the
+    /// condition CONSTANT under `P` the select collapses to one operand — the
+    /// branchless sibling of the Phase-2 no-else `if` elision, and the shape
+    /// gust_mix's `clamp` actually uses (`max`/`min` via `select`).
+    ///
+    /// Two mutually exclusive obligations, both certificate-checked QF_BV.
+    /// `UNSAT(P ∧ cond ≠ 0)` means `cond` is always 0, so the result is `val2`
+    /// (delete `val1`'s producer slice plus the condition-slice-through-
+    /// `select`). `UNSAT(P ∧ cond == 0)` means `cond` is always non-zero, so
+    /// the result is `val1` (delete the `val2`+condition+`select` contiguous
+    /// slice). Anything else (Sat both ways = genuinely non-constant; Unknown;
+    /// an impure/non-contiguous erasable slice) DECLINES LOUDLY and the general
+    /// branchless select stands. Returns the surviving operand's `Val` on
+    /// admit, `None` on decline.
+    fn try_collapse_select(&mut self, i: usize, val1: &Val, val2: &Val, cond: &Val) -> Option<Val> {
+        if self.premises.is_empty() {
+            self.decline(format!(
+                "op#{i} select — no premise reaches this site (no usable value-range fact)"
+            ));
+            return None;
+        }
+        // The condition slice must be a pure, contiguous producer ending
+        // immediately before the `select` — otherwise deleting it could drop
+        // live work (`local.tee`) or leave a gap.
+        let Some(sc) = cond.start else {
+            self.decline(format!(
+                "op#{i} select — condition slice is impure or non-contiguous (not erasable)"
+            ));
+            return None;
+        };
+        if cond.created + 1 != i {
+            self.decline(format!(
+                "op#{i} select — condition is not produced immediately before the select \
+                 (non-contiguous)"
+            ));
+            return None;
+        }
+
+        // Obligation B first (the clamp shape: the guard condition is
+        // constant-FALSE, so the identity operand `val2` survives).
+        let mut solver = new_solver();
+        for p in &self.premises {
+            solver.assert(p);
+        }
+        solver.assert(&cond.bv.ne(BV::from_i64(0, 32)));
+        match solver.check() {
+            CheckOutcome::Unsat => {
+                // cond ≡ 0 ⇒ result = val2. Delete val1's slice AND the
+                // condition-slice-through-select. val2 (kept) sits between.
+                let Some(s1) = val1.start else {
+                    self.decline(format!(
+                        "op#{i} select proven false-arm (UNSAT cond ≠ 0) but the val1 slice \
+                         is not erasable (impure/non-contiguous) — collapse declined"
+                    ));
+                    return None;
+                };
+                if val1.created >= sc {
+                    self.decline(format!(
+                        "op#{i} select — val1 slice overlaps the condition slice; collapse \
+                         declined"
+                    ));
+                    return None;
+                }
+                self.deletions.push((s1, val1.created));
+                self.deletions.push((sc, i));
+                self.admitted.push(format!(
+                    "{}: op#{i} select — collapsed to the false-arm (val2): \
+                     UNSAT(P ∧ cond ≠ 0) via {} (certificate-checked QF_BV; every Unsat \
+                     carries an LRAT proof validated by ordeal-lrat); deleted val1 slice \
+                     [{s1}..={}] + condition/select [{sc}..={i}]; P = {{{}}}; cond = {}",
+                    self.func,
+                    solver.name(),
+                    val1.created,
+                    self.premise_desc.join(" ∧ "),
+                    cond.bv,
+                ));
+                return Some(val2.clone());
+            }
+            CheckOutcome::Sat => { /* cond can be non-zero — try obligation A */ }
+            CheckOutcome::Unknown(reason) => {
+                self.decline(format!(
+                    "op#{i} select — false-arm obligation Unknown ({reason}); conservative \
+                     decline"
+                ));
+                return None;
+            }
+        }
+
+        // Obligation A: cond ≡ non-zero ⇒ result = val1. Delete the
+        // val2+condition+select contiguous slice.
+        let mut solver = new_solver();
+        for p in &self.premises {
+            solver.assert(p);
+        }
+        solver.assert(&cond.bv.eq(BV::from_i64(0, 32)));
+        match solver.check() {
+            CheckOutcome::Unsat => {
+                let Some(s2) = val2.start else {
+                    self.decline(format!(
+                        "op#{i} select proven true-arm (UNSAT cond == 0) but the val2 slice \
+                         is not erasable (impure/non-contiguous) — collapse declined"
+                    ));
+                    return None;
+                };
+                if val2.created + 1 != sc {
+                    self.decline(format!(
+                        "op#{i} select — val2 slice not adjacent to the condition slice \
+                         (non-contiguous); collapse declined"
+                    ));
+                    return None;
+                }
+                // [s2 ..= i] is one contiguous pure range (val2 + cond + select).
+                self.deletions.push((s2, i));
+                self.admitted.push(format!(
+                    "{}: op#{i} select — collapsed to the true-arm (val1): \
+                     UNSAT(P ∧ cond == 0) via {} (certificate-checked QF_BV; every Unsat \
+                     carries an LRAT proof validated by ordeal-lrat); deleted val2/condition/\
+                     select [{s2}..={i}]; P = {{{}}}; cond = {}",
+                    self.func,
+                    solver.name(),
+                    self.premise_desc.join(" ∧ "),
+                    cond.bv,
+                ));
+                Some(val1.clone())
+            }
+            CheckOutcome::Sat => {
+                let cex = self.counterexample(solver.as_ref());
+                self.decline(format!(
+                    "op#{i} select — condition is not constant under P (both arms reachable; \
+                     counterexample: {cex}); branchless select retained"
+                ));
+                None
+            }
+            CheckOutcome::Unknown(reason) => {
+                self.decline(format!(
+                    "op#{i} select — true-arm obligation Unknown ({reason}); conservative \
+                     decline"
+                ));
+                None
+            }
+        }
+    }
+
     fn walk(&mut self) {
         if self.range_facts.is_empty() && self.nonzero_facts.is_empty() {
             self.decline(
@@ -786,6 +932,49 @@ impl<'a> Pass<'a> {
                     }
                     i = end + 1;
                     continue;
+                }
+                // #494 Phase 3: branchless `select` — the sibling of the
+                // Phase-2 no-else `if` elision, and the shape gust_mix's
+                // clamp actually lowers to (`max`/`min` via select). A
+                // value-range premise that pins the condition constant
+                // collapses it to one operand (stream deletion, like `if`).
+                WasmOp::Select => {
+                    let (Some(cond), Some(val2), Some(val1)) =
+                        (self.stack.pop(), self.stack.pop(), self.stack.pop())
+                    else {
+                        self.decline(format!("op#{i} select on underflowing symbolic stack"));
+                        return;
+                    };
+                    // Only the plain i32 `select` (0x1B) is tracked; a typed
+                    // select over i64/f-operands declines and havocs.
+                    if cond.bv.get_size() != 32
+                        || val1.bv.get_size() != 32
+                        || val2.bv.get_size() != 32
+                    {
+                        self.decline(format!(
+                            "op#{i} select on non-32-bit operand(s) — only i32 select is tracked"
+                        ));
+                        let v = self.fresh_var(format!("fs_sel{i}"));
+                        self.push(v, None, i);
+                        i += 1;
+                        continue;
+                    }
+                    match self.try_collapse_select(i, &val1, &val2, &cond) {
+                        // Admitted: the surviving operand's producer slice
+                        // stays; the other operand + condition slice + the
+                        // `select` were recorded for deletion. `start = None`
+                        // keeps the collapsed result out of any later erasable
+                        // slice (conservative).
+                        Some(surviving) => self.push(surviving.bv, None, i),
+                        // Declined (loud): the branchless select stands. Havoc
+                        // the result — a fresh var means any obligation over it
+                        // downstream is Sat, so it can never seed an unsound
+                        // chained collapse.
+                        None => {
+                            let v = self.fresh_var(format!("fs_sel{i}"));
+                            self.push(v, None, i);
+                        }
+                    }
                 }
                 // Function-final `End` (top-level): done.
                 WasmOp::End => break,
@@ -999,6 +1188,119 @@ mod tests {
         assert!(!r.changed());
         assert_eq!(r.ops, ops);
         assert!(!r.declined.is_empty(), "the no-fact case is a loud decline");
+    }
+
+    // ---- #494 Phase 3: branchless select-collapse ----
+
+    /// gust_mix's clamp lowered branchlessly via `select` (the shape LLVM
+    /// emits): `max(v,1000)` = `(v<1000)?1000:v`, `min(v,2000)` =
+    /// `(v>2000)?2000:v`. No `If`/`End` — no block_arity entries.
+    fn select_clamp_ops() -> Vec<WasmOp> {
+        vec![
+            LocalGet(0),    // 0   ch          ← fact target
+            I32Const(476),  // 1
+            I32Add,         // 2   v = ch+476
+            LocalSet(1),    // 3
+            I32Const(1000), // 4   val1 (low clamp)
+            LocalGet(1),    // 5   val2 = v
+            LocalGet(1),    // 6   cond slice
+            I32Const(1000), // 7
+            I32LtS,         // 8   cond = v < 1000
+            Select,         // 9   → max(v,1000)
+            LocalSet(1),    // 10
+            I32Const(2000), // 11  val1 (high clamp)
+            LocalGet(1),    // 12  val2 = v
+            LocalGet(1),    // 13  cond slice
+            I32Const(2000), // 14
+            I32GtS,         // 15  cond = v > 2000
+            Select,         // 16  → min(v,2000) = result
+            End,            // 17
+        ]
+    }
+
+    #[test]
+    fn select_clamp_collapses_both_selects_under_the_proven_bound_494() {
+        let ops = select_clamp_ops();
+        let r = specialize_function("gust_mix", &ops, &[], &[fact(0, 524, 1524)], &[]);
+        assert_eq!(r.admitted.len(), 2, "declines: {:?}", r.declined);
+        assert!(r.changed());
+        assert_eq!(
+            r.ops,
+            vec![
+                LocalGet(0),
+                I32Const(476),
+                I32Add,
+                LocalSet(1),
+                LocalGet(1), // val2 of select 1 (identity survives)
+                LocalSet(1),
+                LocalGet(1), // val2 of select 2 (identity survives)
+                End,
+            ],
+            "both branchless clamps must collapse to the identity operand"
+        );
+        assert_eq!(r.kept, vec![0, 1, 2, 3, 5, 10, 12, 17]);
+        for line in &r.admitted {
+            assert!(line.contains("UNSAT"), "{line}");
+            assert!(line.contains("certificate-checked"), "{line}");
+            assert!(line.contains("select"), "{line}");
+            assert!(line.contains("[524, 1524]"), "{line}");
+        }
+    }
+
+    #[test]
+    fn select_clamp_wrong_bound_is_sat_and_declines_byte_identically_494() {
+        // ch ∈ [0, 4000]: ch=0 → v=476 < 1000 so the low clamp genuinely
+        // fires; both selects are non-constant ⇒ loud Sat decline, no rewrite.
+        let ops = select_clamp_ops();
+        let r = specialize_function("gust_mix", &ops, &[], &[fact(0, 0, 4000)], &[]);
+        assert_eq!(r.admitted.len(), 0);
+        assert!(!r.changed());
+        assert_eq!(r.ops, ops, "declined ⇒ byte-identical op stream");
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("not constant") && d.contains("counterexample")),
+            "declines must be loud and carry a model: {:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn select_collapses_to_true_arm_when_condition_proven_nonzero_494() {
+        // result = cond ? val1 : val2 with cond ≡ 1 (fact ∈ [1,1]) ⇒ keep val1.
+        let ops = vec![
+            I32Const(111), // 0  val1
+            I32Const(222), // 1  val2
+            LocalGet(0),   // 2  cond ← fact ∈ [1,1] (always non-zero)
+            Select,        // 3  → val1
+            End,           // 4
+        ];
+        let r = specialize_function("f", &ops, &[], &[fact(2, 1, 1)], &[]);
+        assert_eq!(r.admitted.len(), 1, "declines: {:?}", r.declined);
+        assert_eq!(r.ops, vec![I32Const(111), End]);
+        assert!(
+            r.admitted[0].contains("true-arm") && r.admitted[0].contains("cond == 0"),
+            "{}",
+            r.admitted[0]
+        );
+    }
+
+    #[test]
+    fn select_without_constraining_premise_declines_no_false_collapse_494() {
+        // A TRUE ValueRange fact exists (so the walk runs) but targets val1,
+        // not the condition; the select's condition carries no premise ⇒
+        // non-constant ⇒ Sat decline, byte-identical.
+        let ops = vec![
+            I32Const(111), // 0  val1 ← fact ∈ [111,111] (true, non-constraining)
+            I32Const(222), // 1  val2
+            LocalGet(0),   // 2  cond — unconstrained
+            Select,        // 3
+            End,           // 4
+        ];
+        let r = specialize_function("f", &ops, &[], &[fact(0, 111, 111)], &[]);
+        assert_eq!(r.admitted.len(), 0);
+        assert!(!r.changed());
+        assert_eq!(r.ops, ops);
     }
 
     #[test]

--- a/scripts/repro/fact_spec_select_494.wat
+++ b/scripts/repro/fact_spec_select_494.wat
@@ -1,0 +1,63 @@
+;; VCR-PERF-002 Phase 3 (#494) — the gust_mix clamp lowered BRANCHLESSLY.
+;;
+;; gust_mix is algebraically clamp(ch + 476, 1000, 2000). The Phase-2 fixture
+;; (fact_spec_clamp_494.wat) writes the clamp with `if`/`end`; a real optimizing
+;; front-end (and LLVM) lowers a min/max clamp BRANCHLESSLY with `select`:
+;;
+;;   max(v, 1000) = (v < 1000) ? 1000 : v
+;;   min(v, 2000) = (v > 2000) ? 2000 : v
+;;
+;; Under the loom-proven premise ch ∈ [524, 1524] (forwarded as a schema-v1
+;; `wsc.facts` value-range record on value_id 0 = the `local.get $ch` producing
+;; ch), v = ch+476 ∈ [1000, 2000], so BOTH select conditions are constant-false.
+;; The Phase-3 select-collapse pass (SYNTH_FACT_SPEC=1) discharges, per site,
+;; UNSAT(P ∧ cond ≠ 0) through the ordeal-backed certificate-checked solver and
+;; collapses each `select` to its identity operand — deleting the guard
+;; comparison + the dead operand + the branchless `select` mux itself. This is
+;; the shape Phase 2's `if`-elision cannot touch (no `if` in the stream); it is
+;; the branchless sibling of that elision and the form gust_mix actually uses.
+;;
+;; The facts section is appended by the harnesses (the .wat itself is
+;; facts-free): scripts/repro/fact_spec_select_494_differential.py.
+;;
+;; Op indices (value_id space, decoded order):
+;;   0 local.get $ch   <- value-range fact target
+;;   1 i32.const 476
+;;   2 i32.add         v = ch+476
+;;   3 local.set $v
+;;   4 i32.const 1000  low-clamp val1 (deleted)
+;;   5 local.get $v    low-clamp val2 (survives — identity)
+;;   6 local.get $v   -+ low-clamp condition slice + select
+;;   7 i32.const 1000  | (deleted: ops 6..=9)
+;;   8 i32.lt_s        |
+;;   9 select         -+
+;;  10 local.set $v
+;;  11 i32.const 2000  high-clamp val1 (deleted)
+;;  12 local.get $v    high-clamp val2 (survives — identity)
+;;  13 local.get $v   -+ high-clamp condition slice + select
+;;  14 i32.const 2000  | (deleted: ops 13..=16)
+;;  15 i32.gt_s        |
+;;  16 select         -+
+;;  17 end
+(module
+  (func (export "gust_mix") (param $ch i32) (result i32)
+    (local $v i32)
+    local.get $ch
+    i32.const 476
+    i32.add
+    local.set $v
+    ;; clamp low: max(v, 1000) = (v < 1000) ? 1000 : v
+    i32.const 1000
+    local.get $v
+    local.get $v
+    i32.const 1000
+    i32.lt_s
+    select
+    local.set $v
+    ;; clamp high: min(v, 2000) = (v > 2000) ? 2000 : v
+    i32.const 2000
+    local.get $v
+    local.get $v
+    i32.const 2000
+    i32.gt_s
+    select))

--- a/scripts/repro/fact_spec_select_494_differential.py
+++ b/scripts/repro/fact_spec_select_494_differential.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""VCR-PERF-002 Phase 3 (#494) — in-bounds differential for the fact-spec
+branchless SELECT-collapse elision (the Phase-2 clamp oracle's sibling).
+
+Builds the gust_mix clamp fixture lowered BRANCHLESSLY with `select` (the shape
+LLVM emits, and the shape Phase 2's `if`-elision cannot touch) WITH a schema-v1
+`wsc.facts` value-range premise appended (default: the proven bound
+ch ∈ [524, 1524]), compiles it twice — SPECIALIZED (SYNTH_FACT_SPEC=1) and
+UNSPECIALIZED (flag off) — and sweeps EVERY value of the premise bound under
+unicorn (Thumb-2), asserting the specialized result is identical to BOTH
+wasmtime ground truth and the unspecialized synth build. Out-of-bound
+divergence is EXPECTED AND CORRECT — the bound is the contract (mirrors gale's
+gust_floor_bench soundness gate mix_proven ≡ mix_native ≡ gust_mix on
+[524,1524]); this harness therefore only sweeps in-bounds.
+
+Non-vacuity: the run FAILS unless the specialized compile actually collapsed
+BOTH selects (2 "fact-spec: ADMIT" on stderr) and shrank gust_mix's .text — so
+a silently-dead lever cannot pass.
+
+Wrong-bound red/green path (the honest-fail contract):
+  --fact-lo/--fact-hi set the premise loom "claims"; the sweep covers that
+  claimed bound. With a deliberately-wrong bound (e.g. --fact-lo 0 --fact-hi
+  4000) the condition is not constant, the obligation is Sat and synth
+  DECLINES; pass --expect-decline to assert the declined build is byte-
+  identical to the flag-off baseline (frozen-safe by construction).
+
+Build (needs the `verify` feature for the ordeal obligation):
+  CARGO_TARGET_DIR=... cargo build -p synth-cli --features verify
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=$CARGO_TARGET_DIR/debug/synth \
+    python scripts/repro/fact_spec_select_494_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import UC_ARM_REG_LR, UC_ARM_REG_R0, UC_ARM_REG_SP
+
+WAT = Path(__file__).with_name("fact_spec_select_494.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+FUNC = "gust_mix"
+
+
+# ---- schema-v1 wsc.facts encoding (docs/design/wsc-facts-encoding.md) ----
+
+def leb_u32(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7F
+        v >>= 7
+        out.append(b | (0x80 if v else 0))
+        if not v:
+            return bytes(out)
+
+
+def leb_s64(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7F
+        v >>= 7
+        done = (v == 0 and not (b & 0x40)) or (v == -1 and (b & 0x40))
+        out.append(b | (0 if done else 0x80))
+        if done:
+            return bytes(out)
+
+
+def facts_payload(func_index, value_id, lo, hi):
+    body = leb_s64(lo) + leb_s64(hi)
+    return (
+        b"\x01"                      # version 1
+        + leb_u32(1)                 # count
+        + b"\x01"                    # kind: value-range
+        + leb_u32(func_index)
+        + leb_u32(value_id)
+        + leb_u32(len(body))
+        + body
+    )
+
+
+def append_custom_section(wasm, name, payload):
+    content = leb_u32(len(name)) + name + payload
+    return wasm + b"\x00" + leb_u32(len(content)) + content
+
+
+# ---- compile + load ----
+
+def compile_elf(wasm_path, out, fact_spec):
+    env = {"PATH": "/usr/bin:/bin"}
+    if fact_spec:
+        env["SYNTH_FACT_SPEC"] = "1"
+    r = subprocess.run(
+        [SYNTH, "compile", str(wasm_path), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env=env,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({out}): {r.stderr}")
+    return r.stderr
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    sizes = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+                    sizes[sym.name] = sym["st_size"]
+    return data, base, syms, sizes
+
+
+def run_arm(code, base, addr, arg):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(base & ~0xFFFF, 0x20000)
+    mu.mem_write(base, code)
+    mu.mem_map(0x90000, 0x10000)
+    ret = 0x90100
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_SP, 0x98000)
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    mu.emu_start(addr | 1, ret, timeout=5_000_000)
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fact-lo", type=int, default=524,
+                    help="value-range premise lower bound (the loom claim)")
+    ap.add_argument("--fact-hi", type=int, default=1524,
+                    help="value-range premise upper bound")
+    ap.add_argument("--expect-decline", action="store_true",
+                    help="assert the collapse was DECLINED (wrong-bound green path)")
+    args = ap.parse_args()
+
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth with `--features verify` first")
+
+    # Build the facts-carrying module: fixture wasm + value-range on
+    # (func 0, value_id 0 = the local.get producing ch).
+    base_wasm = wasmtime.wat2wasm(WAT.read_text())
+    wasm = append_custom_section(
+        bytes(base_wasm), b"wsc.facts",
+        facts_payload(0, 0, args.fact_lo, args.fact_hi))
+    wasm_path = "/tmp/fact_spec_select_494.wasm"
+    Path(wasm_path).write_bytes(wasm)
+
+    spec_elf = "/tmp/fact_spec_select_494_spec.elf"
+    base_elf = "/tmp/fact_spec_select_494_base.elf"
+    stderr_spec = compile_elf(wasm_path, spec_elf, fact_spec=True)
+    compile_elf(wasm_path, base_elf, fact_spec=False)
+
+    admits = stderr_spec.count("fact-spec: ADMIT")
+    declines = stderr_spec.count("fact-spec: DECLINE")
+    print(f"specialized compile: {admits} ADMIT, {declines} DECLINE")
+
+    scode, sbase, ssyms, ssizes = load(spec_elf)
+    bcode, bbase, bsyms, bsizes = load(base_elf)
+    ssize = ssizes.get(FUNC) or len(scode)
+    bsize = bsizes.get(FUNC) or len(bcode)
+    print(f"{FUNC} size: unspecialized {bsize} B -> specialized {ssize} B "
+          f"(win {bsize - ssize} B)")
+
+    if args.expect_decline:
+        if admits != 0:
+            sys.exit(f"expected DECLINE under bound [{args.fact_lo},{args.fact_hi}] "
+                     f"but {admits} selects collapsed")
+        if scode != bcode:
+            sys.exit("declined build must be byte-identical to baseline")
+        print("ORACLE: PASS (declined loudly, branchless select retained)")
+        return
+
+    # Non-vacuity: BOTH selects must actually collapse.
+    if admits != 2:
+        sys.exit(f"expected 2 certificate-backed select collapses, got {admits} — "
+                 f"stderr:\n{stderr_spec}")
+    if ssize >= bsize:
+        sys.exit("specialized gust_mix did not shrink — collapse did not reach codegen")
+
+    # wasmtime ground truth.
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, wasm)
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    gm = inst.exports(st)[FUNC]
+
+    # In-bounds sweep — the proven bound, and ONLY the proven bound.
+    fails = 0
+    for ch in range(args.fact_lo, args.fact_hi + 1):
+        gt = gm(st, ch) & 0xFFFFFFFF
+        got_spec = run_arm(scode, sbase, ssyms[FUNC], ch)
+        got_base = run_arm(bcode, bbase, bsyms[FUNC], ch)
+        if not (got_spec == gt == got_base):
+            fails += 1
+            if fails <= 10:
+                print(f"FAIL ch={ch}: wasmtime={gt} specialized={got_spec} "
+                      f"unspecialized={got_base}")
+    n = args.fact_hi - args.fact_lo + 1
+    print(f"swept {n} in-bounds values on [{args.fact_lo}, {args.fact_hi}]")
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails}/{n})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## VCR-PERF-002 Phase 3 (#494, #242) — branchless select-collapse

Extends the fact-spec pass (`synth-verify`) with a **ValueRange-driven
select-collapse** — the branchless sibling of Phase-2's no-else `if` elision,
and the shape gust_mix's clamp actually lowers to.

### Why this shape
Phase 2 collapsed the `if`-based clamp. But a real optimizing front-end (and
LLVM) lowers `clamp(v, lo, hi)` **branchlessly** with `select`
(`max(v,1000) = (v<1000)?1000:v`, `min(v,2000) = (v>2000)?2000:v`). The shipped
pass declined on that form: `Select` was an untracked op that stopped the walk.
This makes the #494 headline worked example — `clamp(ch+476,1000,2000)` with
`ch∈[524,1524]` collapsing to `add r0,#476; bx lr` — actually fire on the
branchless code LLVM emits.

### What it does
At every `select`, under the accumulated premise `P`, the pass discharges one of
two mutually exclusive, certificate-checked QF_BV obligations via the
ordeal-backed solver:
- `UNSAT(P ∧ cond ≠ 0)` ⇒ collapse to the false-arm (`val2`)
- `UNSAT(P ∧ cond == 0)` ⇒ collapse to the true-arm (`val1`)

Admit deletes the dead operand slice + condition slice + the `select` mux,
**reusing Phase-2's `deletions` stream-rewrite path** — no selector or
`CompileConfig` change. Sat (both arms reachable), Unknown, or an
impure/non-contiguous erasable slice **DECLINE LOUDLY** and the general
branchless select stands (the honest-fail contract).

### Scope note (new elision class, existing fact kind)
This consumes the existing `ValueRange` fact kind (0x01) — it is a **new
*elision* class, not a new fact-kind byte**. On gust_mix that is the only
option: its const shifts are already folded (#686), it has no memory op and no
typed select, so `ShiftBound`/`InBoundsAccess`/`SelectTotality` would fire on
*nothing* there and force an entirely synthetic fixture. The dominant #494
intent is the gust_mix clamp collapse, which is branchless — so the on-target,
measurable increment is select-collapse.

### Measurement (byte proxy)
Under the proven bound `ch∈[524,1524]`, gust_mix's two branchless clamps both
collapse to the identity operand:

```
gust_mix (symtab st_size):  50 B  ->  14 B   (-36 B, -72%)
```

That reaches the **same 14 B floor** as Phase-2's if-elision, on the shape LLVM
structurally cannot beat (it never had the bound).

**Honest floor caveat:** the #494 `0.45×` floor is gale's qemu `-icount`
**cycles** + STM32F100 DWT — this PR measures a **byte** proxy only. The cycle
kill-criterion (`<1.0×` then `≤0.70×` vs native LLVM) is **gale-silicon-measured
and remains OPEN**; the rivet status stays `implemented` (untouched) and
`claims.yaml` is unchanged.

### Oracles (both CI-gated in the fact-spec-oracle job)
- **4 fact_spec unit gates**: both-collapse under the bound; wrong-bound Sat
  loud-decline byte-identity; true-arm (Case A) collapse; non-constraining-
  premise decline.
- **`scripts/repro/fact_spec_select_494_differential.py`**: specialized ≡
  wasmtime ≡ unspecialized over the proven bound `[524,1524]` (1001-value
  unicorn Thumb-2 sweep), 2-collapse + shrink non-vacuity, and the wrong-bound
  `--expect-decline` byte-identity leg.

Differential command:
```
CARGO_TARGET_DIR=... cargo build -p synth-cli --features verify
SYNTH=$CARGO_TARGET_DIR/debug/synth python scripts/repro/fact_spec_select_494_differential.py
```

### Verification run
- `cargo clippy --workspace --all-targets -- -D warnings` — green
- `cargo fmt --check` — green
- fact_spec unit gates (23) — green; Phase-2 clamp (4) + Phase-2b div (4) — green
- frozen fixtures (10/10) — byte-identical (flag+facts gated, frozen-safe)
- differential green path (1001 values PASS) + wrong-bound decline (byte-identical)

### Follow-ups (not in this PR)
- Case A (true-arm collapse) has unit coverage only; add an execution
  differential when a fixture exercises it (gust_mix collapses false-arm only).
- The cycle kill-criterion remains gale's to measure on silicon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)