### PR TITLE
fix(#740): Thumb-2 B<cond>.W (T3) halved the branch offset — wide conditional branches landed mid-shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,16 @@ jobs:
       # declines, nothing to emit) -> GREEN with the relocated arms.
       - name: Run i64/wide above-SP static shrink oracle (#746, cortex-m3)
         run: SYNTH=./target/debug/synth python scripts/repro/wide_static_746_differential.py
+      # #740: the Thumb-2 B<cond>.W (T3) arm packed `halfword_offset >> 1`,
+      # HALVING every conditional branch spanning > 254 bytes — gust_poll's
+      # loop-head `br_if` to an outer block end landed mid-shape (spurious
+      # state write + spurious calls on the empty-budget round). Minimal
+      # loop-inside-block shape with wide exits, direct path (non-tail return
+      # declines the optimized path, #500); return AND a linear-memory window
+      # must match wasmtime. Anti-vacuous: FAILS if `poll` stops containing a
+      # 32-bit T3 conditional branch. RED on v0.42.0 (5/6 cases) -> GREEN.
+      - name: Run wide-B<cond>.W branch-target oracle (#740, cortex-m4)
+        run: SYNTH=./target/debug/synth python scripts/repro/brif_outer_740_differential.py
 
   fact-spec-oracle:
     name: fact-spec elision oracle (#494 phases 2 + 2b + 3+)

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -4094,15 +4094,37 @@ impl ArmEncoder {
                     let instr: u16 = 0xD000 | (cond_bits << 8) | imm8;
                     Ok(instr.to_le_bytes().to_vec())
                 } else {
-                    // 32-bit B<cond>.W for larger offsets
-                    // First halfword: 1111 0 S cond imm6
+                    // 32-bit B<cond>.W (encoding T3) for larger offsets
+                    // First halfword: 1111 0 S cond(4) imm6
                     // Second halfword: 10 J1 0 J2 imm11
-                    let offset = halfword_offset >> 1;
-                    let s = if offset < 0 { 1u32 } else { 0u32 };
-                    let imm6 = ((offset >> 11) as u32) & 0x3F;
-                    let imm11 = (offset as u32) & 0x7FF;
-                    let j1 = if s == 1 { 1 } else { 0 };
-                    let j2 = if s == 1 { 1 } else { 0 };
+                    //
+                    // Per ARMv7-M, the branch BYTE offset is
+                    // SignExtend(S:J2:J1:imm6:imm11:'0'), i.e. the field value
+                    // S:J2:J1:imm6:imm11 IS the signed 20-bit HALFWORD offset —
+                    // imm11/imm6/J1/J2/S take `halfword_offset` bits [10:0],
+                    // [16:11], 17, 18 and 19 directly (mirroring the T4
+                    // unconditional arm above).
+                    //
+                    // #740: this arm previously packed `halfword_offset >> 1`
+                    // into imm6:imm11 — HALVING the displacement — so every
+                    // wide conditional branch (span > 254 bytes) landed at half
+                    // its intended offset: gust_poll's loop-head `br_if` to an
+                    // outer block end jumped mid-shape. Narrow (16-bit) B<cond>
+                    // encodings were unaffected, which is why short-range CF
+                    // fixtures never caught it.
+                    if !(-(1 << 19)..(1 << 19)).contains(&halfword_offset) {
+                        return Err(synth_core::Error::synthesis(format!(
+                            "B<cond>.W (T3) halfword offset {halfword_offset} exceeds \
+                             the signed 20-bit encoding range (±1 MB) — refusing to \
+                             emit a truncated branch"
+                        )));
+                    }
+                    let u = halfword_offset as u32;
+                    let imm11 = u & 0x7FF; // halfword offset bits [10:0]
+                    let imm6 = (u >> 11) & 0x3F; // bits [16:11]
+                    let j1 = (u >> 17) & 1; // bit 17
+                    let j2 = (u >> 18) & 1; // bit 18
+                    let s = (u >> 19) & 1; // sign (range-checked above)
 
                     let hw1: u16 = (0xF000 | (s << 10) | ((cond_bits as u32) << 6) | imm6) as u16;
                     let hw2: u16 = (0x8000 | (j1 << 13) | (j2 << 11) | imm11) as u16;
@@ -10079,6 +10101,72 @@ mod tests {
         );
         assert_ne!(hw2, 0xF800, "0xF800 (addend 0) lands at S+4 (#174)");
         assert_ne!(hw2, 0xD000, "0xD000 bakes in a ~+0x600000 addend (#167)");
+    }
+
+    /// #740: the Thumb-2 32-bit B<cond>.W (encoding T3) must pack the
+    /// HALFWORD offset directly into S:J2:J1:imm6:imm11 — the byte offset is
+    /// SignExtend(S:J2:J1:imm6:imm11:'0'). The old arm packed
+    /// `halfword_offset >> 1`, HALVING every wide conditional branch's
+    /// displacement: gust_poll's loop-head `br_if` to an outer block end
+    /// landed mid-shape (a spurious state write + spurious calls on the
+    /// empty-budget path). Narrow (16-bit) B<cond> was unaffected — only
+    /// spans > 254 bytes hit the bug. Bytes cross-checked against the llvm
+    /// disassembler (`bne.w #0x224` = f040 8112).
+    #[test]
+    fn test_encode_thumb_bcond_wide_t3_halfword_offset_740() {
+        use synth_synthesis::Condition;
+        let encoder = ArmEncoder::new_thumb2();
+
+        // gust_poll's loop-head edge: NE, +0x112 halfwords (+0x224 bytes).
+        let code = encoder
+            .encode(&ArmOp::BCondOffset {
+                cond: Condition::NE,
+                offset: 0x112,
+            })
+            .unwrap();
+        assert_eq!(code.len(), 4, "offset beyond ±127 halfwords must be wide");
+        let hw1 = u16::from_le_bytes([code[0], code[1]]);
+        let hw2 = u16::from_le_bytes([code[2], code[3]]);
+        assert_eq!(hw1, 0xF040, "T3 hw1: 1111 0 S=0 cond=NE imm6=0");
+        assert_eq!(
+            hw2, 0x8112,
+            "T3 hw2 imm11 must carry halfword offset bits [10:0] directly — \
+             0x8089 (offset>>1) is the halved #740 miscompile"
+        );
+
+        // Backward wide branch: EQ, -0x100 halfwords. S=1, J2=J1=1,
+        // imm6=0b111111, imm11=0x700 → f43f af00.
+        let code = encoder
+            .encode(&ArmOp::BCondOffset {
+                cond: Condition::EQ,
+                offset: -0x100,
+            })
+            .unwrap();
+        assert_eq!(code.len(), 4);
+        let hw1 = u16::from_le_bytes([code[0], code[1]]);
+        let hw2 = u16::from_le_bytes([code[2], code[3]]);
+        assert_eq!(hw1, 0xF43F, "T3 hw1: S=1, cond=EQ, imm6=0x3F");
+        assert_eq!(hw2, 0xAF00, "T3 hw2: J1=1 J2=1 imm11=0x700");
+
+        // Narrow encoding stays byte-identical (in-range offsets untouched).
+        let code = encoder
+            .encode(&ArmOp::BCondOffset {
+                cond: Condition::EQ,
+                offset: 5,
+            })
+            .unwrap();
+        assert_eq!(code, vec![0x05, 0xD0], "narrow B<cond> unchanged");
+
+        // Out of the signed 20-bit T3 range: loud Err, never a truncated jump.
+        assert!(
+            encoder
+                .encode(&ArmOp::BCondOffset {
+                    cond: Condition::NE,
+                    offset: 1 << 19,
+                })
+                .is_err(),
+            "out-of-range T3 offset must be a loud decline"
+        );
     }
 
     #[test]

--- a/scripts/repro/brif_outer_740.wat
+++ b/scripts/repro/brif_outer_740.wat
@@ -1,0 +1,133 @@
+(module
+  ;; #740 minimal shape: a `br_if` at a loop head exiting an OUTER block.
+  ;;
+  ;;   block ;; @1
+  ;;     block ;; @2
+  ;;       loop ;; @3
+  ;;         br_if 1 (;@2;)   <- empty-budget style head exit (x1 == 0)
+  ;;         br_if 2 (;@1;)   <- bounds-style exit crossing two levels
+  ;;         <24 stores of >16-bit constants (movw+movt) so both exits
+  ;;          span > 254 bytes and must encode as 32-bit B<cond>.W (T3)>
+  ;;         br_if 0 (;@3;)   <- back edge while the counter is nonzero
+  ;;       end
+  ;;     end
+  ;;     <@2 join: marker store + NON-TAIL return  -> optimized path declines
+  ;;      (#500), the function compiles on the DIRECT selector like gust_poll>
+  ;;   end
+  ;;   <@1 join: distinct marker store + distinct result>
+  ;;
+  ;; Correct execution with x1 == 0 lands at the @2 join: exactly ONE store
+  ;; (mem[64] = 0x1111), result x0. The pre-fix encoder halved every wide
+  ;; conditional-branch displacement, landing the head exit mid-padding —
+  ;; spurious stores wasmtime never performs.
+  (memory (export "memory") 1)
+  (func (export "poll") (param i32 i32) (result i32)
+    block ;; label = @1
+      block ;; label = @2
+        loop ;; label = @3
+          local.get 1
+          i32.eqz
+          br_if 1 (;@2;)
+          local.get 0
+          i32.const 100
+          i32.ge_u
+          br_if 2 (;@1;)
+          ;; ---- padding body: must NOT execute when the head exit is taken.
+          ;; Distinct addresses/values so any mid-shape landing is visible in
+          ;; the compared memory window.
+          i32.const 128
+          i32.const 10551297
+          i32.store
+          i32.const 132
+          i32.const 10551298
+          i32.store
+          i32.const 136
+          local.get 0
+          i32.store
+          i32.const 140
+          i32.const 10551300
+          i32.store
+          i32.const 144
+          i32.const 10551301
+          i32.store
+          i32.const 148
+          i32.const 10551302
+          i32.store
+          i32.const 152
+          i32.const 10551303
+          i32.store
+          i32.const 156
+          i32.const 10551304
+          i32.store
+          i32.const 160
+          local.get 1
+          i32.store
+          i32.const 164
+          i32.const 10551306
+          i32.store
+          i32.const 168
+          i32.const 10551307
+          i32.store
+          i32.const 172
+          i32.const 10551308
+          i32.store
+          i32.const 176
+          i32.const 10551309
+          i32.store
+          i32.const 180
+          i32.const 10551310
+          i32.store
+          i32.const 184
+          local.get 0
+          i32.store
+          i32.const 188
+          i32.const 10551312
+          i32.store
+          i32.const 192
+          i32.const 10551313
+          i32.store
+          i32.const 196
+          i32.const 10551314
+          i32.store
+          i32.const 200
+          i32.const 10551315
+          i32.store
+          i32.const 204
+          i32.const 10551316
+          i32.store
+          i32.const 208
+          local.get 1
+          i32.store
+          i32.const 212
+          i32.const 10551318
+          i32.store
+          i32.const 216
+          i32.const 10551319
+          i32.store
+          i32.const 220
+          i32.const 10551320
+          i32.store
+          ;; ---- back edge: continue while the decremented counter is nonzero
+          local.get 1
+          i32.const 1
+          i32.sub
+          local.tee 1
+          br_if 0 (;@3;)
+        end
+      end
+      ;; @2 join — the loop-head exit and the loop fall-through both land here.
+      i32.const 64
+      i32.const 4369 ;; 0x1111
+      i32.store
+      local.get 0
+      return
+    end
+    ;; @1 join — the bounds-style exit lands here.
+    i32.const 68
+    i32.const 8738 ;; 0x2222
+    i32.store
+    local.get 0
+    i32.const 1
+    i32.add
+  )
+)

--- a/scripts/repro/brif_outer_740_differential.py
+++ b/scripts/repro/brif_outer_740_differential.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""#740 — EXECUTION-validate the direct path's wide conditional branches on the
+loop-inside-block shape: a `br_if` at a loop head exiting an OUTER block.
+
+Root cause (fixed alongside this harness): the Thumb-2 encoder's 32-bit
+B<cond>.W (encoding T3) arm packed `halfword_offset >> 1` into imm6:imm11 —
+per ARMv7-M the field value S:J2:J1:imm6:imm11 IS the halfword offset, so
+every conditional branch spanning > 254 bytes landed at HALF its intended
+displacement. On gust_poll (issue #740) the loop-head empty-budget
+`br_if 1 (;@2;)` jumped mid-shape: a spurious state write plus spurious calls
+on a round that must not touch memory at all. Narrow (16-bit) B<cond>
+encodings were unaffected, which is why the existing short-range CF
+differentials (#483/#497/#500/#508/#509) never caught it.
+
+This harness pins the minimal shape (`brif_outer_740.wat`):
+
+  block @1 { block @2 { loop @3 {
+      br_if 1 (;@2;)    <- head exit, > 254-byte span -> B<cond>.W
+      br_if 2 (;@1;)    <- two-level exit, also wide
+      <padding stores>  <- the bytes that force the wide encoding
+      br_if 0 (;@3;)    <- back edge
+  } } }
+
+with distinct marker stores at each join. The @2 join ends in a NON-TAIL
+`return`, so the optimized path declines the function (#500) and it compiles
+on the DIRECT selector — the same path gust_poll takes.
+
+Anti-vacuity: the harness FAILS if `poll` contains no 32-bit T3 conditional
+branch (e.g. a future codegen change shrinks the function until every branch
+encodes narrow) — the fixture must keep exercising the wide encoding to gate
+anything.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/brif_outer_740_differential.py
+Exits nonzero on any mismatch (return value OR the compared memory window).
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R9,
+    UC_ARM_REG_R10,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+WAT = Path(__file__).with_name("brif_outer_740.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+# Standalone-image machine state (see the emitted Reset_Handler): 1-page
+# linear memory at 0x20000000, r11 = linmem base, r10 = linmem size, r9 =
+# globals base (unused by this module but kept mapped), SP above it all.
+LIN = 0x2000_0000
+LIN_SIZE = 0x1_0000
+CODE = 0x0
+SP_INIT = LIN + 0x2_0000
+
+MEM_WINDOW = 0x100  # bytes of linear memory compared after each call
+
+# (x0, x1) argument pairs.
+#   x1 == 0        -> the loop-head `br_if 1` (the #740 edge) is TAKEN
+#   x0 >= 100      -> the two-level `br_if 2` is taken on the first iteration
+#   otherwise      -> the loop runs x1 times and falls through to the @2 join
+CASES = [
+    (7, 0),  # head exit taken immediately — the exact #740 shape
+    (200, 0),  # head exit taken before the bounds exit is even tested
+    (200, 1),  # two-level bounds exit taken (the second wide branch)
+    (5, 1),  # one full loop iteration, fall-through join
+    (5, 3),  # several iterations
+    (99, 6),  # bounds-exit boundary value, never taken
+]
+
+
+def compile_image(out):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed: {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text").data()
+    lin = f.get_section_by_name(".linear_memory")
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for s in sec.iter_symbols():
+                if s.name:
+                    syms[s.name] = s["st_value"]
+    return text, lin.data() if lin else b"", syms
+
+
+def has_wide_cond_branch(text, start, size):
+    """True if [start, start+size) contains a 32-bit T3 conditional branch:
+    hw1 = 1111 0 S cond(4) imm6 with cond != 111x, hw2 = 10 J1 0 J2 imm11."""
+    off = start
+    end = min(start + size, len(text))
+    while off + 4 <= end:
+        hw1 = int.from_bytes(text[off:off + 2], "little")
+        wide = (hw1 & 0xE000) == 0xE000 and (hw1 & 0x1800) != 0
+        if (hw1 & 0xF800) == 0xF000:
+            hw2 = int.from_bytes(text[off + 2:off + 4], "little")
+            cond = (hw1 >> 6) & 0xF
+            if (hw2 & 0xD000) == 0x8000 and cond < 0xE:
+                return True
+        off += 4 if wide else 2
+    return False
+
+
+def wasmtime_poll(x0, x1):
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    mem = inst.exports(st)["memory"]
+    r = inst.exports(st)["poll"](st, x0, x1)
+    return r & 0xFFFFFFFF, bytes(mem.read(st, 0, MEM_WINDOW))
+
+
+def unicorn_poll(text, lin_init, faddr, x0, x1):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x10000)
+    mu.mem_map(LIN, 0x2_0000)
+    mu.mem_write(CODE, text)
+    if lin_init:
+        mu.mem_write(LIN, lin_init[:LIN_SIZE])
+    mu.reg_write(UC_ARM_REG_R9, LIN + LIN_SIZE)  # globals base (unused, mapped)
+    mu.reg_write(UC_ARM_REG_R10, LIN_SIZE)
+    mu.reg_write(UC_ARM_REG_R11, LIN)
+    mu.reg_write(UC_ARM_REG_SP, SP_INIT)
+    ret = CODE + 0xFF00
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    mu.reg_write(UC_ARM_REG_R0, x0)
+    mu.reg_write(UC_ARM_REG_R1, x1)
+    try:
+        mu.emu_start((faddr & ~1) | 1, ret, timeout=5_000_000, count=200_000)
+    except UcError as e:
+        return f"ERR:{e}", None
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF, bytes(mu.mem_read(LIN, MEM_WINDOW))
+
+
+def main():
+    out = "/tmp/brif_outer_740.elf"
+    compile_image(out)
+    text, lin_init, syms = load(out)
+    if "poll" not in syms:
+        sys.exit("FAIL: symbol 'poll' missing from the compiled image")
+    faddr = syms["poll"] & ~1
+
+    # Anti-vacuity: the fixture only gates #740 while its exits actually
+    # encode as 32-bit B<cond>.W. A poll body of 258+ bytes guarantees the
+    # head exit's span; assert the wide encoding is really present.
+    fsize = next(
+        (s["st_size"] for sec in ELFFile(open(out, "rb")).iter_sections()
+         if sec.header.sh_type == "SHT_SYMTAB"
+         for s in sec.iter_symbols() if s.name == "poll"),
+        0,
+    )
+    if not has_wide_cond_branch(text, faddr, fsize or 0x400):
+        print("FAIL: no 32-bit B<cond>.W (T3) conditional branch found in "
+              "'poll' — the fixture no longer exercises the #740 wide "
+              "encoding; grow the padding body")
+        sys.exit(1)
+    print("OK  engagement: 'poll' contains a wide (T3) conditional branch")
+
+    fails = 0
+    for x0, x1 in CASES:
+        gt_ret, gt_mem = wasmtime_poll(x0, x1)
+        lin = bytearray(lin_init) if lin_init else bytearray(LIN_SIZE)
+        got_ret, got_mem = unicorn_poll(text, bytes(lin), faddr, x0, x1)
+        ok = got_ret == gt_ret and got_mem == gt_mem
+        fails += 0 if ok else 1
+        tag = f"0x{got_ret:08X}" if isinstance(got_ret, int) else got_ret
+        memtag = "mem==" if got_mem == gt_mem else "mem!="
+        print(f"{'OK  ' if ok else 'FAIL'} poll({x0:>3},{x1}) = {tag} "
+              f"(wasmtime 0x{gt_ret:08X}) {memtag}")
+        if not ok and got_mem is not None and got_mem != gt_mem:
+            diffs = [i for i in range(MEM_WINDOW) if got_mem[i] != gt_mem[i]]
+            print(f"      first divergent bytes at offsets: {diffs[:8]}")
+
+    print("\nRESULT:", "PASS" if not fails else f"FAIL ({fails} mismatches)")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/gust_spill_fwd_390_differential.py
+++ b/scripts/repro/gust_spill_fwd_390_differential.py
@@ -117,20 +117,19 @@ def state_bytes(seed):
     return bytes(out)
 
 
-# (state, x, strict). strict=False marks the two zero-state cases KNOWN-
-# DIVERGENT (#740): the direct path mistargets the loop-head empty-budget
-# `br_if` to a mid-shape point after the first transition call, so synth
-# spuriously writes state+0x34 (wasmtime writes nothing). Pre-existing on
-# main v0.41.0, byte-identically in ALL lever configs — NOT a #390 regression.
-# The xfail is anti-vacuous both ways: the RETURN value must still match, and
-# the moment the memory divergence disappears (i.e. #740 is fixed) the case
-# hard-fails and demands promotion to strict.
+# (state, x). The two zero-state cases were KNOWN-DIVERGENT (#740) until the
+# encoder fix landed: the Thumb-2 B<cond>.W (T3) arm halved every wide
+# conditional-branch displacement, so the loop-head empty-budget `br_if`
+# jumped mid-shape and spuriously wrote state+0x34. The anti-vacuous xfail
+# fired the moment the divergence disappeared (FIXD), and the cases are now
+# STRICT: return value AND the full state window must match wasmtime in every
+# config. (Minimal-shape oracle for the fix: brif_outer_740_differential.py.)
 CASES = [
-    (b"\x00" * STATE_SPAN, 0, False),
-    (b"\x00" * STATE_SPAN, 7, False),
-    (state_bytes(1), 3, True),
-    (state_bytes(2), 0x1234, True),
-    (state_bytes(3), -5 & 0xFFFFFFFF, True),
+    (b"\x00" * STATE_SPAN, 0),
+    (b"\x00" * STATE_SPAN, 7),
+    (state_bytes(1), 3),
+    (state_bytes(2), 0x1234),
+    (state_bytes(3), -5 & 0xFFFFFFFF),
 ]
 
 
@@ -210,30 +209,18 @@ def main():
     fails = 0
     for label, _ in cfgs:
         text, lin_init, syms = elves[label]
-        for state, x, strict in CASES:
+        for state, x in CASES:
             gt_ret, gt_mem = wasmtime_poll(state, x)
             # Seed the unicorn state region on a COPY of the initial image.
             lin = bytearray(lin_init) if lin_init else bytearray(LIN_SIZE)
             lin[STATE_OFF:STATE_OFF + STATE_SPAN] = state
             got_ret, got_mem = unicorn_call(text, bytes(lin), syms["gust_poll"], STATE_OFF, x)
-            if strict:
-                ok = got_ret == gt_ret and got_mem == gt_mem
-                verdict = "OK  " if ok else "FAIL"
-            elif got_ret == gt_ret and got_mem != gt_mem:
-                ok = True  # the documented #740 divergence, return still exact
-                verdict = "XF40"
-            elif got_ret == gt_ret and got_mem == gt_mem:
-                ok = False  # divergence gone: #740 fixed — promote to strict!
-                verdict = "FIXD"
-            else:
-                ok = False
-                verdict = "FAIL"
+            ok = got_ret == gt_ret and got_mem == gt_mem
             fails += 0 if ok else 1
             tag = f"0x{got_ret:08X}" if isinstance(got_ret, int) else got_ret
             memtag = "mem==" if got_mem == gt_mem else "mem!="
-            print(f"{verdict} gust_poll {label:16} x={x:>10} = {tag} "
-                  f"(wasmtime 0x{gt_ret:08X}) {memtag}"
-                  + ("" if strict else "  [known-divergent #740; FIXD ⇒ make strict]"))
+            print(f"{'OK  ' if ok else 'FAIL'} gust_poll {label:16} x={x:>10} = {tag} "
+                  f"(wasmtime 0x{gt_ret:08X}) {memtag}")
         for x in (0, 1, 0x7FFF, 0x12345678, 0xFFFF_FF00):
             gt = wasmtime_mix(x)
             got, _ = unicorn_call(text, lin_init, syms["gust_mix"], x, 0)


### PR DESCRIPTION
Closes #740. Part of the #242 Track-C validation lane (v0.43.0 hub, Lane E).

## Root cause

**The encoder, not the selector.** The direct selector's label/branch resolution computes the halfword displacement correctly for the loop-inside-block shape; the bug was in the Thumb-2 encoder's 32-bit `B<cond>.W` (encoding T3) arm in `crates/synth-backend/src/arm_encoder.rs`, which packed `halfword_offset >> 1` into `imm6:imm11`. Per ARMv7-M the branch byte offset is `SignExtend(S:J2:J1:imm6:imm11:'0')` — the 20-bit field `S:J2:J1:imm6:imm11` **is** the signed halfword offset — so every conditional branch spanning > 254 bytes jumped to **half** its intended displacement.

On gust_poll (#740) the loop-head empty-budget `br_if 1 (;@2;)` was the only wide conditional in the function: it landed after the first `transition` call instead of at the block-@2 join, producing the spurious `state+0x34` write plus spurious `transition`/`mix` calls on a round that must not touch memory. Narrow (16-bit) `B<cond>` encodings were unaffected — which is exactly why the short-range CF differentials (#483/#497/#500/#508/#509) never caught it, and why every *other* `br_if @2` in gust_poll (all narrow) landed correctly.

## Fix

Pack the halfword offset directly into `S:J2:J1:imm6:imm11` (mirroring the correct T4 unconditional arm), and **loud-decline** offsets outside the signed 20-bit T3 range instead of emitting a truncated branch. Bytes cross-checked against the llvm disassembler (`bne.w #0x224` = `f040 8112`).

## Red → green

- **New oracle** `scripts/repro/brif_outer_740_differential.py` + `brif_outer_740.wat`: minimal loop-inside-block shape — loop-head `br_if` to the outer block end + a two-level `br_if` exit, padded past the 254-byte span so both encode wide; non-tail `return` keeps it on the DIRECT path (optimized declines, #500 — same path as gust_poll). Return value **and** a linear-memory window vs wasmtime, 6 cases. **RED pre-fix (5/6 FAIL), GREEN with the fix (6/6).** Anti-vacuous: hard-fails if `poll` ever stops containing a 32-bit T3 conditional branch. CI-wired into the emulation-differential job.
- **xfail promotion**: the anti-vacuous #740 xfail in `gust_spill_fwd_390_differential.py` fired (FIXD) the moment the divergence disappeared, as designed; the two zero-state rows are **promoted to strict** — return AND full state window match wasmtime in all three lever configs (default, `SYNTH_NO_STACK_FWD=1`, `SYNTH_SPILL_REALLOC=0`). Full harness PASS.
- **Encoder unit test** `test_encode_thumb_bcond_wide_t3_halfword_offset_740`: forward + backward wide offsets, narrow encoding byte-identical, out-of-range → loud `Err`.

## Frozen status

Frozen anchors **10/10 bit-identical** (`frozen_codegen_bytes`) — the fixtures contain no wide conditional branches, so no refreeze. All existing CF differentials green: `block_brif_483`, `br_table_507`, `br_table_value_509`, `cf_shapes_500`, `control_step` (13/13).

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p synth-cli -p synth-synthesis` (61/61 targets) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L