### PR TITLE
feat(f32): op-completeness for falcon — store/abs/neg/copysign + AAPCS-VFP mixed params (#719)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,14 @@ jobs:
         run: SYNTH=./target/debug/synth python scripts/repro/bulk_local_clobber_677_differential.py
       - name: Run bulk-memory mask-coverage oracle (#679, thumb2)
         run: SYNTH=./target/debug/synth python scripts/repro/bulk_mask_679_differential.py
+      # #708/#709: f32.load/reinterpret bit-casts + i32.trunc_f32 trap table.
+      - name: Run f32 load/reinterpret + trunc-trap oracle (#708/#709, m4f)
+        run: SYNTH=./target/debug/synth python scripts/repro/f32_mem_trunc_708_709_differential.py
+      # #719: the falcon f32 residual — f32.store, abs/neg/copysign, local.set/
+      # tee, and mixed f32/int AAPCS-VFP params — bit-exact vs wasmtime on m4f,
+      # including the copysign ±0/NaN-sign/±inf sign edges. m3 honest-reject.
+      - name: Run f32 store/abs/neg/copysign/local + mixed-param oracle (#719, m4f)
+        run: SYNTH=./target/debug/synth python scripts/repro/f32_ops_719_differential.py
 
   fact-spec-oracle:
     name: fact-spec elision oracle (#494 phases 2 + 2b)

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -7051,23 +7051,23 @@ impl ArmEncoder {
             &Reg::R0,
         )?));
 
-        // AND.W R12, R12, #0x80000000
-        // Thumb-2 modified immediate: 0x80000000 = constant 0x80 with rotation
-        // Using T1 encoding: 11110 i 0 0000 S Rn | 0 imm3 Rd imm8
-        // 0x80000000: i=0, imm3=0b001, imm8=0x00 (rotation=4, value=0x80)
-        // Actually encoding #0x80000000 as modified constant:
-        // bit pattern 1 followed by 31 zeros: enc = 0b0100_00000000 = 0x0100? No.
-        // ARM modified immediate: abcdefgh rotated. 0x80000000 = 0x80 ROR 2 = enc 0x0102
-        // Actually: value = abcdefgh ROR (2*rot). 0x80 = 10000000, ROR 2 gives 0x20000000.
-        // For 0x80000000: 0x02 ROR 2 = 0x80000000. So imm12 = (1<<8) | 0x02 = 0x102
-        let hw1: u16 = 0xF000 | 12; // AND.W R12, R12, #modified_const (i=0, Rn=R12)
-        let hw2: u16 = (0x1 << 12) | (12 << 8) | 0x02; // imm3=1, Rd=R12, imm8=0x02
+        // AND.W R12, R12, #0x80000000  (isolate the sign bit of the sign source)
+        // Thumb-2 T1 data-processing modified immediate: 11110 i 0 0000 S Rn |
+        // 0 imm3 Rd imm8, where the 12-bit constant is i:imm3:imm8. When the
+        // 5-bit rotation `rot = i:imm3:imm8[7]` is >= 8, the value is
+        // `(0x80 | imm8[6:0]) ROR rot`. For 0x80000000: 0x80 ROR 8 = 0x80000000,
+        // so rot=8 (i=0, imm3=0b100), imm8=0x00. (#719: the previous encoding
+        // used imm3=1/imm8=0x02, which decodes to #0x00020002 — a wrong mask that
+        // spliced bits 17 and 1 instead of the sign bit; copysign was never
+        // execution-differentiated until #719 caught it.)
+        let hw1: u16 = 0xF000 | 12; // AND.W R12, R12, #imm (i=0, S=0, Rn=R12)
+        let hw2: u16 = (0x4 << 12) | (12 << 8); // imm3=4, Rd=R12, imm8=0 → #0x80000000
         bytes.extend_from_slice(&hw1.to_le_bytes());
         bytes.extend_from_slice(&hw2.to_le_bytes());
 
-        // BIC.W R0, R0, #0x80000000 (R0 = register 0, fields are zero)
-        let hw1: u16 = 0xF020; // BIC.W R0, R0, #modified_const (i=0, Rn=R0)
-        let hw2: u16 = (0x1 << 12) | 0x02; // imm3=1, Rd=R0, imm8=0x02
+        // BIC.W R0, R0, #0x80000000  (clear the sign bit of the magnitude source)
+        let hw1: u16 = 0xF020; // BIC.W R0, R0, #imm (i=0, S=0, Rn=R0)
+        let hw2: u16 = 0x4 << 12; // imm3=4, Rd=R0, imm8=0 → #0x80000000
         bytes.extend_from_slice(&hw1.to_le_bytes());
         bytes.extend_from_slice(&hw2.to_le_bytes());
 

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -1910,13 +1910,26 @@ fn convert_operator(op: &wasmparser::Operator) -> Option<WasmOp> {
         // proven `i32.load` address sequence (`[R11,idx]`→absolute-base rewrite +
         // bounds guard) into a core register, then a bit-exact `VMOV Sd,Rd`
         // (reinterpret) — a VLDR loads the same 4 bytes, so the bit pattern is
-        // identical. `f32.store` STAYS dropped (falcon's #369 inventory needs
-        // only the load + reinterpret; the store loud-skips at decode until a
-        // consumer needs it — never a silent miscompile).
+        // identical.
         F32Load { memarg } => Some(WasmOp::F32Load {
             offset: memarg.offset as u32,
             align: memarg.align as u32,
         }),
+        // #719 (phase 1b): `f32.store` — the VFP-store twin of `f32.load`. The
+        // selector moves the S-register value into a core register (`VMOV Rn,Sn`,
+        // a reinterpret) and reuses the PROVEN `i32.store` address path; a VSTR
+        // would write the same 4 bytes, so the stored word is bit-exact. (falcon
+        // has 10 f32.store functions, #719.)
+        F32Store { memarg } => Some(WasmOp::F32Store {
+            offset: memarg.offset as u32,
+            align: memarg.align as u32,
+        }),
+        // #719 (phase 1b): scalar f32 sign-family math — `VABS.F32` / `VNEG.F32`
+        // and the `copysign` sign-bit splice. Pure single-precision VFP, no
+        // numeric approximation; bit-exact across ±0.0 / NaN-sign / ±inf.
+        F32Abs => Some(WasmOp::F32Abs),
+        F32Neg => Some(WasmOp::F32Neg),
+        F32Copysign => Some(WasmOp::F32Copysign),
         // #708 (phase 1b): the f32<->i32 bit-casts. Pure `VMOV` between a core
         // register and a single-precision S-register — no numeric conversion.
         F32ReinterpretI32 => Some(WasmOp::F32ReinterpretI32),

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -160,12 +160,25 @@ struct AapcsParamLayout {
 /// For an all-i32 signature this is exactly `index_to_reg(i)` for `i < 4` and
 /// NSAA `(i-4)*4` beyond, so both maps are byte-identical to the legacy
 /// sequential scheme whenever no i64/f64 param is present.
-fn aapcs_param_layout(num_params: u32, params_i64: &[bool]) -> AapcsParamLayout {
+fn aapcs_param_layout(
+    num_params: u32,
+    params_i64: &[bool],
+    params_f32: &[bool],
+) -> AapcsParamLayout {
     let mut regs = std::collections::HashMap::new();
     let mut stack = std::collections::HashMap::new();
     let mut next: u8 = 0; // NCRN: next free core arg-register index (0..=4)
     let mut nsaa: i32 = 0; // next stacked-argument byte offset from entry SP
     for i in 0..num_params {
+        // #719: under the AAPCS-VFP (hard-float) calling convention an f32 param
+        // is passed in a single-precision S-register from the INDEPENDENT VFP
+        // argument pool (seeded separately into `f32_home` at S0,S1,…), so it
+        // consumes neither a core register nor an NSAA stack slot — the core
+        // walk must skip it. `(f32, i32)` therefore maps i32→R0 (not R1). Empty
+        // `params_f32` ⇒ no skips ⇒ byte-identical to the legacy layout.
+        if params_f32.get(i as usize).copied().unwrap_or(false) {
+            continue;
+        }
         let is_wide = params_i64.get(i as usize).copied().unwrap_or(false);
         if is_wide {
             if !next.is_multiple_of(2) {
@@ -200,7 +213,9 @@ fn aapcs_param_layout(num_params: u32, params_i64: &[bool]) -> AapcsParamLayout 
 /// Test-only: the selector itself uses the full layout.
 #[cfg(test)]
 fn aapcs_param_regs(num_params: u32, params_i64: &[bool]) -> std::collections::HashMap<u32, Reg> {
-    aapcs_param_layout(num_params, params_i64).regs
+    // Test helper covers integer signatures only (f32 param homing is exercised
+    // by the #719 execution differential); pass no f32 params.
+    aapcs_param_layout(num_params, params_i64, &[]).regs
 }
 
 /// True if any declared i64/f64 param of this function lands (wholly or its
@@ -1273,6 +1288,7 @@ fn compute_local_layout(
     wasm_ops: &[WasmOp],
     num_params: u32,
     params_i64: &[bool],
+    params_f32: &[bool],
     func_ret_i64: &[bool],
     type_ret_i64: &[bool],
     force_spill_area: bool,
@@ -1284,7 +1300,7 @@ fn compute_local_layout(
     let i64_set = infer_i64_locals(wasm_ops, func_ret_i64, type_ret_i64);
     // #503-i64: the width-aware AAPCS assignment — which params are register-
     // resident and which live on the caller's stack (and at what NSAA offset).
-    let aapcs = aapcs_param_layout(num_params, params_i64);
+    let aapcs = aapcs_param_layout(num_params, params_i64, params_f32);
 
     // Collect non-param local indices, in ascending order for deterministic layout.
     let mut used: BTreeSet<u32> = BTreeSet::new();
@@ -7201,7 +7217,7 @@ impl InstructionSelector {
         // back to a loud skip (warning + absent symbol), never wrong code.
         // (Empty `params_i64` ⇒ all-i32 ⇒ this is a no-op and every existing
         // fixture stays byte-identical.)
-        let param_layout = aapcs_param_layout(num_params, &self.params_i64);
+        let param_layout = aapcs_param_layout(num_params, &self.params_i64, &self.params_f32);
         let has_reg_i64_param = (0..num_params).any(|i| {
             self.params_i64.get(i as usize).copied().unwrap_or(false)
                 && param_layout.regs.contains_key(&i)
@@ -7274,6 +7290,7 @@ impl InstructionSelector {
             wasm_ops,
             num_params,
             &self.params_i64,
+            &self.params_f32,
             &self.func_ret_i64,
             &self.type_ret_i64,
             self.spill_on_exhaustion,
@@ -7593,23 +7610,18 @@ impl InstructionSelector {
                         self.target_name
                     )));
                 }
-                // Phase-1 honest declines (never a miscompile):
-                //  * mixed f32 + integer params — AAPCS-VFP uses independent
-                //    core (R0..R3) and VFP (S0..S15) argument pools, so an f32
-                //    param must not consume a core slot; the phase-1 core-reg
-                //    layout is not yet VFP-aware.
-                let has_int_param =
-                    (0..num_params).any(|i| !params_f32.get(i as usize).copied().unwrap_or(false));
-                if has_f32_param && has_int_param {
-                    return Err(synth_core::Error::synthesis(
-                        "GI-FPU-002 phase 1: mixed f32/integer parameter lists \
-                         are not yet lowered (AAPCS-VFP independent register \
-                         pools) — declining the function"
-                            .to_string(),
-                    ));
-                }
+                // #719: mixed f32 + integer params are now lowered — AAPCS-VFP's
+                // independent core (R0..R3) and VFP (S0..S15) argument pools are
+                // modelled by `aapcs_param_layout`/`compute_local_layout` skipping
+                // f32 params in the core walk (so `(f32, i32)` maps i32→R0, not
+                // R1) while the f32-home seed below assigns S(k) from the VFP
+                // pool. No decline here anymore.
+                //
+                // Phase-1 honest decline (never a miscompile):
                 //  * any call — S0..S15 are caller-saved, so an f32 value or
-                //    param home would be clobbered across a bl (phase 1b).
+                //    param home would be clobbered across a bl (phase 1b, #719
+                //    scopes this out; the full spill/rehome across call sites is
+                //    the next f32 increment).
                 if wasm_ops
                     .iter()
                     .any(|o| matches!(o, WasmOp::Call(_) | WasmOp::CallIndirect { .. }))
@@ -15329,24 +15341,24 @@ mod tests {
     #[test]
     fn test_503_aapcs_stack_offsets() {
         // (i32 x4, i64): p4 wide @ nsaa 0.
-        let l = aapcs_param_layout(5, &[false, false, false, false, true]);
+        let l = aapcs_param_layout(5, &[false, false, false, false, true], &[]);
         assert_eq!(l.stack.get(&4), Some(&(0, true)));
         // (i32 x5, i64): p4 narrow @ 0, p5 wide @ 8 (4-byte alignment hole).
-        let l = aapcs_param_layout(6, &[false, false, false, false, false, true]);
+        let l = aapcs_param_layout(6, &[false, false, false, false, false, true], &[]);
         assert_eq!(l.stack.get(&4), Some(&(0, false)));
         assert_eq!(l.stack.get(&5), Some(&(8, true)));
         // (i32 x3, i64): even-align spills the pair with only 4 params.
-        let l = aapcs_param_layout(4, &[false, false, false, true]);
+        let l = aapcs_param_layout(4, &[false, false, false, true], &[]);
         assert_eq!(l.stack.get(&3), Some(&(0, true)));
         assert_eq!(l.regs.get(&3), None);
         // (i64, i32 x3): p1=R2, p2=R3, p3 narrow @ 0 (no back-fill).
-        let l = aapcs_param_layout(4, &[true, false, false, false]);
+        let l = aapcs_param_layout(4, &[true, false, false, false], &[]);
         assert_eq!(l.regs.get(&0), Some(&Reg::R0));
         assert_eq!(l.regs.get(&1), Some(&Reg::R2));
         assert_eq!(l.regs.get(&2), Some(&Reg::R3));
         assert_eq!(l.stack.get(&3), Some(&(0, false)));
         // all-i32 x6: legacy (k-4)*4 formula, byte-identical.
-        let l = aapcs_param_layout(6, &[false; 6]);
+        let l = aapcs_param_layout(6, &[false; 6], &[]);
         assert_eq!(l.stack.get(&4), Some(&(0, false)));
         assert_eq!(l.stack.get(&5), Some(&(4, false)));
     }
@@ -21233,7 +21245,18 @@ mod tests {
     fn test_compute_local_layout_no_locals() {
         // Function with only params and no LocalGet/Set produces zero frame.
         let ops = vec![WasmOp::LocalGet(0), WasmOp::LocalGet(1), WasmOp::I32Add];
-        let layout = compute_local_layout(&ops, 2, &[], &[], &[], false, false, 0, I64_SPILL_SLOTS);
+        let layout = compute_local_layout(
+            &ops,
+            2,
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            0,
+            I64_SPILL_SLOTS,
+        );
         assert_eq!(layout.frame_size, 0);
         assert!(layout.locals.is_empty());
     }
@@ -21246,7 +21269,18 @@ mod tests {
             WasmOp::LocalSet(1),
             WasmOp::LocalGet(1),
         ];
-        let layout = compute_local_layout(&ops, 1, &[], &[], &[], false, false, 0, I64_SPILL_SLOTS);
+        let layout = compute_local_layout(
+            &ops,
+            1,
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            0,
+            I64_SPILL_SLOTS,
+        );
         assert!(layout.locals.contains_key(&1));
         let (off, is_i64) = layout.locals[&1];
         assert_eq!(off, 0);
@@ -21263,7 +21297,18 @@ mod tests {
             WasmOp::LocalSet(0),
             WasmOp::LocalGet(0),
         ];
-        let layout = compute_local_layout(&ops, 0, &[], &[], &[], false, false, 0, I64_SPILL_SLOTS);
+        let layout = compute_local_layout(
+            &ops,
+            0,
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            0,
+            I64_SPILL_SLOTS,
+        );
         let (off, is_i64) = layout.locals[&0];
         assert_eq!(off, 0);
         assert!(is_i64);
@@ -21283,7 +21328,18 @@ mod tests {
             WasmOp::I64Const(2),
             WasmOp::LocalSet(1),
         ];
-        let layout = compute_local_layout(&ops, 0, &[], &[], &[], false, false, 0, I64_SPILL_SLOTS);
+        let layout = compute_local_layout(
+            &ops,
+            0,
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            0,
+            I64_SPILL_SLOTS,
+        );
         let (off0, is_i64_0) = layout.locals[&0];
         let (off1, is_i64_1) = layout.locals[&1];
         assert_eq!(off0, 0);
@@ -21305,7 +21361,18 @@ mod tests {
             WasmOp::I32Add,
             WasmOp::LocalSet(2),
         ];
-        let layout = compute_local_layout(&ops, 2, &[], &[], &[], false, false, 0, I64_SPILL_SLOTS);
+        let layout = compute_local_layout(
+            &ops,
+            2,
+            &[],
+            &[],
+            &[],
+            &[],
+            false,
+            false,
+            0,
+            I64_SPILL_SLOTS,
+        );
         // Only idx 2 should be in the layout.
         assert!(!layout.locals.contains_key(&0));
         assert!(!layout.locals.contains_key(&1));

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -2023,6 +2023,15 @@ fn is_scope_f32_op(op: &WasmOp) -> bool {
             | F32Load { .. }
             | F32ReinterpretI32
             | I32ReinterpretF32
+            // #719 (phase 1b): f32.store (lowered in the main `select_with_stack`
+            // match — needs `self`'s address machinery, like F32Load) + the
+            // sign-family math ops. Listed here so the FPU gate (m3 honest-reject)
+            // and the S-register result-homing fire for a function whose only f32
+            // op is one of these.
+            | F32Store { .. }
+            | F32Abs
+            | F32Neg
+            | F32Copysign
     )
 }
 
@@ -2035,9 +2044,9 @@ fn try_lower_f32(
     op: &WasmOp,
     idx: usize,
     params_f32: &[bool],
-    f32_home: &std::collections::HashMap<u32, VfpReg>,
+    f32_home: &mut std::collections::HashMap<u32, VfpReg>,
     vfp_used: &mut [bool; 16],
-    vfp_home: &[bool; 16],
+    vfp_home: &mut [bool; 16],
     stack: &mut Vec<StackVal>,
     next_temp: &mut u8,
     spill: &mut SpillState,
@@ -2071,15 +2080,47 @@ fn try_lower_f32(
             let top_is_float = stack.last().and_then(|v| v.as_float()).is_some();
             let target_is_f32 =
                 f32_home.contains_key(i) || params_f32.get(*i as usize).copied().unwrap_or(false);
-            if top_is_float || target_is_f32 {
-                Err(synth_core::Error::synthesis(
-                    "GI-FPU-002 phase 1: f32 local.set/local.tee is not yet \
-                     lowered (VFP home write-back) — declining the function"
-                        .to_string(),
-                ))
-            } else {
-                Ok(false)
+            if !(top_is_float || target_is_f32) {
+                // Not an f32 local — let the integer LocalSet/Tee handle it.
+                return Ok(false);
             }
+            // #719 (phase 1b): f32 VFP home write-back. Copy the top-of-stack
+            // f32 value into the local's STABLE home S-register (allocated once
+            // per local, pinned as a home so no temp ever reallocates it), and
+            // for `local.tee` leave the value on the operand stack.
+            let src = pop_float(stack)?;
+            let home = if let Some(&h) = f32_home.get(i) {
+                h
+            } else {
+                // A fresh non-param f32 local: allocate + pin a home S-register.
+                let h = alloc_vfp_temp(vfp_used)?;
+                if let Some(hi) = vfp_s_index(h) {
+                    vfp_home[hi] = true;
+                }
+                f32_home.insert(*i, h);
+                h
+            };
+            if home != src {
+                // S->S copy is bit-exact via the proven core round-trip (the
+                // phase-1 ArmOp set has no `VMOV.F32 Sd,Sm`): `VMOV Rt,src`
+                // (reinterpret to a core scratch) then `VMOV home,Rt`. Both
+                // moves copy all 32 bits, so ±0.0/NaN/±inf are preserved.
+                let rt = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+                instructions.push(ArmInstruction {
+                    op: ArmOp::I32ReinterpretF32 { rd: rt, sm: src },
+                    source_line: Some(idx),
+                });
+                instructions.push(ArmInstruction {
+                    op: ArmOp::F32ReinterpretI32 { sd: home, rm: rt },
+                    source_line: Some(idx),
+                });
+            }
+            // Free the source temp unless it is itself a permanent home.
+            free_vfp_temp(vfp_used, vfp_home, src);
+            if matches!(op, LocalTee(_)) {
+                stack.push(StackVal::Float { sreg: home });
+            }
+            Ok(true)
         }
         F32Add | F32Sub | F32Mul | F32Div => {
             let sm = pop_float(stack)?;
@@ -2093,6 +2134,43 @@ fn try_lower_f32(
             };
             instructions.push(ArmInstruction {
                 op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_temp(vfp_used, vfp_home, sm);
+            free_vfp_temp(vfp_used, vfp_home, sn);
+            stack.push(StackVal::Float { sreg: sd });
+            Ok(true)
+        }
+        // #719 (phase 1b): sign-family unary math. `VABS.F32` clears the sign
+        // bit; `VNEG.F32` flips it. Both are pure single-precision VFP and
+        // bit-exact on ±0.0/NaN/±inf (sign-only edits, no value change).
+        F32Abs | F32Neg => {
+            let sm = pop_float(stack)?;
+            let sd = alloc_vfp_temp(vfp_used)?;
+            let arm = if matches!(op, F32Abs) {
+                ArmOp::F32Abs { sd, sm }
+            } else {
+                ArmOp::F32Neg { sd, sm }
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_temp(vfp_used, vfp_home, sm);
+            stack.push(StackVal::Float { sreg: sd });
+            Ok(true)
+        }
+        // #719 (phase 1b): `f32.copysign(a, b)` = magnitude of `a` with sign of
+        // `b`. Stack order is `[a, b]` (b on top), so `sm` (popped first) is the
+        // SIGN source `b` and `sn` is the MAGNITUDE source `a` — matching the
+        // encoder's `sd = |sn| | sign(sm)` sign-bit splice. Bit-exact including
+        // the ±0.0/NaN-sign/±inf sign-only edits.
+        F32Copysign => {
+            let sm = pop_float(stack)?; // sign source (b)
+            let sn = pop_float(stack)?; // magnitude source (a)
+            let sd = alloc_vfp_temp(vfp_used)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::F32Copysign { sd, sn, sm },
                 source_line: Some(idx),
             });
             free_vfp_temp(vfp_used, vfp_home, sm);
@@ -7604,9 +7682,9 @@ impl InstructionSelector {
                     op,
                     idx,
                     &params_f32,
-                    &f32_home,
+                    &mut f32_home,
                     &mut vfp_used,
-                    &vfp_home,
+                    &mut vfp_home,
                     &mut stack,
                     &mut next_temp,
                     &mut spill,
@@ -8949,6 +9027,76 @@ impl InstructionSelector {
                         source_line: Some(idx),
                     });
                     stack.push(StackVal::Float { sreg: sd });
+                }
+
+                // #719 (phase 1b): `f32.store` — the VFP-store twin of `f32.load`
+                // (falcon has 10). VSTR takes only a `[Rn,#imm]` address, and the
+                // phase-1 selector does not model the static-data/native-pointer
+                // address rewrites, so we bit-cast the S-register value into a core
+                // register (`VMOV Rn,Sn`, a reinterpret) and store it with the
+                // PROVEN integer path (`generate_store_with_bounds_check`). A VSTR
+                // would write the identical 4 bytes, so the stored word is exact.
+                // Honest-decline the native-pointer static-data + const static-data
+                // address modes we don't yet lower (symmetric to F32Load) — never
+                // a silent miscompile; falcon's dynamic-index stores are unaffected.
+                F32Store { offset, .. } => {
+                    if self.native_pointer_abi
+                        && self.wasm_data_base > 0
+                        && *offset >= self.wasm_data_base
+                    {
+                        return Err(synth_core::Error::synthesis(
+                            "GI-FPU-002 phase 1b: f32.store to the static-data \
+                             region under the native-pointer ABI is not yet \
+                             lowered (#359 address relocation) — declining"
+                                .to_string(),
+                        ));
+                    }
+                    if let Some(eff) = self.try_fold_const_addr_store(wasm_ops, idx, *offset)
+                        && self.static_data_addend(eff).is_some()
+                    {
+                        return Err(synth_core::Error::synthesis(
+                            "GI-FPU-002 phase 1b: f32.store to a constant \
+                             static-data address is not yet lowered (#237 \
+                             relocation) — declining"
+                                .to_string(),
+                        ));
+                    }
+                    // WASM f32.store pops: value (f32) first, then address (i32).
+                    let sval = pop_float(&mut stack)?;
+                    // Bit-cast the f32 value into a core register (VMOV Rn,Sn).
+                    let value = alloc_temp_or_spill(
+                        &mut next_temp,
+                        &mut stack,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    )?;
+                    instructions.push(ArmInstruction {
+                        op: ArmOp::I32ReinterpretF32 {
+                            rd: value,
+                            sm: sval,
+                        },
+                        source_line: Some(idx),
+                    });
+                    free_vfp_temp(&mut vfp_used, &vfp_home, sval);
+                    let addr = pop_operand(
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    )?;
+                    let store_ops =
+                        self.generate_store_with_bounds_check(value, addr, *offset as i32, 4);
+                    for op in store_ops {
+                        instructions.push(ArmInstruction {
+                            op,
+                            source_line: Some(idx),
+                        });
+                    }
+                    // Store pushes nothing.
                 }
 
                 // Memory operations need stack-aware handling

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -15363,6 +15363,54 @@ mod tests {
         assert_eq!(l.stack.get(&5), Some(&(4, false)));
     }
 
+    /// #719: AAPCS-VFP independent register pools — an f32 param consumes no core
+    /// register, so the surrounding integer params fill R0.. as if it were absent.
+    #[test]
+    fn test_719_aapcs_vfp_mixed_param_pools() {
+        // (i32, f32): i32 -> R0, f32 skipped (VFP-homed elsewhere).
+        let l = aapcs_param_layout(2, &[false, false], &[false, true]);
+        assert_eq!(l.regs.get(&0), Some(&Reg::R0));
+        assert_eq!(l.regs.get(&1), None); // f32 not in the core pool
+        assert!(l.stack.is_empty());
+        // (f32, i32): the discriminator — i32 -> R0, NOT R1.
+        let l = aapcs_param_layout(2, &[false, false], &[true, false]);
+        assert_eq!(l.regs.get(&0), None); // f32 skipped
+        assert_eq!(l.regs.get(&1), Some(&Reg::R0)); // i32 back-to-R0
+        // (f32, i32, i32, i32, i32): four i32s fill R0..R3, the 5th spills @ nsaa 0
+        // (the f32 never took a core slot).
+        let l = aapcs_param_layout(5, &[false; 5], &[true, false, false, false, false]);
+        assert_eq!(l.regs.get(&1), Some(&Reg::R0));
+        assert_eq!(l.regs.get(&2), Some(&Reg::R1));
+        assert_eq!(l.regs.get(&3), Some(&Reg::R2));
+        assert_eq!(l.regs.get(&4), Some(&Reg::R3));
+        // (i32, f32, i32): both i32s are R0, R1; f32 consumes nothing.
+        let l = aapcs_param_layout(3, &[false; 3], &[false, true, false]);
+        assert_eq!(l.regs.get(&0), Some(&Reg::R0));
+        assert_eq!(l.regs.get(&2), Some(&Reg::R1));
+        assert_eq!(l.regs.get(&1), None);
+    }
+
+    /// #719: f32-across-a-call is DECLINED loudly this round (S0..S15 are
+    /// caller-saved; the spill/rehome across call sites is the next increment).
+    /// The function must Err (loud skip), never silently miscompile.
+    #[test]
+    fn test_719_f32_with_call_declines_loudly() {
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+        selector.set_params_f32(vec![true]); // one f32 param
+        let ops = vec![WasmOp::LocalGet(0), WasmOp::Call(0)];
+        let result = selector.select_with_stack(&ops, 1);
+        assert!(
+            result.is_err(),
+            "f32-in-a-function-with-a-call must decline"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("caller-saved") && err.contains("call"),
+            "decline must name the caller-saved-across-call cause, got: {err}"
+        );
+    }
+
     /// #587: the i64 spill-slot pool is growable — the same op stream that
     /// exhausts the default 8-slot pool compiles with a grown pool. 20 i64
     /// constants are simultaneously live (~16 concurrent pair spills; the

--- a/scripts/repro/f32_ops_719.wat
+++ b/scripts/repro/f32_ops_719.wat
@@ -1,0 +1,71 @@
+(module
+  ;; #719 phase-1b f32 residual fixture (thumb-2 hard-float). Covers the falcon
+  ;; f32 op residual left after #708 (load + reinterpret):
+  ;;   * f32.store            — the VFP-store twin of f32.load
+  ;;   * f32.abs / f32.neg    — VABS.F32 / VNEG.F32 (sign-bit edits)
+  ;;   * f32.copysign         — sign-bit splice (bit-exact ±0/NaN-sign/±inf)
+  ;;   * f32 local.set/tee     — VFP home write-back
+  ;;   * mixed f32/int params  — AAPCS-VFP independent register pools
+  ;;
+  ;; The scalar-math + store + tee fixtures use ALL-i32 signatures (values enter
+  ;; and leave as i32 BITS via reinterpret), so they are single-register in/out
+  ;; and need no mixed-param support to differentiate — bit-exact vs wasmtime.
+  ;; The `mix*` fixtures use genuine f32 params to exercise the independent
+  ;; AAPCS-VFP core/VFP argument pools.
+  (memory 1)
+  (export "mem" (memory 0))
+
+  ;; ---- sign-family math, bits-in / bits-out -------------------------------
+  (func (export "abs") (param i32) (result i32)
+    local.get 0 f32.reinterpret_i32 f32.abs i32.reinterpret_f32)
+  (func (export "neg") (param i32) (result i32)
+    local.get 0 f32.reinterpret_i32 f32.neg i32.reinterpret_f32)
+  ;; copysign(a, b) = |a| with sign of b. a=param0 (magnitude), b=param1 (sign).
+  (func (export "copysign") (param i32 i32) (result i32)
+    local.get 0 f32.reinterpret_i32
+    local.get 1 f32.reinterpret_i32
+    f32.copysign i32.reinterpret_f32)
+
+  ;; ---- f32.store: store the reinterpreted bits at addr, oracle reads mem ----
+  (func (export "store") (param i32 i32)
+    local.get 0                          ;; address
+    local.get 1 f32.reinterpret_i32      ;; f32 value (from bits)
+    f32.store)
+
+  ;; ---- f32 local.set / local.tee (non-param f32 local write-back) ----------
+  ;; set: value -> local 1 -> read back (identity through a VFP home)
+  (func (export "lset") (param i32) (result i32)
+    (local f32)
+    local.get 0 f32.reinterpret_i32
+    local.set 1
+    local.get 1 i32.reinterpret_f32)
+  ;; tee: value -> (local 1 AND stack) -> abs of the tee'd value
+  (func (export "ltee") (param i32) (result i32)
+    (local f32)
+    local.get 0 f32.reinterpret_i32
+    local.tee 1
+    f32.abs
+    i32.reinterpret_f32)
+
+  ;; ---- mixed f32/int parameter pools (AAPCS-VFP) ---------------------------
+  ;; (i32 f32): i32->R0, f32->S0. Return bits(param0 + reinterpret(param1)).
+  (func (export "mix_if") (param i32 f32) (result i32)
+    local.get 0
+    local.get 1 i32.reinterpret_f32
+    i32.add)
+  ;; (f32 i32): f32->S0, i32->R0 (NOT R1 — the pool-independence discriminator).
+  (func (export "mix_fi") (param f32 i32) (result i32)
+    local.get 0 i32.reinterpret_f32
+    local.get 1
+    i32.add)
+  ;; genuine f32 store from an f32 param + i32 addr param (falcon's `store` shape).
+  (func (export "mix_store") (param i32 f32)
+    local.get 0
+    local.get 1
+    f32.store)
+  ;; f32 arithmetic returning an f32 result via a mixed signature.
+  ;; (i32 f32 f32) -> f32 : returns (p1 + p2), bits read back through S0.
+  (func (export "mix_add") (param i32 f32 f32) (result f32)
+    local.get 1
+    local.get 2
+    f32.add))

--- a/scripts/repro/f32_ops_719_differential.py
+++ b/scripts/repro/f32_ops_719_differential.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""#719 — EXECUTION-validate the phase-1b thumb-2 f32 residual increment.
+
+After #708 (f32.load + reinterpret) landed, falcon's float functions skip on the
+NEXT unsupported f32 op. #719 lands the residual:
+
+  * f32.store            — VFP-store twin of f32.load (VMOV Rn,Sn + i32.store path)
+  * f32.abs / f32.neg    — VABS.F32 / VNEG.F32
+  * f32.copysign         — sign-bit splice (bit-exact ±0 / NaN-sign / ±inf)
+  * f32 local.set/tee     — VFP home write-back
+  * mixed f32/int params  — AAPCS-VFP independent core (R0..) / VFP (S0..) pools
+
+Each op is differentiated on Cortex-M4F under unicorn vs wasmtime, BIT-EXACT (the
+sign edges compare the 32-bit pattern, not the float value — -0.0 == +0.0 by
+value but differs in bits). RED on origin/main: every op REJECTS at compile
+(capability gap) -> nonzero. GREEN after #719 -> exit 0.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=/path/to/synth python scripts/repro/f32_ops_719_differential.py
+"""
+import math
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_S0,
+    UC_ARM_REG_S1,
+    UC_ARM_REG_SP,
+)
+
+try:
+    from unicorn.arm_const import UC_ARM_REG_C1_C0_2, UC_ARM_REG_FPEXC
+except ImportError:  # older unicorn naming
+    UC_ARM_REG_C1_C0_2 = None
+    UC_ARM_REG_FPEXC = None
+
+WAT = Path(__file__).with_name("f32_ops_719.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+MEMBASE = 0x20000000  # R11/fp linear-memory base at reset (cortex_m.rs)
+
+
+def compile_elf(out, target):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+         "--target", target, "--all-exports"],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"},
+    )
+    return r.returncode == 0, (r.stderr + r.stdout)
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":  # #489: synth emits an unnamed symtab
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+    return data, base, syms
+
+
+def f32_bits(x):
+    return struct.unpack("<I", struct.pack("<f", x))[0]
+
+
+def bits_f32(b):
+    return struct.unpack("<f", struct.pack("<I", b & 0xFFFFFFFF))[0]
+
+
+def new_uc(text, text_base):
+    uc = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    map_base = text_base & ~0xFFF
+    size = ((len(text) + (text_base - map_base)) + 0xFFF) & ~0xFFF
+    uc.mem_map(map_base, max(size, 0x1000))
+    uc.mem_write(text_base, text)
+    uc.mem_map(0x30000, 0x10000)  # stack
+    uc.mem_map(MEMBASE, 0x10000)  # linear-memory window (R11/fp base)
+    uc.reg_write(UC_ARM_REG_SP, 0x38000)
+    uc.reg_write(UC_ARM_REG_R11, MEMBASE)
+    # Enable the FPU (M4F FPU is off at reset): CPACR CP10/CP11 + FPEXC.EN.
+    if UC_ARM_REG_C1_C0_2 is not None:
+        uc.reg_write(UC_ARM_REG_C1_C0_2, 0x00F00000)
+    if UC_ARM_REG_FPEXC is not None:
+        uc.reg_write(UC_ARM_REG_FPEXC, 0x40000000)
+    return uc
+
+
+def run(text, base, addr, *, r0=None, r1=None, s0=None, s1=None):
+    """Execute one function; return the unicorn context (post-return)."""
+    uc = new_uc(text, base)
+    if r0 is not None:
+        uc.reg_write(UC_ARM_REG_R0, r0 & 0xFFFFFFFF)
+    if r1 is not None:
+        uc.reg_write(UC_ARM_REG_R1, r1 & 0xFFFFFFFF)
+    if s0 is not None:
+        uc.reg_write(UC_ARM_REG_S0, s0 & 0xFFFFFFFF)
+    if s1 is not None:
+        uc.reg_write(UC_ARM_REG_S1, s1 & 0xFFFFFFFF)
+    uc.reg_write(UC_ARM_REG_LR, 0x38000 | 1)
+    uc.emu_start(addr | 1, 0x38000, count=200)
+    return uc
+
+
+def wasm_instance():
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    store = wasmtime.Store(eng)
+    inst = wasmtime.Instance(store, mod, [])
+    return store, inst
+
+
+# Bit patterns exercising the sign edges + normal magnitudes.
+EDGE_BITS = [
+    0x00000000,  # +0.0
+    0x80000000,  # -0.0
+    0x3FC00000,  # 1.5
+    0xBFC00000,  # -1.5
+    0x7F800000,  # +inf
+    0xFF800000,  # -inf
+    0x7FC00000,  # +NaN (quiet)
+    0xFFC00000,  # -NaN (sign set)
+    0x00000001,  # +subnormal tiny
+    0x80000001,  # -subnormal tiny
+    0x42F60000,  # 123.0
+    0xC2F60000,  # -123.0
+    0x7F7FFFFF,  # +FLT_MAX
+]
+
+
+def main():
+    elf = "/tmp/f32_ops_719.elf"
+
+    # Honest-reject on a no-FPU target (m3): every f32 fn must be REJECTED, so
+    # the whole compile fails (no functions emitted).
+    ok_m3, _ = compile_elf("/tmp/f32_ops_719_m3.elf", "cortex-m3")
+    if ok_m3:
+        sys.exit("FAIL: f32 fixture must be REJECTED on cortex-m3 (no FPU)")
+
+    ok, log = compile_elf(elf, "cortex-m4f")
+    if not ok:
+        print("RED: `synth compile -t cortex-m4f` REJECTED the #719 f32 fixture.")
+        print(log.strip()[:900])
+        sys.exit(1)
+
+    text, base, syms = load(elf)
+    store, inst = wasm_instance()
+    exp = inst.exports(store)
+    mem = exp["mem"]
+    fails = 0
+    checked = 0
+
+    def need(name):
+        if name not in syms:
+            nonlocal_fail(f"symbol '{name}' MISSING — function was skipped, not lowered")
+            return False
+        return True
+
+    def nonlocal_fail(msg):
+        nonlocal fails
+        fails += 1
+        print("  MISMATCH " + msg)
+
+    # ---- abs / neg / lset / ltee: bits in R0 -> bits in R0 ----
+    for fn, wname in (("abs", "abs"), ("neg", "neg"), ("lset", "lset"),
+                      ("ltee", "ltee")):
+        if not need(fn):
+            continue
+        for b in EDGE_BITS:
+            uc = run(text, base, syms[fn], r0=b)
+            got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            want = exp[wname](store, b) & 0xFFFFFFFF
+            checked += 1
+            if got != want:
+                nonlocal_fail(f"{fn}(0x{b:08x}) -> 0x{got:08x} != wasmtime 0x{want:08x}")
+            else:
+                print(f"[{fn}] 0x{b:08x} -> 0x{got:08x} (bit-exact) OK")
+
+    # ---- copysign(a, b): a=R0 (magnitude), b=R1 (sign) -> R0 ----
+    if need("copysign"):
+        for a in EDGE_BITS:
+            for b in (0x00000000, 0x80000000, 0x7FC00000, 0xFFC00000,
+                      0x3F800000, 0xBF800000):
+                uc = run(text, base, syms["copysign"], r0=a, r1=b)
+                got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+                want = exp["copysign"](store, a, b) & 0xFFFFFFFF
+                checked += 1
+                if got != want:
+                    nonlocal_fail(
+                        f"copysign(0x{a:08x},0x{b:08x}) -> 0x{got:08x} "
+                        f"!= wasmtime 0x{want:08x}")
+        print(f"[copysign] {len(EDGE_BITS)*6} sign-splice cases checked")
+
+    # ---- f32.store(addr, bits): store to mem[addr], read back ----
+    if need("store"):
+        for i, b in enumerate(EDGE_BITS):
+            addr = 16 * i
+            uc = new_uc(text, base)
+            uc.reg_write(UC_ARM_REG_R0, addr)
+            uc.reg_write(UC_ARM_REG_R1, b)
+            uc.reg_write(UC_ARM_REG_LR, 0x38000 | 1)
+            uc.emu_start(syms["store"] | 1, 0x38000, count=200)
+            got = struct.unpack("<I", uc.mem_read(MEMBASE + addr, 4))[0]
+            # wasmtime: store then read the same word back.
+            exp["store"](store, addr, b)
+            want = struct.unpack("<I", mem.read(store, addr, addr + 4))[0]
+            checked += 1
+            if got != want or got != b:
+                nonlocal_fail(f"store[{addr}]=0x{b:08x} -> mem 0x{got:08x} "
+                              f"!= wasmtime 0x{want:08x}")
+            else:
+                print(f"[store] mem[{addr}] = 0x{got:08x} (bit-exact) OK")
+
+    # ---- mixed f32/int params (AAPCS-VFP independent pools) ----
+    # mix_if(i32 a, f32 x) -> bits(a + reinterpret(x)); a in R0, x in S0.
+    if need("mix_if"):
+        for a, xb in ((7, 0x3FC00000), (0x1000, 0x7F800000), (0xFFFFFFFF, 0x80000000)):
+            uc = run(text, base, syms["mix_if"], r0=a, r1=0xDEADBEEF, s0=xb)
+            got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            want = exp["mix_if"](store, a, bits_f32(xb)) & 0xFFFFFFFF
+            checked += 1
+            if got != want:
+                nonlocal_fail(f"mix_if(0x{a:08x},0x{xb:08x}) -> 0x{got:08x} "
+                              f"!= wasmtime 0x{want:08x}")
+            else:
+                print(f"[mix_if] (0x{a:08x},0x{xb:08x}) -> 0x{got:08x} OK")
+
+    # mix_fi(f32 x, i32 i) -> bits(reinterpret(x) + i); x in S0, i in R0.
+    # R1 poisoned: the old bug read the i32 param from R1 (pool-collision).
+    if need("mix_fi"):
+        for xb, i in ((0x3FC00000, 9), (0x7F800000, 0x2000), (0x80000000, 0xFFFFFFFF)):
+            uc = run(text, base, syms["mix_fi"], r0=i, r1=0xBADC0DE, s0=xb)
+            got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            want = exp["mix_fi"](store, bits_f32(xb), i) & 0xFFFFFFFF
+            checked += 1
+            if got != want:
+                nonlocal_fail(f"mix_fi(0x{xb:08x},0x{i:08x}) -> 0x{got:08x} "
+                              f"!= wasmtime 0x{want:08x}")
+            else:
+                print(f"[mix_fi] (0x{xb:08x},0x{i:08x}) -> 0x{got:08x} OK")
+
+    # mix_store(i32 addr, f32 val): addr in R0, val in S0.
+    if need("mix_store"):
+        for i, b in enumerate((0x3FC00000, 0xFF800000, 0x7FC00000, 0x00000000)):
+            addr = 256 + 16 * i
+            uc = new_uc(text, base)
+            uc.reg_write(UC_ARM_REG_R0, addr)
+            uc.reg_write(UC_ARM_REG_S0, b)
+            uc.reg_write(UC_ARM_REG_LR, 0x38000 | 1)
+            uc.emu_start(syms["mix_store"] | 1, 0x38000, count=200)
+            got = struct.unpack("<I", uc.mem_read(MEMBASE + addr, 4))[0]
+            exp["mix_store"](store, addr, bits_f32(b))
+            want = struct.unpack("<I", mem.read(store, addr, addr + 4))[0]
+            checked += 1
+            if got != want or got != b:
+                nonlocal_fail(f"mix_store[{addr}]=0x{b:08x} -> mem 0x{got:08x} "
+                              f"!= wasmtime 0x{want:08x}")
+            else:
+                print(f"[mix_store] mem[{addr}] = 0x{got:08x} OK")
+
+    # mix_add(i32 dummy, f32 x, f32 y) -> f32 (x + y); x in S0, y in S1, result S0.
+    if need("mix_add"):
+        for xb, yb in ((0x3FC00000, 0x40000000), (0x7F800000, 0x3F800000),
+                       (0x00000000, 0x80000000)):
+            uc = run(text, base, syms["mix_add"], r0=0, s0=xb, s1=yb)
+            got = uc.reg_read(UC_ARM_REG_S0) & 0xFFFFFFFF
+            want = f32_bits(exp["mix_add"](store, 0, bits_f32(xb), bits_f32(yb)))
+            checked += 1
+            if got != want:
+                nonlocal_fail(f"mix_add(0x{xb:08x},0x{yb:08x}) -> 0x{got:08x} "
+                              f"!= wasmtime 0x{want:08x}")
+            else:
+                print(f"[mix_add] (0x{xb:08x},0x{yb:08x}) -> 0x{got:08x} OK")
+
+    if fails:
+        sys.exit(f"\nFAIL: {fails}/{checked} f32 #719 results diverged")
+    print(f"\nGREEN: {checked}/{checked} f32 #719 results bit-exact vs wasmtime "
+          f"(abs/neg/copysign/store/local.set/tee + mixed AAPCS-VFP params; "
+          f"m3 honest-reject confirmed).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Closes most of #719 — the falcon f32 op residual after v0.40.0's #708 (f32.load + reinterpret). Falcon's float functions now skip on the *next* unsupported f32 op; this lands the scalar + calling-convention set.

## Landed (all bit-exact vs wasmtime)

| op | lowering |
|---|---|
| `f32.store` | `VMOV Rn,Sn` + proven i32.store address path |
| `f32.abs` | `VABS.F32` |
| `f32.neg` | `VNEG.F32` |
| `f32.copysign` | sign-bit splice (verified ±0.0, ±inf, NaN-sign) |
| `f32.local.set/tee` | VFP home write-back |
| mixed `f32`/`int` params | **AAPCS-VFP independent register pools** — `(param i32 f32)` → i32 in R0, f32 in S0; both orderings |

## Declined (loud, never silent)

- **f32 across a call** (`S0..S15` caller-saved): declines with `"f32 in a function with a call is not yet lowered (S0..S15 are caller-saved) — declining"`; the function is skipped, absent from the ELF — not a silent miscompile. This is the ~2-function residual; the spill/rehome-across-`bl` lane is a clean follow-up.

## Gate

- New `scripts/repro/f32_ops_719_differential.py` + `f32_ops_719.wat`: **156/156 bit-exact vs wasmtime** on cortex-m4f (store incl. sign edge cases, abs/neg/copysign, local.set/tee, mixed params both orderings, mix_store, mix_add). **Wired into CI** (`trap-semantics-oracle` job).
- Frozen anchors 10/10; `-b riscv`/`-b aarch64` honest-reject the newly-decoded ops.
- Independently re-verified by the maintainer (oracle re-run + across-call decline + frozen + clippy).

_Note: this branch and #720 both touch `ci.yml` (each adds an f32 oracle step) — expect a trivial union merge; keep both steps._

🤖 Generated with [Claude Code](https://claude.com/claude-code)