### PR TITLE
feat(vfp): FINISH the float story — AAPCS-VFP call marshalling + f64 D-homed params + f64 op tail (#369)

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -430,16 +430,17 @@ fn compile_wasm_to_arm(
         // the epilogue loudly declines a float result reaching it in a core
         // register (never a silent integer R0 return where a caller reads S0/D0).
         selector.set_ret_float(config.current_func_ret_f32, config.current_func_ret_f64);
-        // GI-FPU-002 phase 2 (#719/#369): per-callee float-signature tables, so
-        // `Call`/`CallIndirect` decline LOUDLY when the callee itself has a
-        // float ABI at the boundary (f32/f64 return in S0/D0, f32 params in the
-        // VFP pool) — the un-marshalled cases of this increment.
+        // GI-FPU-002 phase 3 (#369): per-callee float-signature tables. `Call`
+        // marshals the AAPCS-VFP boundary from these (float args into S0../D0..,
+        // float results out of S0/D0); `CallIndirect` still declines a
+        // float-returning static type loudly.
         selector.set_float_call_signatures(
             config.func_ret_f32.clone(),
             config.func_ret_f64.clone(),
             config.type_ret_f32.clone(),
             config.type_ret_f64.clone(),
             config.func_params_f32.clone(),
+            config.func_params_f64.clone(),
         );
         // #509: blocktype-arity side-table of THIS function, so value-carrying
         // br/br_if/br_table land the carried value in the target block's

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -2082,6 +2082,15 @@ impl ArmEncoder {
             ArmOp::F64PromoteF32 { dd, sm } => {
                 return self.encode_arm_f64_promote_f32(dd, sm);
             }
+            // GI-FPU-002 (#369): no synth A32 target carries an FPU (cortex-r5
+            // has none — the selector declines every float op there), so the
+            // A32 encoder refuses loudly instead of shipping an untested
+            // encoding (#615: never a silent wrong byte).
+            ArmOp::F32DemoteF64 { .. } => {
+                return Err(synth_core::Error::synthesis(
+                    "F32DemoteF64 has no A32 encoding (no A32 target has an FPU)",
+                ));
+            }
             ArmOp::F64ReinterpretI64 { dd, rmlo, rmhi } => {
                 encode_vmov_core_dreg(true, dd, rmlo, rmhi)?
             }
@@ -6215,6 +6224,7 @@ impl ArmEncoder {
                 ))
             }
             ArmOp::F64PromoteF32 { dd, sm } => self.encode_thumb_f64_promote_f32(dd, sm),
+            ArmOp::F32DemoteF64 { sd, dm } => self.encode_thumb_f32_demote_f64(sd, dm),
             ArmOp::F64ReinterpretI64 { dd, rmlo, rmhi } => Ok(vfp_to_thumb_bytes(
                 encode_vmov_core_dreg(true, dd, rmlo, rmhi)?,
             )),
@@ -7034,55 +7044,41 @@ impl ArmEncoder {
     }
 
     /// Encode F32 copysign as Thumb-2
+    /// Encode F32 copysign as Thumb-2, clobbering ONLY R12 (the reserved
+    /// encoder scratch, #212), the flags, and Sd:
+    ///
+    ///   VMOV R12, Sm ; CMP R12, #0    (N flag = the sign bit)
+    ///   VABS.F32 Sd, Sn               (magnitude, sign cleared)
+    ///   IT MI ; VNEG.F32(MI) Sd, Sd
+    ///
+    /// Bit-exact on ±0.0/NaN-sign/±inf (VABS/VNEG are sign-bit-only edits).
+    /// The R12 capture happens BEFORE Sd is written, so Sd aliasing Sn or Sm
+    /// is safe. (The previous sequence staged the magnitude through R0 —
+    /// clobbering a live allocator-owned value, the #615 class; caught while
+    /// composing the F64 twin for #369.)
     fn encode_thumb_f32_copysign(&self, sd: &VfpReg, sn: &VfpReg, sm: &VfpReg) -> Result<Vec<u8>> {
         let mut bytes = Vec::new();
 
-        // VMOV R12, Sm (get sign source bits)
+        // VMOV R12, Sm (sign source bits)
         bytes.extend_from_slice(&vfp_to_thumb_bytes(encode_vmov_core_sreg(
             false,
             sm,
             &Reg::R12,
         )?));
-
-        // VMOV R0, Sn (get magnitude source bits)
-        bytes.extend_from_slice(&vfp_to_thumb_bytes(encode_vmov_core_sreg(
-            false,
-            sn,
-            &Reg::R0,
-        )?));
-
-        // AND.W R12, R12, #0x80000000  (isolate the sign bit of the sign source)
-        // Thumb-2 T1 data-processing modified immediate: 11110 i 0 0000 S Rn |
-        // 0 imm3 Rd imm8, where the 12-bit constant is i:imm3:imm8. When the
-        // 5-bit rotation `rot = i:imm3:imm8[7]` is >= 8, the value is
-        // `(0x80 | imm8[6:0]) ROR rot`. For 0x80000000: 0x80 ROR 8 = 0x80000000,
-        // so rot=8 (i=0, imm3=0b100), imm8=0x00. (#719: the previous encoding
-        // used imm3=1/imm8=0x02, which decodes to #0x00020002 — a wrong mask that
-        // spliced bits 17 and 1 instead of the sign bit; copysign was never
-        // execution-differentiated until #719 caught it.)
-        let hw1: u16 = 0xF000 | 12; // AND.W R12, R12, #imm (i=0, S=0, Rn=R12)
-        let hw2: u16 = (0x4 << 12) | (12 << 8); // imm3=4, Rd=R12, imm8=0 → #0x80000000
-        bytes.extend_from_slice(&hw1.to_le_bytes());
-        bytes.extend_from_slice(&hw2.to_le_bytes());
-
-        // BIC.W R0, R0, #0x80000000  (clear the sign bit of the magnitude source)
-        let hw1: u16 = 0xF020; // BIC.W R0, R0, #imm (i=0, S=0, Rn=R0)
-        let hw2: u16 = 0x4 << 12; // imm3=4, Rd=R0, imm8=0 → #0x80000000
-        bytes.extend_from_slice(&hw1.to_le_bytes());
-        bytes.extend_from_slice(&hw2.to_le_bytes());
-
-        // ORR.W R0, R0, R12 (R0 = register 0)
-        let hw1: u16 = 0xEA40; // ORR.W R0, R0, R12 (Rn=R0)
-        let hw2: u16 = 12; // Rd=R0, Rm=R12
-        bytes.extend_from_slice(&hw1.to_le_bytes());
-        bytes.extend_from_slice(&hw2.to_le_bytes());
-
-        // VMOV Sd, R0
-        bytes.extend_from_slice(&vfp_to_thumb_bytes(encode_vmov_core_sreg(
-            true,
-            sd,
-            &Reg::R0,
-        )?));
+        // CMP.W R12, #0 — N = bit31 (the sign, incl. -0.0 / -NaN).
+        bytes.extend_from_slice(&0xF1BC_u16.to_le_bytes());
+        bytes.extend_from_slice(&0x0F00_u16.to_le_bytes());
+        // VABS.F32 Sd, Sn
+        let sd_num = vfp_sreg_to_num(sd)?;
+        let sn_num = vfp_sreg_to_num(sn)?;
+        let (vd, d) = encode_sreg(sd_num);
+        let (vn, n) = encode_sreg(sn_num);
+        let vabs = 0xEEB00AC0 | (d << 22) | (vd << 12) | (n << 5) | vn;
+        bytes.extend_from_slice(&vfp_to_thumb_bytes(vabs));
+        // IT MI ; VNEG.F32(MI) Sd, Sd
+        bytes.extend_from_slice(&0xBF48_u16.to_le_bytes());
+        let vneg = 0xEEB10A40 | (d << 22) | (vd << 12) | (d << 5) | vd;
+        bytes.extend_from_slice(&vfp_to_thumb_bytes(vneg));
 
         Ok(bytes)
     }
@@ -7179,18 +7175,35 @@ impl ArmEncoder {
     }
 
     /// Encode VMOV Sd, Rm + VCVT.F64.S32/U32 Dd, Sd as Thumb-2
+    /// Encode i32 → f64 conversion as Thumb-2. The integer stages through the
+    /// DESTINATION's own low S-alias (`S(2d)`) — allocator-owned by
+    /// definition — never S0 (which may hold a live value; the previous
+    /// pseudo-op's S0 staging was the #615 class). Also fixes the SWAPPED
+    /// signed/unsigned VCVT bases (bit7 = 1 is SIGNED — the same swap the f32
+    /// twin had; latent here because f64.convert_i32_* was decode-dropped
+    /// until #369): clang-verified vcvt.f64.s32 d1,s2 = eeb8 1bc1,
+    /// vcvt.f64.u32 d1,s2 = eeb8 1b41.
     fn encode_thumb_f64_convert_i32(&self, dd: &VfpReg, rm: &Reg, signed: bool) -> Result<Vec<u8>> {
+        let dd_num = vfp_dreg_to_num(dd)?;
+        if dd_num > 7 {
+            return Err(synth_core::Error::synthesis(format!(
+                "F64ConvertI32: destination {dd:?} has no S-register alias \
+                 (D8..D15) — the selector allocates only D0..D7"
+            )));
+        }
         let mut bytes = Vec::new();
 
-        // VMOV S0, Rm
-        let vmov = encode_vmov_core_sreg(true, &VfpReg::S0, rm)?;
+        // VMOV S(2d), Rm — stage the integer in the destination's low word.
+        let (vn_s, n_s) = encode_sreg(2 * dd_num);
+        let rt = reg_to_bits(rm);
+        let vmov = 0xEE000A10 | (vn_s << 16) | (rt << 12) | (n_s << 7);
         bytes.extend_from_slice(&vfp_to_thumb_bytes(vmov));
 
-        // VCVT.F64.S32 Dd, S0 or VCVT.F64.U32 Dd, S0
-        let dd_num = vfp_dreg_to_num(dd)?;
+        // VCVT.F64.S32/U32 Dd, S(2d)
         let (vd, d) = encode_dreg(dd_num);
-        let base = if signed { 0xEEB80B40 } else { 0xEEB80BC0 };
-        let vcvt = base | (d << 22) | (vd << 12);
+        let (vm, m) = encode_sreg(2 * dd_num);
+        let base = if signed { 0xEEB80BC0 } else { 0xEEB80B40 };
+        let vcvt = base | (d << 22) | (vd << 12) | (m << 5) | vm;
         bytes.extend_from_slice(&vfp_to_thumb_bytes(vcvt));
 
         Ok(bytes)
@@ -7207,82 +7220,101 @@ impl ArmEncoder {
         Ok(vfp_to_thumb_bytes(vcvt))
     }
 
-    /// Encode VCVT.S32/U32.F64 S0, Dm + VMOV Rd, S0 as Thumb-2
-    fn encode_thumb_i32_trunc_f64(&self, rd: &Reg, dm: &VfpReg, signed: bool) -> Result<Vec<u8>> {
-        let mut bytes = Vec::new();
+    /// Encode VCVT.F32.F64 Sd, Dm (f32.demote_f64) as Thumb-2 — single
+    /// instruction, round-to-nearest-even per FPSCR default, exactly WASM
+    /// §4.3.3 demote (clang-verified: vcvt.f32.f64 s1,d2 = eef7 0bc2).
+    fn encode_thumb_f32_demote_f64(&self, sd: &VfpReg, dm: &VfpReg) -> Result<Vec<u8>> {
+        let sd_num = vfp_sreg_to_num(sd)?;
         let dm_num = vfp_dreg_to_num(dm)?;
+        let (vd, d) = encode_sreg(sd_num);
         let (vm, m) = encode_dreg(dm_num);
 
-        // VCVT.S32.F64 S0, Dm or VCVT.U32.F64 S0, Dm
+        let vcvt = 0xEEB70BC0 | (d << 22) | (vd << 12) | (m << 5) | vm;
+        Ok(vfp_to_thumb_bytes(vcvt))
+    }
+
+    /// Encode f64 → i32 truncation as Thumb-2 (round-toward-zero VCVT). The
+    /// 32-bit result stages through the SOURCE's own low S-alias (`S(2m)`,
+    /// clobbering half of an operand the selector has already popped) — never
+    /// S0, which may hold an unrelated live value (the #615 class). The
+    /// overlapping write is well-defined: VCVT reads its source operand
+    /// before writing (compilers emit `vcvt.f32.f64 s0, d0` routinely).
+    /// The SELECTOR guarantees `dm` is a dead temp, never a pinned param/
+    /// local home (it copies a home into a fresh D-temp first).
+    fn encode_thumb_i32_trunc_f64(&self, rd: &Reg, dm: &VfpReg, signed: bool) -> Result<Vec<u8>> {
+        let dm_num = vfp_dreg_to_num(dm)?;
+        if dm_num > 7 {
+            return Err(synth_core::Error::synthesis(format!(
+                "I32TruncF64: source {dm:?} has no S-register alias \
+                 (D8..D15) — the selector allocates only D0..D7"
+            )));
+        }
+        let mut bytes = Vec::new();
+
+        // VCVT.S32/U32.F64 S(2m), Dm (clang-verified:
+        // vcvt.s32.f64 s1,d2 = eefd 0bc2 ; vcvt.u32.f64 s1,d2 = eefc 0bc2)
+        let (vm, m) = encode_dreg(dm_num);
+        let (vd_s, d_s) = encode_sreg(2 * dm_num);
         let base = if signed { 0xEEBD0BC0 } else { 0xEEBC0BC0 };
-        let vcvt = base | (m << 5) | vm;
+        let vcvt = base | (d_s << 22) | (vd_s << 12) | (m << 5) | vm;
         bytes.extend_from_slice(&vfp_to_thumb_bytes(vcvt));
 
-        // VMOV Rd, S0
-        let vmov = encode_vmov_core_sreg(false, &VfpReg::S0, rd)?;
+        // VMOV Rd, S(2m)
+        let rt = reg_to_bits(rd);
+        let vmov = 0xEE100A10 | (vd_s << 16) | (rt << 12) | (d_s << 7);
         bytes.extend_from_slice(&vfp_to_thumb_bytes(vmov));
 
         Ok(bytes)
     }
 
-    /// Encode F64 rounding pseudo-op as Thumb-2 via VCVT to integer and back
-    /// Encode F64 rounding as Thumb-2.
-    /// `mode`: FPSCR RMode — 0b00=nearest, 0b01=+inf(ceil), 0b10=-inf(floor), 0b11=zero(trunc)
+    /// Encode F64 rounding as a SINGLE Thumb-2 VRINT (FPv5 / cortex-m7dp).
+    /// `mode` keeps the legacy FPSCR-RMode numbering of the callers —
+    /// 0b00=nearest(ties-to-even)→VRINTN, 0b01=+inf(ceil)→VRINTP,
+    /// 0b10=-inf(floor)→VRINTM, 0b11=zero(trunc)→VRINTZ — but the rounding
+    /// mode is now ENCODED in the instruction, not smuggled through FPSCR.
+    /// (The previous pseudo-op round-tripped through a 32-bit integer in S0:
+    /// wrong for |x| >= 2^31, NaN/±inf collapsed to 0, -0.0 lost, and it
+    /// CLOBBERED S0/R12 behind the allocator's back — the #615 class.)
+    /// VRINT quietens an sNaN and preserves the sign of ±0.0/NaN per IEEE 754
+    /// roundToIntegral, which is exactly WASM Core §4.3.3 f64.ceil/floor/
+    /// trunc/nearest. VRINTN/P/M live in the FE "always-execute" space (never
+    /// IT-conditional; none of these sequences emits them inside an IT block).
     fn encode_thumb_f64_rounding(&self, dd: &VfpReg, dm: &VfpReg, mode: u8) -> Result<Vec<u8>> {
-        let mut bytes = Vec::new();
-        let dm_num = vfp_dreg_to_num(dm)?;
         let dd_num = vfp_dreg_to_num(dd)?;
-        let (vm, m) = encode_dreg(dm_num);
+        let dm_num = vfp_dreg_to_num(dm)?;
         let (vd, d) = encode_dreg(dd_num);
-
-        if mode == 0b11 {
-            // Trunc: VCVTR.S32.F64 — bit[7]=1, always truncates
-            let vcvt_to_int = 0xEEBD0BC0 | (m << 5) | vm;
-            bytes.extend_from_slice(&vfp_to_thumb_bytes(vcvt_to_int));
-        } else {
-            let rt: u32 = 12;
-
-            // VMRS R12, FPSCR
-            let vmrs = 0xEEF10A10 | (rt << 12);
-            bytes.extend_from_slice(&vfp_to_thumb_bytes(vmrs));
-
-            // BIC.W R12, R12, #(3 << 22)
-            let bic_hw1: u16 = 0xF020 | ((rt as u16) & 0xF);
-            let bic_hw2: u16 = (0x05 << 12) | ((rt as u16) << 8) | 0x03;
-            bytes.extend_from_slice(&bic_hw1.to_le_bytes());
-            bytes.extend_from_slice(&bic_hw2.to_le_bytes());
-
-            // ORR.W R12, R12, #(mode << 22)
-            if mode != 0 {
-                let orr_hw1: u16 = 0xF040 | ((rt as u16) & 0xF);
-                let orr_hw2: u16 = (0x05 << 12) | ((rt as u16) << 8) | (mode as u16);
-                bytes.extend_from_slice(&orr_hw1.to_le_bytes());
-                bytes.extend_from_slice(&orr_hw2.to_le_bytes());
-            }
-
-            // VMSR FPSCR, R12
-            let vmsr = 0xEEE10A10 | (rt << 12);
-            bytes.extend_from_slice(&vfp_to_thumb_bytes(vmsr));
-
-            // VCVT.S32.F64 S0, Dm — non-R variant (bit[7]=0)
-            let vcvt_to_int = 0xEEBD0B40 | (m << 5) | vm;
-            bytes.extend_from_slice(&vfp_to_thumb_bytes(vcvt_to_int));
-
-            // Restore FPSCR
-            bytes.extend_from_slice(&vfp_to_thumb_bytes(vmrs));
-            bytes.extend_from_slice(&bic_hw1.to_le_bytes());
-            bytes.extend_from_slice(&bic_hw2.to_le_bytes());
-            bytes.extend_from_slice(&vfp_to_thumb_bytes(vmsr));
-        }
-
-        // VCVT.F64.S32 Dd, S0
-        let vcvt_to_float = 0xEEB80B40 | (d << 22) | (vd << 12);
-        bytes.extend_from_slice(&vfp_to_thumb_bytes(vcvt_to_float));
-
-        Ok(bytes)
+        let (vm, m) = encode_dreg(dm_num);
+        // clang-verified bases (thumbv7em, fpv5-d16):
+        //   vrintn.f64 d1,d2 = feb9 1b42 ; vrintp = feba 1b42
+        //   vrintm.f64 d1,d2 = febb 1b42 ; vrintz = eeb6 1bc2
+        let base: u32 = match mode {
+            0b00 => 0xFEB90B40, // VRINTN.F64 (round to nearest, ties to even)
+            0b01 => 0xFEBA0B40, // VRINTP.F64 (round toward +inf)
+            0b10 => 0xFEBB0B40, // VRINTM.F64 (round toward -inf)
+            _ => 0xEEB60BC0,    // VRINTZ.F64 (round toward zero)
+        };
+        Ok(vfp_to_thumb_bytes(
+            base | (d << 22) | (vd << 12) | (m << 5) | vm,
+        ))
     }
 
-    /// Encode F64 min/max as Thumb-2
+    /// Encode F64 min/max as Thumb-2 with WASM Core §4.3.3 semantics:
+    ///
+    ///   VCMP.F64 Dn, Dm ; VMRS APSR_nzcv, FPSCR
+    ///   VMINNM.F64/VMAXNM.F64 Dd, Dn, Dm      (FPv5; -0.0 < +0.0 ordered)
+    ///   IT VS ; VADD.F64(VS) Dd, Dn, Dm       (unordered ⇒ NaN-propagating)
+    ///
+    /// VMINNM/VMAXNM alone are IEEE minNum/maxNum, which return the NUMBER
+    /// when exactly one operand is NaN — WASM requires NaN. The VS-guarded
+    /// VADD overwrites the result with a quiet NaN whenever the compare was
+    /// unordered (either operand NaN); on the ordered path VMINNM/VMAXNM
+    /// order -0.0 below +0.0, matching WASM's min(+0,-0) = -0 / max = +0.
+    /// Clobbers ONLY Dd and the flags (the previous pseudo-op's ordered IT
+    /// GT/MI select returned the WRONG operand for NaN and ±0 mixes).
+    ///
+    /// Ok-or-Err: `dd` must not alias `dn`/`dm` — the VS fix-up reads them
+    /// AFTER VMINNM wrote `dd` (the selector always allocates a fresh
+    /// destination while both sources are still marked live).
     fn encode_thumb_f64_minmax(
         &self,
         dd: &VfpReg,
@@ -7290,82 +7322,80 @@ impl ArmEncoder {
         dm: &VfpReg,
         is_min: bool,
     ) -> Result<Vec<u8>> {
+        if dd == dn || dd == dm {
+            return Err(synth_core::Error::synthesis(format!(
+                "F64{}: destination {dd:?} aliases a source ({dn:?},{dm:?}) — \
+                 the unordered NaN fix-up would read a clobbered operand \
+                 (compiler bug: the selector must allocate a fresh D-temp)",
+                if is_min { "Min" } else { "Max" },
+            )));
+        }
         let mut bytes = Vec::new();
+        let dd_num = vfp_dreg_to_num(dd)?;
         let dn_num = vfp_dreg_to_num(dn)?;
         let dm_num = vfp_dreg_to_num(dm)?;
-        let dd_num = vfp_dreg_to_num(dd)?;
-
-        // VMOV.F64 Dd, Dn
         let (vd, d) = encode_dreg(dd_num);
         let (vn, n) = encode_dreg(dn_num);
-        let vmov_dn = 0xEEB00B40 | (d << 22) | (vd << 12) | (n << 5) | vn;
-        bytes.extend_from_slice(&vfp_to_thumb_bytes(vmov_dn));
-
-        // VCMP.F64 Dn, Dm
         let (vm, m) = encode_dreg(dm_num);
+
+        // VCMP.F64 Dn, Dm (clang-verified: vcmp.f64 d2,d3 = eeb4 2b43)
         let vcmp = 0xEEB40B40 | (n << 22) | (vn << 12) | (m << 5) | vm;
         bytes.extend_from_slice(&vfp_to_thumb_bytes(vcmp));
-
         // VMRS APSR_nzcv, FPSCR
         bytes.extend_from_slice(&vfp_to_thumb_bytes(0xEEF1FA10));
-
-        // IT GT (for min) or IT MI (for max)
-        let cond: u16 = if is_min { 0xC } else { 0x4 };
-        let it: u16 = 0xBF00 | (cond << 4) | 0x8;
-        bytes.extend_from_slice(&it.to_le_bytes());
-
-        // VMOV{cond}.F64 Dd, Dm
-        let vmov_dm = 0xEEB00B40 | (d << 22) | (vd << 12) | (m << 5) | vm;
-        bytes.extend_from_slice(&vfp_to_thumb_bytes(vmov_dm));
+        // VMINNM.F64 / VMAXNM.F64 Dd, Dn, Dm (clang-verified:
+        // vminnm.f64 d1,d2,d3 = fe82 1b43 ; vmaxnm = fe82 1b03)
+        let base: u32 = if is_min { 0xFE800B40 } else { 0xFE800B00 };
+        let vnm = base | (d << 22) | (vn << 16) | (vd << 12) | (n << 7) | (m << 5) | vm;
+        bytes.extend_from_slice(&vfp_to_thumb_bytes(vnm));
+        // IT VS (unordered ⇒ at least one NaN operand)
+        bytes.extend_from_slice(&0xBF68_u16.to_le_bytes());
+        // VADD.F64(VS) Dd, Dn, Dm — NaN + x propagates a quiet NaN
+        let vadd = 0xEE300B00 | (d << 22) | (vn << 16) | (vd << 12) | (n << 7) | (m << 5) | vm;
+        bytes.extend_from_slice(&vfp_to_thumb_bytes(vadd));
 
         Ok(bytes)
     }
 
-    /// Encode F64 copysign as Thumb-2
+    /// Encode F64 copysign as Thumb-2, clobbering ONLY R12 (the reserved
+    /// encoder scratch, #212), the flags, and Dd:
+    ///
+    ///   VMOV R12, S(2m+1)   (high word of the SIGN source Dm)
+    ///   CMP  R12, #0        (N flag = the sign bit)
+    ///   VABS.F64 Dd, Dn     (magnitude, sign cleared)
+    ///   IT MI ; VNEG.F64(MI) Dd, Dd
+    ///
+    /// Bit-exact on ±0.0/NaN-sign/±inf (VABS/VNEG are sign-bit-only edits).
+    /// The R12 capture happens BEFORE Dd is written, so Dd aliasing Dn or Dm
+    /// is safe. (The previous pseudo-op clobbered R0/R1/R2 behind the
+    /// allocator's back — the #615 class.)
     fn encode_thumb_f64_copysign(&self, dd: &VfpReg, dn: &VfpReg, dm: &VfpReg) -> Result<Vec<u8>> {
+        let dm_num = vfp_dreg_to_num(dm)?;
+        if dm_num > 7 {
+            return Err(synth_core::Error::synthesis(format!(
+                "F64Copysign: sign source {dm:?} has no S-register alias \
+                 (D8..D15) — the selector allocates only D0..D7"
+            )));
+        }
         let mut bytes = Vec::new();
-
-        // VMOV R0, R12, Dm (get sign source)
-        bytes.extend_from_slice(&vfp_to_thumb_bytes(encode_vmov_core_dreg(
-            false,
-            dm,
-            &Reg::R0,
-            &Reg::R12,
-        )?));
-
-        // VMOV R1, R2, Dn (get magnitude source)
-        bytes.extend_from_slice(&vfp_to_thumb_bytes(encode_vmov_core_dreg(
-            false,
-            dn,
-            &Reg::R1,
-            &Reg::R2,
-        )?));
-
-        // AND.W R12, R12, #0x80000000 (i=0, Rn=R12)
-        let hw1: u16 = 0xF000 | 12;
-        let hw2: u16 = (0x1 << 12) | (12 << 8) | 0x02;
-        bytes.extend_from_slice(&hw1.to_le_bytes());
-        bytes.extend_from_slice(&hw2.to_le_bytes());
-
-        // BIC.W R2, R2, #0x80000000 (i=0, Rn=R2)
-        let hw1: u16 = 0xF020 | 2;
-        let hw2: u16 = (0x1 << 12) | (2 << 8) | 0x02;
-        bytes.extend_from_slice(&hw1.to_le_bytes());
-        bytes.extend_from_slice(&hw2.to_le_bytes());
-
-        // ORR.W R2, R2, R12
-        let hw1: u16 = 0xEA40 | 2;
-        let hw2: u16 = (2 << 8) | 12;
-        bytes.extend_from_slice(&hw1.to_le_bytes());
-        bytes.extend_from_slice(&hw2.to_le_bytes());
-
-        // VMOV Dd, R1, R2
-        bytes.extend_from_slice(&vfp_to_thumb_bytes(encode_vmov_core_dreg(
-            true,
-            dd,
-            &Reg::R1,
-            &Reg::R2,
-        )?));
+        // VMOV R12, S(2m+1) — the sign source's high word.
+        let (vn_s, n_s) = encode_sreg(2 * dm_num + 1);
+        let vmov = 0xEE100A10 | (vn_s << 16) | (12 << 12) | (n_s << 7);
+        bytes.extend_from_slice(&vfp_to_thumb_bytes(vmov));
+        // CMP R12, #0 (T2: CMP.W R12, #0) — N = bit31 of the sign word.
+        bytes.extend_from_slice(&0xF1BC_u16.to_le_bytes());
+        bytes.extend_from_slice(&0x0F00_u16.to_le_bytes());
+        // VABS.F64 Dd, Dn
+        let dd_num = vfp_dreg_to_num(dd)?;
+        let dn_num = vfp_dreg_to_num(dn)?;
+        let (vd, d) = encode_dreg(dd_num);
+        let (vn, n) = encode_dreg(dn_num);
+        let vabs = 0xEEB00BC0 | (d << 22) | (vd << 12) | (n << 5) | vn;
+        bytes.extend_from_slice(&vfp_to_thumb_bytes(vabs));
+        // IT MI ; VNEG.F64(MI) Dd, Dd
+        bytes.extend_from_slice(&0xBF48_u16.to_le_bytes());
+        let vneg = 0xEEB10B40 | (d << 22) | (vd << 12) | (d << 5) | vd;
+        bytes.extend_from_slice(&vfp_to_thumb_bytes(vneg));
 
         Ok(bytes)
     }
@@ -10588,8 +10618,175 @@ mod tests {
             dm: VfpReg::D1,
         };
         let code = encoder.encode(&op).unwrap();
-        // Two VFP instructions via Thumb encoding
-        assert_eq!(code.len(), 8);
+        // GI-FPU-002 phase 3 (#369): a single VRINTZ.F64 (clang-verified
+        // vrintz.f64 d0,d1 base) — no more FPSCR dance / S0 clobber.
+        assert_eq!(code.len(), 4);
+        assert_eq!(code, vec![0xb6, 0xee, 0xc1, 0x0b]);
+    }
+
+    /// GI-FPU-002 phase 3 (#369): the rewritten f64 tail sequences, byte-exact
+    /// against clang (`-target thumbv7em-none-eabi -mfpu=fpv5-d16`). Each
+    /// clobbers ONLY its destination (+R12/flags where noted) — the previous
+    /// pseudo-ops staged through live S0/R0-R2 (the #615 class) and the
+    /// min/max/rounding semantics were wrong (ordered IT select returned the
+    /// wrong operand on NaN/±0; rounding round-tripped through a 32-bit int).
+    #[test]
+    fn test_369_f64_tail_thumb2_encodings_match_clang() {
+        let enc = ArmEncoder::new_thumb2();
+        // vrintn/vrintp/vrintm.f64 d1, d2 (FE space, never IT'd).
+        for (op, want) in [
+            (
+                ArmOp::F64Nearest {
+                    dd: VfpReg::D1,
+                    dm: VfpReg::D2,
+                },
+                vec![0xb9, 0xfe, 0x42, 0x1b],
+            ),
+            (
+                ArmOp::F64Ceil {
+                    dd: VfpReg::D1,
+                    dm: VfpReg::D2,
+                },
+                vec![0xba, 0xfe, 0x42, 0x1b],
+            ),
+            (
+                ArmOp::F64Floor {
+                    dd: VfpReg::D1,
+                    dm: VfpReg::D2,
+                },
+                vec![0xbb, 0xfe, 0x42, 0x1b],
+            ),
+        ] {
+            assert_eq!(enc.encode(&op).unwrap(), want, "{op:?}");
+        }
+        // vcmp.f64 d1,d2 ; vmrs ; vminnm.f64 d0,d1,d2 ; it vs ; vaddvs.f64
+        let min = enc
+            .encode(&ArmOp::F64Min {
+                dd: VfpReg::D0,
+                dn: VfpReg::D1,
+                dm: VfpReg::D2,
+            })
+            .unwrap();
+        assert_eq!(
+            min,
+            vec![
+                0xb4, 0xee, 0x42, 0x1b, // vcmp.f64 d1, d2
+                0xf1, 0xee, 0x10, 0xfa, // vmrs APSR_nzcv, fpscr
+                0x81, 0xfe, 0x42, 0x0b, // vminnm.f64 d0, d1, d2
+                0x68, 0xbf, // it vs
+                0x31, 0xee, 0x02, 0x0b, // vaddvs.f64 d0, d1, d2
+            ]
+        );
+        // vmaxnm variant flips only bit6 of the VMINNM word.
+        let max = enc
+            .encode(&ArmOp::F64Max {
+                dd: VfpReg::D0,
+                dn: VfpReg::D1,
+                dm: VfpReg::D2,
+            })
+            .unwrap();
+        assert_eq!(&max[8..12], &[0x81, 0xfe, 0x02, 0x0b]);
+        // Destination aliasing a source must ERR (the NaN fix-up would read
+        // a clobbered operand), never encode.
+        assert!(
+            enc.encode(&ArmOp::F64Min {
+                dd: VfpReg::D1,
+                dn: VfpReg::D1,
+                dm: VfpReg::D2,
+            })
+            .is_err()
+        );
+        // copysign d0,(mag)d1,(sign)d2:
+        // vmov r12,s5 ; cmp.w r12,#0 ; vabs.f64 d0,d1 ; it mi ; vnegmi.f64 d0,d0
+        let cs = enc
+            .encode(&ArmOp::F64Copysign {
+                dd: VfpReg::D0,
+                dn: VfpReg::D1,
+                dm: VfpReg::D2,
+            })
+            .unwrap();
+        assert_eq!(
+            cs,
+            vec![
+                0x12, 0xee, 0x90, 0xca, // vmov r12, s5
+                0xbc, 0xf1, 0x00, 0x0f, // cmp.w r12, #0
+                0xb0, 0xee, 0xc1, 0x0b, // vabs.f64 d0, d1
+                0x48, 0xbf, // it mi
+                0xb1, 0xee, 0x40, 0x0b, // vnegmi.f64 d0, d0
+            ]
+        );
+        // f32 copysign s0,(mag)s1,(sign)s2 — the R0-clobber-free rewrite:
+        // vmov r12,s2 ; cmp.w r12,#0 ; vabs.f32 s0,s1 ; it mi ; vnegmi.f32
+        let cs32 = enc
+            .encode(&ArmOp::F32Copysign {
+                sd: VfpReg::S0,
+                sn: VfpReg::S1,
+                sm: VfpReg::S2,
+            })
+            .unwrap();
+        assert_eq!(
+            cs32,
+            vec![
+                0x11, 0xee, 0x10, 0xca, // vmov r12, s2
+                0xbc, 0xf1, 0x00, 0x0f, // cmp.w r12, #0
+                0xb0, 0xee, 0xe0, 0x0a, // vabs.f32 s0, s1
+                0x48, 0xbf, // it mi
+                0xb1, 0xee, 0x40, 0x0a, // vnegmi.f32 s0, s0
+            ]
+        );
+        // i32 -> f64 stages through the DESTINATION's S-alias (never S0) and
+        // uses the CORRECT signed/unsigned VCVT bases (previously swapped):
+        // vmov s0,r3 ; vcvt.f64.s32 d0,s0
+        let conv_s = enc
+            .encode(&ArmOp::F64ConvertI32S {
+                dd: VfpReg::D0,
+                rm: Reg::R3,
+            })
+            .unwrap();
+        assert_eq!(
+            conv_s,
+            vec![
+                0x00, 0xee, 0x10, 0x3a, // vmov s0, r3
+                0xb8, 0xee, 0xc0, 0x0b, // vcvt.f64.s32 d0, s0
+            ]
+        );
+        let conv_u = enc
+            .encode(&ArmOp::F64ConvertI32U {
+                dd: VfpReg::D0,
+                rm: Reg::R3,
+            })
+            .unwrap();
+        assert_eq!(&conv_u[4..8], &[0xb8, 0xee, 0x40, 0x0b]); // vcvt.f64.u32
+        // f64 -> i32 stages through the SOURCE's S-alias (never S0):
+        // vcvt.s32.f64 s2,d1 ; vmov r3,s2
+        let trunc_s = enc
+            .encode(&ArmOp::I32TruncF64S {
+                rd: Reg::R3,
+                dm: VfpReg::D1,
+            })
+            .unwrap();
+        assert_eq!(
+            trunc_s,
+            vec![
+                0xbd, 0xee, 0xc1, 0x1b, // vcvt.s32.f64 s2, d1
+                0x11, 0xee, 0x10, 0x3a, // vmov r3, s2
+            ]
+        );
+        let trunc_u = enc
+            .encode(&ArmOp::I32TruncF64U {
+                rd: Reg::R3,
+                dm: VfpReg::D1,
+            })
+            .unwrap();
+        assert_eq!(&trunc_u[0..4], &[0xbc, 0xee, 0xc1, 0x1b]); // vcvt.u32.f64
+        // f32.demote_f64: vcvt.f32.f64 s1, d2
+        let demote = enc
+            .encode(&ArmOp::F32DemoteF64 {
+                sd: VfpReg::S1,
+                dm: VfpReg::D2,
+            })
+            .unwrap();
+        assert_eq!(demote, vec![0xf7, 0xee, 0xc2, 0x0b]);
     }
 
     #[test]

--- a/crates/synth-backend/tests/a32_no_silent_nop_615.rs
+++ b/crates/synth-backend/tests/a32_no_silent_nop_615.rs
@@ -30,7 +30,7 @@ const NOP_WORD: [u8; 4] = [0x00, 0x00, 0xA0, 0xE1];
 
 /// Bump when adding an `ArmOp` variant — and add a representative instance to
 /// `representatives()` (the completeness check below counts unique variants).
-const ARM_OP_VARIANT_COUNT: usize = 221;
+const ARM_OP_VARIANT_COUNT: usize = 222;
 
 /// How the A32 encoder must treat each op.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -242,7 +242,10 @@ fn classify(op: &ArmOp) -> Expect {
         | ArmOp::I32TruncF64U { .. } => Real,
 
         // i64<->float conversions need register pairs — typed Err on ARM32.
-        ArmOp::F32ConvertI64S { .. }
+        // F32DemoteF64 (#369) is Thumb-2-only (no A32 target has an FPU) —
+        // typed Err too.
+        ArmOp::F32DemoteF64 { .. }
+        | ArmOp::F32ConvertI64S { .. }
         | ArmOp::F32ConvertI64U { .. }
         | ArmOp::F64ConvertI64S { .. }
         | ArmOp::F64ConvertI64U { .. }
@@ -1144,6 +1147,10 @@ fn representatives() -> Vec<ArmOp> {
         F64PromoteF32 {
             dd: VfpReg::D0,
             sm: VfpReg::S1,
+        },
+        F32DemoteF64 {
+            sd: VfpReg::S1,
+            dm: VfpReg::D0,
         },
         F64ReinterpretI64 {
             dd: VfpReg::D0,

--- a/crates/synth-backend/tests/estimator_encoder_agreement.rs
+++ b/crates/synth-backend/tests/estimator_encoder_agreement.rs
@@ -1059,6 +1059,7 @@ fn coverage(op: &ArmOp) -> Coverage {
         | F64ConvertI64S { .. }
         | F64ConvertI64U { .. }
         | F64PromoteF32 { .. }
+        | F32DemoteF64 { .. }
         | F64ReinterpretI64 { .. }
         | I64ReinterpretF64 { .. }
         | I64TruncF64S { .. }

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -2074,6 +2074,26 @@ fn convert_operator(op: &wasmparser::Operator) -> Option<WasmOp> {
             offset: memarg.offset as u32,
             align: memarg.align as u32,
         }),
+        // GI-FPU-002 phase 3 (#369): the f64 op tail — rounding via single
+        // VRINT{P,M,Z,N}.F64 (FPv5), min/max via VMINNM/VMAXNM + the
+        // NaN-propagating fix-up, copysign via the VABS/conditional-VNEG
+        // splice, f32.demote_f64 / i32<->f64 conversions via VCVT
+        // (i32.trunc_f64_* carries the #709 trap-on-out-of-range domain
+        // guard). Still m7dp-only (the selector preamble honest-rejects any
+        // f64 op elsewhere). Remaining dropped f64 surface: the i64<->f64
+        // conversions and reinterprets (need lowered i64 pair plumbing).
+        F64Ceil => Some(WasmOp::F64Ceil),
+        F64Floor => Some(WasmOp::F64Floor),
+        F64Trunc => Some(WasmOp::F64Trunc),
+        F64Nearest => Some(WasmOp::F64Nearest),
+        F64Min => Some(WasmOp::F64Min),
+        F64Max => Some(WasmOp::F64Max),
+        F64Copysign => Some(WasmOp::F64Copysign),
+        F32DemoteF64 => Some(WasmOp::F32DemoteF64),
+        F64ConvertI32S => Some(WasmOp::F64ConvertI32S),
+        F64ConvertI32U => Some(WasmOp::F64ConvertI32U),
+        I32TruncF64S => Some(WasmOp::I32TruncF64S),
+        I32TruncF64U => Some(WasmOp::I32TruncF64U),
 
         // f32x4
         F32x4Add => Some(WasmOp::F32x4Add),
@@ -2698,7 +2718,9 @@ mod tests {
         // now DECODED (routed to the VFP selector on FPU targets), so `f32.add`
         // is no longer flagged — and since phase 2 (#369) so is the lowered
         // f64 subset (`f64.add` here; the m7dp-only capability gate lives in
-        // the selector). An out-of-scope scalar float op (`f64.min`) is STILL
+        // the selector). Since phase 3 the f64 op TAIL (`f64.min` here) is
+        // decoded too; an out-of-scope scalar float op (`i64.trunc_f64_s` —
+        // the i64<->f64 conversions need lowered pair plumbing) is STILL
         // flagged (loud-skip), never silently dropped — the #369 honesty
         // contract holds for the not-yet-lowered surface. A pure-integer
         // function stays clean.
@@ -2710,6 +2732,8 @@ mod tests {
                     local.get 0 local.get 1 f64.add)
                 (func (export "dmin") (param f64 f64) (result f64)
                     local.get 0 local.get 1 f64.min)
+                (func (export "dtrunc64") (param f64) (result i64)
+                    local.get 0 i64.trunc_f64_s)
                 (func (export "iadd") (param i32 i32) (result i32)
                     local.get 0 local.get 1 i32.add))
         "#;
@@ -2726,6 +2750,10 @@ mod tests {
         let dmin = functions
             .iter()
             .find(|f| f.export_name.as_deref() == Some("dmin"))
+            .unwrap();
+        let dtrunc64 = functions
+            .iter()
+            .find(|f| f.export_name.as_deref() == Some("dtrunc64"))
             .unwrap();
         let iadd = functions
             .iter()
@@ -2753,11 +2781,22 @@ mod tests {
             "f64.add must decode to WasmOp::F64Add: {:?}",
             dadd.ops
         );
+        // In-scope f64 tail op (phase 3, #369): now decoded, not flagged.
+        assert!(
+            dmin.unsupported.is_none(),
+            "GI-FPU-002 phase 3: f64.min must now decode (not be flagged), got {:?}",
+            dmin.unsupported
+        );
+        assert!(
+            dmin.ops.contains(&WasmOp::F64Min),
+            "f64.min must decode to WasmOp::F64Min: {:?}",
+            dmin.ops
+        );
         // Out-of-scope scalar double op: still flagged, never dropped.
         assert!(
-            dmin.unsupported.is_some(),
-            "f64.min must still flag the function unsupported (out of scope), got {:?}",
-            dmin.unsupported
+            dtrunc64.unsupported.is_some(),
+            "i64.trunc_f64_s must still flag the function unsupported (out of scope), got {:?}",
+            dtrunc64.unsupported
         );
         assert!(
             iadd.unsupported.is_none(),

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -12,6 +12,10 @@ use std::collections::HashMap;
 use synth_core::Result;
 use synth_core::WasmOp;
 use synth_core::target::FPUPrecision;
+/// #369 ph3: (has_float_params, returns_float, per-arg VFP homes) for a callee.
+type FloatSig = (bool, bool, Vec<(u32, VfpReg)>);
+/// #369 ph3: (core arg regs, VFP move pairs) staged for a marshalled call.
+type MarshalPlan = (Vec<Reg>, Vec<(VfpReg, VfpReg)>);
 
 /// Bounds checking configuration for memory operations
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1493,6 +1497,7 @@ pub fn read_before_write_locals(
 ///   encoder, in both cases corrupting the caller's stack or the callee's
 ///   own callee-saved-register spill).
 /// - Epilogue: `add sp, sp, #frame_size` before popping registers.
+#[allow(clippy::too_many_arguments)] // f64-param threading (#369 ph3); params-struct refactor is a named follow-up
 fn compute_local_layout(
     wasm_ops: &[WasmOp],
     num_params: u32,
@@ -4090,7 +4095,7 @@ impl InstructionSelector {
     /// call takes the byte-identical legacy path. Ok-or-Err: the VFP argument
     /// pool overflowing 16 S-slots declines loudly (AAPCS-VFP would spill
     /// float args to the stack, which this increment does not marshal).
-    fn callee_float_signature(&self, func_idx: u32) -> Result<(bool, bool, Vec<(u32, VfpReg)>)> {
+    fn callee_float_signature(&self, func_idx: u32) -> Result<FloatSig> {
         let i = func_idx as usize;
         let ret_f32 = self.callee_ret_f32.get(i).copied().unwrap_or(false);
         let ret_f64 = self.callee_ret_f64.get(i).copied().unwrap_or(false);
@@ -7993,7 +7998,7 @@ impl InstructionSelector {
         arg_count: u32,
         float_dst: &std::collections::HashMap<u32, VfpReg>,
         idx: usize,
-    ) -> Result<(Vec<Reg>, Vec<(VfpReg, VfpReg)>)> {
+    ) -> Result<MarshalPlan> {
         let n = arg_count as usize;
         let mut int_srcs: Vec<Reg> = Vec::new();
         let mut float_args: Vec<(VfpReg, VfpReg)> = Vec::new();

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -208,6 +208,57 @@ fn aapcs_param_layout(
     AapcsParamLayout { regs, stack }
 }
 
+/// GI-FPU-002 phase 3 (#369): AAPCS-VFP argument-register assignment for the
+/// FLOAT params of a signature (procedure-call standard §7.1, VFP variant).
+/// The VFP argument pool (S0..S15, aliased by D0..D7) is INDEPENDENT of the
+/// core R0..R3 pool and allocated with BACK-FILLING: an f32 takes the
+/// lowest-numbered free S-register; an f64 takes the lowest-numbered free
+/// even-aligned S-PAIR as `D(k/2)` — so `(f32, f64, f32)` maps to
+/// `S0, D1(=S2:S3), S1` (the second f32 back-fills the S1 hole the f64
+/// skipped). For an f32-only signature this degenerates to sequential
+/// `S0, S1, …` — byte-identical to the #719 seeding it replaces.
+///
+/// Returns `(param_index, vfp_reg)` per float param, in param order (the reg
+/// is an S-reg for f32, a D-reg for f64). Ok-or-Err: a signature whose float
+/// args exceed the 16-slot pool declines loudly — AAPCS-VFP would pass the
+/// overflow on the stack, which is not marshalled yet.
+fn vfp_param_layout(
+    num_params: u32,
+    params_f32: &[bool],
+    params_f64: &[bool],
+) -> std::result::Result<Vec<(u32, VfpReg)>, String> {
+    let mut taken = [false; 16];
+    let mut out = Vec::new();
+    for i in 0..num_params {
+        let is_f32 = params_f32.get(i as usize).copied().unwrap_or(false);
+        let is_f64 = params_f64.get(i as usize).copied().unwrap_or(false);
+        if is_f64 {
+            // Lowest free even-aligned pair S(2k):S(2k+1) = D(k).
+            let Some(k) = (0..8).find(|&k| !taken[2 * k] && !taken[2 * k + 1]) else {
+                return Err(format!(
+                    "float param {i} overflows the AAPCS-VFP argument pool \
+                     (S0..S15 exhausted) — stack-passed float args are not \
+                     marshalled; declining loudly (#369)"
+                ));
+            };
+            taken[2 * k] = true;
+            taken[2 * k + 1] = true;
+            out.push((i, index_to_vfp_dreg(k as u8)));
+        } else if is_f32 {
+            let Some(k) = (0..16).find(|&k| !taken[k]) else {
+                return Err(format!(
+                    "float param {i} overflows the AAPCS-VFP argument pool \
+                     (S0..S15 exhausted) — stack-passed float args are not \
+                     marshalled; declining loudly (#369)"
+                ));
+            };
+            taken[k] = true;
+            out.push((i, index_to_vfp_reg(k as u8)));
+        }
+    }
+    Ok(out)
+}
+
 /// AAPCS core-register assignment only — see [`aapcs_param_layout`]. A param
 /// absent from this map is stack-passed (in the layout's `stack` map).
 /// Test-only: the selector itself uses the full layout.
@@ -1441,6 +1492,7 @@ fn compute_local_layout(
     type_ret_i64: &[bool],
     force_spill_area: bool,
     force_param_backing: bool,
+    force_vfp_area: bool,
     outgoing_arg_bytes: i32,
     i64_spill_slots: usize,
 ) -> LocalLayout {
@@ -1591,7 +1643,14 @@ fn compute_local_layout(
         // GI-FPU-002 phase 2 (#369): f64 values live in D0..D7, which alias
         // S0..S15 — a live double across a call is preserved by the SAME
         // 16-slot area as its two aliased words.
-        || wasm_ops.iter().any(is_scope_f64_op);
+        || wasm_ops.iter().any(is_scope_f64_op)
+        // GI-FPU-002 phase 3 (#369): a call to a FLOAT-SIGNATURE callee needs
+        // the area even when the caller's own op stream has no float-scope op
+        // (e.g. a pure pass-through of one call's float result into another
+        // call) — the arg staging and the result live-range both use it. The
+        // flag is computed from the per-callee signature tables, which this
+        // free function cannot see.
+        || force_vfp_area;
     let vfp_spill_base = if has_f32 && has_call {
         let base = offset;
         offset += 16 * 4;
@@ -2883,19 +2942,23 @@ pub struct InstructionSelector {
     /// return (byte-identical legacy path).
     ret_f32: bool,
     ret_f64: bool,
-    /// GI-FPU-002 phase 2 (#719/#369): per-CALLEE float-signature tables (full
-    /// function index / type index). A call whose callee RETURNS f32/f64 (result
-    /// arrives in S0/D0, which this increment does not marshal onto the operand
-    /// stack) or takes an f32 PARAM (argument must be marshalled into the VFP
-    /// S0.. pool, not R0..R3) is declined LOUDLY at the call site — tagging the
-    /// S0/D0 result as an integer R0, or passing an f32 arg in a core register,
-    /// would be a silent miscompile. Empty ⇒ callees assumed integer-signature
-    /// (hand-built op streams; byte-identical legacy behaviour).
+    /// GI-FPU-002 phase 3 (#369, v0.43): per-CALLEE float-signature tables
+    /// (full function index / type index). `Call` uses them to MARSHAL the
+    /// AAPCS-VFP call boundary: float arguments into the independent VFP
+    /// argument pool (f32 → S0.., f64 → D0.., back-fill allocation via
+    /// [`vfp_param_layout`]) and a float result out of S0/D0 onto the operand
+    /// stack as a `Float`/`Double` entry. `CallIndirect` still declines a
+    /// float-returning static type loudly (indirect marshalling is a later
+    /// increment). Empty ⇒ callees assumed integer-signature (hand-built op
+    /// streams; byte-identical legacy behaviour).
     callee_ret_f32: Vec<bool>,
     callee_ret_f64: Vec<bool>,
     callee_type_ret_f32: Vec<bool>,
     callee_type_ret_f64: Vec<bool>,
     callee_params_f32: Vec<Vec<bool>>,
+    /// GI-FPU-002 phase 3 (#369): per-callee f64-param masks (full function
+    /// index), the D-pool half of the call-site marshalling tables above.
+    callee_params_f64: Vec<Vec<bool>>,
     /// #643: byte width of each defined global's storage slot, indexed by
     /// global index — 4 for i32/f32, 8 for i64/f64, 16 for v128. The globals
     /// table (R9-relative) is laid out by SUMMING these widths, NOT `idx * 4`:
@@ -3068,6 +3131,7 @@ impl InstructionSelector {
             callee_type_ret_f32: Vec::new(),
             callee_type_ret_f64: Vec::new(),
             callee_params_f32: Vec::new(),
+            callee_params_f64: Vec::new(),
             global_widths: Vec::new(),
             block_arity: Vec::new(),
             func_arg_counts: Vec::new(),
@@ -3115,6 +3179,7 @@ impl InstructionSelector {
             callee_type_ret_f32: Vec::new(),
             callee_type_ret_f64: Vec::new(),
             callee_params_f32: Vec::new(),
+            callee_params_f64: Vec::new(),
             global_widths: Vec::new(),
             block_arity: Vec::new(),
             func_arg_counts: Vec::new(),
@@ -3498,9 +3563,11 @@ impl InstructionSelector {
         self.ret_f64 = ret_f64;
     }
 
-    /// GI-FPU-002 phase 2 (#719/#369): register the per-callee float-signature
-    /// tables (see the `callee_ret_f32` field), so `Call`/`CallIndirect` can
-    /// loudly decline a float-ABI call boundary this increment does not marshal.
+    /// GI-FPU-002 phase 2/3 (#719/#369): register the per-callee
+    /// float-signature tables (see the `callee_ret_f32` field). `Call` uses
+    /// them to marshal the AAPCS-VFP boundary (float args into S0../D0..,
+    /// float results out of S0/D0); `CallIndirect` uses the type-keyed return
+    /// tables to decline loudly (indirect marshalling is a later increment).
     pub fn set_float_call_signatures(
         &mut self,
         func_ret_f32: Vec<bool>,
@@ -3508,53 +3575,52 @@ impl InstructionSelector {
         type_ret_f32: Vec<bool>,
         type_ret_f64: Vec<bool>,
         func_params_f32: Vec<Vec<bool>>,
+        func_params_f64: Vec<Vec<bool>>,
     ) {
         self.callee_ret_f32 = func_ret_f32;
         self.callee_ret_f64 = func_ret_f64;
         self.callee_type_ret_f32 = type_ret_f32;
         self.callee_type_ret_f64 = type_ret_f64;
         self.callee_params_f32 = func_params_f32;
+        self.callee_params_f64 = func_params_f64;
     }
 
-    /// GI-FPU-002 phase 2 (#719/#369): loudly decline a `call` whose callee has
-    /// a float ABI at the boundary this increment does not marshal — an f32/f64
-    /// RETURN (the result arrives in S0/D0; tagging it as an integer R0 would be
-    /// a silent miscompile: any use reads the wrong register file) or an f32
-    /// PARAM (the argument belongs in the AAPCS-VFP S0.. pool, not R0..R3).
-    /// Live f32 values ACROSS the call are handled (spill/reload around the BL);
-    /// only the callee's own float signature declines. Ok-or-Err.
-    fn check_callee_float_signature(&self, func_idx: u32) -> Result<()> {
+    /// GI-FPU-002 phase 3 (#369): the callee's float signature at a direct
+    /// `call` site — `(ret_f32, ret_f64, float_param_layout)` where the layout
+    /// maps each float param index to its AAPCS-VFP argument register (f32 →
+    /// S-reg, f64 → D-reg, back-fill allocation). `None` layout entries never
+    /// occur; an all-integer callee returns `(false, false, empty)` and the
+    /// call takes the byte-identical legacy path. Ok-or-Err: the VFP argument
+    /// pool overflowing 16 S-slots declines loudly (AAPCS-VFP would spill
+    /// float args to the stack, which this increment does not marshal).
+    fn callee_float_signature(&self, func_idx: u32) -> Result<(bool, bool, Vec<(u32, VfpReg)>)> {
         let i = func_idx as usize;
         let ret_f32 = self.callee_ret_f32.get(i).copied().unwrap_or(false);
         let ret_f64 = self.callee_ret_f64.get(i).copied().unwrap_or(false);
-        if ret_f32 || ret_f64 {
-            return Err(synth_core::Error::synthesis(format!(
-                "GI-FPU-002 phase 2: call to func_{func_idx} which returns {} — \
-                 the AAPCS-VFP result arrives in {} and this increment does not \
-                 marshal a float call result; declining loudly (#719/#369)",
-                if ret_f64 { "f64" } else { "f32" },
-                if ret_f64 { "D0" } else { "S0" },
-            )));
+        let pf32: &[bool] = self.callee_params_f32.get(i).map_or(&[], |v| v);
+        let pf64: &[bool] = self.callee_params_f64.get(i).map_or(&[], |v| v);
+        if !pf32.iter().any(|&f| f) && !pf64.iter().any(|&f| f) {
+            return Ok((ret_f32, ret_f64, Vec::new()));
         }
-        if self
-            .callee_params_f32
+        let n = self
+            .func_arg_counts
             .get(i)
-            .is_some_and(|p| p.iter().any(|&f| f))
-        {
-            return Err(synth_core::Error::synthesis(format!(
-                "GI-FPU-002 phase 2: call to func_{func_idx} which takes an f32 \
-                 parameter — the argument belongs in the AAPCS-VFP S-register \
-                 pool, which this increment does not marshal; declining loudly \
-                 (#719/#369)"
-            )));
-        }
-        Ok(())
+            .copied()
+            .unwrap_or(pf32.len().max(pf64.len()) as u32);
+        let layout = vfp_param_layout(n, pf32, pf64).map_err(|e| {
+            synth_core::Error::synthesis(format!(
+                "GI-FPU-002 phase 3: call to func_{func_idx}: {e}"
+            ))
+        })?;
+        Ok((ret_f32, ret_f64, layout))
     }
 
-    /// GI-FPU-002 phase 2 (#719/#369): the `call_indirect` analogue of
-    /// [`Self::check_callee_float_signature`], keyed by the static type index.
-    /// (The f32-ARG side needs no type-level check: every f32 producer pushes a
-    /// `Float` operand, which the integer `pop_call_args` path already rejects
+    /// GI-FPU-002 phase 2 (#719/#369): loudly decline a `call_indirect` whose
+    /// STATIC TYPE returns f32/f64, keyed by the type index — indirect float
+    /// marshalling is a later increment (direct calls marshal via
+    /// [`Self::callee_float_signature`]). (The float-ARG side needs no
+    /// type-level check: every f32/f64 producer pushes a `Float`/`Double`
+    /// operand, which the integer `pop_call_args` path already rejects
     /// loudly.)
     fn check_indirect_float_signature(&self, type_idx: u32) -> Result<()> {
         let i = type_idx as usize;
@@ -7376,6 +7442,137 @@ impl InstructionSelector {
         Ok(srcs)
     }
 
+    /// GI-FPU-002 phase 3 (#369): pop the arguments of a FLOAT-signature call.
+    /// Each param is popped per its declared kind — a float param via
+    /// `pop_float`/`pop_double` (recording its AAPCS-VFP destination from
+    /// `float_dst`), an integer param via the legacy `pop_operand`. Returns
+    /// `(int_srcs, float_args)`: `int_srcs[k]` is the k-th INTEGER param's
+    /// source register (the core pool skips float params per AAPCS-VFP, so
+    /// integer position — not wasm param index — maps to `ARG_REGS`/NSAA),
+    /// and `float_args` the float params' `(src, dst)` register pairs.
+    ///
+    /// Ok-or-Err: an i64 integer argument mixed with float args is declined
+    /// loudly (its even-aligned core PAIR is not marshalled on this path —
+    /// the same #503 boundary the integer path has).
+    fn pop_call_args_mixed(
+        stack: &mut Vec<StackVal>,
+        next_temp: &mut u8,
+        instructions: &mut Vec<ArmInstruction>,
+        spill: &mut SpillState,
+        arg_count: u32,
+        float_dst: &std::collections::HashMap<u32, VfpReg>,
+        idx: usize,
+    ) -> Result<(Vec<Reg>, Vec<(VfpReg, VfpReg)>)> {
+        let n = arg_count as usize;
+        let mut int_srcs: Vec<Reg> = Vec::new();
+        let mut float_args: Vec<(VfpReg, VfpReg)> = Vec::new();
+        for i in (0..n).rev() {
+            if let Some(&dst) = float_dst.get(&(i as u32)) {
+                let src = if vfp_d_index(dst).is_some() {
+                    pop_double(stack)?
+                } else {
+                    pop_float(stack)?
+                };
+                float_args.push((src, dst));
+            } else {
+                if stack.last().is_some_and(|v| v.is_i64()) {
+                    return Err(synth_core::Error::synthesis(format!(
+                        "GI-FPU-002 phase 3: call arg {i} is i64 in a \
+                         float-signature call — the even-aligned core register \
+                         pair is not marshalled alongside VFP args; declining \
+                         loudly (#369/#503)"
+                    )));
+                }
+                let r = pop_operand(stack, next_temp, instructions, spill, &[], idx)?;
+                int_srcs.push(r);
+            }
+        }
+        int_srcs.reverse();
+        float_args.reverse();
+        Ok((int_srcs, float_args))
+    }
+
+    /// GI-FPU-002 phase 3 (#369): move the popped float call arguments into
+    /// their AAPCS-VFP argument registers (S0../D0..), overlap-safe. Sources
+    /// and destinations may alias arbitrarily (an argument may already sit in
+    /// another argument's destination), so the move is two-phase through the
+    /// VFP call-spill area: every source is VSTR'd to the frame slot indexed
+    /// by its OWN S-register number first, then every destination VLDRs from
+    /// its argument's source slot — all reads come from memory written before
+    /// any destination register was touched. A double moves as its two
+    /// aliased S-words (bit-exact by the VFP register-file aliasing rule).
+    ///
+    /// Source-indexed slots cannot collide with the caller-saved preservation
+    /// stores that precede this (`preserve_vfp_caller_saved` uses the LIVE
+    /// values' own S-indices): when an argument source IS a live home
+    /// register (an f32/f64 param passed straight through), both stores write
+    /// the register's current — identical — value.
+    ///
+    /// Arguments already in place (`src == dst`) move nothing; an all-in-place
+    /// call emits zero instructions.
+    fn emit_vfp_arg_moves(
+        instructions: &mut Vec<ArmInstruction>,
+        float_args: &[(VfpReg, VfpReg)],
+        layout: &LocalLayout,
+        idx: usize,
+    ) -> Result<()> {
+        // The S-register word indices of a float argument register.
+        fn words(r: VfpReg) -> Vec<usize> {
+            if let Some(d) = vfp_d_index(r) {
+                vec![2 * d, 2 * d + 1]
+            } else {
+                vec![vfp_s_index(r).expect("float arg reg is S or D")]
+            }
+        }
+        let moved: Vec<&(VfpReg, VfpReg)> =
+            float_args.iter().filter(|(src, dst)| src != dst).collect();
+        if moved.is_empty() {
+            return Ok(());
+        }
+        let base = layout.vfp_spill_base.ok_or_else(|| {
+            synth_core::Error::synthesis(
+                "GI-FPU-002 phase 3: VFP call-spill area not reserved despite a \
+                 float-argument call (compiler bug: layout gating)"
+                    .to_string(),
+            )
+        })?;
+        let slot = |w: usize| -> Result<i32> {
+            let off = base + (w as i32) * 4;
+            if off > 1020 {
+                return Err(synth_core::Error::synthesis(format!(
+                    "GI-FPU-002 phase 3: VFP arg-staging slot offset {off} \
+                     exceeds the VLDR/VSTR [sp,#imm] range — frame too large"
+                )));
+            }
+            Ok(off)
+        };
+        // Phase A: park every moving source in its own S-indexed slot.
+        for (src, _) in &moved {
+            for w in words(*src) {
+                instructions.push(ArmInstruction {
+                    op: ArmOp::F32Store {
+                        sd: index_to_vfp_reg(w as u8),
+                        addr: MemAddr::imm(Reg::SP, slot(w)?),
+                    },
+                    source_line: Some(idx),
+                });
+            }
+        }
+        // Phase B: load every destination from its argument's source slot.
+        for (src, dst) in &moved {
+            for (sw, dw) in words(*src).into_iter().zip(words(*dst)) {
+                instructions.push(ArmInstruction {
+                    op: ArmOp::F32Load {
+                        sd: index_to_vfp_reg(dw as u8),
+                        addr: MemAddr::imm(Reg::SP, slot(sw)?),
+                    },
+                    source_line: Some(idx),
+                });
+            }
+        }
+        Ok(())
+    }
+
     /// #359: spill the stack-passed call arguments (index >= 4) into the
     /// outgoing-argument region at the bottom of the current frame, BEFORE
     /// caller-saved preservation, the CallIndirect table-index relocation, and
@@ -7866,6 +8063,27 @@ impl InstructionSelector {
             source_line: None,
         });
 
+        // GI-FPU-002 phase 3 (#369): does any direct call in this function
+        // cross a FLOAT ABI boundary (float args or a float result)? Such a
+        // call needs the VFP call-spill area (arg staging + result liveness)
+        // even when the caller's own op stream has no float-scope op — the
+        // signature tables live on `self`, so the flag is computed here and
+        // passed into the free layout function.
+        let calls_float_boundary = wasm_ops.iter().any(|op| {
+            let WasmOp::Call(fi) = op else { return false };
+            let i = *fi as usize;
+            self.callee_ret_f32.get(i).copied().unwrap_or(false)
+                || self.callee_ret_f64.get(i).copied().unwrap_or(false)
+                || self
+                    .callee_params_f32
+                    .get(i)
+                    .is_some_and(|p| p.iter().any(|&f| f))
+                || self
+                    .callee_params_f64
+                    .get(i)
+                    .is_some_and(|p| p.iter().any(|&f| f))
+        });
+
         // Compute non-param local layout (offsets + total frame size).
         let layout = compute_local_layout(
             wasm_ops,
@@ -7876,6 +8094,7 @@ impl InstructionSelector {
             &self.type_ret_i64,
             self.spill_on_exhaustion,
             self.param_backing_on_exhaustion,
+            calls_float_boundary,
             outgoing_arg_bytes,
             self.i64_spill_slots,
         );
@@ -11303,12 +11522,43 @@ impl InstructionSelector {
                 }
 
                 Call(func_idx) => {
-                    // GI-FPU-002 phase 2 (#719/#369): decline LOUDLY when the
-                    // callee's own signature is a float ABI at the boundary
-                    // (f32/f64 return in S0/D0, f32 params in the VFP pool) —
-                    // this increment marshals live f32 values ACROSS the call
-                    // but not float arguments/results INTO/OUT OF it.
-                    self.check_callee_float_signature(*func_idx)?;
+                    // GI-FPU-002 phase 3 (#369): the callee's float ABI at the
+                    // boundary — marshalled below (float args into the VFP
+                    // S0../D0.. pools before the BL, a float result out of
+                    // S0/D0 after it). All-integer callees take the
+                    // byte-identical legacy path (empty layout, both flags
+                    // false).
+                    let (callee_ret_f32, callee_ret_f64, float_arg_layout) =
+                        self.callee_float_signature(*func_idx)?;
+                    let has_float_boundary =
+                        callee_ret_f32 || callee_ret_f64 || !float_arg_layout.is_empty();
+                    if has_float_boundary {
+                        // Capability gates: the marshalling itself emits VFP
+                        // moves. f32 boundaries need any FPU; an f64 boundary
+                        // (D-register argument or D0 result) needs
+                        // double-precision — on m4f/m7 the callee's own f64
+                        // body declines anyway, so decline the caller
+                        // symmetrically instead of emitting UNDEFINED D-ops.
+                        let needs_double = callee_ret_f64
+                            || float_arg_layout
+                                .iter()
+                                .any(|(_, r)| vfp_d_index(*r).is_some());
+                        if fpu.is_none() || (needs_double && !matches!(fpu, Some(FPUPrecision::Double)))
+                        {
+                            return Err(synth_core::Error::synthesis(format!(
+                                "GI-FPU-002 phase 3: call to func_{func_idx} has {} \
+                                 at the AAPCS-VFP boundary but target '{}' {} — \
+                                 declining loudly (#369)",
+                                if needs_double { "an f64" } else { "an f32" },
+                                self.target_name,
+                                if fpu.is_none() {
+                                    "has no FPU"
+                                } else {
+                                    "has a single-precision FPU (f32 only)"
+                                },
+                            )));
+                        }
+                    }
                     let is_import = *func_idx < self.num_imports;
                     // #197: a relocatable host-link import is a *direct* AAPCS
                     // call (`BL func_N` → wasm field name), so it marshals args
@@ -11316,6 +11566,19 @@ impl InstructionSelector {
                     // dispatch ABI (non-relocatable imports) puts the import
                     // index in R0 and takes no AAPCS args.
                     let meld_dispatch = is_import && !self.relocatable;
+                    // GI-FPU-002 phase 3 (#369): the legacy Meld dispatch ABI
+                    // (import index in R0, no AAPCS args) has no VFP
+                    // marshalling — a float-signature import there declines
+                    // loudly rather than silently dropping its float args.
+                    if meld_dispatch && has_float_boundary {
+                        return Err(synth_core::Error::synthesis(format!(
+                            "GI-FPU-002 phase 3: import func_{func_idx} has a \
+                             float signature but the Meld dispatch import ABI \
+                             marshals no AAPCS-VFP registers — declining loudly \
+                             (compile with --relocatable for direct AAPCS import \
+                             calls, #369)"
+                        )));
+                    }
 
                     // ── #195: AAPCS argument count for this callee ──
                     // Look up how many integer args the callee expects so we can
@@ -11339,14 +11602,39 @@ impl InstructionSelector {
                     // consumed by the call, not live across it). The actual moves
                     // into R0–R3 are emitted AFTER preservation (below), so they
                     // are the last writes before the BL.
-                    let arg_srcs = Self::pop_call_args(
-                        &mut stack,
-                        &mut next_temp,
-                        &mut instructions,
-                        &mut spill,
-                        arg_count,
-                        idx,
-                    )?;
+                    // GI-FPU-002 phase 3 (#369): a float-signature callee pops
+                    // per-kind — float params via pop_float/pop_double with
+                    // their AAPCS-VFP destinations, integer params via the
+                    // legacy path (`arg_srcs` then holds the INTEGER params in
+                    // integer-position order, which is exactly what the core
+                    // R0..R3/NSAA walk consumes since AAPCS-VFP floats occupy
+                    // neither). Integer-only callees keep the byte-identical
+                    // legacy pop.
+                    let (arg_srcs, float_args) = if float_arg_layout.is_empty() {
+                        (
+                            Self::pop_call_args(
+                                &mut stack,
+                                &mut next_temp,
+                                &mut instructions,
+                                &mut spill,
+                                arg_count,
+                                idx,
+                            )?,
+                            Vec::new(),
+                        )
+                    } else {
+                        let float_dst: std::collections::HashMap<u32, VfpReg> =
+                            float_arg_layout.iter().copied().collect();
+                        Self::pop_call_args_mixed(
+                            &mut stack,
+                            &mut next_temp,
+                            &mut instructions,
+                            &mut spill,
+                            arg_count,
+                            &float_dst,
+                            idx,
+                        )?
+                    };
 
                     // #359: store args index>=4 to the outgoing stack region
                     // BEFORE preservation and the r0..r3 move (their sources are
@@ -11383,6 +11671,22 @@ impl InstructionSelector {
                         &layout,
                         idx,
                     )?;
+                    // GI-FPU-002 phase 3 (#369): marshal the float arguments
+                    // into their AAPCS-VFP registers — AFTER preservation (so a
+                    // live value about to be overwritten in S0../D0.. is already
+                    // parked in the frame) and overlap-safe via the two-phase
+                    // source-slot staging. The consumed source registers are
+                    // freed afterwards (a float RESULT below can then reuse
+                    // them); a home register stays pinned by `free_vfp_temp`'s
+                    // home guard.
+                    Self::emit_vfp_arg_moves(&mut instructions, &float_args, &layout, idx)?;
+                    for &(src, _) in &float_args {
+                        if vfp_d_index(src).is_some() {
+                            free_vfp_dtemp(&mut vfp_used, &vfp_home, src);
+                        } else {
+                            free_vfp_temp(&mut vfp_used, &vfp_home, src);
+                        }
+                    }
 
                     // #195: move arguments into R0–R3 — the LAST thing before the
                     // BL, after live values are safely in the spill area. Skipped
@@ -11432,30 +11736,96 @@ impl InstructionSelector {
                     }
                     cf.add_instruction();
 
-                    // #311: tag an i64 result as the R0:R1 pair.
-                    let ret_i64 = self
-                        .func_ret_i64
-                        .get(*func_idx as usize)
-                        .copied()
-                        .unwrap_or(false);
-                    let result_reg = self.restore_caller_saved(
-                        &mut instructions,
-                        &preserved,
-                        &stack_live_regs(&stack),
-                        &local_to_reg,
-                        &layout,
-                        &mut spill,
-                        ret_i64,
-                        idx,
-                    )?;
-                    // #719 phase 2: reload the f32 S-registers the BL clobbered.
-                    // The callee returns in R0 (a float-returning callee is
-                    // declined by the epilogue guard), so reloading S0..S15 here
-                    // cannot destroy the integer result.
-                    restore_vfp_caller_saved(&mut instructions, &vfp_preserved, idx);
-                    // Push the call's return value as a live operand (spilled to
-                    // the frame if no register was free to hold it — #171).
-                    stack.push(result_reg);
+                    if callee_ret_f32 || callee_ret_f64 {
+                        // GI-FPU-002 phase 3 (#369): the float result arrives in
+                        // S0/D0. Capture it into a fresh VFP temp BEFORE the
+                        // preservation reloads below — if S0/S1 held a live
+                        // value before the call, `restore_vfp_caller_saved`
+                        // overwrites them with the OLD value, so the result must
+                        // move out first. The allocator skips every still-live
+                        // register (preserved values stay marked used), and when
+                        // S0/D0 itself is free the temp IS S0/D0 and no move is
+                        // needed. The copies are the bit-exact core round-trips
+                        // the return lowering uses; R0/R1/R12 are dead here (a
+                        // float-returning callee leaves no core result, and every
+                        // live caller-saved value sits in the spill area until
+                        // the reloads below).
+                        let result = if callee_ret_f64 {
+                            let dd = alloc_vfp_dtemp(&mut vfp_used)?;
+                            if dd != VfpReg::D0 {
+                                instructions.push(ArmInstruction {
+                                    op: ArmOp::I64ReinterpretF64 {
+                                        rdlo: Reg::R0,
+                                        rdhi: Reg::R1,
+                                        dm: VfpReg::D0,
+                                    },
+                                    source_line: Some(idx),
+                                });
+                                instructions.push(ArmInstruction {
+                                    op: ArmOp::F64ReinterpretI64 {
+                                        dd,
+                                        rmlo: Reg::R0,
+                                        rmhi: Reg::R1,
+                                    },
+                                    source_line: Some(idx),
+                                });
+                            }
+                            StackVal::Double { dreg: dd }
+                        } else {
+                            let sd = alloc_vfp_temp(&mut vfp_used)?;
+                            if sd != VfpReg::S0 {
+                                instructions.push(ArmInstruction {
+                                    op: ArmOp::I32ReinterpretF32 {
+                                        rd: Reg::R12,
+                                        sm: VfpReg::S0,
+                                    },
+                                    source_line: Some(idx),
+                                });
+                                instructions.push(ArmInstruction {
+                                    op: ArmOp::F32ReinterpretI32 { sd, rm: Reg::R12 },
+                                    source_line: Some(idx),
+                                });
+                            }
+                            StackVal::Float { sreg: sd }
+                        };
+                        // Reload the integer caller-saved values (no R0 result
+                        // relocation — the result lives in the VFP file).
+                        for &(reg, off) in &preserved {
+                            instructions.push(ArmInstruction {
+                                op: ArmOp::Ldr {
+                                    rd: reg,
+                                    addr: MemAddr::imm(Reg::SP, off),
+                                },
+                                source_line: Some(idx),
+                            });
+                        }
+                        restore_vfp_caller_saved(&mut instructions, &vfp_preserved, idx);
+                        stack.push(result);
+                    } else {
+                        // #311: tag an i64 result as the R0:R1 pair.
+                        let ret_i64 = self
+                            .func_ret_i64
+                            .get(*func_idx as usize)
+                            .copied()
+                            .unwrap_or(false);
+                        let result_reg = self.restore_caller_saved(
+                            &mut instructions,
+                            &preserved,
+                            &stack_live_regs(&stack),
+                            &local_to_reg,
+                            &layout,
+                            &mut spill,
+                            ret_i64,
+                            idx,
+                        )?;
+                        // #719 phase 2: reload the f32 S-registers the BL clobbered.
+                        // The callee returns in R0 (never S0/D0 on this branch), so
+                        // reloading S0..S15 here cannot destroy the integer result.
+                        restore_vfp_caller_saved(&mut instructions, &vfp_preserved, idx);
+                        // Push the call's return value as a live operand (spilled to
+                        // the frame if no register was free to hold it — #171).
+                        stack.push(result_reg);
+                    }
                 }
 
                 CallIndirect {
@@ -16531,14 +16901,13 @@ mod tests {
         );
     }
 
-    /// #719 phase 2: a call whose CALLEE has a float signature (f32/f64 return
-    /// in S0/D0, or an f32 param in the VFP pool) is declined LOUDLY at the
-    /// call site — this increment does not marshal a float ABI at the call
-    /// boundary, and tagging an S0 result as integer R0 (or passing an f32 arg
-    /// in a core register) would be a silent miscompile.
+    /// GI-FPU-002 phase 3 (#369): a call whose callee RETURNS f32 now LOWERS —
+    /// the S0 result is captured onto the operand stack as a `Float` entry
+    /// (usable by a following f32 op), never tagged as an integer R0.
+    /// Execution correctness is gated by the extended
+    /// `scripts/repro/f32_ops_719_differential.py` call-boundary rows.
     #[test]
-    fn test_719_float_signature_callee_declines_loudly() {
-        // Callee returns f32.
+    fn test_369_f32_ret_call_marshals_s0_result() {
         let mut selector = fresh_selector();
         selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
         selector.set_float_call_signatures(
@@ -16547,14 +16916,33 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Vec::new(),
+            Vec::new(),
         );
-        let r = selector.select_with_stack(&[WasmOp::Call(0), WasmOp::Drop], 0);
+        let instructions = selector
+            .select_with_stack(&[WasmOp::Call(0), WasmOp::I32ReinterpretF32], 0)
+            .expect("call to an f32-returning callee must marshal S0 (#369 phase 3)");
         assert!(
-            r.as_ref()
-                .is_err_and(|e| e.to_string().contains("returns f32")),
-            "call to an f32-returning callee must decline loudly: {r:?}"
+            instructions
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Bl { .. })),
+            "must emit the BL"
         );
-        // Callee takes an f32 param.
+        // The f32 result flows into the reinterpret (VMOV Rd, Sm) — the S0
+        // capture allocated S0 itself here (nothing else live), so the
+        // reinterpret reads S0 directly.
+        assert!(
+            instructions
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::I32ReinterpretF32 { sm: VfpReg::S0, .. })),
+            "the S0 call result must feed the following f32 op"
+        );
+    }
+
+    /// GI-FPU-002 phase 3 (#369): a call whose callee takes an f32 PARAM now
+    /// LOWERS — the argument is marshalled into the AAPCS-VFP S0.. pool (via
+    /// the overlap-safe frame staging), never a core register.
+    #[test]
+    fn test_369_f32_arg_call_marshals_into_s_pool() {
         let mut selector = fresh_selector();
         selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
         selector.set_func_arg_counts(vec![1], Vec::new());
@@ -16564,21 +16952,118 @@ mod tests {
             Vec::new(),
             Vec::new(),
             vec![vec![true]], // func 0 takes (f32)
+            Vec::new(),
         );
-        let r = selector.select_with_stack(&[WasmOp::I32Const(1), WasmOp::Call(0)], 0);
+        let instructions = selector
+            .select_with_stack(&[WasmOp::F32Const(1.5), WasmOp::Call(0)], 0)
+            .expect("call with an f32 argument must marshal into S0 (#369 phase 3)");
+        let bl_at = instructions
+            .iter()
+            .position(|i| matches!(&i.op, ArmOp::Bl { .. }))
+            .expect("call must emit a BL");
+        // The const lands in S0 (first free S-reg) == the AAPCS-VFP dest, so
+        // the staging elides every move; the load-bearing fact is that S0
+        // holds the argument at the BL and NO core register was written with
+        // it (no I32ReinterpretF32 of the argument).
         assert!(
-            r.as_ref()
-                .is_err_and(|e| e.to_string().contains("f32 parameter")),
-            "call to an f32-param callee must decline loudly: {r:?}"
+            instructions[..bl_at]
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::F32Const { sd: VfpReg::S0, .. })),
+            "the f32 argument must be materialized in S0 before the BL"
         );
-        // call_indirect whose static type returns f64.
+        // A second argument NOT already in place must move via the frame
+        // staging: callee (f32, f32) called with the args produced in
+        // reverse-friendly order still routes S-file-only.
         let mut selector = fresh_selector();
         selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+        selector.set_func_arg_counts(vec![2], Vec::new());
+        selector.set_float_call_signatures(
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            vec![vec![true, true]], // func 0 takes (f32, f32)
+            Vec::new(),
+        );
+        // Produce args, then swap them with local.set-free stack shuffling is
+        // not expressible here; instead pin that a non-identity source still
+        // stages through [SP,#off] VSTR/VLDR pairs: give the callee (f32,f32)
+        // and materialize three consts so arg0's source is S1 (S0 is consumed
+        // by an unrelated f32 value that stays live past the pops — a local
+        // home would pin it; simplest: first const is DROPPED so S0 frees and
+        // the arg sources sit in S0,S1 in-place again). Keep the simple
+        // in-place shape: two consts -> S0,S1 == dests, no moves, BL present.
+        let instructions = selector
+            .select_with_stack(
+                &[
+                    WasmOp::F32Const(1.0),
+                    WasmOp::F32Const(2.0),
+                    WasmOp::Call(0),
+                ],
+                0,
+            )
+            .expect("two-f32-arg call must lower (#369 phase 3)");
+        assert!(
+            instructions
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Bl { .. })),
+            "must emit the BL"
+        );
+    }
+
+    /// GI-FPU-002 phase 3 (#369): an f64 call boundary needs double-precision —
+    /// on a single-precision target (m4f) the caller declines loudly (its
+    /// callee's f64 body declines there anyway); on m7dp it lowers with the D0
+    /// result captured as a `Double`. call_indirect of a float-returning type
+    /// still declines loudly (indirect marshalling is a later increment).
+    #[test]
+    fn test_369_f64_ret_call_needs_double_precision() {
+        // Single-precision: decline.
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+        selector.set_float_call_signatures(
+            Vec::new(),
+            vec![true], // func 0 returns f64
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let r = selector.select_with_stack(&[WasmOp::Call(0), WasmOp::Drop], 0);
+        assert!(
+            r.as_ref()
+                .is_err_and(|e| e.to_string().contains("single-precision")),
+            "f64-returning call on m4f must decline loudly: {r:?}"
+        );
+        // Double-precision: lowers, result captured in the D-file.
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Double), "cortex-m7dp");
+        selector.set_float_call_signatures(
+            Vec::new(),
+            vec![true],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let instructions = selector
+            .select_with_stack(&[WasmOp::Call(0), WasmOp::Drop], 0)
+            .expect("f64-returning call must lower on m7dp (#369 phase 3)");
+        assert!(
+            instructions
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::Bl { .. })),
+            "must emit the BL"
+        );
+        // call_indirect whose static type returns f64 still declines.
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Double), "cortex-m7dp");
         selector.set_float_call_signatures(
             Vec::new(),
             Vec::new(),
             Vec::new(),
             vec![true], // type 0 returns f64
+            Vec::new(),
             Vec::new(),
         );
         let r = selector.select_with_stack(
@@ -16595,6 +17080,57 @@ mod tests {
             r.as_ref()
                 .is_err_and(|e| e.to_string().contains("returns f64")),
             "call_indirect of an f64-returning type must decline loudly: {r:?}"
+        );
+    }
+
+    /// GI-FPU-002 phase 3 (#369): boundaries the marshalling does NOT cover
+    /// keep loud declines — a float-signature import on the legacy Meld
+    /// dispatch ABI, and an i64 integer argument mixed into a float-signature
+    /// call (its even-aligned core pair is not marshalled on this path).
+    #[test]
+    fn test_369_unmarshalled_float_boundaries_decline_loudly() {
+        // Meld-dispatch import (non-relocatable) with a float signature.
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+        selector.set_num_imports(1);
+        selector.set_func_arg_counts(vec![1], Vec::new());
+        selector.set_float_call_signatures(
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            vec![vec![true]], // import 0 takes (f32)
+            Vec::new(),
+        );
+        let r = selector.select_with_stack(&[WasmOp::F32Const(1.5), WasmOp::Call(0)], 0);
+        assert!(
+            r.as_ref()
+                .is_err_and(|e| e.to_string().contains("Meld dispatch")),
+            "float-signature Meld-dispatch import must decline loudly: {r:?}"
+        );
+        // i64 argument mixed with an f32 argument.
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+        selector.set_func_arg_counts(vec![2], Vec::new());
+        selector.set_float_call_signatures(
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            vec![vec![true, false]], // func 0 takes (f32, i64)
+            Vec::new(),
+        );
+        let r = selector.select_with_stack(
+            &[
+                WasmOp::F32Const(1.5),
+                WasmOp::I64Const(7),
+                WasmOp::Call(0),
+            ],
+            0,
+        );
+        assert!(
+            r.as_ref().is_err_and(|e| e.to_string().contains("i64")),
+            "i64 arg in a float-signature call must decline loudly: {r:?}"
         );
     }
 
@@ -22630,6 +23166,7 @@ mod tests {
             &[],
             false,
             false,
+            false,
             0,
             I64_SPILL_SLOTS,
         );
@@ -22652,6 +23189,7 @@ mod tests {
             &[],
             &[],
             &[],
+            false,
             false,
             false,
             0,
@@ -22680,6 +23218,7 @@ mod tests {
             &[],
             &[],
             &[],
+            false,
             false,
             false,
             0,
@@ -22713,6 +23252,7 @@ mod tests {
             &[],
             false,
             false,
+            false,
             0,
             I64_SPILL_SLOTS,
         );
@@ -22744,6 +23284,7 @@ mod tests {
             &[],
             &[],
             &[],
+            false,
             false,
             false,
             0,

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -11668,7 +11668,8 @@ impl InstructionSelector {
                             || float_arg_layout
                                 .iter()
                                 .any(|(_, r)| vfp_d_index(*r).is_some());
-                        if fpu.is_none() || (needs_double && !matches!(fpu, Some(FPUPrecision::Double)))
+                        if fpu.is_none()
+                            || (needs_double && !matches!(fpu, Some(FPUPrecision::Double)))
                         {
                             return Err(synth_core::Error::synthesis(format!(
                                 "GI-FPU-002 phase 3: call to func_{func_idx} has {} \
@@ -17311,11 +17312,7 @@ mod tests {
             Vec::new(),
         );
         let r = selector.select_with_stack(
-            &[
-                WasmOp::F32Const(1.5),
-                WasmOp::I64Const(7),
-                WasmOp::Call(0),
-            ],
+            &[WasmOp::F32Const(1.5), WasmOp::I64Const(7), WasmOp::Call(0)],
             0,
         );
         assert!(

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -2498,6 +2498,27 @@ fn try_lower_f32(
             let signed = matches!(op, I32TruncF32S);
             let sm = pop_float(stack)?;
             let rd = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+            // GI-FPU-002 phase 3 (#369, found composing the f64 twin): the
+            // encoder converts IN PLACE (`VCVT Sm, Sm` then `VMOV Rd, Sm`) —
+            // fine for a dead temp, but a pinned param/local HOME register
+            // must survive the op (a later `local.get` reads it): convert
+            // from a fresh copy instead. `rd` is a safe round-trip scratch
+            // (the guards below overwrite it anyway).
+            let sm_is_home = vfp_s_index(sm).is_some_and(|s| vfp_home[s]);
+            let work = if sm_is_home {
+                let copy = alloc_vfp_temp(vfp_used)?;
+                instructions.push(ArmInstruction {
+                    op: ArmOp::I32ReinterpretF32 { rd, sm },
+                    source_line: Some(idx),
+                });
+                instructions.push(ArmInstruction {
+                    op: ArmOp::F32ReinterpretI32 { sd: copy, rm: rd },
+                    source_line: Some(idx),
+                });
+                copy
+            } else {
+                sm
+            };
 
             // (hi_bound, lo_bound, lower-guard-is-inclusive-GE-vs-strict-GT)
             let (hi, lo) = if signed {
@@ -2524,19 +2545,19 @@ fn try_lower_f32(
                 let cmp = if cmp_is_lt {
                     ArmOp::F32Lt {
                         rd,
-                        sn: sm,
+                        sn: work,
                         sm: s_bound,
                     }
                 } else if signed {
                     ArmOp::F32Ge {
                         rd,
-                        sn: sm,
+                        sn: work,
                         sm: s_bound,
                     }
                 } else {
                     ArmOp::F32Gt {
                         rd,
-                        sn: sm,
+                        sn: work,
                         sm: s_bound,
                     }
                 };
@@ -2570,16 +2591,19 @@ fn try_lower_f32(
             emit_guard(hi, true)?; // upper: x < hi (also traps NaN)
             emit_guard(lo, false)?; // lower: x >= lo (signed) / x > lo (unsigned)
 
-            // In-range: the saturating VCVT is now provably exact.
+            // In-range: the saturating VCVT is now provably exact (and the
+            // in-place clobber lands on `work` — a dead temp or the fresh
+            // copy, never a pinned home).
             let arm = if signed {
-                ArmOp::I32TruncF32S { rd, sm }
+                ArmOp::I32TruncF32S { rd, sm: work }
             } else {
-                ArmOp::I32TruncF32U { rd, sm }
+                ArmOp::I32TruncF32U { rd, sm: work }
             };
             instructions.push(ArmInstruction {
                 op: arm,
                 source_line: Some(idx),
             });
+            free_vfp_temp(vfp_used, vfp_home, work);
             free_vfp_temp(vfp_used, vfp_home, sm);
             stack.push(StackVal::i32(rd));
             Ok(true)
@@ -2720,7 +2744,77 @@ fn is_scope_f64_op(op: &WasmOp) -> bool {
             | F64Ge
             | F64Load { .. }
             | F64Store { .. }
+            // GI-FPU-002 phase 3 (#369): the f64 op tail — rounding (VRINT),
+            // min/max (VMINNM/VMAXNM + NaN fix-up), copysign, demote, and the
+            // i32<->f64 conversions (trunc traps out-of-range per §4.3.3).
+            | F64Ceil
+            | F64Floor
+            | F64Trunc
+            | F64Nearest
+            | F64Min
+            | F64Max
+            | F64Copysign
+            | F32DemoteF64
+            | F64ConvertI32S
+            | F64ConvertI32U
+            | I32TruncF64S
+            | I32TruncF64U
     )
+}
+
+/// GI-FPU-002 phase 3 (#369): materialize a 64-bit f64 pattern into a fresh
+/// D-temp via TWO allocator-owned core temps (MOVW/MOVT each) + `VMOV Dd,lo,hi`.
+/// Deliberately NOT `ArmOp::F64Const`: that encoder pseudo-op hardcodes R0+R12
+/// as scratch, and R0 can hold a live param/temp (the #615 class). Shared by
+/// the `F64Const` lowering and the `i32.trunc_f64_*` domain-guard bounds.
+#[allow(clippy::too_many_arguments)]
+fn materialize_f64_const(
+    bits: u64,
+    idx: usize,
+    vfp_used: &mut [bool; 16],
+    stack: &mut Vec<StackVal>,
+    next_temp: &mut u8,
+    spill: &mut SpillState,
+    instructions: &mut Vec<ArmInstruction>,
+    reserved: &[Reg],
+) -> Result<VfpReg> {
+    let lo = bits as u32;
+    let hi = (bits >> 32) as u32;
+    let rlo = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+    // Keep `rlo` visibly live while allocating `rhi` by pushing it as
+    // a placeholder stack entry (popped right back off).
+    stack.push(StackVal::i32(rlo));
+    let rhi = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx);
+    stack.pop();
+    let rhi = rhi?;
+    for (r, val) in [(rlo, lo), (rhi, hi)] {
+        instructions.push(ArmInstruction {
+            op: ArmOp::Movw {
+                rd: r,
+                imm16: (val & 0xFFFF) as u16,
+            },
+            source_line: Some(idx),
+        });
+        if (val >> 16) != 0 {
+            instructions.push(ArmInstruction {
+                op: ArmOp::Movt {
+                    rd: r,
+                    imm16: (val >> 16) as u16,
+                },
+                source_line: Some(idx),
+            });
+        }
+    }
+    let dd = alloc_vfp_dtemp(vfp_used)?;
+    instructions.push(ArmInstruction {
+        op: ArmOp::F64ReinterpretI64 {
+            dd,
+            rmlo: rlo,
+            rmhi: rhi,
+        },
+        source_line: Some(idx),
+    });
+    Ok(dd)
 }
 
 /// Lower an in-scope scalar f64 op onto the caller-saved D-register file.
@@ -2833,48 +2927,18 @@ fn try_lower_f64(
             Ok(true)
         }
         F64Const(v) => {
-            // Materialize the 64-bit pattern via TWO allocator-owned core
-            // temps (MOVW/MOVT each) + `VMOV Dd, lo, hi`. Deliberately NOT
-            // `ArmOp::F64Const`: that encoder pseudo-op hardcodes R0+R12 as
-            // scratch, and R0 can hold a live param/temp (the #615 "encoder
-            // pseudo-op clobbers allocator state" class).
-            let bits = v.to_bits();
-            let lo = bits as u32;
-            let hi = (bits >> 32) as u32;
-            let rlo = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
-            // Keep `rlo` visibly live while allocating `rhi` by pushing it as
-            // a placeholder stack entry (popped right back off).
-            stack.push(StackVal::i32(rlo));
-            let rhi = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx);
-            stack.pop();
-            let rhi = rhi?;
-            for (r, val) in [(rlo, lo), (rhi, hi)] {
-                instructions.push(ArmInstruction {
-                    op: ArmOp::Movw {
-                        rd: r,
-                        imm16: (val & 0xFFFF) as u16,
-                    },
-                    source_line: Some(idx),
-                });
-                if (val >> 16) != 0 {
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Movt {
-                            rd: r,
-                            imm16: (val >> 16) as u16,
-                        },
-                        source_line: Some(idx),
-                    });
-                }
-            }
-            let dd = alloc_vfp_dtemp(vfp_used)?;
-            instructions.push(ArmInstruction {
-                op: ArmOp::F64ReinterpretI64 {
-                    dd,
-                    rmlo: rlo,
-                    rmhi: rhi,
-                },
-                source_line: Some(idx),
-            });
+            // See `materialize_f64_const` — allocator-owned core temps, never
+            // the R0+R12-hardcoding `ArmOp::F64Const` pseudo-op (#615 class).
+            let dd = materialize_f64_const(
+                v.to_bits(),
+                idx,
+                vfp_used,
+                stack,
+                next_temp,
+                spill,
+                instructions,
+                reserved,
+            )?;
             stack.push(StackVal::Double { dreg: dd });
             Ok(true)
         }
@@ -2949,6 +3013,212 @@ fn try_lower_f64(
             });
             free_vfp_dtemp(vfp_used, vfp_home, dm);
             free_vfp_dtemp(vfp_used, vfp_home, dn);
+            stack.push(StackVal::i32(rd));
+            Ok(true)
+        }
+        // GI-FPU-002 phase 3 (#369): rounding — a single VRINT{P,M,Z,N}.F64
+        // each (FPv5): IEEE roundToIntegral matches WASM §4.3.3 exactly
+        // (±0.0 sign preserved, sNaN quietened, ties-to-even for `nearest`).
+        F64Ceil | F64Floor | F64Trunc | F64Nearest => {
+            let dm = pop_double(stack)?;
+            let dd = alloc_vfp_dtemp(vfp_used)?;
+            let arm = match op {
+                F64Ceil => ArmOp::F64Ceil { dd, dm },
+                F64Floor => ArmOp::F64Floor { dd, dm },
+                F64Trunc => ArmOp::F64Trunc { dd, dm },
+                _ => ArmOp::F64Nearest { dd, dm },
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_dtemp(vfp_used, vfp_home, dm);
+            stack.push(StackVal::Double { dreg: dd });
+            Ok(true)
+        }
+        // GI-FPU-002 phase 3 (#369): min/max — VMINNM/VMAXNM (−0.0 < +0.0
+        // ordered) + the VS-guarded VADD NaN fix-up (WASM: any NaN operand ⇒
+        // NaN result; IEEE minNum/maxNum alone return the NUMBER). The fused
+        // encoder sequence clobbers only `dd` + flags, and errs if `dd`
+        // aliases a source — `alloc_vfp_dtemp` runs while both sources are
+        // still marked live, so the destination is fresh by construction.
+        F64Min | F64Max => {
+            let dm = pop_double(stack)?;
+            let dn = pop_double(stack)?;
+            let dd = alloc_vfp_dtemp(vfp_used)?;
+            let arm = if matches!(op, F64Min) {
+                ArmOp::F64Min { dd, dn, dm }
+            } else {
+                ArmOp::F64Max { dd, dn, dm }
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_dtemp(vfp_used, vfp_home, dm);
+            free_vfp_dtemp(vfp_used, vfp_home, dn);
+            stack.push(StackVal::Double { dreg: dd });
+            Ok(true)
+        }
+        // GI-FPU-002 phase 3 (#369): `f64.copysign(a, b)` — stack order is
+        // `[a, b]` (b on top), so `dm` (popped first) is the SIGN source and
+        // `dn` the MAGNITUDE, matching the encoder's `|dn| ± sign(dm)` VABS/
+        // conditional-VNEG splice (clobbers only R12 + flags + dd; bit-exact
+        // on ±0.0/NaN-sign/±inf).
+        F64Copysign => {
+            let dm = pop_double(stack)?; // sign source (b)
+            let dn = pop_double(stack)?; // magnitude source (a)
+            let dd = alloc_vfp_dtemp(vfp_used)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::F64Copysign { dd, dn, dm },
+                source_line: Some(idx),
+            });
+            free_vfp_dtemp(vfp_used, vfp_home, dm);
+            free_vfp_dtemp(vfp_used, vfp_home, dn);
+            stack.push(StackVal::Double { dreg: dd });
+            Ok(true)
+        }
+        // GI-FPU-002 phase 3 (#369): f64 → f32 demote — a single
+        // `VCVT.F32.F64` (round-to-nearest-even, overflow ⇒ ±inf, underflow ⇒
+        // signed zero/subnormal — exactly WASM §4.3.3 demote).
+        F32DemoteF64 => {
+            let dm = pop_double(stack)?;
+            let sd = alloc_vfp_temp(vfp_used)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::F32DemoteF64 { sd, dm },
+                source_line: Some(idx),
+            });
+            free_vfp_dtemp(vfp_used, vfp_home, dm);
+            stack.push(StackVal::Float { sreg: sd });
+            Ok(true)
+        }
+        // GI-FPU-002 phase 3 (#369): i32 → f64 — exact for every i32 (no
+        // rounding possible: f64 has 53 mantissa bits). The encoder stages
+        // the integer through the DESTINATION's own S-alias, never S0.
+        F64ConvertI32S | F64ConvertI32U => {
+            let rm = pop_operand(stack, next_temp, instructions, spill, reserved, idx)?;
+            let dd = alloc_vfp_dtemp(vfp_used)?;
+            let arm = if matches!(op, F64ConvertI32S) {
+                ArmOp::F64ConvertI32S { dd, rm }
+            } else {
+                ArmOp::F64ConvertI32U { dd, rm }
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            stack.push(StackVal::Double { dreg: dd });
+            Ok(true)
+        }
+        I32TruncF64S | I32TruncF64U => {
+            // #709-class SOUNDNESS: WASM §4.3.3 requires `i32.trunc_f64_{s,u}`
+            // to TRAP on NaN or an out-of-range operand; ARM VCVT SATURATES
+            // (NaN→0). Emit the f64 twin of the #709 f32 domain guard BEFORE
+            // the conversion — the VCVT then provably never saturates.
+            //
+            // Valid domain (every bound exactly representable in f64; the
+            // truncation itself makes the fractional part irrelevant):
+            //   trunc_f64_s: -2^31 - 1 <  x  <  2^31   (lo=-2147483649.0)
+            //   trunc_f64_u:      -1.0 <  x  <  2^32   (hi=4294967296.0)
+            // Both guards are STRICT (F64Lt/F64Gt are ordered ⇒ false on
+            // NaN, so a NaN falls to the UDF at the first guard).
+            let signed = matches!(op, I32TruncF64S);
+            let dm = pop_double(stack)?;
+            // The encoder stages the result through the SOURCE's low S-alias,
+            // clobbering half of `dm` — fine for a dead temp, but a pinned
+            // param/local HOME must survive: convert from a fresh copy.
+            let dm_is_home = vfp_d_index(dm).is_some_and(|d| vfp_home[2 * d]);
+            let work = if dm_is_home {
+                let copy = alloc_vfp_dtemp(vfp_used)?;
+                emit_d_copy(
+                    copy,
+                    dm,
+                    idx,
+                    stack,
+                    next_temp,
+                    spill,
+                    instructions,
+                    reserved,
+                )?;
+                copy
+            } else {
+                dm
+            };
+            let rd = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+
+            let (hi, lo) = if signed {
+                (2147483648.0_f64, -2147483649.0_f64) // 2^31, -(2^31)-1
+            } else {
+                (4294967296.0_f64, -1.0_f64) // 2^32, -1.0
+            };
+            let mut emit_guard = |bound: f64, upper: bool| -> Result<()> {
+                let d_bound = materialize_f64_const(
+                    bound.to_bits(),
+                    idx,
+                    vfp_used,
+                    stack,
+                    next_temp,
+                    spill,
+                    instructions,
+                    reserved,
+                )?;
+                let cmp = if upper {
+                    ArmOp::F64Lt {
+                        rd,
+                        dn: work,
+                        dm: d_bound,
+                    }
+                } else {
+                    ArmOp::F64Gt {
+                        rd,
+                        dn: work,
+                        dm: d_bound,
+                    }
+                };
+                instructions.push(ArmInstruction {
+                    op: cmp,
+                    source_line: Some(idx),
+                });
+                instructions.push(ArmInstruction {
+                    op: ArmOp::Cmp {
+                        rn: rd,
+                        op2: Operand2::Imm(0),
+                    },
+                    source_line: Some(idx),
+                });
+                // Skip the UDF when in-range (rd != 0); else trap.
+                instructions.push(ArmInstruction {
+                    op: ArmOp::BCondOffset {
+                        cond: Condition::NE,
+                        offset: 0,
+                    },
+                    source_line: Some(idx),
+                });
+                instructions.push(ArmInstruction {
+                    op: ArmOp::Udf { imm: 0 },
+                    source_line: Some(idx),
+                });
+                free_vfp_dtemp(vfp_used, vfp_home, d_bound);
+                Ok(())
+            };
+            emit_guard(hi, true)?; // x < hi (also traps NaN)
+            emit_guard(lo, false)?; // x > lo
+
+            let arm = if signed {
+                ArmOp::I32TruncF64S { rd, dm: work }
+            } else {
+                ArmOp::I32TruncF64U { rd, dm: work }
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_dtemp(vfp_used, vfp_home, work);
+            if dm_is_home {
+                // `work` was the fresh copy; the untouched home stays pinned.
+            } else {
+                free_vfp_dtemp(vfp_used, vfp_home, dm);
+            }
             stack.push(StackVal::i32(rd));
             Ok(true)
         }
@@ -17637,6 +17907,155 @@ mod tests {
                     .any(|i| matches!(&i.op, ArmOp::F32Load { sd: s, .. } if *s == sd)),
                 "{what} must be reloaded after the BL: {instructions:#?}"
             );
+        }
+    }
+
+    /// GI-FPU-002 phase 3 (#369): the f64 op TAIL lowers on m7dp — rounding
+    /// (single VRINT each), min/max (fresh D-temp destination, so the fused
+    /// encoder's alias guard never fires), copysign, demote, i32→f64 — and
+    /// every tail op still honest-rejects on a single-precision target.
+    #[test]
+    fn test_369_f64_tail_ops_lower_on_m7dp() {
+        use WasmOp::*;
+        // (op stream, the ArmOp the lowering must contain)
+        let unary = |op: WasmOp| vec![F64Const(1.5), op, Drop];
+        let binary = |op: WasmOp| vec![F64Const(1.5), F64Const(2.5), op, Drop];
+        type Case = (Vec<WasmOp>, fn(&ArmOp) -> bool);
+        let cases: Vec<Case> = vec![
+            (unary(F64Ceil), |o| matches!(o, ArmOp::F64Ceil { .. })),
+            (unary(F64Floor), |o| matches!(o, ArmOp::F64Floor { .. })),
+            (unary(F64Trunc), |o| matches!(o, ArmOp::F64Trunc { .. })),
+            (unary(F64Nearest), |o| matches!(o, ArmOp::F64Nearest { .. })),
+            (binary(F64Min), |o| matches!(o, ArmOp::F64Min { .. })),
+            (binary(F64Max), |o| matches!(o, ArmOp::F64Max { .. })),
+            (binary(F64Copysign), |o| {
+                matches!(o, ArmOp::F64Copysign { .. })
+            }),
+            (unary(F32DemoteF64), |o| {
+                matches!(o, ArmOp::F32DemoteF64 { .. })
+            }),
+            (
+                vec![I32Const(7), F64ConvertI32S, Drop],
+                (|o| matches!(o, ArmOp::F64ConvertI32S { .. })) as fn(&ArmOp) -> bool,
+            ),
+            (vec![I32Const(7), F64ConvertI32U, Drop], |o| {
+                matches!(o, ArmOp::F64ConvertI32U { .. })
+            }),
+        ];
+        for (ops, has) in &cases {
+            let mut selector = fresh_selector();
+            selector.set_target(Some(FPUPrecision::Double), "cortex-m7dp");
+            let instructions = selector
+                .select_with_stack(ops, 0)
+                .unwrap_or_else(|e| panic!("{ops:?} must lower on m7dp: {e}"));
+            assert!(
+                instructions.iter().any(|i| has(&i.op)),
+                "expected lowered ArmOp for {ops:?}: {instructions:#?}"
+            );
+            // Fresh destination invariant for the fused min/max: dd differs
+            // from both sources (the encoder's alias guard is unreachable).
+            for i in &instructions {
+                if let ArmOp::F64Min { dd, dn, dm } | ArmOp::F64Max { dd, dn, dm } = &i.op {
+                    assert!(dd != dn && dd != dm, "min/max dest must be fresh");
+                }
+            }
+            // Single-precision target: honest-reject.
+            let mut selector = fresh_selector();
+            selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+            let r = selector.select_with_stack(ops, 0);
+            assert!(
+                r.as_ref()
+                    .is_err_and(|e| e.to_string().contains("double-precision")),
+                "{ops:?} must honest-reject on m4f: {r:?}"
+            );
+        }
+    }
+
+    /// GI-FPU-002 phase 3 (#369): `i32.trunc_f64_{s,u}` carries the #709
+    /// trap-on-out-of-range domain guard — two strict F64 compares, each
+    /// falling through to a UDF, BEFORE the saturating VCVT.
+    #[test]
+    fn test_369_i32_trunc_f64_emits_domain_guard() {
+        for (op, arm_is_signed) in [(WasmOp::I32TruncF64S, true), (WasmOp::I32TruncF64U, false)] {
+            let mut selector = fresh_selector();
+            selector.set_target(Some(FPUPrecision::Double), "cortex-m7dp");
+            let ops = vec![WasmOp::F64Const(1.5), op, WasmOp::Drop];
+            let instructions = selector
+                .select_with_stack(&ops, 0)
+                .expect("i32.trunc_f64 must lower on m7dp");
+            let udfs = instructions
+                .iter()
+                .filter(|i| matches!(&i.op, ArmOp::Udf { .. }))
+                .count();
+            assert_eq!(udfs, 2, "both domain guards must trap: {instructions:#?}");
+            assert!(
+                instructions
+                    .iter()
+                    .any(|i| matches!(&i.op, ArmOp::F64Lt { .. }))
+                    && instructions
+                        .iter()
+                        .any(|i| matches!(&i.op, ArmOp::F64Gt { .. })),
+                "strict upper (F64Lt) + lower (F64Gt) guards expected"
+            );
+            let has_cvt = instructions.iter().any(|i| match &i.op {
+                ArmOp::I32TruncF64S { .. } => arm_is_signed,
+                ArmOp::I32TruncF64U { .. } => !arm_is_signed,
+                _ => false,
+            });
+            assert!(has_cvt, "the guarded VCVT must follow: {instructions:#?}");
+        }
+    }
+
+    /// GI-FPU-002 phase 3 (#369): the trunc encoders convert IN PLACE
+    /// (clobbering the source S-register / the source D's low alias), so a
+    /// pinned param HOME must be copied to a fresh temp first — a later
+    /// `local.get` of the param still reads the intact home.
+    #[test]
+    fn test_369_trunc_never_clobbers_param_home() {
+        // f32: param home S0; trunc then read the param again.
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+        selector.set_params_f32(vec![true]);
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32TruncF32S,
+            WasmOp::Drop,
+            WasmOp::LocalGet(0),
+            WasmOp::I32ReinterpretF32,
+        ];
+        let instructions = selector
+            .select_with_stack(&ops, 1)
+            .expect("f32 trunc of a param must lower");
+        for i in &instructions {
+            if let ArmOp::I32TruncF32S { sm, .. } = &i.op {
+                assert!(
+                    *sm != VfpReg::S0,
+                    "in-place VCVT must not target the S0 param home: {instructions:#?}"
+                );
+            }
+        }
+        // f64: param home D0; trunc then read the param again.
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Double), "cortex-m7dp");
+        selector.set_params_i64(vec![true]);
+        selector.set_params_f64(vec![true]);
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32TruncF64S,
+            WasmOp::Drop,
+            WasmOp::LocalGet(0),
+            WasmOp::Drop,
+        ];
+        let instructions = selector
+            .select_with_stack(&ops, 1)
+            .expect("f64 trunc of a param must lower");
+        for i in &instructions {
+            if let ArmOp::I32TruncF64S { dm, .. } = &i.op {
+                assert!(
+                    *dm != VfpReg::D0,
+                    "in-place VCVT must not target the D0 param home: {instructions:#?}"
+                );
+            }
         }
     }
 

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -164,6 +164,7 @@ fn aapcs_param_layout(
     num_params: u32,
     params_i64: &[bool],
     params_f32: &[bool],
+    params_f64_vfp: &[bool],
 ) -> AapcsParamLayout {
     let mut regs = std::collections::HashMap::new();
     let mut stack = std::collections::HashMap::new();
@@ -176,7 +177,16 @@ fn aapcs_param_layout(
         // consumes neither a core register nor an NSAA stack slot — the core
         // walk must skip it. `(f32, i32)` therefore maps i32→R0 (not R1). Empty
         // `params_f32` ⇒ no skips ⇒ byte-identical to the legacy layout.
-        if params_f32.get(i as usize).copied().unwrap_or(false) {
+        //
+        // GI-FPU-002 phase 3 (#369): same for a VFP-HOMED f64 param (D-register
+        // from the same independent pool, back-fill assignment via
+        // `vfp_param_layout`). `params_f64_vfp` is non-empty ONLY on a
+        // double-precision target where the D-homing applies — on soft-float
+        // the caller passes an empty slice and the f64 keeps its ABI-correct
+        // core-pair treatment through `params_i64` (which lumps i64/f64).
+        if params_f32.get(i as usize).copied().unwrap_or(false)
+            || params_f64_vfp.get(i as usize).copied().unwrap_or(false)
+        {
             continue;
         }
         let is_wide = params_i64.get(i as usize).copied().unwrap_or(false);
@@ -264,9 +274,9 @@ fn vfp_param_layout(
 /// Test-only: the selector itself uses the full layout.
 #[cfg(test)]
 fn aapcs_param_regs(num_params: u32, params_i64: &[bool]) -> std::collections::HashMap<u32, Reg> {
-    // Test helper covers integer signatures only (f32 param homing is exercised
-    // by the #719 execution differential); pass no f32 params.
-    aapcs_param_layout(num_params, params_i64, &[]).regs
+    // Test helper covers integer signatures only (f32/f64 param homing is
+    // exercised by the #719/#369 execution differentials); pass no float params.
+    aapcs_param_layout(num_params, params_i64, &[], &[]).regs
 }
 
 /// True if any declared i64/f64 param of this function lands (wholly or its
@@ -1488,6 +1498,7 @@ fn compute_local_layout(
     num_params: u32,
     params_i64: &[bool],
     params_f32: &[bool],
+    params_f64_vfp: &[bool],
     func_ret_i64: &[bool],
     type_ret_i64: &[bool],
     force_spill_area: bool,
@@ -1500,7 +1511,9 @@ fn compute_local_layout(
     let i64_set = infer_i64_locals(wasm_ops, func_ret_i64, type_ret_i64);
     // #503-i64: the width-aware AAPCS assignment — which params are register-
     // resident and which live on the caller's stack (and at what NSAA offset).
-    let aapcs = aapcs_param_layout(num_params, params_i64, params_f32);
+    // `params_f64_vfp` is non-empty only on a double-precision target, where
+    // an f64 param is D-register-homed and skipped by the core walk (#369).
+    let aapcs = aapcs_param_layout(num_params, params_i64, params_f32, params_f64_vfp);
 
     // Collect non-param local indices, in ascending order for deterministic layout.
     let mut used: BTreeSet<u32> = BTreeSet::new();
@@ -1639,6 +1652,9 @@ fn compute_local_layout(
     // every other frame field so the existing local/spill/param offsets are
     // unchanged.
     let has_f32 = params_f32.iter().take(num_params as usize).any(|&f| f)
+        // GI-FPU-002 phase 3 (#369): a D-homed f64 param's home is the aliased
+        // S-word pair, preserved across calls by the same 16-slot area.
+        || params_f64_vfp.iter().take(num_params as usize).any(|&f| f)
         || wasm_ops.iter().any(is_scope_f32_op)
         // GI-FPU-002 phase 2 (#369): f64 values live in D0..D7, which alias
         // S0..S15 — a live double across a call is preserved by the SAME
@@ -2716,8 +2732,10 @@ fn is_scope_f64_op(op: &WasmOp) -> bool {
 fn try_lower_f64(
     op: &WasmOp,
     idx: usize,
+    params_f64: &[bool],
+    f64_home: &mut std::collections::HashMap<u32, VfpReg>,
     vfp_used: &mut [bool; 16],
-    vfp_home: &[bool; 16],
+    vfp_home: &mut [bool; 16],
     stack: &mut Vec<StackVal>,
     next_temp: &mut u8,
     spill: &mut SpillState,
@@ -2725,7 +2743,95 @@ fn try_lower_f64(
     reserved: &[Reg],
 ) -> Result<bool> {
     use WasmOp::*;
+    /// Bit-exact D→D copy via the proven core round-trip (`VMOV r,r,Dm` +
+    /// `VMOV Dd,r,r`) — the lowered ArmOp set has no `VMOV.F64 Dd,Dm`, and
+    /// both moves copy all 64 bits, so ±0.0/NaN/±inf are preserved.
+    fn emit_d_copy(
+        dd: VfpReg,
+        dm: VfpReg,
+        idx: usize,
+        stack: &mut Vec<StackVal>,
+        next_temp: &mut u8,
+        spill: &mut SpillState,
+        instructions: &mut Vec<ArmInstruction>,
+        reserved: &[Reg],
+    ) -> Result<()> {
+        let rlo = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+        // Keep `rlo` visibly live while allocating `rhi` (same trick as
+        // the F64Const materialization below).
+        stack.push(StackVal::i32(rlo));
+        let rhi = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx);
+        stack.pop();
+        let rhi = rhi?;
+        instructions.push(ArmInstruction {
+            op: ArmOp::I64ReinterpretF64 {
+                rdlo: rlo,
+                rdhi: rhi,
+                dm,
+            },
+            source_line: Some(idx),
+        });
+        instructions.push(ArmInstruction {
+            op: ArmOp::F64ReinterpretI64 {
+                dd,
+                rmlo: rlo,
+                rmhi: rhi,
+            },
+            source_line: Some(idx),
+        });
+        Ok(())
+    }
     match op {
+        // GI-FPU-002 phase 3 (#369): f64 param/local D-register homes —
+        // the double-precision mirror of the f32 home machinery above.
+        LocalGet(i) => {
+            if let Some(&home) = f64_home.get(i) {
+                // Read-only reference to the home D-register (a `local.set`
+                // writes THROUGH the stable home, so no defensive copy).
+                stack.push(StackVal::Double { dreg: home });
+                Ok(true)
+            } else {
+                Ok(false) // not an f64 local — integer/f32 paths handle it
+            }
+        }
+        LocalSet(i) | LocalTee(i) => {
+            let top_is_double = matches!(stack.last(), Some(StackVal::Double { .. }));
+            let target_is_f64 =
+                f64_home.contains_key(i) || params_f64.get(*i as usize).copied().unwrap_or(false);
+            if !(top_is_double || target_is_f64) {
+                return Ok(false); // not an f64 local — fall through
+            }
+            let src = pop_double(stack)?;
+            let home = if let Some(&h) = f64_home.get(i) {
+                h
+            } else {
+                // A fresh non-param f64 local: allocate + pin a home D-register.
+                let h = alloc_vfp_dtemp(vfp_used)?;
+                if let Some(d) = vfp_d_index(h) {
+                    vfp_home[2 * d] = true;
+                    vfp_home[2 * d + 1] = true;
+                }
+                f64_home.insert(*i, h);
+                h
+            };
+            if home != src {
+                emit_d_copy(
+                    home,
+                    src,
+                    idx,
+                    stack,
+                    next_temp,
+                    spill,
+                    instructions,
+                    reserved,
+                )?;
+            }
+            free_vfp_dtemp(vfp_used, vfp_home, src);
+            if matches!(op, LocalTee(_)) {
+                stack.push(StackVal::Double { dreg: home });
+            }
+            Ok(true)
+        }
         F64Const(v) => {
             // Materialize the 64-bit pattern via TWO allocator-owned core
             // temps (MOVW/MOVT each) + `VMOV Dd, lo, hi`. Deliberately NOT
@@ -7996,7 +8102,22 @@ impl InstructionSelector {
         // back to a loud skip (warning + absent symbol), never wrong code.
         // (Empty `params_i64` ⇒ all-i32 ⇒ this is a no-op and every existing
         // fixture stays byte-identical.)
-        let param_layout = aapcs_param_layout(num_params, &self.params_i64, &self.params_f32);
+        // GI-FPU-002 phase 3 (#369): on a DOUBLE-precision target an f64 param
+        // is homed in a VFP D-register (AAPCS-VFP), so the core walk skips it —
+        // exactly like an f32 param. Everywhere else (soft-float; and m4f,
+        // where the function declines below) the slice is empty and the f64
+        // keeps its core-pair treatment via `params_i64`.
+        let params_f64_vfp: Vec<bool> = if matches!(self.fpu, Some(FPUPrecision::Double)) {
+            self.params_f64.clone()
+        } else {
+            Vec::new()
+        };
+        let param_layout = aapcs_param_layout(
+            num_params,
+            &self.params_i64,
+            &self.params_f32,
+            &params_f64_vfp,
+        );
         let has_reg_i64_param = (0..num_params).any(|i| {
             self.params_i64.get(i as usize).copied().unwrap_or(false)
                 && param_layout.regs.contains_key(&i)
@@ -8091,6 +8212,7 @@ impl InstructionSelector {
             num_params,
             &self.params_i64,
             &self.params_f32,
+            &params_f64_vfp,
             &self.func_ret_i64,
             &self.type_ret_i64,
             self.spill_on_exhaustion,
@@ -8284,8 +8406,12 @@ impl InstructionSelector {
         // is reserved via `i64_pair_hi`) instead of an i32 entry that left the hi
         // unreserved — the exact direct-path #518 mechanism (a following
         // `i64.const` was then allocated into the param's hi register).
+        // GI-FPU-002 phase 3 (#369): a D-HOMED f64 param (double-precision
+        // target) is NOT a core-register pair — `params_i64` lumps i64/f64 by
+        // width, but its home is the VFP D-register, so seeding it here would
+        // make `LocalGet` push a phantom core pair. Skip the VFP-homed ones.
         for (k, &wide) in self.params_i64.iter().take(num_params as usize).enumerate() {
-            if wide {
+            if wide && !params_f64_vfp.get(k).copied().unwrap_or(false) {
                 i64_locals.insert(k as u32);
             }
         }
@@ -8441,25 +8567,6 @@ impl InstructionSelector {
                 //    integer-tagged R0; any later f32 op `pop_float`s it → Err, and
                 //    an f32/f64 function return is caught by the epilogue
                 //    `ret_f32`/`ret_f64` soundness guard above.
-                // Seed f32-param homes. With no mixed params, the k-th param is
-                // the k-th f32 param, homed in AAPCS-VFP arg register S(k).
-                let mut vfp_arg: u8 = 0;
-                for i in 0..num_params {
-                    if params_f32.get(i as usize).copied().unwrap_or(false) {
-                        if vfp_arg >= 16 {
-                            return Err(synth_core::Error::synthesis(
-                                "GI-FPU-002 phase 1: more than 16 f32 params \
-                                 (VFP arg registers exhausted) — declining"
-                                    .to_string(),
-                            ));
-                        }
-                        let home = index_to_vfp_reg(vfp_arg);
-                        vfp_used[vfp_arg as usize] = true;
-                        vfp_home[vfp_arg as usize] = true;
-                        f32_home.insert(i, home);
-                        vfp_arg += 1;
-                    }
-                }
             }
             // GI-FPU-002 phase 2 (#369): scalar f64 capability gates. The
             // lowered f64 subset needs DOUBLE-precision VFP (cortex-m7dp);
@@ -8479,25 +8586,51 @@ impl InstructionSelector {
                     }
                 )));
             }
-            // GI-FPU-002 phase 2 (#369): f64 PARAMS are not yet homed (an f64
-            // param arrives in D0..D7 under AAPCS-VFP). On a hard-float target
-            // the legacy width-inference treats it as an i64 CORE-register
-            // pair — reading R0:R1 where the caller put D0, and shifting every
-            // later integer param's home — a silent wrong-argument class, so
-            // decline LOUDLY. Soft-float targets (no FPU) genuinely pass f64
-            // in core registers, so the i64-pair treatment is ABI-correct
-            // there and stays.
-            if fpu.is_some()
+            // GI-FPU-002 phase 3 (#369): f64 PARAMS. On a DOUBLE-precision
+            // target the param is homed in its AAPCS-VFP D-register (seeded
+            // below via `vfp_param_layout`). On a SINGLE-precision target
+            // (m4f/m7) the AAPCS-VFP caller still puts it in D0.., but every
+            // f64 OP declines there — decline the function symmetrically
+            // rather than home a value nothing can use (and the legacy
+            // i64-pair reading of R0:R1 would be a silent wrong-argument
+            // miscompile). Soft-float targets (no FPU) genuinely pass f64 in
+            // core registers, so the i64-pair treatment is ABI-correct there
+            // and stays.
+            if matches!(fpu, Some(FPUPrecision::Single))
                 && (0..num_params)
                     .any(|i| self.params_f64.get(i as usize).copied().unwrap_or(false))
             {
                 return Err(synth_core::Error::synthesis(format!(
-                    "GI-FPU-002 phase 2: an f64 parameter arrives in a VFP \
-                     D-register under AAPCS-VFP, which '{}' hard-float lowering \
-                     does not yet home — declining loudly (an i64-pair reading \
-                     of R0:R1 would be a silent wrong-argument miscompile, #369)",
+                    "GI-FPU-002 phase 3: an f64 parameter arrives in a VFP \
+                     D-register under AAPCS-VFP, but '{}' has a \
+                     single-precision FPU — no f64 op can consume it; \
+                     declining loudly (#369)",
                     self.target_name
                 )));
+            }
+        }
+        // GI-FPU-002 phase 3 (#369): seed the float-param homes from the
+        // AAPCS-VFP argument layout — f32 params in S-registers, f64 params
+        // (double-precision targets only; `params_f64_vfp` is empty otherwise)
+        // in D-registers, with back-fill allocation: `(f32, f64, f32)` homes
+        // S0, D1(=S2:S3), S1. For an f32-only signature this degenerates to
+        // the sequential `S0, S1, …` seeding it replaces (byte-identical).
+        let mut f64_home: std::collections::HashMap<u32, VfpReg> = std::collections::HashMap::new();
+        if fpu.is_some() {
+            let seeds = vfp_param_layout(num_params, &params_f32, &params_f64_vfp)
+                .map_err(|e| synth_core::Error::synthesis(format!("GI-FPU-002 phase 3: {e}")))?;
+            for (i, home) in seeds {
+                if let Some(d) = vfp_d_index(home) {
+                    vfp_used[2 * d] = true;
+                    vfp_used[2 * d + 1] = true;
+                    vfp_home[2 * d] = true;
+                    vfp_home[2 * d + 1] = true;
+                    f64_home.insert(i, home);
+                } else if let Some(s) = vfp_s_index(home) {
+                    vfp_used[s] = true;
+                    vfp_home[s] = true;
+                    f32_home.insert(i, home);
+                }
             }
         }
 
@@ -8564,8 +8697,10 @@ impl InstructionSelector {
                 && try_lower_f64(
                     op,
                     idx,
+                    &params_f64_vfp,
+                    &mut f64_home,
                     &mut vfp_used,
-                    &vfp_home,
+                    &mut vfp_home,
                     &mut stack,
                     &mut next_temp,
                     &mut spill,
@@ -16999,24 +17134,24 @@ mod tests {
     #[test]
     fn test_503_aapcs_stack_offsets() {
         // (i32 x4, i64): p4 wide @ nsaa 0.
-        let l = aapcs_param_layout(5, &[false, false, false, false, true], &[]);
+        let l = aapcs_param_layout(5, &[false, false, false, false, true], &[], &[]);
         assert_eq!(l.stack.get(&4), Some(&(0, true)));
         // (i32 x5, i64): p4 narrow @ 0, p5 wide @ 8 (4-byte alignment hole).
-        let l = aapcs_param_layout(6, &[false, false, false, false, false, true], &[]);
+        let l = aapcs_param_layout(6, &[false, false, false, false, false, true], &[], &[]);
         assert_eq!(l.stack.get(&4), Some(&(0, false)));
         assert_eq!(l.stack.get(&5), Some(&(8, true)));
         // (i32 x3, i64): even-align spills the pair with only 4 params.
-        let l = aapcs_param_layout(4, &[false, false, false, true], &[]);
+        let l = aapcs_param_layout(4, &[false, false, false, true], &[], &[]);
         assert_eq!(l.stack.get(&3), Some(&(0, true)));
         assert_eq!(l.regs.get(&3), None);
         // (i64, i32 x3): p1=R2, p2=R3, p3 narrow @ 0 (no back-fill).
-        let l = aapcs_param_layout(4, &[true, false, false, false], &[]);
+        let l = aapcs_param_layout(4, &[true, false, false, false], &[], &[]);
         assert_eq!(l.regs.get(&0), Some(&Reg::R0));
         assert_eq!(l.regs.get(&1), Some(&Reg::R2));
         assert_eq!(l.regs.get(&2), Some(&Reg::R3));
         assert_eq!(l.stack.get(&3), Some(&(0, false)));
         // all-i32 x6: legacy (k-4)*4 formula, byte-identical.
-        let l = aapcs_param_layout(6, &[false; 6], &[]);
+        let l = aapcs_param_layout(6, &[false; 6], &[], &[]);
         assert_eq!(l.stack.get(&4), Some(&(0, false)));
         assert_eq!(l.stack.get(&5), Some(&(4, false)));
     }
@@ -17026,23 +17161,23 @@ mod tests {
     #[test]
     fn test_719_aapcs_vfp_mixed_param_pools() {
         // (i32, f32): i32 -> R0, f32 skipped (VFP-homed elsewhere).
-        let l = aapcs_param_layout(2, &[false, false], &[false, true]);
+        let l = aapcs_param_layout(2, &[false, false], &[false, true], &[]);
         assert_eq!(l.regs.get(&0), Some(&Reg::R0));
         assert_eq!(l.regs.get(&1), None); // f32 not in the core pool
         assert!(l.stack.is_empty());
         // (f32, i32): the discriminator — i32 -> R0, NOT R1.
-        let l = aapcs_param_layout(2, &[false, false], &[true, false]);
+        let l = aapcs_param_layout(2, &[false, false], &[true, false], &[]);
         assert_eq!(l.regs.get(&0), None); // f32 skipped
         assert_eq!(l.regs.get(&1), Some(&Reg::R0)); // i32 back-to-R0
         // (f32, i32, i32, i32, i32): four i32s fill R0..R3, the 5th spills @ nsaa 0
         // (the f32 never took a core slot).
-        let l = aapcs_param_layout(5, &[false; 5], &[true, false, false, false, false]);
+        let l = aapcs_param_layout(5, &[false; 5], &[true, false, false, false, false], &[]);
         assert_eq!(l.regs.get(&1), Some(&Reg::R0));
         assert_eq!(l.regs.get(&2), Some(&Reg::R1));
         assert_eq!(l.regs.get(&3), Some(&Reg::R2));
         assert_eq!(l.regs.get(&4), Some(&Reg::R3));
         // (i32, f32, i32): both i32s are R0, R1; f32 consumes nothing.
-        let l = aapcs_param_layout(3, &[false; 3], &[false, true, false]);
+        let l = aapcs_param_layout(3, &[false; 3], &[false, true, false], &[]);
         assert_eq!(l.regs.get(&0), Some(&Reg::R0));
         assert_eq!(l.regs.get(&2), Some(&Reg::R1));
         assert_eq!(l.regs.get(&1), None);
@@ -17384,17 +17519,36 @@ mod tests {
     /// keeps compiling.
     #[test]
     fn test_369_f64_param_declines_on_hard_float_only() {
-        // Hard-float: decline.
+        // GI-FPU-002 phase 3: DOUBLE-precision target — the f64 param is now
+        // HOMED in its AAPCS-VFP D-register (D0). Returning it homes D0->D0
+        // (no move needed); the load-bearing pin is that the function LOWERS
+        // and no core-pair read of R0:R1 appears.
+        let ops_ret = vec![WasmOp::LocalGet(0)];
         let mut selector = fresh_selector();
         selector.set_target(Some(FPUPrecision::Double), "cortex-m7dp");
         selector.set_params_i64(vec![true]); // width table lumps f64 as wide
         selector.set_params_f64(vec![true]);
+        selector.set_ret_float(false, true);
+        let instructions = selector
+            .select_with_stack(&ops_ret, 1)
+            .expect("an f64 param on m7dp must home in D0 (#369 phase 3)");
+        assert!(
+            !instructions
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::I64Ldr { .. })),
+            "the D-homed f64 param must never be read as a core pair: {instructions:#?}"
+        );
+        // Single-precision (m4f): no f64 op can consume the D0 param — decline.
         let ops = vec![WasmOp::I32Const(7)];
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Single), "cortex-m4f");
+        selector.set_params_i64(vec![true]);
+        selector.set_params_f64(vec![true]);
         let r = selector.select_with_stack(&ops, 1);
         assert!(
             r.as_ref()
-                .is_err_and(|e| e.to_string().contains("f64 parameter")),
-            "an f64 param on hard-float must decline loudly: {r:?}"
+                .is_err_and(|e| e.to_string().contains("single-precision")),
+            "an f64 param on m4f must decline loudly: {r:?}"
         );
         // Soft-float (no FPU): the i64-pair treatment is the correct ABI.
         let mut selector = fresh_selector();
@@ -17404,6 +17558,86 @@ mod tests {
         selector
             .select_with_stack(&ops, 1)
             .expect("an f64 param on a soft-float target keeps compiling");
+    }
+
+    /// GI-FPU-002 phase 3 (#369): AAPCS-VFP BACK-FILL — `(f32, f64, f32)`
+    /// homes S0, D1(=S2:S3), S1: the second f32 back-fills the S1 hole the
+    /// f64's even-aligned pair skipped. Pinned via the integer core walk
+    /// (an i32 4th param still maps to R0) and the homed adds lowering.
+    #[test]
+    fn test_369_mixed_float_param_backfill_homes() {
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Double), "cortex-m7dp");
+        selector.set_params_i64(vec![false, true, false, false]);
+        selector.set_params_f32(vec![true, false, true, false]);
+        selector.set_params_f64(vec![false, true, false, false]);
+        selector.set_ret_float(false, true);
+        // f64 result: promote(p0) + p1 + promote(p2), and p3 (i32) is dropped
+        // via a store-free use: just drop it — keeps the core walk observable.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::F64PromoteF32,
+            WasmOp::LocalGet(1),
+            WasmOp::F64Add,
+            WasmOp::LocalGet(2),
+            WasmOp::F64PromoteF32,
+            WasmOp::F64Add,
+        ];
+        let instructions = selector
+            .select_with_stack(&ops, 4)
+            .expect("mixed (f32,f64,f32,i32) params must lower on m7dp");
+        // p0 promotes from its S0 home; p2 from the BACK-FILLED S1 (not S4).
+        assert!(
+            instructions
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::F64PromoteF32 { sm: VfpReg::S0, .. })),
+            "p0 must promote from its S0 home: {instructions:#?}"
+        );
+        assert!(
+            instructions
+                .iter()
+                .any(|i| matches!(&i.op, ArmOp::F64PromoteF32 { sm: VfpReg::S1, .. })),
+            "p2 must promote from the back-filled S1 home (not S4): {instructions:#?}"
+        );
+    }
+
+    /// GI-FPU-002 phase 3 (#369): an f64 PARAM HOME (D0 = S0:S1) is preserved
+    /// across an integer call by the VFP call-spill machinery — both aliased
+    /// words stored before the BL and reloaded after.
+    #[test]
+    fn test_369_f64_param_home_survives_call() {
+        let mut selector = fresh_selector();
+        selector.set_target(Some(FPUPrecision::Double), "cortex-m7dp");
+        selector.set_params_i64(vec![true]);
+        selector.set_params_f64(vec![true]);
+        selector.set_ret_float(false, true);
+        selector.set_func_arg_counts(vec![0], Vec::new());
+        let ops = vec![
+            WasmOp::Call(0), // integer call clobbers S0..S15
+            WasmOp::Drop,
+            WasmOp::LocalGet(0), // read the f64 param AFTER the call
+        ];
+        let instructions = selector
+            .select_with_stack(&ops, 1)
+            .expect("f64 param live across a call must lower");
+        let bl_at = instructions
+            .iter()
+            .position(|i| matches!(&i.op, ArmOp::Bl { .. }))
+            .expect("must emit the BL");
+        for (what, sd) in [("S0 (D0 lo)", VfpReg::S0), ("S1 (D0 hi)", VfpReg::S1)] {
+            assert!(
+                instructions[..bl_at]
+                    .iter()
+                    .any(|i| matches!(&i.op, ArmOp::F32Store { sd: s, .. } if *s == sd)),
+                "{what} must be spilled before the BL: {instructions:#?}"
+            );
+            assert!(
+                instructions[bl_at..]
+                    .iter()
+                    .any(|i| matches!(&i.op, ArmOp::F32Load { sd: s, .. } if *s == sd)),
+                "{what} must be reloaded after the BL: {instructions:#?}"
+            );
+        }
     }
 
     /// GI-FPU-002 phase 2 (#369): a live f64 across an integer call is
@@ -23351,6 +23585,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &[],
             false,
             false,
             false,
@@ -23372,6 +23607,7 @@ mod tests {
         let layout = compute_local_layout(
             &ops,
             1,
+            &[],
             &[],
             &[],
             &[],
@@ -23401,6 +23637,7 @@ mod tests {
         let layout = compute_local_layout(
             &ops,
             0,
+            &[],
             &[],
             &[],
             &[],
@@ -23437,6 +23674,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &[],
             false,
             false,
             false,
@@ -23467,6 +23705,7 @@ mod tests {
         let layout = compute_local_layout(
             &ops,
             2,
+            &[],
             &[],
             &[],
             &[],

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -8153,6 +8153,7 @@ mod tests {
             | F64ConvertI64S { .. }
             | F64ConvertI64U { .. }
             | F64PromoteF32 { .. }
+            | F32DemoteF64 { .. }
             | F64ReinterpretI64 { .. }
             | I64ReinterpretF64 { .. }
             | I64TruncF64S { .. }

--- a/crates/synth-synthesis/src/rules.rs
+++ b/crates/synth-synthesis/src/rules.rs
@@ -1137,6 +1137,10 @@ pub enum ArmOp {
         dd: VfpReg,
         sm: VfpReg,
     }, // VCVT.F64.F32 Dd, Sm
+    F32DemoteF64 {
+        sd: VfpReg,
+        dm: VfpReg,
+    }, // VCVT.F32.F64 Sd, Dm
     F64ReinterpretI64 {
         dd: VfpReg,
         rmlo: Reg,
@@ -1507,6 +1511,7 @@ impl ArmOp {
                 | ArmOp::F64ConvertI64S { .. }
                 | ArmOp::F64ConvertI64U { .. }
                 | ArmOp::F64PromoteF32 { .. }
+                | ArmOp::F32DemoteF64 { .. }
                 | ArmOp::F64ReinterpretI64 { .. }
                 | ArmOp::I64ReinterpretF64 { .. }
                 | ArmOp::I64TruncF64S { .. }
@@ -1552,6 +1557,7 @@ impl ArmOp {
                 | ArmOp::F64ConvertI64S { .. }
                 | ArmOp::F64ConvertI64U { .. }
                 | ArmOp::F64PromoteF32 { .. }
+                | ArmOp::F32DemoteF64 { .. }
                 | ArmOp::F64ReinterpretI64 { .. }
                 | ArmOp::I64ReinterpretF64 { .. }
                 | ArmOp::I64TruncF64S { .. }
@@ -1674,6 +1680,7 @@ impl ArmOp {
             ArmOp::F64ConvertI64S { .. } => "VCVT.F64.S64",
             ArmOp::F64ConvertI64U { .. } => "VCVT.F64.U64",
             ArmOp::F64PromoteF32 { .. } => "VCVT.F64.F32",
+            ArmOp::F32DemoteF64 { .. } => "VCVT.F32.F64",
             ArmOp::F64ReinterpretI64 { .. } => "VMOV (F64<-I64)",
             ArmOp::I64ReinterpretF64 { .. } => "VMOV (I64<-F64)",
             ArmOp::I64TruncF64S { .. } => "VCVT.S64.F64",

--- a/scripts/repro/f32_ops_719.wat
+++ b/scripts/repro/f32_ops_719.wat
@@ -110,14 +110,59 @@
     f32.add
     i32.reinterpret_f32)
 
-  ;; ---- #719 phase 2: float-signature callees DECLINE loudly -----------------
-  ;; These callers must be SKIPPED (absent from the symtab), never miscompiled:
-  ;; the callee's f32 result arrives in S0 / its f32 arg belongs in S0, which
-  ;; this increment does not marshal at the call boundary.
+  ;; ---- GI-FPU-002 phase 3 (#369): the f32 call boundary is MARSHALLED -------
+  ;; Float-signature callees now LOWER: arguments move into the AAPCS-VFP
+  ;; S0.. pool, results come out of S0. Every callee below does real VFP
+  ;; arithmetic (it reads its S-register args and writes S0), so a caller that
+  ;; passed an arg in a core register or read the result from R0 diverges at
+  ;; the VALUE level — non-vacuous rows.
   (func $retf (result f32) f32.const 1.5)
-  (func (export "bad_ret_f32_call") (result i32)
-    call $retf i32.reinterpret_f32)
-  (func $takef (param f32) (result i32)
-    local.get 0 i32.reinterpret_f32)
-  (func (export "bad_f32_arg_call") (param i32) (result i32)
-    local.get 0 f32.reinterpret_i32 call $takef))
+  (func $scale (param f32 f32) (result f32)
+    local.get 0 local.get 1 f32.mul f32.const 1.5 f32.add)
+  (func $addn (param f32 i32) (result f32)
+    local.get 0 local.get 1 f32.convert_i32_s f32.add)
+
+  ;; f32 RESULT out of S0: call_ret(a) = bits($retf() + f32(a)).
+  (func (export "call_ret") (param i32) (result i32)
+    call $retf
+    local.get 0 f32.reinterpret_i32
+    f32.add
+    i32.reinterpret_f32)
+
+  ;; f32 ARGS into S0/S1: call_args(a, b) = bits($scale(f32(a), f32(b))).
+  (func (export "call_args") (param i32 i32) (result i32)
+    local.get 0 f32.reinterpret_i32
+    local.get 1 f32.reinterpret_i32
+    call $scale
+    i32.reinterpret_f32)
+
+  ;; MIXED int+float args: the core pool skips the f32 (i32 arg -> R0, not R1).
+  ;; call_mixed(n, xb) = bits($addn(f32(xb), n)).
+  (func (export "call_mixed") (param i32 i32) (result i32)
+    local.get 1 f32.reinterpret_i32
+    local.get 0
+    call $addn
+    i32.reinterpret_f32)
+
+  ;; OVERLAPPING sources: arg0's value is produced SECOND (lands in S1, must
+  ;; move to S0) while arg1 lives in the S0 local home (must move to S1) — the
+  ;; cross-swap exercises the two-phase frame staging, and the S0 home doubles
+  ;; as a home-register argument source.
+  (func (export "call_swap") (param i32 i32) (result i32)
+    (local f32)
+    local.get 1 f32.reinterpret_i32 local.set 2   ;; y -> S0 local home
+    local.get 0 f32.reinterpret_i32               ;; x -> S1 temp
+    local.get 2                                   ;; y (home S0)
+    call $scale                                   ;; wants x in S0, y in S1
+    i32.reinterpret_f32)
+
+  ;; f32 LIVE ACROSS a float-signature call: the live temp must survive both
+  ;; the callee's clobber AND the argument marshalling into its register.
+  ;; call_live(a, b) = bits(f32(a) + $scale(f32(b), 2.0)).
+  (func (export "call_live") (param i32 i32) (result i32)
+    local.get 0 f32.reinterpret_i32               ;; live f32 across the call
+    local.get 1 f32.reinterpret_i32
+    f32.const 2.0
+    call $scale
+    f32.add
+    i32.reinterpret_f32))

--- a/scripts/repro/f32_ops_719.wat
+++ b/scripts/repro/f32_ops_719.wat
@@ -110,6 +110,19 @@
     f32.add
     i32.reinterpret_f32)
 
+  ;; ---- GI-FPU-002 phase 3 (#369): copysign with a LIVE core value -----------
+  ;; The pre-fix F32Copysign encoder staged the magnitude through R0 — with
+  ;; f32 params (S0/S1) and no core params, the `i32.const 41` temp lands in
+  ;; R0 and is LIVE across the copysign, so the old sequence returned
+  ;; bits(copysign)+bits(copysign) instead of 41+bits(copysign). The rewrite
+  ;; clobbers only R12 (reserved encoder scratch).
+  (func (export "cs_live") (param f32 f32) (result i32)
+    i32.const 41
+    local.get 0
+    local.get 1
+    f32.copysign i32.reinterpret_f32
+    i32.add)
+
   ;; ---- GI-FPU-002 phase 3 (#369): the f32 call boundary is MARSHALLED -------
   ;; Float-signature callees now LOWER: arguments move into the AAPCS-VFP
   ;; S0.. pool, results come out of S0. Every callee below does real VFP

--- a/scripts/repro/f32_ops_719_differential.py
+++ b/scripts/repro/f32_ops_719_differential.py
@@ -332,22 +332,54 @@ def main():
                 print(f"[xhome] (0x{xb:08x},0x{b:08x}) -> 0x{got:08x} OK "
                       f"(param home across bl)")
 
-    # ---- #719 phase 2: float-signature callees must DECLINE (skip), never
-    # miscompile: their symbols must be ABSENT from the symtab.
-    for fn in ("bad_ret_f32_call", "bad_f32_arg_call"):
-        checked += 1
-        if fn in syms:
-            nonlocal_fail(f"{fn} COMPILED -- a float-signature call boundary "
-                          f"must decline loudly (S0/D0 not marshalled)")
-        else:
-            print(f"[{fn}] absent from symtab OK (loud decline)")
+    # ---- GI-FPU-002 phase 3 (#369): the f32 CALL BOUNDARY is marshalled -----
+    # Every callee does real VFP arithmetic (reads its S-register args, writes
+    # S0), so a caller that passed an argument in a core register or read the
+    # result from R0 diverges at the VALUE level. S0/S1 poisoned where they are
+    # not argument registers; NaN-aware compare (real f32 adds).
+    #  call_ret(a)      = bits(retf() + f32(a))          — result out of S0
+    #  call_args(a,b)   = bits(scale(f32(a), f32(b)))    — args into S0/S1
+    #  call_mixed(n,xb) = bits(addn(f32(xb), n))         — int arg skips S-pool
+    #  call_swap(a,b)   = cross-swapped arg sources      — two-phase staging
+    #  call_live(a,b)   = bits(f32(a) + scale(f32(b),2)) — live f32 across call
+    two_arg_rows = ((0x3FC00000, 0x40000000), (0x80000000, 0x7F800000),
+                    (0xC2F60000, 0x00000001), (0x7F7FFFFF, 0x7F7FFFFF),
+                    (0x42F60000, 0xBFC00000))
+    if need("call_ret"):
+        for b in EDGE_BITS:
+            uc = run(text, base, syms["call_ret"], r0=b, s0=0xDEADBEEF)
+            got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            want = exp["call_ret"](store, b) & 0xFFFFFFFF
+            checked += 1
+            if not f32_bits_eq(got, want):
+                nonlocal_fail(f"call_ret(0x{b:08x}) -> 0x{got:08x} "
+                              f"!= wasmtime 0x{want:08x}")
+            else:
+                print(f"[call_ret] 0x{b:08x} -> 0x{got:08x} OK (S0 result)")
+    for fn in ("call_args", "call_mixed", "call_swap", "call_live"):
+        if not need(fn):
+            continue
+        for a, b in two_arg_rows:
+            args = (a & 0x7FFFFFFF, b) if fn == "call_mixed" else (a, b)
+            uc = run(text, base, syms[fn], r0=args[0], r1=args[1],
+                     s0=0xDEADBEEF, s1=0xBADC0DE)
+            got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            want = exp[fn](store, *args) & 0xFFFFFFFF
+            checked += 1
+            if not f32_bits_eq(got, want):
+                nonlocal_fail(f"{fn}(0x{args[0]:08x},0x{args[1]:08x}) -> "
+                              f"0x{got:08x} != wasmtime 0x{want:08x}")
+            else:
+                print(f"[{fn}] (0x{args[0]:08x},0x{args[1]:08x}) -> "
+                      f"0x{got:08x} OK (marshalled boundary)")
 
     if fails:
         sys.exit(f"\nFAIL: {fails}/{checked} f32 #719 results diverged")
     print(f"\nGREEN: {checked}/{checked} f32 #719 results bit-exact vs wasmtime "
           f"(abs/neg/copysign/store/local.set/tee + mixed AAPCS-VFP params + "
-          f"phase-2 f32-across-call spill/reload; m3 honest-reject + "
-          f"float-signature-callee loud-decline confirmed).")
+          f"f32-across-call spill/reload + #369 phase-3 marshalled call "
+          f"boundary (S0 results, S-pool args, mixed, cross-swap staging); "
+          f"m3 honest-reject confirmed).")
 
 
 if __name__ == "__main__":

--- a/scripts/repro/f32_ops_719_differential.py
+++ b/scripts/repro/f32_ops_719_differential.py
@@ -217,6 +217,24 @@ def main():
                         f"!= wasmtime 0x{want:08x}")
         print(f"[copysign] {len(EDGE_BITS)*6} sign-splice cases checked")
 
+    # ---- GI-FPU-002 phase 3 (#369): copysign with a LIVE core value ----------
+    # cs_live(f32 a, f32 b) = 41 + bits(copysign(a, b)); a/b in S0/S1, and the
+    # `i32.const 41` temp lands in R0 — the pre-fix encoder staged the
+    # magnitude through R0 (clobbering the 41), the rewrite uses only R12.
+    if need("cs_live"):
+        for a, b in ((0x3FC00000, 0x80000000), (0xC2F60000, 0x00000000),
+                     (0x7FC00000, 0xFFC00000), (0x00000001, 0xBF800000)):
+            uc = run(text, base, syms["cs_live"], s0=a, s1=b, r0=0xDEAD0000)
+            got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            want = exp["cs_live"](store, bits_f32(a), bits_f32(b)) & 0xFFFFFFFF
+            checked += 1
+            if got != want:
+                nonlocal_fail(f"cs_live(0x{a:08x},0x{b:08x}) -> 0x{got:08x} "
+                              f"!= wasmtime 0x{want:08x}")
+            else:
+                print(f"[cs_live] (0x{a:08x},0x{b:08x}) -> 0x{got:08x} OK "
+                      f"(live R0 survives copysign)")
+
     # ---- f32.store(addr, bits): store to mem[addr], read back ----
     if need("store"):
         for i, b in enumerate(EDGE_BITS):

--- a/scripts/repro/f64_369.wat
+++ b/scripts/repro/f64_369.wat
@@ -82,9 +82,16 @@
   ;; i64-pair reading of R0:R1 would be a silent wrong-argument miscompile.
   (func (export "bad_dparam") (param f64 i32) (result i32)
     local.get 1)
-  ;; call to an f64-RETURNING callee: the result arrives in D0, which the call
-  ;; lowering does not marshal — the callee itself compiles (D0-homed return),
-  ;; the CALLER must decline.
-  (func $dret (result f64) f64.const 2.5)
-  (func (export "bad_dret_call") (param i32)
-    local.get 0 call $dret f64.store))
+
+  ;; ---- GI-FPU-002 phase 3 (#369): f64 RESULT marshalled out of D0 -----------
+  ;; The callee does real double-precision arithmetic (writes D0 and scratch),
+  ;; so a caller that read the result from R0:R1 — or failed to spill its own
+  ;; live double around the bl — diverges at the VALUE level.
+  (func $dret (result f64)
+    (f64.add (f64.load (i32.const 8)) (f64.const 2.5)))
+  (func (export "dretcall") (param i32)
+    local.get 0
+    (f64.load (i32.const 0))        ;; live f64 (D-register) across the call
+    call $dret                      ;; f64-returning callee: result in D0
+    f64.add
+    f64.store))

--- a/scripts/repro/f64_369.wat
+++ b/scripts/repro/f64_369.wat
@@ -77,11 +77,70 @@
     f64.add
     f64.store)
 
-  ;; ---- honest-decline shapes (must be ABSENT from the symtab) ---------------
-  ;; f64 PARAM on a hard-float target: arrives in D0 (AAPCS-VFP); the legacy
-  ;; i64-pair reading of R0:R1 would be a silent wrong-argument miscompile.
-  (func (export "bad_dparam") (param f64 i32) (result i32)
-    local.get 1)
+  ;; ---- GI-FPU-002 phase 3 (#369): f64 PARAMS homed in D-registers -----------
+  ;; dparam(f64 x, i32 addr): mem[addr] = x. x arrives in D0, addr in R0 (the
+  ;; core walk SKIPS the D-homed f64) — the legacy i64-pair reading of R0:R1
+  ;; would store garbage.
+  (func (export "dparam") (param f64 i32)
+    local.get 1 local.get 0 f64.store)
+
+  ;; AAPCS-VFP BACK-FILL: (f32, f64, f32, i32) homes S0, D1(=S2:S3), S1, R0 —
+  ;; the second f32 back-fills the S1 hole the f64's even-aligned pair skipped.
+  ;; dparam_mix(a, b, c, addr): mem[addr] = promote(a) + b + promote(c).
+  (func (export "dparam_mix") (param f32 f64 f32 i32)
+    local.get 3
+    local.get 0 f64.promote_f32
+    local.get 1 f64.add
+    local.get 2 f64.promote_f32 f64.add
+    f64.store)
+
+  ;; f64 PARAM HOME (D0 = S0:S1) live ACROSS an integer call whose callee
+  ;; genuinely clobbers S0/S1. dparam_home(x, b, addr): mem[addr] =
+  ;; promote(f32(fhelp(b))) + x  (x read AFTER the bl).
+  (func (export "dparam_home") (param f64 i32 i32)
+    local.get 2
+    local.get 1 call $fhelp f32.reinterpret_i32 f64.promote_f32
+    local.get 0 f64.add
+    f64.store)
+
+  ;; ---- GI-FPU-002 phase 3 (#369): f64 ARGS marshalled into D0/D1 ------------
+  ;; $dscale does real double-precision arithmetic on BOTH its D-register args,
+  ;; so passing either in a core pair (or in the wrong D-register) diverges.
+  (func $dscale (param f64 f64) (result f64)
+    local.get 0 local.get 1 f64.mul f64.const 2.5 f64.add)
+  (func $dmix (param f64 i32) (result f64)
+    local.get 0
+    local.get 1 f32.reinterpret_i32 f64.promote_f32
+    f64.add)
+
+  ;; in-place sources: mem[0] -> D0, mem[8] -> D1 == the argument registers.
+  (func (export "dcallargs") (param i32)
+    local.get 0
+    (f64.load (i32.const 0))
+    (f64.load (i32.const 8))
+    call $dscale
+    f64.store)
+
+  ;; CROSS-SWAPPED sources: y lives in the D0 local home, x is loaded into D1;
+  ;; the call wants x in D0 and y in D1 — the two-phase frame staging must
+  ;; swap them (and the D0 home doubles as a home-register argument source).
+  (func (export "dcallswap") (param i32)
+    (local f64)
+    (local.set 1 (f64.load (i32.const 8)))  ;; y -> D0 local home
+    local.get 0
+    (f64.load (i32.const 0))                ;; x -> D1
+    local.get 1                             ;; y (home D0)
+    call $dscale                            ;; wants x in D0, y in D1
+    f64.store)
+
+  ;; MIXED int + f64 args: the core pool takes only the i32 (R0), the f64
+  ;; goes to D0. dcallmix(addr, n): mem[addr] = $dmix(mem[0], n).
+  (func (export "dcallmix") (param i32 i32)
+    local.get 0
+    (f64.load (i32.const 0))
+    local.get 1
+    call $dmix
+    f64.store)
 
   ;; ---- GI-FPU-002 phase 3 (#369): f64 RESULT marshalled out of D0 -----------
   ;; The callee does real double-precision arithmetic (writes D0 and scratch),

--- a/scripts/repro/f64_369.wat
+++ b/scripts/repro/f64_369.wat
@@ -142,6 +142,59 @@
     call $dmix
     f64.store)
 
+  ;; ---- GI-FPU-002 phase 3 (#369): the f64 op TAIL ----------------------------
+  ;; rounding: OP(mem[0]) -> mem[addr] (VRINT{P,M,Z,N}.F64 — ties-to-even for
+  ;; nearest, ±0.0 sign preserved, NaN quietened)
+  (func (export "dceil") (param i32)
+    local.get 0 (f64.ceil (f64.load (i32.const 0))) f64.store)
+  (func (export "dfloor") (param i32)
+    local.get 0 (f64.floor (f64.load (i32.const 0))) f64.store)
+  (func (export "dtrunc") (param i32)
+    local.get 0 (f64.trunc (f64.load (i32.const 0))) f64.store)
+  (func (export "dnearest") (param i32)
+    local.get 0 (f64.nearest (f64.load (i32.const 0))) f64.store)
+
+  ;; min/max: mem[0] OP mem[8] -> mem[addr] (VMINNM/VMAXNM + NaN fix-up:
+  ;; any-NaN-operand => NaN, min(+0,-0) = -0, max = +0)
+  (func (export "dmin") (param i32)
+    local.get 0 (f64.min (f64.load (i32.const 0)) (f64.load (i32.const 8)))
+    f64.store)
+  (func (export "dmax") (param i32)
+    local.get 0 (f64.max (f64.load (i32.const 0)) (f64.load (i32.const 8)))
+    f64.store)
+
+  ;; copysign(a=mem[0], b=mem[8]) -> mem[addr] (VABS + conditional VNEG splice)
+  (func (export "dcopysign") (param i32)
+    local.get 0 (f64.copysign (f64.load (i32.const 0)) (f64.load (i32.const 8)))
+    f64.store)
+
+  ;; f32.demote_f64(mem[0]) -> i32 bits (round-to-nearest-even; overflow->inf,
+  ;; underflow->signed zero/subnormal)
+  (func (export "ddemote") (result i32)
+    (i32.reinterpret_f32 (f32.demote_f64 (f64.load (i32.const 0)))))
+
+  ;; i32 -> f64 (exact for every i32): convert(n) -> mem[addr]
+  (func (export "dconvs") (param i32 i32)
+    local.get 1 (f64.convert_i32_s (local.get 0)) f64.store)
+  (func (export "dconvu") (param i32 i32)
+    local.get 1 (f64.convert_i32_u (local.get 0)) f64.store)
+
+  ;; i32.trunc_f64_{s,u}(mem[0]) -> i32 — TRAPS (UDF) on NaN/out-of-range
+  ;; per WASM Core 4.3.3 (the #709 domain guard, f64 twin)
+  (func (export "dtruncs") (result i32)
+    (i32.trunc_f64_s (f64.load (i32.const 0))))
+  (func (export "dtruncu") (result i32)
+    (i32.trunc_f64_u (f64.load (i32.const 0))))
+
+  ;; the trunc encoder converts in place (source D low S-alias) — a PARAM HOME
+  ;; must survive: mem[addr] = x + convert(trunc(x)) reads x AFTER the trunc.
+  (func (export "dtrunchome") (param f64 i32)
+    local.get 1
+    local.get 0
+    (f64.convert_i32_s (i32.trunc_f64_s (local.get 0)))
+    f64.add
+    f64.store)
+
   ;; ---- GI-FPU-002 phase 3 (#369): f64 RESULT marshalled out of D0 -----------
   ;; The callee does real double-precision arithmetic (writes D0 and scratch),
   ;; so a caller that read the result from R0:R1 — or failed to spill its own

--- a/scripts/repro/f64_369_differential.py
+++ b/scripts/repro/f64_369_differential.py
@@ -176,7 +176,8 @@ def main():
         if ok:
             _, _, syms = load(out)
             leaked = [s for s in
-                      ("dconst", "dadd", "dlt", "dpromote", "dxcall")
+                      ("dconst", "dadd", "dlt", "dpromote", "dxcall",
+                       "dretcall")
                       if s in syms]
             if leaked:
                 sys.exit(f"FAIL: f64 functions {leaked} must be REJECTED on "
@@ -291,8 +292,28 @@ def main():
                 print(f"[dxcall] (0x{a:016x},0x{b32:08x}) -> 0x{got:016x} OK "
                       f"(f64 live across bl)")
 
+    # ---- GI-FPU-002 phase 3 (#369): f64 RESULT marshalled out of D0 ---------
+    # dretcall(addr): mem[addr] = mem[0] + dret() where dret() = mem[8] + 2.5
+    # computes in D0 — a caller reading R0:R1, or failing to preserve its live
+    # double around the bl, diverges at the value level.
+    if need("dretcall"):
+        for a, b in PAIRS:
+            uc = run(text, base, syms["dretcall"], mem0=a, mem8=b,
+                     r0=RESULT_ADDR)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            set_wasm_mem(a, b)
+            want = wasm_store_result("dretcall", RESULT_ADDR)
+            checked += 1
+            if not f64_bits_eq(got, want):
+                fail(f"dretcall(0x{a:016x}, 0x{b:016x}) -> 0x{got:016x} "
+                     f"!= wasmtime 0x{want:016x}")
+            else:
+                print(f"[dretcall] (0x{a:016x},0x{b:016x}) -> 0x{got:016x} OK "
+                      f"(D0 result marshalled)")
+
     # ---- honest declines on m7dp: absent from the symtab ---------------------
-    for fn in ("bad_dparam", "bad_dret_call"):
+    for fn in ("bad_dparam",):
         checked += 1
         if fn in syms:
             fail(f"{fn} COMPILED — an f64 ABI boundary this increment does "
@@ -303,9 +324,9 @@ def main():
     if fails:
         sys.exit(f"\nFAIL: {fails}/{checked} f64 #369 results diverged")
     print(f"\nGREEN: {checked}/{checked} f64 #369 results bit-exact vs wasmtime "
-          f"(const/promote/arith/compare/load/store + f64-across-call on "
-          f"cortex-m7dp; m4f + m3 honest-reject + f64-ABI loud-decline "
-          f"confirmed).")
+          f"(const/promote/arith/compare/load/store + f64-across-call + "
+          f"phase-3 D0-result call marshalling on cortex-m7dp; m4f + m3 "
+          f"honest-reject + f64-param loud-decline confirmed).")
 
 
 if __name__ == "__main__":

--- a/scripts/repro/f64_369_differential.py
+++ b/scripts/repro/f64_369_differential.py
@@ -1,26 +1,29 @@
 #!/usr/bin/env python3
-"""#369 (GI-FPU-002 phase 2) — EXECUTION-validate the scalar f64 subset on
+"""#369 (GI-FPU-002 phases 2+3) — EXECUTION-validate scalar f64 on
 cortex-m7dp (double-precision VFP).
 
-Lowered set (everything else f64 stays decode-dropped -> loud-skip):
+Lowered set (still decode-dropped -> loud-skip: only i64<->f64 conversions
+and the f64<->i64 reinterprets, which need lowered pair plumbing):
   * f64.const            — full 64-bit pattern via 2x MOVW/MOVT + VMOV Dd,lo,hi
-  * f64.promote_f32      — VCVT.F64.F32 (falcon's 3-function blocker)
+  * f64.promote_f32 / f32.demote_f64 — VCVT (round-to-nearest-even demote)
   * add/sub/mul/div      — VADD/VSUB/VMUL/VDIV .F64
   * abs/neg/sqrt         — VABS/VNEG/VSQRT .F64
-  * eq/ne/lt/le/gt/ge    — VCMP.F64 + VMRS + IT (NaN-audited ordered set; the
-                           encoder shipped the SAME #712 flag-clobber bug the
-                           f32 compares had — MOVS after VMRS — fixed here)
+  * ceil/floor/trunc/nearest — single VRINT{P,M,Z,N}.F64 (FPv5)
+  * min/max              — VMINNM/VMAXNM + the VS-guarded NaN fix-up
+  * copysign             — VABS + conditional VNEG (R12-only scratch)
+  * eq/ne/lt/le/gt/ge    — VCMP.F64 + VMRS + IT (NaN-audited ordered set)
+  * f64.convert_i32_s/u  — VCVT staged through the dest's own S-alias
+  * i32.trunc_f64_s/u    — #709-twin domain guard: TRAPS (UDF) out of range
   * f64.load/f64.store   — two PROVEN bounds-checked 4-byte integer accesses
-  * f64 live ACROSS an integer call — D0..D7 are caller-saved, preserved as
-                           aliased S-word pairs by the #719 VFP call-spill
+  * f64 live ACROSS calls, f64 PARAMS in AAPCS-VFP D-homes (back-fill
+    layout), and the marshalled call boundary (D0/D1 args, D0 results)
 
 Each op is differentiated under unicorn vs wasmtime, BIT-EXACT on the 64-bit
 result pattern with NaN==NaN per WASM Core §4.3.3 (NaN sign/payload is
 non-deterministic; mirrors f32_bits_eq in f32_vfp_619_differential.py).
 
 Honest rejections pinned: the whole fixture on cortex-m4f (single-precision)
-and cortex-m3 (no FPU); f64-param functions and f64-returning CALLS on m7dp
-(absent from the symtab — loud decline, never a miscompile).
+and cortex-m3 (no FPU).
 
 Run (needs wasmtime + unicorn + pyelftools):
   SYNTH=/path/to/synth python scripts/repro/f64_369_differential.py

--- a/scripts/repro/f64_369_differential.py
+++ b/scripts/repro/f64_369_differential.py
@@ -35,10 +35,15 @@ import wasmtime
 from elftools.elf.elffile import ELFFile
 from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
 from unicorn.arm_const import (
+    UC_ARM_REG_D0,
+    UC_ARM_REG_D1,
     UC_ARM_REG_LR,
     UC_ARM_REG_R0,
     UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
     UC_ARM_REG_R11,
+    UC_ARM_REG_S0,
+    UC_ARM_REG_S1,
     UC_ARM_REG_SP,
 )
 
@@ -119,7 +124,8 @@ def new_uc(text, text_base):
     return uc
 
 
-def run(text, base, addr, mem0=None, mem8=None, r0=None, r1=None):
+def run(text, base, addr, mem0=None, mem8=None, r0=None, r1=None, r2=None,
+        d0=None, d1=None, s0=None, s1=None):
     uc = new_uc(text, base)
     if mem0 is not None:
         uc.mem_write(MEMBASE + 0, struct.pack("<Q", mem0))
@@ -129,6 +135,16 @@ def run(text, base, addr, mem0=None, mem8=None, r0=None, r1=None):
         uc.reg_write(UC_ARM_REG_R0, r0 & 0xFFFFFFFF)
     if r1 is not None:
         uc.reg_write(UC_ARM_REG_R1, r1 & 0xFFFFFFFF)
+    if r2 is not None:
+        uc.reg_write(UC_ARM_REG_R2, r2 & 0xFFFFFFFF)
+    if d0 is not None:
+        uc.reg_write(UC_ARM_REG_D0, d0 & 0xFFFFFFFFFFFFFFFF)
+    if d1 is not None:
+        uc.reg_write(UC_ARM_REG_D1, d1 & 0xFFFFFFFFFFFFFFFF)
+    if s0 is not None:
+        uc.reg_write(UC_ARM_REG_S0, s0 & 0xFFFFFFFF)
+    if s1 is not None:
+        uc.reg_write(UC_ARM_REG_S1, s1 & 0xFFFFFFFF)
     uc.reg_write(UC_ARM_REG_LR, 0x38000 | 1)
     uc.emu_start(addr | 1, 0x38000, count=400)
     return uc
@@ -177,7 +193,8 @@ def main():
             _, _, syms = load(out)
             leaked = [s for s in
                       ("dconst", "dadd", "dlt", "dpromote", "dxcall",
-                       "dretcall")
+                       "dretcall", "dparam", "dparam_mix", "dcallargs",
+                       "dcallswap", "dcallmix")
                       if s in syms]
             if leaked:
                 sys.exit(f"FAIL: f64 functions {leaked} must be REJECTED on "
@@ -312,21 +329,101 @@ def main():
                 print(f"[dretcall] (0x{a:016x},0x{b:016x}) -> 0x{got:016x} OK "
                       f"(D0 result marshalled)")
 
-    # ---- honest declines on m7dp: absent from the symtab ---------------------
-    for fn in ("bad_dparam",):
-        checked += 1
-        if fn in syms:
-            fail(f"{fn} COMPILED — an f64 ABI boundary this increment does "
-                 f"not marshal must decline loudly")
-        else:
-            print(f"[{fn}] absent from symtab OK (loud decline)")
+    # ---- GI-FPU-002 phase 3 (#369): f64 PARAMS homed in D-registers ---------
+    # dparam(f64 x, i32 addr): mem[addr] = x. x in D0, addr in R0 (core walk
+    # skips the D-homed f64); R0:R1 poisoned-by-addr, R1 poisoned explicitly.
+    if need("dparam"):
+        for a, _ in PAIRS:
+            uc = run(text, base, syms["dparam"], d0=a, r0=RESULT_ADDR,
+                     r1=0xBADC0DE)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            want = wasm_store_result("dparam", bits_f64(a), RESULT_ADDR)
+            checked += 1
+            if not f64_bits_eq(got, want):
+                fail(f"dparam(0x{a:016x}) -> 0x{got:016x} "
+                     f"!= wasmtime 0x{want:016x}")
+            else:
+                print(f"[dparam] 0x{a:016x} -> stored bit-exact OK (D0 home)")
+
+    # dparam_mix(f32 a, f64 b, f32 c, i32 addr): back-fill homes S0, D1, S1 —
+    # c read from the back-filled S1 (a sequential-S misassignment diverges).
+    if need("dparam_mix"):
+        for ab, b64, cb in ((0x3FC00000, D(2.25), 0x40200000),
+                            (0x80000000, D(-0.0), 0x00000000),
+                            (0xC2F60000, D(1e10), 0x00000001),
+                            (0x7F800000, D(-1.5), 0x3F800000)):
+            uc = run(text, base, syms["dparam_mix"], s0=ab, s1=cb, d1=b64,
+                     r0=RESULT_ADDR, r1=0xBADC0DE)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            want = wasm_store_result("dparam_mix", bits_f32(ab),
+                                     bits_f64(b64), bits_f32(cb), RESULT_ADDR)
+            checked += 1
+            if not f64_bits_eq(got, want):
+                fail(f"dparam_mix(0x{ab:08x},0x{b64:016x},0x{cb:08x}) -> "
+                     f"0x{got:016x} != wasmtime 0x{want:016x}")
+            else:
+                print(f"[dparam_mix] -> 0x{got:016x} OK (S0/D1/S1 back-fill)")
+
+    # dparam_home(f64 x, i32 b, i32 addr): the D0 param home must survive an
+    # integer call whose callee clobbers S0/S1 (=D0).
+    if need("dparam_home"):
+        for (a, _), b32 in zip(PAIRS, PROMOTE_BITS):
+            uc = run(text, base, syms["dparam_home"], d0=a, r0=b32,
+                     r1=RESULT_ADDR)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            want = wasm_store_result("dparam_home", bits_f64(a), b32,
+                                     RESULT_ADDR)
+            checked += 1
+            if not f64_bits_eq(got, want):
+                fail(f"dparam_home(0x{a:016x},0x{b32:08x}) -> 0x{got:016x} "
+                     f"!= wasmtime 0x{want:016x}")
+            else:
+                print(f"[dparam_home] (0x{a:016x},0x{b32:08x}) -> "
+                      f"0x{got:016x} OK (D0 home across bl)")
+
+    # ---- GI-FPU-002 phase 3 (#369): f64 ARGS marshalled into D0/D1 ----------
+    # dcallargs: in-place sources; dcallswap: CROSS-SWAPPED sources through the
+    # two-phase staging (D0 local home <-> D1 temp); dcallmix: int+f64 mixed.
+    for fn in ("dcallargs", "dcallswap"):
+        if not need(fn):
+            continue
+        for a, b in PAIRS:
+            uc = run(text, base, syms[fn], mem0=a, mem8=b, r0=RESULT_ADDR)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            set_wasm_mem(a, b)
+            want = wasm_store_result(fn, RESULT_ADDR)
+            checked += 1
+            if not f64_bits_eq(got, want):
+                fail(f"{fn}(0x{a:016x}, 0x{b:016x}) -> 0x{got:016x} "
+                     f"!= wasmtime 0x{want:016x}")
+        print(f"[{fn}] {len(PAIRS)} edge pairs OK (D-file args marshalled)")
+    if need("dcallmix"):
+        for (a, _), b32 in zip(PAIRS, PROMOTE_BITS):
+            uc = run(text, base, syms["dcallmix"], mem0=a, r0=RESULT_ADDR,
+                     r1=b32)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            set_wasm_mem(a, 0)
+            want = wasm_store_result("dcallmix", RESULT_ADDR, b32)
+            checked += 1
+            if not f64_bits_eq(got, want):
+                fail(f"dcallmix(0x{a:016x},0x{b32:08x}) -> 0x{got:016x} "
+                     f"!= wasmtime 0x{want:016x}")
+            else:
+                print(f"[dcallmix] (0x{a:016x},0x{b32:08x}) -> 0x{got:016x} "
+                      f"OK (mixed int+f64 args)")
 
     if fails:
         sys.exit(f"\nFAIL: {fails}/{checked} f64 #369 results diverged")
     print(f"\nGREEN: {checked}/{checked} f64 #369 results bit-exact vs wasmtime "
           f"(const/promote/arith/compare/load/store + f64-across-call + "
-          f"phase-3 D0-result call marshalling on cortex-m7dp; m4f + m3 "
-          f"honest-reject + f64-param loud-decline confirmed).")
+          f"phase-3 f64 param D-homes (incl. back-fill + across-call) + "
+          f"D0/D1 argument + D0 result call marshalling on cortex-m7dp; "
+          f"m4f + m3 honest-reject confirmed).")
 
 
 if __name__ == "__main__":

--- a/scripts/repro/f64_369_differential.py
+++ b/scripts/repro/f64_369_differential.py
@@ -33,11 +33,12 @@ from pathlib import Path
 
 import wasmtime
 from elftools.elf.elffile import ELFFile
-from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
 from unicorn.arm_const import (
     UC_ARM_REG_D0,
     UC_ARM_REG_D1,
     UC_ARM_REG_LR,
+    UC_ARM_REG_PC,
     UC_ARM_REG_R0,
     UC_ARM_REG_R1,
     UC_ARM_REG_R2,
@@ -92,6 +93,21 @@ def bits_f32(b):
     return struct.unpack("<f", struct.pack("<I", b & 0xFFFFFFFF))[0]
 
 
+def is_nan32(bits):
+    b = bits & 0xFFFFFFFF
+    return (b & 0x7F800000) == 0x7F800000 and (b & 0x007FFFFF) != 0
+
+
+def f32_bits_eq(got, want):
+    if is_nan32(got) and is_nan32(want):
+        return True
+    return (got & 0xFFFFFFFF) == (want & 0xFFFFFFFF)
+
+
+def f32_bits(x):
+    return struct.unpack("<I", struct.pack("<f", x))[0]
+
+
 def is_nan64(bits):
     b = bits & 0xFFFFFFFFFFFFFFFF
     return (b & 0x7FF0000000000000) == 0x7FF0000000000000 and (
@@ -108,6 +124,16 @@ def f64_bits_eq(got, want):
 
 def new_uc(text, text_base):
     uc = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    # GI-FPU-002 phase 3 (#369): the rounding/min-max lowerings use FPv5
+    # VRINT{N,P,M,Z}.F64 / VMINNM / VMAXNM (ARMv8 FP encodings) — unicorn's
+    # DEFAULT ARM model predates them (UC_ERR_INSN_INVALID), so pick the MAX
+    # feature model. Older unicorns without ctl_set_cpu_model skip (the CI
+    # runner pins a current unicorn).
+    try:
+        from unicorn.arm_const import UC_CPU_ARM_MAX
+        uc.ctl_set_cpu_model(UC_CPU_ARM_MAX)
+    except (ImportError, AttributeError):
+        pass
     map_base = text_base & ~0xFFF
     size = ((len(text) + (text_base - map_base)) + 0xFFF) & ~0xFFF
     uc.mem_map(map_base, max(size, 0x1000))
@@ -150,6 +176,25 @@ def run(text, base, addr, mem0=None, mem8=None, r0=None, r1=None, r2=None,
     return uc
 
 
+def run_or_trap(text, base, addr, mem0=None):
+    """Like `run`, but a UDF trap (the #709 domain guard) returns 'trap'
+    instead of raising — mirrors f32_mem_trunc_708_709_differential.py."""
+    uc = new_uc(text, base)
+    if mem0 is not None:
+        uc.mem_write(MEMBASE + 0, struct.pack("<Q", mem0))
+    uc.reg_write(UC_ARM_REG_LR, 0x38000 | 1)
+    try:
+        uc.emu_start(addr | 1, 0x38000, count=400)
+    except UcError as e:
+        pc = uc.reg_read(UC_ARM_REG_PC)
+        if base <= pc < base + len(text):
+            hw = struct.unpack("<H", text[pc - base:pc - base + 2])[0]
+            if hw & 0xFF00 == 0xDE00:  # Thumb UDF #imm
+                return ("trap", None)
+        return ("fault", f"{e} at pc={pc:#x} (NOT a udf trap)")
+    return ("ok", uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF)
+
+
 def wasm_instance():
     eng = wasmtime.Engine()
     mod = wasmtime.Module(eng, WAT.read_bytes())
@@ -179,6 +224,59 @@ PROMOTE_BITS = [
 
 RESULT_ADDR = 64  # where the store-result functions write
 
+# ---- GI-FPU-002 phase 3 (#369): op-tail edge tables -------------------------
+NAN = float("nan")
+INF = float("inf")
+# Rounding edges: ties (nearest is ties-to-even: 0.5->0, 1.5->2, 2.5->2),
+# signed zeros (ceil(-0.5) = -0.0), NaN/inf propagation, integral-boundary
+# magnitudes (2^52-0.5 is the largest fractional f64), subnormal.
+ROUND_BITS = [
+    D(0.5), D(-0.5), D(1.5), D(-1.5), D(2.5), D(-2.5),
+    D(0.0), D(-0.0), D(0.25), D(-0.25),
+    0x7FF8000000000000,            # NaN
+    D(INF), D(-INF),
+    D(4503599627370495.5),         # 2^52 - 0.5 (largest fractional)
+    D(-4503599627370495.5),
+    0x0000000000000001,            # +subnormal min
+    D(1.7976931348623157e308),
+]
+# min/max: the NaN and signed-zero rows are exactly where VMINNM/VMAXNM alone
+# (IEEE minNum/maxNum) and the old ordered-select pseudo-op diverge from WASM.
+MINMAX_PAIRS = PAIRS + [
+    (D(1.0), 0x7FF8000000000000),  # x op NaN -> NaN (minNum would say x)
+    (0x7FF8000000000000, 0x7FF8000000000000),
+    (D(0.0), D(-0.0)),             # min -> -0.0, max -> +0.0
+    (D(-0.0), D(0.0)),
+    (D(-INF), D(INF)),
+    (D(1.5), D(-2.5)),
+]
+# demote: overflow -> ±inf, rounding, underflow -> signed zero/subnormal.
+DEMOTE_BITS = [
+    D(1.5), D(-1.5), D(0.0), D(-0.0), 0x7FF8000000000000, D(INF), D(-INF),
+    D(1.7976931348623157e308),     # overflows f32 -> +inf
+    D(-1.7976931348623157e308),
+    D(3.4028235677973366e38),      # just above FLT_MAX -> rounds to inf
+    D(1e-45),                      # underflow -> f32 subnormal
+    D(-1e-320),                    # -> -0.0
+    D(3.141592653589793),          # rounding to nearest f32
+]
+# i32 <-> f64 conversion edges (conversions are exact; trunc traps out of range).
+CONV_INTS = [0, 1, 0xFFFFFFFF, 0x80000000, 0x7FFFFFFF, 12345678, 0xDEADBEEF]
+TRUNC_S_TABLE = [
+    (D(2.5), "ok"), (D(-2.5), "ok"), (D(0.0), "ok"), (D(-0.5), "ok"),
+    (D(2147483647.999), "ok"), (D(-2147483648.999), "ok"),  # trunc into range
+    (0x7FF8000000000000, "trap"), (D(INF), "trap"), (D(-INF), "trap"),
+    (D(2147483648.0), "trap"),     # 2^31 exactly
+    (D(-2147483649.0), "trap"),    # -(2^31)-1 exactly
+    (D(3e9), "trap"), (D(-3e9), "trap"),
+]
+TRUNC_U_TABLE = [
+    (D(2.5), "ok"), (D(0.0), "ok"), (D(-0.5), "ok"),
+    (D(4294967295.999), "ok"),
+    (0x7FF8000000000000, "trap"), (D(INF), "trap"),
+    (D(-1.0), "trap"), (D(4294967296.0), "trap"), (D(5e9), "trap"),
+]
+
 
 def main():
     elf = "/tmp/f64_369.elf"
@@ -194,7 +292,8 @@ def main():
             leaked = [s for s in
                       ("dconst", "dadd", "dlt", "dpromote", "dxcall",
                        "dretcall", "dparam", "dparam_mix", "dcallargs",
-                       "dcallswap", "dcallmix")
+                       "dcallswap", "dcallmix", "dceil", "dmin", "dcopysign",
+                       "ddemote", "dconvs", "dtruncs", "dtrunchome")
                       if s in syms]
             if leaked:
                 sys.exit(f"FAIL: f64 functions {leaked} must be REJECTED on "
@@ -292,6 +391,108 @@ def main():
                 fail(f"{fn}(0x{a:016x}, 0x{b:016x}) -> {got} "
                      f"!= wasmtime {want}")
         print(f"[{fn}] {len(PAIRS)} edge pairs OK")
+
+    # ---- GI-FPU-002 phase 3 (#369): rounding (VRINT{P,M,Z,N}.F64) -----------
+    for fn in ("dceil", "dfloor", "dtrunc", "dnearest"):
+        if not need(fn):
+            continue
+        for a in ROUND_BITS:
+            uc = run(text, base, syms[fn], mem0=a, r0=RESULT_ADDR)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            set_wasm_mem(a, 0)
+            want = wasm_store_result(fn, RESULT_ADDR)
+            checked += 1
+            if not f64_bits_eq(got, want):
+                fail(f"{fn}(0x{a:016x}) -> 0x{got:016x} "
+                     f"!= wasmtime 0x{want:016x}")
+        print(f"[{fn}] {len(ROUND_BITS)} rounding edges OK "
+              f"(ties/±0.0/NaN/inf/2^52)")
+
+    # ---- min/max (VMINNM/VMAXNM + the NaN fix-up) + copysign ----------------
+    for fn in ("dmin", "dmax", "dcopysign"):
+        if not need(fn):
+            continue
+        for a, b in MINMAX_PAIRS:
+            uc = run(text, base, syms[fn], mem0=a, mem8=b, r0=RESULT_ADDR)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            set_wasm_mem(a, b)
+            want = wasm_store_result(fn, RESULT_ADDR)
+            checked += 1
+            if not f64_bits_eq(got, want):
+                fail(f"{fn}(0x{a:016x}, 0x{b:016x}) -> 0x{got:016x} "
+                     f"!= wasmtime 0x{want:016x}")
+        print(f"[{fn}] {len(MINMAX_PAIRS)} edge pairs OK (NaN/±0 rows incl.)")
+
+    # ---- f32.demote_f64 ------------------------------------------------------
+    if need("ddemote"):
+        for a in DEMOTE_BITS:
+            uc = run(text, base, syms["ddemote"], mem0=a)
+            got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            set_wasm_mem(a, 0)
+            want = exp["ddemote"](store) & 0xFFFFFFFF
+            checked += 1
+            if not f32_bits_eq(got, want):
+                fail(f"ddemote(0x{a:016x}) -> 0x{got:08x} "
+                     f"!= wasmtime 0x{want:08x}")
+        print(f"[ddemote] {len(DEMOTE_BITS)} edges OK "
+              f"(overflow->inf, underflow->±0/subnormal)")
+
+    # ---- i32 -> f64 conversions (exact) --------------------------------------
+    for fn in ("dconvs", "dconvu"):
+        if not need(fn):
+            continue
+        for n in CONV_INTS:
+            uc = run(text, base, syms[fn], r0=n, r1=RESULT_ADDR)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            want = wasm_store_result(fn, n, RESULT_ADDR)
+            checked += 1
+            if got != want:
+                fail(f"{fn}(0x{n:08x}) -> 0x{got:016x} "
+                     f"!= wasmtime 0x{want:016x}")
+        print(f"[{fn}] {len(CONV_INTS)} conversions bit-exact OK")
+
+    # ---- i32.trunc_f64_{s,u}: TRAP (UDF) on NaN/out-of-range (#709 twin) ----
+    def wasm_call_or_trap(fn):
+        try:
+            return exp[fn](store) & 0xFFFFFFFF
+        except wasmtime.Trap:
+            return "trap"
+
+    for fn, table in (("dtruncs", TRUNC_S_TABLE), ("dtruncu", TRUNC_U_TABLE)):
+        if not need(fn):
+            continue
+        for a, want_kind in table:
+            kind, got = run_or_trap(text, base, syms[fn], mem0=a)
+            set_wasm_mem(a, 0)
+            wv = wasm_call_or_trap(fn)
+            checked += 1
+            if want_kind == "trap":
+                if wv != "trap":
+                    fail(f"{fn}: wasmtime did NOT trap on 0x{a:016x} — "
+                         f"trap table wrong")
+                elif kind != "trap":
+                    fail(f"{fn}(0x{a:016x}) must TRAP (UDF), got {kind}:{got}")
+            elif kind != "ok" or wv == "trap" or got != wv:
+                fail(f"{fn}(0x{a:016x}) -> {kind}:{got} != wasmtime {wv}")
+        print(f"[{fn}] {len(table)} rows OK (traps trap, in-range bit-exact)")
+
+    # the trunc encoder converts in place — the D0 PARAM HOME must survive
+    if need("dtrunchome"):
+        for a in (D(2.5), D(-1234.75), D(0.0), D(2147483000.0)):
+            uc = run(text, base, syms["dtrunchome"], d0=a, r0=RESULT_ADDR)
+            got = struct.unpack("<Q", bytes(
+                uc.mem_read(MEMBASE + RESULT_ADDR, 8)))[0]
+            want = wasm_store_result("dtrunchome", bits_f64(a), RESULT_ADDR)
+            checked += 1
+            if not f64_bits_eq(got, want):
+                fail(f"dtrunchome(0x{a:016x}) -> 0x{got:016x} "
+                     f"!= wasmtime 0x{want:016x}")
+            else:
+                print(f"[dtrunchome] 0x{a:016x} -> 0x{got:016x} OK "
+                      f"(home survives in-place VCVT)")
 
     # ---- f64 live ACROSS an integer call (D-file caller-saved spill) --------
     if need("dxcall"):
@@ -420,10 +621,12 @@ def main():
     if fails:
         sys.exit(f"\nFAIL: {fails}/{checked} f64 #369 results diverged")
     print(f"\nGREEN: {checked}/{checked} f64 #369 results bit-exact vs wasmtime "
-          f"(const/promote/arith/compare/load/store + f64-across-call + "
-          f"phase-3 f64 param D-homes (incl. back-fill + across-call) + "
-          f"D0/D1 argument + D0 result call marshalling on cortex-m7dp; "
-          f"m4f + m3 honest-reject confirmed).")
+          f"(const/promote/arith/compare/load/store + the phase-3 op tail "
+          f"(ceil/floor/trunc/nearest via VRINT, min/max, copysign, demote, "
+          f"i32<->f64 converts, trunc trap table) + f64 param D-homes "
+          f"(incl. back-fill + across-call) + D0/D1 argument + D0 result "
+          f"call marshalling on cortex-m7dp; m4f + m3 honest-reject "
+          f"confirmed).")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Lane C of the v0.43.0 hub: the three residuals PR #741 named are all landed, closing the scalar-float ABI loop end-to-end on hard-float targets. Three commits, one per part, each independently oracle-gated (plus the session-limit salvage snapshot this resumes).

Refs #369, #719, #709, epic #242 (VCR track C: differential-gated increments).

## Part 1 — AAPCS-VFP call-boundary marshalling (`da3f0f4`)

| Case | Status | How |
|---|---|---|
| f32/f64 call **arguments** | **LANDED** | into the independent VFP pool (f32→S0.., f64→D0.., back-fill via `vfp_param_layout`); overlap-safe two-phase staging through the VFP call-spill area (sources parked in their own S-indexed slots first) |
| f32/f64 call **results** | **LANDED** | out of S0/D0 onto the operand stack as `Float`/`Double`, captured into a fresh VFP temp BEFORE the caller-saved reloads |
| capability gates | **LANDED** | f64 boundary needs m7dp; any float boundary needs an FPU — symmetric with the callee's own decline, never an UNDEFINED D-op |
| Meld-dispatch float import / i64 arg mixed into a float call (#503) / `call_indirect` float return / >16-S-slot overflow | **DECLINED loudly** | named follow-ups |

## Part 2 — f64 params in AAPCS-VFP D-homes (`148e1f3`)

| Case | Status | How |
|---|---|---|
| f64 param homing (m7dp) | **LANDED** | D-register homes; core walk skips them (`(f64,i32)` → i32 in **R0**, never the shifted pair); `#518` i64-seed skips them |
| mixed-float back-fill | **LANDED** | `(f32, f64, f32)` homes S0, D1(=S2:S3), **S1** (f32-only signatures byte-identical to #719) |
| f64 `local.get/set/tee` + non-param f64 locals | **LANDED** | stable D-home, bit-exact core-round-trip copies |
| frame-backing across calls | **LANDED** | the D-home's two aliased S-words ride the existing 16-slot VFP call-spill area |
| f64 param on m4f | **DECLINED loudly** (no f64 op could consume it); soft-float keeps the ABI-correct core pair |

## Part 3 — f64 op tail, composed real sequences (`4e57710`)

| Op | Status | How |
|---|---|---|
| `f64.ceil/floor/trunc/nearest` | **LANDED** | single `VRINT{P,M,Z,N}.F64` (FPv5) — the prototype pseudo-op round-tripped through a 32-bit int in S0 (wrong ≥2^31, NaN/±inf→0, −0.0 lost) |
| `f64.min/max` | **LANDED** | `VCMP+VMRS+VMINNM/VMAXNM+IT VS+VADD` NaN fix-up (minNum returns the NUMBER on one NaN; WASM wants NaN); −0.0<+0.0 ordered; encoder errs on dest/source alias |
| `f64.copysign` **and the shipped `f32.copysign`** | **LANDED / FIXED** | `VMOV R12,sign; CMP; VABS; IT MI; VNEG` — R12(reserved)/flags/dest only. The shipped f32 encoder staged the magnitude through **R0**, silently corrupting any live R0 value (#615 class, found composing the f64 twin; `cs_live` oracle row pins it) |
| `f32.demote_f64` | **LANDED** | new `ArmOp::F32DemoteF64`, single `VCVT.F32.F64` |
| `f64.convert_i32_s/u` | **LANDED** + **fix**: the encoder had the signed/unsigned VCVT bases SWAPPED (same latent swap the f32 twin fixed) and staged through live S0 — now via the destination's own S-alias |
| `i32.trunc_f64_s/u` | **LANDED** | #709-twin domain guard (two strict F64 compares → UDF) before the saturating VCVT; converts via the source's S-alias, param/local HOMES copied to a fresh D-temp first (**same latent home-clobber fixed in the f32 trunc**) |
| `i64<->f64` conversions / reinterprets | **stay decode-dropped** (loud-skip) — need lowered i64-pair plumbing |
| any f64 op on m4f/m7/m0/m3/r5 | **honest-reject**, per-op pinned |
| `-b riscv` / `-b aarch64` on the newly-decoded ops | **loud-reject** by op name (verified on the fixture) |

Every new encoding is byte-verified against clang (`thumbv7em-none-eabi`, `fpv5-d16`) in `test_369_f64_tail_thumb2_encodings_match_clang`; A32 keeps typed loud Errs (no A32 target has an FPU; #615 no-wildcard tripwire updated, 221→222).

## Differential evidence (unicorn vs wasmtime, bit-exact, NaN==NaN per §4.3.3)

```
GREEN: 339/339 f64 #369 — const/promote/arith/compare/load/store + op tail
       (rounding edges ±0.5/1.5/2.5 ties-to-even, ±0.0, NaN, inf, 2^52−0.5,
       subnormal; min/max NaN + signed-zero rows; copysign; demote
       overflow→inf/underflow→±0; exact converts; FULL trunc trap table —
       UDF vs wasmtime traps) + f64 param D-homes (back-fill + across-call)
       + D0/D1 args (in-place, CROSS-SWAPPED via two-phase staging, mixed
       int+f64) + D0 results on m7dp; m4f + m3 honest-reject.
GREEN: 222/222 f32 #719 — + call_ret/call_args/call_mixed/call_swap/call_live
       marshalling rows (callees do real VFP arithmetic — non-vacuous at the
       value level) + cs_live (live R0 across copysign); m3 honest-reject.
GREEN: 84/84 f32 619 sibling, 48/48 #708/#709 sibling (regression).
```

Both scripts are already CI-wired (`trap-semantics-oracle` job); the extended rows ride along. Unicorn needs `UC_CPU_ARM_MAX` for the FPv5 encodings (handled in-script with a guarded fallback).

## Gates

- frozen anchors **10/10 byte-identical** (`frozen_codegen_bytes`)
- `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` / **full `cargo test --workspace`** green (628 selector/backend/core/cli tests incl. new pins: marshalling, back-fill homes, D-home across call, trunc domain guards, trunc-home no-clobber, clang-byte encoder pins, min/max alias-guard)
- `claim_check` 18/18
- riscv/aarch64: loud-reject verified on the extended fixture

## Close-#369 verdict

**Recommend CLOSE.** The issue's defect — "hardware FPU never used, silent decoder drop" — is fully resolved: scalar f32 AND f64 are hard-float end-to-end (ops, params, returns, locals, across-call preservation, and now the full direct-call ABI boundary), every lowering execution-differentiated against wasmtime, and every remaining gap is a LOUD decline or loud-skip, never a silent miscompile. Named residuals for follow-up issues rather than this umbrella: f32 rounding/min-max tail (falcon does not use them), i64<->float conversions/reinterprets (need i64-pair plumbing), call_indirect float boundaries, stack-passed float args (>16 S-slots), and Meld-dispatch float imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L