### PR TITLE
fix(#739): static ABOVE sp_init — relocate (never bake) + de-vacuate the in-range oracle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,15 @@ jobs:
       # calls).
       - name: Run f64 const/promote/arith/compare/mem + across-call oracle (#369, m7dp)
         run: SYNTH=./target/debug/synth python scripts/repro/f64_369_differential.py
+      # #739: static ABOVE sp_init under --shadow-stack-size — the sub-word
+      # load/store arms previously BAKED the linmem offset as an un-relocated
+      # MOVW/MOVT immediate (invisible to the #678 reloc-walking rebase AND to
+      # the reloc-walking in-range oracle, which passed on the miscompile — a
+      # vacuous gate, the #712-class lesson). Store/load through the above-SP
+      # static after the shrink must match wasmtime, with .bss/.data mapped at
+      # SEPARATE bases so a baked absolute offset cannot accidentally resolve.
+      - name: Run above-SP static shadow-stack-shrink oracle (#739, cortex-m3)
+        run: SYNTH=./target/debug/synth python scripts/repro/static_above_sp_739_differential.py
 
   fact-spec-oracle:
     name: fact-spec elision oracle (#494 phases 2 + 2b)

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -3307,6 +3307,67 @@ struct NativeGlobalsLayout {
     shadow_stack_size: Option<u32>,
 }
 
+/// #739: scan encoded Thumb-2 text for an UN-RELOCATED `MOVW`/`MOVT` pair (same
+/// `rd`) materializing a constant `k` in `[lo, hi)` — the baked static-region
+/// address class the `--shadow-stack-size` rebase cannot see.
+///
+/// This is the oracle-vacuity fix (the #712-class lesson: a gate that cannot
+/// SEE the access class it guards is a VACUOUS gate). The shrink's in-range /
+/// rebase walk covers RELOCATED accesses (`__synth_wasm_data + C`) only; a
+/// selector path that bakes the linmem offset as a plain immediate (`movw
+/// ip,#0xC; movt ip,#0x10` = 0x10000C, NO reloc — the #739 miscompile) is
+/// invisible to every reloc-walking check, so pre-fix the shrink shipped an
+/// un-rebased OOB access and still logged "all reservation accesses in-range".
+///
+/// `reloc_offsets` are the function's relocation offsets: a legitimate
+/// MovwAbs/MovtAbs symbol materialization carries relocations on the pair and
+/// is skipped. Any surviving un-relocated pair in the window is either the
+/// baked-offset bug class or a scalar VALUE coinciding with the window — both
+/// are declined LOUDLY by the caller (a rare false decline on a coincident
+/// scalar is sound; a silent OOB is not). Scope: PAIRS only — a pair is
+/// emitted only for constants > 0xFFFF, which covers any 64 KiB+ `sp_init`
+/// (including the meld `--memory shared` 1 MiB geometry of #739); offsets
+/// below 64 KiB bake as a lone MOVW and are held out of this scan (a
+/// lone-MOVW window would false-positive on `MOVW+MVN` inverted-constant
+/// materializations) — that sub-window is guarded by the selector-side
+/// static classification itself.
+///
+/// Returns the text offset and the materialized constant of the first hit.
+fn find_baked_static_movw_movt(
+    code: &[u8],
+    reloc_offsets: &[u32],
+    lo: u32,
+    hi: u32,
+) -> Option<(usize, u32)> {
+    // Thumb-2 MOVW (T3) / MOVT (T1) imm16 = imm4:i:imm3:imm8.
+    fn imm16(code: &[u8], off: usize) -> u32 {
+        let hw1 = u16::from_le_bytes([code[off], code[off + 1]]) as u32;
+        let hw2 = u16::from_le_bytes([code[off + 2], code[off + 3]]) as u32;
+        ((hw1 & 0xF) << 12) | (((hw1 >> 10) & 1) << 11) | (((hw2 >> 12) & 0x7) << 8) | (hw2 & 0xFF)
+    }
+    let mut off = 0usize;
+    while off + 8 <= code.len() {
+        // MOVW (hw1 & 0xFBF0 == 0xF240) immediately followed by MOVT
+        // (hw1 & 0xFBF0 == 0xF2C0) on the same rd — the selector's
+        // full-constant materialization shape.
+        let hw1_w = u16::from_le_bytes([code[off], code[off + 1]]);
+        let hw1_t = u16::from_le_bytes([code[off + 4], code[off + 5]]);
+        let rd_w = (u16::from_le_bytes([code[off + 2], code[off + 3]]) >> 8) & 0xF;
+        let rd_t = (u16::from_le_bytes([code[off + 6], code[off + 7]]) >> 8) & 0xF;
+        if hw1_w & 0xFBF0 == 0xF240 && hw1_t & 0xFBF0 == 0xF2C0 && rd_w == rd_t {
+            let k = (imm16(code, off + 4) << 16) | imm16(code, off);
+            let has_reloc = reloc_offsets
+                .iter()
+                .any(|&r| (r as usize) < off + 8 && off < (r + 4) as usize);
+            if !has_reloc && k >= lo && k < hi {
+                return Some((off, k));
+            }
+        }
+        off += 2;
+    }
+    None
+}
+
 fn build_relocatable_elf(
     funcs: &[ElfFunction],
     imports: &[ImportEntry],
@@ -3379,6 +3440,25 @@ fn build_relocatable_elf(
         .flat_map(|f| &f.relocations)
         .any(|r| r.symbol == "__synth_wasm_data" || r.symbol == "__synth_globals");
     let emit_wasm_data = needs_wasm_data && linear_memory_bytes > 0;
+    // #739: `--shadow-stack-size` on a module whose generated code carries NO
+    // `__synth_wasm_data`/`__synth_globals` relocation would silently skip
+    // BOTH the region emission and the shrink (`native_layout` = None below).
+    // The pre-fix #739 fixture hit exactly this: every static access was
+    // BAKED (un-relocated), so the object shipped with its 1 MiB of statics
+    // dropped, the SP global gone, and the flag ignored — vacuously "green".
+    // Refuse loudly instead: the integrator asked to shrink a reservation
+    // that the emitted code never references.
+    if let Some(ng) = &native_globals
+        && ng.shadow_stack_size.is_some()
+        && !emit_wasm_data
+    {
+        anyhow::bail!(
+            "--shadow-stack-size: no __synth_wasm_data/__synth_globals relocation \
+             reaches the native-pointer region (linear memory {linear_memory_bytes} B), \
+             so there is no reservation to shrink — refusing rather than silently \
+             ignoring the flag. VCR-MEM-001/#739."
+        );
+    }
     // #237 (gale, mutex-on-silicon): under the native-pointer ABI the region
     // is sized to the USED extent — data-segment end + shadow stack (the SP
     // global's init is the stack top; the stack grows down inside the
@@ -3728,6 +3808,46 @@ fn build_relocatable_elf(
                     }
                     let new_c = c - down;
                     all_code[pos..pos + 4].copy_from_slice(&new_c.to_le_bytes());
+                }
+            }
+            // #739 oracle-vacuity fix (the #712-class lesson: a gate that
+            // cannot SEE the access class it guards is a VACUOUS gate — it
+            // passed green on a live miscompile). The in-range/rebase walk
+            // above covers RELOCATED static accesses only (`__synth_wasm_data
+            // + C`). A selector path that BAKES a static-region address as a
+            // plain un-relocated `MOVW/MOVT` immediate (the #739 miscompile:
+            // `movw ip,#0xC; movt ip,#0x10` = 0x10000C with no reloc) is
+            // invisible to every reloc-walking check, so the shrink would ship
+            // an un-rebased OOB access and still log "all reservation accesses
+            // in-range". Scan the encoded Thumb-2 text for un-relocated
+            // MOVW/MOVT pairs (same rd) that materialize a constant inside the
+            // original static region `[sp_init, linear_memory_bytes)`: the
+            // selector relocates every static-region ADDRESS it emits (LdrSym
+            // literal pool / MovwSym+MovtSym, all reloc-carrying), so any such
+            // un-relocated pair is either the baked-offset bug class or a
+            // scalar VALUE that happens to fall in the window — both decline
+            // LOUDLY (a rare false decline on a coincident scalar is sound; a
+            // silent OOB is not). Scope: pairs only — a pair is emitted only
+            // for constants > 0xFFFF, which covers any 64 KiB+ sp_init
+            // (including the meld `--memory shared` 1 MiB geometry #739 is
+            // about); offsets below 64 KiB bake as a lone MOVW and are held
+            // out of this scan (a lone-MOVW window would false-positive on
+            // MOVW+MVN inverted-constant materializations) — that sub-window
+            // is guarded by the selector-side classification itself.
+            for func in funcs.iter() {
+                let reloc_offsets: Vec<u32> = func.relocations.iter().map(|r| r.offset).collect();
+                if let Some((off, k)) =
+                    find_baked_static_movw_movt(&func.code, &reloc_offsets, sp, linear_memory_bytes)
+                {
+                    anyhow::bail!(
+                        "--shadow-stack-size: the encoded text bakes the static-region \
+                         address {k:#x} (>= sp_init {sp:#x}, < linear memory \
+                         {linear_memory_bytes:#x}) as an un-relocated MOVW/MOVT \
+                         immediate at text offset {off:#x} — the rebase walks \
+                         relocations and CANNOT re-base it, so the shrunk layout \
+                         would access out of range (silent miscompile, #739). \
+                         Refusing. VCR-MEM-001/#739."
+                    );
                 }
             }
             // Re-base the shadow-stack global slot(s): every MUTABLE global whose
@@ -5749,6 +5869,66 @@ fn link_firmware(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- #739: baked static-region MOVW/MOVT scan (oracle-vacuity fix) --------
+
+    /// The EXACT pre-fix miscompile bytes (from the #739 red disasm):
+    /// `movw r12,#0xc; movt r12,#0x10` = 0x10000C, no relocation. The scan
+    /// must see it — this is the access class the reloc-walking in-range
+    /// oracle was blind to (vacuous gate, the #712-class lesson).
+    const BAKED_10000C: [u8; 8] = [0x40, 0xF2, 0x0C, 0x0C, 0xC0, 0xF2, 0x10, 0x0C];
+
+    #[test]
+    fn baked_static_pair_is_detected_739() {
+        assert_eq!(
+            find_baked_static_movw_movt(&BAKED_10000C, &[], 0x100000, 0x110000),
+            Some((0, 0x10000C)),
+            "the pre-fix baked 0x10000C pair must be flagged"
+        );
+    }
+
+    /// A relocation covering the pair marks it as a legitimate
+    /// MovwAbs/MovtAbs symbol materialization — not flagged.
+    #[test]
+    fn relocated_pair_is_not_flagged_739() {
+        assert_eq!(
+            find_baked_static_movw_movt(&BAKED_10000C, &[0], 0x100000, 0x110000),
+            None
+        );
+        // A reloc on the MOVT half alone also covers the pair.
+        assert_eq!(
+            find_baked_static_movw_movt(&BAKED_10000C, &[4], 0x100000, 0x110000),
+            None
+        );
+    }
+
+    /// Constants outside `[lo, hi)` (scalars below sp_init, host pointers past
+    /// the linear memory) never fire.
+    #[test]
+    fn out_of_window_pair_is_not_flagged_739() {
+        assert_eq!(
+            find_baked_static_movw_movt(&BAKED_10000C, &[], 0x200000, 0x300000),
+            None,
+            "below-window constant must not be flagged"
+        );
+        assert_eq!(
+            find_baked_static_movw_movt(&BAKED_10000C, &[], 0x100000, 0x10000C),
+            None,
+            "hi bound is exclusive"
+        );
+    }
+
+    /// A MOVW/MOVT with DIFFERENT destination registers is two unrelated
+    /// materializations, not a 32-bit constant — never flagged.
+    #[test]
+    fn mismatched_rd_pair_is_not_flagged_739() {
+        let mut bytes = BAKED_10000C;
+        bytes[7] = 0x05; // movt r5 instead of r12
+        assert_eq!(
+            find_baked_static_movw_movt(&bytes, &[], 0x100000, 0x110000),
+            None
+        );
+    }
 
     // ---- #543 Phase 1: `--volatile-segment` parsing ---------------------------
 

--- a/crates/synth-cli/tests/static_above_sp_739.rs
+++ b/crates/synth-cli/tests/static_above_sp_739.rs
@@ -1,0 +1,248 @@
+//! #739 — static ABOVE `sp_init` must be RELOCATED (and thereby re-based by
+//! the #678 `--shadow-stack-size` down-shift), never BAKED as an un-relocated
+//! MOVW/MOVT linmem offset.
+//!
+//! A meld `--memory shared` fused node places component statics ABOVE the
+//! shared SP (17-page linmem, SP init 0x100000, statics at 0x10000C+). The
+//! wit-bindgen byte-copy shape — DYNAMIC index + static-region memarg offset
+//! on a sub-word load/store — previously fell through to the raw
+//! `[R11 + addr + #offset]` lowering, baking `movw ip,#0xC; movt ip,#0x10`
+//! (no relocation). The reloc-walking #678 rebase never touched it, and the
+//! reloc-walking post-link in-range oracle passed anyway (vacuous, the
+//! #712-class lesson) → silent OOB on the shrunk reservation.
+//!
+//! Execution differential: `scripts/repro/static_above_sp_739_differential.py`
+//! (unicorn vs wasmtime, `.bss`/`.data` at separate bases, R11 = 0).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use object::{Object, ObjectSection, ObjectSymbol, RelocationTarget};
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn repro(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro")
+        .join(name)
+}
+
+fn compile(fixture: &str, extra: &[&str], out: &str) -> std::process::Output {
+    let fx = repro(fixture);
+    let mut args = vec![
+        "compile",
+        fx.to_str().unwrap(),
+        "--target",
+        "cortex-m3",
+        "--native-pointer-abi",
+        "--all-exports",
+        "--relocatable",
+        "-o",
+        out,
+    ];
+    args.extend_from_slice(extra);
+    Command::new(synth())
+        .args(&args)
+        .output()
+        .expect("run synth")
+}
+
+fn parse<'a>(bytes: &'a [u8]) -> object::File<'a> {
+    object::File::parse(bytes).expect("parse ELF")
+}
+
+/// All in-place REL addends of `__synth_wasm_data` R_ARM_ABS32 relocs.
+fn wasm_data_addends(path: &str) -> Vec<u32> {
+    let bytes = std::fs::read(path).expect("read .o");
+    let obj = parse(&bytes);
+    let text = obj.section_by_name(".text").expect(".text");
+    let text_data = text.data().expect("text data");
+    let mut addends = Vec::new();
+    for (off, reloc) in text.relocations() {
+        if let RelocationTarget::Symbol(sidx) = reloc.target() {
+            let sym = obj.symbol_by_index(sidx).expect("sym");
+            if sym.name() == Ok("__synth_wasm_data") {
+                let p = off as usize;
+                addends.push(u32::from_le_bytes(text_data[p..p + 4].try_into().unwrap()));
+            }
+        }
+    }
+    addends
+}
+
+fn bss_size(path: &str) -> u64 {
+    let bytes = std::fs::read(path).expect("read .o");
+    let obj = parse(&bytes);
+    obj.sections()
+        .find(|s| s.name() == Ok(".bss"))
+        .expect(".bss present")
+        .size()
+}
+
+/// TRUE if `.text` contains an un-relocated MOVW/MOVT pair (same rd)
+/// materializing a constant in `[lo, hi)` — the baked-offset signature the
+/// #739 miscompile shipped (`movw ip,#0xC; movt ip,#0x10` = 0x10000C).
+fn has_baked_pair_in_window(path: &str, lo: u32, hi: u32) -> bool {
+    let bytes = std::fs::read(path).expect("read .o");
+    let obj = parse(&bytes);
+    let text = obj.section_by_name(".text").expect(".text");
+    let code = text.data().expect("text data");
+    let reloc_offsets: Vec<u64> = text.relocations().map(|(off, _)| off).collect();
+    let imm16 = |off: usize| -> u32 {
+        let hw1 = u16::from_le_bytes([code[off], code[off + 1]]) as u32;
+        let hw2 = u16::from_le_bytes([code[off + 2], code[off + 3]]) as u32;
+        ((hw1 & 0xF) << 12) | (((hw1 >> 10) & 1) << 11) | (((hw2 >> 12) & 0x7) << 8) | (hw2 & 0xFF)
+    };
+    let mut off = 0usize;
+    while off + 8 <= code.len() {
+        let hw1_w = u16::from_le_bytes([code[off], code[off + 1]]);
+        let hw1_t = u16::from_le_bytes([code[off + 4], code[off + 5]]);
+        let rd_w = (u16::from_le_bytes([code[off + 2], code[off + 3]]) >> 8) & 0xF;
+        let rd_t = (u16::from_le_bytes([code[off + 6], code[off + 7]]) >> 8) & 0xF;
+        if hw1_w & 0xFBF0 == 0xF240 && hw1_t & 0xFBF0 == 0xF2C0 && rd_w == rd_t {
+            let k = (imm16(off + 4) << 16) | imm16(off);
+            let covered = reloc_offsets
+                .iter()
+                .any(|&r| (r as usize) < off + 8 && off < (r + 4) as usize);
+            if !covered && k >= lo && k < hi {
+                return true;
+            }
+        }
+        off += 2;
+    }
+    false
+}
+
+const SP_INIT: u32 = 1_048_576; // 0x100000
+const LINMEM: u32 = 1_114_112; // 17 pages
+const BSS_STATIC: u32 = 1_048_588; // 0x10000C, above sp_init
+const BUDGET: u32 = 2048;
+
+/// RED before the fix (the object carried ZERO relocations — the sub-word
+/// accesses baked 0x10000C/0x100020 as plain MOVW/MOVT immediates and the
+/// whole native-pointer region was silently dropped) / GREEN after: the
+/// above-SP BSS static relocates as `__synth_wasm_data + 0x10000C` and the
+/// #678 shrink down-shifts it to `budget + 12 = 2060`.
+#[test]
+fn above_sp_static_relocates_and_downshifts_739() {
+    let out = compile(
+        "mem739_above_sp.wat",
+        &["--shadow-stack-size", "2048"],
+        "/tmp/mem739_shrunk_test.o",
+    );
+    assert!(
+        out.status.success(),
+        "must compile: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let addends = wasm_data_addends("/tmp/mem739_shrunk_test.o");
+    assert!(
+        addends.contains(&(BUDGET + (BSS_STATIC - SP_INIT))),
+        "above-SP static must down-shift to budget + 12 = 2060, got addends {addends:?}"
+    );
+    // Reservation = budget + above-SP tail — nowhere near the 1 MiB page.
+    let bss = bss_size("/tmp/mem739_shrunk_test.o");
+    assert!(
+        (BUDGET as u64..=(BUDGET + 4096) as u64).contains(&bss),
+        ".bss must be the shrunk reservation, got {bss}"
+    );
+    // The #739 signature itself: NO un-relocated MOVW/MOVT pair may
+    // materialize a static-region address (post-shrink window starts at the
+    // budget — anything at/above it is un-rebased).
+    assert!(
+        !has_baked_pair_in_window("/tmp/mem739_shrunk_test.o", BUDGET, LINMEM),
+        "un-relocated baked static-region MOVW/MOVT pair survived the shrink"
+    );
+}
+
+/// The relocation fix stands on its own (no shrink): the above-SP static must
+/// be `__synth_wasm_data + 0x10000C`, never a baked immediate — a baked
+/// absolute linmem offset mis-addresses as soon as the linker places the
+/// region anywhere.
+#[test]
+fn above_sp_static_relocates_without_shrink_739() {
+    let out = compile("mem739_above_sp.wat", &[], "/tmp/mem739_noshrink_test.o");
+    assert!(
+        out.status.success(),
+        "must compile: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let addends = wasm_data_addends("/tmp/mem739_noshrink_test.o");
+    assert!(
+        addends.contains(&BSS_STATIC),
+        "above-SP static must relocate as __synth_wasm_data + 0x10000C, got {addends:?}"
+    );
+    assert!(
+        !has_baked_pair_in_window("/tmp/mem739_noshrink_test.o", SP_INIT, LINMEM),
+        "un-relocated baked static-region MOVW/MOVT pair in the un-shrunk object"
+    );
+}
+
+/// #739 flag-honesty: `--shadow-stack-size` on a module whose code never
+/// references the native-pointer region (no `__synth_wasm_data` /
+/// `__synth_globals` reloc) must refuse LOUDLY — pre-fix it was silently
+/// ignored (no region, no shrink, no diagnostic).
+#[test]
+fn shadow_stack_size_without_region_refuses_739() {
+    let out = compile(
+        "mem739_no_static.wat",
+        &["--shadow-stack-size", "2048"],
+        "/tmp/mem739_no_static_test.o",
+    );
+    assert!(
+        !out.status.success(),
+        "--shadow-stack-size with no reservation must refuse, not silently no-op"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("#739") && stderr.contains("no reservation to shrink"),
+        "refusal must name the hole: {stderr}"
+    );
+}
+
+/// i64 accesses with a static-region memarg offset are not yet relocated —
+/// they must DECLINE loudly (function loud-skips), never bake. Pre-fix this
+/// shape silently miscompiled exactly like the sub-word case.
+#[test]
+fn i64_static_offset_declines_loudly_739() {
+    let dir = std::env::temp_dir().join("mem739_i64_test");
+    std::fs::create_dir_all(&dir).unwrap();
+    let wat = dir.join("i64_above_sp.wat");
+    std::fs::write(
+        &wat,
+        r#"(module
+  (memory (export "memory") 17)
+  (global $sp (mut i32) (i32.const 1048576))
+  (func (export "run") (param i32) (result i32)
+    local.get 0
+    i64.load offset=1048584
+    i32.wrap_i64))"#,
+    )
+    .unwrap();
+    let out = Command::new(synth())
+        .args([
+            "compile",
+            wat.to_str().unwrap(),
+            "--target",
+            "cortex-m3",
+            "--native-pointer-abi",
+            "--all-exports",
+            "--relocatable",
+            "-o",
+            dir.join("i64_above_sp.o").to_str().unwrap(),
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        !out.status.success(),
+        "single-function module with an i64 static-region access must not emit"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("#739") && stderr.contains("declining"),
+        "decline must be loud and name #739: {stderr}"
+    );
+}

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -3439,6 +3439,25 @@ impl InstructionSelector {
         (self.wasm_data_base <= addr && addr < self.linear_memory_bytes).then_some(addr as i32)
     }
 
+    /// #739: TRUE when a memory access's constant memarg `offset` lands in the
+    /// static-data region under the native-pointer ABI (a meld
+    /// `--memory shared` fused node places component statics ABOVE the shared
+    /// SP, so wit-bindgen byte copies carry `offset >= sp_init` memargs).
+    ///
+    /// Such an access must NEVER reach the raw `[R11 + addr + #offset]`
+    /// lowering: that BAKES the wasm linmem offset as a plain `MOVW/MOVT`
+    /// immediate — carrying NO relocation — so (a) it mis-addresses as soon as
+    /// the linker places the `__synth_wasm_data` region anywhere, and (b) it is
+    /// invisible to the `--shadow-stack-size` static down-shift (#678) and the
+    /// post-link in-range oracle, which walk RELOCATIONS (the #739 silent OOB
+    /// miscompile). Callers either relocate the base via
+    /// [`Self::emit_wasm_data_addr`] (i32 word + sub-word accesses) or decline
+    /// loudly with a typed `Err` (i64 pair accesses, not yet relocated) —
+    /// never bake.
+    fn is_native_pointer_static_offset(&self, offset: u32) -> bool {
+        self.native_pointer_abi && self.wasm_data_base > 0 && offset >= self.wasm_data_base
+    }
+
     /// #237: register the stack-pointer global discovered by the backend. Its
     /// initializer doubles as the static-data base (`wasm_data_base`), so const
     /// addresses at/above it relocate while frame-size scalars below it don't.
@@ -10184,7 +10203,16 @@ impl InstructionSelector {
 
                     if let Some(eff_offset) = folded {
                         Self::drop_prev_const_materialization(&mut instructions, idx - 1);
-                        let mem = MemAddr::imm(Reg::R11, eff_offset as i32);
+                        // #739: same static-region classification as I32Load —
+                        // a folded const address in the static region must be
+                        // relocated (`__synth_wasm_data + C`), never baked as a
+                        // raw `[R11, #imm]` offset.
+                        let mem = if let Some(addend) = self.static_data_addend(eff_offset) {
+                            Self::emit_wasm_data_addr(&mut instructions, dst, addend, idx);
+                            MemAddr::imm(dst, 0)
+                        } else {
+                            MemAddr::imm(Reg::R11, eff_offset as i32)
+                        };
                         let arm_op = match (access_size, sign_extend) {
                             (1, false) => ArmOp::Ldrb { rd: dst, addr: mem },
                             (1, true) => ArmOp::Ldrsb { rd: dst, addr: mem },
@@ -10196,6 +10224,49 @@ impl InstructionSelector {
                             op: arm_op,
                             source_line: Some(idx),
                         });
+                    } else if self.is_native_pointer_static_offset(*offset) {
+                        // #739 (gale's gust:os buffer node): a DYNAMIC-index
+                        // sub-word load whose constant memarg `offset` lands in
+                        // the static-data region. Pre-fix this fell through to
+                        // the raw `[R11 + addr + #offset]` path below, BAKING
+                        // the 1 MiB-region linmem offset as an un-relocated
+                        // `MOVW/MOVT ip` immediate — invisible to the #678
+                        // `--shadow-stack-size` rebase (which walks relocations)
+                        // → silent OOB on the shrunk reservation. Relocate the
+                        // base to `__synth_wasm_data + offset` (the ELF builder
+                        // retargets it to the owning segment symbol) and add the
+                        // dynamic index — exactly the I32Load #359 branch, with
+                        // the sub-word LDR form.
+                        let base = alloc_temp_or_spill(
+                            &mut next_temp,
+                            &mut stack,
+                            &mut instructions,
+                            &mut spill,
+                            &[live_params.as_slice(), &[addr, dst]].concat(),
+                            idx,
+                        )?;
+                        Self::emit_wasm_data_addr(&mut instructions, base, *offset as i32, idx);
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Add {
+                                rd: base,
+                                rn: base,
+                                op2: Operand2::Reg(addr),
+                            },
+                            source_line: Some(idx),
+                        });
+                        let mem = MemAddr::imm(base, 0);
+                        let arm_op = match (access_size, sign_extend) {
+                            (1, false) => ArmOp::Ldrb { rd: dst, addr: mem },
+                            (1, true) => ArmOp::Ldrsb { rd: dst, addr: mem },
+                            (2, false) => ArmOp::Ldrh { rd: dst, addr: mem },
+                            (2, true) => ArmOp::Ldrsh { rd: dst, addr: mem },
+                            _ => unreachable!(),
+                        };
+                        instructions.push(ArmInstruction {
+                            op: arm_op,
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
                     } else {
                         let load_ops = self.generate_subword_load_with_bounds_check(
                             dst,
@@ -10247,7 +10318,23 @@ impl InstructionSelector {
                             idx - 2,
                             idx - 1,
                         );
-                        let mem = MemAddr::imm(Reg::R11, eff_offset as i32);
+                        // #739: same static-region classification as I32Store —
+                        // a folded const address in the static region must be
+                        // relocated, never baked as a raw `[R11, #imm]` offset.
+                        let mem = if let Some(addend) = self.static_data_addend(eff_offset) {
+                            let a = alloc_temp_or_spill(
+                                &mut next_temp,
+                                &mut stack,
+                                &mut instructions,
+                                &mut spill,
+                                &[live_params.as_slice(), &[value]].concat(),
+                                idx,
+                            )?;
+                            Self::emit_wasm_data_addr(&mut instructions, a, addend, idx);
+                            MemAddr::imm(a, 0)
+                        } else {
+                            MemAddr::imm(Reg::R11, eff_offset as i32)
+                        };
                         let arm_op = match access_size {
                             1 => ArmOp::Strb {
                                 rd: value,
@@ -10263,6 +10350,48 @@ impl InstructionSelector {
                             op: arm_op,
                             source_line: Some(idx),
                         });
+                    } else if self.is_native_pointer_static_offset(*offset) {
+                        // #739 (symmetric to the sub-word load): a dynamic-index
+                        // sub-word store into the static-data region must
+                        // relocate its base to `__synth_wasm_data + offset` +
+                        // the dynamic index — the raw path below would bake the
+                        // linmem offset as an un-relocated MOVW/MOVT immediate
+                        // (silent OOB once `--shadow-stack-size` shrinks the
+                        // reservation; the store lands in unmapped memory).
+                        let base = alloc_temp_or_spill(
+                            &mut next_temp,
+                            &mut stack,
+                            &mut instructions,
+                            &mut spill,
+                            &[live_params.as_slice(), &[addr, value]].concat(),
+                            idx,
+                        )?;
+                        Self::emit_wasm_data_addr(&mut instructions, base, *offset as i32, idx);
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Add {
+                                rd: base,
+                                rn: base,
+                                op2: Operand2::Reg(addr),
+                            },
+                            source_line: Some(idx),
+                        });
+                        let mem = MemAddr::imm(base, 0);
+                        let arm_op = match access_size {
+                            1 => ArmOp::Strb {
+                                rd: value,
+                                addr: mem,
+                            },
+                            2 => ArmOp::Strh {
+                                rd: value,
+                                addr: mem,
+                            },
+                            _ => unreachable!(),
+                        };
+                        instructions.push(ArmInstruction {
+                            op: arm_op,
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
                     } else {
                         let store_ops = self.generate_subword_store_with_bounds_check(
                             value,
@@ -10293,6 +10422,21 @@ impl InstructionSelector {
                 | I64Load16U { offset, .. }
                 | I64Load32S { offset, .. }
                 | I64Load32U { offset, .. } => {
+                    // #739: a static-region memarg offset must not reach the
+                    // raw `[R11 + addr + #offset]` lowering below — it would
+                    // bake an un-relocated linmem offset (invisible to the
+                    // #678 `--shadow-stack-size` rebase → silent OOB). The i64
+                    // pair lowering does not yet model the relocated base;
+                    // decline loudly (the function loud-skips), never bake.
+                    if self.is_native_pointer_static_offset(*offset) {
+                        return Err(synth_core::Error::synthesis(format!(
+                            "#739: i64 sub-word load with static-region memarg offset {offset} \
+                             (>= wasm_data_base {}) under the native-pointer ABI is not yet \
+                             relocated — declining rather than baking an un-rebased linmem \
+                             offset",
+                            self.wasm_data_base
+                        )));
+                    }
                     let addr = pop_operand(
                         &mut stack,
                         &mut next_temp,
@@ -10414,6 +10558,17 @@ impl InstructionSelector {
                 I64Store8 { offset, .. }
                 | I64Store16 { offset, .. }
                 | I64Store32 { offset, .. } => {
+                    // #739: see the i64 sub-word load arm — decline loudly,
+                    // never bake an un-relocated static-region offset.
+                    if self.is_native_pointer_static_offset(*offset) {
+                        return Err(synth_core::Error::synthesis(format!(
+                            "#739: i64 sub-word store with static-region memarg offset {offset} \
+                             (>= wasm_data_base {}) under the native-pointer ABI is not yet \
+                             relocated — declining rather than baking an un-rebased linmem \
+                             offset",
+                            self.wasm_data_base
+                        )));
+                    }
                     // Pop i64 value (lo register) and address
                     let value_lo = pop_operand(
                         &mut stack,
@@ -12597,6 +12752,17 @@ impl InstructionSelector {
                 }
 
                 I64Load { offset, .. } => {
+                    // #739: see the i64 sub-word load arm — decline loudly,
+                    // never bake an un-relocated static-region offset.
+                    if self.is_native_pointer_static_offset(*offset) {
+                        return Err(synth_core::Error::synthesis(format!(
+                            "#739: i64.load with static-region memarg offset {offset} \
+                             (>= wasm_data_base {}) under the native-pointer ABI is not yet \
+                             relocated — declining rather than baking an un-rebased linmem \
+                             offset",
+                            self.wasm_data_base
+                        )));
+                    }
                     // Pop address from stack
                     let addr = pop_operand(
                         &mut stack,
@@ -12635,6 +12801,17 @@ impl InstructionSelector {
                 }
 
                 I64Store { offset, .. } => {
+                    // #739: see the i64 sub-word load arm — decline loudly,
+                    // never bake an un-relocated static-region offset.
+                    if self.is_native_pointer_static_offset(*offset) {
+                        return Err(synth_core::Error::synthesis(format!(
+                            "#739: i64.store with static-region memarg offset {offset} \
+                             (>= wasm_data_base {}) under the native-pointer ABI is not yet \
+                             relocated — declining rather than baking an un-rebased linmem \
+                             offset",
+                            self.wasm_data_base
+                        )));
+                    }
                     // WASM i64.store pops: value first, then address
                     let value_lo = pop_operand(
                         &mut stack,
@@ -24544,6 +24721,111 @@ mod tests {
         assert!(
             !off.iter().any(is_data_sym),
             "without a static-data base the dynamic access stays base-relative. got: {off:#?}"
+        );
+    }
+
+    /// #739: the SUB-WORD twins of #359 — a dynamic-index `i32.load8_u` /
+    /// `i32.store8` whose constant memarg `offset` lands in the static-data
+    /// region (meld `--memory shared` places fused-component statics ABOVE the
+    /// shared SP: 17-page linmem, sp_init 0x100000, static at 0x10000C). The
+    /// word-sized I32Load/I32Store had the relocated branch since #359; the
+    /// sub-word arms fell through to the raw path and BAKED
+    /// `movw ip,#0xC; movt ip,#0x10` — un-relocated, invisible to the #678
+    /// `--shadow-stack-size` rebase → silent OOB. Both must relocate via
+    /// `LdrSym __synth_wasm_data` + dynamic-index Add, and NEVER materialize
+    /// the raw offset as a plain Movw/Movt immediate.
+    #[test]
+    fn test_739_dynamic_subword_static_offset_is_relocated() {
+        let db = RuleDatabase::new();
+        let is_data_sym = |i: &ArmInstruction| matches!(&i.op, ArmOp::LdrSym { symbol, .. } if symbol == "__synth_wasm_data");
+        // (memory 17) = 1114112 bytes; sp_init = 0x100000; static at 0x10000C.
+        let load_ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32Load8U {
+                offset: 1048588,
+                align: 0,
+            },
+            WasmOp::End,
+        ];
+        let mut sel = InstructionSelector::new(db.rules().to_vec());
+        sel.set_relocatable(true);
+        sel.set_native_pointer_abi(true, 1114112);
+        sel.set_native_pointer_stack(0, 1048576);
+        let ln = sel.select_with_stack(&load_ops, 1).unwrap();
+        assert!(
+            ln.iter().any(is_data_sym),
+            "dynamic sub-word static load must relocate via LdrSym __synth_wasm_data. got: {ln:#?}"
+        );
+        assert!(
+            !ln.iter().any(
+                |i| matches!(&i.op, ArmOp::Movt { imm16, .. } if *imm16 == (1048588 >> 16) as u16)
+            ),
+            "the static offset must NOT be baked as a Movt immediate (#739). got: {ln:#?}"
+        );
+
+        let store_ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32Const(42),
+            WasmOp::I32Store8 {
+                offset: 1048588,
+                align: 0,
+            },
+            WasmOp::End,
+        ];
+        let mut sel_s = InstructionSelector::new(db.rules().to_vec());
+        sel_s.set_relocatable(true);
+        sel_s.set_native_pointer_abi(true, 1114112);
+        sel_s.set_native_pointer_stack(0, 1048576);
+        let sn = sel_s.select_with_stack(&store_ops, 1).unwrap();
+        assert!(
+            sn.iter().any(is_data_sym),
+            "dynamic sub-word static store must relocate via LdrSym __synth_wasm_data. got: {sn:#?}"
+        );
+        assert!(
+            sn.iter().any(|i| matches!(&i.op, ArmOp::Strb { .. })),
+            "store8 must still emit STRB. got: {sn:#?}"
+        );
+    }
+
+    /// #739: i64 accesses with a static-region memarg offset are not yet
+    /// relocated — they must DECLINE with a typed Err (loud-skip), never fall
+    /// through to the raw path and bake the offset (silent OOB).
+    #[test]
+    fn test_739_i64_static_offset_declines_loudly() {
+        let db = RuleDatabase::new();
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I64Load {
+                offset: 1048584,
+                align: 3,
+            },
+            WasmOp::End,
+        ];
+        let mut sel = InstructionSelector::new(db.rules().to_vec());
+        sel.set_relocatable(true);
+        sel.set_native_pointer_abi(true, 1114112);
+        sel.set_native_pointer_stack(0, 1048576);
+        let err = sel.select_with_stack(&ops, 1).unwrap_err();
+        assert!(
+            err.to_string().contains("#739"),
+            "i64 static-region access must decline loudly naming #739. got: {err}"
+        );
+        // Below the static base the raw path is untouched (frozen behavior).
+        let low_ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I64Load {
+                offset: 8,
+                align: 3,
+            },
+            WasmOp::End,
+        ];
+        let mut sel_low = InstructionSelector::new(db.rules().to_vec());
+        sel_low.set_relocatable(true);
+        sel_low.set_native_pointer_abi(true, 1114112);
+        sel_low.set_native_pointer_stack(0, 1048576);
+        assert!(
+            sel_low.select_with_stack(&low_ops, 1).is_ok(),
+            "below-base i64 access must keep compiling"
         );
     }
 

--- a/scripts/repro/mem739_above_sp.wat
+++ b/scripts/repro/mem739_above_sp.wat
@@ -1,0 +1,34 @@
+(module
+  ;; #739: meld-fused shared-memory geometry — 17-page (1088 KiB) linear
+  ;; memory, one __stack_pointer global init 0x100000 (1 MiB), and statics
+  ;; ABOVE sp_init (meld `--memory shared` places a fused component's data
+  ;; above the shared SP).
+  ;;
+  ;; The access shape is the wit-bindgen byte-copy one: a DYNAMIC index in a
+  ;; register plus a STATIC-REGION memarg offset on a sub-word load/store.
+  ;; Pre-fix the selector lowered these through the raw
+  ;; `[R11 + addr + #offset]` path, baking the 1 MiB linmem offset as a plain
+  ;; `movw/movt ip` immediate (NO relocation) — invisible to the
+  ;; `--shadow-stack-size` rebase (#678) and to the post-link in-range
+  ;; oracle, i.e. the #739 silent OOB miscompile.
+  (memory (export "memory") 17)
+  (global $sp (mut i32) (i32.const 1048576))
+  ;; An initialized (data) segment ABOVE sp_init at 0x100020 (the "log
+  ;; buffer that correctly lives in .data").
+  (data (i32.const 1048608) "\11\22\33\44")
+  ;; BSS static above sp_init at 0x10000C: store a computed byte through the
+  ;; dynamic-index + static-offset shape, then read it back.
+  (func (export "run") (param i32) (result i32)
+    local.get 0
+    local.get 0
+    i32.const 2
+    i32.mul
+    i32.const 43
+    i32.add
+    i32.store8 offset=1048588
+    local.get 0
+    i32.load8_u offset=1048588)
+  ;; .data static above sp_init: byte read from the initialized segment.
+  (func (export "peek_data") (param i32) (result i32)
+    local.get 0
+    i32.load8_u offset=1048608))

--- a/scripts/repro/mem739_no_static.wat
+++ b/scripts/repro/mem739_no_static.wat
@@ -1,0 +1,13 @@
+(module
+  ;; #739 companion: an SP global + 17-page memory but NO static/global access
+  ;; in the code — the generated object carries no __synth_wasm_data /
+  ;; __synth_globals relocation, so there is no native-pointer region and
+  ;; nothing for --shadow-stack-size to shrink. Pre-fix this shape compiled
+  ;; "green" with the flag SILENTLY ignored (and, on the #739 fixture, with
+  ;; 1 MiB of statics dropped); post-fix it must refuse loudly.
+  (memory (export "memory") 17)
+  (global $sp (mut i32) (i32.const 1048576))
+  (func (export "run") (param i32) (result i32)
+    local.get 0
+    i32.const 1
+    i32.add))

--- a/scripts/repro/static_above_sp_739_differential.py
+++ b/scripts/repro/static_above_sp_739_differential.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""#739 execution differential: static ABOVE sp_init under --shadow-stack-size.
+
+A meld `--memory shared` fused node places component statics ABOVE the shared
+SP (17-page linmem, SP init 0x100000, statics at 0x10000C / 0x100020). Pre-fix
+the sub-word load/store lowering BAKED those static-region memarg offsets as
+plain un-relocated `MOVW/MOVT ip` immediates (`movw ip,#0xC; movt ip,#0x10`),
+so:
+  * the #678 `--shadow-stack-size` rebase (which walks RELOCATIONS) never
+    re-based them -> OOB access on the shrunk reservation (read zeros /
+    unmapped) — gale's gust:os zeroed log buffer;
+  * the post-link "all reservation accesses in-range" oracle (also
+    reloc-walking) passed anyway — a vacuous gate (the #712-class lesson).
+
+This oracle runs the compiled object (unicorn Thumb-2, R11 = 0 native deref,
+`.bss`/`.data` at SEPARATE bases so a baked absolute linmem offset cannot
+accidentally work) against wasmtime ground truth on the same wat:
+
+  run(p)       — store (43+2p) as a byte through the DYNAMIC-index +
+                 static-offset shape at [0x10000C + p], read it back.
+                 RED pre-fix: the baked access faults / reads zero.
+  peek_data(i) — byte read from the initialized `(data)` segment ABOVE
+                 sp_init at [0x100020 + i] (retargeted to __synth_wasm_seg_0).
+
+Also pins that the shrink actually FIRED (the `.bss` reservation is the
+shrunk budget-sized one, not the 1 MiB page) and that every relocated
+static falls inside it — the in-range property the old oracle only claimed.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/static_above_sp_739_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("mem739_above_sp.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+ABS32 = 2
+BUDGET = 2048
+SP_INIT = 0x100000
+
+# Distinct bases per linker-placed region — the point: a BAKED absolute wasm
+# linmem offset (0x10000C) lands in none of them, while a properly relocated
+# `__synth_wasm_data + C'` resolves into the shrunk `.bss`.
+BASES = {".text": 0x10000, ".bss": 0x40000, ".data": 0x60000}
+MAPSZ = 0x10000
+
+
+def wasmtime_truth(fn, arg):
+    """Fresh instance per call (store-then-load must not leak across cases)."""
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_text())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    return inst.exports(store)[fn](store, arg) & 0xFFFFFFFF
+
+
+def main():
+    obj = Path(tempfile.mkdtemp(prefix="mem739_")) / "mem739.o"
+    subprocess.run(
+        [
+            SYNTH,
+            "compile",
+            str(WAT),
+            "-o",
+            str(obj),
+            "--target",
+            "cortex-m3",
+            "--native-pointer-abi",
+            "--all-exports",
+            "--relocatable",
+            "--shadow-stack-size",
+            str(BUDGET),
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    e = ELFFile(open(obj, "rb"))
+    secname_by_idx = {i: s.name for i, s in enumerate(e.iter_sections())}
+    text = bytearray(e.get_section_by_name(".text").data())
+    bss = e.get_section_by_name(".bss")
+    data_sec = e.get_section_by_name(".data")
+    if bss is None or data_sec is None:
+        print("FAIL: object lacks .bss/.data — the native-pointer region was dropped")
+        return 1
+    data = bytearray(data_sec.data())
+    bss_size = bss["sh_size"]
+
+    # The shrink must have FIRED: reservation ~= budget + above-SP tail,
+    # nowhere near the 1 MiB page. Pre-fix the compile either drops the
+    # region entirely (no relocs at all) or reserves the full extent.
+    if not (BUDGET <= bss_size <= BUDGET + 4096):
+        print(f"FAIL: .bss is {bss_size} B — shrink did not fire (budget {BUDGET})")
+        return 1
+
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {}
+    for s in symtab.iter_symbols():
+        syms[s.name] = (s["st_shndx"], s["st_value"])
+
+    # Relocate every R_ARM_ABS32 literal-pool word in place: final address =
+    # base(section owning the symbol) + symbol value + in-place addend (REL).
+    # In-range pin: a reloc into `.bss` must target the SHRUNK reservation —
+    # the property the pre-fix oracle claimed without seeing baked offsets.
+    for r in e.get_section_by_name(".rel.text").iter_relocations():
+        if r["r_info_type"] != ABS32:
+            continue
+        sym = symtab.get_symbol(r["r_info_sym"])
+        shndx, val = syms[sym.name]
+        secname = secname_by_idx[shndx]
+        (add,) = struct.unpack_from("<I", text, r["r_offset"])
+        if secname == ".bss" and val + add + 1 > bss_size:
+            print(
+                f"FAIL: reloc {sym.name}+{add:#x} targets past the shrunk "
+                f".bss ({bss_size} B) — un-rebased static (#739)"
+            )
+            return 1
+        struct.pack_into(
+            "<I", text, r["r_offset"], (BASES[secname] + val + add) & 0xFFFFFFFF
+        )
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    for _, base in BASES.items():
+        mu.mem_map(base, MAPSZ)
+    mu.mem_write(BASES[".text"], bytes(text))
+    mu.mem_write(BASES[".data"], bytes(data))
+    RET = BASES[".text"] + 0xFF0
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+    def run_arm(fn, arg):
+        # Re-zero .bss between runs (fresh wasm instance semantics).
+        mu.mem_write(BASES[".bss"], b"\x00" * bss_size)
+        mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R11, 0)  # native deref: fp/base = 0
+        mu.reg_write(UC_ARM_REG_SP, BASES[".bss"] + MAPSZ - 0x100)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        entry = BASES[".text"] + (syms[fn][1] & ~1)
+        mu.emu_start(entry | 1, RET, timeout=5_000_000)
+        return mu.reg_read(UC_ARM_REG_R0)
+
+    ok = True
+    cases = [("run", p) for p in (0, 1, 5, 7)] + [("peek_data", i) for i in range(4)]
+    for fn, arg in cases:
+        exp = wasmtime_truth(fn, arg)
+        try:
+            got = run_arm(fn, arg)
+        except UcError as ex:
+            print(f"{fn}({arg}) = UNICORN FAULT {ex} (expect {exp})")
+            ok = False
+            continue
+        match = "" if got == exp else "  <-- MISMATCH"
+        print(f"{fn}({arg}) = {got} (expect {exp}){match}")
+        ok &= got == exp
+
+    print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #739 (VCR-MEM-001; builds on #383 shrink, #678 down-shift, #707 multi-SP co-rebase).

## Root cause

The **sub-word** i32 load/store arms (`i32.load8/16*`, `i32.store8/16`) never got the #359 native-pointer static classification that the word-sized `I32Load`/`I32Store` arms have. A dynamic-index access with a static-region memarg offset (the wit-bindgen byte-copy shape a meld `--memory shared` fused node produces — statics ABOVE the shared SP at `0x10000C`) fell through to the raw `[R11 + addr + #offset]` lowering and **baked** the linmem offset as a plain un-relocated immediate:

```
movw r12, #0xc
movt r12, #0x10      ; 0x10000C — an immediate, NOT a reloc
add.w r12, r0, r12
ldrb.w r0, [r11, r12]
```

The #678 `--shadow-stack-size` rebase walks **relocations**, so it never touched the baked offset → OOB on the shrunk reservation (gale's zeroed log buffer). And the post-link "all reservation accesses in-range" oracle **also** walks relocations → vacuously green on the miscompile (the #712-class lesson: a gate that cannot see the access class it guards is a vacuous gate). On the minimal fixture the failure is even deeper: with ZERO relocs the whole native-pointer region was dropped and `--shadow-stack-size` silently ignored.

## Fix (red-first)

1. **Repro** `scripts/repro/mem739_above_sp.wat` (17-page memory, SP init 0x100000, BSS static at 0x10000C + `(data)` static at 0x100020) shows the exact baked signature on main.
2. **Selector** (`instruction_selector.rs`): sub-word arms now mirror `I32Load`/`I32Store` — dynamic-index static accesses relocate the base to `__synth_wasm_data + offset` (+ Add index); folded const addresses classify via `static_data_addend` first. **i64** accesses (full + sub-word) with a static-region offset **decline loudly** (typed Err, loud-skip) — pre-fix they silently miscompiled the same way; the pair lowering doesn't yet model the relocated base (follow-up candidate).
3. **Oracle de-vacuation** (`main.rs`): the shrink now scans the encoded Thumb-2 text for **un-relocated MOVW/MOVT pairs** materializing a constant in `[sp_init, linear_memory_bytes)` and refuses loudly (`find_baked_static_movw_movt`, unit-tested against the exact pre-fix byte sequence). Scope honestly documented: pairs cover every 64 KiB+ `sp_init` (incl. this 1 MiB geometry); the sub-64 KiB lone-MOVW window is guarded by the selector-side classification (a lone-MOVW scan would false-positive on MOVW+MVN inverted constants). Plus: `--shadow-stack-size` on a module with no reloc into the region now refuses instead of silently no-op'ing.
4. **Execution differential** `scripts/repro/static_above_sp_739_differential.py` (modeled on the #678 oracle): store/load through the above-SP static after the shrink == wasmtime, unicorn with `.bss`/`.data` at SEPARATE bases so a baked absolute offset cannot accidentally resolve; also pins the shrink fired and every `.bss` reloc lands in the shrunk reservation. **RED on main (exit 1), GREEN here** — wired into the `trap-semantics-oracle` CI job.

After the fix the fixture's static relocates as `__synth_wasm_data + 0x10000C`, down-shifted by #678 to `budget + 12 = 2060` inside the 2088-B reservation; the `(data)` static retargets to `__synth_wasm_seg_0`.

## Evidence

- Differential: main → `FAIL (region dropped)` exit 1; branch → `ORACLE: PASS` (8/8 cases vs wasmtime).
- New tests: 4 integration (`static_above_sp_739.rs`), 2 selector, 4 oracle-scan unit tests — all green.
- Regressions: `static_downshift_678` / `multi_sp_rebase_707` / `shadow_stack_shrink_383` suites green; `native_pointer_static_downshift_678.py` PASS; `multi_sp_707_differential.py` PASS (immutable-const discriminator stays 4096); **frozen anchors 10/10**; workspace **2166 passed / 0 failed**; `cargo fmt --check` + `clippy -D warnings` clean; claim-check 18/18.

Maintainer note: please re-run the differential before merging (`SYNTH=./target/debug/synth python scripts/repro/static_above_sp_739_differential.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L