### PR TITLE
feat(f32): #709 trunc-must-trap + #708 f32.load/reinterpret (+ f32-compare flag-clobber fix)

### DIFF
--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -6814,18 +6814,20 @@ impl ArmEncoder {
         let mut bytes = Vec::new();
         let rd_bits = reg_to_bits(rd);
 
-        // VCMP.F32 Sn, Sm
-        let sn_num = vfp_sreg_to_num(sn)?;
-        let sm_num = vfp_sreg_to_num(sm)?;
-        let (vd, d) = encode_sreg(sn_num);
-        let (vm, m) = encode_sreg(sm_num);
-        let vcmp = 0xEEB40A40 | (d << 22) | (vd << 12) | (m << 5) | vm;
-        bytes.extend_from_slice(&vfp_to_thumb_bytes(vcmp));
+        // #709 (bug found under #708/#709): the `MOVS Rd,#0` below is a
+        // FLAG-SETTING 16-bit move. Emitting it AFTER `VMRS APSR_nzcv, FPSCR`
+        // (as the original code did) clobbered the N/Z/C/V flags the VMRS just
+        // transferred from the VFP compare, so the following `IT<cond>` read
+        // stale flags and every f32 comparison silently returned 0 (verified:
+        // `flt(1.0,2.0)` → 0 on Cortex-M4F). The 619 harness never caught it
+        // because it deliberately skipped compare EXECUTION on a false premise
+        // (unicorn DOES model VMRS→APSR). Fix: materialize the `#0` FIRST, then
+        // VCMP+VMRS set the flags the `IT` consumes. Instruction sizes are
+        // unchanged (pure reorder), so the estimator↔encoder oracle (#511) is
+        // untouched — only the byte ORDER differs.
 
-        // VMRS APSR_nzcv, FPSCR: 0xEEF1FA10
-        bytes.extend_from_slice(&vfp_to_thumb_bytes(0xEEF1FA10));
-
-        // MOVS Rd, #0 (16-bit): 0010 0 Rd(3) 0000 0000
+        // MOVS Rd, #0 (16-bit): 0010 0 Rd(3) 0000 0000 — its flag side effect
+        // is immediately overwritten by the VMRS below.
         if rd_bits < 8 {
             let movs_zero: u16 = 0x2000 | ((rd_bits as u16) << 8);
             bytes.extend_from_slice(&movs_zero.to_le_bytes());
@@ -6836,6 +6838,17 @@ impl ArmEncoder {
             bytes.extend_from_slice(&hw1.to_le_bytes());
             bytes.extend_from_slice(&hw2.to_le_bytes());
         }
+
+        // VCMP.F32 Sn, Sm
+        let sn_num = vfp_sreg_to_num(sn)?;
+        let sm_num = vfp_sreg_to_num(sm)?;
+        let (vd, d) = encode_sreg(sn_num);
+        let (vm, m) = encode_sreg(sm_num);
+        let vcmp = 0xEEB40A40 | (d << 22) | (vd << 12) | (m << 5) | vm;
+        bytes.extend_from_slice(&vfp_to_thumb_bytes(vcmp));
+
+        // VMRS APSR_nzcv, FPSCR: 0xEEF1FA10 (sets the flags IT consumes)
+        bytes.extend_from_slice(&vfp_to_thumb_bytes(0xEEF1FA10));
 
         // IT<cond> — If-Then for conditional MOV
         // IT encoding: 1011 1111 cond(4) mask(4)

--- a/crates/synth-backend/tests/f32_vfp_encoding_test.rs
+++ b/crates/synth-backend/tests/f32_vfp_encoding_test.rs
@@ -275,19 +275,26 @@ fn test_f32_eq_comparison_thumb() {
             sm: VfpReg::S0,
         })
         .unwrap();
-    // Should be: VCMP(4) + VMRS(4) + MOVS(2) + IT(2) + MOV(2) = 14 bytes
+    // #709: MOVS Rd,#0 is emitted BEFORE the VCMP so its flag side-effect is
+    // overwritten by VMRS (a MOVS after VMRS clobbered the transferred flags,
+    // making every f32 compare return 0). Order: MOVS(2) + VCMP(4) + VMRS(4) +
+    // IT(2) + MOV(2) = 14 bytes (sizes unchanged; only the byte order moved).
     assert_eq!(
         bytes.len(),
         14,
         "F32 comparison should be 14 bytes for low regs"
     );
 
-    // First 4 bytes: VCMP.F32 S0, S0
-    let vcmp = thumb_bytes_to_word(&bytes[0..4]);
+    // First 2 bytes: MOVS R0, #0 (its flags are overwritten by the VMRS below).
+    let movs = u16::from_le_bytes([bytes[0], bytes[1]]);
+    assert_eq!(movs, 0x2000, "MOVS R0, #0 must precede the VCMP (#709)");
+
+    // Bytes 2..6: VCMP.F32 S0, S0
+    let vcmp = thumb_bytes_to_word(&bytes[2..6]);
     assert_eq!(vcmp, 0xEEB40A40, "VCMP.F32 S0, S0");
 
-    // Next 4 bytes: VMRS APSR_nzcv, FPSCR
-    let vmrs = thumb_bytes_to_word(&bytes[4..8]);
+    // Bytes 6..10: VMRS APSR_nzcv, FPSCR — sets the flags the IT consumes.
+    let vmrs = thumb_bytes_to_word(&bytes[6..10]);
     assert_eq!(vmrs, 0xEEF1FA10, "VMRS APSR_nzcv, FPSCR");
 }
 

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -1906,10 +1906,21 @@ fn convert_operator(op: &wasmparser::Operator) -> Option<WasmOp> {
         F32Gt => Some(WasmOp::F32Gt),
         F32Ge => Some(WasmOp::F32Ge),
         F32Const { value } => Some(WasmOp::F32Const(f32::from_bits(value.bits()))),
-        // F32Load / F32Store (linear-memory f32 access) stay dropped in phase 1
-        // — VFP VLDR/VSTR take a [Rn,#imm] address, so the computed base+offset
-        // needs an extra materialization the phase-1 selector does not yet emit.
-        // They loud-skip at decode (phase 1b).
+        // #708 (phase 1b): `f32.load` un-dropped. The selector lowers it as the
+        // proven `i32.load` address sequence (`[R11,idx]`→absolute-base rewrite +
+        // bounds guard) into a core register, then a bit-exact `VMOV Sd,Rd`
+        // (reinterpret) — a VLDR loads the same 4 bytes, so the bit pattern is
+        // identical. `f32.store` STAYS dropped (falcon's #369 inventory needs
+        // only the load + reinterpret; the store loud-skips at decode until a
+        // consumer needs it — never a silent miscompile).
+        F32Load { memarg } => Some(WasmOp::F32Load {
+            offset: memarg.offset as u32,
+            align: memarg.align as u32,
+        }),
+        // #708 (phase 1b): the f32<->i32 bit-casts. Pure `VMOV` between a core
+        // register and a single-precision S-register — no numeric conversion.
+        F32ReinterpretI32 => Some(WasmOp::F32ReinterpretI32),
+        I32ReinterpretF32 => Some(WasmOp::I32ReinterpretF32),
         F32ConvertI32S => Some(WasmOp::F32ConvertI32S),
         F32ConvertI32U => Some(WasmOp::F32ConvertI32U),
         I32TruncF32S => Some(WasmOp::I32TruncF32S),

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -2015,6 +2015,14 @@ fn is_scope_f32_op(op: &WasmOp) -> bool {
             | F32ConvertI32U
             | I32TruncF32S
             | I32TruncF32U
+            // #708 (phase 1b): un-dropped f32 memory-load + f32<->i32 bitcasts.
+            // `F32Load` itself is lowered in the main `select_with_stack` match
+            // (it needs `self`'s bounds/base-rewrite machinery); listing it here
+            // trips the FPU gate (m3 honest-reject) and the S0 result-homing for
+            // a function whose only f32 op is the load.
+            | F32Load { .. }
+            | F32ReinterpretI32
+            | I32ReinterpretF32
     )
 }
 
@@ -2131,15 +2139,128 @@ fn try_lower_f32(
             Ok(true)
         }
         I32TruncF32S | I32TruncF32U => {
+            // #709 (SOUNDNESS): WASM Core §4.3.3 requires `i32.trunc_f32_{s,u}`
+            // to TRAP on NaN, ±∞, or an out-of-integer-range operand. ARM
+            // `VCVT.S32.F32`/`VCVT.U32.F32` instead SATURATE (NaN→0), so the
+            // bare VCVT was a silent miscompile. Emit a domain guard BEFORE the
+            // conversion; the VCVT then provably never saturates.
+            //
+            // Valid range (both bounds exactly representable in f32):
+            //   trunc_f32_s: -2^31 <= x < 2^31   (lo=-2147483648, hi=2147483648)
+            //   trunc_f32_u:  -1.0 <  x < 2^32   (lo=-1.0,        hi=4294967296)
+            // The guard reuses the div-by-zero trap idiom (`Cmp; B<cond> +0 to
+            // skip; Udf`) driven by the SHIPPED f32 compares, whose condition
+            // codes are ORDERED (F32Lt=MI, F32Ge=GE, F32Gt=GT) — every compare
+            // against NaN yields 0, so a NaN fails the in-range test and falls
+            // to the UDF. Two guards (upper then lower); NaN is caught by the
+            // first. `F32Lt` is STRICT, so `x == 2^31` (and `x == -1.0` for the
+            // unsigned lower bound via strict `F32Gt`) correctly traps.
+            let signed = matches!(op, I32TruncF32S);
             let sm = pop_float(stack)?;
             let rd = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
-            let arm = if matches!(op, I32TruncF32S) {
+
+            // (hi_bound, lo_bound, lower-guard-is-inclusive-GE-vs-strict-GT)
+            let (hi, lo) = if signed {
+                (2147483648.0_f32, -2147483648.0_f32) // 2^31, -2^31
+            } else {
+                (4294967296.0_f32, -1.0_f32) // 2^32, -1.0
+            };
+
+            // A guard: materialize `bound` into a scratch S-reg, set `rd` to the
+            // ordered compare result (`sm <cmp> bound`), then trap unless `rd!=0`.
+            let mut emit_guard = |bound: f32, cmp_is_lt: bool| -> Result<()> {
+                let s_bound = alloc_vfp_temp(vfp_used)?;
+                instructions.push(ArmInstruction {
+                    op: ArmOp::F32Const {
+                        sd: s_bound,
+                        value: bound,
+                    },
+                    source_line: Some(idx),
+                });
+                // Upper guard uses F32Lt (x < hi); lower guard uses F32Ge for the
+                // signed inclusive `x >= -2^31` and F32Gt for the unsigned strict
+                // `x > -1.0`. All three set rd=1 only when the ordered relation
+                // holds (rd=0 on NaN).
+                let cmp = if cmp_is_lt {
+                    ArmOp::F32Lt {
+                        rd,
+                        sn: sm,
+                        sm: s_bound,
+                    }
+                } else if signed {
+                    ArmOp::F32Ge {
+                        rd,
+                        sn: sm,
+                        sm: s_bound,
+                    }
+                } else {
+                    ArmOp::F32Gt {
+                        rd,
+                        sn: sm,
+                        sm: s_bound,
+                    }
+                };
+                instructions.push(ArmInstruction {
+                    op: cmp,
+                    source_line: Some(idx),
+                });
+                instructions.push(ArmInstruction {
+                    op: ArmOp::Cmp {
+                        rn: rd,
+                        op2: Operand2::Imm(0),
+                    },
+                    source_line: Some(idx),
+                });
+                // Skip the UDF when in-range (rd != 0); else fall through to trap.
+                instructions.push(ArmInstruction {
+                    op: ArmOp::BCondOffset {
+                        cond: Condition::NE,
+                        offset: 0,
+                    },
+                    source_line: Some(idx),
+                });
+                instructions.push(ArmInstruction {
+                    op: ArmOp::Udf { imm: 0 },
+                    source_line: Some(idx),
+                });
+                free_vfp_temp(vfp_used, vfp_home, s_bound);
+                Ok(())
+            };
+
+            emit_guard(hi, true)?; // upper: x < hi (also traps NaN)
+            emit_guard(lo, false)?; // lower: x >= lo (signed) / x > lo (unsigned)
+
+            // In-range: the saturating VCVT is now provably exact.
+            let arm = if signed {
                 ArmOp::I32TruncF32S { rd, sm }
             } else {
                 ArmOp::I32TruncF32U { rd, sm }
             };
             instructions.push(ArmInstruction {
                 op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_temp(vfp_used, vfp_home, sm);
+            stack.push(StackVal::i32(rd));
+            Ok(true)
+        }
+        F32ReinterpretI32 => {
+            // #708: i32 bits → f32 (VMOV Sd, Rm). Pure bit-cast, no conversion.
+            let rm = pop_operand(stack, next_temp, instructions, spill, reserved, idx)?;
+            let sd = alloc_vfp_temp(vfp_used)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::F32ReinterpretI32 { sd, rm },
+                source_line: Some(idx),
+            });
+            stack.push(StackVal::Float { sreg: sd });
+            Ok(true)
+        }
+        I32ReinterpretF32 => {
+            // #708: f32 bits → i32 (VMOV Rd, Sm). Pure bit-cast, no conversion.
+            let sm = pop_float(stack)?;
+            let rd = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::I32ReinterpretF32 { rd, sm },
                 source_line: Some(idx),
             });
             free_vfp_temp(vfp_used, vfp_home, sm);
@@ -2937,6 +3058,72 @@ impl InstructionSelector {
                 "Replacement::Inline not implemented — would silently emit NOP".to_string(),
             )),
         }
+    }
+
+    /// #709: the `i32.trunc_f32_{s,u}` domain guard (WASM Core §4.3.3), as a
+    /// sequence of `ArmOp`s to prepend before the saturating VCVT. Mirrors the
+    /// execution-oracle'd guard in the free-function `try_lower_f32`; see there
+    /// for the condition-code / NaN reasoning. Trap unless the operand is in the
+    /// exactly-representable valid range (signed: `-2^31 <= x < 2^31`; unsigned:
+    /// `-1.0 < x < 2^32`). Ordered compares (F32Lt=MI, F32Ge=GE, F32Gt=GT) each
+    /// yield 0 on NaN, so a NaN fails the in-range test and falls to the UDF.
+    fn f32_trunc_range_guard(&mut self, rd: Reg, sm: VfpReg, signed: bool) -> Vec<ArmOp> {
+        let (hi, lo) = if signed {
+            (2147483648.0_f32, -2147483648.0_f32) // 2^31, -2^31
+        } else {
+            (4294967296.0_f32, -1.0_f32) // 2^32, -1.0
+        };
+        let s_hi = self.alloc_vfp_reg();
+        let s_lo = self.alloc_vfp_reg();
+        let lower = if signed {
+            ArmOp::F32Ge {
+                rd,
+                sn: sm,
+                sm: s_lo,
+            } // inclusive x >= -2^31
+        } else {
+            ArmOp::F32Gt {
+                rd,
+                sn: sm,
+                sm: s_lo,
+            } // strict x > -1.0
+        };
+        vec![
+            // Upper bound: trap unless x < hi (also traps NaN).
+            ArmOp::F32Const {
+                sd: s_hi,
+                value: hi,
+            },
+            ArmOp::F32Lt {
+                rd,
+                sn: sm,
+                sm: s_hi,
+            },
+            ArmOp::Cmp {
+                rn: rd,
+                op2: Operand2::Imm(0),
+            },
+            ArmOp::BCondOffset {
+                cond: Condition::NE,
+                offset: 0,
+            },
+            ArmOp::Udf { imm: 0 },
+            // Lower bound: trap unless x >= lo (signed) / x > lo (unsigned).
+            ArmOp::F32Const {
+                sd: s_lo,
+                value: lo,
+            },
+            lower,
+            ArmOp::Cmp {
+                rn: rd,
+                op2: Operand2::Imm(0),
+            },
+            ArmOp::BCondOffset {
+                cond: Condition::NE,
+                offset: 0,
+            },
+            ArmOp::Udf { imm: 0 },
+        ]
     }
 
     /// Select default ARM instruction(s) for a WASM operation (no pattern match)
@@ -4206,13 +4393,22 @@ impl InstructionSelector {
                 vec![ArmOp::I32ReinterpretF32 { rd, sm }]
             }
 
+            // #709: domain guard before the saturating VCVT (see the identical,
+            // execution-oracle'd guard in `try_lower_f32`). This `select_default`
+            // path is the legacy pattern-matcher's fallback and is NOT reached by
+            // the shipping compile path (`select_with_stack`), so it is untested
+            // by the #709 differential — guarded here for soundness parity only.
             I32TruncF32S if self.fpu.is_some() => {
                 let sm = self.alloc_vfp_reg();
-                vec![ArmOp::I32TruncF32S { rd, sm }]
+                let mut seq = self.f32_trunc_range_guard(rd, sm, true);
+                seq.push(ArmOp::I32TruncF32S { rd, sm });
+                seq
             }
             I32TruncF32U if self.fpu.is_some() => {
                 let sm = self.alloc_vfp_reg();
-                vec![ArmOp::I32TruncF32U { rd, sm }]
+                let mut seq = self.f32_trunc_range_guard(rd, sm, false);
+                seq.push(ArmOp::I32TruncF32U { rd, sm });
+                seq
             }
 
             // F32 rounding pseudo-ops — emit ArmOp variants, encoder expands to
@@ -8630,6 +8826,80 @@ impl InstructionSelector {
                         });
                         stack.push(StackVal::i32(dst));
                     }
+                }
+
+                // #708 (phase 1b): `f32.load` — the VFP-load twin of the i32
+                // load. VLDR takes only a `[Rn,#imm]` address (no index reg) and
+                // the phase-1 selector does not model the static-data/native-
+                // pointer address rewrites, so rather than reinvent the address
+                // machinery we LOAD the 4-byte word with the PROVEN integer path
+                // (`generate_load_with_bounds_check`: the `[R11,idx]`→absolute-
+                // base rewrite + optional bounds guard) into a core register,
+                // then bit-cast it into an S-register with `VMOV Sd,Rd`. A VLDR
+                // would load the identical 4 bytes, so the result bit pattern is
+                // exact. Honest-decline the native-pointer static-data address
+                // mode (#359) we don't yet lower here — never a silent miscompile.
+                F32Load { offset, .. } => {
+                    if self.native_pointer_abi
+                        && self.wasm_data_base > 0
+                        && *offset >= self.wasm_data_base
+                    {
+                        return Err(synth_core::Error::synthesis(
+                            "GI-FPU-002 phase 1b: f32.load from the static-data \
+                             region under the native-pointer ABI is not yet \
+                             lowered (#359 address relocation) — declining"
+                                .to_string(),
+                        ));
+                    }
+                    // The i32.load path (#95/#237) relocates a CONST effective
+                    // address that lands in the static-data region; this f32.load
+                    // arm only lowers the dynamic-index (branch-3) form, so a
+                    // const static-data address would mis-address. Detect it with
+                    // the same helpers and DECLINE loudly (never a silent
+                    // miscompile). Dynamic-index loads — falcon's shape — are
+                    // unaffected (`try_fold_const_addr` returns None).
+                    if let Some(eff) = self.try_fold_const_addr(wasm_ops, idx, *offset)
+                        && self.static_data_addend(eff).is_some()
+                    {
+                        return Err(synth_core::Error::synthesis(
+                            "GI-FPU-002 phase 1b: f32.load from a constant \
+                             static-data address is not yet lowered (#237 \
+                             relocation) — declining"
+                                .to_string(),
+                        ));
+                    }
+                    let addr = pop_operand(
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    )?;
+                    // Core scratch for the loaded 32-bit word.
+                    let dst = alloc_temp_or_spill(
+                        &mut next_temp,
+                        &mut stack,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    )?;
+                    let load_ops =
+                        self.generate_load_with_bounds_check(dst, addr, *offset as i32, 4);
+                    for op in load_ops {
+                        instructions.push(ArmInstruction {
+                            op,
+                            source_line: Some(idx),
+                        });
+                    }
+                    // Bit-cast the loaded word into an S-register (VMOV Sd,Rd).
+                    let sd = alloc_vfp_temp(&mut vfp_used)?;
+                    instructions.push(ArmInstruction {
+                        op: ArmOp::F32ReinterpretI32 { sd, rm: dst },
+                        source_line: Some(idx),
+                    });
+                    stack.push(StackVal::Float { sreg: sd });
                 }
 
                 // Memory operations need stack-aware handling

--- a/scripts/repro/f32_mem_trunc_708_709.wat
+++ b/scripts/repro/f32_mem_trunc_708_709.wat
@@ -1,0 +1,15 @@
+(module
+  ;; #708/#709 phase-1b f32 differential fixture (thumb-2 hard-float).
+  ;;  * #709: `i32.trunc_f32_{s,u}` must TRAP (UDF) on NaN/±Inf/out-of-range —
+  ;;    the domain guard precedes the (now provably exact) VCVT.
+  ;;  * #708: `f32.load` (VLDR twin via LDR+VMOV bitcast) + the f32<->i32
+  ;;    reinterpret bit-casts (pure VMOV).
+  (memory 1)
+  (export "mem" (memory 0))
+  (func (export "trunc_s") (param f32) (result i32) local.get 0 i32.trunc_f32_s)
+  (func (export "trunc_u") (param f32) (result i32) local.get 0 i32.trunc_f32_u)
+  (func (export "load")    (param i32) (result f32) local.get 0 f32.load)
+  (func (export "r2i")     (param f32) (result i32) local.get 0 i32.reinterpret_f32)
+  (func (export "i2r")     (param i32) (result f32) local.get 0 f32.reinterpret_i32)
+  (func (export "rt")      (param i32) (result i32)
+        local.get 0 f32.reinterpret_i32 i32.reinterpret_f32))

--- a/scripts/repro/f32_mem_trunc_708_709_differential.py
+++ b/scripts/repro/f32_mem_trunc_708_709_differential.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""#708/#709 — EXECUTION-validate the phase-1b thumb-2 f32 increment.
+
+Two capabilities land on the v0.39.0 hard-float path:
+
+  #709 (SOUNDNESS): `i32.trunc_f32_s/u` were lowered to a BARE saturating VCVT
+    (NaN->0, out-of-range->saturated) where WASM Core §4.3.3 mandates a TRAP.
+    The fix emits a domain guard (VCMP against the exact f32-representable
+    bounds + VMRS + ordered conditional branch, div-by-zero-style `B<c> +0 / UDF`)
+    BEFORE the VCVT. This harness runs the exact #709 trap table on Cortex-M4F
+    under unicorn and asserts every NaN/Inf/out-of-range input STOPS AT A UDF
+    (like the #374/#642 trap oracles), while in-range inputs stay bit-exact vs
+    wasmtime.
+
+  #708: `f32.load` (lowered as the proven i32.load address sequence + a VMOV
+    bitcast into an S-register) and the `i32.reinterpret_f32` / `f32.reinterpret_i32`
+    bit-casts (pure VMOV). Asserted bit-exact vs wasmtime.
+
+RED on origin/main: `trunc` traps are MISSED (returns a saturated value, not a
+UDF) and `f32.load`/reinterpret REJECT at compile (capability gap) -> nonzero.
+GREEN after this PR -> exit 0.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=/path/to/synth python scripts/repro/f32_mem_trunc_708_709_differential.py
+"""
+import math
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_PC,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_S0,
+    UC_ARM_REG_SP,
+)
+
+try:
+    from unicorn.arm_const import UC_ARM_REG_C1_C0_2, UC_ARM_REG_FPEXC
+except ImportError:  # older unicorn naming
+    UC_ARM_REG_C1_C0_2 = None
+    UC_ARM_REG_FPEXC = None
+
+WAT = Path(__file__).with_name("f32_mem_trunc_708_709.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+# Linear-memory base the self-contained cortex-m image loads into R11/fp at
+# reset (cortex_m.rs: R11 = 0x2000_0000). The harness runs functions directly,
+# so we place a mapped window there and set R11 to it.
+MEMBASE = 0x20000000
+
+
+def compile_elf(out, target):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+         "--target", target, "--all-exports"],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"},
+    )
+    return r.returncode == 0, (r.stderr + r.stdout)
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":  # #489: synth emits an unnamed symtab
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+    return data, base, syms
+
+
+def f32_bits(x):
+    return struct.unpack("<I", struct.pack("<f", x))[0]
+
+
+def bits_f32(b):
+    return struct.unpack("<f", struct.pack("<I", b & 0xFFFFFFFF))[0]
+
+
+def new_uc(text, text_base):
+    uc = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    map_base = text_base & ~0xFFF
+    size = ((len(text) + (text_base - map_base)) + 0xFFF) & ~0xFFF
+    uc.mem_map(map_base, max(size, 0x1000))
+    uc.mem_write(text_base, text)
+    uc.mem_map(0x30000, 0x10000)  # stack
+    uc.mem_map(MEMBASE, 0x10000)  # linear memory window (R11/fp base)
+    uc.reg_write(UC_ARM_REG_SP, 0x38000)
+    uc.reg_write(UC_ARM_REG_R11, MEMBASE)
+    # Enable the FPU (M4F FPU is off at reset): CPACR CP10/CP11 + FPEXC.EN.
+    if UC_ARM_REG_C1_C0_2 is not None:
+        uc.reg_write(UC_ARM_REG_C1_C0_2, 0x00F00000)
+    if UC_ARM_REG_FPEXC is not None:
+        uc.reg_write(UC_ARM_REG_FPEXC, 0x40000000)
+    return uc
+
+
+def run(text, base, addr, *, s0=None, r0=None):
+    """Execute one function. Returns ('ok', uc) or ('trap-udf', pc) or ('fault', msg)."""
+    uc = new_uc(text, base)
+    if s0 is not None:
+        uc.reg_write(UC_ARM_REG_S0, s0)
+    if r0 is not None:
+        uc.reg_write(UC_ARM_REG_R0, r0 & 0xFFFFFFFF)
+    ret = 0x38000
+    from unicorn.arm_const import UC_ARM_REG_LR
+    uc.reg_write(UC_ARM_REG_LR, ret | 1)
+    try:
+        uc.emu_start(addr | 1, ret & ~1, count=200)
+    except UcError as e:
+        pc = uc.reg_read(UC_ARM_REG_PC)
+        if base <= pc < base + len(text):
+            hw = struct.unpack("<H", text[pc - base : pc - base + 2])[0]
+            if hw & 0xFF00 == 0xDE00:  # Thumb UDF #imm
+                return ("trap-udf", pc)
+        return ("fault", f"{e} at pc={pc:#x} (NOT a udf trap)")
+    return ("ok", uc)
+
+
+def wasm_instance():
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    store = wasmtime.Store(eng)
+    inst = wasmtime.Instance(store, mod, [])
+    return store, inst
+
+
+# ---- #709 trap tables (the EXACT issue table) -----------------------------
+NAN = float("nan")
+INF = float("inf")
+TRUNC_S = [
+    (2.5, "ok"), (NAN, "trap"), (INF, "trap"), (-INF, "trap"),
+    (3e9, "trap"), (-3e9, "trap"), (2147483648.0, "trap"),  # 2^31 exactly
+    # extra in-range bit-exact anchors:
+    (0.0, "ok"), (-2.5, "ok"), (123.75, "ok"), (-123.75, "ok"),
+    (2147483000.0, "ok"), (-2147483648.0, "ok"),  # -2^31 exactly is IN range
+]
+TRUNC_U = [
+    (2.5, "ok"), (NAN, "trap"), (-1.0, "trap"), (INF, "trap"), (5e9, "trap"),
+    # extra in-range bit-exact anchors:
+    (0.0, "ok"), (0.5, "ok"), (123.75, "ok"), (4000000000.0, "ok"),
+    (4294967000.0, "ok"),
+]
+
+
+def main():
+    elf = "/tmp/f32_mem_trunc_708_709.elf"
+
+    # Honest-reject on a no-FPU target (m3) must still hold.
+    ok_m3, _ = compile_elf("/tmp/f32_mt_m3.elf", "cortex-m3")
+    if ok_m3:
+        sys.exit("FAIL: f32 must be REJECTED on cortex-m3 (no FPU), but compiled")
+
+    ok, log = compile_elf(elf, "cortex-m4f")
+    if not ok:
+        print("RED: `synth compile -t cortex-m4f` REJECTED the f32 fixture.")
+        print(log.strip()[:600])
+        sys.exit(1)
+
+    text, base, syms = load(elf)
+    store, inst = wasm_instance()
+    exp = inst.exports(store)
+    fails = 0
+    checked = 0
+
+    def wasm_call_or_trap(fn, *args):
+        try:
+            return exp[fn](store, *args)
+        except wasmtime.Trap:
+            return "trap"
+
+    # ---- #709 trunc trap tables ----
+    for fn, table in (("trunc_s", TRUNC_S), ("trunc_u", TRUNC_U)):
+        for x, want_kind in table:
+            kind, payload = run(text, base, syms[fn], s0=f32_bits(x))
+            wv = wasm_call_or_trap(fn, x)
+            checked += 1
+            xr = "NaN" if math.isnan(x) else repr(x)
+            if want_kind == "trap":
+                if wv != "trap":
+                    sys.exit(f"BUG in oracle: wasmtime did not trap on {fn}({xr})")
+                if kind == "trap-udf":
+                    print(f"[#709] {fn}({xr}) -> UDF trap @ {payload:#x} "
+                          f"(wasmtime: trap) OK")
+                else:
+                    fails += 1
+                    print(f"[#709] {fn}({xr}) -> {kind}:{payload} "
+                          f"(wasmtime: trap) MISMATCH — MISSED TRAP")
+            else:
+                want = wv & 0xFFFFFFFF
+                if kind != "ok":
+                    fails += 1
+                    print(f"[#709] {fn}({xr}) -> {kind}:{payload} "
+                          f"(wasmtime: {want}) MISMATCH — spurious trap")
+                    continue
+                got = payload.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+                if got != want:
+                    fails += 1
+                    print(f"[#709] {fn}({xr}) -> {got} != wasmtime {want} MISMATCH")
+                else:
+                    print(f"[#709] {fn}({xr}) = {got} (wasmtime: {want}) OK")
+
+    # ---- #708 f32.load: write a known word, load it, compare bits ----
+    mem = exp["mem"]
+    LOAD_CASES = [(0, 0x3FC00000),   # 1.5
+                  (16, 0xC0100000),  # -2.25
+                  (64, 0x7F800000),  # +Inf bit pattern (load is a pure bitcopy)
+                  (128, 0x00000001)]  # subnormal-ish tiny
+    for addr, word in LOAD_CASES:
+        # seed wasmtime + unicorn memories identically
+        mem.write(store, struct.pack("<I", word), addr)
+        uc = new_uc(text, base)
+        uc.mem_write(MEMBASE + addr, struct.pack("<I", word))
+        from unicorn.arm_const import UC_ARM_REG_LR
+        uc.reg_write(UC_ARM_REG_R0, addr)
+        uc.reg_write(UC_ARM_REG_LR, 0x38000 | 1)
+        uc.emu_start(syms["load"] | 1, 0x38000, count=200)
+        got = uc.reg_read(UC_ARM_REG_S0) & 0xFFFFFFFF
+        want = f32_bits(exp["load"](store, addr))
+        checked += 1
+        if got != want or got != word:
+            fails += 1
+            print(f"[#708] load[{addr}] -> 0x{got:08x} != want 0x{want:08x} "
+                  f"(mem 0x{word:08x}) MISMATCH")
+        else:
+            print(f"[#708] load[{addr}] = 0x{got:08x} (wasmtime bit-exact) OK")
+
+    # ---- #708 reinterprets + round-trip ----
+    REINT = [0x3FC00000, 0xC0100000, 0x7FC00000, 0x80000000, 0x00000000,
+             0xFFFFFFFF, 0x12345678]
+    for word in REINT:
+        # i32.reinterpret_f32(x): S0 bits -> R0 (== bits)
+        kind, uc = run(text, base, syms["r2i"], s0=word)
+        got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF if kind == "ok" else None
+        want = exp["r2i"](store, bits_f32(word)) & 0xFFFFFFFF
+        checked += 1
+        if got != want or got != word:
+            fails += 1
+            print(f"[#708] r2i(0x{word:08x}) -> {got} != want 0x{want:08x} MISMATCH")
+        else:
+            print(f"[#708] r2i(0x{word:08x}) = 0x{got:08x} OK")
+
+        # f32.reinterpret_i32(i): R0 -> S0 (== bits)
+        kind, uc = run(text, base, syms["i2r"], r0=word)
+        got = uc.reg_read(UC_ARM_REG_S0) & 0xFFFFFFFF if kind == "ok" else None
+        want = f32_bits(exp["i2r"](store, word))
+        checked += 1
+        if got != want or got != word:
+            fails += 1
+            print(f"[#708] i2r(0x{word:08x}) -> {got} != want 0x{want:08x} MISMATCH")
+        else:
+            print(f"[#708] i2r(0x{word:08x}) = 0x{got:08x} OK")
+
+        # round-trip rt(i) == i
+        kind, uc = run(text, base, syms["rt"], r0=word)
+        got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF if kind == "ok" else None
+        checked += 1
+        if got != word:
+            fails += 1
+            print(f"[#708] rt(0x{word:08x}) -> {got} != 0x{word:08x} MISMATCH")
+        else:
+            print(f"[#708] rt(0x{word:08x}) = 0x{got:08x} OK")
+
+    if fails:
+        sys.exit(f"\nFAIL: {fails}/{checked} f32 #708/#709 results diverged")
+    print(f"\nGREEN: {checked}/{checked} f32 #708/#709 results correct "
+          f"(trap table + load + reinterpret; m3 honest-reject confirmed).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/f32_vfp_619_differential.py
+++ b/scripts/repro/f32_vfp_619_differential.py
@@ -71,15 +71,16 @@ I32_INPUTS = [0, 1, -1, 7, -7, 2147483647, -2147483648, 100000]
 TRUNC_INPUTS = [0.0, 1.9, -1.9, 2.5, -2.5, 123.75, -123.75, 2000000.5]
 
 BINOP_F32 = ["fadd", "fsub", "fmul", "fdiv"]
-# NOTE: the f32 comparisons (flt/fgt/…) compile to VCMP.F32 + VMRS APSR_nzcv,
-# FPSCR + IT + MOV. unicorn does NOT model the VMRS FPSCR->APSR flag transfer
-# (the APSR flags stay 0, so every predicated set reads false and the result is
-# uniformly 0) — an EMULATOR gap, not a synth defect. The compare ENCODING is
-# byte-pinned in crates/synth-backend/tests/f32_vfp_encoding_test.rs and the MI
-# (a<b) / GT (a>b) condition selection is verified by inspection, so we exercise
-# the compares at COMPILE time (they are in the fixture) but do not execution-
-# differentiate them here. Arithmetic, convert, and trunc use no flag transfer
-# and are fully validated below.
+CMP_F32 = ["flt", "fgt"]
+# The f32 comparisons compile to VCMP.F32 + VMRS APSR_nzcv, FPSCR + IT + MOV.
+# HISTORY (#709): this harness ORIGINALLY skipped compare execution on the
+# premise that "unicorn does not model the VMRS FPSCR->APSR transfer." That
+# premise was FALSE — unicorn transfers the N/Z/C/V bits correctly — and the
+# skip is exactly why a shipped compare bug went unnoticed: the encoder emitted
+# a flag-setting `MOVS Rd,#0` AFTER the VMRS, clobbering the transferred flags,
+# so every f32 comparison returned 0. The encoder now materializes the #0
+# BEFORE the VCMP (byte reorder, sizes unchanged), and the compares are
+# execution-differentiated here against wasmtime on FPU-boundary values.
 
 
 def compile_elf(out, target):
@@ -179,6 +180,19 @@ def main():
                 fails += 1
                 print(f"MISMATCH {fn}({a},{b}): synth 0x{got:08x} ({bits_f32(got)}) "
                       f"!= wasmtime 0x{want:08x} ({bits_f32(want)})")
+
+    # #709: the f32 comparisons now execution-differentiate (the flag-clobber
+    # bug is fixed). Result is an i32 (0/1) in R0.
+    for fn in CMP_F32:
+        wf = inst.exports(store)[fn]
+        for a, b in F32_PAIRS:
+            uc = run_unicorn(text, base, syms[fn], s0_bits=f32_bits(a), s1_bits=f32_bits(b))
+            got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            want = wf(store, a, b) & 0xFFFFFFFF
+            checked += 1
+            if got != want:
+                fails += 1
+                print(f"MISMATCH {fn}({a},{b}): synth {got} != wasmtime {want}")
 
     wf = inst.exports(store)["trunc_s"]
     for a in TRUNC_INPUTS:


### PR DESCRIPTION
Phase-1b of the thumb-2 f32 hard-float path (v0.39.0 GI-FPU-002). Closes the #709 soundness bug, un-blocks falcon's f32 float functions (#708), and fixes a shipped f32-compare bug found underneath.

Refs #709, #708, #369, #242.

## 1. #709 — `i32.trunc_f32_{s,u}` must TRAP, not saturate (SOUNDNESS)

The bare `VCVT.S32.F32`/`VCVT.U32.F32` saturates (NaN→0, out-of-range→clamped) where WASM Core §4.3.3 mandates a trap. A domain guard now precedes the (now provably exact) VCVT.

**Trap bounds** (all four exactly representable in f32):
- `trunc_f32_s` valid iff `-2^31 <= x < 2^31`  (lo `0xCF000000`, hi `0x4F000000`)
- `trunc_f32_u` valid iff `-1.0 < x < 2^32`     (lo `0xBF800000`, hi `0x4F800000`)

**Lowering** (reuses the div-by-zero trap idiom — no new ArmOp, no encoder change):
```
; upper: trap unless x < hi  (F32Lt = ordered MI → 0 on NaN, STRICT)
movs r1,#0 ; vmov s1,<hi> ; vcmp.f32 s0,s1 ; vmrs APSR_nzcv,fpscr ; it mi ; movmi r1,#1
cmp r1,#0 ; bne +2 ; udf #0
; lower: trap unless x >= lo (signed, F32Ge) / x > lo (unsigned, strict F32Gt)
... ; udf #0
vcvt.s32.f32 s0,s0   ; provably never saturates
```
Every ordered compare yields 0 on NaN, so NaN fails the in-range test and falls to the UDF. `F32Lt`/`F32Gt` are strict, so `x==2^31` and `x==-1.0` trap; `x==-2^31` is in-range (inclusive `F32Ge`). Guarded in the shipping path (`try_lower_f32`) and the legacy `select_default` fallback (soundness parity; that path is not reached by `select_with_stack`, so it is untested by the oracle).

### #709 trap-table oracle (Cortex-M4F / unicorn vs wasmtime)
```
[#709] trunc_s(2.5) = 2 (wasmtime: 2) OK
[#709] trunc_s(NaN) -> UDF trap @ 0xde (wasmtime: trap) OK
[#709] trunc_s(inf) -> UDF trap @ 0xde (wasmtime: trap) OK
[#709] trunc_s(-inf) -> UDF trap @ 0xfe (wasmtime: trap) OK
[#709] trunc_s(3e9) -> UDF trap @ 0xde (wasmtime: trap) OK
[#709] trunc_s(-3e9) -> UDF trap @ 0xfe (wasmtime: trap) OK
[#709] trunc_s(2^31) -> UDF trap @ 0xde (wasmtime: trap) OK
[#709] trunc_s(-2^31) = 2147483648 (wasmtime: 2147483648) OK   # in-range (inclusive)
[#709] trunc_u(2.5) = 2 (wasmtime: 2) OK
[#709] trunc_u(NaN) -> UDF trap @ 0x132 (wasmtime: trap) OK
[#709] trunc_u(-1.0) -> UDF trap @ 0x152 (wasmtime: trap) OK
[#709] trunc_u(inf) -> UDF trap @ 0x132 (wasmtime: trap) OK
[#709] trunc_u(5e9) -> UDF trap @ 0x132 (wasmtime: trap) OK
(+ in-range bit-exact anchors: 0.0, ±123.75, 2147483000, 4e9, 4294967000, …)
```

## 2. #708 — `f32.load` + `i32.reinterpret_f32` / `f32.reinterpret_i32`

Un-dropped at decode (falcon's #369 residual: 13 `F32Load` + 7 reinterpret skips). 

- **f32.load** is lowered as the PROVEN `i32.load` address sequence (`generate_load_with_bounds_check`: the `[R11,idx]`→absolute-base rewrite + optional bounds guard) into a core register, then a bit-exact `VMOV Sd,Rd`. A VLDR would load the identical 4 bytes — and note `encode_vfp_ldst` silently **drops** the index register, so a direct `VLDR [R11,idx]` (as the dead `select_default` arm does) would MISS the dynamic index. Const static-data addresses (#237) and native-pointer static region (#359) **decline loudly** (not yet relocated) — dynamic-index loads (falcon's shape) are unaffected.
- **reinterprets** are pure `VMOV` bit-casts.

### #708 load/reinterpret oracle (bit-exact vs wasmtime)
```
[#708] load[0]  = 0x3fc00000  OK      [#708] load[16] = 0xc0100000 OK
[#708] load[64] = 0x7f800000  OK      [#708] load[128]= 0x00000001 OK
[#708] r2i/i2r/rt over {1.5,-2.25,NaN,-0.0,0,0xFFFFFFFF,0x12345678} — all bit-exact, round-trip clean
```

## 3. Bug found underneath: shipped f32 comparisons silently returned 0

The v0.39.0 f32 compares emitted a flag-setting `MOVS Rd,#0` **after** `VMRS APSR_nzcv,FPSCR`, clobbering the flags the VMRS just transferred; the following `IT<cond>` read stale flags. Verified on Cortex-M4F: `flt(1.0,2.0) → 0`. It shipped because the 619 differential **skipped compare execution** on a false premise ("unicorn doesn't model VMRS→APSR" — it does). Fix: materialize `#0` before the VCMP (pure byte reorder, sizes unchanged → estimator↔encoder oracle #511 untouched). The 619 harness now **execution-tests** the compares (60/60 bit-exact vs wasmtime), and its false comment is corrected.

## Declined (loud, never silent)
- **f32.store** — falcon's inventory needs only load + reinterpret; stays dropped at decode (honest skip).
- **f32.load** from a const static-data address (#237) or native-pointer static region (#359) — loud decline.
- **f32.convert_i64**, **f32.demote_f64**, f64 ops — out of phase-1 scope (unchanged).
- Cross-backend: `-b riscv` / `-b aarch64` honest-reject the newly-decoded ops ("unsupported wasm op"), verified.

## Known follow-up
`encode_thumb_f64_compare` has the same MOVS-after-VMRS twin; f64 is dropped at decode (phase 2) so it never ships and no harness exercises it — fix when f64 lands.

## Verification
- **48/48** GREEN — `scripts/repro/f32_mem_trunc_708_709_differential.py` (trap table + load + reinterpret; m3 honest-reject confirmed).
- **60/60** GREEN — `scripts/repro/f32_vfp_619_differential.py` (now incl. compares).
- **Frozen anchors 10/10** — no existing fixture bytes change (f32 is a new path).
- `cargo test -p synth-cli -p synth-synthesis -p synth-backend -p synth-backend-riscv -p synth-backend-aarch64` green; `fmt --check` + `clippy -D warnings` clean.

DO NOT MERGE until the trap table is adversarially verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)