### PR TITLE
feat(vfp): f32-across-call spill/rehome (#719 residual) + scalar f64 phase 2 for falcon (#369)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,8 +372,20 @@ jobs:
       # #719: the falcon f32 residual — f32.store, abs/neg/copysign, local.set/
       # tee, and mixed f32/int AAPCS-VFP params — bit-exact vs wasmtime on m4f,
       # including the copysign ±0/NaN-sign/±inf sign edges. m3 honest-reject.
+      # #719 phase 2 extension (same harness): f32 live ACROSS an integer call
+      # (spill/reload around the bl, non-vacuous — the callee clobbers S0/S1)
+      # + float-signature-callee loud-decline pinned via symtab absence.
       - name: Run f32 store/abs/neg/copysign/local + mixed-param oracle (#719, m4f)
         run: SYNTH=./target/debug/synth python scripts/repro/f32_ops_719_differential.py
+      # #369 (GI-FPU-002 phase 2): the scalar f64 subset on cortex-m7dp —
+      # const/promote_f32/arith/compare/load/store + f64-across-call, bit-exact
+      # (NaN==NaN per Core §4.3.3) vs wasmtime under unicorn. Pins the
+      # #712-class f64 compare flag-clobber fix (MOVS after VMRS returned
+      # stale-flag results), the m4f/m3 honest-reject (single-precision / no
+      # FPU), and the f64-ABI-boundary loud-declines (f64 params, f64-returning
+      # calls).
+      - name: Run f64 const/promote/arith/compare/mem + across-call oracle (#369, m7dp)
+        run: SYNTH=./target/debug/synth python scripts/repro/f64_369_differential.py
 
   fact-spec-oracle:
     name: fact-spec elision oracle (#494 phases 2 + 2b)

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -96,6 +96,12 @@ impl Backend for ArmBackend {
                 .func_params_f32
                 .get(func.index as usize)
                 .filter(|p| !p.is_empty());
+            // GI-FPU-002 phase 2 (#369): THIS function's declared f64-param
+            // mask (hard-float targets decline f64 params loudly).
+            let params_f64 = config
+                .func_params_f64
+                .get(func.index as usize)
+                .filter(|p| !p.is_empty());
             // GI-FPU-002 phase 2 (#719/#369): THIS function's declared f32/f64
             // return flag, so the epilogue soundness guard fires on every driver
             // path (not only the CLI loops).
@@ -111,6 +117,7 @@ impl Backend for ArmBackend {
                 .unwrap_or(false);
             let func_config = if params.is_some()
                 || params_f32.is_some()
+                || params_f64.is_some()
                 || !func.block_arity.is_empty()
                 || declared_params.is_some()
                 || ret_f32
@@ -119,6 +126,7 @@ impl Backend for ArmBackend {
                 Some(CompileConfig {
                     current_func_params_i64: params.cloned().unwrap_or_default(),
                     current_func_params_f32: params_f32.cloned().unwrap_or_default(),
+                    current_func_params_f64: params_f64.cloned().unwrap_or_default(),
                     current_func_ret_f32: ret_f32,
                     current_func_ret_f64: ret_f64,
                     current_func_block_arity: func.block_arity.clone(),
@@ -415,6 +423,9 @@ fn compile_wasm_to_arm(
         // GI-FPU-002 (#619/#369): declared f32-param mask — home hard-float f32
         // args in S0..S15 (AAPCS-VFP) instead of the R0..R3 integer path.
         selector.set_params_f32(config.current_func_params_f32.clone());
+        // GI-FPU-002 phase 2 (#369): declared f64-param mask — hard-float
+        // targets decline f64-param functions loudly (no D-register homing yet).
+        selector.set_params_f64(config.current_func_params_f64.clone());
         // GI-FPU-002 phase 2 (#719/#369): THIS function's f32/f64 return flag, so
         // the epilogue loudly declines a float result reaching it in a core
         // register (never a silent integer R0 return where a caller reads S0/D0).

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -96,14 +96,31 @@ impl Backend for ArmBackend {
                 .func_params_f32
                 .get(func.index as usize)
                 .filter(|p| !p.is_empty());
+            // GI-FPU-002 phase 2 (#719/#369): THIS function's declared f32/f64
+            // return flag, so the epilogue soundness guard fires on every driver
+            // path (not only the CLI loops).
+            let ret_f32 = config
+                .func_ret_f32
+                .get(func.index as usize)
+                .copied()
+                .unwrap_or(false);
+            let ret_f64 = config
+                .func_ret_f64
+                .get(func.index as usize)
+                .copied()
+                .unwrap_or(false);
             let func_config = if params.is_some()
                 || params_f32.is_some()
                 || !func.block_arity.is_empty()
                 || declared_params.is_some()
+                || ret_f32
+                || ret_f64
             {
                 Some(CompileConfig {
                     current_func_params_i64: params.cloned().unwrap_or_default(),
                     current_func_params_f32: params_f32.cloned().unwrap_or_default(),
+                    current_func_ret_f32: ret_f32,
+                    current_func_ret_f64: ret_f64,
                     current_func_block_arity: func.block_arity.clone(),
                     current_func_param_count: declared_params,
                     ..config.clone()
@@ -398,6 +415,21 @@ fn compile_wasm_to_arm(
         // GI-FPU-002 (#619/#369): declared f32-param mask — home hard-float f32
         // args in S0..S15 (AAPCS-VFP) instead of the R0..R3 integer path.
         selector.set_params_f32(config.current_func_params_f32.clone());
+        // GI-FPU-002 phase 2 (#719/#369): THIS function's f32/f64 return flag, so
+        // the epilogue loudly declines a float result reaching it in a core
+        // register (never a silent integer R0 return where a caller reads S0/D0).
+        selector.set_ret_float(config.current_func_ret_f32, config.current_func_ret_f64);
+        // GI-FPU-002 phase 2 (#719/#369): per-callee float-signature tables, so
+        // `Call`/`CallIndirect` decline LOUDLY when the callee itself has a
+        // float ABI at the boundary (f32/f64 return in S0/D0, f32 params in the
+        // VFP pool) — the un-marshalled cases of this increment.
+        selector.set_float_call_signatures(
+            config.func_ret_f32.clone(),
+            config.func_ret_f64.clone(),
+            config.type_ret_f32.clone(),
+            config.type_ret_f64.clone(),
+            config.func_params_f32.clone(),
+        );
         // #509: blocktype-arity side-table of THIS function, so value-carrying
         // br/br_if/br_table land the carried value in the target block's
         // designated result register instead of dropping it. Empty ⇒ legacy

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -7098,16 +7098,15 @@ impl ArmEncoder {
         let mut bytes = Vec::new();
         let rd_bits = reg_to_bits(rd);
 
-        // VCMP.F64 Dn, Dm
-        let dn_num = vfp_dreg_to_num(dn)?;
-        let dm_num = vfp_dreg_to_num(dm)?;
-        let (vd, d) = encode_dreg(dn_num);
-        let (vm, m) = encode_dreg(dm_num);
-        let vcmp = 0xEEB40B40 | (d << 22) | (vd << 12) | (m << 5) | vm;
-        bytes.extend_from_slice(&vfp_to_thumb_bytes(vcmp));
-
-        // VMRS APSR_nzcv, FPSCR
-        bytes.extend_from_slice(&vfp_to_thumb_bytes(0xEEF1FA10));
+        // #712-class fix (found at f64-phase-2 wiring, #369): the 16-bit
+        // `MOVS Rd,#0` is FLAG-SETTING. The original order emitted it AFTER
+        // `VMRS APSR_nzcv, FPSCR`, clobbering the N/Z/C/V flags the VMRS just
+        // transferred, so the following `IT<cond>` read stale flags and every
+        // f64 comparison silently returned 0 — the exact bug the f32 compare
+        // encoder shipped with and #712 fixed. Same fix: materialize the `#0`
+        // FIRST (its flag side effect is overwritten by the VMRS), then
+        // VCMP+VMRS set the flags the IT consumes. Pure reorder — sizes
+        // unchanged.
 
         // MOVS Rd, #0
         if rd_bits < 8 {
@@ -7119,6 +7118,17 @@ impl ArmEncoder {
             bytes.extend_from_slice(&hw1.to_le_bytes());
             bytes.extend_from_slice(&hw2.to_le_bytes());
         }
+
+        // VCMP.F64 Dn, Dm
+        let dn_num = vfp_dreg_to_num(dn)?;
+        let dm_num = vfp_dreg_to_num(dm)?;
+        let (vd, d) = encode_dreg(dn_num);
+        let (vm, m) = encode_dreg(dm_num);
+        let vcmp = 0xEEB40B40 | (d << 22) | (vd << 12) | (m << 5) | vm;
+        bytes.extend_from_slice(&vfp_to_thumb_bytes(vcmp));
+
+        // VMRS APSR_nzcv, FPSCR (sets the flags the IT consumes)
+        bytes.extend_from_slice(&vfp_to_thumb_bytes(0xEEF1FA10));
 
         // IT<cond>
         let it: u16 = 0xBF00 | ((cond_code as u16) << 4) | 0x8;

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1395,6 +1395,15 @@ fn compile_command(
     // Empty for the demo path (no module signature).
     let mut current_func_params_f32: Vec<bool> = Vec::new();
     let mut func_params_f32_all: Vec<Vec<bool>> = Vec::new();
+    // GI-FPU-002 phase 2 (#719/#369): the CURRENT function's f32/f64 return flag
+    // (epilogue soundness guard, see CompileConfig) + the per-function/per-type
+    // return-float tables (call-site decline of f32/f64-signature callees).
+    let mut current_func_ret_f32 = false;
+    let mut current_func_ret_f64 = false;
+    let mut func_ret_f32_all: Vec<bool> = Vec::new();
+    let mut func_ret_f64_all: Vec<bool> = Vec::new();
+    let mut type_ret_f32_all: Vec<bool> = Vec::new();
+    let mut type_ret_f64_all: Vec<bool> = Vec::new();
     // #457: declared param count of THIS function — caps the access-pattern
     // param inference (a read-before-write local is otherwise indistinguishable
     // from a param). None for the demo path (no module signature).
@@ -1466,6 +1475,12 @@ fn compile_command(
             let module_func_params_i64 = module.func_params_i64;
             let module_func_arg_counts = module.func_arg_counts;
             func_params_f32_all = module.func_params_f32.clone();
+            // GI-FPU-002 phase 2 (#719/#369): per-function/per-type f32/f64
+            // return tables (epilogue guard + call-site callee-signature decline).
+            func_ret_f32_all = module.func_ret_f32.clone();
+            func_ret_f64_all = module.func_ret_f64.clone();
+            type_ret_f32_all = module.type_ret_f32.clone();
+            type_ret_f64_all = module.type_ret_f64.clone();
             // VCR-PERF-002 Phase 1 (#494): whatever facts loom forwarded
             // (empty for a section-less module — the overwhelmingly common
             // case — and for any malformed section, per the fail-safe rule).
@@ -1517,6 +1532,15 @@ fn compile_command(
             if let Some(p) = func_params_f32_all.get(func.index as usize) {
                 current_func_params_f32 = p.clone();
             }
+            // GI-FPU-002 phase 2 (#719/#369): THIS function's f32/f64 return flag.
+            current_func_ret_f32 = func_ret_f32_all
+                .get(func.index as usize)
+                .copied()
+                .unwrap_or(false);
+            current_func_ret_f64 = func_ret_f64_all
+                .get(func.index as usize)
+                .copied()
+                .unwrap_or(false);
             // #457: THIS function's declared param count from the type section.
             current_func_param_count = module_func_arg_counts.get(func.index as usize).copied();
             current_func_block_arity = func.block_arity.clone();
@@ -1624,6 +1648,14 @@ fn compile_command(
         // GI-FPU-002 (#619/#369): AAPCS-VFP f32-param homing.
         current_func_params_f32,
         func_params_f32: func_params_f32_all,
+        // GI-FPU-002 phase 2 (#719/#369): f32/f64 return-soundness guard +
+        // call-site callee-signature decline tables.
+        current_func_ret_f32,
+        current_func_ret_f64,
+        func_ret_f32: func_ret_f32_all,
+        func_ret_f64: func_ret_f64_all,
+        type_ret_f32: type_ret_f32_all,
+        type_ret_f64: type_ret_f64_all,
         // #457: declared param count — caps the param-count inference so a
         // read-before-write local lands in a zero-inited frame slot.
         current_func_param_count,
@@ -2371,6 +2403,10 @@ fn compile_all_exports(
         all_type_ret_i64,  // #311: per-type returns-i64 (call_indirect)
         all_func_params_i64, // #359: per-function declared param widths (stack-arg ABI)
         all_func_params_f32, // GI-FPU-002: per-function declared f32-param mask (AAPCS-VFP)
+        all_func_ret_f32,  // GI-FPU-002 phase 2 (#719/#369): per-function returns-f32
+        all_func_ret_f64,  // GI-FPU-002 phase 2 (#719/#369): per-function returns-f64
+        all_type_ret_f32,  // GI-FPU-002 phase 2 (#719/#369): per-type returns-f32 (call_indirect)
+        all_type_ret_f64,  // GI-FPU-002 phase 2 (#719/#369): per-type returns-f64 (call_indirect)
         all_wsc_facts,     // VCR-PERF-002 Phase 1 (#494): loom wsc.facts premises
         all_call_indirect_guards, // #642: table size + closed-world type verdicts
     ) = if path.extension().is_some_and(|ext| ext == "wast") {
@@ -2471,6 +2507,10 @@ fn compile_all_exports(
             Vec::new(),
             Vec::new(), // #359: WAST fixture suite is i32-only — no stack params
             Vec::new(), // GI-FPU-002: WAST fixture suite is i32-only — no f32 params
+            Vec::new(), // GI-FPU-002 phase 2: WAST fixture suite is i32-only — no f32 returns
+            Vec::new(), // GI-FPU-002 phase 2: WAST fixture suite is i32-only — no f64 returns
+            Vec::new(), // GI-FPU-002 phase 2: WAST fixture suite is i32-only — no f32-ret types
+            Vec::new(), // GI-FPU-002 phase 2: WAST fixture suite is i32-only — no f64-ret types
             Vec::new(), // #494: facts are a loom-emitted-.wasm channel; WAST fixtures carry none
             // #642: the multi-module WAST merge has no single table image to
             // verify — the default guards DECLINE any call_indirect (the WAST
@@ -2567,6 +2607,10 @@ fn compile_all_exports(
             module.type_ret_i64,
             module.func_params_i64,
             module.func_params_f32,
+            module.func_ret_f32,
+            module.func_ret_f64,
+            module.type_ret_f32,
+            module.type_ret_f64,
             module.wsc_facts,
             guards, // #642
         )
@@ -2648,6 +2692,15 @@ fn compile_all_exports(
         // GI-FPU-002 (#619/#369): per-function AAPCS-VFP f32-param homing.
         func_params_f32: all_func_params_f32.clone(),
         current_func_params_f32: Vec::new(),
+        // GI-FPU-002 phase 2 (#719/#369): set per function in the compile loop;
+        // the per-function/per-type tables feed the call-site callee-signature
+        // decline in the selector.
+        current_func_ret_f32: false,
+        current_func_ret_f64: false,
+        func_ret_f32: all_func_ret_f32.clone(),
+        func_ret_f64: all_func_ret_f64.clone(),
+        type_ret_f32: all_type_ret_f32.clone(),
+        type_ret_f64: all_type_ret_f64.clone(),
         // #543 Phase 1: threaded but not yet consumed (inert plumbing). The
         // Phase-2 back-off (const-CSE + #468 base-CSE decline inside these ranges)
         // lives on the optimized path this config feeds. See VCR-DMA-001.
@@ -2714,6 +2767,15 @@ fn compile_all_exports(
             {
                 fc.current_func_params_f32 = p.clone();
             }
+            // GI-FPU-002 phase 2 (#719/#369): THIS function's f32/f64 return flag.
+            fc.current_func_ret_f32 = all_func_ret_f32
+                .get(func.index as usize)
+                .copied()
+                .unwrap_or(false);
+            fc.current_func_ret_f64 = all_func_ret_f64
+                .get(func.index as usize)
+                .copied()
+                .unwrap_or(false);
             fc.current_func_block_arity = func.block_arity.clone();
             // #457: THIS function's DECLARED param count, so the backends can
             // cap the access-pattern param inference that mistook a

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -1395,6 +1395,10 @@ fn compile_command(
     // Empty for the demo path (no module signature).
     let mut current_func_params_f32: Vec<bool> = Vec::new();
     let mut func_params_f32_all: Vec<Vec<bool>> = Vec::new();
+    // GI-FPU-002 phase 2 (#369): declared f64-param masks (hard-float targets
+    // decline f64-param functions loudly).
+    let mut current_func_params_f64: Vec<bool> = Vec::new();
+    let mut func_params_f64_all: Vec<Vec<bool>> = Vec::new();
     // GI-FPU-002 phase 2 (#719/#369): the CURRENT function's f32/f64 return flag
     // (epilogue soundness guard, see CompileConfig) + the per-function/per-type
     // return-float tables (call-site decline of f32/f64-signature callees).
@@ -1475,6 +1479,7 @@ fn compile_command(
             let module_func_params_i64 = module.func_params_i64;
             let module_func_arg_counts = module.func_arg_counts;
             func_params_f32_all = module.func_params_f32.clone();
+            func_params_f64_all = module.func_params_f64.clone();
             // GI-FPU-002 phase 2 (#719/#369): per-function/per-type f32/f64
             // return tables (epilogue guard + call-site callee-signature decline).
             func_ret_f32_all = module.func_ret_f32.clone();
@@ -1531,6 +1536,10 @@ fn compile_command(
             // GI-FPU-002 (#619/#369): THIS function's declared f32-param mask.
             if let Some(p) = func_params_f32_all.get(func.index as usize) {
                 current_func_params_f32 = p.clone();
+            }
+            // GI-FPU-002 phase 2 (#369): THIS function's declared f64-param mask.
+            if let Some(p) = func_params_f64_all.get(func.index as usize) {
+                current_func_params_f64 = p.clone();
             }
             // GI-FPU-002 phase 2 (#719/#369): THIS function's f32/f64 return flag.
             current_func_ret_f32 = func_ret_f32_all
@@ -1648,6 +1657,9 @@ fn compile_command(
         // GI-FPU-002 (#619/#369): AAPCS-VFP f32-param homing.
         current_func_params_f32,
         func_params_f32: func_params_f32_all,
+        // GI-FPU-002 phase 2 (#369): f64-param loud-decline masks.
+        current_func_params_f64,
+        func_params_f64: func_params_f64_all,
         // GI-FPU-002 phase 2 (#719/#369): f32/f64 return-soundness guard +
         // call-site callee-signature decline tables.
         current_func_ret_f32,
@@ -2403,6 +2415,7 @@ fn compile_all_exports(
         all_type_ret_i64,  // #311: per-type returns-i64 (call_indirect)
         all_func_params_i64, // #359: per-function declared param widths (stack-arg ABI)
         all_func_params_f32, // GI-FPU-002: per-function declared f32-param mask (AAPCS-VFP)
+        all_func_params_f64, // GI-FPU-002 phase 2 (#369): per-function declared f64-param mask
         all_func_ret_f32,  // GI-FPU-002 phase 2 (#719/#369): per-function returns-f32
         all_func_ret_f64,  // GI-FPU-002 phase 2 (#719/#369): per-function returns-f64
         all_type_ret_f32,  // GI-FPU-002 phase 2 (#719/#369): per-type returns-f32 (call_indirect)
@@ -2507,6 +2520,7 @@ fn compile_all_exports(
             Vec::new(),
             Vec::new(), // #359: WAST fixture suite is i32-only — no stack params
             Vec::new(), // GI-FPU-002: WAST fixture suite is i32-only — no f32 params
+            Vec::new(), // GI-FPU-002 phase 2: WAST fixture suite is i32-only — no f64 params
             Vec::new(), // GI-FPU-002 phase 2: WAST fixture suite is i32-only — no f32 returns
             Vec::new(), // GI-FPU-002 phase 2: WAST fixture suite is i32-only — no f64 returns
             Vec::new(), // GI-FPU-002 phase 2: WAST fixture suite is i32-only — no f32-ret types
@@ -2607,6 +2621,7 @@ fn compile_all_exports(
             module.type_ret_i64,
             module.func_params_i64,
             module.func_params_f32,
+            module.func_params_f64,
             module.func_ret_f32,
             module.func_ret_f64,
             module.type_ret_f32,
@@ -2692,6 +2707,8 @@ fn compile_all_exports(
         // GI-FPU-002 (#619/#369): per-function AAPCS-VFP f32-param homing.
         func_params_f32: all_func_params_f32.clone(),
         current_func_params_f32: Vec::new(),
+        func_params_f64: all_func_params_f64.clone(),
+        current_func_params_f64: Vec::new(),
         // GI-FPU-002 phase 2 (#719/#369): set per function in the compile loop;
         // the per-function/per-type tables feed the call-site callee-signature
         // decline in the selector.
@@ -2766,6 +2783,13 @@ fn compile_all_exports(
                 && !p.is_empty()
             {
                 fc.current_func_params_f32 = p.clone();
+            }
+            // GI-FPU-002 phase 2 (#369): THIS function's declared f64-param mask.
+            if let Some(p) = all_func_params_f64
+                .get(func.index as usize)
+                .filter(|p| !p.is_empty())
+            {
+                fc.current_func_params_f64 = p.clone();
             }
             // GI-FPU-002 phase 2 (#719/#369): THIS function's f32/f64 return flag.
             fc.current_func_ret_f32 = all_func_ret_f32

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -193,6 +193,33 @@ pub struct CompileConfig {
     /// Set per function from [`func_params_f32`], mirroring
     /// [`current_func_params_i64`]. Empty ⇒ no f32 params.
     pub current_func_params_f32: Vec<bool>,
+    /// GI-FPU-002 phase 2 (#719/#369): whether the function CURRENTLY being
+    /// compiled returns f32. Set per function from the decoder's `func_ret_f32`.
+    /// The direct selector's epilogue uses it to loudly decline a result that
+    /// reaches the return in a core register instead of an S-register (a call
+    /// that returned f32 as integer-tagged R0 would otherwise be a silent
+    /// miscompile — the AAPCS-VFP caller reads S0). `false` for hand-built op
+    /// streams / non-f32 returns (byte-identical to before).
+    pub current_func_ret_f32: bool,
+    /// GI-FPU-002 phase 2 (#719/#369): whether the function CURRENTLY being
+    /// compiled returns f64 (D0 under AAPCS-VFP). Same epilogue-soundness role.
+    pub current_func_ret_f64: bool,
+    /// GI-FPU-002 phase 2 (#719/#369): per-function (full index, imports first)
+    /// "returns f32/f64" tables. The direct selector declines a `call` to an
+    /// f32/f64-returning callee LOUDLY at the call site — the result arrives in
+    /// S0/D0 (AAPCS-VFP), which this increment does not marshal into the operand
+    /// stack; tagging it as an integer R0 would be a silent miscompile. Also the
+    /// source for [`current_func_ret_f32`]/[`current_func_ret_f64`] in the
+    /// per-function driver loops. Empty ⇒ callees assumed non-float-returning
+    /// (hand-built op streams; byte-identical legacy behaviour).
+    pub func_ret_f32: Vec<bool>,
+    /// See [`func_ret_f32`](Self::func_ret_f32).
+    pub func_ret_f64: Vec<bool>,
+    /// GI-FPU-002 phase 2 (#719/#369): per-type "returns f32/f64" — the
+    /// `call_indirect` analogue of [`func_ret_f32`](Self::func_ret_f32).
+    pub type_ret_f32: Vec<bool>,
+    /// See [`type_ret_f32`](Self::type_ret_f32).
+    pub type_ret_f64: Vec<bool>,
     /// #457: DECLARED parameter count of the function CURRENTLY being compiled,
     /// from the module's type section (`func_arg_counts[func.index]`). Set per
     /// function by the driver loops like [`current_func_params_i64`].
@@ -362,6 +389,16 @@ impl Default for CompileConfig {
             current_func_params_i64: Vec::new(),
             func_params_f32: Vec::new(),
             current_func_params_f32: Vec::new(),
+            // GI-FPU-002 phase 2 (#719/#369): false ⇒ non-float return (or a
+            // hand-built op stream); driver loops set it per function.
+            current_func_ret_f32: false,
+            current_func_ret_f64: false,
+            // GI-FPU-002 phase 2 (#719/#369): empty ⇒ callees assumed
+            // non-float-returning (hand-built op streams).
+            func_ret_f32: Vec::new(),
+            func_ret_f64: Vec::new(),
+            type_ret_f32: Vec::new(),
+            type_ret_f64: Vec::new(),
             // #457: None ⇒ declared signature unknown ⇒ param-count inference
             // only (unit tests / hand-built op streams); driver loops fill it.
             current_func_param_count: None,

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -193,6 +193,15 @@ pub struct CompileConfig {
     /// Set per function from [`func_params_f32`], mirroring
     /// [`current_func_params_i64`]. Empty ⇒ no f32 params.
     pub current_func_params_f32: Vec<bool>,
+    /// GI-FPU-002 phase 2 (#369): per-function declared f64-param mask (full
+    /// index, imports first) and the CURRENT function's slice. Hard-float
+    /// targets decline f64-param functions loudly — the legacy width
+    /// inference treats an f64 param as an i64 CORE-register pair, which
+    /// reads the wrong registers under AAPCS-VFP (the caller put it in a
+    /// D-register). Empty ⇒ no f64 params (byte-identical legacy path).
+    pub func_params_f64: Vec<Vec<bool>>,
+    /// See [`func_params_f64`](Self::func_params_f64).
+    pub current_func_params_f64: Vec<bool>,
     /// GI-FPU-002 phase 2 (#719/#369): whether the function CURRENTLY being
     /// compiled returns f32. Set per function from the decoder's `func_ret_f32`.
     /// The direct selector's epilogue uses it to loudly decline a result that
@@ -395,6 +404,8 @@ impl Default for CompileConfig {
             current_func_ret_f64: false,
             // GI-FPU-002 phase 2 (#719/#369): empty ⇒ callees assumed
             // non-float-returning (hand-built op streams).
+            func_params_f64: Vec::new(),
+            current_func_params_f64: Vec::new(),
             func_ret_f32: Vec::new(),
             func_ret_f64: Vec::new(),
             type_ret_f32: Vec::new(),

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -310,6 +310,24 @@ pub struct DecodedModule {
     /// f32. The direct selector homes hard-float f32 args in S0..S15 (AAPCS-VFP),
     /// which op-stream inference cannot recover for a pure-passthrough f32 param.
     pub func_params_f32: Vec<Vec<bool>>,
+    /// GI-FPU-002 phase 2 (#719/#369): whether each *function* (full index,
+    /// imports first) returns f32. The direct selector's epilogue homes an f32
+    /// result in S0 (AAPCS-VFP); when the result value transited a core register
+    /// (e.g. it came from a call that returned f32 as an integer-tagged R0), the
+    /// epilogue must loudly decline rather than emit the integer R0 return (a
+    /// silent miscompile — the caller reads S0). Op-stream inference cannot see a
+    /// pure-passthrough f32 return, so it is carried from the declared signature.
+    pub func_ret_f32: Vec<bool>,
+    /// GI-FPU-002 phase 2 (#719/#369): whether each *function* returns f64 (D0
+    /// under AAPCS-VFP). Same epilogue-soundness role as `func_ret_f32`.
+    pub func_ret_f64: Vec<bool>,
+    /// GI-FPU-002 phase 2 (#719/#369): whether each *function type* returns
+    /// f32 / f64 — the `call_indirect` analogue of `func_ret_f32`/`func_ret_f64`
+    /// (the selector loudly declines an indirect call whose static type returns
+    /// a float this increment does not marshal, rather than tag S0/D0 as R0).
+    pub type_ret_f32: Vec<bool>,
+    /// See [`Self::type_ret_f32`].
+    pub type_ret_f64: Vec<bool>,
     /// Defined globals with their initializers (#237). Empty if the module has
     /// no global section. Used by the native-pointer ABI to make a global whose
     /// initializer is a linear-memory address (e.g. `$__stack_pointer`)
@@ -591,6 +609,13 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     let mut func_arg_counts: Vec<u32> = Vec::new();
     let mut type_ret_i64: Vec<bool> = Vec::new();
     let mut func_ret_i64: Vec<bool> = Vec::new();
+    // GI-FPU-002 phase 2 (#719/#369): per-type / per-function f32/f64 return
+    // flags, so the direct selector's epilogue can loudly decline an f32/f64
+    // result that reaches it in a core register (never a silent R0 return).
+    let mut type_ret_f32: Vec<bool> = Vec::new();
+    let mut func_ret_f32: Vec<bool> = Vec::new();
+    let mut type_ret_f64: Vec<bool> = Vec::new();
+    let mut func_ret_f64: Vec<bool> = Vec::new();
     // #359: declared param widths per type / per function (full index).
     let mut type_params_i64: Vec<Vec<bool>> = Vec::new();
     let mut func_params_i64: Vec<Vec<bool>> = Vec::new();
@@ -692,8 +717,24 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                                 .collect::<Vec<bool>>(),
                             _ => Vec::new(),
                         };
+                        // GI-FPU-002 phase 2: f32/f64 return flags for this type.
+                        let (ret_f32, ret_f64) = match &sub_ty.composite_type.inner {
+                            wasmparser::CompositeInnerType::Func(func_ty) => (
+                                func_ty
+                                    .results()
+                                    .first()
+                                    .is_some_and(|t| *t == wasmparser::ValType::F32),
+                                func_ty
+                                    .results()
+                                    .first()
+                                    .is_some_and(|t| *t == wasmparser::ValType::F64),
+                            ),
+                            _ => (false, false),
+                        };
                         type_arg_counts.push(count);
                         type_ret_i64.push(ret_i64);
+                        type_ret_f32.push(ret_f32);
+                        type_ret_f64.push(ret_f64);
                         type_params_i64.push(params_i64);
                         type_params_f32.push(params_f32);
                         // #680: v128 anywhere in the signature.
@@ -736,6 +777,18 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                                 .push(type_arg_counts.get(type_idx as usize).copied().unwrap_or(0));
                             func_ret_i64.push(
                                 type_ret_i64
+                                    .get(type_idx as usize)
+                                    .copied()
+                                    .unwrap_or(false),
+                            );
+                            func_ret_f32.push(
+                                type_ret_f32
+                                    .get(type_idx as usize)
+                                    .copied()
+                                    .unwrap_or(false),
+                            );
+                            func_ret_f64.push(
+                                type_ret_f64
                                     .get(type_idx as usize)
                                     .copied()
                                     .unwrap_or(false),
@@ -808,6 +861,18 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                         .push(type_arg_counts.get(type_idx as usize).copied().unwrap_or(0));
                     func_ret_i64.push(
                         type_ret_i64
+                            .get(type_idx as usize)
+                            .copied()
+                            .unwrap_or(false),
+                    );
+                    func_ret_f32.push(
+                        type_ret_f32
+                            .get(type_idx as usize)
+                            .copied()
+                            .unwrap_or(false),
+                    );
+                    func_ret_f64.push(
+                        type_ret_f64
                             .get(type_idx as usize)
                             .copied()
                             .unwrap_or(false),
@@ -1096,6 +1161,10 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
         type_ret_i64,
         func_params_i64,
         func_params_f32,
+        func_ret_f32,
+        func_ret_f64,
+        type_ret_f32,
+        type_ret_f64,
         globals,
         elem_func_indices,
         table_size: table_sizes.first().copied().flatten(),

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -310,6 +310,13 @@ pub struct DecodedModule {
     /// f32. The direct selector homes hard-float f32 args in S0..S15 (AAPCS-VFP),
     /// which op-stream inference cannot recover for a pure-passthrough f32 param.
     pub func_params_f32: Vec<Vec<bool>>,
+    /// GI-FPU-002 phase 2 (#369): declared f64-param mask per *function*
+    /// (full index, imports first): `func_params_f64[f][k]` is true when param
+    /// `k` is f64. Hard-float targets decline such functions loudly (the
+    /// legacy width inference treats the param as an i64 CORE pair — wrong
+    /// registers under AAPCS-VFP). Distinct from `func_params_i64`, which
+    /// deliberately lumps i64 and f64 for frame-layout purposes.
+    pub func_params_f64: Vec<Vec<bool>>,
     /// GI-FPU-002 phase 2 (#719/#369): whether each *function* (full index,
     /// imports first) returns f32. The direct selector's epilogue homes an f32
     /// result in S0 (AAPCS-VFP); when the result value transited a core register
@@ -625,6 +632,11 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
     // `params_i64` (which lumps f64 with i64): an f32 param is neither.
     let mut type_params_f32: Vec<Vec<bool>> = Vec::new();
     let mut func_params_f32: Vec<Vec<bool>> = Vec::new();
+    // GI-FPU-002 phase 2 (#369): per-type / per-function f64-param mask —
+    // hard-float targets decline f64 params loudly (D-register homing is a
+    // later increment; the legacy i64-pair treatment reads wrong registers).
+    let mut type_params_f64: Vec<Vec<bool>> = Vec::new();
+    let mut func_params_f64: Vec<Vec<bool>> = Vec::new();
     // #509: (param_count, result_count) per type index, for FuncType blocktypes.
     let mut type_block_arity: Vec<(u8, u8)> = Vec::new();
     let mut elem_func_indices: Vec<u32> = Vec::new();
@@ -717,6 +729,15 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                                 .collect::<Vec<bool>>(),
                             _ => Vec::new(),
                         };
+                        // GI-FPU-002 phase 2: declared f64-param mask.
+                        let params_f64 = match &sub_ty.composite_type.inner {
+                            wasmparser::CompositeInnerType::Func(func_ty) => func_ty
+                                .params()
+                                .iter()
+                                .map(|t| matches!(t, wasmparser::ValType::F64))
+                                .collect::<Vec<bool>>(),
+                            _ => Vec::new(),
+                        };
                         // GI-FPU-002 phase 2: f32/f64 return flags for this type.
                         let (ret_f32, ret_f64) = match &sub_ty.composite_type.inner {
                             wasmparser::CompositeInnerType::Func(func_ty) => (
@@ -737,6 +758,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                         type_ret_f64.push(ret_f64);
                         type_params_i64.push(params_i64);
                         type_params_f32.push(params_f32);
+                        type_params_f64.push(params_f64);
                         // #680: v128 anywhere in the signature.
                         type_has_v128.push(match &sub_ty.composite_type.inner {
                             wasmparser::CompositeInnerType::Func(f) => f
@@ -801,6 +823,12 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                             );
                             func_params_f32.push(
                                 type_params_f32
+                                    .get(type_idx as usize)
+                                    .cloned()
+                                    .unwrap_or_default(),
+                            );
+                            func_params_f64.push(
+                                type_params_f64
                                     .get(type_idx as usize)
                                     .cloned()
                                     .unwrap_or_default(),
@@ -885,6 +913,12 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
                     );
                     func_params_f32.push(
                         type_params_f32
+                            .get(type_idx as usize)
+                            .cloned()
+                            .unwrap_or_default(),
+                    );
+                    func_params_f64.push(
+                        type_params_f64
                             .get(type_idx as usize)
                             .cloned()
                             .unwrap_or_default(),
@@ -1161,6 +1195,7 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
         type_ret_i64,
         func_params_i64,
         func_params_f32,
+        func_params_f64,
         func_ret_f32,
         func_ret_f64,
         type_ret_f32,
@@ -2008,6 +2043,38 @@ fn convert_operator(op: &wasmparser::Operator) -> Option<WasmOp> {
         I32TruncF32S => Some(WasmOp::I32TruncF32S),
         I32TruncF32U => Some(WasmOp::I32TruncF32U),
 
+        // === Scalar f64 (GI-FPU-002 phase 2, #369) ===
+        // Un-dropped for the DOUBLE-precision FPU target (cortex-m7dp D0..D15);
+        // the capability gate lives in `select_with_stack`'s preamble — any
+        // f64 op on m4f/m7 (single-precision) or m0/m3/r5 (no FPU) still
+        // honest-rejects its function. Exactly this set is lowered by
+        // `try_lower_f64` + the `F64Load`/`F64Store` selector arms; the rest
+        // of the f64 surface (min/max/copysign/rounding/i64<->f64/…) stays at
+        // `_ => None` (loud-skip) until a later increment wires it.
+        F64Const { value } => Some(WasmOp::F64Const(f64::from_bits(value.bits()))),
+        F64PromoteF32 => Some(WasmOp::F64PromoteF32),
+        F64Add => Some(WasmOp::F64Add),
+        F64Sub => Some(WasmOp::F64Sub),
+        F64Mul => Some(WasmOp::F64Mul),
+        F64Div => Some(WasmOp::F64Div),
+        F64Abs => Some(WasmOp::F64Abs),
+        F64Neg => Some(WasmOp::F64Neg),
+        F64Sqrt => Some(WasmOp::F64Sqrt),
+        F64Eq => Some(WasmOp::F64Eq),
+        F64Ne => Some(WasmOp::F64Ne),
+        F64Lt => Some(WasmOp::F64Lt),
+        F64Le => Some(WasmOp::F64Le),
+        F64Gt => Some(WasmOp::F64Gt),
+        F64Ge => Some(WasmOp::F64Ge),
+        F64Load { memarg } => Some(WasmOp::F64Load {
+            offset: memarg.offset as u32,
+            align: memarg.align as u32,
+        }),
+        F64Store { memarg } => Some(WasmOp::F64Store {
+            offset: memarg.offset as u32,
+            align: memarg.align as u32,
+        }),
+
         // f32x4
         F32x4Add => Some(WasmOp::F32x4Add),
         F32x4Sub => Some(WasmOp::F32x4Sub),
@@ -2629,16 +2696,20 @@ mod tests {
         // GI-FPU-002 (#619): the in-scope scalar f32 ops (add/sub/mul/div,
         // comparisons, i32.trunc_f32_s/u, f32.convert_i32_s/u, f32.const) are
         // now DECODED (routed to the VFP selector on FPU targets), so `f32.add`
-        // is no longer flagged. An out-of-scope scalar float op (`f64.add`,
-        // phase 2) is STILL flagged (loud-skip), never silently dropped — the
-        // #369 honesty contract holds for the not-yet-lowered surface. A
-        // pure-integer function stays clean.
+        // is no longer flagged — and since phase 2 (#369) so is the lowered
+        // f64 subset (`f64.add` here; the m7dp-only capability gate lives in
+        // the selector). An out-of-scope scalar float op (`f64.min`) is STILL
+        // flagged (loud-skip), never silently dropped — the #369 honesty
+        // contract holds for the not-yet-lowered surface. A pure-integer
+        // function stays clean.
         let wat = r#"
             (module
                 (func (export "fadd") (param f32 f32) (result f32)
                     local.get 0 local.get 1 f32.add)
                 (func (export "dadd") (param f64 f64) (result f64)
                     local.get 0 local.get 1 f64.add)
+                (func (export "dmin") (param f64 f64) (result f64)
+                    local.get 0 local.get 1 f64.min)
                 (func (export "iadd") (param i32 i32) (result i32)
                     local.get 0 local.get 1 i32.add))
         "#;
@@ -2651,6 +2722,10 @@ mod tests {
         let dadd = functions
             .iter()
             .find(|f| f.export_name.as_deref() == Some("dadd"))
+            .unwrap();
+        let dmin = functions
+            .iter()
+            .find(|f| f.export_name.as_deref() == Some("dmin"))
             .unwrap();
         let iadd = functions
             .iter()
@@ -2667,11 +2742,22 @@ mod tests {
             "f32.add must decode to WasmOp::F32Add: {:?}",
             fadd.ops
         );
-        // Out-of-scope scalar double op: still flagged (phase 2), never dropped.
+        // In-scope f64 op (phase 2, #369): now decoded, not flagged.
         assert!(
-            dadd.unsupported.is_some(),
-            "f64.add must still flag the function unsupported (phase 2), got {:?}",
+            dadd.unsupported.is_none(),
+            "GI-FPU-002 phase 2: f64.add must now decode (not be flagged), got {:?}",
             dadd.unsupported
+        );
+        assert!(
+            dadd.ops.contains(&WasmOp::F64Add),
+            "f64.add must decode to WasmOp::F64Add: {:?}",
+            dadd.ops
+        );
+        // Out-of-scope scalar double op: still flagged, never dropped.
+        assert!(
+            dmin.unsupported.is_some(),
+            "f64.min must still flag the function unsupported (out of scope), got {:?}",
+            dmin.unsupported
         );
         assert!(
             iadd.unsupported.is_none(),

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -704,6 +704,97 @@ fn stack_live_regs(stack: &[StackVal]) -> Vec<Reg> {
     live
 }
 
+/// GI-FPU-002 phase 2 (#719): the distinct single-precision S-register indices
+/// (0..16) holding a live f32 value at a call site — every operand-stack `Float`
+/// entry plus every pinned param/local home (`vfp_home`). These reside in
+/// S0..S15, which are AAPCS-VFP CALLER-saved, so each must be spilled before a
+/// `bl` and reloaded after. Reloading a home that is never read again is
+/// harmless, so the pinned-home union is a sound overapproximation.
+fn vfp_live_set(stack: &[StackVal], vfp_home: &[bool; 16]) -> Vec<usize> {
+    let mut set = [false; 16];
+    for v in stack {
+        if let Some(sreg) = v.as_float()
+            && let Some(k) = vfp_s_index(sreg)
+        {
+            set[k] = true;
+        }
+    }
+    for (k, &h) in vfp_home.iter().enumerate() {
+        if h {
+            set[k] = true;
+        }
+    }
+    (0..16).filter(|&k| set[k]).collect()
+}
+
+/// GI-FPU-002 phase 2 (#719): spill every live f32 S-register (see
+/// [`vfp_live_set`]) to the VFP call-spill area before a `bl`, mirroring the
+/// #188 integer [`InstructionSelector::preserve_caller_saved`]. Slot for `S(k)`
+/// is `vfp_spill_base + k*4`. Returns the `(sreg, slot_offset)` pairs to reload.
+/// Ok-or-Err (#180/#185): `VSTR`/`VLDR` encode the byte offset as `imm8*4`, so
+/// the reachable range is `0..=1020`; beyond it the encoder silently masks the
+/// offset, so a too-large slot declines loudly instead of writing a wrong
+/// address.
+fn preserve_vfp_caller_saved(
+    instructions: &mut Vec<ArmInstruction>,
+    stack: &[StackVal],
+    vfp_home: &[bool; 16],
+    layout: &LocalLayout,
+    idx: usize,
+) -> Result<Vec<(VfpReg, i32)>> {
+    let live = vfp_live_set(stack, vfp_home);
+    if live.is_empty() {
+        return Ok(Vec::new());
+    }
+    let base = layout.vfp_spill_base.ok_or_else(|| {
+        synth_core::Error::synthesis(
+            "GI-FPU-002 phase 2: VFP call-spill area not reserved despite an f32 \
+             value live across a call (compiler bug: compute_local_layout mismatch)"
+                .to_string(),
+        )
+    })?;
+    let mut preserved: Vec<(VfpReg, i32)> = Vec::with_capacity(live.len());
+    for k in live {
+        let off = base + (k as i32) * 4;
+        if off > 1020 {
+            return Err(synth_core::Error::synthesis(format!(
+                "GI-FPU-002 phase 2: VFP spill slot offset {off} exceeds the \
+                 VSTR/VLDR [sp,#imm] range (1020) — frame too large; declining \
+                 (#719/#369)"
+            )));
+        }
+        let sreg = index_to_vfp_reg(k as u8);
+        instructions.push(ArmInstruction {
+            op: ArmOp::F32Store {
+                sd: sreg,
+                addr: MemAddr::imm(Reg::SP, off),
+            },
+            source_line: Some(idx),
+        });
+        preserved.push((sreg, off));
+    }
+    Ok(preserved)
+}
+
+/// GI-FPU-002 phase 2 (#719): reload the f32 S-registers spilled by
+/// [`preserve_vfp_caller_saved`] after a call returns. The `bl` clobbered
+/// S0..S15, so each spilled value is restored from its VFP call-spill slot.
+fn restore_vfp_caller_saved(
+    instructions: &mut Vec<ArmInstruction>,
+    preserved: &[(VfpReg, i32)],
+    idx: usize,
+) {
+    for &(sreg, off) in preserved {
+        instructions.push(ArmInstruction {
+            op: ArmOp::F32Load {
+                sd: sreg,
+                addr: MemAddr::imm(Reg::SP, off),
+            },
+            source_line: Some(idx),
+        });
+    }
+}
+
 /// Allocate a temporary register, skipping any reserved by the virtual stack.
 /// Returns Error if all allocatable registers are in use.
 fn alloc_temp_safe(next_temp: &mut u8, stack: &[StackVal], reserved: &[Reg]) -> Result<Reg> {
@@ -1210,6 +1301,16 @@ struct LocalLayout {
     /// AAPCS-clobbering branch-and-link. `None` when the function contains no
     /// calls (no scratch reserved). See the `Call` lowering for usage.
     spill_base: Option<i32>,
+    /// GI-FPU-002 phase 2 (#719/#369): byte offset (from SP) of the VFP
+    /// call-spill area — 16 word slots (one per single-precision S-register
+    /// S0..S15, indexed by S-register number: `S(k)` at `vfp_spill_base + k*4`).
+    /// Live f32 values (operand-stack `Float` entries + pinned param/local
+    /// homes) are `VSTR`ed here before a `bl` and `VLDR`ed back after, since
+    /// S0..S15 are AAPCS-VFP caller-saved. `None` when the function has no f32
+    /// AND-a-call (no area reserved; every previously-compiling function keeps
+    /// its frame byte-identical — an f32 function with a call previously
+    /// declined outright). The analogue of `spill_base` for the VFP file.
+    vfp_spill_base: Option<i32>,
     /// Byte offset (from SP) of the i64 register-pair spill area (#171): up to
     /// `I64_SPILL_SLOTS` 8-byte slots. `alloc_consecutive_pair` spills a deep
     /// i64 value here when the consecutive-pair budget is exhausted and reloads
@@ -1430,6 +1531,24 @@ fn compute_local_layout(
         }
     }
 
+    // GI-FPU-002 phase 2 (#719/#369): reserve the VFP call-spill area — 16 word
+    // slots, one per single-precision S-register (S0..S15), when the function has
+    // BOTH an f32 value/param AND a call. Live f32 values are VSTR'd here around
+    // each `bl` (S0..S15 are caller-saved). Gated on `has_f32 && has_call`, and an
+    // f32 function WITH a call previously declined outright, so no
+    // previously-compiling function's frame changes (frozen-safe). Placed after
+    // every other frame field so the existing local/spill/param offsets are
+    // unchanged.
+    let has_f32 = params_f32.iter().take(num_params as usize).any(|&f| f)
+        || wasm_ops.iter().any(is_scope_f32_op);
+    let vfp_spill_base = if has_f32 && has_call {
+        let base = offset;
+        offset += 16 * 4;
+        Some(base)
+    } else {
+        None
+    };
+
     // Round frame to 8-byte multiple for AAPCS SP alignment.
     let frame_size = (offset + 7) & !7;
 
@@ -1464,6 +1583,7 @@ fn compute_local_layout(
         locals,
         frame_size,
         spill_base,
+        vfp_spill_base,
         i64_spill_base,
         param_slots,
         incoming_params,
@@ -2441,6 +2561,28 @@ pub struct InstructionSelector {
     /// homed in an AAPCS-VFP argument S-register (S0..S15) rather than the
     /// R0..R3 integer path. Empty ⇒ no f32 params (byte-identical legacy path).
     params_f32: Vec<bool>,
+    /// GI-FPU-002 phase 2 (#719/#369): whether the function being compiled
+    /// returns f32 / f64. The epilogue homes a float result in S0 (f32) / D0
+    /// (f64); if the top-of-stack at return is NOT a `Float` (e.g. a call that
+    /// returned f32 arrived as an integer-tagged R0), the epilogue loudly
+    /// declines rather than emit the integer R0 return — the AAPCS-VFP caller
+    /// reads S0/D0, so an R0 return is a silent miscompile. `false` ⇒ non-float
+    /// return (byte-identical legacy path).
+    ret_f32: bool,
+    ret_f64: bool,
+    /// GI-FPU-002 phase 2 (#719/#369): per-CALLEE float-signature tables (full
+    /// function index / type index). A call whose callee RETURNS f32/f64 (result
+    /// arrives in S0/D0, which this increment does not marshal onto the operand
+    /// stack) or takes an f32 PARAM (argument must be marshalled into the VFP
+    /// S0.. pool, not R0..R3) is declined LOUDLY at the call site — tagging the
+    /// S0/D0 result as an integer R0, or passing an f32 arg in a core register,
+    /// would be a silent miscompile. Empty ⇒ callees assumed integer-signature
+    /// (hand-built op streams; byte-identical legacy behaviour).
+    callee_ret_f32: Vec<bool>,
+    callee_ret_f64: Vec<bool>,
+    callee_type_ret_f32: Vec<bool>,
+    callee_type_ret_f64: Vec<bool>,
+    callee_params_f32: Vec<Vec<bool>>,
     /// #643: byte width of each defined global's storage slot, indexed by
     /// global index — 4 for i32/f32, 8 for i64/f64, 16 for v128. The globals
     /// table (R9-relative) is laid out by SUMMING these widths, NOT `idx * 4`:
@@ -2605,6 +2747,13 @@ impl InstructionSelector {
             type_ret_i64: Vec::new(),
             params_i64: Vec::new(),
             params_f32: Vec::new(),
+            ret_f32: false,
+            ret_f64: false,
+            callee_ret_f32: Vec::new(),
+            callee_ret_f64: Vec::new(),
+            callee_type_ret_f32: Vec::new(),
+            callee_type_ret_f64: Vec::new(),
+            callee_params_f32: Vec::new(),
             global_widths: Vec::new(),
             block_arity: Vec::new(),
             func_arg_counts: Vec::new(),
@@ -2644,6 +2793,13 @@ impl InstructionSelector {
             type_ret_i64: Vec::new(),
             params_i64: Vec::new(),
             params_f32: Vec::new(),
+            ret_f32: false,
+            ret_f64: false,
+            callee_ret_f32: Vec::new(),
+            callee_ret_f64: Vec::new(),
+            callee_type_ret_f32: Vec::new(),
+            callee_type_ret_f64: Vec::new(),
+            callee_params_f32: Vec::new(),
             global_widths: Vec::new(),
             block_arity: Vec::new(),
             func_arg_counts: Vec::new(),
@@ -2990,6 +3146,90 @@ impl InstructionSelector {
     /// f32 args in their AAPCS-VFP argument S-registers (S0..S15).
     pub fn set_params_f32(&mut self, params_f32: Vec<bool>) {
         self.params_f32 = params_f32;
+    }
+
+    /// GI-FPU-002 phase 2 (#719/#369): record whether the function about to be
+    /// compiled returns f32 / f64, so the epilogue can loudly decline a float
+    /// result that reaches it in a core register (a silent-miscompile guard —
+    /// see the `ret_f32` field).
+    pub fn set_ret_float(&mut self, ret_f32: bool, ret_f64: bool) {
+        self.ret_f32 = ret_f32;
+        self.ret_f64 = ret_f64;
+    }
+
+    /// GI-FPU-002 phase 2 (#719/#369): register the per-callee float-signature
+    /// tables (see the `callee_ret_f32` field), so `Call`/`CallIndirect` can
+    /// loudly decline a float-ABI call boundary this increment does not marshal.
+    pub fn set_float_call_signatures(
+        &mut self,
+        func_ret_f32: Vec<bool>,
+        func_ret_f64: Vec<bool>,
+        type_ret_f32: Vec<bool>,
+        type_ret_f64: Vec<bool>,
+        func_params_f32: Vec<Vec<bool>>,
+    ) {
+        self.callee_ret_f32 = func_ret_f32;
+        self.callee_ret_f64 = func_ret_f64;
+        self.callee_type_ret_f32 = type_ret_f32;
+        self.callee_type_ret_f64 = type_ret_f64;
+        self.callee_params_f32 = func_params_f32;
+    }
+
+    /// GI-FPU-002 phase 2 (#719/#369): loudly decline a `call` whose callee has
+    /// a float ABI at the boundary this increment does not marshal — an f32/f64
+    /// RETURN (the result arrives in S0/D0; tagging it as an integer R0 would be
+    /// a silent miscompile: any use reads the wrong register file) or an f32
+    /// PARAM (the argument belongs in the AAPCS-VFP S0.. pool, not R0..R3).
+    /// Live f32 values ACROSS the call are handled (spill/reload around the BL);
+    /// only the callee's own float signature declines. Ok-or-Err.
+    fn check_callee_float_signature(&self, func_idx: u32) -> Result<()> {
+        let i = func_idx as usize;
+        let ret_f32 = self.callee_ret_f32.get(i).copied().unwrap_or(false);
+        let ret_f64 = self.callee_ret_f64.get(i).copied().unwrap_or(false);
+        if ret_f32 || ret_f64 {
+            return Err(synth_core::Error::synthesis(format!(
+                "GI-FPU-002 phase 2: call to func_{func_idx} which returns {} — \
+                 the AAPCS-VFP result arrives in {} and this increment does not \
+                 marshal a float call result; declining loudly (#719/#369)",
+                if ret_f64 { "f64" } else { "f32" },
+                if ret_f64 { "D0" } else { "S0" },
+            )));
+        }
+        if self
+            .callee_params_f32
+            .get(i)
+            .is_some_and(|p| p.iter().any(|&f| f))
+        {
+            return Err(synth_core::Error::synthesis(format!(
+                "GI-FPU-002 phase 2: call to func_{func_idx} which takes an f32 \
+                 parameter — the argument belongs in the AAPCS-VFP S-register \
+                 pool, which this increment does not marshal; declining loudly \
+                 (#719/#369)"
+            )));
+        }
+        Ok(())
+    }
+
+    /// GI-FPU-002 phase 2 (#719/#369): the `call_indirect` analogue of
+    /// [`Self::check_callee_float_signature`], keyed by the static type index.
+    /// (The f32-ARG side needs no type-level check: every f32 producer pushes a
+    /// `Float` operand, which the integer `pop_call_args` path already rejects
+    /// loudly.)
+    fn check_indirect_float_signature(&self, type_idx: u32) -> Result<()> {
+        let i = type_idx as usize;
+        let ret_f32 = self.callee_type_ret_f32.get(i).copied().unwrap_or(false);
+        let ret_f64 = self.callee_type_ret_f64.get(i).copied().unwrap_or(false);
+        if ret_f32 || ret_f64 {
+            return Err(synth_core::Error::synthesis(format!(
+                "GI-FPU-002 phase 2: call_indirect of type {type_idx} which \
+                 returns {} — the AAPCS-VFP result arrives in {} and this \
+                 increment does not marshal a float call result; declining \
+                 loudly (#719/#369)",
+                if ret_f64 { "f64" } else { "f32" },
+                if ret_f64 { "D0" } else { "S0" },
+            )));
+        }
+        Ok(())
     }
 
     /// #509: register the blocktype-arity side-table of the function about to
@@ -7437,10 +7677,20 @@ impl InstructionSelector {
         for i in 0..num_params.min(4) {
             if let Some(&(off, is_i64)) = layout.param_slots.get(&i) {
                 // #503-i64: `param_slots` only contains REGISTER-resident
-                // params now, and every reg-resident param below a stack spill
-                // is sequential from R0 (a wide reg param + has_call is
-                // declined above), so `index_to_reg(i)` is its true home.
-                let reg = index_to_reg(i as u8);
+                // params now, so the AAPCS map has this index. #719 phase 2:
+                // the home must come from the AAPCS-VFP-aware map, NOT the raw
+                // `index_to_reg(i)` — under mixed f32/int params the integer
+                // pool skips f32 indices (e.g. `(f32, i32)` homes the i32 in
+                // R0, not R1), and backing the wrong register fed the callee
+                // caller garbage (caught by the xhome execution differential).
+                // For an all-i32 signature the two maps are identical, so
+                // every previously-compiling function is byte-identical.
+                let reg = param_aapcs.get(&i).copied().ok_or_else(|| {
+                    synth_core::Error::synthesis(format!(
+                        "param {i} has a frame-backing slot but no AAPCS home \
+                         register (compiler bug: param_slots/aapcs mismatch)"
+                    ))
+                })?;
                 let op = if is_i64 {
                     ArmOp::I64Str {
                         rdlo: reg,
@@ -7617,21 +7867,19 @@ impl InstructionSelector {
                 // R1) while the f32-home seed below assigns S(k) from the VFP
                 // pool. No decline here anymore.
                 //
-                // Phase-1 honest decline (never a miscompile):
-                //  * any call — S0..S15 are caller-saved, so an f32 value or
-                //    param home would be clobbered across a bl (phase 1b, #719
-                //    scopes this out; the full spill/rehome across call sites is
-                //    the next f32 increment).
-                if wasm_ops
-                    .iter()
-                    .any(|o| matches!(o, WasmOp::Call(_) | WasmOp::CallIndirect { .. }))
-                {
-                    return Err(synth_core::Error::synthesis(
-                        "GI-FPU-002 phase 1: f32 in a function with a call is \
-                         not yet lowered (S0..S15 are caller-saved) — declining"
-                            .to_string(),
-                    ));
-                }
+                // #719 phase 2: f32 values LIVE ACROSS A CALL are now spilled and
+                // reloaded around each `bl` (S0..S15 are caller-saved) via the
+                // VFP call-spill area (`layout.vfp_spill_base`) — the exact analogue
+                // of the #188 integer caller-saved preservation, emitted at the
+                // Call/CallIndirect sites below. Two float-ABI-at-the-call cases
+                // that this increment does NOT marshal still decline SOUNDLY through
+                // pre-existing guards (never a miscompile):
+                //  * passing an f32 as a call ARGUMENT — `pop_call_args`→`pop_operand`
+                //    rejects a `Float` operand (an integer op never pops an f32).
+                //  * a call that RETURNS f32/f64 — its result is pushed as an
+                //    integer-tagged R0; any later f32 op `pop_float`s it → Err, and
+                //    an f32/f64 function return is caught by the epilogue
+                //    `ret_f32`/`ret_f64` soundness guard above.
                 // Seed f32-param homes. With no mixed params, the k-th param is
                 // the k-th f32 param, homed in AAPCS-VFP arg register S(k).
                 let mut vfp_arg: u8 = 0;
@@ -10327,6 +10575,12 @@ impl InstructionSelector {
                 }
 
                 Call(func_idx) => {
+                    // GI-FPU-002 phase 2 (#719/#369): decline LOUDLY when the
+                    // callee's own signature is a float ABI at the boundary
+                    // (f32/f64 return in S0/D0, f32 params in the VFP pool) —
+                    // this increment marshals live f32 values ACROSS the call
+                    // but not float arguments/results INTO/OUT OF it.
+                    self.check_callee_float_signature(*func_idx)?;
                     let is_import = *func_idx < self.num_imports;
                     // #197: a relocatable host-link import is a *direct* AAPCS
                     // call (`BL func_N` → wasm field name), so it marshals args
@@ -10386,6 +10640,18 @@ impl InstructionSelector {
                         &mut instructions,
                         &stack_live_regs(&stack),
                         &local_to_reg,
+                        &layout,
+                        idx,
+                    )?;
+                    // #719 phase 2: spill every live f32 value (S0..S15 caller-saved)
+                    // to the VFP call-spill area before the BL — the VFP analogue of
+                    // the #188 integer preservation above. Disjoint register file
+                    // and disjoint frame slots, so order vs the integer spill and
+                    // the R0..R3 arg move is immaterial.
+                    let vfp_preserved = preserve_vfp_caller_saved(
+                        &mut instructions,
+                        &stack,
+                        &vfp_home,
                         &layout,
                         idx,
                     )?;
@@ -10454,6 +10720,11 @@ impl InstructionSelector {
                         ret_i64,
                         idx,
                     )?;
+                    // #719 phase 2: reload the f32 S-registers the BL clobbered.
+                    // The callee returns in R0 (a float-returning callee is
+                    // declined by the epilogue guard), so reloading S0..S15 here
+                    // cannot destroy the integer result.
+                    restore_vfp_caller_saved(&mut instructions, &vfp_preserved, idx);
                     // Push the call's return value as a live operand (spilled to
                     // the frame if no register was free to hold it — #171).
                     stack.push(result_reg);
@@ -10476,6 +10747,12 @@ impl InstructionSelector {
                     // table.grow/table.set are unsupported ops that loud-skip
                     // their functions). If any input is missing, DECLINE
                     // loudly — never emit an unchecked indirect branch.
+                    // GI-FPU-002 phase 2 (#719/#369): decline loudly when the
+                    // static callee type RETURNS f32/f64 (S0/D0 result, not yet
+                    // marshalled). f32 ARGS need no type-level check here: every
+                    // f32 producer pushes a `Float` operand, which the integer
+                    // `pop_call_args` path below already rejects loudly.
+                    self.check_indirect_float_signature(*type_index)?;
                     let (table_size, table_byte_offset, null_check, type_check) =
                         self.resolve_call_indirect_guards(*table_index, *type_index)?;
 
@@ -10556,6 +10833,16 @@ impl InstructionSelector {
                         &layout,
                         idx,
                     )?;
+                    // #719 phase 2: spill live f32 values across the indirect call
+                    // (S0..S15 caller-saved). The relocated table index on `stack`
+                    // is an integer, invisible to `vfp_live_set`.
+                    let vfp_preserved = preserve_vfp_caller_saved(
+                        &mut instructions,
+                        &stack,
+                        &vfp_home,
+                        &layout,
+                        idx,
+                    )?;
 
                     // #195: marshal args into R0–R3 (after preservation, last
                     // writes before the indirect branch). The relocated table
@@ -10615,6 +10902,9 @@ impl InstructionSelector {
                         ret_i64,
                         idx,
                     )?;
+                    // #719 phase 2: reload the f32 S-registers the indirect call
+                    // clobbered.
+                    restore_vfp_caller_saved(&mut instructions, &vfp_preserved, idx);
                     stack.push(result_reg);
                 }
 
@@ -13435,6 +13725,28 @@ impl InstructionSelector {
         // If the producing S-register is not already S0, copy it there via a
         // core scratch (phase 1 has no VMOV Sd,Sm op; R12/IP is caller-saved,
         // safe to clobber at the epilogue). Skip the integer return-value move.
+        // GI-FPU-002 phase 2 (#719/#369) SOUNDNESS: a function that RETURNS f32
+        // or f64 must present its result in an S/D register (a `Float` stack
+        // entry). If the top-of-stack is anything else — most importantly an
+        // integer-tagged `Reg` produced by a call that returned f32/f64 as R0
+        // (#719 "f32 in a fn with a call": the call result is pushed as an
+        // integer operand) — emitting the integer R0 return would be a SILENT
+        // MISCOMPILE: the AAPCS-VFP caller reads S0/D0. Decline loudly instead
+        // (skip-and-continue). This also catches the pre-existing pure-passthrough
+        // shape `(func (result f32) (call $g))` that never entered the VFP path.
+        if self.ret_f32 || self.ret_f64 {
+            let top_is_float = stack.last().and_then(|v| v.as_float()).is_some();
+            if !top_is_float {
+                return Err(synth_core::Error::synthesis(format!(
+                    "GI-FPU-002 phase 2: function returns {} but its result reached \
+                     the epilogue in a core register (e.g. an f32/f64-returning \
+                     call's R0 result) — refusing to emit an integer R0 return \
+                     where an AAPCS-VFP caller reads {} (declining, #719/#369)",
+                    if self.ret_f64 { "f64" } else { "f32" },
+                    if self.ret_f64 { "D0" } else { "S0" },
+                )));
+            }
+        }
         let f32_result = stack.last().and_then(|v| v.as_float());
         if let Some(sreg) = f32_result {
             if vfp_s_index(sreg) != Some(0) {
@@ -15390,24 +15702,132 @@ mod tests {
         assert_eq!(l.regs.get(&1), None);
     }
 
-    /// #719: f32-across-a-call is DECLINED loudly this round (S0..S15 are
-    /// caller-saved; the spill/rehome across call sites is the next increment).
-    /// The function must Err (loud skip), never silently miscompile.
+    /// #719 phase 2: f32 ACROSS a call now LOWERS — the live f32 param home
+    /// (S0, caller-saved) is VSTR'd to the VFP call-spill area before the BL
+    /// and VLDR'd back after it (the VFP analogue of the #188 integer
+    /// preservation). Execution correctness is gated by
+    /// `scripts/repro/f32_ops_719_differential.py` (xcall/xhome cases).
     #[test]
-    fn test_719_f32_with_call_declines_loudly() {
+    fn test_719_f32_across_call_spills_and_reloads() {
         let mut selector = fresh_selector();
         selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
-        selector.set_params_f32(vec![true]); // one f32 param
-        let ops = vec![WasmOp::LocalGet(0), WasmOp::Call(0)];
-        let result = selector.select_with_stack(&ops, 1);
+        selector.set_params_f32(vec![true]); // one f32 param, homed in S0
+        // Read the f32 param AFTER an integer call: the home must survive.
+        let ops = vec![
+            WasmOp::Call(0),
+            WasmOp::Drop,
+            WasmOp::LocalGet(0),
+            WasmOp::I32ReinterpretF32,
+        ];
+        let instructions = selector
+            .select_with_stack(&ops, 1)
+            .expect("f32 live across an integer call must now lower (#719 phase 2)");
+        // Find the BL; a VSTR (F32Store to [SP,#off]) must precede it and a
+        // VLDR (F32Load from the same slot) must follow it, both for S0.
+        let bl_at = instructions
+            .iter()
+            .position(|i| matches!(&i.op, ArmOp::Bl { .. }))
+            .expect("call must emit a BL");
+        let vstr_before = instructions[..bl_at].iter().any(|i| {
+            matches!(&i.op, ArmOp::F32Store { sd, addr }
+                if *sd == VfpReg::S0 && addr.base == Reg::SP)
+        });
+        let vldr_after = instructions[bl_at..].iter().any(|i| {
+            matches!(&i.op, ArmOp::F32Load { sd, addr }
+                if *sd == VfpReg::S0 && addr.base == Reg::SP)
+        });
         assert!(
-            result.is_err(),
-            "f32-in-a-function-with-a-call must decline"
+            vstr_before,
+            "live f32 home S0 must be VSTR'd to the frame before the BL"
         );
-        let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("caller-saved") && err.contains("call"),
-            "decline must name the caller-saved-across-call cause, got: {err}"
+            vldr_after,
+            "live f32 home S0 must be VLDR'd back after the BL"
+        );
+    }
+
+    /// #719 phase 2: a call whose CALLEE has a float signature (f32/f64 return
+    /// in S0/D0, or an f32 param in the VFP pool) is declined LOUDLY at the
+    /// call site — this increment does not marshal a float ABI at the call
+    /// boundary, and tagging an S0 result as integer R0 (or passing an f32 arg
+    /// in a core register) would be a silent miscompile.
+    #[test]
+    fn test_719_float_signature_callee_declines_loudly() {
+        // Callee returns f32.
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+        selector.set_float_call_signatures(
+            vec![true], // func 0 returns f32
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let r = selector.select_with_stack(&[WasmOp::Call(0), WasmOp::Drop], 0);
+        assert!(
+            r.as_ref()
+                .is_err_and(|e| e.to_string().contains("returns f32")),
+            "call to an f32-returning callee must decline loudly: {r:?}"
+        );
+        // Callee takes an f32 param.
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+        selector.set_func_arg_counts(vec![1], Vec::new());
+        selector.set_float_call_signatures(
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            vec![vec![true]], // func 0 takes (f32)
+        );
+        let r = selector.select_with_stack(&[WasmOp::I32Const(1), WasmOp::Call(0)], 0);
+        assert!(
+            r.as_ref()
+                .is_err_and(|e| e.to_string().contains("f32 parameter")),
+            "call to an f32-param callee must decline loudly: {r:?}"
+        );
+        // call_indirect whose static type returns f64.
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+        selector.set_float_call_signatures(
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            vec![true], // type 0 returns f64
+            Vec::new(),
+        );
+        let r = selector.select_with_stack(
+            &[
+                WasmOp::I32Const(0),
+                WasmOp::CallIndirect {
+                    type_index: 0,
+                    table_index: 0,
+                },
+            ],
+            0,
+        );
+        assert!(
+            r.as_ref()
+                .is_err_and(|e| e.to_string().contains("returns f64")),
+            "call_indirect of an f64-returning type must decline loudly: {r:?}"
+        );
+    }
+
+    /// #719 phase 2 epilogue soundness guard: a function DECLARED to return
+    /// f32 whose result reaches the epilogue in a core register (here: an
+    /// integer constant — the well-typed analogue is an f32-returning call's
+    /// R0-tagged result) must decline loudly, never emit the integer R0 return
+    /// (the AAPCS-VFP caller reads S0).
+    #[test]
+    fn test_719_ret_f32_core_register_result_declines_loudly() {
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+        selector.set_ret_float(true, false);
+        let r = selector.select_with_stack(&[WasmOp::I32Const(7)], 0);
+        assert!(
+            r.as_ref()
+                .is_err_and(|e| e.to_string().contains("core register")),
+            "an f32-returning function with a core-register result must decline: {r:?}"
         );
     }
 
@@ -21809,6 +22229,7 @@ mod tests {
             locals: std::collections::HashMap::new(),
             frame_size: 0,
             spill_base: None,
+            vfp_spill_base: None,
             i64_spill_base: 0,
             param_slots: std::collections::HashMap::new(),
             incoming_params: std::collections::HashMap::new(),

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -254,6 +254,15 @@ enum StackVal {
     /// integer op only pops integer entries); they reject it defensively rather
     /// than misread it. f32 ops manage these via the dedicated VFP allocator.
     Float { sreg: VfpReg },
+    /// GI-FPU-002 phase 2 (#369): an f64 value in VFP double-precision register
+    /// `dreg` (D0..D7 only — the caller-saved half of the D-file; D8..D15 are
+    /// AAPCS-VFP callee-saved and this increment emits no VPUSH prologue, so
+    /// allocating them would clobber the caller's registers). Each `D(i)`
+    /// aliases the S-register pair `S(2i):S(2i+1)`, so the f32 and f64
+    /// allocators share ONE 16-slot usage map (`vfp_used`) and the f32
+    /// call-spill machinery preserves a live double as its two aliased words —
+    /// bit-exact by the VFP register-file aliasing rule.
+    Double { dreg: VfpReg },
 }
 
 impl StackVal {
@@ -274,6 +283,10 @@ impl StackVal {
             StackVal::Reg { is_i64, .. } | StackVal::Spilled { is_i64, .. } => *is_i64,
             // GI-FPU-002: an f32 is a single 32-bit S-register value.
             StackVal::Float { .. } => false,
+            // GI-FPU-002 phase 2: an f64 is 64-bit but NEVER an integer
+            // register pair — the integer pop/peek/spill paths that consult
+            // this reject a `Double` outright before width matters.
+            StackVal::Double { .. } => false,
         }
     }
     /// GI-FPU-002: the S-register of an f32 stack value, if this is one.
@@ -281,6 +294,15 @@ impl StackVal {
     fn as_float(&self) -> Option<VfpReg> {
         match self {
             StackVal::Float { sreg } => Some(*sreg),
+            _ => None,
+        }
+    }
+    /// GI-FPU-002 phase 2 (#369): the D-register of an f64 stack value, if
+    /// this is one.
+    #[inline]
+    fn as_double(&self) -> Option<VfpReg> {
+        match self {
+            StackVal::Double { dreg } => Some(*dreg),
             _ => None,
         }
     }
@@ -718,6 +740,16 @@ fn vfp_live_set(stack: &[StackVal], vfp_home: &[bool; 16]) -> Vec<usize> {
         {
             set[k] = true;
         }
+        // GI-FPU-002 phase 2 (#369): a live f64 in D(i) is preserved as its
+        // two aliased S-words S(2i):S(2i+1) — bit-exact by the VFP D/S
+        // register-file aliasing (D-temps are confined to D0..D7, so both
+        // word indices are always inside the 16-slot area).
+        if let Some(dreg) = v.as_double()
+            && let Some(i) = vfp_d_index(dreg)
+        {
+            set[2 * i] = true;
+            set[2 * i + 1] = true;
+        }
     }
     for (k, &h) in vfp_home.iter().enumerate() {
         if h {
@@ -1005,6 +1037,14 @@ fn pop_operand(
              invalid wasm or an unlowered float op reached the integer path"
                 .to_string(),
         )),
+        // GI-FPU-002 phase 2 (#369): same contract for f64 — an integer op
+        // (incl. call-argument marshalling) never consumes a D-register value.
+        StackVal::Double { .. } => Err(synth_core::Error::synthesis(
+            "GI-FPU-002 phase 2: an integer operation popped an f64 (VFP D) \
+             stack value — invalid wasm or an unlowered f64 op reached the \
+             integer path"
+                .to_string(),
+        )),
         StackVal::Spilled { lo_slot, is_i64 } => {
             // Reload against the *remaining* stack (this entry already popped).
             // i32: one temp + one LDR. i64: a consecutive pair + LDR lo/hi.
@@ -1072,6 +1112,13 @@ fn peek_operand(
         Some(StackVal::Float { .. }) => Err(synth_core::Error::synthesis(
             "GI-FPU-002: an integer operation peeked an f32 (VFP) stack value — \
              invalid wasm or an unlowered float op reached the integer path"
+                .to_string(),
+        )),
+        // GI-FPU-002 phase 2 (#369): same contract for f64.
+        Some(StackVal::Double { .. }) => Err(synth_core::Error::synthesis(
+            "GI-FPU-002 phase 2: an integer operation peeked an f64 (VFP D) \
+             stack value — invalid wasm or an unlowered f64 op reached the \
+             integer path"
                 .to_string(),
         )),
         Some(StackVal::Spilled { lo_slot, is_i64 }) => {
@@ -1540,7 +1587,11 @@ fn compute_local_layout(
     // every other frame field so the existing local/spill/param offsets are
     // unchanged.
     let has_f32 = params_f32.iter().take(num_params as usize).any(|&f| f)
-        || wasm_ops.iter().any(is_scope_f32_op);
+        || wasm_ops.iter().any(is_scope_f32_op)
+        // GI-FPU-002 phase 2 (#369): f64 values live in D0..D7, which alias
+        // S0..S15 — a live double across a call is preserved by the SAME
+        // 16-slot area as its two aliased words.
+        || wasm_ops.iter().any(is_scope_f64_op);
     let vfp_spill_base = if has_f32 && has_call {
         let base = offset;
         offset += 16 * 4;
@@ -2485,6 +2536,261 @@ fn try_lower_f32(
     }
 }
 
+// ============================================================================
+// GI-FPU-002 phase 2 (#369): scalar f64 (double-precision VFP) lowering for
+// the direct `select_with_stack` selector — cortex-m7dp (`FPUPrecision::Double`)
+// only. The honest-subset scope mirrors the f32 story: f64.const,
+// f64.promote_f32 (falcon's two blockers), add/sub/mul/div, abs/neg/sqrt, the
+// six comparisons, and f64.load/f64.store (lowered in the main match via the
+// PROVEN 4-byte integer memory path, twice). Everything else f64 stays dropped
+// at decode (loud-skip). D-temps are confined to the CALLER-SAVED half D0..D7
+// (no VPUSH prologue needed); each D(i) aliases S(2i):S(2i+1), so allocation
+// shares the f32 `vfp_used` map and the #719 f32 call-spill machinery
+// transparently preserves live doubles across calls as two aliased words.
+// ============================================================================
+
+/// The 0..8 file index of a caller-saved double-precision VFP register
+/// `D0..D7`, or `None` for anything else (S-registers; the callee-saved
+/// `D8..D15`, which this increment never allocates).
+fn vfp_d_index(r: VfpReg) -> Option<usize> {
+    use VfpReg::*;
+    Some(match r {
+        D0 => 0,
+        D1 => 1,
+        D2 => 2,
+        D3 => 3,
+        D4 => 4,
+        D5 => 5,
+        D6 => 6,
+        D7 => 7,
+        _ => return None,
+    })
+}
+
+/// Allocate the lowest-numbered free caller-saved D-register (D0..D7), marking
+/// BOTH aliased S-slots in the shared `vfp_used` map. Errs (honest decline)
+/// when no aligned pair of S-slots is free — no VFP spilling mid-expression.
+fn alloc_vfp_dtemp(used: &mut [bool; 16]) -> Result<VfpReg> {
+    for i in 0..8usize {
+        if !used[2 * i] && !used[2 * i + 1] {
+            used[2 * i] = true;
+            used[2 * i + 1] = true;
+            return Ok(index_to_vfp_dreg(i as u8));
+        }
+    }
+    Err(synth_core::Error::synthesis(
+        "GI-FPU-002 phase 2: caller-saved VFP D-register file exhausted \
+         (D0..D7 all live) — f64 expression too deep for this increment \
+         (no VFP spilling, and D8..D15 are callee-saved) — declining (#369)"
+            .to_string(),
+    ))
+}
+
+/// Free a D-temp's two aliased S-slots unless either is a pinned f32 home
+/// (defensive — an f32 home never aliases an allocated D-temp, because the
+/// D-alloc requires both slots free).
+fn free_vfp_dtemp(used: &mut [bool; 16], home: &[bool; 16], r: VfpReg) {
+    if let Some(i) = vfp_d_index(r) {
+        if !home[2 * i] {
+            used[2 * i] = false;
+        }
+        if !home[2 * i + 1] {
+            used[2 * i + 1] = false;
+        }
+    }
+}
+
+/// Pop the top operand as an f64 (VFP D-register) value; err loudly if it is
+/// not one (invalid wasm or an unlowered mixed sequence).
+fn pop_double(stack: &mut Vec<StackVal>) -> Result<VfpReg> {
+    match stack.pop() {
+        Some(StackVal::Double { dreg }) => Ok(dreg),
+        Some(_) => Err(synth_core::Error::synthesis(
+            "GI-FPU-002 phase 2: an f64 operation expected an f64 (VFP D) \
+             operand but the stack top was not one — invalid wasm or an \
+             unlowered mixed sequence"
+                .to_string(),
+        )),
+        None => Err(synth_core::Error::synthesis(
+            "stack underflow: malformed WASM or compiler bug".to_string(),
+        )),
+    }
+}
+
+/// True if `op` is one of the in-scope scalar f64 ops this phase-2 increment
+/// lowers (mirrors the decoder's un-dropped f64 set EXACTLY — every decoded
+/// f64 op must be intercepted before the main match's `select_default`
+/// fallback, which is register-blind). `F64Load`/`F64Store` are lowered in the
+/// main `select_with_stack` match (they need `self`'s address machinery, like
+/// `F32Load`); they are listed here so the FPU gate fires for a function whose
+/// only f64 op is a memory access.
+fn is_scope_f64_op(op: &WasmOp) -> bool {
+    use WasmOp::*;
+    matches!(
+        op,
+        F64Const(_)
+            | F64PromoteF32
+            | F64Add
+            | F64Sub
+            | F64Mul
+            | F64Div
+            | F64Abs
+            | F64Neg
+            | F64Sqrt
+            | F64Eq
+            | F64Ne
+            | F64Lt
+            | F64Le
+            | F64Gt
+            | F64Ge
+            | F64Load { .. }
+            | F64Store { .. }
+    )
+}
+
+/// Lower an in-scope scalar f64 op onto the caller-saved D-register file.
+/// Returns `Ok(true)` when handled, `Ok(false)` when `op` is not an f64 op
+/// (fall through), `Err` on an honest decline. Gated by the caller on
+/// `FPUPrecision::Double` (cortex-m7dp); a single-precision or no-FPU target
+/// never reaches here (preamble honest-reject).
+#[allow(clippy::too_many_arguments)]
+fn try_lower_f64(
+    op: &WasmOp,
+    idx: usize,
+    vfp_used: &mut [bool; 16],
+    vfp_home: &[bool; 16],
+    stack: &mut Vec<StackVal>,
+    next_temp: &mut u8,
+    spill: &mut SpillState,
+    instructions: &mut Vec<ArmInstruction>,
+    reserved: &[Reg],
+) -> Result<bool> {
+    use WasmOp::*;
+    match op {
+        F64Const(v) => {
+            // Materialize the 64-bit pattern via TWO allocator-owned core
+            // temps (MOVW/MOVT each) + `VMOV Dd, lo, hi`. Deliberately NOT
+            // `ArmOp::F64Const`: that encoder pseudo-op hardcodes R0+R12 as
+            // scratch, and R0 can hold a live param/temp (the #615 "encoder
+            // pseudo-op clobbers allocator state" class).
+            let bits = v.to_bits();
+            let lo = bits as u32;
+            let hi = (bits >> 32) as u32;
+            let rlo = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+            // Keep `rlo` visibly live while allocating `rhi` by pushing it as
+            // a placeholder stack entry (popped right back off).
+            stack.push(StackVal::i32(rlo));
+            let rhi = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx);
+            stack.pop();
+            let rhi = rhi?;
+            for (r, val) in [(rlo, lo), (rhi, hi)] {
+                instructions.push(ArmInstruction {
+                    op: ArmOp::Movw {
+                        rd: r,
+                        imm16: (val & 0xFFFF) as u16,
+                    },
+                    source_line: Some(idx),
+                });
+                if (val >> 16) != 0 {
+                    instructions.push(ArmInstruction {
+                        op: ArmOp::Movt {
+                            rd: r,
+                            imm16: (val >> 16) as u16,
+                        },
+                        source_line: Some(idx),
+                    });
+                }
+            }
+            let dd = alloc_vfp_dtemp(vfp_used)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::F64ReinterpretI64 {
+                    dd,
+                    rmlo: rlo,
+                    rmhi: rhi,
+                },
+                source_line: Some(idx),
+            });
+            stack.push(StackVal::Double { dreg: dd });
+            Ok(true)
+        }
+        F64PromoteF32 => {
+            // VCVT.F64.F32 Dd, Sm — exact (every f32 is representable in f64;
+            // a signalling NaN is quietened, as WASM Core §4.3.3 permits).
+            let sm = pop_float(stack)?;
+            let dd = alloc_vfp_dtemp(vfp_used)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::F64PromoteF32 { dd, sm },
+                source_line: Some(idx),
+            });
+            free_vfp_temp(vfp_used, vfp_home, sm);
+            stack.push(StackVal::Double { dreg: dd });
+            Ok(true)
+        }
+        F64Add | F64Sub | F64Mul | F64Div => {
+            let dm = pop_double(stack)?;
+            let dn = pop_double(stack)?;
+            let dd = alloc_vfp_dtemp(vfp_used)?;
+            let arm = match op {
+                F64Add => ArmOp::F64Add { dd, dn, dm },
+                F64Sub => ArmOp::F64Sub { dd, dn, dm },
+                F64Mul => ArmOp::F64Mul { dd, dn, dm },
+                _ => ArmOp::F64Div { dd, dn, dm },
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_dtemp(vfp_used, vfp_home, dm);
+            free_vfp_dtemp(vfp_used, vfp_home, dn);
+            stack.push(StackVal::Double { dreg: dd });
+            Ok(true)
+        }
+        F64Abs | F64Neg | F64Sqrt => {
+            let dm = pop_double(stack)?;
+            let dd = alloc_vfp_dtemp(vfp_used)?;
+            let arm = match op {
+                F64Abs => ArmOp::F64Abs { dd, dm },
+                F64Neg => ArmOp::F64Neg { dd, dm },
+                _ => ArmOp::F64Sqrt { dd, dm },
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_dtemp(vfp_used, vfp_home, dm);
+            stack.push(StackVal::Double { dreg: dd });
+            Ok(true)
+        }
+        F64Eq | F64Ne | F64Lt | F64Le | F64Gt | F64Ge => {
+            // VCMP.F64 + VMRS + IT — the encoder's condition codes are the
+            // NaN-audited ordered set (EQ/NE/MI/LS/GT/GE): every ordered
+            // relation is false on an unordered (NaN) compare and `ne` is
+            // true, matching WASM §4.3.3 exactly (same table the #712 f32
+            // audit pinned).
+            let dm = pop_double(stack)?;
+            let dn = pop_double(stack)?;
+            let rd = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+            let arm = match op {
+                F64Eq => ArmOp::F64Eq { rd, dn, dm },
+                F64Ne => ArmOp::F64Ne { rd, dn, dm },
+                F64Lt => ArmOp::F64Lt { rd, dn, dm },
+                F64Le => ArmOp::F64Le { rd, dn, dm },
+                F64Gt => ArmOp::F64Gt { rd, dn, dm },
+                _ => ArmOp::F64Ge { rd, dn, dm },
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_dtemp(vfp_used, vfp_home, dm);
+            free_vfp_dtemp(vfp_used, vfp_home, dn);
+            stack.push(StackVal::i32(rd));
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
 /// Convert Q-register index to QReg enum (Q0-Q7, wrapping)
 fn index_to_qreg(index: u8) -> QReg {
     match index % 8 {
@@ -2561,6 +2867,13 @@ pub struct InstructionSelector {
     /// homed in an AAPCS-VFP argument S-register (S0..S15) rather than the
     /// R0..R3 integer path. Empty ⇒ no f32 params (byte-identical legacy path).
     params_f32: Vec<bool>,
+    /// GI-FPU-002 phase 2 (#369): `params_f64[k]` true ⇒ param `k` is an f64
+    /// (arrives in a VFP D-register under AAPCS-VFP). Hard-float targets
+    /// decline such functions loudly — the legacy width inference treats the
+    /// param as an i64 CORE pair, a silent wrong-argument miscompile. Distinct
+    /// from `params_i64`, which deliberately lumps i64 and f64 for frame
+    /// layout. Empty ⇒ no f64 params (byte-identical legacy path).
+    params_f64: Vec<bool>,
     /// GI-FPU-002 phase 2 (#719/#369): whether the function being compiled
     /// returns f32 / f64. The epilogue homes a float result in S0 (f32) / D0
     /// (f64); if the top-of-stack at return is NOT a `Float` (e.g. a call that
@@ -2747,6 +3060,7 @@ impl InstructionSelector {
             type_ret_i64: Vec::new(),
             params_i64: Vec::new(),
             params_f32: Vec::new(),
+            params_f64: Vec::new(),
             ret_f32: false,
             ret_f64: false,
             callee_ret_f32: Vec::new(),
@@ -2793,6 +3107,7 @@ impl InstructionSelector {
             type_ret_i64: Vec::new(),
             params_i64: Vec::new(),
             params_f32: Vec::new(),
+            params_f64: Vec::new(),
             ret_f32: false,
             ret_f64: false,
             callee_ret_f32: Vec::new(),
@@ -3146,6 +3461,13 @@ impl InstructionSelector {
     /// f32 args in their AAPCS-VFP argument S-registers (S0..S15).
     pub fn set_params_f32(&mut self, params_f32: Vec<bool>) {
         self.params_f32 = params_f32;
+    }
+
+    /// GI-FPU-002 phase 2 (#369): register the declared f64-param mask of the
+    /// function about to be compiled — hard-float targets decline f64 params
+    /// loudly (see the `params_f64` field).
+    pub fn set_params_f64(&mut self, params_f64: Vec<bool>) {
+        self.params_f64 = params_f64;
     }
 
     /// GI-FPU-002 phase 2 (#719/#369): record whether the function about to be
@@ -7900,6 +8222,44 @@ impl InstructionSelector {
                     }
                 }
             }
+            // GI-FPU-002 phase 2 (#369): scalar f64 capability gates. The
+            // lowered f64 subset needs DOUBLE-precision VFP (cortex-m7dp);
+            // m4f/m7 are single-precision (VCVT.F64/VADD.F64 would be
+            // UNDEFINED), and m0/m3/r5 have no FPU — honest-reject all three.
+            let has_f64_op = wasm_ops.iter().any(is_scope_f64_op);
+            if has_f64_op && !matches!(fpu, Some(FPUPrecision::Double)) {
+                return Err(synth_core::Error::synthesis(format!(
+                    "GI-FPU-002 phase 2: scalar f64 requires a double-precision \
+                     FPU target (cortex-m7dp); '{}' {} — refusing to emit f64 \
+                     (declining the function, #369)",
+                    self.target_name,
+                    if fpu.is_some() {
+                        "has a single-precision FPU (f32 only)"
+                    } else {
+                        "has no FPU"
+                    }
+                )));
+            }
+            // GI-FPU-002 phase 2 (#369): f64 PARAMS are not yet homed (an f64
+            // param arrives in D0..D7 under AAPCS-VFP). On a hard-float target
+            // the legacy width-inference treats it as an i64 CORE-register
+            // pair — reading R0:R1 where the caller put D0, and shifting every
+            // later integer param's home — a silent wrong-argument class, so
+            // decline LOUDLY. Soft-float targets (no FPU) genuinely pass f64
+            // in core registers, so the i64-pair treatment is ABI-correct
+            // there and stays.
+            if fpu.is_some()
+                && (0..num_params)
+                    .any(|i| self.params_f64.get(i as usize).copied().unwrap_or(false))
+            {
+                return Err(synth_core::Error::synthesis(format!(
+                    "GI-FPU-002 phase 2: an f64 parameter arrives in a VFP \
+                     D-register under AAPCS-VFP, which '{}' hard-float lowering \
+                     does not yet home — declining loudly (an i64-pair reading \
+                     of R0:R1 would be a silent wrong-argument miscompile, #369)",
+                    self.target_name
+                )));
+            }
         }
 
         for (idx, op) in wasm_ops.iter().enumerate() {
@@ -7945,6 +8305,28 @@ impl InstructionSelector {
                     &mut f32_home,
                     &mut vfp_used,
                     &mut vfp_home,
+                    &mut stack,
+                    &mut next_temp,
+                    &mut spill,
+                    &mut instructions,
+                    &live_params,
+                )?
+            {
+                continue;
+            }
+            // GI-FPU-002 phase 2 (#369): intercept in-scope scalar f64 ops
+            // BEFORE the integer match — the main match's `_ =>` arm falls
+            // back to the register-blind `select_default`, which would
+            // miscompile them. Gated on double-precision VFP (the preamble
+            // honest-rejects any f64 op on m4f/m7/m3, so this arm is
+            // unreachable there); F64Load/F64Store fall through to their
+            // dedicated main-match arms below.
+            if matches!(fpu, Some(FPUPrecision::Double))
+                && try_lower_f64(
+                    op,
+                    idx,
+                    &mut vfp_used,
+                    &vfp_home,
                     &mut stack,
                     &mut next_temp,
                     &mut spill,
@@ -9355,6 +9737,197 @@ impl InstructionSelector {
                             op,
                             source_line: Some(idx),
                         });
+                    }
+                    // Store pushes nothing.
+                }
+
+                // GI-FPU-002 phase 2 (#369): `f64.load` — two PROVEN 4-byte
+                // integer loads (lo word at `offset`, hi word at `offset+4`,
+                // each with its own bounds guard, jointly covering the 8-byte
+                // access) bit-cast into a D-register via `VMOV Dd, lo, hi`.
+                // Same honest declines as `F32Load` for the address modes this
+                // phase does not lower; additionally declines `--safety-bounds
+                // mask`, whose masking MUTATES the address register in place,
+                // so a second masked access off the same register would
+                // re-mask an already-masked address (wrong effective address).
+                F64Load { offset, .. } => {
+                    if self.bounds_check == BoundsCheckConfig::Masking {
+                        return Err(synth_core::Error::synthesis(
+                            "GI-FPU-002 phase 2: f64.load under --safety-bounds                              mask is not lowered (the two-word access would                              re-mask its address register) — declining (#369)"
+                                .to_string(),
+                        ));
+                    }
+                    if self.native_pointer_abi
+                        && self.wasm_data_base > 0
+                        && *offset >= self.wasm_data_base
+                    {
+                        return Err(synth_core::Error::synthesis(
+                            "GI-FPU-002 phase 2: f64.load from the static-data                              region under the native-pointer ABI is not yet                              lowered (#359 address relocation) — declining"
+                                .to_string(),
+                        ));
+                    }
+                    if let Some(eff) = self.try_fold_const_addr(wasm_ops, idx, *offset)
+                        && self.static_data_addend(eff).is_some()
+                    {
+                        return Err(synth_core::Error::synthesis(
+                            "GI-FPU-002 phase 2: f64.load from a constant                              static-data address is not yet lowered (#237                              relocation) — declining"
+                                .to_string(),
+                        ));
+                    }
+                    if *offset > (i32::MAX as u32) - 8 {
+                        return Err(synth_core::Error::synthesis(
+                            "GI-FPU-002 phase 2: f64.load static offset too                              large (hi-word offset would overflow) — declining"
+                                .to_string(),
+                        ));
+                    }
+                    let addr = pop_operand(
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    )?;
+                    // Two core scratches for the loaded words. Keep `addr` and
+                    // `rlo` visibly live (placeholder stack entries) while
+                    // allocating, so neither is handed out twice — the first
+                    // load must not clobber the address the second one reads.
+                    stack.push(StackVal::i32(addr));
+                    let rlo = match alloc_temp_or_spill(
+                        &mut next_temp,
+                        &mut stack,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    ) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            stack.pop();
+                            return Err(e);
+                        }
+                    };
+                    stack.push(StackVal::i32(rlo));
+                    let rhi = alloc_temp_or_spill(
+                        &mut next_temp,
+                        &mut stack,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    );
+                    stack.pop();
+                    stack.pop();
+                    let rhi = rhi?;
+                    for (dst, off) in [(rlo, *offset as i32), (rhi, *offset as i32 + 4)] {
+                        for op in self.generate_load_with_bounds_check(dst, addr, off, 4) {
+                            instructions.push(ArmInstruction {
+                                op,
+                                source_line: Some(idx),
+                            });
+                        }
+                    }
+                    let dd = alloc_vfp_dtemp(&mut vfp_used)?;
+                    instructions.push(ArmInstruction {
+                        op: ArmOp::F64ReinterpretI64 {
+                            dd,
+                            rmlo: rlo,
+                            rmhi: rhi,
+                        },
+                        source_line: Some(idx),
+                    });
+                    stack.push(StackVal::Double { dreg: dd });
+                }
+
+                // GI-FPU-002 phase 2 (#369): `f64.store` — `VMOV lo, hi, Dm`
+                // then two PROVEN 4-byte integer stores. Mirrors `F64Load`'s
+                // declines (masking / native-pointer static / const static
+                // address / offset overflow).
+                F64Store { offset, .. } => {
+                    if self.bounds_check == BoundsCheckConfig::Masking {
+                        return Err(synth_core::Error::synthesis(
+                            "GI-FPU-002 phase 2: f64.store under --safety-bounds                              mask is not lowered (the two-word access would                              re-mask its address register) — declining (#369)"
+                                .to_string(),
+                        ));
+                    }
+                    if self.native_pointer_abi
+                        && self.wasm_data_base > 0
+                        && *offset >= self.wasm_data_base
+                    {
+                        return Err(synth_core::Error::synthesis(
+                            "GI-FPU-002 phase 2: f64.store to the static-data                              region under the native-pointer ABI is not yet                              lowered (#359 address relocation) — declining"
+                                .to_string(),
+                        ));
+                    }
+                    if let Some(eff) = self.try_fold_const_addr_store(wasm_ops, idx, *offset)
+                        && self.static_data_addend(eff).is_some()
+                    {
+                        return Err(synth_core::Error::synthesis(
+                            "GI-FPU-002 phase 2: f64.store to a constant                              static-data address is not yet lowered (#237                              relocation) — declining"
+                                .to_string(),
+                        ));
+                    }
+                    if *offset > (i32::MAX as u32) - 8 {
+                        return Err(synth_core::Error::synthesis(
+                            "GI-FPU-002 phase 2: f64.store static offset too                              large (hi-word offset would overflow) — declining"
+                                .to_string(),
+                        ));
+                    }
+                    // WASM f64.store pops: value (f64) first, then address.
+                    let dval = pop_double(&mut stack)?;
+                    let addr = pop_operand(
+                        &mut stack,
+                        &mut next_temp,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    )?;
+                    // Two core scratches for the value words; keep `addr` and
+                    // `rlo` visibly live during allocation (see F64Load).
+                    stack.push(StackVal::i32(addr));
+                    let rlo = match alloc_temp_or_spill(
+                        &mut next_temp,
+                        &mut stack,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    ) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            stack.pop();
+                            return Err(e);
+                        }
+                    };
+                    stack.push(StackVal::i32(rlo));
+                    let rhi = alloc_temp_or_spill(
+                        &mut next_temp,
+                        &mut stack,
+                        &mut instructions,
+                        &mut spill,
+                        &live_params,
+                        idx,
+                    );
+                    stack.pop();
+                    stack.pop();
+                    let rhi = rhi?;
+                    instructions.push(ArmInstruction {
+                        op: ArmOp::I64ReinterpretF64 {
+                            rdlo: rlo,
+                            rdhi: rhi,
+                            dm: dval,
+                        },
+                        source_line: Some(idx),
+                    });
+                    free_vfp_dtemp(&mut vfp_used, &vfp_home, dval);
+                    for (src, off) in [(rlo, *offset as i32), (rhi, *offset as i32 + 4)] {
+                        for op in self.generate_store_with_bounds_check(src, addr, off, 4) {
+                            instructions.push(ArmInstruction {
+                                op,
+                                source_line: Some(idx),
+                            });
+                        }
                     }
                     // Store pushes nothing.
                 }
@@ -13734,9 +14307,19 @@ impl InstructionSelector {
         // MISCOMPILE: the AAPCS-VFP caller reads S0/D0. Decline loudly instead
         // (skip-and-continue). This also catches the pre-existing pure-passthrough
         // shape `(func (result f32) (call $g))` that never entered the VFP path.
-        if self.ret_f32 || self.ret_f64 {
-            let top_is_float = stack.last().and_then(|v| v.as_float()).is_some();
-            if !top_is_float {
+        // Gated on `fpu.is_some()`: the guard protects the HARD-float
+        // (AAPCS-VFP) return convention. A soft-float target (m0/m3/r5)
+        // genuinely returns f32 in R0 / f64 in R0:R1, so an integer-tagged
+        // result at the epilogue is ABI-CORRECT there (e.g. the f64-param
+        // passthrough `(param f64) (result f64) local.get 0` on cortex-m3,
+        // where the i64-pair treatment matches the soft-float ABI exactly).
+        if (self.ret_f32 || self.ret_f64) && self.fpu.is_some() {
+            let top_matches = if self.ret_f64 {
+                stack.last().and_then(|v| v.as_double()).is_some()
+            } else {
+                stack.last().and_then(|v| v.as_float()).is_some()
+            };
+            if !top_matches {
                 return Err(synth_core::Error::synthesis(format!(
                     "GI-FPU-002 phase 2: function returns {} but its result reached \
                      the epilogue in a core register (e.g. an f32/f64-returning \
@@ -13748,7 +14331,32 @@ impl InstructionSelector {
             }
         }
         let f32_result = stack.last().and_then(|v| v.as_float());
-        if let Some(sreg) = f32_result {
+        let f64_result = stack.last().and_then(|v| v.as_double());
+        if let Some(dreg) = f64_result {
+            // GI-FPU-002 phase 2 (#369): an f64 result is returned in D0
+            // (AAPCS-VFP). Copy via the core round-trip (`VMOV lo,hi,Dm` +
+            // `VMOV D0,lo,hi` — bit-exact, no D→D move in the ArmOp set).
+            // R0/R1 are dead at the epilogue of an f64-returning function
+            // (the integer return registers are unused), R12 is IP scratch.
+            if vfp_d_index(dreg) != Some(0) {
+                instructions.push(ArmInstruction {
+                    op: ArmOp::I64ReinterpretF64 {
+                        rdlo: Reg::R0,
+                        rdhi: Reg::R1,
+                        dm: dreg,
+                    },
+                    source_line: None,
+                });
+                instructions.push(ArmInstruction {
+                    op: ArmOp::F64ReinterpretI64 {
+                        dd: VfpReg::D0,
+                        rmlo: Reg::R0,
+                        rmhi: Reg::R1,
+                    },
+                    source_line: None,
+                });
+            }
+        } else if let Some(sreg) = f32_result {
             if vfp_s_index(sreg) != Some(0) {
                 instructions.push(ArmInstruction {
                     op: ArmOp::I32ReinterpretF32 {
@@ -15811,6 +16419,129 @@ mod tests {
                 .is_err_and(|e| e.to_string().contains("returns f64")),
             "call_indirect of an f64-returning type must decline loudly: {r:?}"
         );
+    }
+
+    /// GI-FPU-002 phase 2 (#369): f64 requires DOUBLE-precision VFP — a
+    /// single-precision target (m4f) and a no-FPU target must both decline
+    /// any f64 op loudly (VADD.F64 on m4f is UNDEFINED, not slow).
+    #[test]
+    fn test_369_f64_requires_double_precision_fpu() {
+        for (fpu, name) in [
+            (Some(FPUPrecision::Single), "cortex-m4f"),
+            (None, "cortex-m3"),
+        ] {
+            let mut selector = fresh_selector();
+            selector.set_target(fpu, name);
+            let ops = vec![WasmOp::F64Const(1.5), WasmOp::Drop];
+            let r = selector.select_with_stack(&ops, 0);
+            assert!(
+                r.as_ref()
+                    .is_err_and(|e| e.to_string().contains("double-precision")),
+                "f64 on {name} must decline loudly: {r:?}"
+            );
+        }
+    }
+
+    /// GI-FPU-002 phase 2 (#369): the lowered f64 subset compiles on m7dp —
+    /// f64.const materializes the full 64-bit pattern via two core consts +
+    /// `VMOV Dd, lo, hi` (NOT the R0/R12-clobbering encoder pseudo-op), and
+    /// an f64 result is homed in D0.
+    #[test]
+    fn test_369_f64_const_composes_and_homes_d0() {
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Double), "cortex-m7dp");
+        selector.set_ret_float(false, true);
+        let ops = vec![WasmOp::F64Const(1.5), WasmOp::F64Sqrt];
+        let instructions = selector
+            .select_with_stack(&ops, 0)
+            .expect("f64 const+sqrt must lower on m7dp");
+        // The 64-bit pattern is built with allocator-owned core registers and
+        // VMOV'd into a D-register — never ArmOp::F64Const (R0/R12 clobber).
+        assert!(
+            !instructions
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::F64Const { .. })),
+            "f64.const must not use the R0/R12-clobbering encoder pseudo-op"
+        );
+        assert!(
+            instructions
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::F64ReinterpretI64 { .. })),
+            "f64.const must materialize via VMOV Dd, lo, hi"
+        );
+        assert!(
+            instructions
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::F64Sqrt { .. })),
+            "f64.sqrt must lower to VSQRT.F64"
+        );
+    }
+
+    /// GI-FPU-002 phase 2 (#369): an f64 PARAM on a hard-float target declines
+    /// loudly (the caller put it in D0; the legacy i64-pair treatment would
+    /// read R0:R1 — a silent wrong-argument miscompile). On a NO-FPU target
+    /// the core-register pair IS the soft-float ABI, so the same signature
+    /// keeps compiling.
+    #[test]
+    fn test_369_f64_param_declines_on_hard_float_only() {
+        // Hard-float: decline.
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Double), "cortex-m7dp");
+        selector.set_params_i64(vec![true]); // width table lumps f64 as wide
+        selector.set_params_f64(vec![true]);
+        let ops = vec![WasmOp::I32Const(7)];
+        let r = selector.select_with_stack(&ops, 1);
+        assert!(
+            r.as_ref()
+                .is_err_and(|e| e.to_string().contains("f64 parameter")),
+            "an f64 param on hard-float must decline loudly: {r:?}"
+        );
+        // Soft-float (no FPU): the i64-pair treatment is the correct ABI.
+        let mut selector = fresh_selector();
+        selector.set_target(None, "cortex-m3");
+        selector.set_params_i64(vec![true]);
+        selector.set_params_f64(vec![true]);
+        selector
+            .select_with_stack(&ops, 1)
+            .expect("an f64 param on a soft-float target keeps compiling");
+    }
+
+    /// GI-FPU-002 phase 2 (#369): a live f64 across an integer call is
+    /// preserved as its two aliased S-words (D0 = S0:S1) via the #719 VFP
+    /// call-spill area — VSTR both words before the BL, VLDR both after.
+    #[test]
+    fn test_369_f64_across_call_spills_aliased_words() {
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Double), "cortex-m7dp");
+        selector.set_ret_float(false, true);
+        let ops = vec![
+            WasmOp::F64Const(2.5), // live f64 in D0 (S0:S1)
+            WasmOp::Call(0),
+            WasmOp::Drop,
+        ];
+        let instructions = selector
+            .select_with_stack(&ops, 0)
+            .expect("f64 live across an integer call must lower");
+        let bl_at = instructions
+            .iter()
+            .position(|i| matches!(&i.op, ArmOp::Bl { .. }))
+            .expect("call must emit a BL");
+        for (sreg, word) in [(VfpReg::S0, "lo"), (VfpReg::S1, "hi")] {
+            assert!(
+                instructions[..bl_at].iter().any(|i| {
+                    matches!(&i.op, ArmOp::F32Store { sd, addr }
+                        if *sd == sreg && addr.base == Reg::SP)
+                }),
+                "live f64 {word} word ({sreg:?}) must be VSTR'd before the BL"
+            );
+            assert!(
+                instructions[bl_at..].iter().any(|i| {
+                    matches!(&i.op, ArmOp::F32Load { sd, addr }
+                        if *sd == sreg && addr.base == Reg::SP)
+                }),
+                "live f64 {word} word ({sreg:?}) must be VLDR'd after the BL"
+            );
+        }
     }
 
     /// #719 phase 2 epilogue soundness guard: a function DECLARED to return

--- a/scripts/repro/f32_ops_719.wat
+++ b/scripts/repro/f32_ops_719.wat
@@ -68,4 +68,56 @@
   (func (export "mix_add") (param i32 f32 f32) (result f32)
     local.get 1
     local.get 2
-    f32.add))
+    f32.add)
+
+  ;; ---- #719 phase 2: f32 live ACROSS an integer call ------------------------
+  ;; Helper with an INTEGER signature that uses VFP internally: its own f32
+  ;; lowering allocates S0/S1, so a call to it GENUINELY clobbers the caller's
+  ;; low S-registers -- the spill/reload differential is non-vacuous without any
+  ;; host code. fhelp(bits) = bits(-f32(bits)).
+  (func $fhelp (param i32) (result i32)
+    local.get 0 f32.reinterpret_i32 f32.neg i32.reinterpret_f32)
+
+  ;; f32 TEMP live across the call: x + f32(-x_bits reinterpreted back).
+  ;; xcall(b) = bits(f32(b) + f32(fhelp(b))) = bits(x + (-x)).
+  (func (export "xcall") (param i32) (result i32)
+    local.get 0 f32.reinterpret_i32      ;; live f32 temp in an S-register
+    local.get 0 call $fhelp              ;; integer call; callee clobbers S0/S1
+    f32.reinterpret_i32
+    f32.add
+    i32.reinterpret_f32)
+
+  ;; f32 PARAM HOME (S0) live across the call: read the param AFTER the bl.
+  ;; xhome(x, b) = bits(x) + fhelp(b)  (f32 home read post-call, plus the
+  ;; integer result -- proves BOTH register files survive).
+  (func (export "xhome") (param f32 i32) (result i32)
+    local.get 1 call $fhelp
+    local.get 0 i32.reinterpret_f32
+    i32.add)
+
+  ;; MULTIPLE live f32 values across the call: a non-param f32 LOCAL home and
+  ;; an f32 temp, both live across the bl.
+  ;; xcall2(b) = bits(((-x) + (-x)) + |x|) where x = f32(b); local 1 = |x| home.
+  (func (export "xcall2") (param i32) (result i32)
+    (local f32)
+    local.get 0 f32.reinterpret_i32 f32.abs
+    local.set 1                          ;; f32 local home, live across the call
+    local.get 0 f32.reinterpret_i32 f32.neg  ;; f32 temp, live across the call
+    local.get 0 call $fhelp              ;; clobbers low S-registers
+    f32.reinterpret_i32
+    f32.add
+    local.get 1
+    f32.add
+    i32.reinterpret_f32)
+
+  ;; ---- #719 phase 2: float-signature callees DECLINE loudly -----------------
+  ;; These callers must be SKIPPED (absent from the symtab), never miscompiled:
+  ;; the callee's f32 result arrives in S0 / its f32 arg belongs in S0, which
+  ;; this increment does not marshal at the call boundary.
+  (func $retf (result f32) f32.const 1.5)
+  (func (export "bad_ret_f32_call") (result i32)
+    call $retf i32.reinterpret_f32)
+  (func $takef (param f32) (result i32)
+    local.get 0 i32.reinterpret_f32)
+  (func (export "bad_f32_arg_call") (param i32) (result i32)
+    local.get 0 f32.reinterpret_i32 call $takef))

--- a/scripts/repro/f32_ops_719_differential.py
+++ b/scripts/repro/f32_ops_719_differential.py
@@ -75,6 +75,21 @@ def f32_bits(x):
     return struct.unpack("<I", struct.pack("<f", x))[0]
 
 
+def is_nan32(bits):
+    b = bits & 0xFFFFFFFF
+    return (b & 0x7F800000) == 0x7F800000 and (b & 0x007FFFFF) != 0
+
+
+def f32_bits_eq(got, want):
+    """WASM leaves the sign+payload of a NaN result NON-DETERMINISTIC (Core
+    4.3.3 NaN propagation) -- a bit-exact compare of a NaN is over-specified
+    and diverges by wasmtime version. NaN==NaN regardless of bits; every
+    non-NaN result stays bit-exact (mirrors f32_vfp_619_differential.py)."""
+    if is_nan32(got) and is_nan32(want):
+        return True
+    return (got & 0xFFFFFFFF) == (want & 0xFFFFFFFF)
+
+
 def bits_f32(b):
     return struct.unpack("<f", struct.pack("<I", b & 0xFFFFFFFF))[0]
 
@@ -283,11 +298,56 @@ def main():
             else:
                 print(f"[mix_add] (0x{xb:08x},0x{yb:08x}) -> 0x{got:08x} OK")
 
+    # ---- #719 phase 2: f32 live ACROSS an integer call (spill/reload) ------
+    # The callee $fhelp has an integer signature but uses VFP internally, so
+    # the BL genuinely clobbers the caller's low S-registers -- these cases are
+    # non-vacuous at the value level, not just compile-level. NaN-aware compare:
+    # xcall/xcall2 do real f32 adds whose NaN payloads are non-deterministic.
+    for fn, wname, arity in (("xcall", "xcall", 1), ("xcall2", "xcall2", 1)):
+        if not need(fn):
+            continue
+        for b in EDGE_BITS:
+            uc = run(text, base, syms[fn], r0=b, s0=0x7F7FFFFF, s1=0x7F7FFFFF)
+            got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            want = exp[wname](store, b) & 0xFFFFFFFF
+            checked += 1
+            if not f32_bits_eq(got, want):
+                nonlocal_fail(f"{fn}(0x{b:08x}) -> 0x{got:08x} != wasmtime 0x{want:08x}")
+            else:
+                print(f"[{fn}] 0x{b:08x} -> 0x{got:08x} OK (f32 live across bl)")
+
+    # xhome(f32 x, i32 b): the f32 PARAM HOME S0 must survive the call. S1..
+    # poisoned so a wrong reload source shows up.
+    if need("xhome"):
+        for xb, b in ((0x3FC00000, 0x40000000), (0x80000001, 0x7F800000),
+                      (0xC2F60000, 0x00000001)):
+            uc = run(text, base, syms["xhome"], r0=b, s0=xb, s1=0xDEADBEEF)
+            got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            want = exp["xhome"](store, bits_f32(xb), b) & 0xFFFFFFFF
+            checked += 1
+            if got != want:
+                nonlocal_fail(f"xhome(0x{xb:08x},0x{b:08x}) -> 0x{got:08x} "
+                              f"!= wasmtime 0x{want:08x}")
+            else:
+                print(f"[xhome] (0x{xb:08x},0x{b:08x}) -> 0x{got:08x} OK "
+                      f"(param home across bl)")
+
+    # ---- #719 phase 2: float-signature callees must DECLINE (skip), never
+    # miscompile: their symbols must be ABSENT from the symtab.
+    for fn in ("bad_ret_f32_call", "bad_f32_arg_call"):
+        checked += 1
+        if fn in syms:
+            nonlocal_fail(f"{fn} COMPILED -- a float-signature call boundary "
+                          f"must decline loudly (S0/D0 not marshalled)")
+        else:
+            print(f"[{fn}] absent from symtab OK (loud decline)")
+
     if fails:
         sys.exit(f"\nFAIL: {fails}/{checked} f32 #719 results diverged")
     print(f"\nGREEN: {checked}/{checked} f32 #719 results bit-exact vs wasmtime "
-          f"(abs/neg/copysign/store/local.set/tee + mixed AAPCS-VFP params; "
-          f"m3 honest-reject confirmed).")
+          f"(abs/neg/copysign/store/local.set/tee + mixed AAPCS-VFP params + "
+          f"phase-2 f32-across-call spill/reload; m3 honest-reject + "
+          f"float-signature-callee loud-decline confirmed).")
 
 
 if __name__ == "__main__":

--- a/scripts/repro/f64_369.wat
+++ b/scripts/repro/f64_369.wat
@@ -1,0 +1,90 @@
+(module
+  ;; GI-FPU-002 phase 2 (#369) f64 fixture (thumb-2, cortex-m7dp ONLY — m4f is
+  ;; single-precision and must honest-reject every f64 function).
+  ;;
+  ;; Values enter through linear memory (the harness writes the two 8-byte
+  ;; operands at mem[0] / mem[8]) and leave through an f64.store at a
+  ;; caller-chosen address — all-i32 signatures, so no f64 param/return
+  ;; marshalling is needed to differentiate. Covers the phase-2 lowered set:
+  ;;   f64.const, f64.promote_f32, add/sub/mul/div, abs/neg/sqrt, the six
+  ;;   comparisons, f64.load, f64.store — and an f64 LIVE ACROSS an integer
+  ;;   call (D0..D7 are caller-saved; preserved as aliased S-word pairs).
+  (memory 1)
+  (export "mem" (memory 0))
+
+  ;; ---- f64.const -> f64.store (full 64-bit pattern materialization) --------
+  (func (export "dconst") (param i32)
+    local.get 0 f64.const 1.5 f64.store)
+  (func (export "dconst_pi") (param i32)
+    local.get 0 f64.const 3.141592653589793 f64.store)
+  (func (export "dconst_nz") (param i32)
+    local.get 0 f64.const -0.0 f64.store)
+
+  ;; ---- f64.promote_f32 (falcon's 3-function blocker) ------------------------
+  (func (export "dpromote") (param i32 i32)
+    local.get 0
+    local.get 1 f32.reinterpret_i32 f64.promote_f32
+    f64.store)
+
+  ;; ---- binary arithmetic: mem[0] OP mem[8] -> mem[addr] ---------------------
+  (func (export "dadd") (param i32)
+    local.get 0 (f64.add (f64.load (i32.const 0)) (f64.load (i32.const 8)))
+    f64.store)
+  (func (export "dsub") (param i32)
+    local.get 0 (f64.sub (f64.load (i32.const 0)) (f64.load (i32.const 8)))
+    f64.store)
+  (func (export "dmul") (param i32)
+    local.get 0 (f64.mul (f64.load (i32.const 0)) (f64.load (i32.const 8)))
+    f64.store)
+  (func (export "ddiv") (param i32)
+    local.get 0 (f64.div (f64.load (i32.const 0)) (f64.load (i32.const 8)))
+    f64.store)
+
+  ;; ---- unary: OP(mem[0]) -> mem[addr] ---------------------------------------
+  (func (export "dabs") (param i32)
+    local.get 0 (f64.abs (f64.load (i32.const 0))) f64.store)
+  (func (export "dneg") (param i32)
+    local.get 0 (f64.neg (f64.load (i32.const 0))) f64.store)
+  (func (export "dsqrt") (param i32)
+    local.get 0 (f64.sqrt (f64.load (i32.const 0))) f64.store)
+
+  ;; ---- the six comparisons: mem[0] CMP mem[8] -> i32 ------------------------
+  (func (export "deq") (result i32)
+    (f64.eq (f64.load (i32.const 0)) (f64.load (i32.const 8))))
+  (func (export "dne") (result i32)
+    (f64.ne (f64.load (i32.const 0)) (f64.load (i32.const 8))))
+  (func (export "dlt") (result i32)
+    (f64.lt (f64.load (i32.const 0)) (f64.load (i32.const 8))))
+  (func (export "dle") (result i32)
+    (f64.le (f64.load (i32.const 0)) (f64.load (i32.const 8))))
+  (func (export "dgt") (result i32)
+    (f64.gt (f64.load (i32.const 0)) (f64.load (i32.const 8))))
+  (func (export "dge") (result i32)
+    (f64.ge (f64.load (i32.const 0)) (f64.load (i32.const 8))))
+
+  ;; ---- f64 live ACROSS an integer call --------------------------------------
+  ;; $fhelp has an integer signature but uses VFP internally (allocates S0/S1
+  ;; = the D0 alias), so the bl GENUINELY clobbers a live double unless the
+  ;; caller spills/reloads it. dxcall(addr, b): mem[addr] = mem[0] +
+  ;; promote(f32(fhelp(b))) where fhelp(b) = bits(-f32(b)).
+  (func $fhelp (param i32) (result i32)
+    local.get 0 f32.reinterpret_i32 f32.neg i32.reinterpret_f32)
+  (func (export "dxcall") (param i32 i32)
+    local.get 0
+    i32.const 0 f64.load          ;; live f64 (D-register) across the call
+    local.get 1 call $fhelp       ;; integer call; callee clobbers S0/S1 (=D0)
+    f32.reinterpret_i32 f64.promote_f32
+    f64.add
+    f64.store)
+
+  ;; ---- honest-decline shapes (must be ABSENT from the symtab) ---------------
+  ;; f64 PARAM on a hard-float target: arrives in D0 (AAPCS-VFP); the legacy
+  ;; i64-pair reading of R0:R1 would be a silent wrong-argument miscompile.
+  (func (export "bad_dparam") (param f64 i32) (result i32)
+    local.get 1)
+  ;; call to an f64-RETURNING callee: the result arrives in D0, which the call
+  ;; lowering does not marshal — the callee itself compiles (D0-homed return),
+  ;; the CALLER must decline.
+  (func $dret (result f64) f64.const 2.5)
+  (func (export "bad_dret_call") (param i32)
+    local.get 0 call $dret f64.store))

--- a/scripts/repro/f64_369_differential.py
+++ b/scripts/repro/f64_369_differential.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""#369 (GI-FPU-002 phase 2) — EXECUTION-validate the scalar f64 subset on
+cortex-m7dp (double-precision VFP).
+
+Lowered set (everything else f64 stays decode-dropped -> loud-skip):
+  * f64.const            — full 64-bit pattern via 2x MOVW/MOVT + VMOV Dd,lo,hi
+  * f64.promote_f32      — VCVT.F64.F32 (falcon's 3-function blocker)
+  * add/sub/mul/div      — VADD/VSUB/VMUL/VDIV .F64
+  * abs/neg/sqrt         — VABS/VNEG/VSQRT .F64
+  * eq/ne/lt/le/gt/ge    — VCMP.F64 + VMRS + IT (NaN-audited ordered set; the
+                           encoder shipped the SAME #712 flag-clobber bug the
+                           f32 compares had — MOVS after VMRS — fixed here)
+  * f64.load/f64.store   — two PROVEN bounds-checked 4-byte integer accesses
+  * f64 live ACROSS an integer call — D0..D7 are caller-saved, preserved as
+                           aliased S-word pairs by the #719 VFP call-spill
+
+Each op is differentiated under unicorn vs wasmtime, BIT-EXACT on the 64-bit
+result pattern with NaN==NaN per WASM Core §4.3.3 (NaN sign/payload is
+non-deterministic; mirrors f32_bits_eq in f32_vfp_619_differential.py).
+
+Honest rejections pinned: the whole fixture on cortex-m4f (single-precision)
+and cortex-m3 (no FPU); f64-param functions and f64-returning CALLS on m7dp
+(absent from the symtab — loud decline, never a miscompile).
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=/path/to/synth python scripts/repro/f64_369_differential.py
+"""
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+try:
+    from unicorn.arm_const import UC_ARM_REG_C1_C0_2, UC_ARM_REG_FPEXC
+except ImportError:  # older unicorn naming
+    UC_ARM_REG_C1_C0_2 = None
+    UC_ARM_REG_FPEXC = None
+
+WAT = Path(__file__).with_name("f64_369.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+MEMBASE = 0x20000000  # R11/fp linear-memory base at reset (cortex_m.rs)
+
+
+def compile_elf(out, target):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+         "--target", target, "--all-exports"],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"},
+    )
+    return r.returncode == 0, (r.stderr + r.stdout)
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":  # #489: symtab, not disasm text
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+    return data, base, syms
+
+
+def f64_bits(x):
+    return struct.unpack("<Q", struct.pack("<d", x))[0]
+
+
+def bits_f64(b):
+    return struct.unpack("<d", struct.pack("<Q", b & 0xFFFFFFFFFFFFFFFF))[0]
+
+
+def bits_f32(b):
+    return struct.unpack("<f", struct.pack("<I", b & 0xFFFFFFFF))[0]
+
+
+def is_nan64(bits):
+    b = bits & 0xFFFFFFFFFFFFFFFF
+    return (b & 0x7FF0000000000000) == 0x7FF0000000000000 and (
+        b & 0x000FFFFFFFFFFFFF) != 0
+
+
+def f64_bits_eq(got, want):
+    """NaN==NaN regardless of sign/payload (WASM Core §4.3.3 leaves NaN
+    results non-deterministic); every non-NaN result stays bit-exact."""
+    if is_nan64(got) and is_nan64(want):
+        return True
+    return (got & 0xFFFFFFFFFFFFFFFF) == (want & 0xFFFFFFFFFFFFFFFF)
+
+
+def new_uc(text, text_base):
+    uc = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    map_base = text_base & ~0xFFF
+    size = ((len(text) + (text_base - map_base)) + 0xFFF) & ~0xFFF
+    uc.mem_map(map_base, max(size, 0x1000))
+    uc.mem_write(text_base, text)
+    uc.mem_map(0x30000, 0x10000)  # stack
+    uc.mem_map(MEMBASE, 0x10000)  # linear-memory window (R11/fp base)
+    uc.reg_write(UC_ARM_REG_SP, 0x38000)
+    uc.reg_write(UC_ARM_REG_R11, MEMBASE)
+    # Enable the FPU (off at reset): CPACR CP10/CP11 + FPEXC.EN.
+    if UC_ARM_REG_C1_C0_2 is not None:
+        uc.reg_write(UC_ARM_REG_C1_C0_2, 0x00F00000)
+    if UC_ARM_REG_FPEXC is not None:
+        uc.reg_write(UC_ARM_REG_FPEXC, 0x40000000)
+    return uc
+
+
+def run(text, base, addr, mem0=None, mem8=None, r0=None, r1=None):
+    uc = new_uc(text, base)
+    if mem0 is not None:
+        uc.mem_write(MEMBASE + 0, struct.pack("<Q", mem0))
+    if mem8 is not None:
+        uc.mem_write(MEMBASE + 8, struct.pack("<Q", mem8))
+    if r0 is not None:
+        uc.reg_write(UC_ARM_REG_R0, r0 & 0xFFFFFFFF)
+    if r1 is not None:
+        uc.reg_write(UC_ARM_REG_R1, r1 & 0xFFFFFFFF)
+    uc.reg_write(UC_ARM_REG_LR, 0x38000 | 1)
+    uc.emu_start(addr | 1, 0x38000, count=400)
+    return uc
+
+
+def wasm_instance():
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    store = wasmtime.Store(eng)
+    inst = wasmtime.Instance(store, mod, [])
+    return store, inst
+
+
+# 64-bit operand pairs (mem[0], mem[8]) hitting the arithmetic edges.
+D = f64_bits
+PAIRS = [
+    (D(1.5), D(2.25)),
+    (D(-0.0), D(0.0)),
+    (D(float("inf")), D(-float("inf"))),
+    (0x7FF8000000000000, D(1.0)),          # NaN op x
+    (D(3.141592653589793), 0x0000000000000001),  # pi op +subnormal-min
+    (D(1.7976931348623157e308), D(1.7976931348623157e308)),  # MAX (overflow)
+    (D(1.0), D(0.0)),                       # div-by-zero -> inf
+    (D(-2.5), D(-2.5)),
+]
+
+# f32 bit patterns for promote (covers sign/inf/NaN/subnormal).
+PROMOTE_BITS = [
+    0x00000000, 0x80000000, 0x3FC00000, 0xBFC00000,
+    0x7F800000, 0xFF800000, 0x7FC00000, 0x00000001, 0x7F7FFFFF,
+]
+
+RESULT_ADDR = 64  # where the store-result functions write
+
+
+def main():
+    elf = "/tmp/f64_369.elf"
+
+    # Honest-reject: single-precision m4f and no-FPU m3 must SKIP every f64
+    # function (the integer helper $fhelp may still compile, so check the
+    # symtab rather than the exit code).
+    for tgt in ("cortex-m4f", "cortex-m3"):
+        out = f"/tmp/f64_369_{tgt}.elf"
+        ok, _ = compile_elf(out, tgt)
+        if ok:
+            _, _, syms = load(out)
+            leaked = [s for s in
+                      ("dconst", "dadd", "dlt", "dpromote", "dxcall")
+                      if s in syms]
+            if leaked:
+                sys.exit(f"FAIL: f64 functions {leaked} must be REJECTED on "
+                         f"{tgt} (no double-precision FPU)")
+        print(f"[{tgt}] f64 functions honest-rejected OK")
+
+    ok, log = compile_elf(elf, "cortex-m7dp")
+    if not ok:
+        print("RED: `synth compile -t cortex-m7dp` REJECTED the f64 fixture.")
+        print(log.strip()[:900])
+        sys.exit(1)
+
+    text, base, syms = load(elf)
+    store, inst = wasm_instance()
+    exp = inst.exports(store)
+    mem = exp["mem"]
+    fails = 0
+    checked = 0
+
+    def fail(msg):
+        nonlocal fails
+        fails += 1
+        print("  MISMATCH " + msg)
+
+    def need(name):
+        if name not in syms:
+            fail(f"symbol '{name}' MISSING — function was skipped, not lowered")
+            return False
+        return True
+
+    def wasm_store_result(fn, *args):
+        """Run the wasmtime twin (which f64.stores at RESULT_ADDR), read back."""
+        exp[fn](store, *args)
+        return struct.unpack("<Q", bytes(
+            mem.read(store, RESULT_ADDR, RESULT_ADDR + 8)))[0]
+
+    def set_wasm_mem(a, b):
+        mem.write(store, struct.pack("<Q", a), 0)
+        mem.write(store, struct.pack("<Q", b), 8)
+
+    # ---- f64.const ----------------------------------------------------------
+    for fn in ("dconst", "dconst_pi", "dconst_nz"):
+        if not need(fn):
+            continue
+        uc = run(text, base, syms[fn], r0=RESULT_ADDR)
+        got = struct.unpack("<Q", bytes(uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+        want = wasm_store_result(fn, RESULT_ADDR)
+        checked += 1
+        if got != want:
+            fail(f"{fn} -> 0x{got:016x} != wasmtime 0x{want:016x}")
+        else:
+            print(f"[{fn}] 0x{got:016x} (bit-exact) OK")
+
+    # ---- f64.promote_f32 ----------------------------------------------------
+    if need("dpromote"):
+        for b32 in PROMOTE_BITS:
+            uc = run(text, base, syms["dpromote"], r0=RESULT_ADDR, r1=b32)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            want = wasm_store_result("dpromote", RESULT_ADDR, b32)
+            checked += 1
+            if not f64_bits_eq(got, want):
+                fail(f"dpromote(0x{b32:08x}) -> 0x{got:016x} "
+                     f"!= wasmtime 0x{want:016x}")
+            else:
+                print(f"[dpromote] 0x{b32:08x} -> 0x{got:016x} OK")
+
+    # ---- binary + unary arithmetic ------------------------------------------
+    for fn in ("dadd", "dsub", "dmul", "ddiv", "dabs", "dneg", "dsqrt"):
+        if not need(fn):
+            continue
+        for a, b in PAIRS:
+            uc = run(text, base, syms[fn], mem0=a, mem8=b, r0=RESULT_ADDR)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            set_wasm_mem(a, b)
+            want = wasm_store_result(fn, RESULT_ADDR)
+            checked += 1
+            if not f64_bits_eq(got, want):
+                fail(f"{fn}(0x{a:016x}, 0x{b:016x}) -> 0x{got:016x} "
+                     f"!= wasmtime 0x{want:016x}")
+        print(f"[{fn}] {len(PAIRS)} edge pairs OK")
+
+    # ---- the six comparisons (NaN rows: every ordered relation false, ne true)
+    for fn in ("deq", "dne", "dlt", "dle", "dgt", "dge"):
+        if not need(fn):
+            continue
+        for a, b in PAIRS:
+            uc = run(text, base, syms[fn], mem0=a, mem8=b)
+            got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            set_wasm_mem(a, b)
+            want = exp[fn](store) & 0xFFFFFFFF
+            checked += 1
+            if got != want:
+                fail(f"{fn}(0x{a:016x}, 0x{b:016x}) -> {got} "
+                     f"!= wasmtime {want}")
+        print(f"[{fn}] {len(PAIRS)} edge pairs OK")
+
+    # ---- f64 live ACROSS an integer call (D-file caller-saved spill) --------
+    if need("dxcall"):
+        for (a, _), b32 in zip(PAIRS, PROMOTE_BITS):
+            uc = run(text, base, syms["dxcall"], mem0=a, r0=RESULT_ADDR, r1=b32)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            set_wasm_mem(a, 0)
+            want = wasm_store_result("dxcall", RESULT_ADDR, b32)
+            checked += 1
+            if not f64_bits_eq(got, want):
+                fail(f"dxcall(0x{a:016x}, 0x{b32:08x}) -> 0x{got:016x} "
+                     f"!= wasmtime 0x{want:016x}")
+            else:
+                print(f"[dxcall] (0x{a:016x},0x{b32:08x}) -> 0x{got:016x} OK "
+                      f"(f64 live across bl)")
+
+    # ---- honest declines on m7dp: absent from the symtab ---------------------
+    for fn in ("bad_dparam", "bad_dret_call"):
+        checked += 1
+        if fn in syms:
+            fail(f"{fn} COMPILED — an f64 ABI boundary this increment does "
+                 f"not marshal must decline loudly")
+        else:
+            print(f"[{fn}] absent from symtab OK (loud decline)")
+
+    if fails:
+        sys.exit(f"\nFAIL: {fails}/{checked} f64 #369 results diverged")
+    print(f"\nGREEN: {checked}/{checked} f64 #369 results bit-exact vs wasmtime "
+          f"(const/promote/arith/compare/load/store + f64-across-call on "
+          f"cortex-m7dp; m4f + m3 honest-reject + f64-ABI loud-decline "
+          f"confirmed).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
v0.42.0 hub lane: completes the VFP story for falcon — the last #719 f32 residual (f32 live across a `bl`) plus the GI-FPU-002 phase-2 scalar f64 subset (`f64.const` + `f64.promote_f32` were falcon's remaining float blockers). Two commits, one per step, each independently oracle-gated.

Refs #719, #369, epic #242 (VCR track C: differential-gated increments).

## Per-op status

### Step 1 — f32 across a call (`322d884`)

| Case | Status | How |
|---|---|---|
| f32 temp live across `bl` | **LANDED** | VSTR to a 16-slot VFP call-spill area before the BL, VLDR after (the VFP analogue of #188 integer preservation) |
| f32 param/local S-home live across `bl` | **LANDED** | same spill/reload; homes conservatively preserved |
| mixed f32/int params + call | **LANDED** (fix) | the #204 param frame-backing prologue stored `index_to_reg(i)` — wrong under the #719 mixed pools (`(f32,i32)` homes the i32 in **R0**, not R1): the callee read caller garbage. Caught by the new `xhome` execution differential; now uses the AAPCS-VFP-aware map (identical for all-i32 signatures) |
| call to f32/f64-**returning** callee | **DECLINED loudly** (call site, per-callee sig tables) — closes a pre-existing silent hole: an f32-free caller calling an f32-returning callee compiled and returned R0 where the AAPCS-VFP caller reads S0 |
| call with f32 **argument** | **DECLINED loudly** (call site; VFP arg-pool marshalling is the next increment) |
| declared f32/f64 return reaching the epilogue in a core register | **DECLINED loudly** (defense-in-depth guard) |

### Step 2 — scalar f64 phase 2, cortex-m7dp only (`47c8de1`)

| Op | Status | How |
|---|---|---|
| `f64.const` | **LANDED** | 2× allocator-owned MOVW/MOVT + `VMOV Dd,lo,hi` — NOT `ArmOp::F64Const` (that pseudo-op hardcodes R0+R12 scratch, #615 class) |
| `f64.promote_f32` | **LANDED** | `VCVT.F64.F32` |
| `f64.add/sub/mul/div` | **LANDED** | `VADD/VSUB/VMUL/VDIV.F64` |
| `f64.abs/neg/sqrt` | **LANDED** | `VABS/VNEG/VSQRT.F64` |
| `f64.eq/ne/lt/le/gt/ge` | **LANDED** + **encoder soundness fix**: `encode_thumb_f64_compare` had the exact #712 flag-clobber (`MOVS Rd,#0` AFTER `VMRS APSR_nzcv`) — every f64 compare would have returned stale-flag garbage. Pure reorder, execution-validated non-vacuously |
| `f64.load` / `f64.store` | **LANDED** | two PROVEN bounds-checked 4-byte integer accesses + `VMOV`; `--safety-bounds mask` declines loudly (masking mutates the address register in place) |
| f64 live across a call | **LANDED** | D-temps confined to caller-saved D0..D7; each aliases `S(2i):S(2i+1)`, so the step-1 spill area preserves doubles as two aliased words |
| f64 function **result** | **LANDED** | homed in D0 via the bit-exact core round-trip |
| f64 **params** (hard-float) | **DECLINED loudly** — closes a pre-existing silent wrong-argument class (legacy width inference read the i64 core pair R0:R1 where AAPCS-VFP put D0, shifting later int params too). Soft-float targets keep the ABI-correct core-pair treatment |
| calls to f64-returning callees | **DECLINED loudly** (call site) |
| f64 min/max/copysign/rounding/convert/trunc/reinterpret/i64↔f64 | **stay decode-dropped** (loud-skip) — their encoder pseudo-ops clobber S0/R0–R2 or round-trip through S32; a later increment |
| any f64 op on m4f/m7 (single-precision) or m0/m3/r5 (no FPU) | **honest-reject** with a precise message (`VADD.F64` on m4f is UNDEFINED, not slow) |
| `-b riscv` / `-b aarch64` on newly-decoded f64 | **loud-reject** via catch-all Unsupported arms (verified on the fixture) |

## Differential evidence (unicorn vs wasmtime, bit-exact, NaN==NaN per Core §4.3.3)

```
GREEN: 187/187 f32 #719 results bit-exact vs wasmtime (abs/neg/copysign/store/local.set/tee
       + mixed AAPCS-VFP params + phase-2 f32-across-call spill/reload; m3 honest-reject
       + float-signature-callee loud-decline confirmed).
GREEN: 126/126 f64 #369 results bit-exact vs wasmtime (const/promote/arith/compare/load/store
       + f64-across-call on cortex-m7dp; m4f + m3 honest-reject + f64-ABI loud-decline confirmed).
GREEN: 84/84 f32 results bit-exact vs wasmtime (m3 honest-reject confirmed).            [619 sibling]
GREEN: 48/48 f32 #708/#709 results correct (trap table + load + reinterpret; m3 …).     [708/709 sibling]
```

The across-call cases are non-vacuous at the VALUE level: the callee has an integer signature but uses VFP internally, so the `bl` genuinely clobbers S0/S1 (=D0) unless the caller spills/reloads. New oracle `scripts/repro/f64_369_differential.py` + extended `f32_ops_719_differential.py`, both CI-wired into the `trap-semantics-oracle` job.

## Gates

- frozen anchors **10/10 byte-identical** (`frozen_codegen_bytes`) — the VFP spill area is reserved only for functions with f32/f64 content AND a call, which previously declined outright
- `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test -p synth-cli -p synth-synthesis -p synth-backend -p synth-core` all green (609 selector tests incl. new pins for spill/reload placement, float-sig call declines, m7dp gating, f64-param hard-float-only decline)
- `claim_check` 17/17
- new selector unit pins: `test_719_f32_across_call_spills_and_reloads`, `test_719_float_signature_callee_declines_loudly`, `test_719_ret_f32_core_register_result_declines_loudly`, `test_369_f64_requires_double_precision_fpu`, `test_369_f64_const_composes_and_homes_d0`, `test_369_f64_param_declines_on_hard_float_only`, `test_369_f64_across_call_spills_aliased_words`

## Not in scope (declines loudly, named follow-ups)

- f32/f64 call-boundary marshalling (float args into S0../D0.., float results out) — the remaining piece for f32/f64-signature callees
- f64 param homing (D0..D7) and the out-of-scope f64 op tail (min/max/copysign/rounding/conversions)
- `f64.load/store` under `--safety-bounds mask`

DO NOT MERGE — v0.42.0 hub lane; hub owner lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L