### PR TITLE
perf(#390): conditional-branch-transparent stack-reload forwarding — gust_poll 740→724 B (VCR-RA)

### DIFF
--- a/artifacts/size_attribution_390.md
+++ b/artifacts/size_attribution_390.md
@@ -15,11 +15,11 @@ thumbv7m baseline (gust_poll 208 B, gust_mix 12 B, 3.9x) is **CITED** from issue
 
 | function | synth .text (measured) | LLVM (cited #390) | ratio | #390 cited synth |
 |---|---|---|---|---|
-| gust_poll | 740 B | 208 B | 3.56x | 816 B (v0.11.50) |
+| gust_poll | 724 B | 208 B | 3.48x | 816 B (v0.11.50) |
 | gust_mix  | 32 B | 12 B | 2.67x | 44 B (v0.11.50) |
 
 synth has already shrunk since #390 was filed (levers landed v0.12–v0.39): the
-gap is now ~3.56x / ~2.67x, not 3.9x / 3.7x. In particular the
+gap is now ~3.48x / ~2.67x, not 3.9x / 3.7x. In particular the
 `and #0xffff -> uxth` peephole (issue Pass 5) has landed — gust_mix now emits
 `uxth r3, r0`, not the `movw+and` pair. Still open: spill churn, address
 re-materialization, the shadow-stack dance, and bool materialization.
@@ -28,7 +28,7 @@ re-materialization, the shadow-stack dance, and bool materialization.
 
 | function | .text B | spill_reload | addr_materialize | redundant_const | prologue_shadow | guard_bool | copy_move | productive | align_pad |
 |---|---|---|---|---|---|---|---|---|---|
-| gust_poll | 740 | 228 | 56 | 62 | 36 | 108 | 56 | 194 | 0 |
+| gust_poll | 724 | 200 | 56 | 62 | 36 | 108 | 66 | 194 | 2 |
 | gust_mix | 32 | 4 | 0 | 0 | 16 | 0 | 6 | 6 | 0 |
 | func_0 | 408 | 8 | 44 | 130 | 8 | 46 | 14 | 156 | 2 |
 | func_1 | 76 | 0 | 0 | 28 | 8 | 12 | 8 | 20 | 0 |

--- a/crates/synth-cli/tests/frozen_codegen_bytes.rs
+++ b/crates/synth-cli/tests/frozen_codegen_bytes.rs
@@ -209,13 +209,29 @@ fn assert_frozen(cases: &[(&str, &str, usize)], backend: &str, target: &str) {
 /// `frozen_fixtures_uxth_fold_escape_hatch_restores_old_bytes`). Prior
 /// goldens were control_step 158b036b…/300, flight_seam 1e1d2b75…/726,
 /// flight_seam_flat d11849db…/866.
+/// Goldens RE-FROZEN for the #390 stack-fwd strengthening (v0.42 lane):
+/// `forward_stack_reloads` upgraded to a conditional-branch-transparent
+/// holder-lattice walk (forwards/deletes reloads across `br_if`
+/// compare→branch ladders — joins still reset all state). control_step
+/// 314→308 (−6), flight_seam_flat 1014→1010 (−4); flight_seam and
+/// signed_div_const are byte-identical. Execution differentials re-run green
+/// on the new default bytes BEFORE this re-pin: the full
+/// scripts/repro/*_differential.py sweep (86/87 — u64_unpack_riscv is
+/// env-broken identically on the old bytes) incl. flight_seam flat+inlined
+/// flight_algo 0x07FDF307, control_step, frame_slot_dce, const_cse,
+/// spill_rung_581, and the NEW gust_spill_fwd_390_differential.py
+/// (gust_poll state+return vs wasmtime in default + both lever opt-outs).
+/// `SYNTH_NO_STACK_FWD=1` restores the prior stack-fwd-off bytes (asserted by
+/// `frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes`, pins
+/// untouched). Prior goldens were control_step f962794f…/314,
+/// flight_seam_flat 64388237…/1014.
 #[test]
 fn frozen_fixtures_text_is_bit_identical_oracle_001() {
     let cases = [
         (
             "control_step.wasm",
-            "f962794f128223b5212fc5cc25bb8393bcae758e89b93c07eb23deb4fffe5c0d",
-            314usize,
+            "b365a29ef47ddd3e5ef8755d54cbd0d46c504af64dd24d08e9500385f674d892",
+            308usize,
         ),
         (
             "flight_seam.wasm",
@@ -224,8 +240,8 @@ fn frozen_fixtures_text_is_bit_identical_oracle_001() {
         ),
         (
             "flight_seam_flat.wasm",
-            "643882379d3c25cd1acc34129f5456d54b6864b127184c1f81823daeb267401c",
-            1014,
+            "7d3145c4ed0493cd326f867ab068930a64f3813bce60d031b19f535d0f800998",
+            1010,
         ),
         (
             "signed_div_const.wasm",
@@ -336,18 +352,25 @@ fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
 /// #242), which would otherwise rewrite traffic these goldens pin.
 #[test]
 fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
-    // (fixture, PRE-flip golden sha256, PRE-flip len) — the pre-spill-realloc
-    // goldens (the SYNTH_STACK_FWD-era defaults).
+    // (fixture, opt-out golden sha256, len). RE-DERIVED at the #390 stack-fwd
+    // strengthening: stack-fwd stays ON in this config, and its
+    // conditional-branch-transparent forwarding now catches (earlier in the
+    // pipeline) the same reloads spill-realloc's stage 1 forwarded — so these
+    // are no longer the historical pre-spill-realloc defaults byte-for-byte.
+    // The gate's TRIPWIRE semantics are unchanged: `SYNTH_SPILL_REALLOC=0`
+    // must land exactly here, so any stage-2/3 leak into the opt-out path
+    // still reddens. Prior pins were flight_seam b590aea8…/902,
+    // flight_seam_flat 49ebf8a1…/1046.
     let old = [
         (
             "flight_seam.wasm",
-            "b590aea84d62b5dd58702a1a4dd5628683615b0482f1610bdf700509f8c8e360",
-            902usize,
+            "d8af257f82594e0a41d75c2fba2aaee62041fff54863342f4a9c3aebe39e10f3",
+            894usize,
         ),
         (
             "flight_seam_flat.wasm",
-            "49ebf8a1b48d96f66ad4d91f401cd78ce8bcbacc9340941039301a18aba2ec83",
-            1046,
+            "b521284d672f0b420ba0db65281259f5824fdd7fe39a217730529fd6f5661006",
+            1038,
         ),
     ];
     for &(wasm, golden, golden_len) in &old {
@@ -421,13 +444,16 @@ fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
 /// control_step (uxth) and flight_seam (dead-frame).
 #[test]
 fn frozen_fixtures_const_cse_escape_hatch_restores_old_bytes() {
-    // (fixture, PRE-flip golden sha256, PRE-flip len) — the pre-const-CSE
-    // goldens (the SYNTH_BASE_CSE-flip-era defaults).
+    // (fixture, opt-out golden sha256, len). control_step RE-DERIVED at the
+    // #390 stack-fwd strengthening (stack-fwd stays ON in this config and now
+    // forwards −6 B of control_step's reload traffic; prior pin was
+    // 93ef2610…/324); flight_seam is untouched by that change. The tripwire
+    // semantics are unchanged: `SYNTH_CONST_CSE=0` must land exactly here.
     let old = [
         (
             "control_step.wasm",
-            "93ef2610ce177e30e28767182ceecfa455d4e69968429145c967f16d7b2e22f1",
-            324usize,
+            "5771a1a1e74e2aedfd07daa526b7b8301022cc76c5d3ed79c0adb2c81404c838",
+            318usize,
         ),
         (
             "flight_seam.wasm",
@@ -505,8 +531,12 @@ fn frozen_fixtures_const_cse_escape_hatch_restores_old_bytes() {
 /// above locks them.)
 #[test]
 fn frozen_fixtures_dead_frame_elim_escape_hatch_restores_old_bytes() {
-    // (fixture, PRE-flip golden sha256, PRE-flip len) — the const-CSE-flip-era
-    // defaults.
+    // (fixture, opt-out golden sha256, len). flight_seam_flat RE-DERIVED at
+    // the #390 stack-fwd strengthening (stack-fwd stays ON in this config;
+    // the holder-lattice walk deletes a now-no-op reload, −4 B; prior pin was
+    // d62bdfa3…/1034); flight_seam is untouched by that change. The tripwire
+    // semantics are unchanged: `SYNTH_DEAD_FRAME_ELIM=0` must land exactly
+    // here.
     let old = [
         (
             "flight_seam.wasm",
@@ -515,8 +545,8 @@ fn frozen_fixtures_dead_frame_elim_escape_hatch_restores_old_bytes() {
         ),
         (
             "flight_seam_flat.wasm",
-            "d62bdfa3faed21aef1ad943d824817f3adb04f0f400c1dd498690a437dd2bf43",
-            1034,
+            "aacd064cefc3087fe63e969796c5f87e659f3c8724a4d0999c817de38ef824a1",
+            1030,
         ),
     ];
     for &(wasm, golden, golden_len) in &old {
@@ -586,12 +616,15 @@ fn frozen_fixtures_dead_frame_elim_escape_hatch_restores_old_bytes() {
 /// `=0` alone lands exactly on the previous shipped default.
 #[test]
 fn frozen_fixtures_uxth_fold_escape_hatch_restores_old_bytes() {
-    // (fixture, PRE-flip golden sha256, PRE-flip len) — the const-CSE-flip-era
-    // default.
+    // (fixture, opt-out golden sha256, len). RE-DERIVED at the #390 stack-fwd
+    // strengthening (stack-fwd stays ON in this config and forwards −6 B of
+    // control_step's reload traffic; prior pin was fdcfbac1…/320). The
+    // tripwire semantics are unchanged: `SYNTH_UXTH_FOLD=0` must land exactly
+    // here.
     let old = [(
         "control_step.wasm",
-        "fdcfbac168dcd71ae4a981103f618bb661ffb74c9fd2248c876e5c9b007a65fe",
-        320usize,
+        "3a488afa1612a5698d3a1817a4ad526f9e3cde9f62a324195027a48780b635e6",
+        314usize,
     )];
     for &(wasm, golden, golden_len) in &old {
         let elf = format!("/tmp/frozen_nouxth_{wasm}.elf");

--- a/crates/synth-cli/tests/size_attribution_390.rs
+++ b/crates/synth-cli/tests/size_attribution_390.rs
@@ -95,8 +95,18 @@ fn per_function_sizes() -> BTreeMap<String, u64> {
 /// gust_poll/gust_mix are gale's #390 benchmark functions; func_0 is the kiln
 /// `transition` body, func_1 the internal `mix`. To repin after a deliberate
 /// size change, run the test and copy the printed REPIN block.
+///
+/// REPINNED (#390 spill-reduction, v0.42 lane): gust_poll 740 → 724 (−16 B by
+/// this oracle's symbol-delta method; machine code is 722 + 2 B alignment
+/// pad, −18) — `forward_stack_reloads` upgraded to a
+/// conditional-branch-transparent holder-lattice walk (19 reloads forwarded /
+/// deleted across gust_poll's br_if compare→branch ladders). Correctness
+/// evidence on the new bytes BEFORE this repin: the full
+/// scripts/repro/*_differential.py sweep incl. the new
+/// gust_spill_fwd_390_differential.py (gust_poll state+return vs wasmtime in
+/// default + both lever opt-outs).
 const LOCKED: &[(&str, u64)] = &[
-    ("gust_poll", 740),
+    ("gust_poll", 724),
     ("gust_mix", 32),
     ("func_0", 408),
     ("func_1", 76),

--- a/crates/synth-cli/tests/spill_realloc_242.rs
+++ b/crates/synth-cli/tests/spill_realloc_242.rs
@@ -195,20 +195,20 @@ fn spill_realloc_no_grow_and_fires_on_flight_seam_242() {
             "no function may grow flag-on: {name} off={o}B on={n}B"
         );
     }
-    assert!(
-        on["flight_algo"] < off["flight_algo"],
-        "the spike must shrink flight_seam::flight_algo (measured 306→300 B): off={}B on={}B",
-        off["flight_algo"],
-        on["flight_algo"]
-    );
-    let fired = forwarded_total(&on_err);
-    assert!(
-        fired >= 3,
-        "expected ≥3 reloads forwarded on flight_seam (measured 3); got {fired} — the pass went inert"
-    );
+    // #390 UPDATE: the conditional-branch-transparent `forward_stack_reloads`
+    // (which runs in BOTH configs — it is the SYNTH_NO_STACK_FWD lever, not
+    // this one) now forwards flight_seam's 3 stage-1 reloads before this pass
+    // ever sees them, so the flag-on/flag-off byte delta on flight_seam is
+    // ZERO and the old "must shrink flight_algo / ≥3 forwarded" firing claims
+    // are structurally unsatisfiable here. The lever's NON-VACUITY is owned by
+    // the flat_flight block below (stage 2 Belady re-choice + stage 3
+    // whole-function slot liveness — shapes stack-fwd structurally cannot
+    // touch: every holder is clobbered). flight_seam keeps the NO-GROW claim.
+    let _ = &on_err;
     eprintln!(
-        "[spill-realloc-242] flight_seam::flight_algo off={}B on={}B, {} reload(s) forwarded",
-        off["flight_algo"], on["flight_algo"], fired
+        "[spill-realloc-242] flight_seam::flight_algo off={}B on={}B (stage-1 \
+         subsumed by stack-fwd since #390 — non-vacuity owned by flat_flight)",
+        off["flight_algo"], on["flight_algo"]
     );
 
     // flat_flight — the Belady re-choice target. Stage 1 has nothing to

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -435,28 +435,49 @@ pub fn fuse_cmp_select_with_stats(
 /// #209, epic #242). synth lowers every wasm local to a frame slot, so a
 /// `local.set` then `local.get` of the same local emits `str rX,[sp,#N]; … ;
 /// ldr rY,[sp,#N]` — a memory store-then-reload of one slot (≈18 % of the hot
-/// fixture's instructions are sp traffic; an M4 stack load is ~2 cycles). When the
-/// stored register `rX` still holds the value at the `ldr` — nothing rewrites `rX`,
-/// nothing rewrites slot `N`, `sp` does not move, and there is no call / branch /
-/// label between (the forward scan bails via `reg_effect → None` on any of those,
-/// the same soundness lynchpin as [`fuse_cmp_select`]) — the `ldr` is replaced by
-/// `mov rY, rX` (~1 cycle). The `str` is KEPT: the slot may still be read past a
-/// boundary the scan bailed at. Removal-of-a-load + rename only ⇒ NO new instruction
-/// form (no validator change) and labels/branch offsets are untouched.
+/// fixture's instructions are sp traffic; an M4 stack load is ~2 cycles). A
+/// single forward walk tracks, per slot `#N`, the set of registers PROVABLY
+/// holding slot `N`'s value (the same holder lattice as
+/// [`spill_forward_segment`]: the feeding `str rX,[sp,#N]` seeds `rX`, an
+/// earlier reload seeds its target, and `mov rZ,rY` copies value identity).
+/// A reload `ldr rY,[sp,#N]` with a surviving holder `rX` is replaced by
+/// `mov rY, rX` (~1 cycle) — or DELETED outright when `rY` itself still holds
+/// the value (the reload is a no-op; an identity `mov rY,rY` would be strictly
+/// worse than the deletion the downstream [`spill_forward_segment`] used to
+/// perform on that shape). The `str` is KEPT: the slot may still be read past
+/// a boundary the walk reset at. Replacements are 1-for-1 and deletions only
+/// shrink; label-form branches are re-resolved after this pass
+/// (`resolve_label_branches`), and a deletion inside a resolved numeric
+/// branch→target span is declined (see GEOMETRY below), so branch offsets
+/// stay valid.
+///
+/// BARRIERS — the holder state is fully reset at every point another edge can
+/// enter or the walk cannot model: a `Label` / call / unmodeled op
+/// (`reg_effect → None`, the same soundness lynchpin as [`fuse_cmp_select`]),
+/// an UNCONDITIONAL branch (the code after it is reachable only via a join),
+/// a resolved-branch TARGET (`geo.targets`, an invisible join — #606), any
+/// `[sp]` access that cannot be pinned to a single whole-word slot
+/// (register-offset or sub-word), `Push`/`Pop`, and any SP def. A CONDITIONAL
+/// branch, however, is TRANSPARENT (#390): on the fall-through edge it has no
+/// register or memory effect, and a rewrite site is only ever executed on that
+/// edge. The taken edge cannot re-enter the window unseen — every label-form
+/// branch (`B`/`Bcc`/`Bhs`/`Blo`/`BrTable`) targets a `Label` instruction and
+/// every numeric branch's target is in `geo.targets` (or the geometry mapping
+/// failed and the whole function declined), both of which reset the state. So
+/// the feeding def still dominates each rewritten reload with only the walked
+/// instructions between them on any execution — the forwarding invariant is
+/// path-insensitive here. This is what lets the pass fire across the
+/// compare→branch ladders the direct selector emits for `br_if` chains
+/// (gust_poll's dominant spill shape, the #390 `spill_reload` bucket).
 ///
 /// RESOLVED-BRANCH GEOMETRY (#606, the #604 hazard class): on the optimized
 /// path the stream arrives with ALREADY-RESOLVED `BOffset`/`BCondOffset`
-/// displacements that are never re-resolved, so (1) a branch TARGET is an
-/// invisible join — the forward scan stops there (`rX` proven on the
-/// fall-through edge is unproven on the taken edge, e.g. a loop back-edge
-/// re-entering between the `str` and the `ldr`), and (2) a replacement inside
-/// a branch→target span must be exactly byte-size-neutral (a 32-bit `ldr.w`
+/// displacements that are never re-resolved, so a replacement inside a
+/// branch→target span must be exactly byte-size-neutral (a 32-bit `ldr.w`
 /// folding to a 16-bit `mov` would shift the pre-resolved displacement — the
 /// `nested(1,)` overshoot class). An unmappable stream declines wholesale.
-/// Today's optimized-path streams cannot present the firing shape (the
-/// eviction store's source register is redefined immediately after it) — the
-/// gate turns that accidental safety into a structural one. Returns the
-/// rewritten stream and the number of reloads forwarded (0 ⇒ input unchanged).
+/// Returns the rewritten stream and the number of reloads forwarded (0 ⇒
+/// input unchanged).
 pub fn forward_stack_reloads(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>, usize) {
     use crate::optimizer_bridge::estimate_arm_byte_size;
     let n = instrs.len();
@@ -465,68 +486,158 @@ pub fn forward_stack_reloads(instrs: &[ArmInstruction]) -> (Vec<ArmInstruction>,
     let Some(geo) = resolved_branch_geometry_labels_as_zero(instrs) else {
         return (instrs.to_vec(), 0);
     };
-    let mut out = instrs.to_vec();
     let mut rewrites = 0usize;
+    // Staged edits: index → Some(op) = replace, None = delete. Applied at the
+    // end so the walk's indices stay aligned with `geo`'s.
+    let mut staged: BTreeMap<usize, Option<ArmOp>> = BTreeMap::new();
+    // slot #N → set of registers currently holding slot N's value. State is
+    // tracked over the ORIGINAL stream: every committed edit leaves the
+    // identical register state by construction (the mov writes — and the
+    // deleted reload's target already holds — the exact value the load would
+    // have fetched), so the facts remain valid for the rewritten stream.
+    let mut holders: BTreeMap<i32, BTreeSet<Reg>> = BTreeMap::new();
 
-    for i in 0..n {
-        // [i] must be `str rX, [sp, #N]` (immediate slot, no register offset).
-        let (rx, slot) = match &instrs[i].op {
-            ArmOp::Str { rd, addr } if addr.base == Reg::SP && addr.offset_reg.is_none() => {
-                (*rd, addr.offset)
-            }
-            _ => continue,
-        };
-        // Forward `rX` into same-slot loads until it (or the slot, or sp) changes
-        // or the scan reaches an op it cannot reason past.
-        for j in (i + 1)..n {
-            // #606: a resolved-branch TARGET is an invisible join — a taken
-            // edge enters here with an unproven `rX`. Stop the scan.
-            if geo.targets.contains(&j) {
-                break;
-            }
-            // A reload of the same slot ⇒ rewrite to `mov rY, rX`. `rX` is still
-            // the live source, so keep scanning — a later same-slot load forwards too.
-            if let ArmOp::Ldr { rd: ry, addr } = &out[j].op
-                && addr.base == Reg::SP
-                && addr.offset_reg.is_none()
-                && addr.offset == slot
-            {
-                let ry = *ry;
-                let mov = ArmOp::Mov {
-                    rd: ry,
-                    op2: Operand2::Reg(rx),
-                };
-                // #606 span byte-freeze: inside a branch→target span the
-                // replacement must not change the instruction's byte size, or
-                // the pre-resolved displacement overshoots. Keep the `ldr`
-                // (it re-reads the same value, so scanning continues soundly).
-                if geo.frozen[j]
-                    && estimate_arm_byte_size(&mov) != estimate_arm_byte_size(&out[j].op)
-                {
+    for (j, ins) in instrs.iter().enumerate() {
+        // #606: a resolved-branch TARGET is an invisible join — a taken edge
+        // enters here with unproven register state. Reset everything.
+        if geo.targets.contains(&j) {
+            holders.clear();
+        }
+        match &ins.op {
+            // Full-word reload of a pinnable slot — the forwarding candidate.
+            ArmOp::Ldr { rd, addr } if sp_slot(addr).is_some() => {
+                let slot = sp_slot(addr).unwrap();
+                let rd = *rd;
+                if rd == Reg::SP {
+                    // `ldr sp,[sp,#N]` redefines the frame pointer: every slot
+                    // name is invalidated. (Never emitted today; sound anyway.)
+                    holders.clear();
                     continue;
                 }
-                out[j].op = mov;
-                rewrites += 1;
-                continue;
+                let known = holders.get(&slot).cloned().unwrap_or_default();
+                if !is_reserved_reg(rd) && known.contains(&rd) {
+                    // rd already holds the slot's value — the reload is a
+                    // no-op; delete it. #606: a deletion inside a resolved
+                    // branch→target span would shift the displacement — keep
+                    // the `ldr` there (it re-reads the same value; state below
+                    // is identical either way).
+                    if !geo.frozen[j] {
+                        staged.insert(j, None);
+                        rewrites += 1;
+                    }
+                } else if !is_reserved_reg(rd) && !known.is_empty() {
+                    let rx = *known.iter().next().unwrap(); // lowest: deterministic
+                    let mov = ArmOp::Mov {
+                        rd,
+                        op2: Operand2::Reg(rx),
+                    };
+                    // #606 span byte-freeze: inside a branch→target span the
+                    // replacement must not change the instruction's byte size,
+                    // or the pre-resolved displacement overshoots. Keep the
+                    // `ldr` (it re-reads the same value — state below is
+                    // identical either way).
+                    if !(geo.frozen[j]
+                        && estimate_arm_byte_size(&mov) != estimate_arm_byte_size(&ins.op))
+                    {
+                        staged.insert(j, Some(mov));
+                        rewrites += 1;
+                    }
+                }
+                // Either way rd now holds the slot's value.
+                for set in holders.values_mut() {
+                    set.remove(&rd);
+                }
+                if !is_reserved_reg(rd) {
+                    holders.entry(slot).or_default().insert(rd);
+                }
             }
-            // A store that could land in slot N (same immediate, or any register
-            // offset we cannot resolve) ⇒ the slot's value may change; stop.
-            if let ArmOp::Str { addr, .. } = &instrs[j].op
-                && addr.base == Reg::SP
-                && (addr.offset_reg.is_some() || addr.offset == slot)
+            // Full-word store to a pinnable slot: the slot now holds rd's value.
+            ArmOp::Str { rd, addr } if sp_slot(addr).is_some() => {
+                let slot = sp_slot(addr).unwrap();
+                let mut set = BTreeSet::new();
+                if !is_reserved_reg(*rd) {
+                    set.insert(*rd);
+                }
+                holders.insert(slot, set);
+            }
+            // Any [sp] access we cannot pin to a single whole-word slot:
+            // register offset (unresolvable) or sub-word (partial overlap).
+            ArmOp::Ldr { addr, .. } | ArmOp::Str { addr, .. } if addr.base == Reg::SP => {
+                holders.clear();
+            }
+            ArmOp::Ldrb { addr, .. }
+            | ArmOp::Ldrsb { addr, .. }
+            | ArmOp::Ldrh { addr, .. }
+            | ArmOp::Ldrsh { addr, .. }
+            | ArmOp::Strb { addr, .. }
+            | ArmOp::Strh { addr, .. }
+                if addr.base == Reg::SP =>
             {
-                break;
+                holders.clear();
             }
-            match reg_effect(&instrs[j].op) {
-                // `rX` clobbered or the frame pointer moved ⇒ value no longer valid.
-                Some(eff) if eff.defs.contains(&rx) || eff.defs.contains(&Reg::SP) => break,
-                Some(_) => {}
-                // call / branch / label / unmodeled op ⇒ cannot reason past it.
-                None => break,
+            // SP moves + stack memory touched — every slot name is invalidated.
+            ArmOp::Push { .. } | ArmOp::Pop { .. } => {
+                holders.clear();
             }
+            // Register-to-register copy propagates value identity.
+            ArmOp::Mov {
+                rd,
+                op2: Operand2::Reg(rm),
+            } if rd != rm => {
+                let (rd, rm) = (*rd, *rm);
+                let member: Vec<i32> = holders
+                    .iter()
+                    .filter(|(_, s)| s.contains(&rm))
+                    .map(|(k, _)| *k)
+                    .collect();
+                for set in holders.values_mut() {
+                    set.remove(&rd);
+                }
+                if !is_reserved_reg(rd) {
+                    for k in member {
+                        if let Some(s) = holders.get_mut(&k) {
+                            s.insert(rd);
+                        }
+                    }
+                }
+            }
+            // #390: CONDITIONAL branches are transparent (see the doc block).
+            ArmOp::BCondOffset { .. }
+            | ArmOp::Bcc { .. }
+            | ArmOp::Bhs { .. }
+            | ArmOp::Blo { .. } => {}
+            op => match reg_effect(op) {
+                Some(eff) => {
+                    if eff.defs.contains(&Reg::SP) {
+                        holders.clear();
+                    }
+                    for d in &eff.defs {
+                        for set in holders.values_mut() {
+                            set.remove(d);
+                        }
+                    }
+                }
+                // Label / unconditional branch / call / unmodeled op ⇒ another
+                // edge may enter here or effects are unknown. Reset.
+                None => holders.clear(),
+            },
         }
     }
 
+    if staged.is_empty() {
+        return (instrs.to_vec(), 0);
+    }
+    let mut out: Vec<ArmInstruction> = Vec::with_capacity(n);
+    for (j, ins) in instrs.iter().enumerate() {
+        match staged.get(&j) {
+            None => out.push(ins.clone()),
+            Some(None) => {} // deleted no-op reload
+            Some(Some(op)) => out.push(ArmInstruction {
+                op: op.clone(),
+                source_line: ins.source_line,
+            }),
+        }
+    }
     (out, rewrites)
 }
 

--- a/scripts/repro/frame_slot_dce_differential.py
+++ b/scripts/repro/frame_slot_dce_differential.py
@@ -153,14 +153,23 @@ def main():
     off_code, off_base, off_syms = load(off)
     on_code, on_base, on_syms = load(on)
 
-    # The DEFAULT (fwd-on) and the opt-out (fwd-off) must produce DIFFERENT bytes
-    # — proof the flip is actually engaged in the shipped default — yet identical
-    # RESULTS. (If these match, the default isn't doing anything.)
+    # ENGAGEMENT (#390 update): since the conditional-branch-transparent
+    # holder-lattice rewrite of `forward_stack_reloads`, the downstream
+    # SYNTH_SPILL_REALLOC stages reach the SAME final bytes on this fixture
+    # with the stack-fwd lever off — so default-vs-opt-out byte identity here
+    # no longer proves the lever inert (the two levers converge). The
+    # engagement check lives where the lever is uniquely load-bearing —
+    # gust_kernel's compare→branch ladders, which spill-realloc's
+    # branch-barriered segments structurally cannot forward across — in
+    # gust_spill_fwd_390_differential.py. THIS harness keeps what is unique to
+    # it: execution correctness of flight_seam_flat in BOTH configs.
     if off_code == on_code:
-        print("FAIL: default and SYNTH_NO_STACK_FWD opt-out emit identical bytes "
-              "— the flip is not engaged")
-        sys.exit(1)
-    print("OK  default vs SYNTH_NO_STACK_FWD opt-out: bytes differ (flip engaged)")
+        print("NOTE default and SYNTH_NO_STACK_FWD opt-out bytes converge on "
+              "flight_seam_flat (spill-realloc subsumes stack-fwd here, #390); "
+              "lever engagement is asserted on gust_kernel by "
+              "gust_spill_fwd_390_differential.py")
+    else:
+        print("OK  default vs SYNTH_NO_STACK_FWD opt-out: bytes differ (flip engaged)")
 
     fails = 0
     # flight_algo is the optimization target — the only export with frame-slot

--- a/scripts/repro/gust_spill_fwd_390_differential.py
+++ b/scripts/repro/gust_spill_fwd_390_differential.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""#390 (VCR-RA) — EXECUTION-validate conditional-branch-transparent stack-reload
+forwarding on the gust hot path, and own the SYNTH_NO_STACK_FWD flip-engagement
+check.
+
+The #390 size-attribution report measured `spill_reload` as gust_poll's biggest
+overhead bucket (228 B / ~31%). The direct selector lowers gust_poll's `br_if`
+ladders as compare→branch chains, and the pre-#390 `forward_stack_reloads`
+stopped its forward scan at EVERY branch — so a value provably register-resident
+across a conditional branch (fall-through edge, no register effect) was reloaded
+from its frame slot anyway. The strengthened pass walks a holder lattice through
+CONDITIONAL branches (joins — labels / resolved-branch targets — still reset all
+state) and forwards or deletes those reloads: gust_poll 740 -> 722 B measured.
+
+This harness is the execution oracle for that change:
+
+  1. ENGAGEMENT — the shipped DEFAULT and the `SYNTH_NO_STACK_FWD=1` opt-out
+     must emit DIFFERENT bytes on gust_kernel (the fixture where the lever is
+     load-bearing; on flat_flight the downstream SYNTH_SPILL_REALLOC stages now
+     reach the same bytes, so engagement is asserted HERE — see
+     frame_slot_dce_differential.py's note).
+  2. CORRECTNESS — gust_poll (state-mutating scheduler poll: return value AND
+     the post-call state struct bytes) and gust_mix match wasmtime ground truth
+     in ALL THREE configs: default, `SYNTH_NO_STACK_FWD=1`, and
+     `SYNTH_SPILL_REALLOC=0` (a default is only safe if the shipped path and
+     its rollbacks all match).
+
+unicorn runs the DEFAULT-path standalone image exactly as Reset_Handler leaves
+the machine: r9 = globals base (globals seeded 0x100000 / __data_end /
+__heap_base), r10 = linmem size, r11 = linmem base, initial SP above linmem,
+`.linear_memory` section contents loaded at the base.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/gust_spill_fwd_390_differential.py
+Exits nonzero on identical engagement bytes or any execution mismatch.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R9,
+    UC_ARM_REG_R10,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+WASM = REPO / "scripts" / "repro" / "gust_kernel.wasm"
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+# Reset_Handler's machine state (see the emitted prologue): linmem at
+# 0x20000000, 17 pages = 0x110000 bytes, globals base right above it, initial
+# SP at 0x20120000. Globals: [r9] = shadow-stack top, [r9,4] = __data_end,
+# [r9,8] = __heap_base.
+LIN = 0x2000_0000
+LIN_SIZE = 0x11_0000
+GLOBALS = 0x2011_0000
+SP_INIT = 0x2012_0000
+CODE = 0x0
+
+STATE_OFF = 0x400  # word-aligned scratch offset in linear memory for the state
+STATE_SPAN = 0x200  # bytes of state region compared after each call
+
+
+def compile_cfg(out, env_extra):
+    env = dict(os.environ)
+    env.pop("SYNTH_NO_STACK_FWD", None)
+    env.pop("SYNTH_SPILL_REALLOC", None)
+    env.update(env_extra)
+    r = subprocess.run(
+        [SYNTH, "compile", str(WASM), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env=env,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({env_extra}): {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    lin = f.get_section_by_name(".linear_memory")
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for s in sec.iter_symbols():
+                if s.name:
+                    syms[s.name] = s["st_value"]
+    return text.data(), lin.data() if lin else b"", syms
+
+
+def state_bytes(seed):
+    # Deterministic pseudo-random state struct (xorshift), identical for
+    # wasmtime and unicorn; both engines interpret the same bytes, so any
+    # semantic divergence is a synth miscompile, not an input judgement.
+    # The cursor/budget words at +0x30/+0x34 are clamped small: +0x34 seeds
+    # the poll round's countdown (a random u32 there spins wasmtime for
+    # minutes), +0x30 is the 0..5 slot cursor.
+    x = seed or 0x9E3779B9
+    out = bytearray()
+    while len(out) < STATE_SPAN:
+        x ^= (x << 13) & 0xFFFFFFFF
+        x ^= x >> 17
+        x ^= (x << 5) & 0xFFFFFFFF
+        out += x.to_bytes(4, "little")
+    out[0x30:0x34] = (seed % 6).to_bytes(4, "little")
+    out[0x34:0x38] = (2 + seed % 5).to_bytes(4, "little")
+    return bytes(out)
+
+
+# (state, x, strict). strict=False marks the two zero-state cases KNOWN-
+# DIVERGENT (#740): the direct path mistargets the loop-head empty-budget
+# `br_if` to a mid-shape point after the first transition call, so synth
+# spuriously writes state+0x34 (wasmtime writes nothing). Pre-existing on
+# main v0.41.0, byte-identically in ALL lever configs — NOT a #390 regression.
+# The xfail is anti-vacuous both ways: the RETURN value must still match, and
+# the moment the memory divergence disappears (i.e. #740 is fixed) the case
+# hard-fails and demands promotion to strict.
+CASES = [
+    (b"\x00" * STATE_SPAN, 0, False),
+    (b"\x00" * STATE_SPAN, 7, False),
+    (state_bytes(1), 3, True),
+    (state_bytes(2), 0x1234, True),
+    (state_bytes(3), -5 & 0xFFFFFFFF, True),
+]
+
+
+def wasmtime_poll(state, x):
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WASM.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    mem = inst.exports(st)["memory"]
+    mem.write(st, state, STATE_OFF)
+    r = inst.exports(st)["gust_poll"](st, STATE_OFF, x - (1 << 32) if x >= 1 << 31 else x)
+    return r & 0xFFFFFFFF, bytes(mem.read(st, STATE_OFF, STATE_OFF + STATE_SPAN))
+
+
+def wasmtime_mix(x):
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WASM.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    return inst.exports(st)["gust_mix"](st, x - (1 << 32) if x >= 1 << 31 else x) & 0xFFFFFFFF
+
+
+def unicorn_call(text, lin_init, faddr, r0, r1):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x10000)
+    # Whole linmem + shadow stack + globals + machine stack, contiguous
+    # (0x20000000..0x20120000) — exactly the Reset_Handler RAM layout.
+    mu.mem_map(LIN, 0x12_0000)
+    mu.mem_write(CODE, text)
+    if lin_init:
+        # .linear_memory carries the full initial linmem image.
+        mu.mem_write(LIN, lin_init[:0x12_0000])
+    # Reset_Handler machine state.
+    mu.reg_write(UC_ARM_REG_R9, GLOBALS)
+    mu.reg_write(UC_ARM_REG_R10, LIN_SIZE)
+    mu.reg_write(UC_ARM_REG_R11, LIN)
+    mu.mem_write(GLOBALS, (0x10_0000).to_bytes(4, "little"))
+    mu.mem_write(GLOBALS + 4, (0x10_008F).to_bytes(4, "little"))
+    mu.mem_write(GLOBALS + 8, (0x10_0090).to_bytes(4, "little"))
+    mu.reg_write(UC_ARM_REG_SP, SP_INIT)
+    ret = CODE + 0xFF00
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    mu.reg_write(UC_ARM_REG_R0, r0)
+    mu.reg_write(UC_ARM_REG_R1, r1)
+    try:
+        mu.emu_start((faddr & ~1) | 1, ret, timeout=5_000_000, count=200_000)
+    except UcError as e:
+        return f"ERR:{e}", None
+    return (
+        mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF,
+        bytes(mu.mem_read(LIN + STATE_OFF, STATE_SPAN)),
+    )
+
+
+def main():
+    cfgs = [
+        ("default", {}),
+        ("no-stack-fwd", {"SYNTH_NO_STACK_FWD": "1"}),
+        ("no-spill-realloc", {"SYNTH_SPILL_REALLOC": "0"}),
+    ]
+    elves = {}
+    for label, env in cfgs:
+        out = f"/tmp/gust390_{label}.elf"
+        compile_cfg(out, env)
+        elves[label] = load(out)
+
+    # 1. ENGAGEMENT: the SYNTH_NO_STACK_FWD lever must change gust_kernel's
+    # bytes (this fixture is where the #390 conditional-branch-transparent
+    # forwarding lives; an inert lever cannot pass).
+    if elves["default"][0] == elves["no-stack-fwd"][0]:
+        print("FAIL: default and SYNTH_NO_STACK_FWD opt-out emit identical bytes "
+              "on gust_kernel — the stack-fwd lever is not engaged")
+        sys.exit(1)
+    print("OK  default vs SYNTH_NO_STACK_FWD opt-out: gust bytes differ (lever engaged)")
+
+    fails = 0
+    for label, _ in cfgs:
+        text, lin_init, syms = elves[label]
+        for state, x, strict in CASES:
+            gt_ret, gt_mem = wasmtime_poll(state, x)
+            # Seed the unicorn state region on a COPY of the initial image.
+            lin = bytearray(lin_init) if lin_init else bytearray(LIN_SIZE)
+            lin[STATE_OFF:STATE_OFF + STATE_SPAN] = state
+            got_ret, got_mem = unicorn_call(text, bytes(lin), syms["gust_poll"], STATE_OFF, x)
+            if strict:
+                ok = got_ret == gt_ret and got_mem == gt_mem
+                verdict = "OK  " if ok else "FAIL"
+            elif got_ret == gt_ret and got_mem != gt_mem:
+                ok = True  # the documented #740 divergence, return still exact
+                verdict = "XF40"
+            elif got_ret == gt_ret and got_mem == gt_mem:
+                ok = False  # divergence gone: #740 fixed — promote to strict!
+                verdict = "FIXD"
+            else:
+                ok = False
+                verdict = "FAIL"
+            fails += 0 if ok else 1
+            tag = f"0x{got_ret:08X}" if isinstance(got_ret, int) else got_ret
+            memtag = "mem==" if got_mem == gt_mem else "mem!="
+            print(f"{verdict} gust_poll {label:16} x={x:>10} = {tag} "
+                  f"(wasmtime 0x{gt_ret:08X}) {memtag}"
+                  + ("" if strict else "  [known-divergent #740; FIXD ⇒ make strict]"))
+        for x in (0, 1, 0x7FFF, 0x12345678, 0xFFFF_FF00):
+            gt = wasmtime_mix(x)
+            got, _ = unicorn_call(text, lin_init, syms["gust_mix"], x, 0)
+            ok = got == gt
+            fails += 0 if ok else 1
+            tag = f"0x{got:08X}" if isinstance(got, int) else got
+            print(f"{'OK  ' if ok else 'FAIL'} gust_mix  {label:16} x={x:>10} = {tag} "
+                  f"(wasmtime 0x{gt:08X})")
+
+    print("\nRESULT:", "PASS" if not fails else f"FAIL ({fails} mismatches)")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
One measured, verified spill/reload reduction on the gust hot path (#390, VCR-RA lane of the v0.42.0 hub, epic #242).

## What

`forward_stack_reloads` is upgraded from single-store source forwarding to a **holder-lattice forward walk** (the `spill_forward_segment` stage-1 lattice): per frame slot, track every register provably holding the slot's value (feeding `str`, earlier reloads, reg-reg copies); a reload with a surviving holder becomes `mov` — or is **deleted** when its target already holds the value.

The unlock is that a **conditional branch is transparent** to the walk: it has no register/memory effect on the fall-through edge, and the taken edge cannot re-enter the window unseen — every label-form branch targets a `Label` (state reset) and every numeric branch's target is in the #606 geometry (or the function declines wholesale), so the feeding def still dominates each rewritten reload. That fires across the compare→branch ladders the direct selector emits for `br_if` chains — exactly gust_poll's dominant `spill_reload` shape (228 B / 31 % in `artifacts/size_attribution_390.md`). Joins, unconditional branches, calls, unmodeled ops, unpinnable `[sp]` accesses, `Push`/`Pop`, SP defs still reset all state; the #606 frozen-span byte-size discipline is unchanged.

## Before / after (bytes, default path, main v0.41.0 → this PR)

| function | before | after | Δ |
|---|---|---|---|
| **gust_poll** | **740** | **724** | **−16** (19 reloads forwarded/deleted; machine code −18 + 2 align pad) |
| control_step (frozen) | 314 | 308 | −6 |
| flight_seam_flat (frozen) | 1014 | 1010 | −4 |
| sret_decide | 776 | 762 | −14 |
| msgq_put_359 | 1232 | 1212 | −20 |
| loop_param_bound_663 | 486 | 476 | −10 |

Corpus sweep vs the main binary, 115 fixtures × 2 paths (default + `--relocatable`): **26 shrink, 0 grow, rest byte-identical**. gust_poll ratio vs LLVM: 3.56× → **3.48×**; `spill_reload` bucket 228 → 200 B (report regenerated).

## Correctness evidence (refreeze ritual — differentials BEFORE pins)

- **Full `scripts/repro/*_differential.py` sweep: 86/87 PASS** on the new bytes, including flight_seam flat+inlined `flight_algo` `0x07FDF307`, control_step, frame_slot_dce, const_cse, spill_rung_581, sret_decide (`--native-pointer-abi`), dyn_table_359, wake_path (gale gist), a32_i64_615. The one non-pass, `u64_unpack_riscv`, fails **identically with the main binary** (harness env; RV32 output is untouched by this ARM-only pass — RV32 frozen byte gates green).
- **New `scripts/repro/gust_spill_fwd_390_differential.py`**: gust_poll (return **and** post-call state-struct bytes) + gust_mix vs wasmtime under unicorn, in default + `SYNTH_NO_STACK_FWD=1` + `SYNTH_SPILL_REALLOC=0` — PASS. It also owns the stack-fwd flip-engagement byte check (moved from flight_seam_flat, where the levers now converge).
- **Flag-off byte-identical**: `frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes` passes with UNTOUCHED pins — `SYNTH_NO_STACK_FWD=1` still restores the pre-flip goldens byte-for-byte.
- **Frozen gate 10/10** after deliberate re-pins (default: control_step/flight_seam_flat; escape hatches for spill_realloc/const_cse/uxth/dead_frame re-derived because stack-fwd stays ON in those configs — tripwire semantics unchanged, provenance in the comments).
- `cargo test -p synth-cli -p synth-synthesis` green (59 suites, 0 failures), `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` green.

## Found & filed while gating (pre-existing, NOT introduced here)

**#740** — direct path mistargets gust_poll's loop-head empty-budget `br_if` to a mid-shape point (spurious `state+0x34` write + spurious transition/mix calls on the zero-budget round). Byte-identical divergence with the main binary in all three lever configs; unicorn trace in the issue. The new gust harness pins those two cases KNOWN-DIVERGENT with anti-vacuous xfail semantics (returns must still match; the cases hard-fail the moment #740 is fixed, forcing promotion to strict).

Also retired in `spill_realloc_242.rs`: the flight_seam "must shrink / ≥3 forwarded" firing claims — structurally unsatisfiable now that stack-fwd forwards those reloads first in both configs; non-vacuity is owned by the flat_flight stage-2/3 block (unchanged).

Refs #390, #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L