### PR TITLE
fix(#275): self-contained --cortex-m call_indirect — loud-decline the R11/linmem silent miscompile

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -381,6 +381,13 @@ fn compile_wasm_to_arm(
         // bounds guard + closed-world type verdicts). Without them, every
         // call_indirect lowering declines loudly.
         selector.set_call_indirect_guards(config.call_indirect_guards.clone());
+        // #275: on the self-contained image path (NOT --relocatable) decline
+        // call_indirect loudly — the R11 funcref-table region is only populated
+        // by an external runtime, which a self-contained ELF does not have, so
+        // the dispatch would read function pointers from linear-memory data (a
+        // silent miscompile). The host-linked (--relocatable) path keeps the
+        // guarded dispatch: there a runtime places the table region at R11.
+        selector.set_reject_self_contained_call_indirect(!config.relocatable);
         // #237: native-pointer ABI — wasm statics become __synth_wasm_data-relative.
         selector.set_native_pointer_abi(config.native_pointer_abi, config.linear_memory_bytes);
         // #311: i64 call results are register PAIRS — tag them.

--- a/crates/synth-cli/tests/call_indirect_275_selfcontained.rs
+++ b/crates/synth-cli/tests/call_indirect_275_selfcontained.rs
@@ -1,0 +1,140 @@
+//! #275 — the self-contained `--cortex-m` `call_indirect` silent-miscompile
+//! close (outcome B: loud decline).
+//!
+//! The self-contained image path (`build_multi_func_cortex_m_elf`, i.e. no
+//! `--relocatable`) has no runtime to populate the contiguous R11 funcref-table
+//! region — R11 is the linear-memory base — so the guarded dispatch would load
+//! function pointers from linear-memory DATA (a silent miscompile: `entry`
+//! compiled to `exit 0, 0 skips` but stored garbage). Until the dedicated
+//! func-table fix (silicon-gated) lands, the self-contained path DECLINES
+//! `call_indirect` LOUDLY (AFD-008: an unlowerable op must `Err`, never
+//! silently continue).
+//!
+//! This locks:
+//!  1. self-contained: the `call_indirect` function is LOUD-skipped (a `#275`
+//!     diagnostic + a skip count) and is ABSENT from the output — no silent
+//!     colliding dispatch is emitted; the non-`call_indirect` functions still
+//!     compile;
+//!  2. `--relocatable`: the SAME module still emits `entry` with its guarded
+//!     dispatch — the host-linked path (a runtime places the table region at
+//!     R11) is untouched (the #642/#650/#664/#676 oracles gate its bytes).
+
+use std::process::Command;
+
+use object::{Object, ObjectSymbol};
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro")
+        .join("call_indirect_275_selfcontained.wat")
+}
+
+fn has_symbol(bytes: &[u8], name: &str) -> bool {
+    let obj = object::File::parse(bytes).expect("parse object");
+    obj.symbols().any(|s| s.name() == Ok(name))
+}
+
+/// Outcome B: self-contained `--cortex-m` DECLINES `call_indirect` loudly —
+/// the function is skipped (named, counted) and absent from the ELF, never a
+/// silent colliding dispatch.
+#[test]
+fn test_275_selfcontained_call_indirect_declines_loudly() {
+    let path = fixture();
+    let elf = "/tmp/ci275_selfcontained.elf";
+    let out = Command::new(synth())
+        .args([
+            "compile",
+            path.to_str().unwrap(),
+            "--cortex-m",
+            "--target",
+            "cortex-m3",
+            "-o",
+            elf,
+        ])
+        .output()
+        .expect("run synth");
+
+    // The overall compile still succeeds (skip-and-continue), but the decline
+    // is LOUD — the diagnostic names #275 and the linear-memory collision.
+    assert!(
+        out.status.success(),
+        "compile should skip-and-continue: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("skipping function 'entry'"),
+        "the call_indirect function must be a LOUD skip, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("#275"),
+        "the decline diagnostic must name #275, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("were skipped"),
+        "the skip must be surfaced in the summary count, got:\n{stderr}"
+    );
+
+    // The declined function is ABSENT from the output — no silent dispatch.
+    let bytes = std::fs::read(elf).expect("read elf");
+    assert!(
+        !has_symbol(&bytes, "entry"),
+        "`entry` must NOT be emitted — a declined function is absent, not a \
+         silent colliding dispatch (#275)"
+    );
+    // The non-call_indirect functions still compile (the decline is scoped to
+    // the call_indirect function, not the whole module).
+    for f in ["func_1", "func_2", "func_3"] {
+        assert!(
+            has_symbol(&bytes, f),
+            "{f} must still compile — only the call_indirect function declines"
+        );
+    }
+}
+
+/// The `--relocatable` (host-linked) path is UNTOUCHED: the same module still
+/// emits `entry` with its guarded dispatch — the runtime places the R11 table
+/// region there, so the dispatch is sound (the #642/#650/#664/#676 oracles
+/// gate its exact bytes).
+#[test]
+fn test_275_relocatable_call_indirect_untouched() {
+    let path = fixture();
+    for target in ["cortex-m3", "cortex-r5"] {
+        let elf = format!("/tmp/ci275_reloc_{target}.o");
+        let out = Command::new(synth())
+            .args([
+                "compile",
+                path.to_str().unwrap(),
+                "--target",
+                target,
+                "--all-exports",
+                "--relocatable",
+                "--no-optimize",
+                "-o",
+                &elf,
+            ])
+            .output()
+            .expect("run synth");
+        assert!(
+            out.status.success(),
+            "relocatable compile failed ({target}): {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !stderr.contains("skipping function 'entry'"),
+            "relocatable path must NOT decline entry ({target}):\n{stderr}"
+        );
+        let bytes = std::fs::read(&elf).expect("read object");
+        assert!(
+            has_symbol(&bytes, "entry"),
+            "relocatable path must still emit `entry` with its dispatch ({target}) — #275 \
+             must not touch the host-linked path"
+        );
+    }
+}

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -2299,6 +2299,19 @@ pub struct InstructionSelector {
     /// direct `BL func_N` (the relocatable-ELF builder rewrites `func_N` to the
     /// wasm field name, e.g. `k_spin_lock`) instead of `__meld_dispatch_import`.
     relocatable: bool,
+    /// #275: reject `call_indirect` on the SELF-CONTAINED image path. The
+    /// dispatch loads the function pointer from the contiguous R11 table
+    /// region, but R11 is the LINEAR-MEMORY base and the funcref table is a
+    /// SEPARATE WASM address space. In `--relocatable`/host-linked mode a
+    /// runtime places the table region at R11+offset, so the dispatch is
+    /// sound; in a self-contained image NOTHING populates that region, so the
+    /// load collides with linear-memory data — a SILENT MISCOMPILE. Until the
+    /// full fix (a dedicated, Thumb-bit-set func-pointer table + a non-R11
+    /// table base, silicon-gated — see #275) lands, decline LOUDLY on this
+    /// path (AFD-008: an unlowerable op must `Err`, never silently continue).
+    /// Set by the backend from `!config.relocatable`; the selector's own unit
+    /// tests construct it directly (default `false`) and are unaffected.
+    reject_self_contained_call_indirect: bool,
     /// #237: native-pointer ABI — wasm statics become `__synth_wasm_data`-
     /// relative (MOVW/MOVT), so a `base=0` host-pointer trampoline doesn't
     /// mis-address them.
@@ -2489,6 +2502,7 @@ impl InstructionSelector {
             bounds_check: BoundsCheckConfig::None,
             num_imports: 0,
             relocatable: false,
+            reject_self_contained_call_indirect: false,
             native_pointer_abi: false,
             linear_memory_bytes: 0,
             wasm_data_base: 0,
@@ -2527,6 +2541,7 @@ impl InstructionSelector {
             bounds_check,
             num_imports: 0,
             relocatable: false,
+            reject_self_contained_call_indirect: false,
             native_pointer_abi: false,
             linear_memory_bytes: 0,
             wasm_data_base: 0,
@@ -2656,6 +2671,29 @@ impl InstructionSelector {
         table_index: u32,
         type_index: u32,
     ) -> Result<ResolvedCallIndirectGuards> {
+        // #275: SELF-CONTAINED image path — decline LOUDLY. The R11 table-region
+        // layout contract (see `CallIndirectGuards`) requires an external
+        // runtime/harness to place the contiguous funcref-pointer region at
+        // R11+offset. R11 is the LINEAR-MEMORY base; in a `--relocatable`
+        // host-linked object the runtime supplies that region, but a
+        // self-contained ELF has no such runtime — nothing populates the
+        // region, so the pointer load `ldr ip, [r11, idx*4]` reads function
+        // pointers from linear-memory DATA (a silent miscompile: the dispatched
+        // "function pointer" is whatever data byte lives at that linmem offset).
+        // The sound fix (a dedicated, Thumb-bit-set func-pointer table + a
+        // non-R11 table base) is silicon-gated (#275); until it lands, refuse
+        // rather than emit the colliding dispatch (AFD-008).
+        if self.reject_self_contained_call_indirect {
+            return Err(synth_core::Error::synthesis(format!(
+                "call_indirect (table {table_index}, expected type {type_index}): \
+                 the self-contained Cortex-M image has no runtime to populate the \
+                 R11 funcref-table region (R11 is the linear-memory base), so the \
+                 dispatch would read function pointers from linear-memory data — a \
+                 silent miscompile. Declining (use --relocatable for a host-linked \
+                 object whose runtime places the table region, or await the \
+                 dedicated func-table fix) — #275"
+            )));
+        }
         let n_tables = self.call_indirect_guards.tables.len();
         let table = self
             .call_indirect_guards
@@ -2796,6 +2834,17 @@ impl InstructionSelector {
     /// builder) instead of dispatching through `__meld_dispatch_import`.
     pub fn set_relocatable(&mut self, relocatable: bool) {
         self.relocatable = relocatable;
+    }
+
+    /// #275: on the SELF-CONTAINED image path, decline `call_indirect` loudly
+    /// rather than emit the R11-table dispatch — R11 is the linear-memory
+    /// base and no runtime populates the funcref table region there, so the
+    /// dispatch reads function pointers from linear-memory data (a SILENT
+    /// MISCOMPILE). The backend sets this from `!config.relocatable`; the
+    /// `--relocatable`/host-linked path (where a runtime provides the table
+    /// region) leaves it `false` and keeps emitting the guarded dispatch.
+    pub fn set_reject_self_contained_call_indirect(&mut self, reject: bool) {
+        self.reject_self_contained_call_indirect = reject;
     }
 
     /// #237: enable the native-pointer ABI and supply the active data-segment

--- a/scripts/repro/call_indirect_275_selfcontained.wat
+++ b/scripts/repro/call_indirect_275_selfcontained.wat
@@ -1,0 +1,25 @@
+;; #275 — self-contained `--cortex-m` call_indirect silent-miscompile repro.
+;;
+;; `entry` dispatches through a constant table (index loaded from linmem[100]).
+;; wasmtime stores 100/200/300 to linmem[0] for table indices 0/1/2.
+;;
+;; On the SELF-CONTAINED image path (build_multi_func_cortex_m_elf, i.e. NO
+;; --relocatable) the dispatch loads the function pointer from the contiguous
+;; R11 table region — but R11 is the LINEAR-MEMORY base and NOTHING populates
+;; that region in a self-contained image, so `ldr ip,[r11,idx*4]` reads
+;; function pointers from linear-memory DATA (a silent miscompile). Until the
+;; dedicated func-table fix (silicon-gated) lands, the self-contained path must
+;; DECLINE this loudly (AFD-008) rather than emit the colliding dispatch.
+;;
+;; The `--relocatable` path (where a runtime places the table region at R11)
+;; keeps emitting the guarded dispatch — see the #642/#650/#664/#676 oracles.
+(module
+  (memory (export "memory") 1)
+  (type $ret (func (result i32)))
+  (func (export "entry")
+    (i32.store (i32.const 0)
+      (call_indirect (type $ret) (i32.load (i32.const 100)))))
+  (func $f0 (type $ret) (i32.const 100))
+  (func $f1 (type $ret) (i32.const 200))
+  (func $f2 (type $ret) (i32.const 300))
+  (table 3 funcref) (elem (i32.const 0) $f0 $f1 $f2))

--- a/scripts/repro/call_indirect_275_selfcontained_differential.py
+++ b/scripts/repro/call_indirect_275_selfcontained_differential.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""#275 — self-contained `--cortex-m` call_indirect: LOUD-DECLINE oracle.
+
+Companion to the #642/#650/#664/#676 EXECUTION differentials, but this one
+gates outcome B (the sound interim): on the SELF-CONTAINED image path
+(`build_multi_func_cortex_m_elf`, no `--relocatable`) `call_indirect` must
+DECLINE LOUDLY rather than silently emit the R11-table dispatch that reads
+function pointers from linear-memory DATA (a silent miscompile).
+
+Root cause: the guarded dispatch loads the function pointer from the contiguous
+R11 funcref-table region, but R11 is the LINEAR-MEMORY base and a self-contained
+image has NO runtime to populate that region — so `ldr ip,[r11,idx*4]` reads
+whatever linear-memory data lives at that offset. Until the dedicated
+func-pointer table (silicon-gated, #275) lands, the self-contained path refuses
+(AFD-008: an unlowerable op must Err, never silently continue).
+
+This oracle asserts, using only `synth` + pyelftools (no unicorn/wasmtime):
+  1. self-contained: the `entry` (call_indirect) function is LOUD-skipped (a
+     `#275` diagnostic + a skip count) and is ABSENT from the ELF symtab — no
+     silent colliding dispatch — while `func_1/2/3` still compile;
+  2. `--relocatable`: the SAME module still emits `entry` (the host-linked path,
+     where a runtime places the table region at R11, is untouched).
+
+Run:  SYNTH=<path-to-synth> python scripts/repro/call_indirect_275_selfcontained_differential.py
+Exits nonzero on a silent emit (regression) or a declined relocatable path.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from elftools.elf.elffile import ELFFile
+
+WAT = Path(__file__).with_name("call_indirect_275_selfcontained.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+
+def symbols(elf_path: str) -> set:
+    with open(elf_path, "rb") as fh:
+        e = ELFFile(fh)
+        st = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"]
+        if not st:
+            return set()
+        return {s.name for s in st[0].iter_symbols() if s.name}
+
+
+def run(args):
+    return subprocess.run([SYNTH, "compile", str(WAT), *args], capture_output=True, text=True)
+
+
+def check_selfcontained() -> int:
+    out = "/tmp/ci275_selfcontained_oracle.elf"
+    r = run(["--cortex-m", "--target", "cortex-m3", "-o", out])
+    fails = 0
+    if r.returncode != 0:
+        print(f"self-contained: compile hard-failed (expected skip-and-continue):\n{r.stderr}")
+        return 1
+    if "skipping function 'entry'" not in r.stderr or "#275" not in r.stderr:
+        print(f"self-contained: call_indirect was NOT loud-declined (#275):\n{r.stderr}")
+        fails += 1
+    else:
+        print("self-contained: entry LOUD-declined with a #275 diagnostic OK")
+    syms = symbols(out)
+    if "entry" in syms:
+        print("self-contained: `entry` EMITTED — a silent colliding dispatch (regression) MISMATCH")
+        fails += 1
+    else:
+        print("self-contained: `entry` absent from the ELF (no silent dispatch) OK")
+    for f in ("func_1", "func_2", "func_3"):
+        if f not in syms:
+            print(f"self-contained: {f} missing — decline must be scoped to call_indirect MISMATCH")
+            fails += 1
+    if fails == 0:
+        print("self-contained: non-call_indirect functions still compile OK")
+    return fails
+
+
+def check_relocatable() -> int:
+    fails = 0
+    for target in ("cortex-m3", "cortex-r5"):
+        out = f"/tmp/ci275_reloc_oracle_{target}.o"
+        r = run(["--target", target, "--all-exports", "--relocatable", "--no-optimize", "-o", out])
+        if r.returncode != 0:
+            print(f"relocatable ({target}): compile failed:\n{r.stderr}")
+            fails += 1
+            continue
+        if "skipping function 'entry'" in r.stderr:
+            print(f"relocatable ({target}): entry declined — #275 must NOT touch this path MISMATCH")
+            fails += 1
+            continue
+        if "entry" not in symbols(out):
+            print(f"relocatable ({target}): `entry` missing — dispatch dropped MISMATCH")
+            fails += 1
+            continue
+        print(f"relocatable ({target}): `entry` still emits its guarded dispatch OK")
+    return fails
+
+
+def main() -> int:
+    fails = check_selfcontained() + check_relocatable()
+    if fails == 0:
+        print("ORACLE: PASS")
+        return 0
+    print(f"ORACLE: FAIL — {fails} check(s) diverged (#275)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Outcome: **B (loud decline)** — and what the gate is

**Read this first (silent-miscompile fix):** the gate here is a **decline oracle**, NOT an execution differential. Outcome B removes the wrong dispatch, so there is nothing left to *execute* on the self-contained path — a generic "compile → assert `linmem[0]==100`" check will now find `entry` **absent** (loud-skipped), which is the fix, not a regression. An execution differential asserting `linmem[0]==100/200/300` is what **outcome A** (the dedicated func-table) would need, and A is silicon-gated (see below).

**To verify:**
```
SYNTH=/path/to/target/debug/synth \
  python scripts/repro/call_indirect_275_selfcontained_differential.py   # ORACLE: PASS
# or, by hand:
synth compile scripts/repro/call_indirect_275_selfcontained.wat --cortex-m -t cortex-m3 -o /tmp/ci.elf
#   → warning: skipping function 'entry': ... — #275   +   "1 of 4 functions were skipped"
#   → `entry` absent from the ELF (no silent dispatch)
```
(The oracle defaults `SYNTH` to `./target/debug/synth` — set it to your real target dir to avoid the stale-binary trap.)

## Root cause (residual of #275, after the v0.11.33 reachability closure)

On the **self-contained** image path (`build_multi_func_cortex_m_elf`, i.e. **no** `--relocatable` — falcon's actual firmware path), `call_indirect` emits its guarded dispatch, but the function-pointer load is:
```
lsl.w  r12, idx, #2
ldr.w  r12, [r11, r12]   ; R11 = LINEAR-MEMORY base
blx    r12
```
The contiguous R11 funcref-table region is only ever populated by an **external runtime/harness** (the `--relocatable` layout contract). A self-contained image has no such runtime, so `ldr [r11, idx*4]` reads "function pointers" from **linear-memory DATA** — a **silent miscompile** (`exit 0`, `0 skips`, garbage dispatched; the repro stored the *selector* to `linmem[0]` instead of 100/200/300).

## The fix (B, the sound interim — AFD-008)

The self-contained path now **declines `call_indirect` LOUDLY**: the function is skipped with a `#275` diagnostic naming the linmem collision, surfaced in the skip count, and **absent** from the output — never a silent colliding dispatch. "An unlowerable op must `Err`, never silently `continue`."

- Selector gains `reject_self_contained_call_indirect`, set by the backend from **`!config.relocatable`**, and checked at the top of `resolve_call_indirect_guards` (covers **both** the direct `select_with_stack` path **and** the optimized→direct fallback — the optimizer already declines `call_indirect`).
- `!config.relocatable` is the right discriminator: every non-relocatable ARM path (optimized abs-base, native-pointer ABI, `build_cortex_m_elf`) has R11=linmem with no external table provider.

## Untouched: the relocatable / host-linked path

Scoped by `!config.relocatable`, so the `--relocatable` path — where a runtime places the table region at R11 — is **byte-for-byte untouched**:

- `--relocatable` compile of the same module still emits `entry` with the full guarded dispatch (`cmp; udf; lsl.w; ldr.w r12,[r11,r12]; blx r12`), both `cortex-m3` (Thumb-2) and `cortex-r5` (A32).
- **#642 / #650 / #664 / #676 differentials: `ORACLE: PASS`** (bounds trap, multi-table, null-slot, heterogeneous type-id).
- Selector unit tests construct the selector directly (flag defaults `false`) — unaffected.

## Non-goals / upgrade path

- **B does not foreclose A.** When the silicon-gated dedicated-table fix lands (a Thumb-bit-set func-pointer table in a dedicated region + a non-R11 table base), the flag simply stops declining. Even a unicorn-green A would be "held for silicon" per the maintainer's own comment on this issue, so B closes the actual soundness bug now and A stays a clean follow-up.
- **RISC-V** has its own selector — out of scope for a `--cortex-m` issue (not a regression).

## Gate / evidence

- `crates/synth-cli/tests/call_indirect_275_selfcontained.rs` — self-contained declines loudly (`#275` + skip count + `entry` absent + `func_1/2/3` still compile) **and** `--relocatable` still emits `entry` (both ISAs). 2/2 pass.
- `scripts/repro/call_indirect_275_selfcontained{.wat,_differential.py}` — decline oracle, `ORACLE: PASS`.
- `cargo test -p synth-backend -p synth-synthesis -p synth-cli` green; `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.
- **Frozen anchors 10/10.**

Part of **VCR (#242)**; the on-target Cortex-M long pole for jess (falcon's fused core has 61 `call_indirect` sites).

Refs #275, #242. **DO NOT MERGE** — maintainer gates (will re-run the decline oracle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)