### PR TITLE
chore(release): v0.40.0 — five-lane North-Star hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.0] - 2026-07-11
+
+**A five-lane North-Star feature hub: the f32 hard-float path completes and
+becomes sound, the verified selector now generates its own Rocq model, the
+beat-LLVM lane collapses branchless clamps, the gust size gap is quantified and
+pinned, and a self-contained `call_indirect` silent miscompile becomes an honest
+decline.**
+
+### Fixed
+
+- **Self-contained `--cortex-m` `call_indirect` no longer silently miscompiles
+  (#275, soundness).** On the self-contained path the dispatch read the
+  function-pointer table from `[R11, idx*4]`, but R11 is the *linear-memory*
+  base and nothing populates a funcref table there (only the `--relocatable`
+  runtime does) — so it dispatched through linear-memory *data*. It now declines
+  LOUDLY with a precise message pointing at `--relocatable`, per the AFD-008
+  "unlowerable op must Err, never silently continue" contract. The relocatable
+  path (where the runtime places the table) is byte-untouched — #642/#650/#664/
+  #676 differentials all still pass. The dedicated func-table fix (a non-R11
+  table base) is a silicon-gated follow-up.
+- **f32 `i32.trunc_f32_s/u` now TRAP on NaN/±∞/out-of-range instead of silently
+  saturating (#709, soundness).** The v0.39.0 hard-float path lowered trunc to a
+  bare saturating `VCVT` (NaN→0, overflow→saturated) where WASM Core §4.3.3
+  requires a trap. Now a domain guard (reusing the div-by-zero `Cmp;BNE;UDF`
+  idiom) precedes the — now provably in-range — `VCVT`: signed valid iff
+  `-2³¹ ≤ x < 2³¹`, unsigned iff `-1.0 < x < 2³²`; every compare against NaN is
+  false, so NaN traps for free. 48/48 vs wasmtime incl. the full trap table.
+- **f32 comparisons no longer silently return 0 (#709 prerequisite, soundness).**
+  A flag-setting `MOVS Rd,#0` emitted *after* `VMRS` clobbered the transferred
+  FPSCR flags, so every v0.39.0 f32 compare returned 0 on hardware — it shipped
+  because the #619 harness skipped compare *execution* on a false premise
+  (unicorn does model `VMRS`→APSR). Fixed by ordering the `#0` before the `VCMP`
+  (byte sizes unchanged); the harness now execution-tests compares (60/60).
+
+### Added
+
+- **f32.load + i32.reinterpret_f32 / f32.reinterpret_i32 lowering (#708, #369).**
+  `f32.load` lowers via the proven i32.load address path into a core reg then a
+  bit-exact `VMOV Sd,Rd`; the reinterprets are pure `VMOV` bit-casts. This
+  unblocks the falcon float path — its float functions START with an f32 load or
+  reinterpret, so all 24 were declining; 20 now compile (f64 = phase 2).
+  FPU-gated, honest-reject on M0/M3; f32.store declined loudly (not needed).
+- **The verified selector now generates its own Rocq model (#667, VCR-ISA-001).**
+  The shipped DSL rule table emits `VcrSelRulesGenerated.v` + a per-rule
+  `reflexivity` Qed proving `Gen.rule_X = rule_X`, wired into `//coq:verify_proofs`
+  — Coq's kernel is now the model↔selector divergence gate, directly closing the
+  #682 vacuous-proof class. +40 generated-vs-model gate lemmas (proof count
+  472→512, framed as gate lemmas, not new correctness proofs).
+- **gust hot-path size-gap attribution + tracked size oracle (#390, VCR-PERF-001).**
+  A harness attributes synth's `.text` size into causal buckets (spill/reload,
+  addressing-mode, const, prologue, guard) and a CI test pins it. Measured:
+  gust_poll 740 B vs LLVM's 208 B = 3.56×, overhead led by spill/reload (~31%).
+
+### Changed
+
+- **fact-spec collapses branchless `select` clamps (#494 ph3, VCR-PERF-002).**
+  The proof-carrying specialization pass now handles the branchless `select`
+  form a real optimizing front-end (and LLVM) lowers `clamp()` to — under a
+  ValueRange premise it discharges an ordeal QF_BV obligation per select and
+  deletes the dead arm+condition+mux. gust_mix 50 B → 14 B (−72%) on a shape
+  LLVM structurally can't beat. Opt-in (verify feature + SYNTH_FACT_SPEC),
+  frozen-safe; the 0.45× *cycle* floor remains gale's silicon measurement.
+
 ## [0.39.1] - 2026-07-11
 
 **A single-fix release that unblocks the gust:os multi-provider OS node — the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,10 @@ cd coq && make proofs
 ### Proof Status
 
 See `coq/STATUS.md` for the complete coverage matrix. Current: 512 Qed / 6 Admitted
-(+2 `admit.` tactics) across `coq/Synth/`. This count is CI-gated: `claims.yaml` +
+(+2 `admit.` tactics) across `coq/Synth/`, of which 40 are VCR-ISA-001 (#667)
+generated-vs-model GATE lemmas (`VcrSelRulesGenCheck.v`, `reflexivity` checks that
+the generated model equals the shipped selector — NOT new correctness proofs).
+This count is CI-gated: `claims.yaml` +
 `scripts/claim_check.py` re-derive it on every commit — when a proof lands, update
 the docs AND `claims.yaml` in the same PR. Proofs are tiered:
 T1 (result-correspondence), T2 (existence-only), T3 (admitted). Remaining admits:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,14 +1805,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1871,11 +1871,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.39.1"
+version = "0.40.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1930,14 +1930,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1945,11 +1945,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.39.1"
+version = "0.40.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.39.1"
+version = "0.40.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.39.1"
+version = "0.40.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.39.1",
+    version = "0.40.0",
 )
 
 # Bazel dependencies

--- a/README.md
+++ b/README.md
@@ -216,7 +216,9 @@ Mechanized proofs in Rocq 9 show that `compile_wasm_to_arm` preserves WASM seman
   incl. 40 Qed selector-DSL rule theorems (Synth/VcrSelRules.v, 1:1 with
      coq/vcr_sel_rules.manifest), 7 Qed VCR-SEL-001 pilot lemmas
      (Synth/VcrSelPilot.v, #386), 92 Qed Sail/ASL bridge lemmas
-     (ARM/SailArmBridge.v, VCR-ISA-001)
+     (ARM/SailArmBridge.v, VCR-ISA-001), and 40 Qed generated-vs-model GATE
+     lemmas (Synth/VcrSelRulesGenCheck.v, #667) — reflexivity checks that the
+     generated model equals the shipped rules, NOT new correctness proofs
 ```
 
 i32 and i64 operations have full T1 (result-correspondence) proofs; i64 parity landed in v0.11.0. Division proofs were re-admitted after updating Compilation.v to emit trap guard sequences (CMP+BCondOffset+UDF) matching the actual compiler — the sequential exec_program model needs PC-relative branching support to verify these. The f32, f64, and SIMD instruction selection has T2 existence proofs but not T1 result-correspondence.

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.39.1" }
+synth-core = { path = "../synth-core", version = "0.40.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.39.1" }
+synth-core = { path = "../synth-core", version = "0.40.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.39.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.39.1" }
+synth-core = { path = "../synth-core", version = "0.40.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.40.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.39.1" }
+synth-core = { path = "../synth-core", version = "0.40.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.39.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.39.1", optional = true }
+synth-core = { path = "../synth-core", version = "0.40.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.40.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.39.1", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.40.0", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -44,23 +44,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.39.1" }
-synth-frontend = { path = "../synth-frontend", version = "0.39.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.39.1" }
-synth-backend = { path = "../synth-backend", version = "0.39.1" }
+synth-core = { path = "../synth-core", version = "0.40.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.40.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.40.0" }
+synth-backend = { path = "../synth-backend", version = "0.40.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.39.1" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.40.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.39.1", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.39.1", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.39.1", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.40.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.40.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.40.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.39.1", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.40.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.39.1" }
+synth-core = { path = "../synth-core", version = "0.40.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.39.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.40.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.39.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.39.1" }
-synth-opt = { path = "../synth-opt", version = "0.39.1" }
+synth-core = { path = "../synth-core", version = "0.40.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.40.0" }
+synth-opt = { path = "../synth-opt", version = "0.40.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.39.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.39.1" }
-synth-opt = { path = "../synth-opt", version = "0.39.1" }
+synth-core = { path = "../synth-core", version = "0.40.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.40.0" }
+synth-opt = { path = "../synth-opt", version = "0.40.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.39.1", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.40.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553)
 ordeal = "0.4"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"


### PR DESCRIPTION
Five-lane supervised feature hub. Each lane landed as its own gated PR (#713/#714/#715/#716/#717); this cuts the release.

## Lanes
- **#716 (#709 + #708 + f32-compare fix)** — f32 `trunc` now **traps** on NaN/±∞/OOR (soundness); fixed a v0.39.0 f32-compare flag-clobber that made every compare return 0 (soundness); `f32.load` + reinterprets lower, unblocking falcon (20/24 float skips). 48/48 + 60/60 vs wasmtime.
- **#714 (#667, VCR-ISA-001)** — the verified selector generates its own Rocq model + per-rule `reflexivity` gate; Coq's kernel is now the model↔selector divergence gate (closes the #682 vacuous-proof class). Proof count 472→512 (framed as generated-vs-model gate lemmas).
- **#715 (#494 ph3, VCR-PERF-002)** — fact-spec collapses branchless `select` clamps; gust_mix 50→14 B. Opt-in, frozen-safe; cycle floor stays gale's silicon.
- **#713 (#390, VCR-PERF-001)** — gust size-gap attribution + tracked size oracle (3.56× quantified, spill/reload ~31%).
- **#717 (#275, soundness)** — self-contained `call_indirect` silent-miscompile (R11/linmem table-base collision) → honest loud decline; relocatable path byte-untouched (#642/#650/#664/#676 pass).

## Gates
- Pin sweep 0.39.1→0.40.0 (workspace + path deps + MODULE.bazel + npm).
- Claim gate **17/17**, frozen anchors **10/10**, clippy/fmt clean.
- Two soundness fixes independently re-verified against wasmtime by the hub supervisor before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)