### PR TITLE
fix(#746): i64/wide static-region loads/stores get the #744 relocation treatment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,6 +395,16 @@ jobs:
       # SEPARATE bases so a baked absolute offset cannot accidentally resolve.
       - name: Run above-SP static shadow-stack-shrink oracle (#739, cortex-m3)
         run: SYNTH=./target/debug/synth python scripts/repro/static_above_sp_739_differential.py
+      # #746 (the #739 residual): the i64/WIDE static-region arms — i64.load/
+      # i64.store pair accesses plus the i64 narrow loads/stores (load8/16/32,
+      # store8/16/32) — get the #744 relocation treatment instead of the loud
+      # decline that skipped gale's gust:os log-emit function. i64 store/load
+      # round-trips + narrow sign/zero-extend reads through an above-sp_init
+      # static after the --shadow-stack-size shrink must match wasmtime
+      # (unicorn, .bss/.data at SEPARATE bases). RED on v0.42.0 (compile
+      # declines, nothing to emit) -> GREEN with the relocated arms.
+      - name: Run i64/wide above-SP static shrink oracle (#746, cortex-m3)
+        run: SYNTH=./target/debug/synth python scripts/repro/wide_static_746_differential.py
 
   fact-spec-oracle:
     name: fact-spec elision oracle (#494 phases 2 + 2b + 3+)

--- a/crates/synth-cli/tests/static_above_sp_739.rs
+++ b/crates/synth-cli/tests/static_above_sp_739.rs
@@ -203,12 +203,13 @@ fn shadow_stack_size_without_region_refuses_739() {
     );
 }
 
-/// i64 accesses with a static-region memarg offset are not yet relocated —
-/// they must DECLINE loudly (function loud-skips), never bake. Pre-fix this
-/// shape silently miscompiled exactly like the sub-word case.
+/// #746 (the #739 residual): i64 accesses with a static-region memarg offset
+/// get the #744 relocation treatment. Pre-#746 this exact module DECLINED
+/// loudly ("#739: i64.load ... not yet relocated") and nothing was emitted —
+/// now the i64 arm relocates `__synth_wasm_data + 0x100008` and compiles.
 #[test]
-fn i64_static_offset_declines_loudly_739() {
-    let dir = std::env::temp_dir().join("mem739_i64_test");
+fn i64_static_offset_relocates_746() {
+    let dir = std::env::temp_dir().join("mem746_i64_test");
     std::fs::create_dir_all(&dir).unwrap();
     let wat = dir.join("i64_above_sp.wat");
     std::fs::write(
@@ -222,6 +223,7 @@ fn i64_static_offset_declines_loudly_739() {
     i32.wrap_i64))"#,
     )
     .unwrap();
+    let obj = dir.join("i64_above_sp.o");
     let out = Command::new(synth())
         .args([
             "compile",
@@ -232,17 +234,58 @@ fn i64_static_offset_declines_loudly_739() {
             "--all-exports",
             "--relocatable",
             "-o",
-            dir.join("i64_above_sp.o").to_str().unwrap(),
+            obj.to_str().unwrap(),
         ])
         .output()
         .expect("run synth");
     assert!(
-        !out.status.success(),
-        "single-function module with an i64 static-region access must not emit"
+        out.status.success(),
+        "i64 static-region access must compile (relocated, #746): {}",
+        String::from_utf8_lossy(&out.stderr)
     );
-    let stderr = String::from_utf8_lossy(&out.stderr);
+    let addends = wasm_data_addends(obj.to_str().unwrap());
     assert!(
-        stderr.contains("#739") && stderr.contains("declining"),
-        "decline must be loud and name #739: {stderr}"
+        addends.contains(&1_048_584),
+        "i64 static must relocate as __synth_wasm_data + 0x100008, got {addends:?}"
+    );
+    assert!(
+        !has_baked_pair_in_window(obj.to_str().unwrap(), SP_INIT, LINMEM),
+        "un-relocated baked static-region MOVW/MOVT pair in the i64 object"
+    );
+}
+
+/// #746 end-to-end shrink: the i64 wide + narrow static-region accesses of
+/// the differential fixture relocate AND down-shift under
+/// `--shadow-stack-size` — BSS statics 0x100010/0x100018 become
+/// `budget + 16 / + 24`, the reservation is the shrunk one, and no baked
+/// MOVW/MOVT static-region pair survives. RED on v0.42.0: the compile itself
+/// fails (all 7 functions loud-decline, nothing to emit).
+#[test]
+fn wide_static_relocates_and_downshifts_746() {
+    let out = compile(
+        "mem746_wide_static.wat",
+        &["--shadow-stack-size", "2048"],
+        "/tmp/mem746_shrunk_test.o",
+    );
+    assert!(
+        out.status.success(),
+        "must compile: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let addends = wasm_data_addends("/tmp/mem746_shrunk_test.o");
+    for want in [BUDGET + 16, BUDGET + 24] {
+        assert!(
+            addends.contains(&want),
+            "above-SP i64 static must down-shift to {want}, got addends {addends:?}"
+        );
+    }
+    let bss = bss_size("/tmp/mem746_shrunk_test.o");
+    assert!(
+        (BUDGET as u64..=(BUDGET + 4096) as u64).contains(&bss),
+        ".bss must be the shrunk reservation, got {bss}"
+    );
+    assert!(
+        !has_baked_pair_in_window("/tmp/mem746_shrunk_test.o", BUDGET, LINMEM),
+        "un-relocated baked static-region MOVW/MOVT pair survived the shrink"
     );
 }

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -3450,9 +3450,10 @@ impl InstructionSelector {
     /// the linker places the `__synth_wasm_data` region anywhere, and (b) it is
     /// invisible to the `--shadow-stack-size` static down-shift (#678) and the
     /// post-link in-range oracle, which walk RELOCATIONS (the #739 silent OOB
-    /// miscompile). Callers either relocate the base via
-    /// [`Self::emit_wasm_data_addr`] (i32 word + sub-word accesses) or decline
-    /// loudly with a typed `Err` (i64 pair accesses, not yet relocated) —
+    /// miscompile). Callers relocate the base via
+    /// [`Self::emit_wasm_data_addr`]: i32 word + sub-word accesses (#744) and
+    /// the i64 pair / narrow accesses (#746). The float load/store arms still
+    /// decline loudly with a typed `Err` (GI-FPU-002, not yet relocated) —
     /// never bake.
     fn is_native_pointer_static_offset(&self, offset: u32) -> bool {
         self.native_pointer_abi && self.wasm_data_base > 0 && offset >= self.wasm_data_base
@@ -10422,21 +10423,6 @@ impl InstructionSelector {
                 | I64Load16U { offset, .. }
                 | I64Load32S { offset, .. }
                 | I64Load32U { offset, .. } => {
-                    // #739: a static-region memarg offset must not reach the
-                    // raw `[R11 + addr + #offset]` lowering below — it would
-                    // bake an un-relocated linmem offset (invisible to the
-                    // #678 `--shadow-stack-size` rebase → silent OOB). The i64
-                    // pair lowering does not yet model the relocated base;
-                    // decline loudly (the function loud-skips), never bake.
-                    if self.is_native_pointer_static_offset(*offset) {
-                        return Err(synth_core::Error::synthesis(format!(
-                            "#739: i64 sub-word load with static-region memarg offset {offset} \
-                             (>= wasm_data_base {}) under the native-pointer ABI is not yet \
-                             relocated — declining rather than baking an un-rebased linmem \
-                             offset",
-                            self.wasm_data_base
-                        )));
-                    }
                     let addr = pop_operand(
                         &mut stack,
                         &mut next_temp,
@@ -10454,6 +10440,104 @@ impl InstructionSelector {
                         &live_params,
                         idx,
                     )?;
+
+                    if self.is_native_pointer_static_offset(*offset) {
+                        // #746 (the #739 residual): a dynamic-index i64
+                        // NARROW load whose constant memarg `offset` lands in
+                        // the static-data region. Pre-fix this arm declined
+                        // loudly (#744 relocated only the i32 sub-word arms);
+                        // the raw path below would bake the linmem offset as
+                        // an un-relocated MOVW/MOVT immediate — invisible to
+                        // the #678 `--shadow-stack-size` rebase → silent OOB.
+                        // Relocate the base to `__synth_wasm_data + offset` +
+                        // the dynamic index, load the low half through it,
+                        // then fill the high half (sign / zero extend) —
+                        // exactly the #744 sub-word branch, plus the hi fill.
+                        let base = alloc_temp_or_spill(
+                            &mut next_temp,
+                            &mut stack,
+                            &mut instructions,
+                            &mut spill,
+                            &[live_params.as_slice(), &[addr, dst_lo, dst_hi]].concat(),
+                            idx,
+                        )?;
+                        Self::emit_wasm_data_addr(&mut instructions, base, *offset as i32, idx);
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Add {
+                                rd: base,
+                                rn: base,
+                                op2: Operand2::Reg(addr),
+                            },
+                            source_line: Some(idx),
+                        });
+                        let mem = MemAddr::imm(base, 0);
+                        let (load_op, sign_extend) = match op {
+                            I64Load8S { .. } => (
+                                ArmOp::Ldrsb {
+                                    rd: dst_lo,
+                                    addr: mem,
+                                },
+                                true,
+                            ),
+                            I64Load8U { .. } => (
+                                ArmOp::Ldrb {
+                                    rd: dst_lo,
+                                    addr: mem,
+                                },
+                                false,
+                            ),
+                            I64Load16S { .. } => (
+                                ArmOp::Ldrsh {
+                                    rd: dst_lo,
+                                    addr: mem,
+                                },
+                                true,
+                            ),
+                            I64Load16U { .. } => (
+                                ArmOp::Ldrh {
+                                    rd: dst_lo,
+                                    addr: mem,
+                                },
+                                false,
+                            ),
+                            I64Load32S { .. } => (
+                                ArmOp::Ldr {
+                                    rd: dst_lo,
+                                    addr: mem,
+                                },
+                                true,
+                            ),
+                            I64Load32U { .. } => (
+                                ArmOp::Ldr {
+                                    rd: dst_lo,
+                                    addr: mem,
+                                },
+                                false,
+                            ),
+                            _ => unreachable!(),
+                        };
+                        let hi_fill = if sign_extend {
+                            ArmOp::Asr {
+                                rd: dst_hi,
+                                rn: dst_lo,
+                                shift: 31,
+                            }
+                        } else {
+                            ArmOp::Mov {
+                                rd: dst_hi,
+                                op2: Operand2::Imm(0),
+                            }
+                        };
+                        for arm_op in [load_op, hi_fill] {
+                            instructions.push(ArmInstruction {
+                                op: arm_op,
+                                source_line: Some(idx),
+                            });
+                        }
+                        cf.add_instruction();
+                        stack.push(StackVal::i64(dst_lo));
+                        continue;
+                    }
 
                     let ops: Vec<ArmOp> = match op {
                         I64Load8S { .. } => {
@@ -10558,17 +10642,6 @@ impl InstructionSelector {
                 I64Store8 { offset, .. }
                 | I64Store16 { offset, .. }
                 | I64Store32 { offset, .. } => {
-                    // #739: see the i64 sub-word load arm — decline loudly,
-                    // never bake an un-relocated static-region offset.
-                    if self.is_native_pointer_static_offset(*offset) {
-                        return Err(synth_core::Error::synthesis(format!(
-                            "#739: i64 sub-word store with static-region memarg offset {offset} \
-                             (>= wasm_data_base {}) under the native-pointer ABI is not yet \
-                             relocated — declining rather than baking an un-rebased linmem \
-                             offset",
-                            self.wasm_data_base
-                        )));
-                    }
                     // Pop i64 value (lo register) and address
                     let value_lo = pop_operand(
                         &mut stack,
@@ -10586,6 +10659,58 @@ impl InstructionSelector {
                         &live_params,
                         idx,
                     )?;
+
+                    if self.is_native_pointer_static_offset(*offset) {
+                        // #746 (symmetric to the i64 narrow load): a
+                        // dynamic-index i64 narrow store into the static-data
+                        // region must relocate its base to `__synth_wasm_data
+                        // + offset` + the dynamic index (only the LOW half is
+                        // stored — wrapping semantics, same as the raw path).
+                        // Pre-fix this arm declined loudly (#744 relocated
+                        // only the i32 sub-word arms); the raw path below
+                        // would bake the linmem offset as an un-relocated
+                        // MOVW/MOVT immediate (silent OOB once
+                        // `--shadow-stack-size` shrinks the reservation).
+                        let base = alloc_temp_or_spill(
+                            &mut next_temp,
+                            &mut stack,
+                            &mut instructions,
+                            &mut spill,
+                            &[live_params.as_slice(), &[addr, value_lo]].concat(),
+                            idx,
+                        )?;
+                        Self::emit_wasm_data_addr(&mut instructions, base, *offset as i32, idx);
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Add {
+                                rd: base,
+                                rn: base,
+                                op2: Operand2::Reg(addr),
+                            },
+                            source_line: Some(idx),
+                        });
+                        let mem = MemAddr::imm(base, 0);
+                        let arm_op = match op {
+                            I64Store8 { .. } => ArmOp::Strb {
+                                rd: value_lo,
+                                addr: mem,
+                            },
+                            I64Store16 { .. } => ArmOp::Strh {
+                                rd: value_lo,
+                                addr: mem,
+                            },
+                            I64Store32 { .. } => ArmOp::Str {
+                                rd: value_lo,
+                                addr: mem,
+                            },
+                            _ => unreachable!(),
+                        };
+                        instructions.push(ArmInstruction {
+                            op: arm_op,
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                        continue;
+                    }
 
                     let ops: Vec<ArmOp> = match op {
                         I64Store8 { .. } => self.generate_subword_store_with_bounds_check(
@@ -12752,17 +12877,6 @@ impl InstructionSelector {
                 }
 
                 I64Load { offset, .. } => {
-                    // #739: see the i64 sub-word load arm — decline loudly,
-                    // never bake an un-relocated static-region offset.
-                    if self.is_native_pointer_static_offset(*offset) {
-                        return Err(synth_core::Error::synthesis(format!(
-                            "#739: i64.load with static-region memarg offset {offset} \
-                             (>= wasm_data_base {}) under the native-pointer ABI is not yet \
-                             relocated — declining rather than baking an un-rebased linmem \
-                             offset",
-                            self.wasm_data_base
-                        )));
-                    }
                     // Pop address from stack
                     let addr = pop_operand(
                         &mut stack,
@@ -12788,30 +12902,65 @@ impl InstructionSelector {
                         idx,
                     )?;
 
-                    // Generate bounds-checked i64 load into the allocated pair
-                    let load_ops =
-                        self.generate_i64_load_into_regs(dst_lo, dst_hi, addr, *offset as i32);
-                    for arm_op in load_ops {
+                    if self.is_native_pointer_static_offset(*offset) {
+                        // #746 (the #739 residual): a DYNAMIC-index i64 load
+                        // whose constant memarg `offset` lands in the
+                        // static-data region (gale's gust:os `log.line`
+                        // bulk-copies its message via i64.load from static
+                        // data ABOVE sp_init). Pre-fix this arm DECLINED
+                        // loudly (#744 gave only the sub-word arms the
+                        // relocation treatment); the raw path below would
+                        // BAKE the linmem offset as an un-relocated
+                        // MOVW/MOVT immediate — invisible to the #678
+                        // `--shadow-stack-size` rebase → silent OOB.
+                        // Relocate the base to `__synth_wasm_data + offset`
+                        // (the ELF builder retargets it to the owning
+                        // segment symbol) and add the dynamic index —
+                        // exactly the I32Load #359 branch, with the I64Ldr
+                        // pair form. The base temp stays disjoint from the
+                        // dst pair: I64Ldr reads its base for BOTH halves,
+                        // so neither half may alias it.
+                        let base = alloc_temp_or_spill(
+                            &mut next_temp,
+                            &mut stack,
+                            &mut instructions,
+                            &mut spill,
+                            &[live_params.as_slice(), &[addr, dst_lo, dst_hi]].concat(),
+                            idx,
+                        )?;
+                        Self::emit_wasm_data_addr(&mut instructions, base, *offset as i32, idx);
                         instructions.push(ArmInstruction {
-                            op: arm_op,
+                            op: ArmOp::Add {
+                                rd: base,
+                                rn: base,
+                                op2: Operand2::Reg(addr),
+                            },
                             source_line: Some(idx),
                         });
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::I64Ldr {
+                                rdlo: dst_lo,
+                                rdhi: dst_hi,
+                                addr: MemAddr::imm(base, 0),
+                            },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    } else {
+                        // Generate bounds-checked i64 load into the allocated pair
+                        let load_ops =
+                            self.generate_i64_load_into_regs(dst_lo, dst_hi, addr, *offset as i32);
+                        for arm_op in load_ops {
+                            instructions.push(ArmInstruction {
+                                op: arm_op,
+                                source_line: Some(idx),
+                            });
+                        }
                     }
                     stack.push(StackVal::i64(dst_lo));
                 }
 
                 I64Store { offset, .. } => {
-                    // #739: see the i64 sub-word load arm — decline loudly,
-                    // never bake an un-relocated static-region offset.
-                    if self.is_native_pointer_static_offset(*offset) {
-                        return Err(synth_core::Error::synthesis(format!(
-                            "#739: i64.store with static-region memarg offset {offset} \
-                             (>= wasm_data_base {}) under the native-pointer ABI is not yet \
-                             relocated — declining rather than baking an un-rebased linmem \
-                             offset",
-                            self.wasm_data_base
-                        )));
-                    }
                     // WASM i64.store pops: value first, then address
                     let value_lo = pop_operand(
                         &mut stack,
@@ -12831,14 +12980,55 @@ impl InstructionSelector {
                     )?;
                     let value_hi = i64_pair_hi(value_lo)?;
 
-                    // Generate bounds-checked i64 store from the value pair
-                    let store_ops =
-                        self.generate_i64_store_from_regs(value_lo, value_hi, addr, *offset as i32);
-                    for arm_op in store_ops {
+                    if self.is_native_pointer_static_offset(*offset) {
+                        // #746 (symmetric to the I64Load arm): a dynamic-index
+                        // i64 store into the static-data region must relocate
+                        // its base to `__synth_wasm_data + offset` + the
+                        // dynamic index — pre-fix this arm declined loudly
+                        // (#744 relocated only the sub-word arms); the raw
+                        // path below would bake the linmem offset as an
+                        // un-relocated MOVW/MOVT immediate (silent OOB once
+                        // `--shadow-stack-size` shrinks the reservation).
+                        let base = alloc_temp_or_spill(
+                            &mut next_temp,
+                            &mut stack,
+                            &mut instructions,
+                            &mut spill,
+                            &[live_params.as_slice(), &[addr, value_lo, value_hi]].concat(),
+                            idx,
+                        )?;
+                        Self::emit_wasm_data_addr(&mut instructions, base, *offset as i32, idx);
                         instructions.push(ArmInstruction {
-                            op: arm_op,
+                            op: ArmOp::Add {
+                                rd: base,
+                                rn: base,
+                                op2: Operand2::Reg(addr),
+                            },
                             source_line: Some(idx),
                         });
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::I64Str {
+                                rdlo: value_lo,
+                                rdhi: value_hi,
+                                addr: MemAddr::imm(base, 0),
+                            },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    } else {
+                        // Generate bounds-checked i64 store from the value pair
+                        let store_ops = self.generate_i64_store_from_regs(
+                            value_lo,
+                            value_hi,
+                            addr,
+                            *offset as i32,
+                        );
+                        for arm_op in store_ops {
+                            instructions.push(ArmInstruction {
+                                op: arm_op,
+                                source_line: Some(idx),
+                            });
+                        }
                     }
                     // Store doesn't push anything to stack
                 }
@@ -24787,13 +24977,20 @@ mod tests {
         );
     }
 
-    /// #739: i64 accesses with a static-region memarg offset are not yet
-    /// relocated — they must DECLINE with a typed Err (loud-skip), never fall
-    /// through to the raw path and bake the offset (silent OOB).
+    /// #746 (the #739 residual): i64 WIDE accesses with a static-region memarg
+    /// offset get the #744 relocation treatment — relocate the base to
+    /// `__synth_wasm_data + offset` + the dynamic index (LdrSym, reloc-visible
+    /// to the #678 `--shadow-stack-size` rebase), never bake the linmem offset
+    /// as a Movw/Movt immediate, and never decline (pre-#746 these arms
+    /// loud-declined, skipping gale's gust:os log-emit function entirely).
     #[test]
-    fn test_739_i64_static_offset_declines_loudly() {
+    fn test_746_i64_wide_static_offset_is_relocated() {
         let db = RuleDatabase::new();
-        let ops = vec![
+        let is_data_sym = |i: &ArmInstruction| matches!(&i.op, ArmOp::LdrSym { symbol, .. } if symbol == "__synth_wasm_data");
+        let baked_movt = |i: &ArmInstruction| matches!(&i.op, ArmOp::Movt { imm16, .. } if *imm16 == (1048584u32 >> 16) as u16);
+
+        // (memory 17) = 1114112 bytes; sp_init = 0x100000; static at 0x100008.
+        let load_ops = vec![
             WasmOp::LocalGet(0),
             WasmOp::I64Load {
                 offset: 1048584,
@@ -24805,11 +25002,49 @@ mod tests {
         sel.set_relocatable(true);
         sel.set_native_pointer_abi(true, 1114112);
         sel.set_native_pointer_stack(0, 1048576);
-        let err = sel.select_with_stack(&ops, 1).unwrap_err();
+        let ln = sel.select_with_stack(&load_ops, 1).unwrap();
         assert!(
-            err.to_string().contains("#739"),
-            "i64 static-region access must decline loudly naming #739. got: {err}"
+            ln.iter().any(is_data_sym),
+            "dynamic i64 static load must relocate via LdrSym __synth_wasm_data. got: {ln:#?}"
         );
+        assert!(
+            ln.iter()
+                .any(|i| matches!(&i.op, ArmOp::I64Ldr { addr, .. } if addr.offset_reg.is_none())),
+            "i64.load must go through the relocated base (pair load, no index reg). got: {ln:#?}"
+        );
+        assert!(
+            !ln.iter().any(baked_movt),
+            "the static offset must NOT be baked as a Movt immediate (#746). got: {ln:#?}"
+        );
+
+        let store_ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I64Const(0x1122_3344_5566_7788),
+            WasmOp::I64Store {
+                offset: 1048584,
+                align: 3,
+            },
+            WasmOp::End,
+        ];
+        let mut sel_s = InstructionSelector::new(db.rules().to_vec());
+        sel_s.set_relocatable(true);
+        sel_s.set_native_pointer_abi(true, 1114112);
+        sel_s.set_native_pointer_stack(0, 1048576);
+        let sn = sel_s.select_with_stack(&store_ops, 1).unwrap();
+        assert!(
+            sn.iter().any(is_data_sym),
+            "dynamic i64 static store must relocate via LdrSym __synth_wasm_data. got: {sn:#?}"
+        );
+        assert!(
+            sn.iter()
+                .any(|i| matches!(&i.op, ArmOp::I64Str { addr, .. } if addr.offset_reg.is_none())),
+            "i64.store must go through the relocated base (pair store, no index reg). got: {sn:#?}"
+        );
+        assert!(
+            !sn.iter().any(baked_movt),
+            "the static offset must NOT be baked as a Movt immediate (#746). got: {sn:#?}"
+        );
+
         // Below the static base the raw path is untouched (frozen behavior).
         let low_ops = vec![
             WasmOp::LocalGet(0),
@@ -24823,10 +25058,149 @@ mod tests {
         sel_low.set_relocatable(true);
         sel_low.set_native_pointer_abi(true, 1114112);
         sel_low.set_native_pointer_stack(0, 1048576);
+        let low = sel_low.select_with_stack(&low_ops, 1).unwrap();
         assert!(
-            sel_low.select_with_stack(&low_ops, 1).is_ok(),
-            "below-base i64 access must keep compiling"
+            !low.iter().any(is_data_sym),
+            "below-base i64 access must keep the raw [R11+addr+#off] path. got: {low:#?}"
         );
+    }
+
+    /// #746: the i64 NARROW load/store arms (i64.load8/16/32, i64.store8/16/32)
+    /// with a static-region memarg offset relocate like the #744 i32 sub-word
+    /// arms, with the correct hi-half fill (sign vs zero extend) on loads.
+    #[test]
+    fn test_746_i64_narrow_static_offset_is_relocated() {
+        let db = RuleDatabase::new();
+        let is_data_sym = |i: &ArmInstruction| matches!(&i.op, ArmOp::LdrSym { symbol, .. } if symbol == "__synth_wasm_data");
+
+        // (op, expected mem op predicate, hi fill is sign-extend)
+        type OpPred = fn(&ArmOp) -> bool;
+        let load_cases: Vec<(WasmOp, OpPred, bool)> = vec![
+            (
+                WasmOp::I64Load8U {
+                    offset: 1048588,
+                    align: 0,
+                },
+                (|op| matches!(op, ArmOp::Ldrb { .. })) as OpPred,
+                false,
+            ),
+            (
+                WasmOp::I64Load8S {
+                    offset: 1048588,
+                    align: 0,
+                },
+                |op| matches!(op, ArmOp::Ldrsb { .. }),
+                true,
+            ),
+            (
+                WasmOp::I64Load16U {
+                    offset: 1048588,
+                    align: 1,
+                },
+                |op| matches!(op, ArmOp::Ldrh { .. }),
+                false,
+            ),
+            (
+                WasmOp::I64Load16S {
+                    offset: 1048588,
+                    align: 1,
+                },
+                |op| matches!(op, ArmOp::Ldrsh { .. }),
+                true,
+            ),
+            (
+                WasmOp::I64Load32U {
+                    offset: 1048588,
+                    align: 2,
+                },
+                |op| matches!(op, ArmOp::Ldr { .. }),
+                false,
+            ),
+            (
+                WasmOp::I64Load32S {
+                    offset: 1048588,
+                    align: 2,
+                },
+                |op| matches!(op, ArmOp::Ldr { .. }),
+                true,
+            ),
+        ];
+        for (op, mem_pred, sign) in load_cases {
+            let ops = vec![WasmOp::LocalGet(0), op.clone(), WasmOp::End];
+            let mut sel = InstructionSelector::new(db.rules().to_vec());
+            sel.set_relocatable(true);
+            sel.set_native_pointer_abi(true, 1114112);
+            sel.set_native_pointer_stack(0, 1048576);
+            let n = sel.select_with_stack(&ops, 1).unwrap();
+            assert!(
+                n.iter().any(is_data_sym),
+                "{op:?}: must relocate via LdrSym __synth_wasm_data. got: {n:#?}"
+            );
+            assert!(
+                n.iter().any(|i| mem_pred(&i.op)),
+                "{op:?}: wrong memory-op form. got: {n:#?}"
+            );
+            let hi_ok = if sign {
+                n.iter()
+                    .any(|i| matches!(&i.op, ArmOp::Asr { shift: 31, .. }))
+            } else {
+                n.iter().any(|i| {
+                    matches!(
+                        &i.op,
+                        ArmOp::Mov {
+                            op2: Operand2::Imm(0),
+                            ..
+                        }
+                    )
+                })
+            };
+            assert!(hi_ok, "{op:?}: missing hi-half fill. got: {n:#?}");
+        }
+
+        let store_cases: Vec<(WasmOp, OpPred)> = vec![
+            (
+                WasmOp::I64Store8 {
+                    offset: 1048588,
+                    align: 0,
+                },
+                (|op| matches!(op, ArmOp::Strb { .. })) as OpPred,
+            ),
+            (
+                WasmOp::I64Store16 {
+                    offset: 1048588,
+                    align: 1,
+                },
+                |op| matches!(op, ArmOp::Strh { .. }),
+            ),
+            (
+                WasmOp::I64Store32 {
+                    offset: 1048588,
+                    align: 2,
+                },
+                |op| matches!(op, ArmOp::Str { .. }),
+            ),
+        ];
+        for (op, mem_pred) in store_cases {
+            let ops = vec![
+                WasmOp::LocalGet(0),
+                WasmOp::I64Const(0x0102_0304_0506_0708),
+                op.clone(),
+                WasmOp::End,
+            ];
+            let mut sel = InstructionSelector::new(db.rules().to_vec());
+            sel.set_relocatable(true);
+            sel.set_native_pointer_abi(true, 1114112);
+            sel.set_native_pointer_stack(0, 1048576);
+            let n = sel.select_with_stack(&ops, 1).unwrap();
+            assert!(
+                n.iter().any(is_data_sym),
+                "{op:?}: must relocate via LdrSym __synth_wasm_data. got: {n:#?}"
+            );
+            assert!(
+                n.iter().any(|i| mem_pred(&i.op)),
+                "{op:?}: wrong memory-op form. got: {n:#?}"
+            );
+        }
     }
 
     /// #237: register-promote the stack-pointer global so a dissolved leaf object

--- a/scripts/repro/mem746_wide_static.wat
+++ b/scripts/repro/mem746_wide_static.wat
@@ -1,0 +1,76 @@
+(module
+  ;; #746 (the #739 residual): meld-fused shared-memory geometry — 17-page
+  ;; (1088 KiB) linear memory, one __stack_pointer global init 0x100000
+  ;; (1 MiB), and statics ABOVE sp_init (meld `--memory shared` places a
+  ;; fused component's data above the shared SP).
+  ;;
+  ;; The access shape is gale's gust:os `log.line` bulk-copy one: a DYNAMIC
+  ;; index in a register plus a STATIC-REGION memarg offset on a WIDE (i64)
+  ;; load/store. #744 relocated the i32 sub-word arms; the i64 wide + narrow
+  ;; arms still LOUD-DECLINED ("#739: i64.load ... not yet relocated"), so
+  ;; the emit function was skipped and the node unlinkable. Post-#746 they
+  ;; relocate: base = `__synth_wasm_data + offset` (reloc-visible to the
+  ;; #678 `--shadow-stack-size` rebase) + dynamic index.
+  (memory (export "memory") 17)
+  (global $sp (mut i32) (i32.const 1048576))
+  ;; An initialized (data) segment ABOVE sp_init at 0x100020 (the "log
+  ;; message that correctly lives in .data") — read via i64 narrow loads.
+  (data (i32.const 1048608) "\11\22\33\44\55\66\77\88")
+  ;; BSS static above sp_init at 0x100010: store an i64 computed from the
+  ;; dynamic index through the dynamic-index + static-offset shape, then
+  ;; read it back. run64lo/run64hi return the low/high word.
+  (func (export "run64lo") (param i32) (result i32)
+    local.get 0
+    local.get 0
+    i64.extend_i32_u
+    i64.const 0x1122334455667788
+    i64.add
+    i64.store offset=1048592
+    local.get 0
+    i64.load offset=1048592
+    i32.wrap_i64)
+  (func (export "run64hi") (param i32) (result i32)
+    local.get 0
+    local.get 0
+    i64.extend_i32_u
+    i64.const 0x55667788AABBCCDD
+    i64.add
+    i64.store offset=1048592
+    local.get 0
+    i64.load offset=1048592
+    i64.const 32
+    i64.shr_u
+    i32.wrap_i64)
+  ;; i64 NARROW stores + loads through a BSS static at 0x100018: store32
+  ;; then read back with zero- and sign-extending narrow loads.
+  (func (export "narrow32") (param i32) (result i32)
+    local.get 0
+    i64.const 0x0102030485868788
+    i64.store32 offset=1048600
+    local.get 0
+    i64.load32_u offset=1048600
+    i32.wrap_i64)
+  (func (export "narrow16s") (param i32) (result i32)
+    local.get 0
+    i64.const 0xF9E8
+    i64.store16 offset=1048600
+    local.get 0
+    i64.load16_s offset=1048600
+    i32.wrap_i64)
+  (func (export "narrow8") (param i32) (result i32)
+    local.get 0
+    i64.const 0xAB
+    i64.store8 offset=1048600
+    local.get 0
+    i64.load8_u offset=1048600
+    i32.wrap_i64)
+  ;; Byte reads from the initialized (data) segment above sp_init through the
+  ;; i64 narrow-load arm (retargeted to __synth_wasm_seg_0 by the ELF builder).
+  (func (export "peek_data8") (param i32) (result i32)
+    local.get 0
+    i64.load8_u offset=1048608
+    i32.wrap_i64)
+  (func (export "peek_data16s") (param i32) (result i32)
+    local.get 0
+    i64.load16_s offset=1048608
+    i32.wrap_i64))

--- a/scripts/repro/wide_static_746_differential.py
+++ b/scripts/repro/wide_static_746_differential.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""#746 execution differential: i64/wide static ABOVE sp_init under
+--shadow-stack-size (the #739 residual — sub-word arms were fixed in #744).
+
+A meld `--memory shared` fused node places component statics ABOVE the shared
+SP (17-page linmem, SP init 0x100000, statics at 0x100010 / 0x100020). #744
+relocated the i32 sub-word static-region arms; the WIDE (i64) and i64 NARROW
+(load8/16/32, store8/16/32) arms still LOUD-DECLINED:
+
+    #739: i64.load with static-region memarg offset 1048584 (>= wasm_data_base
+    1048576) under the native-pointer ABI is not yet relocated — declining
+
+so any function bulk-copying a static via i64 (gale's gust:os `log.line`
+message emit) was skipped and the object unlinkable. RED pre-#746: this
+script's compile step fails ("no functions compiled successfully"). GREEN
+post-#746: every arm relocates its base to `__synth_wasm_data + offset`
+(reloc-visible to the #678 shrink rebase) + the dynamic index, and execution
+matches wasmtime.
+
+This oracle runs the compiled object (unicorn Thumb-2, R11 = 0 native deref,
+`.bss`/`.data` at SEPARATE bases so a baked absolute linmem offset cannot
+accidentally work) against wasmtime ground truth on the same wat:
+
+  run64lo/run64hi(p) — i64 store + load through the dynamic-index +
+                       static-offset shape at [0x100010 + p], both halves.
+  narrow32/16s/8(p)  — i64.store32/16/8 + i64.load32_u/16_s/8_u round-trips
+                       through the BSS static at [0x100018 + p].
+  peek_data8/16s(i)  — i64 narrow reads from the initialized `(data)` segment
+                       ABOVE sp_init (retargeted to __synth_wasm_seg_0).
+
+Also pins that the shrink actually FIRED (the `.bss` reservation is the
+shrunk budget-sized one, not the 1 MiB page) and that every relocated static
+falls inside it.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/wide_static_746_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("mem746_wide_static.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+ABS32 = 2
+BUDGET = 2048
+SP_INIT = 0x100000
+
+# Distinct bases per linker-placed region — the point: a BAKED absolute wasm
+# linmem offset (0x100010) lands in none of them, while a properly relocated
+# `__synth_wasm_data + C'` resolves into the shrunk `.bss`.
+BASES = {".text": 0x10000, ".bss": 0x40000, ".data": 0x60000}
+MAPSZ = 0x10000
+
+
+def wasmtime_truth(fn, arg):
+    """Fresh instance per call (store-then-load must not leak across cases)."""
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_text())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    return inst.exports(store)[fn](store, arg) & 0xFFFFFFFF
+
+
+def main():
+    obj = Path(tempfile.mkdtemp(prefix="mem746_")) / "mem746.o"
+    proc = subprocess.run(
+        [
+            SYNTH,
+            "compile",
+            str(WAT),
+            "-o",
+            str(obj),
+            "--target",
+            "cortex-m3",
+            "--native-pointer-abi",
+            "--all-exports",
+            "--relocatable",
+            "--shadow-stack-size",
+            str(BUDGET),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        # RED pre-#746: the i64/wide arms decline and every function is
+        # skipped -> "no functions compiled successfully".
+        print(proc.stderr.strip())
+        print("FAIL: compile declined — the i64/wide static-region arms are")
+        print("      not relocated (#746 residual of #739)")
+        return 1
+
+    e = ELFFile(open(obj, "rb"))
+    secname_by_idx = {i: s.name for i, s in enumerate(e.iter_sections())}
+    text = bytearray(e.get_section_by_name(".text").data())
+    bss = e.get_section_by_name(".bss")
+    data_sec = e.get_section_by_name(".data")
+    if bss is None or data_sec is None:
+        print("FAIL: object lacks .bss/.data — the native-pointer region was dropped")
+        return 1
+    data = bytearray(data_sec.data())
+    bss_size = bss["sh_size"]
+
+    # The shrink must have FIRED: reservation ~= budget + above-SP tail,
+    # nowhere near the 1 MiB page.
+    if not (BUDGET <= bss_size <= BUDGET + 4096):
+        print(f"FAIL: .bss is {bss_size} B — shrink did not fire (budget {BUDGET})")
+        return 1
+
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {}
+    for s in symtab.iter_symbols():
+        syms[s.name] = (s["st_shndx"], s["st_value"])
+
+    # Relocate every R_ARM_ABS32 literal-pool word in place: final address =
+    # base(section owning the symbol) + symbol value + in-place addend (REL).
+    # In-range pin: a reloc into `.bss` must target the SHRUNK reservation
+    # (the hi half of each i64 pair access, [base, #4], is exercised by the
+    # run64hi execution cases below).
+    for r in e.get_section_by_name(".rel.text").iter_relocations():
+        if r["r_info_type"] != ABS32:
+            continue
+        sym = symtab.get_symbol(r["r_info_sym"])
+        shndx, val = syms[sym.name]
+        secname = secname_by_idx[shndx]
+        (add,) = struct.unpack_from("<I", text, r["r_offset"])
+        if secname == ".bss" and val + add + 1 > bss_size:
+            print(
+                f"FAIL: reloc {sym.name}+{add:#x} targets past the shrunk "
+                f".bss ({bss_size} B) — un-rebased static (#746)"
+            )
+            return 1
+        struct.pack_into(
+            "<I", text, r["r_offset"], (BASES[secname] + val + add) & 0xFFFFFFFF
+        )
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    for _, base in BASES.items():
+        mu.mem_map(base, MAPSZ)
+    mu.mem_write(BASES[".text"], bytes(text))
+    mu.mem_write(BASES[".data"], bytes(data))
+    RET = BASES[".text"] + 0xFF0
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+    def run_arm(fn, arg):
+        # Re-zero .bss between runs (fresh wasm instance semantics).
+        mu.mem_write(BASES[".bss"], b"\x00" * bss_size)
+        mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R11, 0)  # native deref: fp/base = 0
+        mu.reg_write(UC_ARM_REG_SP, BASES[".bss"] + MAPSZ - 0x100)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        entry = BASES[".text"] + (syms[fn][1] & ~1)
+        mu.emu_start(entry | 1, RET, timeout=5_000_000)
+        return mu.reg_read(UC_ARM_REG_R0)
+
+    ok = True
+    cases = (
+        [("run64lo", p) for p in (0, 4, 8)]
+        + [("run64hi", p) for p in (0, 4, 8)]
+        + [("narrow32", p) for p in (0, 4)]
+        + [("narrow16s", p) for p in (0, 2)]
+        + [("narrow8", p) for p in (0, 1, 3)]
+        + [("peek_data8", i) for i in range(8)]
+        + [("peek_data16s", i) for i in (0, 2, 4, 6)]
+    )
+    for fn, arg in cases:
+        exp = wasmtime_truth(fn, arg)
+        try:
+            got = run_arm(fn, arg)
+        except UcError as ex:
+            print(f"{fn}({arg}) = UNICORN FAULT {ex} (expect {exp})")
+            ok = False
+            continue
+        match = "" if got == exp else "  <-- MISMATCH"
+        print(f"{fn}({arg}) = {got:#x} (expect {exp:#x}){match}")
+        ok &= got == exp
+
+    print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #746 (the #739 residual): the i64/WIDE static-region load/store arms get the exact #744 relocation treatment instead of the loud decline that skipped gale's gust:os `log.line` emit function.

**Relocated (decline → `__synth_wasm_data + offset` reloc + dynamic-index Add), all in `select_with_stack`:**
- `i64.load` / `i64.store` — pair access through the relocated base (`I64Ldr`/`I64Str` imm form, `[base,#0]`/`[base,#4]`; the base temp is kept disjoint from the dst pair since both halves read it)
- `i64.load8_s/8_u/16_s/16_u/32_s/32_u` — narrow load of the low half through the relocated base + the sign/zero hi-half fill
- `i64.store8/16/32` — narrow store of the low half (wrapping semantics, same as the raw path)

The relocation is the same `LdrSym __synth_wasm_data + offset` literal-pool form as #359/#744, so it is visible to the #678 `--shadow-stack-size` rebase walk, the post-link in-range oracle, and the #744 baked-MOVW/MOVT refusal scan. Below `wasm_data_base` the raw `[R11 + addr + #offset]` path is untouched (frozen behavior).

**Still declines loudly (out of scope, as before):** the f32/f64 load/store static-region arms (GI-FPU-002 phase 1b/2 message, the FPU lane) — documented on `is_native_pointer_static_offset`. There is no i64 folded-const arm to classify: `try_fold_const_addr` caps at imm12 (`eff <= 0xFFF`), and a const static-region *address* is already relocated at `i32.const` materialization (#237).

The issue's exact 12-line minimal repro (`i64.load offset=1048584` above `sp_init` under `--native-pointer-abi --shadow-stack-size 2048`) now compiles cleanly.

## Oracle (red-first): `scripts/repro/wide_static_746_differential.py`

New fixture `mem746_wide_static.wat` (#739 meld `--memory shared` geometry: 17-page linmem, `sp_init` 0x100000, statics at 0x100010/0x100018/0x100020): i64 store/load round-trips + narrow sign/zero-extend reads through above-SP statics after the shrink, unicorn vs wasmtime, `.bss`/`.data` at SEPARATE bases so a baked absolute linmem offset cannot accidentally resolve. Wired into the `trap-semantics-oracle` CI job next to the #739 sub-word oracle.

**RED on v0.42.0 (`main`):**
```
warning: skipping function 'run64lo': ... #739: i64.store with static-region memarg offset 1048592 (>= wasm_data_base 1048576) under the native-pointer ABI is not yet relocated — declining ...
warning: 7 of 7 functions were skipped (not in output): run64lo, run64hi, narrow32, narrow16s, narrow8, peek_data8, peek_data16s
Error: no functions compiled successfully (7 skipped) — nothing to emit
FAIL: compile declined — the i64/wide static-region arms are not relocated (#746 residual of #739)
```

**GREEN with this PR (25/25):**
```
run64lo(0) = 0x55667788 (expect 0x55667788)
run64lo(4) = 0x5566778c (expect 0x5566778c)
run64hi(0) = 0x55667788 (expect 0x55667788)
narrow32(0) = 0x85868788 (expect 0x85868788)
narrow16s(0) = 0xfffff9e8 (expect 0xfffff9e8)
narrow8(1) = 0xab (expect 0xab)
peek_data8(7) = 0x88 (expect 0x88)
peek_data16s(6) = 0xffff8877 (expect 0xffff8877)
... (25 cases total)
ORACLE: PASS
```

## Gates

- Selector unit tests: `test_746_i64_wide_static_offset_is_relocated` + `test_746_i64_narrow_static_offset_is_relocated` (all nine arms: LdrSym reloc present, correct mem-op form, hi fill, offset never baked as a `Movt` immediate; below-base raw path frozen). The pre-#746 decline test is superseded.
- CLI gates (`static_above_sp_739.rs`): `i64_static_offset_relocates_746` (the pre-#746 decline module now compiles, reloc `__synth_wasm_data + 0x100008`, no baked pair) + `wide_static_relocates_and_downshifts_746` (BSS i64 statics down-shift to `budget+16`/`budget+24`, shrunk reservation, no baked pair).

## Regressions (all green)

- `cargo test -p synth-cli -p synth-synthesis` — 61 test binaries, 0 failures
- #739 oracle (`static_above_sp_739_differential.py`) PASS; #707 (`multi_sp_707_differential.py`) PASS; #678 (`native_pointer_static_downshift_678.py`) PASS
- Suites: `shadow_stack_shrink_383` 3/3, `static_downshift_678` 4/4, `multi_sp_rebase_707` 2/2, `static_above_sp_739` 5/5
- Frozen anchors: `frozen_codegen_bytes` **10/10**
- `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean

Refs #746, #739, #242 (VCR-MEM-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
