### PR TITLE
feat(verify): VCR-VER-002 Phase B — float→int trunc trap class via ordeal 0.9.1 (#166)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -1063,11 +1063,12 @@ artifacts:
 
   - id: VCR-VER-002
     type: sys-verification
-    title: "Trap-preservation VC catches dropped WASM traps (div/rem, memory OOB, call_indirect, unreachable); live-validator wiring in progress"
+    title: "Trap-preservation VC catches dropped WASM traps (div/rem, memory OOB, call_indirect, unreachable, float→int trunc); live-validator wiring in progress"
     description: >
       Make trap-preservation a checkable, oracle-gated proof obligation so a
       lowering that DROPS a WASM trap (div-by-zero / overflow guard, OOB
-      bounds check, call_indirect bounds/null/type, unreachable) can no longer
+      bounds check, call_indirect bounds/null/type, unreachable, float→int
+      truncation NaN/∞/out-of-range) can no longer
       pass value-only equivalence — the systematic end of the per-op
       soundness whack-a-mole (#633/#666/#665/#642/#709).
 
@@ -1094,6 +1095,27 @@ artifacts:
       condition derived structurally from the Udf guard), exercised by unit
       tests: an unguarded i32 div/rem is rejected with a divisor==0
       counterexample, a guarded one accepted.
+      (5) Phase B (ordeal 0.9.1, ordeal#59/TR-020): the float->int TRUNC trap
+      class (#709). ordeal's `trap_trunc` classifies the trap predicate
+      (NaN / +-inf / out-of-range) purely over the float operand's BIT PATTERN
+      - exponent-field patterns plus sign-split monotonic magnitude threshold
+      compares; floats enter as BV32/BV64, no FP theory. synth_verify::trap
+      maps all six WasmOp trunc variants (i32/i64.trunc_f32/f64_s/u as decoded;
+      i64.trunc_f32_* are not WasmOp variants) via trunc_op + trap_trunc,
+      trap-clause-only VC (synth models no float->int value). Red-first gate
+      extended (11 tests total): for all six variants a guard-dropping lowering
+      is CAUGHT (Dropped/Sat) with a counterexample validated as genuinely
+      trapping against the real-float reference, an identical-guard lowering
+      accepted (Preserved/Unsat, LRAT re-checked); a signedness-confused guard
+      (unsigned range check on trunc_f32_s - the VCVT-saturate partial-drop
+      shape) is caught; and the classifier ENCODING itself is eval-tested
+      against the synth #709 boundary table (the reference-oracle check
+      ordeal#59 called for: 2^31/0x4F000000 traps signed, -2^31/0xCF000000
+      in range, -1.0 traps unsigned, 2^32 traps, NaN/+-inf trap, 3e9/-3e9
+      trap, 2.5/0.5/-0.0 in range, plus f64 and i64-target anchors) - both
+      directly via ordeal::eval and at ground inputs through the
+      certificate-checked pipeline, with a wrong-expectation non-vacuity
+      control.
 
       DOCUMENTED GAP (why in-progress, not implemented):
       - The live validation entry points (verify_rule -> verify_equivalence ->
@@ -1106,7 +1128,8 @@ artifacts:
         term is a structural Udf-presence proxy — sound in the REJECT direction
         but not a full proof the guard fires on exactly div0-or-overflow. The
         method currently handles i32 only (32-bit operands).
-      - The other partial classes (load/store, call_indirect, unreachable) have
+      - The other partial classes (load/store, call_indirect, unreachable,
+        float->int trunc) have
         no ARM trap term on this path and remain gated at the unit level.
       Closing the gap (auto-deriving opt.may_trap from the shipped lowering for
       all classes, on the live path) needs a may_trap flag threaded through the
@@ -1123,11 +1146,13 @@ artifacts:
       method: formal-verification
       preconditions:
         - "ordeal 0.9.0 `ordeal::trap` module available (ordeal#59)"
+        - "ordeal 0.9.1 `trap_trunc` float→int classifier available (ordeal#59/TR-020)"
       steps:
         - "Bump synth-verify to ordeal 0.9; build + tests green"
         - "Wrap ordeal::trap over synth BV/Bool (synth_verify::trap)"
         - "Red-first gate: Sat-on-drop / Unsat-on-preserve for every op class"
         - "Wire div/rem trap-preservation into the translation validator"
+        - "Phase B: map the six WasmOp trunc variants to ordeal 0.9.1 trap_trunc; eval-gate the classifier against the #709 boundary table"
       pass-criteria: >
         A trap-dropping lowering is rejected (Sat/Dropped) and a
         trap-preserving lowering accepted (Unsat/Preserved) for every partial-op

--- a/claims.yaml
+++ b/claims.yaml
@@ -165,9 +165,11 @@ claims:
   # in-progress, not implemented: div/rem wired mandatorily into the validator;
   # the other partial-op classes are gated at the unit level pending the
   # exec-model trap flag (documented follow-on in the roadmap entry).
+  # Phase B (ordeal 0.9.1, ordeal#59/TR-020): float→int trunc trap class
+  # covered — trunc_op/trap_trunc wrapper + #709 boundary-table eval gate.
   - id: SYNTH-VCR-VER-002-STATUS
     doc: artifacts/verified-codegen-roadmap.yaml
-    text: "Trap-preservation VC catches dropped WASM traps (div/rem, memory OOB, call_indirect, unreachable); live-validator wiring in progress"
+    text: "Trap-preservation VC catches dropped WASM traps (div/rem, memory OOB, call_indirect, unreachable, float→int trunc); live-validator wiring in progress"
     evidence:
       - kind: yaml-field
         path: artifacts/verified-codegen-roadmap.yaml

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -30,8 +30,9 @@ synth-opt = { path = "../synth-opt", version = "0.41.0" }
 synth-synthesis = { path = "../synth-synthesis", version = "0.41.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
-# 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166).
-ordeal = "0.9"
+# 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);
+# 0.9.1 adds the float→int trunc trap classifier (`trap_trunc`, ordeal#59/TR-020).
+ordeal = "0.9.1"
 
 # Z3: optional differential oracle (feature `z3-solver`) — no longer default.
 # Default features only (NO `static-link-z3`/`bundled`): z3-sys links the

--- a/crates/synth-verify/src/lib.rs
+++ b/crates/synth-verify/src/lib.rs
@@ -36,7 +36,8 @@ pub mod solver;
 pub mod term;
 
 // Trap-preservation obligations over `ordeal::trap` (VCR-VER-002, #166): maps
-// WASM partial ops (div/rem, load/store, call_indirect, unreachable) to trap
+// WASM partial ops (div/rem, load/store, call_indirect, unreachable,
+// float→int trunc) to trap
 // conditions and gates a lowering on preserving them. Backend-agnostic (builds
 // on `term`), so always available like `wasm_semantics`.
 pub mod trap;

--- a/crates/synth-verify/src/trap.rs
+++ b/crates/synth-verify/src/trap.rs
@@ -1,7 +1,8 @@
 //! Trap-preservation obligations (VCR-VER-002, synth #166 / ordeal#59).
 //!
-//! WASM operations like `div_s`, `load`/`store`, `call_indirect`, and
-//! `unreachable` are **partial**: they trap on some inputs. A validator that
+//! WASM operations like `div_s`, `load`/`store`, `call_indirect`,
+//! `unreachable`, and the float→int truncations (`iN.trunc_fM_s/u`) are
+//! **partial**: they trap on some inputs. A validator that
 //! proves only *value* equivalence over a total model cannot see a lowering that
 //! **drops a trap** — deleting a trapping guard looks value-equal
 //! (synth#633/#666/#665/#642/#709). This module is the thin synth-facing layer
@@ -27,13 +28,22 @@
 //!   *contents* nor table *values*, so these use
 //!   [`prove_trap_condition_equivalence`] (trap clause only). This is the
 //!   ordeal#59 agreement.
+//! - **float→int trunc** (`i32/i64.trunc_f{32,64}_{s,u}`, Phase B) — the trap
+//!   predicate is a pure bit-pattern classifier over the float OPERAND's bits
+//!   (NaN/±∞ exponent patterns + sign-split monotonic magnitude thresholds,
+//!   ordeal 0.9.1's `trap_trunc`; floats enter as BV32/BV64, no FP theory).
+//!   synth's QF_BV model carries no float→int *value* function, so this class
+//!   uses [`prove_trap_condition_equivalence`] (trap clause only) — exactly
+//!   the #709 soundness surface: ARM `VCVT` saturates where WASM traps, so a
+//!   lowering that keeps the saturated value but drops the guard is the bug
+//!   shape this clause rejects.
 
 use crate::term::{BV, Bool};
 use ordeal::CheckResult;
 use ordeal::trap as ot;
 use synth_core::WasmOp;
 
-pub use ordeal::trap::DivOp;
+pub use ordeal::trap::{DivOp, FpFmt, IntTarget};
 
 /// A value paired with the condition under which the op **traps** instead of
 /// producing it — the synth-`BV`/`Bool` mirror of [`ordeal::trap::DefineOrTrap`].
@@ -128,6 +138,40 @@ pub fn trap_div(op: DivOp, dividend: &BV, divisor: &BV) -> Bool {
     ))
 }
 
+/// Map a float→int truncation [`WasmOp`] to its
+/// `(float format, integer target, signedness)` triple; `None` for any
+/// non-trunc op. Covers all six trunc variants synth's decoder produces
+/// (`i64.trunc_f32_s/u` are not `WasmOp` variants; the raw [`trap_trunc`]
+/// builder still covers those shapes if they ever land).
+pub fn trunc_op(op: &WasmOp) -> Option<(FpFmt, IntTarget, bool)> {
+    Some(match op {
+        WasmOp::I32TruncF32S => (FpFmt::F32, IntTarget::I32, true),
+        WasmOp::I32TruncF32U => (FpFmt::F32, IntTarget::I32, false),
+        WasmOp::I32TruncF64S => (FpFmt::F64, IntTarget::I32, true),
+        WasmOp::I32TruncF64U => (FpFmt::F64, IntTarget::I32, false),
+        WasmOp::I64TruncF64S => (FpFmt::F64, IntTarget::I64, true),
+        WasmOp::I64TruncF64U => (FpFmt::F64, IntTarget::I64, false),
+        _ => return None,
+    })
+}
+
+/// Trap condition for `iN.trunc_fM_s/u` (WASM float→int truncation, #709):
+/// `NaN ∨ ±∞ ∨ out-of-range` classified purely over the float operand's
+/// **bit pattern** (`bits` is the BV32/BV64 the float travels as — no FP
+/// theory). Pass the triple from [`trunc_op`]. `bits` must be exactly
+/// `fmt.total_bits()` wide (32 for f32, 64 for f64) — a width mismatch is an
+/// internal bug, so it panics loud rather than returning an ill-sorted term.
+pub fn trap_trunc(bits: &BV, fmt: FpFmt, target: IntTarget, signed: bool) -> Bool {
+    assert_eq!(
+        bits.get_size(),
+        fmt.total_bits(),
+        "trap_trunc: float operand term must be {} bits wide for {:?}",
+        fmt.total_bits(),
+        fmt
+    );
+    Bool::from_ordeal(ot::trap_trunc(bits.term(), fmt, target, signed))
+}
+
 /// Trap condition for `unreachable`: an unconditional trap.
 pub fn trap_always() -> Bool {
     Bool::from_ordeal(ot::trap_always())
@@ -192,7 +236,8 @@ pub fn prove_trap_equivalence(orig: &DefineOrTrap, opt: &DefineOrTrap) -> TrapVe
 }
 
 /// Trap-clause-only gate (`orig.may_trap ⇔ opt.may_trap`) — for ops whose value
-/// synth does not model (load/store, call_indirect, unreachable).
+/// synth does not model (load/store, call_indirect, unreachable, float→int
+/// trunc).
 /// [`TrapVerdict::Preserved`] ⟹ the lowering neither drops nor spuriously adds
 /// the trap.
 pub fn prove_trap_condition_equivalence(orig_may_trap: &Bool, opt_may_trap: &Bool) -> TrapVerdict {

--- a/crates/synth-verify/tests/trap_preservation.rs
+++ b/crates/synth-verify/tests/trap_preservation.rs
@@ -15,14 +15,23 @@
 //!
 //! div/rem carry a value synth models, so they use the full
 //! [`prove_trap_equivalence`] (trap + guarded value). load/store,
-//! call_indirect, and unreachable have no synth value/contents model, so they
-//! use [`prove_trap_condition_equivalence`] (trap clause only) — the ordeal#59
-//! agreement.
+//! call_indirect, unreachable, and the float→int truncations have no synth
+//! value/contents model, so they use [`prove_trap_condition_equivalence`]
+//! (trap clause only) — the ordeal#59 agreement.
+//!
+//! Phase B (ordeal 0.9.1, ordeal#59/TR-020): the float→int trunc class. The
+//! trap predicate is a pure QF_BV classifier over the float operand's BIT
+//! PATTERN, so on top of the two gate directions the classifier itself is
+//! eval-tested against the synth #709 boundary table (the reference oracle
+//! ordeal#59 called for) — both directly via `ordeal::eval` and through the
+//! certificate-checked pipeline on the synth wrapper.
 
+use synth_core::WasmOp;
 use synth_verify::term::{BV, Bool};
 use synth_verify::trap::{
-    CallIndirect, DefineOrTrap, DivOp, TrapVerdict, TypeTrap, prove_trap_condition_equivalence,
-    prove_trap_equivalence, trap_always, trap_call_indirect, trap_div, trap_mem_oob,
+    CallIndirect, DefineOrTrap, DivOp, FpFmt, IntTarget, TrapVerdict, TypeTrap,
+    prove_trap_condition_equivalence, prove_trap_equivalence, trap_always, trap_call_indirect,
+    trap_div, trap_mem_oob, trap_trunc, trunc_op,
 };
 
 fn v(name: &str, width: u32) -> BV {
@@ -241,5 +250,376 @@ fn unreachable_elision_is_caught_and_preservation_accepted() {
     assert_preserved(
         prove_trap_condition_equivalence(&orig, &trap_always()),
         "unreachable (trap preserved)",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// float→int trunc — trap-clause-only VC (NaN ∨ ±∞ ∨ out-of-range) — Phase B
+// (ordeal 0.9.1 `trap_trunc`, ordeal#59/TR-020, synth #709)
+// ---------------------------------------------------------------------------
+
+/// The float value (widened to f64, exactly) of a bit pattern of `fmt`.
+fn fval(fmt: FpFmt, p: u64) -> f64 {
+    match fmt {
+        FpFmt::F32 => f32::from_bits(p as u32) as f64,
+        FpFmt::F64 => f64::from_bits(p),
+    }
+}
+
+/// Reference: the exact WASM `iN.trunc_fM_s/u` trap predicate, computed on the
+/// REAL host float. All range math is in f64, which is exact for every case
+/// here (f32→f64 is exact; `trunc` of a finite float is an integer-valued f64;
+/// the ±2^31 / ±2^63 / 2^32 / 2^64 / 0 bounds are exact f64 values).
+fn ref_trap_trunc(x: f64, target: IntTarget, signed: bool) -> bool {
+    if !x.is_finite() {
+        return true;
+    }
+    let t = x.trunc();
+    let n = target.width() as i32;
+    if signed {
+        !(t >= -(2f64.powi(n - 1)) && t < 2f64.powi(n - 1))
+    } else {
+        !(t >= 0.0 && t < 2f64.powi(n))
+    }
+}
+
+/// The six trunc variants synth's decoder produces, with their WASM names.
+const TRUNC_VARIANTS: [(FpFmt, IntTarget, bool, &str); 6] = [
+    (FpFmt::F32, IntTarget::I32, true, "i32.trunc_f32_s"),
+    (FpFmt::F32, IntTarget::I32, false, "i32.trunc_f32_u"),
+    (FpFmt::F64, IntTarget::I32, true, "i32.trunc_f64_s"),
+    (FpFmt::F64, IntTarget::I32, false, "i32.trunc_f64_u"),
+    (FpFmt::F64, IntTarget::I64, true, "i64.trunc_f64_s"),
+    (FpFmt::F64, IntTarget::I64, false, "i64.trunc_f64_u"),
+];
+
+#[test]
+fn trunc_op_maps_all_six_wasm_variants() {
+    assert_eq!(
+        trunc_op(&WasmOp::I32TruncF32S),
+        Some((FpFmt::F32, IntTarget::I32, true))
+    );
+    assert_eq!(
+        trunc_op(&WasmOp::I32TruncF32U),
+        Some((FpFmt::F32, IntTarget::I32, false))
+    );
+    assert_eq!(
+        trunc_op(&WasmOp::I32TruncF64S),
+        Some((FpFmt::F64, IntTarget::I32, true))
+    );
+    assert_eq!(
+        trunc_op(&WasmOp::I32TruncF64U),
+        Some((FpFmt::F64, IntTarget::I32, false))
+    );
+    assert_eq!(
+        trunc_op(&WasmOp::I64TruncF64S),
+        Some((FpFmt::F64, IntTarget::I64, true))
+    );
+    assert_eq!(
+        trunc_op(&WasmOp::I64TruncF64U),
+        Some((FpFmt::F64, IntTarget::I64, false))
+    );
+    assert_eq!(trunc_op(&WasmOp::I32Add), None);
+    assert_eq!(trunc_op(&WasmOp::I32DivS), None);
+}
+
+#[test]
+fn trunc_all_six_ops_catch_the_drop_and_accept_preservation() {
+    for (fmt, target, signed, name) in TRUNC_VARIANTS {
+        let f = v("f", fmt.total_bits());
+        let orig = trap_trunc(&f, fmt, target, signed);
+
+        // Trap-DROPPING lowering: the guard was removed entirely — the #709
+        // shape (ARM VCVT saturates where WASM must trap; keeping the
+        // saturated value and dropping the guard looks value-equal).
+        let verdict = prove_trap_condition_equivalence(&orig, &Bool::from_bool(false));
+        assert_dropped(verdict.clone(), name);
+        // The counterexample must be a genuinely trapping input per the
+        // real-float reference.
+        if let TrapVerdict::Dropped(model) = verdict {
+            let p = model
+                .iter()
+                .find(|(n, _)| n == "f")
+                .map(|(_, x)| *x)
+                .unwrap_or_else(|| panic!("{name}: counterexample model must assign f"));
+            let x = fval(fmt, p as u64);
+            assert!(
+                ref_trap_trunc(x, target, signed),
+                "{name}: counterexample {p:#x} (value {x:e}) must be a genuinely trapping input"
+            );
+        }
+
+        // Trap-PRESERVING lowering: identical classifier.
+        assert_preserved(
+            prove_trap_condition_equivalence(&orig, &trap_trunc(&f, fmt, target, signed)),
+            name,
+        );
+    }
+}
+
+#[test]
+fn trunc_signedness_confused_guard_is_caught() {
+    // A lowering that guards `i32.trunc_f32_s` with the UNSIGNED range check
+    // (a partial #709-class drop: NaN/∞ still guarded, range thresholds
+    // wrong) must be caught — e.g. -5.0 spuriously traps unsigned, and
+    // 3e9 traps signed but not unsigned.
+    let f = v("f", 32);
+    let orig = trap_trunc(&f, FpFmt::F32, IntTarget::I32, true);
+    let confused = trap_trunc(&f, FpFmt::F32, IntTarget::I32, false);
+    let verdict = prove_trap_condition_equivalence(&orig, &confused);
+    assert_dropped(
+        verdict.clone(),
+        "i32.trunc_f32_s (signedness-confused guard)",
+    );
+    // The counterexample must be an input where the two predicates genuinely
+    // disagree per the real-float reference.
+    if let TrapVerdict::Dropped(model) = verdict {
+        let p = model
+            .iter()
+            .find(|(n, _)| n == "f")
+            .map(|(_, x)| *x)
+            .expect("counterexample model must assign f");
+        let x = fval(FpFmt::F32, p as u64);
+        assert_ne!(
+            ref_trap_trunc(x, IntTarget::I32, true),
+            ref_trap_trunc(x, IntTarget::I32, false),
+            "counterexample {p:#x} (value {x:e}) must separate signed from unsigned trapping"
+        );
+    }
+}
+
+/// The synth #709 boundary table: `(fmt, target, signed, bits, traps, label)`.
+/// This is the reference oracle for the classifier-encoding check ordeal#59
+/// called for.
+fn boundary_table_709() -> Vec<(FpFmt, IntTarget, bool, u64, bool, &'static str)> {
+    let b32 = |x: f32| x.to_bits() as u64;
+    let b64 = |x: f64| x.to_bits();
+    use FpFmt::{F32, F64};
+    use IntTarget::{I32, I64};
+    vec![
+        // --- i32.trunc_f32_s ---
+        (F32, I32, true, b32(f32::NAN), true, "f32→i32_s: NaN traps"),
+        (
+            F32,
+            I32,
+            true,
+            b32(f32::INFINITY),
+            true,
+            "f32→i32_s: +∞ traps",
+        ),
+        (
+            F32,
+            I32,
+            true,
+            b32(f32::NEG_INFINITY),
+            true,
+            "f32→i32_s: -∞ traps",
+        ),
+        (F32, I32, true, b32(3e9), true, "f32→i32_s: 3e9 traps"),
+        (F32, I32, true, b32(-3e9), true, "f32→i32_s: -3e9 traps"),
+        (
+            F32,
+            I32,
+            true,
+            0x4F00_0000, // 2^31
+            true,
+            "f32→i32_s: 2^31 (0x4F000000) TRAPS",
+        ),
+        (
+            F32,
+            I32,
+            true,
+            0xCF00_0000, // -2^31
+            false,
+            "f32→i32_s: -2^31 (0xCF000000) is IN-RANGE",
+        ),
+        (
+            F32,
+            I32,
+            true,
+            b32(2_147_483_520.0), // 2^31 - 128: largest f32 below 2^31
+            false,
+            "f32→i32_s: largest f32 below 2^31 converts",
+        ),
+        (F32, I32, true, b32(2.5), false, "f32→i32_s: 2.5 → 2"),
+        // --- i32.trunc_f32_u ---
+        (F32, I32, false, b32(-1.0), true, "f32→i32_u: -1.0 traps"),
+        (F32, I32, false, b32(0.5), false, "f32→i32_u: 0.5 → 0"),
+        (F32, I32, false, b32(-0.0), false, "f32→i32_u: -0.0 → 0"),
+        (
+            F32,
+            I32,
+            false,
+            b32(4_294_967_296.0), // 2^32 (0x4F800000)
+            true,
+            "f32→i32_u: 2^32 traps",
+        ),
+        (
+            F32,
+            I32,
+            false,
+            b32(4_294_967_040.0), // 2^32 - 256: largest f32 below 2^32
+            false,
+            "f32→i32_u: largest f32 below 2^32 converts",
+        ),
+        (F32, I32, false, b32(f32::NAN), true, "f32→i32_u: NaN traps"),
+        // --- i32.trunc_f64_s ---
+        (
+            F64,
+            I32,
+            true,
+            b64(2f64.powi(31)),
+            true,
+            "f64→i32_s: 2^31 traps",
+        ),
+        (
+            F64,
+            I32,
+            true,
+            b64(2_147_483_647.5),
+            false,
+            "f64→i32_s: 2^31-0.5 → 2^31-1",
+        ),
+        (
+            F64,
+            I32,
+            true,
+            b64(-(2f64.powi(31))),
+            false,
+            "f64→i32_s: -2^31 is in range",
+        ),
+        (
+            F64,
+            I32,
+            true,
+            b64(-2_147_483_649.0),
+            true,
+            "f64→i32_s: -(2^31+1) traps",
+        ),
+        (F64, I32, true, b64(f64::NAN), true, "f64→i32_s: NaN traps"),
+        // --- i32.trunc_f64_u ---
+        (F64, I32, false, b64(-1.0), true, "f64→i32_u: -1.0 traps"),
+        (
+            F64,
+            I32,
+            false,
+            b64(4_294_967_295.5),
+            false,
+            "f64→i32_u: 2^32-0.5 → 2^32-1",
+        ),
+        (
+            F64,
+            I32,
+            false,
+            b64(2f64.powi(32)),
+            true,
+            "f64→i32_u: 2^32 traps",
+        ),
+        // --- i64.trunc_f64_s ---
+        (
+            F64,
+            I64,
+            true,
+            b64(2f64.powi(63)),
+            true,
+            "f64→i64_s: 2^63 traps",
+        ),
+        (
+            F64,
+            I64,
+            true,
+            0x43DF_FFFF_FFFF_FFFF, // 2^63 - 1024: largest f64 below 2^63
+            false,
+            "f64→i64_s: largest f64 below 2^63 converts",
+        ),
+        (
+            F64,
+            I64,
+            true,
+            b64(-(2f64.powi(63))),
+            false,
+            "f64→i64_s: -2^63 is in range",
+        ),
+        (
+            F64,
+            I64,
+            true,
+            0xC3E0_0000_0000_0001, // -(2^63 + 2048): next f64 below -2^63
+            true,
+            "f64→i64_s: below -2^63 traps",
+        ),
+        // --- i64.trunc_f64_u ---
+        (F64, I64, false, b64(-1.0), true, "f64→i64_u: -1.0 traps"),
+        (F64, I64, false, b64(0.5), false, "f64→i64_u: 0.5 → 0"),
+        (
+            F64,
+            I64,
+            false,
+            b64(2f64.powi(64)),
+            true,
+            "f64→i64_u: 2^64 traps",
+        ),
+        (
+            F64,
+            I64,
+            false,
+            0x43EF_FFFF_FFFF_FFFF, // 2^64 - 2048: largest f64 below 2^64
+            false,
+            "f64→i64_u: largest f64 below 2^64 converts",
+        ),
+    ]
+}
+
+/// Encoding-correctness check (ordeal#59): eval ordeal's trunc classifier
+/// directly (`ordeal::eval::eval_bool`) at the exact #709 boundary bit
+/// patterns — synth's boundary table is the reference oracle. Every case is
+/// also cross-checked against the real-float reference predicate, so the
+/// table itself cannot drift.
+#[test]
+fn trunc_classifier_eval_matches_709_boundary_table() {
+    use ordeal::{BvTerm, Sort, eval, trap as ot};
+    for (fmt, target, signed, bits, traps, label) in boundary_table_709() {
+        // The table row must agree with the real-float reference.
+        assert_eq!(
+            ref_trap_trunc(fval(fmt, bits), target, signed),
+            traps,
+            "boundary-table self-check: {label}"
+        );
+        let f = BvTerm::Var {
+            name: "f".into(),
+            sort: Sort::new(fmt.total_bits()),
+        };
+        let classifier = ot::trap_trunc(&f, fmt, target, signed);
+        let mut env = eval::Env::new();
+        env.insert("f".into(), bits as u128);
+        assert_eq!(
+            eval::eval_bool(&classifier, &env).expect("classifier must evaluate"),
+            traps,
+            "classifier eval: {label} (pattern {bits:#x})"
+        );
+    }
+}
+
+/// The same #709 table through the certificate-checked pipeline on the synth
+/// wrapper: at a GROUND input, `trap_trunc(const) ⇔ expected` is valid iff the
+/// classifier decides the pattern exactly as the table says — so `Preserved`
+/// (an LRAT-re-checked Unsat) is a per-pattern verdict check.
+#[test]
+fn trunc_gate_decides_709_boundary_table_through_certified_pipeline() {
+    for (fmt, target, signed, bits, traps, label) in boundary_table_709() {
+        let ground = BV::from_u64(bits, fmt.total_bits());
+        let cond = trap_trunc(&ground, fmt, target, signed);
+        assert_preserved(
+            prove_trap_condition_equivalence(&cond, &Bool::from_bool(traps)),
+            label,
+        );
+    }
+    // Non-vacuity control: a deliberately WRONG expectation must be rejected
+    // (Dropped), so `Preserved` above is a real per-pattern decision.
+    let nan = BV::from_u64(f32::NAN.to_bits() as u64, 32);
+    let cond = trap_trunc(&nan, FpFmt::F32, IntTarget::I32, true);
+    assert_dropped(
+        prove_trap_condition_equivalence(&cond, &Bool::from_bool(false)),
+        "f32→i32_s: claiming NaN does not trap",
     );
 }


### PR DESCRIPTION
## VCR-VER-002 Phase B — the float→int truncation trap class (#166, ordeal#59/TR-020)

Follows #723 (Phase A). ordeal 0.9.1 adds `trap_trunc`: the WASM `iN.trunc_fM_s/u` trap predicate (NaN ∨ ±∞ ∨ out-of-range) classified **purely over the float operand's bit pattern** — exponent-field patterns + sign-split monotonic magnitude threshold compares. Floats enter as BV32/BV64; no FP theory, pure QF_BV, LRAT-certified pipeline unchanged. This is exactly the #709 soundness surface: ARM `VCVT` *saturates* where WASM must *trap*, so a lowering that keeps the saturated value and drops the guard is value-equal and invisible to a value-only VC.

### Wrapper (`crates/synth-verify/src/trap.rs`)
- `trunc_op(WasmOp) → Option<(FpFmt, IntTarget, bool)>` — maps all six decoder-reachable trunc variants (`i32/i64.trunc_f{32,64}_{s,u}`; `i64.trunc_f32_*` are not `WasmOp` variants, the raw builder still covers those shapes).
- `trap_trunc(bits, fmt, target, signed)` — ordeal's classifier over synth `BV`/`Bool`, loud width assert. Trap-clause-only VC class (synth models no float→int value function).
- Cargo pin `0.9` → `0.9.1` (`trap_trunc` is 0.9.1-only; the lockfile already resolved 0.9.1 since #723 — no lock change).

### Red-first gate (`tests/trap_preservation.rs`, 6 → 11 tests) — **which drops are caught**

| direction | result |
|---|---|
| guard-**dropping** lowering (`may_trap=false`), all six variants | **CAUGHT** — `Dropped/Sat`, counterexample validated as genuinely trapping against the real-float reference |
| signedness-**confused** guard (unsigned range check on `i32.trunc_f32_s` — NaN/∞ kept, thresholds wrong: the partial-drop VCVT shape) | **CAUGHT** — `Sat`, counterexample separates signed from unsigned trapping |
| guard-**preserving** lowering, all six variants | accepted — `Preserved/Unsat`, LRAT certificate re-checked |
| wrong-expectation control (claiming NaN doesn't trap at a ground input) | **CAUGHT** — non-vacuity of the ground gate |

### Classifier-encoding check (the ordeal#59 ask; synth's #709 table is the reference oracle)
The 31-row #709 boundary table evaluated two ways, every row self-checked against the real-float reference so the table cannot drift:
1. **directly via `ordeal::eval`** on the classifier — `i32.trunc_f32_s`: NaN / +∞ / −∞ / 3e9 / −3e9 trap, 2^31 (`0x4F000000`) **TRAPS**, −2^31 (`0xCF000000`) **in-range**, 2.5 in-range; `i32.trunc_f32_u`: −1.0 traps, 0.5 / −0.0 in-range, 2^32 traps; plus f64 and i64-target boundary anchors (largest-below-threshold floats, ±2^63, 2^64, −(2^31+1), …).
2. **through the certificate-checked pipeline** on the synth wrapper: at ground inputs, `trap_trunc(const) ⇔ expected` proven valid per pattern (certified Unsat).

### Roadmap / claims
`VCR-VER-002` title + description updated (Phase B landed, LANDED item 5); **status stays `proposed`** — the live-validator wiring gap is unchanged (trunc, like load/store / call_indirect / unreachable, is gated at the unit level pending the exec-model trap flag). `claims.yaml` SYNTH-VCR-VER-002-STATUS text updated verbatim; `claim_check` 18/18.

### Gates
- `cargo test -p synth-verify` + `--test trap_preservation` (11/11) green
- `cargo test --workspace` green (119 test binaries, 0 failures)
- `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --check` clean
- `python3 scripts/claim_check.py claims.yaml` — 18/18 claims hold

Refs #166, #242, ordeal#59. Follows #723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L