### PR TITLE
feat(vcr-perf): redundant-mask elision — proof-carrying #494 phase 3+ (VCR-PERF-002)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,7 @@ jobs:
         run: SYNTH=./target/debug/synth python scripts/repro/f32_ops_719_differential.py
 
   fact-spec-oracle:
-    name: fact-spec elision oracle (#494 phases 2 + 2b)
+    name: fact-spec elision oracle (#494 phases 2 + 2b + 3+)
     # VCR-PERF-002 Phase 2 (#494): the proof-carrying-specialization lever
     # (SYNTH_FACT_SPEC, default off; per-elision ordeal obligation). Built
     # with the `verify` feature (the solver lives in synth-verify — pure-Rust
@@ -443,6 +443,20 @@ jobs:
         run: >
           python scripts/repro/fact_spec_select_494_differential.py
           --fact-lo 0 --fact-hi 4000 --expect-decline
+      # #494 phase 3+ — redundant-mask (narrowing) elision: a proven-narrow
+      # value makes an `i32.and` mask the identity, so it is deleted. On the
+      # representative gust_kernel lane-pack (`lo | (hi<<11)`, both lanes proven
+      # ∈ [0,2047], masks `& 0x7FF` that are NOT uxtb/uxth-foldable) this is an
+      # unambiguous byte win LLVM cannot make (no range on the dissolved
+      # params): in-bounds differential (specialized ≡ wasmtime ≡ unspecialized,
+      # 2 elisions + a required shrink) and the wrong-bound loud-decline
+      # byte-identity leg (bound [0,4095] makes `x & 0x7FF != x` Sat).
+      - name: Run mask-elision in-bounds differential (proven bound)
+        run: python scripts/repro/fact_spec_mask_494_differential.py
+      - name: Run mask-elision wrong-bound loud-decline path
+        run: >
+          python scripts/repro/fact_spec_mask_494_differential.py
+          --fact-lo 0 --fact-hi 4095 --expect-decline
 
   rv32-shift-fold-oracle:
     name: rv32 immediate-shift-fold execution oracle

--- a/crates/synth-verify/src/fact_spec.rs
+++ b/crates/synth-verify/src/fact_spec.rs
@@ -731,6 +731,80 @@ impl<'a> Pass<'a> {
         }
     }
 
+    /// #494 Phase 3+: redundant-mask (narrowing) elision. When the value `a`
+    /// is proven narrow enough that `a & b == a` on every P-admissible input
+    /// (`UNSAT(P ∧ (a & b) ≠ a)`), the `i32.and` is the identity — its mask
+    /// operand `b` and the `and` op itself are deleted and `a` flows through
+    /// unchanged. This is the "known-narrow-value ⇒ drop the mask" class: a
+    /// dissolved primitive gives LLVM no range on the value, so it keeps the
+    /// `and`/`uxtb`; the fact makes the mask provably dead. Only the common
+    /// wasm order (`value ; const-mask ; and`, keep `a`) is handled — anything
+    /// else DECLINES LOUDLY and the general `and` stands. Returns the surviving
+    /// operand's `Val` on admit (deletion recorded), `None` on decline.
+    fn try_elide_mask(&mut self, i: usize, a: &Val, b: &Val, result_bv: &BV) -> Option<Val> {
+        if self.premises.is_empty() {
+            self.decline(format!(
+                "op#{i} i32.and — no premise reaches this site (no usable value-range fact)"
+            ));
+            return None;
+        }
+        // The mask operand `b` must be a pure, contiguous producer sitting
+        // immediately between `a`'s slice and the `and` — otherwise deleting
+        // it could drop live work (`local.tee`) or leave a gap.
+        let Some(sb) = b.start else {
+            self.decline(format!(
+                "op#{i} i32.and — mask slice is impure or non-contiguous (not erasable)"
+            ));
+            return None;
+        };
+        if a.created + 1 != sb || b.created + 1 != i {
+            self.decline(format!(
+                "op#{i} i32.and — mask operand is not produced immediately before the and \
+                 (non-contiguous)"
+            ));
+            return None;
+        }
+        let mut solver = new_solver();
+        for p in &self.premises {
+            solver.assert(p);
+        }
+        // UNSAT(P ∧ (value & mask) ≠ value) ⇒ the mask never clears a bit of
+        // the value under P ⇒ the `and` is the identity, so the general and
+        // the specialized lowerings (result = value) agree on every P input.
+        solver.assert(&result_bv.ne(&a.bv));
+        match solver.check() {
+            CheckOutcome::Unsat => {
+                self.deletions.push((sb, i));
+                self.admitted.push(format!(
+                    "{}: op#{i} i32.and — redundant mask elided (value proven narrow): \
+                     UNSAT(P ∧ (value & mask) ≠ value) via {} (certificate-checked QF_BV; \
+                     every Unsat carries an LRAT proof validated by ordeal-lrat); deleted \
+                     mask/and [{sb}..={i}]; P = {{{}}}; value = {}",
+                    self.func,
+                    solver.name(),
+                    self.premise_desc.join(" ∧ "),
+                    a.bv,
+                ));
+                Some(a.clone())
+            }
+            CheckOutcome::Sat => {
+                let cex = self.counterexample(solver.as_ref());
+                self.decline(format!(
+                    "op#{i} i32.and — mask is not redundant under P (value can carry a bit \
+                     outside the mask; counterexample: {cex}); general and retained"
+                ));
+                None
+            }
+            CheckOutcome::Unknown(reason) => {
+                self.decline(format!(
+                    "op#{i} i32.and — mask-redundancy obligation Unknown ({reason}); \
+                     conservative decline, general and retained"
+                ));
+                None
+            }
+        }
+    }
+
     fn walk(&mut self) {
         if self.range_facts.is_empty() && self.nonzero_facts.is_empty() {
             self.decline(
@@ -802,12 +876,46 @@ impl<'a> Pass<'a> {
                     let start = a.start.filter(|_| a.created + 1 == i);
                     self.push(bv, start, i);
                 }
+                // #494 Phase 3+: `i32.and` — tracked like the other trap-free
+                // binops, but additionally attempts the redundant-mask elision
+                // (a proven-narrow value makes the mask the identity). A
+                // NON-eliding `and` pushes the EXACT `(bv, start, i)` the
+                // general binop arm below produces — so flag-off stays
+                // byte-identical.
+                WasmOp::I32And => {
+                    let (Some(b), Some(a)) = (self.stack.pop(), self.stack.pop()) else {
+                        self.decline(format!("op#{i} binop on underflowing symbolic stack"));
+                        return;
+                    };
+                    if a.bv.get_size() != 32 || b.bv.get_size() != 32 {
+                        self.decline(format!("op#{i} i32 binop on a non-32-bit operand"));
+                        return;
+                    }
+                    let bv = self.sem.encode_op(op, &[a.bv.clone(), b.bv.clone()]);
+                    self.attach_fact(i, &bv);
+                    // The general binop arm's contiguity proof, verbatim.
+                    let start = match (a.start, b.start) {
+                        (Some(sa), Some(sb)) if a.created + 1 == sb && b.created + 1 == i => {
+                            Some(sa)
+                        }
+                        _ => None,
+                    };
+                    match self.try_elide_mask(i, &a, &b, &bv) {
+                        // Admitted: the mask/and slice was recorded for
+                        // deletion; the surviving value flows through. `start =
+                        // None` keeps the collapsed result out of any later
+                        // erasable slice (conservative, like select-collapse).
+                        Some(surviving) => self.push(surviving.bv, None, i),
+                        // Declined (loud): the general `and` stands, pushed
+                        // exactly as the general binop arm would.
+                        None => self.push(bv, start, i),
+                    }
+                }
                 // Tracked, trap-free i32 binops (div/rem excluded on purpose:
                 // they can trap, and a deleted slice must be effect-free).
                 WasmOp::I32Add
                 | WasmOp::I32Sub
                 | WasmOp::I32Mul
-                | WasmOp::I32And
                 | WasmOp::I32Or
                 | WasmOp::I32Xor
                 | WasmOp::I32Shl
@@ -1662,6 +1770,132 @@ mod tests {
             vec![6],
             "mark remapped from original op#13 to rewritten op#6"
         );
+    }
+
+    // ============ #494 Phase 3+: redundant-mask (narrowing) elision ============
+
+    /// A representative dissolved DSP kernel: pack two proven-11-bit lanes,
+    /// `lo | (hi << 11)`. Both `& 0x7FF` masks are redundant under the lane
+    /// bounds — LLVM keeps them (no range on the params); the facts drop them.
+    fn pack_lanes_ops() -> Vec<WasmOp> {
+        vec![
+            LocalGet(0),     // 0  lo    ← fact [0, 2047]
+            I32Const(0x7FF), // 1
+            I32And,          // 2  lo & 0x7FF  (redundant)
+            LocalGet(1),     // 3  hi    ← fact [0, 2047]
+            I32Const(0x7FF), // 4
+            I32And,          // 5  hi & 0x7FF  (redundant)
+            I32Const(11),    // 6
+            I32Shl,          // 7  hi << 11
+            I32Or,           // 8  lo | (hi << 11)
+            End,             // 9
+        ]
+    }
+
+    #[test]
+    fn narrow_value_elides_redundant_mask_494() {
+        // lo, hi ∈ [0, 2047] ⇒ `x & 0x7FF == x`: both masks fall to
+        // UNSAT(P ∧ (value & mask) ≠ value); each deletes its `const;and` pair.
+        let ops = pack_lanes_ops();
+        let r = specialize_function(
+            "gust_kernel",
+            &ops,
+            &[],
+            &[fact(0, 0, 2047), fact(3, 0, 2047)],
+            &[],
+        );
+        assert_eq!(r.admitted.len(), 2, "declines: {:?}", r.declined);
+        assert!(r.changed());
+        assert_eq!(
+            r.ops,
+            vec![
+                LocalGet(0), // lo flows through the elided mask
+                LocalGet(1), // hi flows through the elided mask
+                I32Const(11),
+                I32Shl,
+                I32Or,
+                End,
+            ],
+            "both redundant masks must be gone, the arithmetic intact"
+        );
+        assert_eq!(r.kept, vec![0, 3, 6, 7, 8, 9]);
+        for line in &r.admitted {
+            assert!(line.contains("UNSAT(P ∧ (value & mask) ≠ value)"), "{line}");
+            assert!(line.contains("certificate-checked"), "{line}");
+            assert!(line.contains("redundant mask elided"), "{line}");
+        }
+    }
+
+    #[test]
+    fn wide_bound_makes_mask_live_and_declines_byte_identically_494() {
+        // lo ∈ [0, 0xFFF]: value 0x800 has bit 11 set, OUTSIDE the 0x7FF mask,
+        // so `x & 0x7FF != x` is Sat — the mask is genuinely live. BOTH sites
+        // decline loudly with a counterexample; the stream is byte-identical.
+        let ops = pack_lanes_ops();
+        let r = specialize_function(
+            "gust_kernel",
+            &ops,
+            &[],
+            &[fact(0, 0, 0xFFF), fact(3, 0, 0xFFF)],
+            &[],
+        );
+        assert_eq!(r.admitted.len(), 0);
+        assert!(!r.changed());
+        assert_eq!(r.ops, ops, "declined ⇒ byte-identical op stream");
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("not redundant") && d.contains("counterexample")),
+            "declines must be loud and carry a model: {:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn mask_without_constraining_premise_declines_no_false_elision_494() {
+        // A TRUE ValueRange fact exists (so the walk runs) but targets the mask
+        // const, not the value; the masked value carries no premise ⇒ the
+        // obligation is Sat ⇒ loud decline, byte-identical.
+        let ops = vec![
+            LocalGet(0),     // 0  value — unconstrained
+            I32Const(0x7FF), // 1  mask ← fact [0x7FF, 0x7FF] (true, non-constraining)
+            I32And,          // 2
+            End,             // 3
+        ];
+        let r = specialize_function("f", &ops, &[], &[fact(1, 0x7FF, 0x7FF)], &[]);
+        assert_eq!(r.admitted.len(), 0);
+        assert!(!r.changed());
+        assert_eq!(r.ops, ops);
+    }
+
+    #[test]
+    fn signed_narrow_bound_that_admits_negative_keeps_the_mask_494() {
+        // value ∈ [-1, 2047]: -1 is all-ones, so `-1 & 0x7FF = 0x7FF != -1` —
+        // the obligation is Sat and the mask is (correctly) retained. Guards
+        // against a naive "hi ≤ mask" shortcut that ignores the sign bit.
+        let ops = vec![
+            LocalGet(0),     // 0  ← fact [-1, 2047]
+            I32Const(0x7FF), // 1
+            I32And,          // 2
+            End,             // 3
+        ];
+        let r = specialize_function("f", &ops, &[], &[fact(0, -1, 2047)], &[]);
+        assert_eq!(
+            r.admitted.len(),
+            0,
+            "a negative value fails the mask identity"
+        );
+        assert!(!r.changed());
+        assert_eq!(r.ops, ops);
+    }
+
+    #[test]
+    fn mask_elision_no_facts_changes_nothing_494() {
+        let ops = pack_lanes_ops();
+        let r = specialize_function("gust_kernel", &ops, &[], &[], &[]);
+        assert!(!r.changed());
+        assert_eq!(r.ops, ops);
+        assert!(!r.declined.is_empty(), "the no-fact case is a loud decline");
     }
 
     #[test]

--- a/scripts/repro/fact_spec_mask_494.wat
+++ b/scripts/repro/fact_spec_mask_494.wat
@@ -1,0 +1,25 @@
+;; VCR-PERF-002 Phase 3+ (#494) — redundant-mask (narrowing) elision fixture.
+;;
+;; A representative dissolved DSP kernel: pack two lanes into one word,
+;; `lo | (hi << 11)`. Each lane is masked with `& 0x7FF` (11 bits). When loom
+;; proves both lanes are already in [0, 2047] (a wsc.facts ValueRange premise
+;; appended by the differential harness), each `x & 0x7FF == x` — the masks are
+;; provably the identity and synth deletes them. LLVM keeps them: a dissolved
+;; primitive gives it no range on the params. 0x7FF is NOT a Thumb-2 modified
+;; immediate and is NOT uxtb/uxth-foldable, so the flag-off baseline emits
+;; `movw + and` per mask — an unambiguous 2-instruction-per-mask byte win.
+;;
+;; Value ids (0-based operator index within the body):
+;;   0 = local.get $lo   ← fact target (lane bound)
+;;   3 = local.get $hi   ← fact target (lane bound)
+(module
+  (func $gust_kernel (export "gust_kernel") (param $lo i32) (param $hi i32) (result i32)
+    local.get $lo    ;; 0
+    i32.const 0x7FF  ;; 1
+    i32.and          ;; 2  lo & 0x7FF  (redundant under the proven bound)
+    local.get $hi    ;; 3
+    i32.const 0x7FF  ;; 4
+    i32.and          ;; 5  hi & 0x7FF  (redundant under the proven bound)
+    i32.const 11     ;; 6
+    i32.shl          ;; 7  hi << 11
+    i32.or))         ;; 8  lo | (hi << 11)

--- a/scripts/repro/fact_spec_mask_494_differential.py
+++ b/scripts/repro/fact_spec_mask_494_differential.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""VCR-PERF-002 Phase 3+ (#494) — redundant-mask (narrowing) elision oracle.
+
+Builds the `gust_kernel` lane-pack fixture WITH schema-v1 `wsc.facts`
+value-range premises appended (default: both lanes proven ∈ [0, 2047]),
+compiles it twice — SPECIALIZED (SYNTH_FACT_SPEC=1) and UNSPECIALIZED (flag
+off) — and asserts three things:
+
+  (a) BYTE WIN — the specialized `gust_kernel` .text is strictly smaller: each
+      redundant `& 0x7FF` mask (a `movw + and`, NOT uxtb/uxth-foldable) is
+      gone. Non-vacuity: the run FAILS unless exactly 2 certificate-backed
+      elisions were admitted AND the function shrank.
+  (b) EXECUTION MATCHES wasmtime — sweeps a grid of in-bounds (lo, hi) under
+      unicorn (Thumb-2) and asserts specialized ≡ wasmtime ground truth ≡
+      unspecialized synth. Out-of-bound behavior is deliberately unconstrained
+      (the bound is the contract) so the sweep stays in-bounds.
+  (c) SOUND DECLINE without the premise — `--expect-decline` re-runs with a
+      wrong (too-wide) bound under which `x & 0x7FF != x` is Sat: synth must
+      DECLINE loudly (0 admits) and emit a byte-identical-to-baseline stream.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/fact_spec_mask_494_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("fact_spec_mask_494.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+FUNC = "gust_kernel"
+
+
+# ---- schema-v1 wsc.facts encoding (docs/design/wsc-facts-encoding.md) ----
+
+def leb_u32(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7F
+        v >>= 7
+        out.append(b | (0x80 if v else 0))
+        if not v:
+            return bytes(out)
+
+
+def leb_s64(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7F
+        v >>= 7
+        done = (v == 0 and not (b & 0x40)) or (v == -1 and (b & 0x40))
+        out.append(b | (0 if done else 0x80))
+        if done:
+            return bytes(out)
+
+
+def value_range_record(func_index, value_id, lo, hi):
+    body = leb_s64(lo) + leb_s64(hi)
+    return (
+        b"\x01"                       # kind: value-range
+        + leb_u32(func_index)
+        + leb_u32(value_id)
+        + leb_u32(len(body))
+        + body
+    )
+
+
+def facts_payload(records):
+    out = b"\x01" + leb_u32(len(records))  # version 1, count
+    for r in records:
+        out += r
+    return out
+
+
+def append_custom_section(wasm, name, payload):
+    content = leb_u32(len(name)) + name + payload
+    return wasm + b"\x00" + leb_u32(len(content)) + content
+
+
+# ---- compile + load ----
+
+def compile_elf(wasm_path, out, fact_spec):
+    env = {"PATH": "/usr/bin:/bin"}
+    if fact_spec:
+        env["SYNTH_FACT_SPEC"] = "1"
+    r = subprocess.run(
+        [SYNTH, "compile", str(wasm_path), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env=env,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({out}): {r.stderr}")
+    return r.stderr
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms, sizes = {}, {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+                    sizes[sym.name] = sym["st_size"]
+    return data, base, syms, sizes
+
+
+def run_arm(code, base, addr, lo, hi):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(base & ~0xFFFF, 0x20000)
+    mu.mem_write(base, code)
+    mu.mem_map(0x90000, 0x10000)
+    ret = 0x90100
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    mu.reg_write(UC_ARM_REG_R0, lo & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_R1, hi & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_SP, 0x98000)
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    mu.emu_start(addr | 1, ret, timeout=5_000_000)
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+# The in-bounds grid: lane boundaries + a few interior points (full 2048^2
+# cross product is needless — these exercise every bit boundary of 0x7FF).
+GRID = [0, 1, 2, 255, 256, 511, 512, 1023, 1024, 1536, 2046, 2047]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fact-lo", type=int, default=0,
+                    help="lane value-range premise lower bound (the loom claim)")
+    ap.add_argument("--fact-hi", type=int, default=2047,
+                    help="lane value-range premise upper bound")
+    ap.add_argument("--expect-decline", action="store_true",
+                    help="assert the elision was DECLINED (wrong-bound green path)")
+    args = ap.parse_args()
+
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth first")
+
+    base_wasm = wasmtime.wat2wasm(WAT.read_text())
+    # Two value-range records: lane lo at value_id 0, lane hi at value_id 3.
+    payload = facts_payload([
+        value_range_record(0, 0, args.fact_lo, args.fact_hi),
+        value_range_record(0, 3, args.fact_lo, args.fact_hi),
+    ])
+    wasm = append_custom_section(bytes(base_wasm), b"wsc.facts", payload)
+    wasm_path = "/tmp/fact_spec_mask_494.wasm"
+    Path(wasm_path).write_bytes(wasm)
+
+    spec_elf = "/tmp/fact_spec_mask_494_spec.elf"
+    base_elf = "/tmp/fact_spec_mask_494_base.elf"
+    stderr_spec = compile_elf(wasm_path, spec_elf, fact_spec=True)
+    compile_elf(wasm_path, base_elf, fact_spec=False)
+
+    admits = stderr_spec.count("fact-spec: ADMIT")
+    declines = stderr_spec.count("fact-spec: DECLINE")
+    print(f"specialized compile: {admits} ADMIT, {declines} DECLINE")
+
+    scode, sbase, ssyms, ssizes = load(spec_elf)
+    bcode, bbase, bsyms, bsizes = load(base_elf)
+    ssize = ssizes.get(FUNC) or len(scode)
+    bsize = bsizes.get(FUNC) or len(bcode)
+    print(f"{FUNC} size: unspecialized {bsize} B -> specialized {ssize} B")
+
+    if args.expect_decline:
+        if admits != 0:
+            sys.exit(f"expected DECLINE under bound [{args.fact_lo},{args.fact_hi}] "
+                     f"but {admits} elisions were admitted")
+        if scode != bcode:
+            sys.exit("declined build must be byte-identical to baseline")
+        print("ORACLE: PASS (declined loudly, general lowering emitted)")
+        return
+
+    # Non-vacuity: both redundant masks must actually be gone.
+    if admits != 2:
+        sys.exit(f"expected 2 certificate-backed mask elisions, got {admits} — "
+                 f"stderr:\n{stderr_spec}")
+    if ssize >= bsize:
+        sys.exit("specialized gust_kernel did not shrink — elision did not reach codegen")
+
+    # wasmtime ground truth.
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, wasm)
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    gk = inst.exports(st)[FUNC]
+
+    fails = 0
+    checked = 0
+    for lo in GRID:
+        for hi in GRID:
+            if not (args.fact_lo <= lo <= args.fact_hi):
+                continue
+            if not (args.fact_lo <= hi <= args.fact_hi):
+                continue
+            checked += 1
+            gt = gk(st, lo, hi) & 0xFFFFFFFF
+            got_spec = run_arm(scode, sbase, ssyms[FUNC], lo, hi)
+            got_base = run_arm(bcode, bbase, bsyms[FUNC], lo, hi)
+            if not (got_spec == gt == got_base):
+                fails += 1
+                if fails <= 10:
+                    print(f"FAIL lo={lo} hi={hi}: wasmtime={gt} "
+                          f"specialized={got_spec} unspecialized={got_base}")
+    print(f"swept {checked} in-bounds (lo, hi) pairs on [{args.fact_lo}, {args.fact_hi}]")
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails}/{checked})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## VCR-PERF-002 / #494 phase 3+ — ONE new proof-carrying elision class: **redundant-mask elision**

A value proven narrow by a loom `wsc.facts` **ValueRange** premise makes an `i32.and` mask the identity — so the mask materialization and the `and` itself are certificate-elided. This is information LLVM structurally lacks (a dissolved primitive gives it no range on the params), so it keeps the `movw + and.w` pair forever; synth deletes it with a proof.

### The obligation (per site, ordeal-certified)

```
UNSAT( P ∧ (value & mask) ≠ value )
```

discharged through the ordeal-backed certificate-checked QF_BV solver (every Unsat carries an LRAT proof validated by `ordeal-lrat`) — **never attempted without a premise**, and only when the mask operand is a pure, contiguous producer sitting immediately before the `and` (the clamp/select erasability discipline, reused verbatim). Pure stream deletion — no selector wiring, no new trust.

### Sound decline (b)

- Sat (`value` can carry a bit outside the mask, e.g. bound `[0, 4095]` vs mask `0x7FF`) ⇒ **loud decline with a counterexample**, byte-identical to flag-off — CI-pinned by the oracle's `--expect-decline` leg.
- Unknown / impure slice / non-contiguous / no premise ⇒ loud decline, general `and` stands.
- Signed subtlety covered: bound `[-1, 2047]` is Sat (`-1 & 0x7FF = 0x7FF ≠ -1`) — unit test pins that a naive "hi ≤ mask" shortcut is not what ships.

### Measured byte win (c) — `gust_kernel` lane-pack fixture

`lo | (hi << 11)` with both lanes defensively masked `& 0x7FF` (11-bit lanes; deliberately NOT uxtb/uxth-foldable and not a Thumb-2 modified immediate — the mask genuinely costs `movw + 2× and.w`):

| build | gust_kernel `.text` |
|---|---|
| flag-off (and declined-under-wrong-bound) | **34 B** |
| `SYNTH_FACT_SPEC=1` + proven lane bound `[0, 2047]` | **20 B** (−14 B, −41 %) |

Disasm ground truth: specialized body is `movs #11; and #0x1f; lsl.w; orr.w` — no `movw #0x7ff`, no masks. (Bytes are the buildable proxy; cycles stay gale's silicon call.)

### Oracle — `scripts/repro/fact_spec_mask_494_differential.py` (wired into `fact-spec-oracle` CI job)

- **Green leg**: requires exactly 2 certificate-backed ADMITs + a strict shrink (non-vacuity: a verify-less or silently-dead lever fails loud — demonstrated during bring-up when a default-feature rebuild overwrote the binary and the oracle went red), then sweeps a 144-pair in-bounds grid (every bit boundary of `0x7FF`) asserting **specialized ≡ wasmtime ≡ unspecialized**.
- **Decline leg** (`--fact-lo 0 --fact-hi 4095 --expect-decline`): 0 admits, declined build **byte-identical** to baseline.

### Frozen-safety / gates (all re-run green on this commit)

- flag-OFF byte-identical by construction (pass runs only under `SYNTH_FACT_SPEC` + a parseable `wsc.facts` section; the non-eliding `i32.and` pushes the exact `(bv, start, created)` the general binop arm produced) — `frozen_codegen_bytes` **10/10**
- 28 fact_spec unit tests (5 new), `cargo test -p synth-verify` 176/176
- pre-existing clamp / select / div oracles: all 7 legs green (incl. the div force-admit RED demo)
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings` (+ `--features verify`) clean
- `claim_check.py` 17/17 (claims.yaml untouched)

Refs #494, #242 (VCR-PERF-002).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
