### PR TITLE
feat(#494 x #390): ordeal-certified bounds-check elision — the guard_bool lane (v0.43.0 Lane F)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,7 @@ jobs:
         run: SYNTH=./target/debug/synth python scripts/repro/wide_static_746_differential.py
 
   fact-spec-oracle:
-    name: fact-spec elision oracle (#494 phases 2 + 2b + 3+)
+    name: fact-spec elision oracle (#494 phases 2 + 2b + 3+ + bounds)
     # VCR-PERF-002 Phase 2 (#494): the proof-carrying-specialization lever
     # (SYNTH_FACT_SPEC, default off; per-elision ordeal obligation). Built
     # with the `verify` feature (the solver lives in synth-verify — pure-Rust
@@ -418,8 +418,11 @@ jobs:
     # green path. Phase 2b (divisor-nonzero, kind 3): the div/rem trap-guard
     # elision byte gates + differential (incl. the two-guard distinction — the
     # i64 INT64_MIN/-1 overflow guard is RETAINED under a nonzero-only fact —
-    # and the RED force-admit divergence demo, debug-build lever). Isolated
-    # job: emulation deps pip-installed here ONLY.
+    # and the RED force-admit divergence demo, debug-build lever). Bounds
+    # elision (#494 × #390 guard_bool): the software memory bounds guard falls
+    # to a per-site certificate — byte gates, 1024-case sweep, retained-trap,
+    # decline and RED legs (steps below). Isolated job: emulation deps
+    # pip-installed here ONLY.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -488,6 +491,24 @@ jobs:
         run: >
           python scripts/repro/fact_spec_mask_494_differential.py
           --fact-lo 0 --fact-hi 4095 --expect-decline
+      # #494 bounds-elision × #390 guard_bool — the `--safety-bounds software`
+      # memory bounds guard falls to a per-site certificate:
+      # UNSAT(P ∧ trap_mem_oob(zext64(index) + offset, size, min_memory_bytes))
+      # (ordeal 0.9.1 trap_mem_oob shape, wraparound-safe 64-bit extension).
+      # Byte gates (poll 184 -> 104 B, all 8 guard UDFs gone, specialized
+      # .text BYTE-IDENTICAL to the unguarded floor), the 1024-case in-bounds
+      # sweep vs wasmtime + unspecialized (return value + full memory image),
+      # the retained-trap leg (out-of-premise inputs still trap on the
+      # UNSPECIALIZED path), the Sat loud-decline byte-identity leg, and the
+      # RED force-admit sandbox-escape demonstration (debug-build lever).
+      - name: Run bounds-elision gates (#494 bounds byte evidence)
+        run: cargo test -p synth-cli --features verify --test fact_spec_bounds_494
+      - name: Run bounds-elision in-bounds differential (green)
+        run: python scripts/repro/fact_spec_bounds_494_differential.py
+      - name: Run bounds-including-OOB loud-decline path
+        run: python scripts/repro/fact_spec_bounds_494_differential.py --expect-decline
+      - name: Run RED bounds force-admit divergence demonstration
+        run: python scripts/repro/fact_spec_bounds_494_differential.py --force-admit
 
   rv32-shift-fold-oracle:
     name: rv32 immediate-shift-fold execution oracle

--- a/artifacts/parity-benchmark.md
+++ b/artifacts/parity-benchmark.md
@@ -22,8 +22,18 @@ Regenerate everything on this page:
   `arm-none-eabi-gcc -Os`, and within 2 B of the **12 B LLVM floor** (CITED
   #494). C has no channel to carry the range premise — the native compiler
   must keep both compares; synth carries the proof (#494).
+- **Sandbox bounds checks become FREE under a proven premise**: the
+  gust_poll-shaped record-array kernel under `--safety-bounds software`
+  carries 8 inline guards (**184 B**); with
+  the premise slot∈[0,63] every guard falls to a per-site ordeal certificate
+  (`UNSAT(P ∧ trap_mem_oob(zext64(index)+offset, size, min_mem))`) —
+  **104 B, byte-identical to the unguarded
+  floor**. The sandbox-safety tax native C never pays drops to exactly zero
+  for wasm-AOT too, and only when proven (#494 × #390 `guard_bool`; wrong
+  premise ⇒ Sat ⇒ loud decline, guards retained).
 - **General register allocation is still the gap**: gust_poll is
-  **740 B vs 208 B** (CITED #390) = 3.56×, with
+  **724 B vs 208 B** (CITED #390) =
+  3.48x, with
   `spill_reload` alone ~31% of the function
   (`artifacts/size_attribution_390.md` — the productive-work residual, 194 B,
   is already comparable to LLVM's entire output; the gap is overhead buckets).
@@ -37,7 +47,7 @@ Regenerate everything on this page:
 
 ## Pinned toolchain (versions that produced the MEASURED numbers)
 
-- **synth**: `synth 0.41.0` (debug build, `--features verify` — the fact-spec row needs the ordeal solver)
+- **synth**: `synth 0.42.0` (debug build, `--features verify` — the fact-spec row needs the ordeal solver)
 - **arm-none-eabi-gcc**: `arm-none-eabi-gcc (Arm GNU Toolchain 13.2.rel1 (Build arm-13.7)) 13.2.1 20231009`
 - **arm-none-eabi-objdump**: `GNU objdump (Arm GNU Toolchain 13.2.rel1 (Build arm-13.7)) 2.41.0.20231009`
 - **wat2wasm**: `1.0.39`
@@ -71,7 +81,7 @@ Regenerate everything on this page:
 
 | kernel | path | .text B | provenance | vs native ref | cycles |
 |---|---|---|---|---|---|
-| gust_poll | synth AOT (default) | 740 | MEASURED | 3.56x | OPEN — gale silicon (DWT) |
+| gust_poll | synth AOT (default) | 724 | MEASURED | 3.48x | OPEN — gale silicon (DWT) |
 | gust_poll | native rustc/LLVM thumbv7m | 208 | CITED #390 | ref | OPEN — gale silicon (DWT) |
 | gust_mix (Q8 wrapper) | synth AOT (default) | 32 | MEASURED | 2.67x | OPEN — gale silicon (DWT) |
 | gust_mix (Q8 wrapper) | native rustc/LLVM thumbv7m | 12 | CITED #390 | ref | OPEN — gale silicon (DWT) |
@@ -79,6 +89,9 @@ Regenerate everything on this page:
 | gust_mix clamp | synth AOT + SYNTH_FACT_SPEC=1 (proven ch∈[524,1524]) | 14 | MEASURED (2 ordeal ADMITs) | 0.54x | OPEN — gale silicon (DWT) |
 | gust_mix clamp | native C — arm-none-eabi-gcc -Os | 26 | MEASURED | ref | OPEN — gale silicon (DWT) |
 | gust_mix clamp | native LLVM floor (gale gust_floor_bench) | 12 | CITED #494 | 0.46x | OPEN — gale silicon (DWT) |
+| gust_poll bounds (8 sw guards) | synth AOT --safety-bounds software (no facts) | 184 | MEASURED | 1.77x | OPEN — gale silicon (DWT) |
+| gust_poll bounds (8 sw guards) | synth AOT sw bounds + SYNTH_FACT_SPEC=1 (proven slot∈[0,63]) | 104 | MEASURED (8 ordeal ADMITs) | 1.00x | OPEN — gale silicon (DWT) |
+| gust_poll bounds (8 sw guards) | synth AOT unguarded floor (no --safety-bounds) — group ref | 104 | MEASURED | ref | OPEN — gale silicon (DWT) |
 | flat_flight | synth AOT (default) | 458 | MEASURED | 2.54x | OPEN — gale silicon (DWT) |
 | flat_flight | native C — arm-none-eabi-gcc -Os | 180 | MEASURED | ref | OPEN — gale silicon (DWT) |
 | falcon_axis (f32) | synth AOT (cortex-m4f, VFP) | 72 | MEASURED | 1.64x | OPEN — gale silicon (DWT) |
@@ -87,7 +100,10 @@ Regenerate everything on this page:
 Synth-side byte numbers are pinned by
 `crates/synth-cli/tests/parity_benchmark_735.rs` (default rows) and its
 verify-feature test (fact-spec row) — prose and measurement cannot drift
-apart without reddening CI.
+apart without reddening CI. The bounds-group rows are pinned by
+`crates/synth-cli/tests/fact_spec_bounds_494.rs` (guarded 184 B /
+specialized 104 B, 8-ADMIT non-vacuity, floor byte-identity) in the same
+fact-spec CI job.
 
 ## Falsification — one command per row group
 
@@ -104,6 +120,11 @@ table line (nonzero exit on any failure):
     # gust_mix clamp under the proven premise (needs a verify-feature synth;
     # fails loudly unless BOTH elisions are certificate-ADMITted)
     SYNTH=$CARGO_TARGET_DIR/debug/synth python3 scripts/repro/parity_benchmark/run.py --only clamp_spec
+
+    # gust_poll bounds group: software guards vs certified elision vs the
+    # unguarded floor (needs a verify-feature synth; fails loudly unless all
+    # EIGHT elisions are certificate-ADMITted)
+    SYNTH=$CARGO_TARGET_DIR/debug/synth python3 scripts/repro/parity_benchmark/run.py --only bounds
 
     # flat_flight: synth vs the in-tree C source it was compiled from
     SYNTH=$CARGO_TARGET_DIR/debug/synth python3 scripts/repro/parity_benchmark/run.py --only flat_flight
@@ -124,13 +145,14 @@ The gap is CLOSING release-over-release, lever by lever, each evidence-gated:
 
 | datum | then | now (this page) | source |
 |---|---|---|---|
-| gust_poll .text | 816 B (v0.11.50, CITED #390) | 740 B MEASURED | levers v0.12–v0.41 |
+| gust_poll .text | 816 B (v0.11.50, CITED #390) | 724 B MEASURED | levers v0.12–v0.41 |
 | gust_mix (Q8) .text | 44 B (v0.11.50, CITED #390) | 32 B MEASURED | uxth-fold, const-CSE, shift-mask-elide |
 | gust_mix clamp (proven premise) | no lever | 14 B MEASURED vs 12 B LLVM floor | #494 fact-spec (v0.31+) |
 | flat_flight frame traffic | 17 spills (#209, CITED) | Belady optimum, frame traffic 0 (since v0.24.0) | VCR-RA-001 |
 
 Open, tracked, and honestly not yet won: general regalloc overhead
-(gust_poll 3.56×, spill_reload ~31%, #390/#242 Track A), flat_flight at
+(gust_poll 3.48x,
+spill_reload ~31%, #390/#242 Track A), flat_flight at
 2.54x vs gcc, falcon f32 at
 1.64x vs gcc (constant materialization
 via `movw/movt+vmov` instead of a literal pool, unused callee-save push), and

--- a/artifacts/size_attribution_390.md
+++ b/artifacts/size_attribution_390.md
@@ -75,6 +75,14 @@ unused callee-save, frame setup, and un-coalesced copies around a one-line wrapp
   `cmp rN,#0`, `cmn`, dead mod-32 shift mask (`and ip,rN,#31`), `udf`.
   Comparisons feeding a `br_if` materialize a bool then re-`cmp #0` instead of
   branching off flags. Opportunity: branch-on-flags peephole + shift-mask elide.
+  PREMISE-GATED LEVER (#494 bounds-elision, v0.43+): under `--safety-bounds
+  software` each memory access adds a 10 B ADD/CMP/BLO/UDF guard to this
+  class; with `SYNTH_FACT_SPEC=1` + a `wsc.facts` range premise on the index,
+  each guard falls to a per-site ordeal certificate
+  (`UNSAT(P ∧ trap_mem_oob(...))`) — measured on the gust_poll-shaped
+  fixture: 184 → 104 B, byte-identical to the unguarded floor
+  (`fact_spec_bounds_494_differential.py`). The numbers on THIS page are the
+  default path (no `--safety-bounds`, no facts) and are unchanged by it.
 - **copy_move** (Pass 5) — plain `mov rD, rS`. Un-coalesced identity/near-identity
   copies. Opportunity: copy coalescing (pairs with the allocator).
 - **productive** — residual: real arithmetic, the memory loads/stores themselves,

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -311,17 +311,26 @@ fn compile_wasm_to_arm(
     // walk never crosses (it stops at the first untracked op, so no mark can
     // follow one). Defense in depth: if the fold fired at all, drop the marks
     // loudly rather than risk keying a guard elision to the wrong op.
-    let (fact_div_zero_elide, fact_div_ovf_elide): (&[usize], &[usize]) = if rewritten.len()
-        == wasm_ops.len()
-    {
-        (&config.fact_div_zero_elide, &config.fact_div_ovf_elide)
+    let (fact_div_zero_elide, fact_div_ovf_elide, fact_mem_bounds_elide): (
+        &[usize],
+        &[usize],
+        &[usize],
+    ) = if rewritten.len() == wasm_ops.len() {
+        (
+            &config.fact_div_zero_elide,
+            &config.fact_div_ovf_elide,
+            &config.fact_mem_bounds_elide,
+        )
     } else {
-        if !config.fact_div_zero_elide.is_empty() || !config.fact_div_ovf_elide.is_empty() {
+        if !config.fact_div_zero_elide.is_empty()
+            || !config.fact_div_ovf_elide.is_empty()
+            || !config.fact_mem_bounds_elide.is_empty()
+        {
             eprintln!(
-                "fact-spec: DECLINE div-guard elision marks dropped — the                      memory.grow(0) fold shifted op indices (#494 defensive gate);                      general lowering emitted"
+                "fact-spec: DECLINE guard elision marks dropped — the                      memory.grow(0) fold shifted op indices (#494 defensive gate);                      general lowering emitted"
             );
         }
-        (&[], &[])
+        (&[], &[], &[])
     };
     let wasm_ops: &[WasmOp] = &rewritten;
 
@@ -484,6 +493,9 @@ fn compile_wasm_to_arm(
         // marks (empty in every compile without SYNTH_FACT_SPEC + facts).
         selector
             .set_fact_div_guard_elisions(fact_div_zero_elide.to_vec(), fact_div_ovf_elide.to_vec());
+        // #494 bounds-elision: certificate-discharged memory bounds-guard
+        // marks (empty in every compile without SYNTH_FACT_SPEC + facts).
+        selector.set_fact_mem_bounds_elisions(fact_mem_bounds_elide.to_vec());
         selector.select_with_stack(wasm_ops, num_params)
     };
     let select_direct = || -> Result<Vec<ArmInstruction>, String> {
@@ -659,7 +671,11 @@ fn compile_wasm_to_arm(
     // them. Route marked functions direct (the #507/#509 honest-degradation
     // pattern). Never fires without SYNTH_FACT_SPEC + facts + a discharged
     // obligation, so every existing compile keeps its path byte-identical.
-    let has_fact_div_elide = !fact_div_zero_elide.is_empty() || !fact_div_ovf_elide.is_empty();
+    let has_fact_div_elide = !fact_div_zero_elide.is_empty()
+        || !fact_div_ovf_elide.is_empty()
+        // #494 bounds-elision: memory bounds-guard marks are direct-selector
+        // keyed for the same reason (IR passes renumber instructions).
+        || !fact_mem_bounds_elide.is_empty();
     // #643: the optimized path's global lowering is width-naive — `GlobalGet`/
     // `GlobalSet` are single-word `[R9, idx*4]` accesses, which (a) silently
     // dropped the high word of every i64 global and (b) mis-address every

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -31,6 +31,14 @@ required-features = ["verify"]
 name = "fact_spec_div_494"
 required-features = ["verify"]
 
+# #494 bounds-elision (#390 guard_bool): same contract — the memory
+# bounds-guard byte gates need the solver-carrying binary; the fact-spec CI
+# job runs it via
+# `cargo test -p synth-cli --features verify --test fact_spec_bounds_494`.
+[[test]]
+name = "fact_spec_bounds_494"
+required-features = ["verify"]
+
 [features]
 default = ["riscv"]
 awsm = ["synth-backend-awsm"]

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -69,6 +69,10 @@ struct SpecializedFn {
     /// certificate-elided (a SEPARATE obligation — divisor-nonzero alone
     /// never lands here, #633/#634).
     elide_div_ovf: Vec<usize>,
+    /// #494 bounds-elision (#390 `guard_bool`): i32 memory-access sites whose
+    /// `--safety-bounds software` guard was certificate-elided — threaded to
+    /// `CompileConfig::fact_mem_bounds_elide` for the direct selector.
+    elide_mem_bounds: Vec<usize>,
 }
 
 /// Run the fact-spec pass (value-range facts ⇒ dead conditional-branch
@@ -85,6 +89,7 @@ fn maybe_fact_spec(
     block_arity: &[(u8, u8)],
     facts: &[WscFact],
     params_i64: &[bool],
+    linear_memory_bytes: u32,
 ) -> Option<SpecializedFn> {
     if !fact_spec_enabled() || facts.is_empty() {
         return None;
@@ -97,6 +102,7 @@ fn maybe_fact_spec(
             block_arity,
             facts,
             params_i64,
+            linear_memory_bytes,
         );
         // Loud by contract: every decline names its site and reason; every
         // admit carries the certificate line (the evidence trail).
@@ -106,16 +112,22 @@ fn maybe_fact_spec(
         for line in &r.admitted {
             eprintln!("fact-spec: ADMIT {line}");
         }
-        if r.changed() || !r.elide_div_zero.is_empty() || !r.elide_div_ovf.is_empty() {
+        if r.changed()
+            || !r.elide_div_zero.is_empty()
+            || !r.elide_div_ovf.is_empty()
+            || !r.elide_mem_bounds.is_empty()
+        {
             eprintln!(
                 "fact-spec: '{func_name}' specialized — {} elision(s) admitted, \
-                 {} declined ({} → {} ops, {} zero-guard + {} overflow-guard marks)",
+                 {} declined ({} → {} ops, {} zero-guard + {} overflow-guard + \
+                 {} bounds-guard marks)",
                 r.admitted.len(),
                 r.declined.len(),
                 ops.len(),
                 r.ops.len(),
                 r.elide_div_zero.len(),
                 r.elide_div_ovf.len(),
+                r.elide_mem_bounds.len(),
             );
             return Some(SpecializedFn {
                 ops: r.ops,
@@ -123,13 +135,21 @@ fn maybe_fact_spec(
                 kept: r.kept,
                 elide_div_zero: r.elide_div_zero,
                 elide_div_ovf: r.elide_div_ovf,
+                elide_mem_bounds: r.elide_mem_bounds,
             });
         }
         None
     }
     #[cfg(not(feature = "verify"))]
     {
-        let _ = (func_name, ops, block_arity, facts, params_i64);
+        let _ = (
+            func_name,
+            ops,
+            block_arity,
+            facts,
+            params_i64,
+            linear_memory_bytes,
+        );
         // Decline loudly (the design doc's rule): without the solver the
         // obligation cannot be discharged, so no elision may fire — but the
         // user asked for specialization, so say why nothing happens.
@@ -1624,12 +1644,16 @@ fn compile_command(
     let mut wasm_ops = wasm_ops;
     let mut fact_div_zero_elide = Vec::new();
     let mut fact_div_ovf_elide = Vec::new();
+    let mut fact_mem_bounds_elide = Vec::new();
     if let Some(spec) = maybe_fact_spec(
         &func_name,
         &wasm_ops,
         &current_func_block_arity,
         &current_func_facts,
         &current_func_params_i64,
+        // The plain per-function path has no module memory context — every
+        // memory bounds-guard obligation declines loudly (0 = unknown).
+        0,
     ) {
         wasm_ops = spec.ops;
         current_func_block_arity = spec.block_arity;
@@ -1637,6 +1661,7 @@ fn compile_command(
         // keyed by index into the (possibly rewritten) stream above.
         fact_div_zero_elide = spec.elide_div_zero;
         fact_div_ovf_elide = spec.elide_div_ovf;
+        fact_mem_bounds_elide = spec.elide_mem_bounds;
     }
 
     info!("WASM operations: {:?}", wasm_ops);
@@ -1685,6 +1710,7 @@ fn compile_command(
         // empty unless SYNTH_FACT_SPEC + facts + a discharged obligation.
         fact_div_zero_elide,
         fact_div_ovf_elide,
+        fact_mem_bounds_elide,
         // #642: call_indirect guard inputs — the default declines every
         // call_indirect lowering, so the demo path (no module) stays safe.
         call_indirect_guards,
@@ -2841,6 +2867,9 @@ fn compile_all_exports(
             &func_config.current_func_block_arity,
             &func_config.current_func_facts,
             &func_config.current_func_params_i64,
+            // #494 bounds-elision: the module's declared minimum memory size
+            // bounds every reachable runtime extent (R10 ≥ declared min).
+            func_config.linear_memory_bytes,
         );
         let (ops_for_compile, op_offsets_for_elf): (&[WasmOp], Vec<u32>) = match &spec {
             Some(s) => {
@@ -2850,6 +2879,7 @@ fn compile_all_exports(
                 // is about to consume.
                 func_config.fact_div_zero_elide = s.elide_div_zero.clone();
                 func_config.fact_div_ovf_elide = s.elide_div_ovf.clone();
+                func_config.fact_mem_bounds_elide = s.elide_mem_bounds.clone();
                 (
                     &s.ops,
                     s.kept

--- a/crates/synth-cli/tests/fact_spec_bounds_494.rs
+++ b/crates/synth-cli/tests/fact_spec_bounds_494.rs
@@ -1,0 +1,288 @@
+//! #494 bounds-elision × #390 `guard_bool` — end-to-end byte gates for the
+//! ordeal-certified memory bounds-guard elision (`SYNTH_FACT_SPEC`, default
+//! OFF; per-site obligation `UNSAT(P ∧ trap_mem_oob(zext64(index) + offset,
+//! size, min_memory_bytes))`, ordeal 0.9.1 `trap_mem_oob` shape with
+//! wraparound-safe 64-bit width extension).
+//!
+//! Requires the `verify` feature (the pass needs the ordeal-backed solver):
+//! `cargo test -p synth-cli --features verify --test fact_spec_bounds_494`
+//! (the fact-spec CI job does). The execution differential (in-bounds sweep
+//! ≡ wasmtime ≡ unspecialized, the retained-trap leg, and the red
+//! force-admit divergence demo) lives in
+//! `scripts/repro/fact_spec_bounds_494_differential.py`; here we lock the
+//! byte evidence and the certificate trail on
+//! `scripts/repro/fact_spec_bounds_494.wat` (the gust_poll-shaped fixture —
+//! 8 software-guarded accesses over a 16 B task-record array):
+//!
+//! - flag OFF + facts present → byte-identical to baseline (no consumer);
+//! - flag ON + proven `slot ∈ [0, 63]` → all EIGHT guard UDFs are GONE and
+//!   `poll` shrinks by 80 B (184 → 104 B — each guard is ADD.w 4 B + CMP
+//!   2 B + BLO 2 B + UDF 2 B), one ADMIT certificate line per site;
+//! - flag ON + a bound admitting OOB (`slot ∈ [0, 8192]`) → Sat, loud
+//!   decline, byte-identical (the guard is restored by the OBLIGATION, not
+//!   by prudence);
+//! - flag ON + facts but WITHOUT `--safety-bounds software` → the marks are
+//!   admitted (the obligation is mode-independent) but there is no guard to
+//!   strip — the lowering stays sound and UDF-free either way.
+//!
+//! Frozen anchors are untouched by construction (no fixture carries a facts
+//! section) and additionally locked by `frozen_codegen_bytes.rs`.
+
+use object::{Object, ObjectSection, ObjectSymbol};
+use std::process::Command;
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture_wasm() -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro/fact_spec_bounds_494.wat");
+    let wat = std::fs::read(path).expect("read fixture wat");
+    wat::parse_bytes(&wat)
+        .expect("fixture wat must parse")
+        .into_owned()
+}
+
+// ---- schema-v1 encoders (mirror docs/design/wsc-facts-encoding.md) ----
+
+fn leb_u32(mut v: u32, out: &mut Vec<u8>) {
+    loop {
+        let mut b = (v & 0x7f) as u8;
+        v >>= 7;
+        if v != 0 {
+            b |= 0x80;
+        }
+        out.push(b);
+        if v == 0 {
+            return;
+        }
+    }
+}
+
+fn leb_s64(mut v: i64, out: &mut Vec<u8>) {
+    loop {
+        let mut b = (v & 0x7f) as u8;
+        v >>= 7;
+        let done = (v == 0 && b & 0x40 == 0) || (v == -1 && b & 0x40 != 0);
+        if !done {
+            b |= 0x80;
+        }
+        out.push(b);
+        if done {
+            return;
+        }
+    }
+}
+
+/// Append one value-range fact (`slot ∈ [lo, hi]` on func 0, value_id 0 —
+/// the fixture's first `local.get $slot`) as a `wsc.facts` custom section.
+fn with_slot_range(mut wasm: Vec<u8>, lo: i64, hi: i64) -> Vec<u8> {
+    let mut payload = vec![0x01]; // version
+    leb_u32(1, &mut payload); // one record
+    let mut body = Vec::new();
+    leb_s64(lo, &mut body);
+    leb_s64(hi, &mut body);
+    payload.push(0x01); // kind: ValueRange
+    leb_u32(0, &mut payload); // func_index
+    leb_u32(0, &mut payload); // value_id
+    leb_u32(body.len() as u32, &mut payload);
+    payload.extend_from_slice(&body);
+    let name = b"wsc.facts";
+    let mut content = Vec::new();
+    leb_u32(name.len() as u32, &mut content);
+    content.extend_from_slice(name);
+    content.extend_from_slice(&payload);
+    wasm.push(0x00);
+    leb_u32(content.len() as u32, &mut wasm);
+    wasm.extend_from_slice(&content);
+    wasm
+}
+
+/// Compile on the shipped ARM path; return (.text, per-function slices, stderr).
+fn compile(wasm: &[u8], tag: &str, fact_spec: bool, software_bounds: bool) -> Compiled {
+    let dir = std::env::temp_dir().join("fact_spec_bounds_494");
+    std::fs::create_dir_all(&dir).expect("mk tempdir");
+    let input = dir.join(format!("{tag}.wasm"));
+    let elf = dir.join(format!("{tag}.elf"));
+    std::fs::write(&input, wasm).expect("write wasm");
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        input.to_str().unwrap(),
+        "-o",
+        elf.to_str().unwrap(),
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+    ]);
+    if software_bounds {
+        cmd.args(["--safety-bounds", "software"]);
+    }
+    if fact_spec {
+        cmd.env("SYNTH_FACT_SPEC", "1");
+    } else {
+        cmd.env_remove("SYNTH_FACT_SPEC");
+    }
+    cmd.env_remove("SYNTH_FACT_SPEC_FORCE_ADMIT");
+    let out = cmd.output().expect("run synth");
+    assert!(
+        out.status.success(),
+        "compile of '{tag}' failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let bytes = std::fs::read(&elf).expect("read elf");
+    let obj = object::File::parse(&*bytes).expect("parse elf");
+    let text_section = obj.section_by_name(".text").expect(".text");
+    let text = text_section.data().expect("read .text").to_vec();
+    let text_addr = text_section.address();
+    // Function regions from the symtab (the #489 lesson: symbols, not disasm
+    // text). st_size may be 0 on this builder — slice to the next symbol.
+    let text_end = text_addr + text.len() as u64;
+    let mut syms: Vec<(String, u64)> = obj
+        .symbols()
+        .filter(|s| {
+            // Thumb function symbols may carry the interworking bit.
+            let addr = s.address() & !1;
+            !s.name().unwrap_or("").is_empty() && addr >= text_addr && addr < text_end
+        })
+        .map(|s| {
+            (
+                s.name().unwrap().to_string(),
+                (s.address() & !1) - text_addr,
+            )
+        })
+        .collect();
+    syms.sort_by_key(|&(_, a)| a);
+    let mut funcs = std::collections::HashMap::new();
+    for (i, (name, start)) in syms.iter().enumerate() {
+        let end = syms
+            .get(i + 1)
+            .map(|&(_, a)| a as usize)
+            .unwrap_or(text.len())
+            .min(text.len());
+        funcs.insert(name.clone(), text[*start as usize..end].to_vec());
+    }
+    Compiled {
+        text,
+        funcs,
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+struct Compiled {
+    text: Vec<u8>,
+    funcs: std::collections::HashMap<String, Vec<u8>>,
+    stderr: String,
+}
+
+impl Compiled {
+    fn func(&self, name: &str) -> &[u8] {
+        self.funcs
+            .get(name)
+            .unwrap_or_else(|| panic!("symbol '{name}' missing from symtab"))
+    }
+
+    /// Count aligned 16-bit words equal to `hw` in a function's region.
+    fn halfword_count(&self, func: &str, hw: u16) -> usize {
+        self.func(func)
+            .chunks_exact(2)
+            .filter(|c| u16::from_le_bytes([c[0], c[1]]) == hw)
+            .count()
+    }
+}
+
+const UDF0: u16 = 0xDE00; // the software bounds-guard trap (#377 inline UDF)
+
+/// Flag OFF is byte-identical to baseline even with facts present.
+#[test]
+fn flag_off_with_facts_is_byte_identical_494() {
+    let base = fixture_wasm();
+    let facts = with_slot_range(base.clone(), 0, 63);
+    let t_base = compile(&base, "off_base", false, true);
+    let t_facts = compile(&facts, "off_facts", false, true);
+    assert_eq!(
+        t_base.text, t_facts.text,
+        "SYNTH_FACT_SPEC unset must never consume facts"
+    );
+}
+
+/// THE BOUNDS-ELISION GATE (byte evidence): under `slot ∈ [0, 63]` all eight
+/// software bounds guards are certificate-elided — the UDFs vanish and the
+/// function sheds exactly 8 × 10 B of guard code (#390's `guard_bool` class).
+#[test]
+fn proven_slot_bound_elides_all_eight_guards_494() {
+    let base = fixture_wasm();
+    let facts = with_slot_range(base.clone(), 0, 63);
+    let b = compile(&base, "proven_base", false, true);
+    let s = compile(&facts, "proven_spec", true, true);
+
+    // Baseline guard census: eight inline guards, one per access.
+    assert_eq!(b.halfword_count("poll", UDF0), 8, "baseline guards present");
+    assert_eq!(s.halfword_count("poll", UDF0), 0, "all guards elided");
+
+    // The measured byte win — pinned exactly so a regression (or an
+    // improvement) shows as a required update, like the size oracle.
+    let (b_len, s_len) = (b.func("poll").len(), s.func("poll").len());
+    assert_eq!(b_len, 184, "baseline poll size drifted");
+    assert_eq!(s_len, 104, "specialized poll size drifted");
+    assert_eq!(b_len - s_len, 80, "8 guards x 10 B (ADD.w+CMP+BLO+UDF)");
+
+    // Certificate trail: one ADMIT per access, naming the obligation.
+    let admits = s.stderr.matches("fact-spec: ADMIT").count();
+    assert_eq!(admits, 8, "stderr:\n{}", s.stderr);
+    assert!(
+        s.stderr.contains("software bounds guard elided")
+            && s.stderr.contains("trap_mem_oob")
+            && s.stderr.contains("certificate-checked"),
+        "admits name their obligation:\n{}",
+        s.stderr
+    );
+}
+
+/// A bound admitting OOB (`slot = 4096` ⇒ base = 65792 > 65536) is Sat:
+/// loud decline, guard bytes byte-identical to baseline — the obligation is
+/// the gate, not the fact's say-so.
+#[test]
+fn oob_admissible_bound_declines_and_restores_guards_byte_identically_494() {
+    let base = fixture_wasm();
+    let facts = with_slot_range(base.clone(), 0, 8192);
+    let b = compile(&base, "sat_base", false, true);
+    let s = compile(&facts, "sat_spec", true, true);
+    assert_eq!(
+        s.stderr.matches("fact-spec: ADMIT").count(),
+        0,
+        "a Sat obligation must never admit:\n{}",
+        s.stderr
+    );
+    assert!(
+        s.stderr.contains("bounds-guard obligation Sat") && s.stderr.contains("counterexample"),
+        "declines are loud and carry a model:\n{}",
+        s.stderr
+    );
+    assert_eq!(
+        s.text, b.text,
+        "declined build must be byte-identical to baseline"
+    );
+    assert_eq!(s.halfword_count("poll", UDF0), 8, "all guards retained");
+}
+
+/// Marks without `--safety-bounds software`: nothing to strip — the
+/// unguarded lowering is emitted either way (mode-independent soundness;
+/// `Masking` never consumes a mark by construction).
+#[test]
+fn marks_without_software_bounds_have_no_guard_to_strip_494() {
+    let base = fixture_wasm();
+    let facts = with_slot_range(base.clone(), 0, 63);
+    let s = compile(&facts, "nobounds_spec", true, false);
+    assert_eq!(
+        s.stderr.matches("fact-spec: ADMIT").count(),
+        8,
+        "the obligation is bounds-mode-independent:\n{}",
+        s.stderr
+    );
+    assert_eq!(s.halfword_count("poll", UDF0), 0, "no guards, no UDFs");
+}

--- a/crates/synth-cli/tests/parity_benchmark_735.rs
+++ b/crates/synth-cli/tests/parity_benchmark_735.rs
@@ -3,7 +3,7 @@
 //! `scripts/repro/parity_benchmark/run.py --report`).
 //!
 //! The benchmark's prose says "AOT-wasm ≥ native today on certified-elision
-//! shapes; general regalloc still 3.56x" — this test makes those MEASURED
+//! shapes; general regalloc still ~3.5x" — this test makes those MEASURED
 //! numbers machine-checked so the document cannot drift from measurement:
 //! a size regression reddens CI, and a size WIN reddens it too, forcing a
 //! deliberate repin + report regeneration (the pin going DOWN is the visible

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -335,6 +335,17 @@ pub struct CompileConfig {
     /// divisor-nonzero fact alone NEVER lands here: divisor ≠ 0 does not
     /// exclude -1 (#633/#634 two-guard distinction). Empty ⇒ guard emitted.
     pub fact_div_ovf_elide: Vec<usize>,
+    /// #494 bounds-elision (#390 `guard_bool`): op indices of i32 memory
+    /// accesses whose `--safety-bounds software` inline guard is proven dead
+    /// — the fact-spec pass discharged
+    /// `UNSAT(P ∧ trap_mem_oob(zext64(index) + offset, size,
+    /// min_memory_bytes))` per site through the certificate-checked ordeal
+    /// solver BEFORE the driver set this field (ordeal 0.9.1 `trap_mem_oob`
+    /// shape, wraparound-safe 64-bit extension). Consumed by the ARM direct
+    /// selector (`select_with_stack`); every other path ignores it (guards
+    /// stay — sound). Empty (the default) ⇒ every guard is emitted,
+    /// byte-identical to today.
+    pub fact_mem_bounds_elide: Vec<usize>,
     /// #642: `call_indirect` guard inputs — the compile-time table size for
     /// the runtime bounds check and the per-expected-type closed-world type
     /// verdicts — computed from the decoded module by
@@ -429,6 +440,7 @@ impl Default for CompileConfig {
             // every div/rem trap guard is emitted, byte-identical.
             fact_div_zero_elide: Vec::new(),
             fact_div_ovf_elide: Vec::new(),
+            fact_mem_bounds_elide: Vec::new(),
             // #642: no guard inputs ⇒ every call_indirect lowering declines
             // loudly (never an unchecked indirect branch). Driver loops fill
             // this from the decoded module.

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -3009,10 +3009,11 @@ pub struct InstructionSelector {
     fact_div_ovf_elide: Vec<usize>,
     /// #494 bounds-elision (#390 `guard_bool`): op indices of i32 memory
     /// accesses whose `--safety-bounds software` inline guard is proven dead
-    /// — the fact-spec pass discharged `UNSAT(P ∧ trap_mem_oob(zext64(index)
-    /// + offset, size, min_memory_bytes))` per site through the
-    /// certificate-checked ordeal solver BEFORE selection. Empty (the
-    /// default) ⇒ every guard is emitted, byte-identical to today.
+    /// — the fact-spec pass discharged
+    /// `UNSAT(P ∧ trap_mem_oob(zext64(index) + offset, size,
+    /// min_memory_bytes))` per site through the certificate-checked ordeal
+    /// solver BEFORE selection. Empty (the default) ⇒ every guard is
+    /// emitted, byte-identical to today.
     fact_mem_bounds_elide: Vec<usize>,
     /// #642: `call_indirect` guard inputs — compile-time table size (for the
     /// encoder's runtime bounds guard) + per-expected-type closed-world type

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -3007,6 +3007,13 @@ pub struct InstructionSelector {
     /// (`UNSAT(P ∧ dividend == INT_MIN ∧ divisor == -1)`; divisor ≠ 0 alone
     /// never justifies it, #633/#634). Empty ⇒ guard emitted.
     fact_div_ovf_elide: Vec<usize>,
+    /// #494 bounds-elision (#390 `guard_bool`): op indices of i32 memory
+    /// accesses whose `--safety-bounds software` inline guard is proven dead
+    /// — the fact-spec pass discharged `UNSAT(P ∧ trap_mem_oob(zext64(index)
+    /// + offset, size, min_memory_bytes))` per site through the
+    /// certificate-checked ordeal solver BEFORE selection. Empty (the
+    /// default) ⇒ every guard is emitted, byte-identical to today.
+    fact_mem_bounds_elide: Vec<usize>,
     /// #642: `call_indirect` guard inputs — compile-time table size (for the
     /// encoder's runtime bounds guard) + per-expected-type closed-world type
     /// verdicts (the compile-time discharge of the §4.4.8 type check). Set
@@ -3086,6 +3093,7 @@ impl InstructionSelector {
             sel_dsl: sel_dsl_from_env(),
             fact_div_zero_elide: Vec::new(),
             fact_div_ovf_elide: Vec::new(),
+            fact_mem_bounds_elide: Vec::new(),
             call_indirect_guards: synth_core::CallIndirectGuards::default(),
         }
     }
@@ -3133,6 +3141,7 @@ impl InstructionSelector {
             sel_dsl: sel_dsl_from_env(),
             fact_div_zero_elide: Vec::new(),
             fact_div_ovf_elide: Vec::new(),
+            fact_mem_bounds_elide: Vec::new(),
             call_indirect_guards: synth_core::CallIndirectGuards::default(),
         }
     }
@@ -3205,6 +3214,38 @@ impl InstructionSelector {
     pub fn set_fact_div_guard_elisions(&mut self, zero: Vec<usize>, ovf: Vec<usize>) {
         self.fact_div_zero_elide = zero;
         self.fact_div_ovf_elide = ovf;
+    }
+
+    /// #494 bounds-elision (#390 `guard_bool`): per-site memory bounds-guard
+    /// elision marks, keyed by op index into the stream fed to
+    /// `select_with_stack`. Every mark was discharged by the fact-spec pass
+    /// (`UNSAT(P ∧ trap_mem_oob(zext64(index) + offset, size,
+    /// min_memory_bytes))`, ordeal 0.9.1 shape, certificate-checked) BEFORE
+    /// selection — this setter only CONSUMES marks, it never derives them.
+    /// Empty (the default) ⇒ every guard is emitted, byte-identical to today.
+    pub fn set_fact_mem_bounds_elisions(&mut self, marks: Vec<usize>) {
+        self.fact_mem_bounds_elide = marks;
+    }
+
+    /// #494 bounds-elision: strip the certificate-elided SOFTWARE bounds
+    /// guard from a generated access sequence, keeping the access op itself
+    /// (always the LAST element — the generators' documented contract,
+    /// `result.last() is Ldr/Str/...`; under `Software` the access op's
+    /// address is identical to the `None`-mode emission, so stripping the
+    /// guard prefix yields exactly the unguarded lowering). No-op unless the
+    /// op index carries a mark AND the mode is `Software` — `Masking`
+    /// rewrites the address itself (a different scheme than the proven-dead
+    /// compare-and-trap), so a mark never applies to it.
+    fn apply_mem_bounds_elision(&self, idx: usize, ops: Vec<ArmOp>) -> Vec<ArmOp> {
+        if self.bounds_check != BoundsCheckConfig::Software
+            || !self.fact_mem_bounds_elide.contains(&idx)
+        {
+            return ops;
+        }
+        // Software mode emits [ADD, CMP, BLO, UDF, access] — exactly 5 ops.
+        debug_assert_eq!(ops.len(), 5, "software bounds guard shape drifted");
+        let last = ops.len() - 1;
+        ops.into_iter().skip(last).collect()
     }
 
     /// #642: thread the module's `call_indirect` guard inputs (compile-time
@@ -10046,9 +10087,13 @@ impl InstructionSelector {
                         });
                         cf.add_instruction();
                     } else {
-                        // Generate load with optional bounds checking
-                        let load_ops =
-                            self.generate_load_with_bounds_check(dst, addr, *offset as i32, 4);
+                        // Generate load with optional bounds checking.
+                        // #494 bounds-elision: a certificate-discharged mark
+                        // for THIS op index strips the software guard.
+                        let load_ops = self.apply_mem_bounds_elision(
+                            idx,
+                            self.generate_load_with_bounds_check(dst, addr, *offset as i32, 4),
+                        );
                         for op in load_ops {
                             instructions.push(ArmInstruction {
                                 op,
@@ -10150,9 +10195,13 @@ impl InstructionSelector {
                         });
                         cf.add_instruction();
                     } else {
-                        // Generate store with optional bounds checking
-                        let store_ops =
-                            self.generate_store_with_bounds_check(value, addr, *offset as i32, 4);
+                        // Generate store with optional bounds checking.
+                        // #494 bounds-elision: a certificate-discharged mark
+                        // for THIS op index strips the software guard.
+                        let store_ops = self.apply_mem_bounds_elision(
+                            idx,
+                            self.generate_store_with_bounds_check(value, addr, *offset as i32, 4),
+                        );
                         for op in store_ops {
                             instructions.push(ArmInstruction {
                                 op,
@@ -10268,12 +10317,17 @@ impl InstructionSelector {
                         });
                         cf.add_instruction();
                     } else {
-                        let load_ops = self.generate_subword_load_with_bounds_check(
-                            dst,
-                            addr,
-                            *offset as i32,
-                            access_size,
-                            sign_extend,
+                        // #494 bounds-elision: a certificate-discharged mark
+                        // for THIS op index strips the software guard.
+                        let load_ops = self.apply_mem_bounds_elision(
+                            idx,
+                            self.generate_subword_load_with_bounds_check(
+                                dst,
+                                addr,
+                                *offset as i32,
+                                access_size,
+                                sign_extend,
+                            ),
                         );
                         for arm_op in load_ops {
                             instructions.push(ArmInstruction {
@@ -10393,11 +10447,16 @@ impl InstructionSelector {
                         });
                         cf.add_instruction();
                     } else {
-                        let store_ops = self.generate_subword_store_with_bounds_check(
-                            value,
-                            addr,
-                            *offset as i32,
-                            access_size,
+                        // #494 bounds-elision: a certificate-discharged mark
+                        // for THIS op index strips the software guard.
+                        let store_ops = self.apply_mem_bounds_elision(
+                            idx,
+                            self.generate_subword_store_with_bounds_check(
+                                value,
+                                addr,
+                                *offset as i32,
+                                access_size,
+                            ),
                         );
                         for arm_op in store_ops {
                             instructions.push(ArmInstruction {

--- a/crates/synth-verify/src/fact_spec.rs
+++ b/crates/synth-verify/src/fact_spec.rs
@@ -83,6 +83,33 @@
 //! the driver threads them to the direct selector, which omits exactly that
 //! guard. Sat / Unknown / no-premise ⇒ loud decline, the guard is emitted.
 //!
+//! # The memory bounds-guard obligation (#494 × #390 `guard_bool`)
+//!
+//! Under `--safety-bounds software` every i32 linear-memory access carries a
+//! 4-instruction inline guard (`ADD ip, addr, #(offset+size-1); CMP ip, R10;
+//! BLO +0; UDF #0` — see `generate_load_with_bounds_check`). When a premise
+//! on the INDEX proves the access in-bounds, the guard is provably dead:
+//!
+//! ```text
+//! UNSAT( P ∧ trap_mem_oob(zext64(index) + offset, size, min_memory_bytes) )
+//! ```
+//!
+//! The encoding is [`crate::trap::trap_mem_oob`] (ordeal 0.9.1's shape,
+//! `addr + size >u mem_bound` wraparound-safe), posed at width 64 — the
+//! 32-bit index is ZERO-extended and the static memarg `offset` added at 64
+//! bits, so the `index + offset` sum can never wrap the obligation into a
+//! false Unsat (WASM's effective address is `i + offset` at infinite
+//! precision for a 32-bit memory). `min_memory_bytes` is the module's
+//! DECLARED minimum linear-memory size: the runtime extent (R10) is always
+//! ≥ the declared minimum, so an access proven inside the minimum is inside
+//! every reachable runtime bound. Like div/rem, a memory op can trap, so it
+//! is TRACKED but never DELETED — the discharged obligation becomes a
+//! per-site mark ([`FactSpecResult::elide_mem_bounds`]) the direct selector
+//! consumes by emitting the access WITHOUT the software guard. Sat /
+//! Unknown / no-premise / unknown memory size ⇒ loud decline, the guard is
+//! emitted. Loaded values are havocked to fresh variables (memory contents
+//! are not modeled); stores need no memory model for the same reason.
+//!
 //! # Flag gating
 //!
 //! The driver only invokes this pass when `SYNTH_FACT_SPEC` is set (default
@@ -122,6 +149,13 @@ pub struct FactSpecResult {
     /// SEPARATE obligation (`UNSAT(P ∧ dividend == INT_MIN ∧ divisor == -1)`);
     /// a divisor-nonzero fact alone never lands here (#633/#634).
     pub elide_div_ovf: Vec<usize>,
+    /// #494 bounds-elision (#390 `guard_bool`): indices (into the RETURNED
+    /// `ops` stream) of i32 memory accesses whose `--safety-bounds software`
+    /// guard was certificate-elided —
+    /// `UNSAT(P ∧ trap_mem_oob(zext64(index) + offset, size,
+    /// min_memory_bytes))` discharged per site (ordeal 0.9.1 `trap_mem_oob`
+    /// shape, wraparound-safe 64-bit extension).
+    pub elide_mem_bounds: Vec<usize>,
     /// True when `ops` differs from the input (at least one region deletion).
     stream_changed: bool,
 }
@@ -155,16 +189,27 @@ struct Val {
 /// slice (`CompileConfig::current_func_facts`); `params_i64` is the declared
 /// param-width table (`CompileConfig::current_func_params_i64` — `true` ⇒
 /// param `k` is 64-bit), which fixes the symbolic width of a param
-/// `local.get` (Phase 2b tracks i64 divisors). Total: every input yields a
-/// result — inapplicable shapes surface as loud declines, never errors.
+/// `local.get` (Phase 2b tracks i64 divisors); `linear_memory_bytes` is the
+/// module's DECLARED minimum linear-memory size in bytes
+/// (`CompileConfig::linear_memory_bytes`; `0` = unknown — every memory
+/// bounds-guard obligation then declines loudly). Total: every input yields
+/// a result — inapplicable shapes surface as loud declines, never errors.
 pub fn specialize_function(
     func_name: &str,
     ops: &[WasmOp],
     block_arity: &[(u8, u8)],
     facts: &[WscFact],
     params_i64: &[bool],
+    linear_memory_bytes: u32,
 ) -> FactSpecResult {
-    let mut pass = Pass::new(func_name, ops, block_arity, facts, params_i64);
+    let mut pass = Pass::new(
+        func_name,
+        ops,
+        block_arity,
+        facts,
+        params_i64,
+        linear_memory_bytes,
+    );
     pass.walk();
     pass.finish()
 }
@@ -198,6 +243,9 @@ struct Pass<'a> {
     nonzero_facts: HashSet<usize>,
     /// Declared param widths (`true` ⇒ 64-bit) — fixes `local.get` widths.
     params_i64: &'a [bool],
+    /// The module's DECLARED minimum linear-memory size in bytes; `0` =
+    /// unknown (bounds-guard obligations decline).
+    mem_bound: u32,
     sem: WasmSemantics,
     stack: Vec<Val>,
     locals: HashMap<u32, BV>,
@@ -214,6 +262,9 @@ struct Pass<'a> {
     zero_marks: Vec<usize>,
     /// #494 phase 2b: ORIGINAL op indices marked for overflow-guard elision.
     ovf_marks: Vec<usize>,
+    /// #494 bounds-elision: ORIGINAL op indices of memory accesses whose
+    /// software bounds guard was certificate-proven dead.
+    mem_marks: Vec<usize>,
 }
 
 impl<'a> Pass<'a> {
@@ -223,6 +274,7 @@ impl<'a> Pass<'a> {
         block_arity: &'a [(u8, u8)],
         facts: &'a [WscFact],
         params_i64: &'a [bool],
+        mem_bound: u32,
     ) -> Self {
         let mut opener_ordinal = HashMap::new();
         let mut ord = 0usize;
@@ -262,8 +314,10 @@ impl<'a> Pass<'a> {
             range_facts,
             nonzero_facts,
             params_i64,
-            // No memory model needed: memory ops are outside the tracked
-            // fragment (the walk stops there).
+            mem_bound,
+            // No memory model needed: loaded values are havocked to fresh
+            // variables (only the ACCESS BOUND is reasoned about, never the
+            // contents), so stores need no modeling either.
             sem: WasmSemantics::new_with_memory(Vec::new()),
             stack: Vec::new(),
             locals: HashMap::new(),
@@ -276,6 +330,7 @@ impl<'a> Pass<'a> {
             declined: Vec::new(),
             zero_marks: Vec::new(),
             ovf_marks: Vec::new(),
+            mem_marks: Vec::new(),
         }
     }
 
@@ -484,6 +539,111 @@ impl<'a> Pass<'a> {
             CheckOutcome::Unknown(reason) => {
                 self.decline(format!(
                     "op#{i} {op_name} — overflow-guard obligation Unknown ({reason});                      conservative decline, the #633 overflow guard is RETAINED"
+                ));
+            }
+        }
+    }
+
+    /// #494 bounds-elision (#390 `guard_bool`): discharge the software
+    /// bounds-guard obligation for the i32 memory access at `i` (`op_name`,
+    /// byte width `access_size`, static memarg `offset`, index value `addr`),
+    /// recording an elision mark for the lowering:
+    ///
+    /// ```text
+    /// UNSAT( P ∧ trap_mem_oob(zext64(addr) + offset, access_size,
+    ///                         min_memory_bytes) )
+    /// ```
+    ///
+    /// The trap condition is [`crate::trap::trap_mem_oob`] (ordeal 0.9.1's
+    /// `addr + size >u mem_bound`, wraparound-safe), posed at width 64: the
+    /// 32-bit index is ZERO-extended and `offset` added at 64 bits, so the
+    /// effective-address sum cannot wrap into a false Unsat — exactly WASM's
+    /// infinite-precision `i + offset`. Proving the access inside the
+    /// DECLARED minimum memory (`mem_bound`) proves it inside every runtime
+    /// extent R10 can hold (runtime size ≥ declared minimum). Sat / Unknown
+    /// / no-premise / unknown memory size ⇒ loud decline; the guard is
+    /// emitted.
+    fn try_elide_mem_bounds(
+        &mut self,
+        i: usize,
+        op_name: &str,
+        access_size: u32,
+        offset: u32,
+        addr: &Val,
+    ) {
+        if self.mem_bound == 0 {
+            self.decline(format!(
+                "op#{i} {op_name} — linear-memory size unknown (no module memory \
+                 context); bounds guard retained"
+            ));
+            return;
+        }
+        if self.premises.is_empty() {
+            self.decline(format!(
+                "op#{i} {op_name} — no premise reaches this site; bounds guard retained"
+            ));
+            return;
+        }
+        // Wraparound-safe width extension: zext the 32-bit index to 64 bits,
+        // add the static offset at 64 bits (no 2^64 wrap is reachable:
+        // index < 2^32, offset < 2^32, size ≤ 8).
+        let ea = addr
+            .bv
+            .zero_ext(32)
+            .bvadd(BV::from_u64(u64::from(offset), 64));
+        let trap = crate::trap::trap_mem_oob(
+            &ea,
+            &BV::from_u64(u64::from(access_size), 64),
+            &BV::from_u64(u64::from(self.mem_bound), 64),
+        );
+        let mut solver = new_solver();
+        for p in &self.premises {
+            solver.assert(p);
+        }
+        solver.assert(&trap);
+        match solver.check() {
+            CheckOutcome::Unsat => {
+                self.mem_marks.push(i);
+                self.admitted.push(format!(
+                    "{}: op#{i} {op_name} (offset={offset}, {access_size} B) — software \
+                     bounds guard elided: UNSAT(P ∧ trap_mem_oob(zext64(index) + offset, \
+                     size, {} B declared-min memory)) via {} (certificate-checked QF_BV; \
+                     every Unsat carries an LRAT proof validated by ordeal-lrat); \
+                     P = {{{}}}; index = {}",
+                    self.func,
+                    self.mem_bound,
+                    solver.name(),
+                    self.premise_desc.join(" ∧ "),
+                    addr.bv,
+                ));
+            }
+            CheckOutcome::Sat => {
+                let cex = self.counterexample(solver.as_ref());
+                if force_admit_unsound() {
+                    // RED-TEAM lever (debug builds only): admit the Sat site
+                    // anyway so the differential oracle can demonstrate the
+                    // divergence. Screams, and still logs the model.
+                    self.mem_marks.push(i);
+                    self.admitted.push(format!(
+                        "{}: op#{i} {op_name} — bounds guard elided by UNSOUND FORCED \
+                         ADMIT (SYNTH_FACT_SPEC_FORCE_ADMIT, red-team oracle lever, \
+                         debug builds only) — obligation was Sat (counterexample: \
+                         {cex}); NEVER use in production",
+                        self.func,
+                    ));
+                } else {
+                    self.decline(format!(
+                        "op#{i} {op_name} — bounds-guard obligation Sat (the access can \
+                         exceed the {} B declared-min memory under P; counterexample: \
+                         {cex}); guard retained",
+                        self.mem_bound,
+                    ));
+                }
+            }
+            CheckOutcome::Unknown(reason) => {
+                self.decline(format!(
+                    "op#{i} {op_name} — bounds-guard obligation Unknown ({reason}); \
+                     conservative decline, guard retained"
                 ));
             }
         }
@@ -1002,6 +1162,70 @@ impl<'a> Pass<'a> {
                     self.attach_fact(i, &v);
                     self.push(v, None, i);
                 }
+                // #494 bounds-elision: i32 memory LOADS — TRACKED, never
+                // DELETED (an OOB access traps, so the op is not effect-free;
+                // same discipline as div/rem). The walk discharges the
+                // per-site software bounds-guard obligation and marks the op
+                // for the lowering; the loaded value is havocked to a fresh
+                // variable (memory contents are not modeled) with
+                // `start = None` (a possibly-trapping op never sits inside an
+                // erasable condition slice). Downstream soundness: if the
+                // access traps, nothing after it executes (any later admitted
+                // elision is vacuous on that path).
+                WasmOp::I32Load { offset, .. }
+                | WasmOp::I32Load8S { offset, .. }
+                | WasmOp::I32Load8U { offset, .. }
+                | WasmOp::I32Load16S { offset, .. }
+                | WasmOp::I32Load16U { offset, .. } => {
+                    let Some(a) = self.stack.pop() else {
+                        self.decline(format!("op#{i} memory load on empty symbolic stack"));
+                        return;
+                    };
+                    if a.bv.get_size() != 32 {
+                        self.decline(format!("op#{i} memory load on a non-32-bit index"));
+                        return;
+                    }
+                    let (op_name, size) = match op {
+                        WasmOp::I32Load { .. } => ("i32.load", 4),
+                        WasmOp::I32Load8S { .. } => ("i32.load8_s", 1),
+                        WasmOp::I32Load8U { .. } => ("i32.load8_u", 1),
+                        WasmOp::I32Load16S { .. } => ("i32.load16_s", 2),
+                        _ => ("i32.load16_u", 2),
+                    };
+                    self.try_elide_mem_bounds(i, op_name, size, *offset, &a);
+                    // Havoc the loaded value; `start = None` keeps a possibly-
+                    // trapping op out of every erasable condition slice.
+                    let n = self.fresh;
+                    self.fresh += 1;
+                    let v = self.fresh_var(format!("fs_m{n}"));
+                    self.attach_fact(i, &v);
+                    self.push(v, None, i);
+                }
+                // #494 bounds-elision: i32 memory STORES — same obligation
+                // over the index. No memory model is needed: loads are always
+                // havocked, so a store's effect on the symbolic state is
+                // vacuous; only the guard obligation is discharged.
+                WasmOp::I32Store { offset, .. }
+                | WasmOp::I32Store8 { offset, .. }
+                | WasmOp::I32Store16 { offset, .. } => {
+                    let (Some(val), Some(a)) = (self.stack.pop(), self.stack.pop()) else {
+                        self.decline(format!(
+                            "op#{i} memory store on underflowing symbolic stack"
+                        ));
+                        return;
+                    };
+                    if a.bv.get_size() != 32 || val.bv.get_size() != 32 {
+                        self.decline(format!("op#{i} memory store on a non-32-bit operand"));
+                        return;
+                    }
+                    let (op_name, size) = match op {
+                        WasmOp::I32Store { .. } => ("i32.store", 4),
+                        WasmOp::I32Store8 { .. } => ("i32.store8", 1),
+                        _ => ("i32.store16", 2),
+                    };
+                    self.try_elide_mem_bounds(i, op_name, size, *offset, &a);
+                    // Store pushes nothing.
+                }
                 WasmOp::If => {
                     let Some(cond) = self.stack.pop() else {
                         self.decline(format!("op#{i} `if` on empty symbolic stack"));
@@ -1111,6 +1335,7 @@ impl<'a> Pass<'a> {
             declined,
             zero_marks,
             ovf_marks,
+            mem_marks,
             ..
         } = self;
         if deletions.is_empty() {
@@ -1123,6 +1348,7 @@ impl<'a> Pass<'a> {
                 // No rewrite ⇒ original indices ARE the output indices.
                 elide_div_zero: zero_marks,
                 elide_div_ovf: ovf_marks,
+                elide_mem_bounds: mem_marks,
                 stream_changed: false,
             };
         }
@@ -1163,6 +1389,7 @@ impl<'a> Pass<'a> {
             block_arity: out_arity,
             elide_div_zero: remap(zero_marks),
             elide_div_ovf: remap(ovf_marks),
+            elide_mem_bounds: remap(mem_marks),
             kept,
             admitted,
             declined,
@@ -1216,7 +1443,7 @@ mod tests {
     #[test]
     fn clamp_shape_elides_both_branches_under_the_proven_bound_494() {
         let ops = clamp_ops();
-        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 524, 1524)], &[]);
+        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 524, 1524)], &[], 0);
         assert_eq!(r.admitted.len(), 2, "declines: {:?}", r.declined);
         assert!(r.changed());
         assert_eq!(
@@ -1246,7 +1473,7 @@ mod tests {
         // ch ∈ [0, 4000] does NOT make the clamp dead (ch=0 → v=476 < 1000):
         // the obligation is Sat and BOTH sites decline with a counterexample.
         let ops = clamp_ops();
-        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 0, 4000)], &[]);
+        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 0, 4000)], &[], 0);
         assert_eq!(r.admitted.len(), 0);
         assert!(!r.changed());
         assert_eq!(r.ops, ops, "declined ⇒ byte-identical op stream");
@@ -1265,7 +1492,7 @@ mod tests {
         // ch ∈ [524, 4000]: v ≥ 1000 so the LOW clamp is dead, but v can
         // exceed 2000 so the HIGH clamp must survive.
         let ops = clamp_ops();
-        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 524, 4000)], &[]);
+        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[fact(0, 524, 4000)], &[], 0);
         assert_eq!(r.admitted.len(), 1, "declines: {:?}", r.declined);
         assert_eq!(r.declined.len(), 1);
         assert_eq!(
@@ -1292,7 +1519,7 @@ mod tests {
     #[test]
     fn no_facts_changes_nothing_494() {
         let ops = clamp_ops();
-        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[], &[]);
+        let r = specialize_function("gust_mix", &ops, CLAMP_ARITY, &[], &[], 0);
         assert!(!r.changed());
         assert_eq!(r.ops, ops);
         assert!(!r.declined.is_empty(), "the no-fact case is a loud decline");
@@ -1329,7 +1556,7 @@ mod tests {
     #[test]
     fn select_clamp_collapses_both_selects_under_the_proven_bound_494() {
         let ops = select_clamp_ops();
-        let r = specialize_function("gust_mix", &ops, &[], &[fact(0, 524, 1524)], &[]);
+        let r = specialize_function("gust_mix", &ops, &[], &[fact(0, 524, 1524)], &[], 0);
         assert_eq!(r.admitted.len(), 2, "declines: {:?}", r.declined);
         assert!(r.changed());
         assert_eq!(
@@ -1360,7 +1587,7 @@ mod tests {
         // ch ∈ [0, 4000]: ch=0 → v=476 < 1000 so the low clamp genuinely
         // fires; both selects are non-constant ⇒ loud Sat decline, no rewrite.
         let ops = select_clamp_ops();
-        let r = specialize_function("gust_mix", &ops, &[], &[fact(0, 0, 4000)], &[]);
+        let r = specialize_function("gust_mix", &ops, &[], &[fact(0, 0, 4000)], &[], 0);
         assert_eq!(r.admitted.len(), 0);
         assert!(!r.changed());
         assert_eq!(r.ops, ops, "declined ⇒ byte-identical op stream");
@@ -1383,7 +1610,7 @@ mod tests {
             Select,        // 3  → val1
             End,           // 4
         ];
-        let r = specialize_function("f", &ops, &[], &[fact(2, 1, 1)], &[]);
+        let r = specialize_function("f", &ops, &[], &[fact(2, 1, 1)], &[], 0);
         assert_eq!(r.admitted.len(), 1, "declines: {:?}", r.declined);
         assert_eq!(r.ops, vec![I32Const(111), End]);
         assert!(
@@ -1405,7 +1632,7 @@ mod tests {
             Select,        // 3
             End,           // 4
         ];
-        let r = specialize_function("f", &ops, &[], &[fact(0, 111, 111)], &[]);
+        let r = specialize_function("f", &ops, &[], &[fact(0, 111, 111)], &[], 0);
         assert_eq!(r.admitted.len(), 0);
         assert!(!r.changed());
         assert_eq!(r.ops, ops);
@@ -1437,7 +1664,7 @@ mod tests {
             LocalGet(1),    // 16
             End,            // 17
         ];
-        let r = specialize_function("f", &ops, CLAMP_ARITY, &[fact(0, 524, 1524)], &[]);
+        let r = specialize_function("f", &ops, CLAMP_ARITY, &[fact(0, 524, 1524)], &[], 0);
         assert_eq!(
             r.admitted.len(),
             0,
@@ -1461,7 +1688,7 @@ mod tests {
             LocalGet(1), // 8
             End,         // 9
         ];
-        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 0, 0)], &[]);
+        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 0, 0)], &[], 0);
         assert_eq!(r.admitted.len(), 0);
         assert!(
             r.declined.iter().any(|d| d.contains("else")),
@@ -1490,7 +1717,7 @@ mod tests {
             End,         // 11
         ];
         let arity = &[(0, 0), (0, 0), (0, 1)];
-        let r = specialize_function("f", &ops, arity, &[fact(0, 5, 5)], &[]);
+        let r = specialize_function("f", &ops, arity, &[fact(0, 5, 5)], &[], 0);
         assert_eq!(r.admitted.len(), 1, "declines: {:?}", r.declined);
         // The condition slice starts at op 0 (LocalGet feeds the eqz), so the
         // whole deleted range is [0..=8]; only the trailing block survives.
@@ -1517,7 +1744,7 @@ mod tests {
             End,         // 6
             End,         // 7
         ];
-        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 1, 1)], &[]);
+        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 1, 1)], &[], 0);
         assert_eq!(r.admitted.len(), 0);
         assert!(
             r.declined
@@ -1537,7 +1764,7 @@ mod tests {
             Drop,          // 2
             End,           // 3
         ];
-        let r = specialize_function("f", &ops, &[], &[fact(0, 1, 2)], &[]);
+        let r = specialize_function("f", &ops, &[], &[fact(0, 1, 2)], &[], 0);
         assert!(!r.changed());
         assert!(
             r.declined.iter().any(|d| d.contains("outside the tracked")),
@@ -1576,7 +1803,7 @@ mod tests {
             End,         // 11
         ];
         let facts = [fact(1, 1, 100), fact(5, 1, 100), fact(9, 1, 100)];
-        let r = specialize_function("f", &ops, &[], &facts, &[]);
+        let r = specialize_function("f", &ops, &[], &facts, &[], 0);
         assert_eq!(
             r.elide_div_zero,
             vec![2, 6, 10],
@@ -1610,7 +1837,7 @@ mod tests {
             I32DivS,     // 2
             End,         // 3
         ];
-        let r = specialize_function("f", &ops, &[], &[nonzero_fact(1)], &[]);
+        let r = specialize_function("f", &ops, &[], &[nonzero_fact(1)], &[], 0);
         assert_eq!(r.elide_div_zero, vec![2], "declines: {:?}", r.declined);
         assert_eq!(
             r.elide_div_ovf,
@@ -1631,7 +1858,7 @@ mod tests {
         // divisor ∈ [1, 100] excludes BOTH 0 and -1 — the two obligations
         // are discharged independently and both guards fall.
         let ops = vec![LocalGet(0), LocalGet(1), I32DivS, End];
-        let r = specialize_function("f", &ops, &[], &[fact(1, 1, 100)], &[]);
+        let r = specialize_function("f", &ops, &[], &[fact(1, 1, 100)], &[], 0);
         assert_eq!(r.elide_div_zero, vec![2], "declines: {:?}", r.declined);
         assert_eq!(r.elide_div_ovf, vec![2]);
         assert_eq!(r.admitted.len(), 2, "one certificate line per obligation");
@@ -1650,7 +1877,7 @@ mod tests {
         // divisor ∈ [0, 100]: divisor == 0 is P-admissible — the obligation
         // is Sat, the decline is loud and carries a model, no mark is set.
         let ops = vec![LocalGet(0), LocalGet(1), I32DivU, End];
-        let r = specialize_function("f", &ops, &[], &[fact(1, 0, 100)], &[]);
+        let r = specialize_function("f", &ops, &[], &[fact(1, 0, 100)], &[], 0);
         assert_eq!(r.elide_div_zero, Vec::<usize>::new());
         assert!(
             r.declined
@@ -1667,7 +1894,7 @@ mod tests {
         // carrying a divisor-nonzero fact — the zero guard is proven dead,
         // the INT64_MIN/-1 overflow guard (#633/#634) is RETAINED.
         let ops = vec![LocalGet(0), LocalGet(1), I64DivS, End];
-        let r = specialize_function("f", &ops, &[], &[nonzero_fact(1)], &[true, true]);
+        let r = specialize_function("f", &ops, &[], &[nonzero_fact(1)], &[true, true], 0);
         assert_eq!(r.elide_div_zero, vec![2], "declines: {:?}", r.declined);
         assert_eq!(
             r.elide_div_ovf,
@@ -1684,7 +1911,7 @@ mod tests {
     #[test]
     fn i64_div_s_positive_range_discharges_both_obligations_494() {
         let ops = vec![LocalGet(0), LocalGet(1), I64DivS, End];
-        let r = specialize_function("f", &ops, &[], &[fact(1, 1, 1000)], &[true, true]);
+        let r = specialize_function("f", &ops, &[], &[fact(1, 1, 1000)], &[true, true], 0);
         assert_eq!(r.elide_div_zero, vec![2], "declines: {:?}", r.declined);
         assert_eq!(r.elide_div_ovf, vec![2]);
     }
@@ -1695,7 +1922,7 @@ mod tests {
         // 32-bit — the width check declines rather than building a
         // wrong-width obligation.
         let ops = vec![LocalGet(0), LocalGet(1), I64DivU, End];
-        let r = specialize_function("f", &ops, &[], &[nonzero_fact(1)], &[]);
+        let r = specialize_function("f", &ops, &[], &[nonzero_fact(1)], &[], 0);
         assert_eq!(r.elide_div_zero, Vec::<usize>::new());
         assert!(
             r.declined.iter().any(|d| d.contains("unexpected width")),
@@ -1716,7 +1943,7 @@ mod tests {
         ];
         // A fact on op 0 (the dividend): premises exist but do not constrain
         // the divisor — Sat, decline.
-        let r = specialize_function("f", &ops, &[], &[fact(0, 1, 5)], &[]);
+        let r = specialize_function("f", &ops, &[], &[fact(0, 1, 5)], &[], 0);
         assert_eq!(r.elide_div_zero, Vec::<usize>::new());
         assert!(
             r.declined
@@ -1749,7 +1976,7 @@ mod tests {
             I32DivU,        // 13  → zero mark (rewritten index 6)
             End,            // 14
         ];
-        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 524, 1524)], &[]);
+        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 524, 1524)], &[], 0);
         assert!(r.changed(), "declines: {:?}", r.declined);
         assert_eq!(r.kept, vec![0, 1, 2, 3, 11, 12, 13, 14]);
         assert_eq!(
@@ -1803,6 +2030,7 @@ mod tests {
             &[],
             &[fact(0, 0, 2047), fact(3, 0, 2047)],
             &[],
+            0,
         );
         assert_eq!(r.admitted.len(), 2, "declines: {:?}", r.declined);
         assert!(r.changed());
@@ -1838,6 +2066,7 @@ mod tests {
             &[],
             &[fact(0, 0, 0xFFF), fact(3, 0, 0xFFF)],
             &[],
+            0,
         );
         assert_eq!(r.admitted.len(), 0);
         assert!(!r.changed());
@@ -1862,7 +2091,7 @@ mod tests {
             I32And,          // 2
             End,             // 3
         ];
-        let r = specialize_function("f", &ops, &[], &[fact(1, 0x7FF, 0x7FF)], &[]);
+        let r = specialize_function("f", &ops, &[], &[fact(1, 0x7FF, 0x7FF)], &[], 0);
         assert_eq!(r.admitted.len(), 0);
         assert!(!r.changed());
         assert_eq!(r.ops, ops);
@@ -1879,7 +2108,7 @@ mod tests {
             I32And,          // 2
             End,             // 3
         ];
-        let r = specialize_function("f", &ops, &[], &[fact(0, -1, 2047)], &[]);
+        let r = specialize_function("f", &ops, &[], &[fact(0, -1, 2047)], &[], 0);
         assert_eq!(
             r.admitted.len(),
             0,
@@ -1892,7 +2121,7 @@ mod tests {
     #[test]
     fn mask_elision_no_facts_changes_nothing_494() {
         let ops = pack_lanes_ops();
-        let r = specialize_function("gust_kernel", &ops, &[], &[], &[]);
+        let r = specialize_function("gust_kernel", &ops, &[], &[], &[], 0);
         assert!(!r.changed());
         assert_eq!(r.ops, ops);
         assert!(!r.declined.is_empty(), "the no-fact case is a loud decline");
@@ -1901,8 +2130,186 @@ mod tests {
     #[test]
     fn out_of_range_value_id_is_vacuous_494() {
         let ops = clamp_ops();
-        let r = specialize_function("f", &ops, CLAMP_ARITY, &[fact(999, 524, 1524)], &[]);
+        let r = specialize_function("f", &ops, CLAMP_ARITY, &[fact(999, 524, 1524)], &[], 0);
         assert!(!r.changed());
         assert_eq!(r.ops, ops);
+    }
+
+    // ========= #494 bounds-elision (#390 guard_bool): memory bounds guards =========
+
+    /// The gust_poll shape: a record array indexed by a proven-bounded slot —
+    /// `base = slot*16 + 256`, then field loads/stores at static offsets.
+    fn poll_ops() -> Vec<WasmOp> {
+        vec![
+            LocalGet(0),                        // 0  slot ← fact target
+            I32Const(4),                        // 1
+            I32Shl,                             // 2  slot*16
+            I32Const(256),                      // 3
+            I32Add,                             // 4  base
+            LocalSet(1),                        // 5
+            LocalGet(1),                        // 6
+            I32Load8U { offset: 0, align: 0 },  // 7  → mark (byte)
+            LocalGet(1),                        // 8
+            I32Load { offset: 4, align: 2 },    // 9  → mark (word)
+            I32Add,                             // 10
+            LocalGet(1),                        // 11
+            I32Const(7),                        // 12
+            I32Store16 { offset: 2, align: 1 }, // 13 → mark (halfword store)
+            End,                                // 14
+        ]
+    }
+
+    #[test]
+    fn bounded_index_elides_all_mem_bounds_guards_494() {
+        // slot ∈ [0, 63] ⇒ base ∈ [256, 1264]; every access's last byte is
+        // < 65536, so all three obligations fall to
+        // UNSAT(P ∧ trap_mem_oob(...)). Marks only — the stream is untouched.
+        let ops = poll_ops();
+        let r = specialize_function("poll", &ops, &[], &[fact(0, 0, 63)], &[], 65536);
+        assert_eq!(
+            r.elide_mem_bounds,
+            vec![7, 9, 13],
+            "declines: {:?}",
+            r.declined
+        );
+        assert!(!r.changed(), "guard marks never rewrite the op stream");
+        assert_eq!(r.ops, ops);
+        assert_eq!(r.admitted.len(), 3);
+        for line in &r.admitted {
+            assert!(line.contains("bounds guard elided"), "{line}");
+            assert!(line.contains("trap_mem_oob"), "{line}");
+            assert!(line.contains("certificate-checked"), "{line}");
+            assert!(line.contains("[0, 63]"), "{line}");
+        }
+    }
+
+    #[test]
+    fn oob_admissible_bound_is_sat_and_declines_494() {
+        // slot ∈ [0, 8192]: slot = 4096 ⇒ base = 65792 > 65536 — the access
+        // can genuinely escape, the obligation is Sat, the guard stays.
+        let ops = poll_ops();
+        let r = specialize_function("poll", &ops, &[], &[fact(0, 0, 8192)], &[], 65536);
+        assert_eq!(r.elide_mem_bounds, Vec::<usize>::new());
+        assert_eq!(r.admitted.len(), 0);
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("bounds-guard obligation Sat")
+                    && d.contains("counterexample")),
+            "declines must be loud and carry a model: {:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn unknown_memory_size_declines_mem_bounds_494() {
+        // linear_memory_bytes == 0 (no module memory context): the bound of
+        // the obligation does not exist — decline loudly, never guess.
+        let ops = poll_ops();
+        let r = specialize_function("poll", &ops, &[], &[fact(0, 0, 63)], &[], 0);
+        assert_eq!(r.elide_mem_bounds, Vec::<usize>::new());
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("linear-memory size unknown")),
+            "{:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn unconstrained_index_declines_mem_bounds_494() {
+        // A TRUE fact exists (so the walk runs) but targets the stored VALUE,
+        // not the index — the index is unconstrained ⇒ Sat ⇒ loud decline.
+        let ops = vec![
+            LocalGet(0),                      // 0  index — unconstrained
+            LocalGet(1),                      // 1  value ← fact (non-constraining)
+            I32Store { offset: 0, align: 2 }, // 2
+            End,                              // 3
+        ];
+        let r = specialize_function("f", &ops, &[], &[fact(1, 0, 63)], &[], 65536);
+        assert_eq!(r.elide_mem_bounds, Vec::<usize>::new());
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("bounds-guard obligation Sat")),
+            "{:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn wraparound_index_plus_offset_never_falsely_unsat_494() {
+        // THE WIDTH-EXTENSION GOTCHA: index = -256 (0xFFFFFF00 unsigned) with
+        // offset = 0x200. A naive 32-bit encoding wraps the effective address
+        // to 0x104 — "in bounds" — and would falsely elide; WASM's effective
+        // address is infinite-precision (4294967040 + 512 > 65536 ⇒ TRAPS).
+        // The 64-bit zero-extension keeps the obligation Sat ⇒ guard retained.
+        let ops = vec![
+            LocalGet(0),                         // 0 ← fact [-256, -256]
+            I32Load { offset: 0x200, align: 2 }, // 1
+            End,                                 // 2
+        ];
+        let r = specialize_function("f", &ops, &[], &[fact(0, -256, -256)], &[], 65536);
+        assert_eq!(
+            r.elide_mem_bounds,
+            Vec::<usize>::new(),
+            "a wrapped effective address must NOT elide the guard: {:?}",
+            r.admitted
+        );
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("bounds-guard obligation Sat")),
+            "{:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn access_ending_exactly_at_bound_is_in_bounds_boundary_494() {
+        // Boundary semantics: a 4-byte load at index 65532 ends exactly AT
+        // the bound (addr + size == mem_bound) — in bounds per WASM (§4.4.5:
+        // trap iff ea + size > mem size) and per the guard's `>u`. One past
+        // (65533) must decline.
+        let ops = vec![
+            LocalGet(0),                     // 0 ← fact
+            I32Load { offset: 0, align: 2 }, // 1
+            End,                             // 2
+        ];
+        let ok = specialize_function("f", &ops, &[], &[fact(0, 0, 65532)], &[], 65536);
+        assert_eq!(ok.elide_mem_bounds, vec![1], "declines: {:?}", ok.declined);
+        let over = specialize_function("f", &ops, &[], &[fact(0, 0, 65533)], &[], 65536);
+        assert_eq!(over.elide_mem_bounds, Vec::<usize>::new());
+    }
+
+    #[test]
+    fn mem_marks_are_remapped_through_a_clamp_elision_494() {
+        // A clamp elision rewrites the stream; a downstream load's mark must
+        // land on the REWRITTEN index (the selector keys by its own op index).
+        let ops = vec![
+            LocalGet(0),                     // 0  ← fact [524, 1524]
+            I32Const(476),                   // 1
+            I32Add,                          // 2
+            LocalSet(1),                     // 3
+            LocalGet(1),                     // 4  -+ low clamp (elided 4..=10)
+            I32Const(1000),                  // 5   |
+            I32LtS,                          // 6   |
+            If,                              // 7   |
+            I32Const(1000),                  // 8   |
+            LocalSet(1),                     // 9   |
+            End,                             // 10 -+
+            LocalGet(0),                     // 11  index = ch ∈ [524, 1524]
+            I32Load { offset: 0, align: 2 }, // 12  → mark (rewritten index 5)
+            End,                             // 13
+        ];
+        let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 524, 1524)], &[], 65536);
+        assert!(r.changed(), "declines: {:?}", r.declined);
+        assert_eq!(r.kept, vec![0, 1, 2, 3, 11, 12, 13]);
+        assert_eq!(
+            r.elide_mem_bounds,
+            vec![5],
+            "mark remapped from original op#12 to rewritten op#5"
+        );
     }
 }

--- a/crates/synth-verify/src/fact_spec.rs
+++ b/crates/synth-verify/src/fact_spec.rs
@@ -2141,21 +2141,30 @@ mod tests {
     /// `base = slot*16 + 256`, then field loads/stores at static offsets.
     fn poll_ops() -> Vec<WasmOp> {
         vec![
-            LocalGet(0),                        // 0  slot ← fact target
-            I32Const(4),                        // 1
-            I32Shl,                             // 2  slot*16
-            I32Const(256),                      // 3
-            I32Add,                             // 4  base
-            LocalSet(1),                        // 5
-            LocalGet(1),                        // 6
-            I32Load8U { offset: 0, align: 0 },  // 7  → mark (byte)
-            LocalGet(1),                        // 8
-            I32Load { offset: 4, align: 2 },    // 9  → mark (word)
-            I32Add,                             // 10
-            LocalGet(1),                        // 11
-            I32Const(7),                        // 12
-            I32Store16 { offset: 2, align: 1 }, // 13 → mark (halfword store)
-            End,                                // 14
+            LocalGet(0),   // 0  slot ← fact target
+            I32Const(4),   // 1
+            I32Shl,        // 2  slot*16
+            I32Const(256), // 3
+            I32Add,        // 4  base
+            LocalSet(1),   // 5
+            LocalGet(1),   // 6
+            I32Load8U {
+                offset: 0,
+                align: 0,
+            }, // 7  → mark (byte)
+            LocalGet(1),   // 8
+            I32Load {
+                offset: 4,
+                align: 2,
+            }, // 9  → mark (word)
+            I32Add,        // 10
+            LocalGet(1),   // 11
+            I32Const(7),   // 12
+            I32Store16 {
+                offset: 2,
+                align: 1,
+            }, // 13 → mark (halfword store)
+            End,           // 14
         ]
     }
 
@@ -2194,8 +2203,7 @@ mod tests {
         assert!(
             r.declined
                 .iter()
-                .any(|d| d.contains("bounds-guard obligation Sat")
-                    && d.contains("counterexample")),
+                .any(|d| d.contains("bounds-guard obligation Sat") && d.contains("counterexample")),
             "declines must be loud and carry a model: {:?}",
             r.declined
         );
@@ -2222,10 +2230,13 @@ mod tests {
         // A TRUE fact exists (so the walk runs) but targets the stored VALUE,
         // not the index — the index is unconstrained ⇒ Sat ⇒ loud decline.
         let ops = vec![
-            LocalGet(0),                      // 0  index — unconstrained
-            LocalGet(1),                      // 1  value ← fact (non-constraining)
-            I32Store { offset: 0, align: 2 }, // 2
-            End,                              // 3
+            LocalGet(0), // 0  index — unconstrained
+            LocalGet(1), // 1  value ← fact (non-constraining)
+            I32Store {
+                offset: 0,
+                align: 2,
+            }, // 2
+            End,         // 3
         ];
         let r = specialize_function("f", &ops, &[], &[fact(1, 0, 63)], &[], 65536);
         assert_eq!(r.elide_mem_bounds, Vec::<usize>::new());
@@ -2246,9 +2257,12 @@ mod tests {
         // address is infinite-precision (4294967040 + 512 > 65536 ⇒ TRAPS).
         // The 64-bit zero-extension keeps the obligation Sat ⇒ guard retained.
         let ops = vec![
-            LocalGet(0),                         // 0 ← fact [-256, -256]
-            I32Load { offset: 0x200, align: 2 }, // 1
-            End,                                 // 2
+            LocalGet(0), // 0 ← fact [-256, -256]
+            I32Load {
+                offset: 0x200,
+                align: 2,
+            }, // 1
+            End,         // 2
         ];
         let r = specialize_function("f", &ops, &[], &[fact(0, -256, -256)], &[], 65536);
         assert_eq!(
@@ -2273,9 +2287,12 @@ mod tests {
         // trap iff ea + size > mem size) and per the guard's `>u`. One past
         // (65533) must decline.
         let ops = vec![
-            LocalGet(0),                     // 0 ← fact
-            I32Load { offset: 0, align: 2 }, // 1
-            End,                             // 2
+            LocalGet(0), // 0 ← fact
+            I32Load {
+                offset: 0,
+                align: 2,
+            }, // 1
+            End,         // 2
         ];
         let ok = specialize_function("f", &ops, &[], &[fact(0, 0, 65532)], &[], 65536);
         assert_eq!(ok.elide_mem_bounds, vec![1], "declines: {:?}", ok.declined);
@@ -2288,20 +2305,23 @@ mod tests {
         // A clamp elision rewrites the stream; a downstream load's mark must
         // land on the REWRITTEN index (the selector keys by its own op index).
         let ops = vec![
-            LocalGet(0),                     // 0  ← fact [524, 1524]
-            I32Const(476),                   // 1
-            I32Add,                          // 2
-            LocalSet(1),                     // 3
-            LocalGet(1),                     // 4  -+ low clamp (elided 4..=10)
-            I32Const(1000),                  // 5   |
-            I32LtS,                          // 6   |
-            If,                              // 7   |
-            I32Const(1000),                  // 8   |
-            LocalSet(1),                     // 9   |
-            End,                             // 10 -+
-            LocalGet(0),                     // 11  index = ch ∈ [524, 1524]
-            I32Load { offset: 0, align: 2 }, // 12  → mark (rewritten index 5)
-            End,                             // 13
+            LocalGet(0),    // 0  ← fact [524, 1524]
+            I32Const(476),  // 1
+            I32Add,         // 2
+            LocalSet(1),    // 3
+            LocalGet(1),    // 4  -+ low clamp (elided 4..=10)
+            I32Const(1000), // 5   |
+            I32LtS,         // 6   |
+            If,             // 7   |
+            I32Const(1000), // 8   |
+            LocalSet(1),    // 9   |
+            End,            // 10 -+
+            LocalGet(0),    // 11  index = ch ∈ [524, 1524]
+            I32Load {
+                offset: 0,
+                align: 2,
+            }, // 12  → mark (rewritten index 5)
+            End,            // 13
         ];
         let r = specialize_function("f", &ops, &[(0, 0)], &[fact(0, 524, 1524)], &[], 65536);
         assert!(r.changed(), "declines: {:?}", r.declined);

--- a/scripts/repro/fact_spec_bounds_494.wat
+++ b/scripts/repro/fact_spec_bounds_494.wat
@@ -1,0 +1,59 @@
+;; #494 bounds-elision × #390 guard_bool — the gust_poll-shaped fixture.
+;;
+;; One scheduler-poll round over a task-record array in linear memory:
+;; records are 16 B each at base 256, indexed by $slot. Fields:
+;;   state  u8  @0     prio   u8  @1     flags  u16 @2
+;;   deadline u32 @4   budget u32 @8     ticks  u32 @12
+;;
+;; Under `--safety-bounds software` every one of the EIGHT accesses carries
+;; the 4-instruction inline guard (ADD ip; CMP ip, r10; BLO +0; UDF #0 —
+;; instruction_selector.rs `generate_*_with_bounds_check`). A `wsc.facts`
+;; ValueRange premise `slot ∈ [0, 63]` (value_id 0 = the first `local.get`)
+;; proves every access's last byte < 65536 (the declared 1-page minimum), so
+;; all eight guards fall to
+;;   UNSAT( P ∧ trap_mem_oob(zext64(index) + offset, size, 65536) )
+;; — certificate-checked per site by the fact-spec pass (SYNTH_FACT_SPEC=1).
+;;
+;; Oracles: crates/synth-cli/tests/fact_spec_bounds_494.rs (byte evidence)
+;; and scripts/repro/fact_spec_bounds_494_differential.py (four-way
+;; execution differential), both CI-wired in the fact-spec-oracle job.
+(module
+  (memory (export "mem") 1)
+  (func (export "poll") (param $slot i32) (result i32)
+    (local $base i32)
+    (local $acc i32)
+    ;; base = 256 + slot*16
+    local.get $slot        ;; op 0  <- ValueRange fact target (value_id 0)
+    i32.const 4            ;; op 1
+    i32.shl                ;; op 2
+    i32.const 256          ;; op 3
+    i32.add                ;; op 4
+    local.set $base        ;; op 5
+    ;; acc = state + prio + flags + deadline + budget
+    local.get $base        ;; op 6
+    i32.load8_u            ;; op 7   guarded byte load
+    local.get $base        ;; op 8
+    i32.load8_u offset=1   ;; op 9   guarded byte load
+    i32.add                ;; op 10
+    local.get $base        ;; op 11
+    i32.load16_u offset=2  ;; op 12  guarded halfword load
+    i32.add                ;; op 13
+    local.get $base        ;; op 14
+    i32.load offset=4      ;; op 15  guarded word load
+    i32.add                ;; op 16
+    local.get $base        ;; op 17
+    i32.load offset=8      ;; op 18  guarded word load
+    i32.add                ;; op 19
+    local.set $acc         ;; op 20
+    ;; ticks++
+    local.get $base        ;; op 21
+    local.get $base        ;; op 22
+    i32.load offset=12     ;; op 23  guarded word load
+    i32.const 1            ;; op 24
+    i32.add                ;; op 25
+    i32.store offset=12    ;; op 26  guarded word store
+    ;; state := 2 (polled)
+    local.get $base        ;; op 27
+    i32.const 2            ;; op 28
+    i32.store8             ;; op 29  guarded byte store
+    local.get $acc))       ;; op 30 (+ implicit End = op 31)

--- a/scripts/repro/fact_spec_bounds_494_differential.py
+++ b/scripts/repro/fact_spec_bounds_494_differential.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""#494 bounds-elision × #390 guard_bool — four-way execution differential
+for the ordeal-certified memory bounds-guard elision.
+
+Builds scripts/repro/fact_spec_bounds_494.wat (the gust_poll-shaped fixture:
+a 16 B task-record array at base 256, EIGHT `--safety-bounds software`
+guarded accesses) WITH a schema-v1 `wsc.facts` value-range section appended
+(green default: slot ∈ [0, 63] on the record index), compiles it three ways —
+SPECIALIZED (SYNTH_FACT_SPEC=1 + software bounds), UNSPECIALIZED (software
+bounds, no fact-spec) and the unguarded FLOOR (no --safety-bounds) — then:
+
+  1. BYTE EVIDENCE: reports the measured poll shrink (symtab deltas; the
+     guarded baseline carries 8 × 10 B of ADD/CMP/BLO/UDF guard — the #390
+     `guard_bool` instruction class; gust_poll's whole guard_bool bucket is
+     108 B) and asserts the specialized `.text` is BYTE-IDENTICAL to the
+     unguarded floor: under the proven premise the sandbox bounds-guard tax
+     is exactly zero.
+  2. IN-BOUNDS SWEEP (1024 cases = 64 slots x 16 memory seeds): specialized
+     ≡ wasmtime ≡ unspecialized on BOTH the return value and the full final
+     64 KiB memory image (the fixture stores ticks+1 and state=2 back).
+  3. RETAINED-TRAP LEG: out-of-premise slots whose access escapes the 1-page
+     memory must TRAP in wasmtime AND in the UNSPECIALIZED build (the guard
+     that was NOT elided still fires; out-of-premise behavior of the
+     SPECIALIZED build is outside the premise contract and not asserted).
+
+Non-vacuity: the run FAILS unless the specialized compile admitted exactly 8
+certificate-backed elisions (one per access) on stderr.
+
+Modes:
+  (default)         green run: byte evidence + in-bounds sweep + retained-trap.
+  --expect-decline  facts claim slot ∈ [0, 8192] (slot 4080+ escapes): assert
+                    the Sat obligation DECLINED loudly and the build is
+                    byte-identical to the guarded baseline (the guard is
+                    restored by the OBLIGATION, not by prudence).
+  --force-admit     RED run (debug synth builds only): same wrong bound, but
+                    SYNTH_FACT_SPEC_FORCE_ADMIT=1 forces the Sat admit —
+                    assert poll(4096) TRAPS in wasmtime but does NOT trap in
+                    the forced build (the silent OOB access an unsound admit
+                    would cause, which the per-site obligation + this harness
+                    exist to prevent).
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/fact_spec_bounds_494_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import (
+    UC_ARCH_ARM,
+    UC_ERR_INSN_INVALID,
+    UC_HOOK_CODE,
+    UC_MODE_THUMB,
+    Uc,
+    UcError,
+)
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R10,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("fact_spec_bounds_494.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+TRAP = "<trap>"
+
+MEM_BYTES = 0x10000  # 1 page = 64 KiB (matches the wat `(memory 1)`)
+CODE, LIN, STK, RET = 0x200000, 0x400000, 0x90000, 0x300000
+
+
+def seed(k):
+    """Deterministic per-case memory image (the fixture reads AND writes)."""
+    return bytes((i * 31 + 11 * k + 7) & 0xFF for i in range(MEM_BYTES))
+
+
+# ---- schema-v1 wsc.facts encoding (docs/design/wsc-facts-encoding.md) ----
+
+def leb_u32(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7F
+        v >>= 7
+        out.append(b | (0x80 if v else 0))
+        if not v:
+            return bytes(out)
+
+
+def leb_s64(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7F
+        v >>= 7
+        done = (v == 0 and not (b & 0x40)) or (v == -1 and (b & 0x40))
+        out.append(b | (0 if done else 0x80))
+        if done:
+            return bytes(out)
+
+
+def with_slot_range(wasm, lo, hi):
+    """Append `slot ∈ [lo, hi]` on (func 0, value_id 0 — the first local.get)."""
+    body = leb_s64(lo) + leb_s64(hi)
+    payload = (b"\x01" + leb_u32(1) + b"\x01" + leb_u32(0) + leb_u32(0)
+               + leb_u32(len(body)) + body)
+    name = b"wsc.facts"
+    content = leb_u32(len(name)) + name + payload
+    return wasm + b"\x00" + leb_u32(len(content)) + content
+
+
+# ---- compile + load ----
+
+def compile_elf(wasm_path, out, fact_spec, software_bounds=True,
+                force_admit=False):
+    env = {"PATH": "/usr/bin:/bin"}
+    if fact_spec:
+        env["SYNTH_FACT_SPEC"] = "1"
+    if force_admit:
+        env["SYNTH_FACT_SPEC_FORCE_ADMIT"] = "1"
+    cmd = [SYNTH, "compile", str(wasm_path), "-o", out, "-b", "arm",
+           "--target", "cortex-m4", "--all-exports"]
+    if software_bounds:
+        cmd += ["--safety-bounds", "software"]
+    r = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({out}): {r.stderr}")
+    return r.stderr
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"] & ~1
+    return data, base, syms
+
+
+def func_size(elf, name):
+    """Function size = sorted symbol-address delta (st_size unreliable)."""
+    data, base, syms = load(elf)
+    addrs = sorted(a for a in syms.values() if base <= a < base + len(data))
+    start = syms[name]
+    nxt = next((a for a in addrs if a > start), base + len(data))
+    return nxt - start
+
+
+def run_poll(code, base, addr, slot, mem_seed, trap_addr=None, extra_pages=0):
+    """Execute poll(slot) over mem_seed; return (ret, memory image), TRAP,
+    or an ERR string. `addr`/`trap_addr` are LINKED addresses; the code is
+    rebased to CODE (offset `a - base`).
+
+    The direct selector's ABI: R11 = linear-memory base, R10 = memory size in
+    bytes (the software guard compares against it). The linmem mapping is
+    EXACTLY one page (an access a bad elision lets through faults as ERR,
+    never a silent match); `extra_pages` widens it only for the red
+    force-admit leg, where the divergence IS the unguarded access succeeding.
+    """
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x10000)
+    mu.mem_map(LIN, MEM_BYTES + extra_pages * 0x10000)
+    mu.mem_map(STK - 0x8000, 0x10000)
+    mu.mem_map(RET, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.mem_write(LIN, mem_seed)
+    mu.reg_write(UC_ARM_REG_SP, STK)
+    mu.reg_write(UC_ARM_REG_R11, LIN)        # linear-memory base
+    mu.reg_write(UC_ARM_REG_R10, MEM_BYTES)  # memory size (bytes) for bounds
+    mu.reg_write(UC_ARM_REG_R0, slot & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    trapped = [False]
+    if trap_addr is not None:
+        trap_rebased = CODE + trap_addr - base
+
+        def hook(uc, address, size, ud):
+            if address == trap_rebased:
+                trapped[0] = True
+                uc.emu_stop()
+        mu.hook_add(UC_HOOK_CODE, hook)
+    try:
+        mu.emu_start((CODE + addr - base) | 1, RET, count=200_000)
+    except UcError as e:
+        # The inline bounds guard is a UDF -> UC_ERR_INSN_INVALID: that IS the
+        # wasm trap. Any OTHER fault (READ/WRITE_UNMAPPED) means an access
+        # escaped without a guard — report as ERR, never as a match.
+        if e.errno == UC_ERR_INSN_INVALID:
+            return TRAP
+        return f"ERR:{e}"
+    if trapped[0]:
+        return TRAP
+    return (mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF,
+            bytes(mu.mem_read(LIN, MEM_BYTES)))
+
+
+def wasmtime_poll(module_bytes, slot, mem_seed):
+    """Fresh instance per call; return (ret, memory image) or TRAP."""
+    eng = wasmtime.Engine()
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, wasmtime.Module(eng, module_bytes), [])
+    mem = inst.exports(st)["mem"]
+    mem.write(st, mem_seed, 0)
+    try:
+        ret = inst.exports(st)["poll"](st, slot) & 0xFFFFFFFF
+    except Exception:
+        return TRAP
+    return ret, bytes(mem.read(st, 0, MEM_BYTES))
+
+
+def show(v, gt=None):
+    if v == TRAP or isinstance(v, str):
+        return v
+    if gt is not None and gt != TRAP and not isinstance(gt, str) and v[1] != gt[1]:
+        i = next(i for i in range(MEM_BYTES) if v[1][i] != gt[1][i])
+        return f"ret={v[0]} (mem differs @{i})"
+    return f"ret={v[0]}"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--expect-decline", action="store_true",
+                    help="claim slot ∈ [0,8192]: assert Sat loud-decline + "
+                         "byte-identity to the guarded baseline")
+    ap.add_argument("--force-admit", action="store_true",
+                    help="RED: wrong bound + SYNTH_FACT_SPEC_FORCE_ADMIT — "
+                         "demonstrate the silent-OOB divergence")
+    args = ap.parse_args()
+
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth first")
+
+    base_wasm = bytes(wasmtime.wat2wasm(WAT.read_text()))
+    tmp = Path("/tmp")
+
+    # ---------- red / decline legs: the claim admits OOB (slot 4080+) --------
+    if args.expect_decline or args.force_admit:
+        wasm = with_slot_range(base_wasm, 0, 8192)
+        wasm_path = tmp / "fact_spec_bounds_494_wrong.wasm"
+        wasm_path.write_bytes(wasm)
+        spec_elf = str(tmp / "fact_spec_bounds_494_wrong_spec.elf")
+        base_elf = str(tmp / "fact_spec_bounds_494_wrong_base.elf")
+        stderr = compile_elf(wasm_path, spec_elf, fact_spec=True,
+                             force_admit=args.force_admit)
+        compile_elf(wasm_path, base_elf, fact_spec=False)
+        scode, sbase, ssyms = load(spec_elf)
+        bcode, _, _ = load(base_elf)
+
+        if args.expect_decline:
+            if "fact-spec: ADMIT" in stderr:
+                sys.exit(f"expected DECLINE under slot ∈ [0,8192], got an "
+                         f"admit:\n{stderr}")
+            if "bounds-guard obligation Sat" not in stderr:
+                sys.exit(f"decline must name the Sat obligation:\n{stderr}")
+            if scode != bcode:
+                sys.exit("declined build must be byte-identical to the "
+                         "guarded baseline")
+            print("ORACLE: PASS (Sat obligation declined loudly; all 8 guards "
+                  "restored byte-identically)")
+            return
+
+        # --force-admit: the unsound build must silently READ PAST the bound.
+        if "UNSOUND FORCED ADMIT" not in stderr:
+            sys.exit("force-admit run must scream UNSOUND FORCED ADMIT "
+                     "(release synth builds compile the lever out):\n" + stderr)
+        slot = 4096  # base = 256 + 65536 = 65792 > 65536: every access OOB
+        gt = wasmtime_poll(wasm, slot, seed(0))
+        got = run_poll(scode, sbase, ssyms["poll"], slot, seed(0),
+                       extra_pages=2)
+        print(f"poll({slot}): wasmtime={show(gt)} forced-specialized={show(got)}")
+        if gt != TRAP:
+            sys.exit("wasmtime must trap on the out-of-bounds access")
+        if got == TRAP or isinstance(got, str):
+            sys.exit("forced build still trapped/faulted — the red lever did "
+                     "not elide the guard (vacuous red run)")
+        print("ORACLE: PASS (red) — the forced admit DIVERGES exactly as the "
+              "certificate gate predicts: wasmtime traps, the unsound build "
+              "silently accesses past the memory bound and returns a value. "
+              "This is the sandbox-escape class the per-site obligation + "
+              "this harness exist to prevent.")
+        return
+
+    # ---------- green leg: proven slot ∈ [0, 63] ----------
+    wasm = with_slot_range(base_wasm, 0, 63)
+    wasm_path = tmp / "fact_spec_bounds_494.wasm"
+    wasm_path.write_bytes(wasm)
+    spec_elf = str(tmp / "fact_spec_bounds_494_spec.elf")
+    base_elf = str(tmp / "fact_spec_bounds_494_base.elf")
+    floor_elf = str(tmp / "fact_spec_bounds_494_floor.elf")
+    stderr_spec = compile_elf(wasm_path, spec_elf, fact_spec=True)
+    compile_elf(wasm_path, base_elf, fact_spec=False)
+    compile_elf(wasm_path, floor_elf, fact_spec=False, software_bounds=False)
+
+    admits = stderr_spec.count("fact-spec: ADMIT")
+    declines = stderr_spec.count("fact-spec: DECLINE")
+    print(f"specialized compile: {admits} ADMIT, {declines} DECLINE")
+    # Non-vacuity: one certificate-backed elision per guarded access.
+    if admits != 8:
+        sys.exit(f"expected 8 certificate-backed guard elisions, got "
+                 f"{admits}:\n{stderr_spec}")
+    for token in ("software bounds guard elided", "trap_mem_oob",
+                  "certificate-checked"):
+        if token not in stderr_spec:
+            sys.exit(f"admit lines must name the obligation ('{token}' "
+                     f"missing):\n{stderr_spec}")
+
+    # ---- byte evidence (the #390 guard_bool class) ----
+    b_len = func_size(base_elf, "poll")
+    s_len = func_size(spec_elf, "poll")
+    f_len = func_size(floor_elf, "poll")
+    print(f"poll: guarded {b_len} B -> specialized {s_len} B "
+          f"(-{b_len - s_len} B = 8 guards x 10 B ADD/CMP/BLO/UDF; the #390 "
+          f"guard_bool instruction class — gust_poll's whole guard_bool "
+          f"bucket is 108 B); unguarded floor {f_len} B")
+    if b_len - s_len != 80:
+        sys.exit(f"byte win drifted: expected exactly 80 B "
+                 f"(got {b_len - s_len})")
+    scode, sbase, ssyms = load(spec_elf)
+    fcode, _, _ = load(floor_elf)
+    if scode != fcode:
+        sys.exit("specialized .text must be BYTE-IDENTICAL to the unguarded "
+                 "floor (the proven premise makes the bounds-guard tax "
+                 "exactly zero)")
+    print("specialized .text == unguarded floor .text (bounds-guard tax = 0)")
+
+    bcode, bbase, bsyms = load(base_elf)
+    trap_spec = ssyms.get("Trap_Handler")
+    trap_base = bsyms.get("Trap_Handler")
+
+    # ---- in-bounds sweep: 64 slots x 16 memory seeds = 1024 cases ----
+    fails = 0
+    count = 0
+    for k in range(16):
+        mem = seed(k)
+        for slot in range(64):
+            gt = wasmtime_poll(wasm, slot, mem)
+            got_s = run_poll(scode, sbase, ssyms["poll"], slot, mem,
+                             trap_addr=trap_spec)
+            got_b = run_poll(bcode, bbase, bsyms["poll"], slot, mem,
+                             trap_addr=trap_base)
+            count += 1
+            if not (got_s == gt == got_b):
+                fails += 1
+                if fails <= 10:
+                    print(f"FAIL poll({slot}) seed {k}: wasmtime={show(gt)} "
+                          f"specialized={show(got_s, gt)} "
+                          f"unspecialized={show(got_b, gt)}")
+    print(f"swept {count} in-bounds cases (64 slots x 16 memory images, "
+          f"return value + full final memory image)")
+
+    # ---- retained-trap leg: out-of-premise inputs on the UNSPECIALIZED
+    # path must still trap (its guards were never elided) ----
+    for slot in (4080, 4096, 8192, 1_000_000):
+        gt = wasmtime_poll(wasm, slot, seed(0))
+        got_b = run_poll(bcode, bbase, bsyms["poll"], slot, seed(0),
+                         trap_addr=trap_base)
+        count += 1
+        if gt != TRAP:
+            sys.exit(f"vector expectation wrong: wasmtime must trap on "
+                     f"poll({slot})")
+        if got_b != TRAP:
+            fails += 1
+            print(f"FAIL poll({slot}): unspecialized build must TRAP "
+                  f"(wasmtime traps), got {show(got_b)}")
+        else:
+            print(f"poll({slot}): TRAP in both wasmtime and the "
+                  f"unspecialized build (guard retained)")
+
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails}/{count})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/parity_benchmark/run.py
+++ b/scripts/repro/parity_benchmark/run.py
@@ -14,6 +14,10 @@ Kernels (all in-tree; see artifacts/parity-benchmark.md for provenance):
   gust_mix_q8  scripts/repro/gust_kernel.wasm      (Q8 mix wrapper)
   clamp        scripts/repro/fact_spec_clamp_494.wat  (gust_mix clamp shape)
                + native twin  scripts/repro/parity_benchmark/gust_mix_clamp.c
+  bounds       scripts/repro/fact_spec_bounds_494.wat (gust_poll-shaped record
+               array; --safety-bounds software guard tax vs certified elision
+               vs the unguarded floor — synth-internal group, no C twin: C has
+               no sandbox bounds checks)
   flat_flight  scripts/repro/flat_flight/flat_flight.loom.wasm
                + native twin  scripts/repro/flat_flight/flat_flight.c
   falcon_axis  scripts/repro/parity_benchmark/falcon_axis.wat  (f32, VFP)
@@ -61,6 +65,7 @@ REPORT = REPO / "artifacts" / "parity-benchmark.md"
 
 GUST_KERNEL = REPO / "scripts/repro/gust_kernel.wasm"
 CLAMP_WAT = REPO / "scripts/repro/fact_spec_clamp_494.wat"
+BOUNDS_WAT = REPO / "scripts/repro/fact_spec_bounds_494.wat"
 FLAT_FLIGHT_WASM = REPO / "scripts/repro/flat_flight/flat_flight.loom.wasm"
 FLAT_FLIGHT_C = REPO / "scripts/repro/flat_flight/flat_flight.c"
 FLAT_FLIGHT_INC = REPO / "scripts/repro/flat_flight"
@@ -200,7 +205,8 @@ def func_sizes(elf: Path) -> dict:
     return out
 
 
-def synth_compile(wasm: Path, out: Path, target: str, fact_spec: bool = False) -> str:
+def synth_compile(wasm: Path, out: Path, target: str, fact_spec: bool = False,
+                  extra_args=()) -> str:
     env = dict(os.environ)
     env.pop("SYNTH_FACT_SPEC", None)
     if fact_spec:
@@ -208,6 +214,7 @@ def synth_compile(wasm: Path, out: Path, target: str, fact_spec: bool = False) -
     cmd = [
         synth_bin(), "compile", str(wasm),
         "-o", str(out), "-b", "arm", "--target", target, "--all-exports",
+        *extra_args,
     ]
     r = subprocess.run(cmd, capture_output=True, text=True, env=env)
     if r.returncode != 0:
@@ -276,6 +283,37 @@ def measure(tmp: Path, only=None) -> dict:
                 )
             m["clamp_spec_synth"] = func_sizes(elf)["gust_mix"]
             m["clamp_spec_admits"] = admits
+
+    if want("bounds"):
+        # #494 bounds-elision × #390 guard_bool: the gust_poll-shaped
+        # record-array kernel under `--safety-bounds software` (8 inline
+        # ADD/CMP/BLO/UDF guards) vs the same build under the proven premise
+        # slot ∈ [0, 63] (every guard ordeal-certificate-elided) vs the
+        # unguarded floor (no --safety-bounds — the group's reference).
+        base = tmp / "bounds_base.wasm"
+        wat2wasm(BOUNDS_WAT, base)
+        sw = ("--safety-bounds", "software")
+        guarded = tmp / "bounds_guarded.o"
+        synth_compile(base, guarded, "cortex-m4", extra_args=sw)
+        m["bounds_guarded_synth"] = func_sizes(guarded)["poll"]
+        floor = tmp / "bounds_floor.o"
+        synth_compile(base, floor, "cortex-m4")
+        m["bounds_floor_synth"] = func_sizes(floor)["poll"]
+        facts = tmp / "bounds_facts.wasm"
+        facts.write_bytes(with_range_fact(base.read_bytes(), 0, 63))
+        spec = tmp / "bounds_spec.o"
+        stderr = synth_compile(facts, spec, "cortex-m4", fact_spec=True,
+                               extra_args=sw)
+        admits = stderr.count("fact-spec: ADMIT")
+        if admits != 8:
+            sys.exit(
+                f"bounds: expected 8 certificate ADMITs, got {admits}.\n"
+                "The fact-spec pass needs the ordeal solver — build synth "
+                "with `cargo build -p synth-cli --features verify` and "
+                "point $SYNTH at it.\n--- synth stderr ---\n" + stderr
+            )
+        m["bounds_spec_synth"] = func_sizes(spec)["poll"]
+        m["bounds_spec_admits"] = admits
 
     if want("flat_flight"):
         elf = tmp / "ff_synth.o"
@@ -357,6 +395,24 @@ def table_lines(m: dict) -> list:
         L.append(("gust_mix clamp", "native LLVM floor (gale gust_floor_bench)",
                   CITED["clamp_llvm_floor"], "CITED #494",
                   ratio(CITED["clamp_llvm_floor"], ref), CYCLES_OPEN))
+    if "bounds_guarded_synth" in m:
+        # The group's reference is synth's OWN unguarded floor: native C has
+        # no sandbox bounds checks at all, so the honest comparison for the
+        # guard tax is guarded-vs-floor (and the specialized build lands ON
+        # the floor, byte-identical — asserted by fact_spec_bounds_494.rs and
+        # the differential harness).
+        ref = m.get("bounds_floor_synth")
+        L.append(("gust_poll bounds (8 sw guards)",
+                  "synth AOT --safety-bounds software (no facts)",
+                  m["bounds_guarded_synth"], "MEASURED",
+                  ratio(m["bounds_guarded_synth"], ref), CYCLES_OPEN))
+        L.append(("gust_poll bounds (8 sw guards)",
+                  "synth AOT sw bounds + SYNTH_FACT_SPEC=1 (proven slot∈[0,63])",
+                  m["bounds_spec_synth"], "MEASURED (8 ordeal ADMITs)",
+                  ratio(m["bounds_spec_synth"], ref), CYCLES_OPEN))
+        L.append(("gust_poll bounds (8 sw guards)",
+                  "synth AOT unguarded floor (no --safety-bounds) — group ref",
+                  m["bounds_floor_synth"], "MEASURED", "ref", CYCLES_OPEN))
     if "flat_flight_synth" in m:
         ref = m.get("flat_flight_gcc")
         L.append(("flat_flight", "synth AOT (default)", m["flat_flight_synth"],
@@ -432,8 +488,18 @@ Regenerate everything on this page:
   `arm-none-eabi-gcc -Os`, and within 2 B of the **12 B LLVM floor** (CITED
   #494). C has no channel to carry the range premise — the native compiler
   must keep both compares; synth carries the proof (#494).
+- **Sandbox bounds checks become FREE under a proven premise**: the
+  gust_poll-shaped record-array kernel under `--safety-bounds software`
+  carries 8 inline guards (**{m.get('bounds_guarded_synth', '—')} B**); with
+  the premise slot∈[0,63] every guard falls to a per-site ordeal certificate
+  (`UNSAT(P ∧ trap_mem_oob(zext64(index)+offset, size, min_mem))`) —
+  **{m.get('bounds_spec_synth', '—')} B, byte-identical to the unguarded
+  floor**. The sandbox-safety tax native C never pays drops to exactly zero
+  for wasm-AOT too, and only when proven (#494 × #390 `guard_bool`; wrong
+  premise ⇒ Sat ⇒ loud decline, guards retained).
 - **General register allocation is still the gap**: gust_poll is
-  **{m.get('gust_poll_synth', '—')} B vs 208 B** (CITED #390) = 3.56×, with
+  **{m.get('gust_poll_synth', '—')} B vs 208 B** (CITED #390) =
+  {ratio(m.get('gust_poll_synth'), CITED['gust_poll_llvm'])}, with
   `spill_reload` alone ~31% of the function
   (`artifacts/size_attribution_390.md` — the productive-work residual, 194 B,
   is already comparable to LLVM's entire output; the gap is overhead buckets).
@@ -481,7 +547,10 @@ Regenerate everything on this page:
 Synth-side byte numbers are pinned by
 `crates/synth-cli/tests/parity_benchmark_735.rs` (default rows) and its
 verify-feature test (fact-spec row) — prose and measurement cannot drift
-apart without reddening CI.
+apart without reddening CI. The bounds-group rows are pinned by
+`crates/synth-cli/tests/fact_spec_bounds_494.rs` (guarded 184 B /
+specialized 104 B, 8-ADMIT non-vacuity, floor byte-identity) in the same
+fact-spec CI job.
 
 ## Falsification — one command per row group
 
@@ -498,6 +567,11 @@ table line (nonzero exit on any failure):
     # gust_mix clamp under the proven premise (needs a verify-feature synth;
     # fails loudly unless BOTH elisions are certificate-ADMITted)
     SYNTH=$CARGO_TARGET_DIR/debug/synth python3 scripts/repro/parity_benchmark/run.py --only clamp_spec
+
+    # gust_poll bounds group: software guards vs certified elision vs the
+    # unguarded floor (needs a verify-feature synth; fails loudly unless all
+    # EIGHT elisions are certificate-ADMITted)
+    SYNTH=$CARGO_TARGET_DIR/debug/synth python3 scripts/repro/parity_benchmark/run.py --only bounds
 
     # flat_flight: synth vs the in-tree C source it was compiled from
     SYNTH=$CARGO_TARGET_DIR/debug/synth python3 scripts/repro/parity_benchmark/run.py --only flat_flight
@@ -524,7 +598,8 @@ The gap is CLOSING release-over-release, lever by lever, each evidence-gated:
 | flat_flight frame traffic | 17 spills (#209, CITED) | Belady optimum, frame traffic 0 (since v0.24.0) | VCR-RA-001 |
 
 Open, tracked, and honestly not yet won: general regalloc overhead
-(gust_poll 3.56×, spill_reload ~31%, #390/#242 Track A), flat_flight at
+(gust_poll {ratio(m.get('gust_poll_synth'), CITED['gust_poll_llvm'])},
+spill_reload ~31%, #390/#242 Track A), flat_flight at
 {ratio(m.get('flat_flight_synth'), ff_gcc)} vs gcc, falcon f32 at
 {ratio(m.get('falcon_synth'), falcon_gcc)} vs gcc (constant materialization
 via `movw/movt+vmov` instead of a literal pool, unused callee-save push), and
@@ -538,7 +613,7 @@ attribution), #209 (perf epic), #242 (North Star).
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--only", choices=[
-        "gust_poll", "gust_mix_q8", "clamp", "clamp_spec",
+        "gust_poll", "gust_mix_q8", "clamp", "clamp_spec", "bounds",
         "flat_flight", "falcon_axis",
     ], help="re-measure a single row group (falsification mode)")
     ap.add_argument("--report", action="store_true",

--- a/scripts/repro/size_attribution_390.py
+++ b/scripts/repro/size_attribution_390.py
@@ -317,6 +317,14 @@ unused callee-save, frame setup, and un-coalesced copies around a one-line wrapp
   `cmp rN,#0`, `cmn`, dead mod-32 shift mask (`and ip,rN,#31`), `udf`.
   Comparisons feeding a `br_if` materialize a bool then re-`cmp #0` instead of
   branching off flags. Opportunity: branch-on-flags peephole + shift-mask elide.
+  PREMISE-GATED LEVER (#494 bounds-elision, v0.43+): under `--safety-bounds
+  software` each memory access adds a 10 B ADD/CMP/BLO/UDF guard to this
+  class; with `SYNTH_FACT_SPEC=1` + a `wsc.facts` range premise on the index,
+  each guard falls to a per-site ordeal certificate
+  (`UNSAT(P ∧ trap_mem_oob(...))`) — measured on the gust_poll-shaped
+  fixture: 184 → 104 B, byte-identical to the unguarded floor
+  (`fact_spec_bounds_494_differential.py`). The numbers on THIS page are the
+  default path (no `--safety-bounds`, no facts) and are unchanged by it.
 - **copy_move** (Pass 5) — plain `mov rD, rS`. Un-coalesced identity/near-identity
   copies. Opportunity: copy coalescing (pairs with the allocator).
 - **productive** — residual: real arithmetic, the memory loads/stores themselves,


### PR DESCRIPTION
## What

**Premise-proven memory accesses drop their `--safety-bounds software` guard — per-site, certificate-checked, flag-gated.** The fact-spec pass (#494, `SYNTH_FACT_SPEC`, default OFF) now discharges, for every i32 linear-memory load/store it walks:

```
UNSAT( P ∧ trap_mem_oob(zext64(index) + offset, size, min_memory_bytes) )
```

via the certificate-checked ordeal solver (ordeal 0.9.1 `trap_mem_oob` shape, `addr + size >u mem_bound`), posed at width 64 — the 32-bit index is ZERO-extended and the static memarg offset added at 64 bits, so a wrapped effective address can never falsely elide (unit-gated, incl. the boundary `addr + size == bound` case and the `index = -256, offset = 0x200` wrap counterexample). Sat / Unknown / no-premise / unknown memory size ⇒ loud decline, guard emitted. Like div/rem, memory ops are TRACKED but never DELETED — the discharged obligation becomes a per-site mark the direct selector consumes by stripping the 4-instruction guard (`ADD ip; CMP ip, R10; BLO +0; UDF #0`), keeping the access op itself.

## Measured (the #390 `guard_bool` bucket)

On the gust_poll-shaped fixture (`scripts/repro/fact_spec_bounds_494.wat`, 16 B task-record array, 8 guarded accesses, proven `slot ∈ [0, 63]`):

| build | poll `.text` |
|---|---|
| `--safety-bounds software`, no facts | **184 B** |
| + `SYNTH_FACT_SPEC=1`, proven premise | **104 B** (8 ordeal ADMITs) |
| unguarded floor (no `--safety-bounds`) | **104 B** — specialized `.text` is **byte-identical** |

**−80 B = 8 × 10 B of guard code — the sandbox bounds-guard tax goes to exactly zero under a proven premise** (gust_poll's whole #390 `guard_bool` bucket is 108 B; this lane makes its guard portion premise-elidable). No cycle claims — cycles stay OPEN for gale's DWT silicon rows.

## Four-way differential (`scripts/repro/fact_spec_bounds_494_differential.py`, CI-wired)

- **green**: 8-ADMIT non-vacuity; byte evidence above; **1024-case in-bounds sweep** (64 slots × 16 memory seeds, return value + full final 64 KiB memory image) specialized ≡ wasmtime ≡ unspecialized; **retained-trap leg** — out-of-premise slots (4080/4096/8192/10⁶) TRAP in both wasmtime and the UNSPECIALIZED build.
- **--expect-decline**: `slot ∈ [0, 8192]` admits OOB ⇒ Sat ⇒ loud decline naming the obligation + counterexample, build byte-identical to the guarded baseline.
- **--force-admit (RED, debug builds)**: the forced Sat admit diverges — wasmtime traps, the unsound build silently reads past the bound (`poll(4096)`: trap vs ret=0) — the sandbox-escape class the per-site obligation prevents.

Plus the Rust byte gates `crates/synth-cli/tests/fact_spec_bounds_494.rs` (flag-off byte-identity, 184→104 pin, decline byte-identity, no-guard-mode leg), all in the `fact-spec-oracle` CI job.

## Soundness notes

- `min_memory_bytes` is the module's DECLARED minimum — every reachable runtime extent (R10) is ≥ it, so proving inside the minimum proves inside every runtime bound. The plain per-function path passes 0 = unknown = loud decline.
- Loaded values are havocked (memory contents never modeled); a possibly-trapping op never enters an erasable condition slice; marks are remapped through stream rewrites and defensively dropped (loudly) if the memory.grow(0) fold shifted indices.
- `Masking` mode never consumes a mark (different scheme); marked functions route to the direct selector (IR passes renumber indices — same rationale as the phase-2b div marks).
- Flag OFF is byte-identical: frozen anchors 10/10, full workspace suite green, fmt/clippy `-D warnings` clean, claim-check 18/18 (no ledger claims touched).

## Benchmark artifacts

`artifacts/parity-benchmark.md` gains the bounds row group (guarded 184 B / specialized 104 B / floor 104 B ref, pinned by `fact_spec_bounds_494.rs`); `artifacts/size_attribution_390.md` guard_bool bucket notes the premise-gated lever (default-path numbers regenerated unchanged). Regenerating also refreshed the parity page's stale gust_poll row (740 → 724 B, drifted on main since the v0.41 generation; pinned green in `size_attribution_390.rs`).

Refs #494 (proof-carrying specialization), #390 (size attribution / guard_bool), #242 (VCR North Star, Track C oracle discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L