### PR TITLE
verification-arc closure: LIVE trap-preservation VC for five trap classes + the LAST i32 div_s admit discharged (#166, #73)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ cd coq && make proofs
 
 ### Proof Status
 
-See `coq/STATUS.md` for the complete coverage matrix. Current: 472 Qed / 6 Admitted
+See `coq/STATUS.md` for the complete coverage matrix. Current: 473 Qed / 5 Admitted
 (+2 `admit.` tactics) across `coq/Synth/`. The 40 selector-DSL rule theorems
 (`VcrSelRules.v`) are stated directly about the GENERATED model (VCR-ISA-001
 #667: `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v` emitted
@@ -99,9 +99,9 @@ reflexivity gate was retired as vacuous once the hand-written mirror was gone
 `scripts/claim_check.py` re-derive it on every commit — when a proof lands, update
 the docs AND `claims.yaml` in the same PR. Proofs are tiered:
 T1 (result-correspondence), T2 (existence-only), T3 (admitted). Remaining admits:
-1 i32 division trap guard (div_s INT_MIN/-1 double guard, #73 — div_u/rem_s/rem_u
-discharged against `exec_program_br`), 2 Compilation.v,
-1 CorrectnessSimple.v, 2 ArmRefinement.v — 0 i64 admits.
+2 Compilation.v, 1 CorrectnessSimple.v, 2 ArmRefinement.v — 0 division admits
+(all four i32 div/rem trap guards discharged against `exec_program_br`, #73)
+and 0 i64 admits.
 All i32 AND i64 operations have T1 proofs (i64 T1 parity since v0.11.0).
 
 ### Claim-verification gate

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 | ELF output with vector table | Implemented | Thumb bit set on symbols; not linked on real hardware |
 | Linker scripts (STM32, nRF52840, generic) | Implemented | Generated, not tested with real boards |
 | Cross-compilation (`--link` flag) | Implemented | Requires `arm-none-eabi-gcc` in PATH; not CI-tested |
-| Rocq mechanized proofs | 472 Qed / 6 Admitted | i32 + i64 T1 correctness proofs; the 40 selector-DSL rule theorems are stated directly about the GENERATED model (VCR-ISA-001 #667 — `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v`); div_s trap guard re-admitted (div_u/rem_s/rem_u discharged) |
+| Rocq mechanized proofs | 473 Qed / 5 Admitted | i32 + i64 T1 correctness proofs; the 40 selector-DSL rule theorems are stated directly about the GENERATED model (VCR-ISA-001 #667 — `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v`); all four i32 div/rem trap guards discharged against the branch-taking executor (#73) |
 | SMT translation validation | ordeal (pure-Rust QF_BV) default | v0.27.0 (#553); Z3 demoted to feature-gated differential oracle — 141/141 agreement |
 | WebAssembly spec test suite | 227/257 compile | Compilation only — not executed on emulator |
 
@@ -194,7 +194,7 @@ Per the [PulseEngine Verification Guide](https://pulseengine.eu/guides/VERIFICAT
 
 | Track | Status | Coverage |
 |-------|--------|----------|
-| **Rocq** | Partial | 472 Qed / 6 Admitted (40 selector-DSL rule theorems stated directly about the GENERATED model, VCR-ISA-001 #667) — div_s trap guard re-admitted (div_u/rem_s/rem_u discharged) |
+| **Rocq** | Partial | 473 Qed / 5 Admitted (40 selector-DSL rule theorems stated directly about the GENERATED model, VCR-ISA-001 #667) — all four i32 div/rem trap guards discharged (#73) |
 | **Kani** | Starting | 18 bounded model checking harnesses for ARM encoder |
 | **Verus** | Starting | 8 spec functions in `synth-synthesis/src/contracts.rs`; Bazel integration via `rules_verus` |
 | **Lean** | Not started | — |
@@ -206,13 +206,13 @@ See `artifacts/verification-gaps.yaml` for the detailed gap analysis (VG-001 thr
 Mechanized proofs in Rocq 9 show that `compile_wasm_to_arm` preserves WASM semantics for each operation. The proof suite lives in `coq/Synth/` and covers ARM instruction semantics, WASM stack-machine semantics, and per-operation correctness theorems.
 
 ```
-472 Qed / 6 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
+473 Qed / 5 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
   T1 result-correspondence (ARM output = WASM result): all i32 ops and all
      i64 ops — i64 T1 parity since v0.11.0, 0 i64 admits (coq/STATUS.md)
   T2 existence-only: f32/f64 and remaining categories
-  T3 admitted (6): 1 i32 division trap guard (div_s INT_MIN/-1 double guard, #73;
-     div_u/rem_s/rem_u discharged against exec_program_br),
-     2 Compilation.v, 1 CorrectnessSimple.v, 2 ArmRefinement.v
+  T3 admitted (5): 2 Compilation.v, 1 CorrectnessSimple.v, 2 ArmRefinement.v
+     (0 division admits — all four i32 div/rem trap guards discharged against
+     exec_program_br, #73 closed at i32)
   incl. 40 Qed selector-DSL rule theorems (Synth/VcrSelRules.v, 1:1 with
      coq/vcr_sel_rules.manifest) — stated directly about the GENERATED model
      (VCR-ISA-001 #667: rule_X := Gen.rule_X, single source

--- a/claims.yaml
+++ b/claims.yaml
@@ -29,20 +29,20 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-PROOF-COUNT-README
     doc: README.md
-    text: "472 Qed / 6 Admitted"
+    text: "473 Qed / 5 Admitted"
     evidence:
       - kind: count-eq                       # ALL THREE README spots must agree —
-        pattern: '472 Qed / 6 Admitted'      # a verbatim check alone greens if one
+        pattern: '473 Qed / 5 Admitted'      # a verbatim check alone greens if one
         glob: ['README.md']                  # of them drifts while another matches
         expect: 3
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 472
+        expect: 473
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 6
+        expect: 5
       - kind: count-eq                       # the "+2 admit. tactics" disclosure
         pattern: '^\s*admit\.'
         glob: ['coq/Synth/**/*.v']
@@ -50,33 +50,33 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-CLAUDE-MD
     doc: CLAUDE.md
-    text: "472 Qed / 6 Admitted"
+    text: "473 Qed / 5 Admitted"
     evidence:
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 472
+        expect: 473
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 6
+        expect: 5
 
   - id: SYNTH-PROOF-COUNT-STATUS-MD
     doc: coq/STATUS.md
-    text: "472 Qed / 6 Admitted"
+    text: "473 Qed / 5 Admitted"
     evidence:
       - kind: count-eq                       # headline + Total line must both agree
-        pattern: '472 Qed / 6 Admitted'
+        pattern: '473 Qed / 5 Admitted'
         glob: ['coq/STATUS.md']
         expect: 2
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 472
+        expect: 473
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 6
+        expect: 5
 
   # ---------------------------------------------------------------------------
   # The admit breakdown the docs disclose — per-file, so a new admit anywhere
@@ -84,12 +84,12 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-ADMIT-BREAKDOWN
     doc: README.md
-    text: "1 i32 division trap guard"
+    text: "0 division admits"
     evidence:
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/Synth/CorrectnessI32.v']
-        expect: 1
+        expect: 0
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/Synth/Compilation.v']

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -1,6 +1,6 @@
 # Rocq Proof Suite — Honest Status
 
-**Last Updated: 2026-07-14 (recount: 472 Qed / 6 Admitted, +2 admit., crude
+**Last Updated: 2026-07-15 (recount: 473 Qed / 5 Admitted, +2 admit., crude
 `grep "Qed\."` over `coq/Synth/**/*.v` — same method as prior recounts; the
 -40 vs the prior 512 are the retired VCR-ISA-001 #667 cross-check lemmas of
 `VcrSelRulesGenCheck.v`: `VcrSelRules.v` now DEFINES every `rule_X` as the
@@ -33,19 +33,22 @@ The flat-executor capability gap named by VCR-SEL-001 increment 4 is closed:
   I64SetCond rules re-proven at EXPANSION tier — against the encoder's
   actual dual-precision chains (CMP lo,lo; SBCS/CMPEQ hi,hi; MOVcc) —
   with no `i64_setcond_bits` axiom.
-- **`i32_divu_correct` + `i32_rems_correct` + `i32_remu_correct`**
-  (CorrectnessI32.v): three of the four #73 trap-guard admits DISCHARGED,
-  each restated against `exec_program_br` (the BNE skips the UDF; extra
-  `I32.valid_unsigned` divisor hypothesis makes the raw-Z guard and the
-  mod-2^32 Z-flag agree; SDIV/UDIV then MLS computes the remainder tail).
-  Compilation.v's I32DivS guard offsets corrected for real branch
-  semantics (2→3, 0→1). Only `i32_divs_correct` — whose model carries the
-  extra INT_MIN/-1 double guard — remains Admitted.
+- **`i32_divs_correct` + `i32_divu_correct` + `i32_rems_correct` +
+  `i32_remu_correct`** (CorrectnessI32.v): ALL FOUR #73 trap-guard admits
+  DISCHARGED, each restated against `exec_program_br` (the BNE skips the
+  UDF; extra `I32.valid_unsigned` divisor hypothesis makes the raw-Z guard
+  and the mod-2^32 Z-flag agree; SDIV/UDIV then MLS computes the remainder
+  tail). Compilation.v's I32DivS guard offsets corrected for real branch
+  semantics (2→3, 0→1). `i32_divs_correct` (2026-07-15, the last of the
+  family) discharges the INT_MIN/-1 DOUBLE guard with a case split on the
+  dividend-is-INT_MIN compare; enabling model fix: `I32.divs`'s overflow
+  guard now tests the SIGNED interpretation (the old raw-representative
+  `Z.eqb x min_signed` was vacuous for register-normalized values, so the
+  model under-trapped exactly where the compiled guard and the WASM spec
+  trap — the theorem was FALSE as previously stated).
 
-**Total admits: 6** (was 8) — 1 i32 division trap guard (div_s only, #73 —
-the INT_MIN/-1 double-guard restatement against `exec_program_br` pending;
-div_u/rem_s/rem_u discharged), 2 Compilation.v, 1 CorrectnessSimple.v,
-2 ArmRefinement.v. The headline count grew 291 → 467 because the recount
+**Total admits: 5** (was 8) — 2 Compilation.v, 1 CorrectnessSimple.v,
+2 ArmRefinement.v; 0 division admits (#73 CLOSED at i32). The headline count grew 291 → 467 because the recount
 now includes everything landed since 2026-06-04 (SailArmBridge rounds 1–3,
 VcrSelRules increments, VcrSelExpansion, i64 certifying validation lemmas).
 
@@ -156,7 +159,7 @@ umbrella #147).
 |------|---------|-------|
 | **T1: Result Correspondence** | ARM output register = WASM result value | 37¹ |
 | **T2: Existence-Only** | ARM execution succeeds (no result claim) | 139¹ |
-| **T3: Admitted / admit.** | Not yet proven | 8 (6 Admitted + 2 admit.) |
+| **T3: Admitted / admit.** | Not yet proven | 7 (5 Admitted + 2 admit.) |
 | **Infrastructure** | Properties of integers, states, flag lemmas | 65¹ |
 
 ¹ T1/T2/Infrastructure tier classification is the 2026-06-04 semantic recount
@@ -164,7 +167,7 @@ and predates the VcrSelRules (42), VcrSelPilot (7) and SailArmBridge (92) Qed;
 see the per-file breakdown below for current per-file counts. The T3 row and
 the headline total are re-derived by the claim gate.
 
-**Total: 472 Qed / 6 Admitted (+2 admit.) across all files** (recount 2026-07-14, CI-gated via `claims.yaml`)
+**Total: 473 Qed / 5 Admitted (+2 admit.) across all files** (recount 2026-07-15, CI-gated via `claims.yaml`)
 
 v0.10.0 PR 1: +2 T1 Qed (i64_add_correct, i64_sub_correct) and +9
 infrastructure Qed (combine_i32_unsigned, carry_split_add,
@@ -419,7 +422,7 @@ Recount 2026-07-10 (`grep -oE 'Qed\.'` / `'Admitted\.'` per file):
 |------|-----|----------|------|
 | Correctness.v | 6 | 0 | T1 |
 | CorrectnessSimple.v | 28 | 1 | T2 + 1 admitted (i64_const_correct) |
-| CorrectnessI32.v | 30 | 1 | T1 + 1 admitted (div_u/rem_s/rem_u discharged against `exec_program_br` #697/#73; only i32_divs_correct — INT_MIN/-1 double guard — remains) |
+| CorrectnessI32.v | 31 | 0 | T1 — all four #73 div/rem trap-guard proofs discharged against `exec_program_br` (i32_divs_correct closed 2026-07-15 with the INT_MIN/-1 double-guard case split) |
 | CorrectnessI64.v | 46 | 0 | T1 (arith/bitwise/div/rem) + T2 (shifts/cmps/bit-manip) — 0 i64 admits since v0.11.0 |
 | CorrectnessI64Comparisons.v | 19 | 0 | T2 |
 | CorrectnessF32.v | 20 | 0 | T2 |
@@ -441,7 +444,7 @@ Recount 2026-07-10 (`grep -oE 'Qed\.'` / `'Admitted\.'` per file):
 | WasmValues.v | 2 | 0 | Infra |
 | VcrSelPilot.v | 7 | 0 | T1 (register-polymorphic; VCR-SEL-001 go/abandon measurement) |
 | VcrSelRules.v | 42 | 0 | T1 (register-polymorphic; the WIRED VCR-SEL-001 increment-1+2+3+4 rule table — 40 rule theorems 1:1 with `coq/vcr_sel_rules.manifest`, coverage-gated by `//coq:vcr_sel_rules_coverage`, + 2 mod-32 helper lemmas #683. VCR-ISA-001 #667 increment 2: every `rule_X` is DEFINED as the GENERATED `Gen.rule_X` of `VcrSelRulesGenerated.v` — emitted from the shipped `sel_dsl::RULES` — so the theorems are stated directly about the shipped sequences; a table change regenerates `Gen` and breaks the matching Qed. The former `VcrSelRulesGenCheck.v` 40-lemma `reflexivity` gate is retired as vacuous/subsumed) |
-| **Total** | **472** | **6** | (+2 `admit.`) |
+| **Total** | **473** | **5** | (+2 `admit.`) |
 
 ## VCR-SEL-001 increments 1 (2026-07-07) + 2 + 3 + 4 (2026-07-08): VcrSelRules.v
 

--- a/coq/Synth/Common/Integers.v
+++ b/coq/Synth/Common/Integers.v
@@ -52,9 +52,16 @@ Module I32.
   Definition sub (x y : int) : int := repr (x - y).
   Definition mul (x y : int) : int := repr (x * y).
 
+  (** Signed division. The INT_MIN/-1 overflow trap tests the SIGNED
+      interpretation of the operands (#73): the previous raw-representative
+      guard [Z.eqb x min_signed] was vacuous for register-normalized values
+      (a normalized [int] lies in [0, 2^32), never equal to the negative
+      [min_signed]), so the model under-trapped exactly where the compiled
+      double guard — and the WASM spec — trap. [signed] is invariant across
+      representatives mod 2^32, so this guard also subsumes the old raw one. *)
   Definition divs (x y : int) : option int :=
     if Z.eqb y 0 then None
-    else if andb (Z.eqb x min_signed) (Z.eqb y (-1)) then None
+    else if andb (Z.eqb (signed x) min_signed) (Z.eqb (signed y) (-1)) then None
     else Some (repr (signed x / signed y)).
 
   Definition divu (x y : int) : option int :=

--- a/coq/Synth/Synth/CorrectnessComplete.v
+++ b/coq/Synth/Synth/CorrectnessComplete.v
@@ -2,6 +2,15 @@
 
     This file serves as the master index for all correctness proofs.
 
+    NOTE (2026-07-15): the tier tallies below are the v0.8.0-era HISTORICAL
+    snapshot; `coq/STATUS.md` (CI-gated via `claims.yaml`) is the
+    authoritative current count. Since this snapshot, the i64 div/rem +
+    i64_const admits were discharged (v0.8–v0.11), the Integers.v Z.mod_mod
+    admit was closed (v0.10.0 PR 2), and ALL FOUR i32 div/rem trap-guard
+    admits were discharged against the branch-taking `exec_program_br`
+    (#73 — divs closed 2026-07-15 with the INT_MIN/-1 double-guard case
+    split).
+
     After v0.8.0 PR 1a (Compilation.v i64 alignment) the i64 operations now
     compile to dual-register-pair sequences (R0:R1 result, R2:R3 second
     operand) matching the Rust codegen, via ADDS/ADC/SUBS/SBC for arithmetic

--- a/coq/Synth/Synth/CorrectnessI32.v
+++ b/coq/Synth/Synth/CorrectnessI32.v
@@ -1,16 +1,15 @@
 (** * I32 Operations Correctness
 
     This file contains correctness proofs for all i32 WebAssembly operations.
-    Total: 29 theorems — 28 Qed, 1 Admitted
+    Total: 29 theorems — 29 Qed, 0 Admitted
 
     Strategy:
     - Arithmetic (add, sub, mul, and, or, xor): synth_binop_proof tactic
-    - Division (divu) + remainder (rems, remu): Qed against the
+    - Division (divs, divu) + remainder (rems, remu): Qed against the
       branch-taking executor exec_program_br — the trap guard's BCondOffset
-      actually skips the UDF (#73)
-    - Division (divs): Admitted — same trap-guard restatement pending, but
-      the divs model carries the extra INT_MIN/-1 (overflow) guard on top
-      of the divide-by-zero guard (no new executor capability needed)
+      actually skips the UDF (#73); divs discharges the DOUBLE guard
+      (divide-by-zero + INT_MIN/-1 overflow) with a case split on the
+      dividend-is-INT_MIN compare
     - Comparisons: flag-correspondence lemmas from ArmFlagLemmas.v
     - Bit manipulation: axiom-based (I32.clz/rbit/popcnt)
     - Shifts: Qed — mod-32 mask + register shift (#682)
@@ -80,26 +79,182 @@ Proof. synth_binop_proof. Qed.
     [exec_program_br] (ArmSemantics.v) is the model that can take the
     guard's skip.
 
-    Status: [i32_divu_correct], [i32_rems_correct] and [i32_remu_correct]
-    are DISCHARGED against [exec_program_br] below (guard + UDIV/SDIV + MLS
-    tail). Only [i32_divs_correct] remains Admitted — its model carries the
-    extra INT_MIN/-1 (overflow) guard on top of the divide-by-zero guard;
-    the same restatement applies but needs no new executor capability. *)
+    Status: ALL FOUR div/rem theorems are DISCHARGED against
+    [exec_program_br] below (guard + UDIV/SDIV + MLS tail);
+    [i32_divs_correct] closes the family with the INT_MIN/-1 double-guard
+    case split — the last i32 admit of #73. *)
 
+(** i32.div_s — the LAST div/rem trap-guard proof, discharged against the
+    branch-taking executor [exec_program_br] (#73). The compiled sequence
+    carries the DOUBLE guard: CMP R1,#0; BNE +1; UDF (divide-by-zero), then
+    MOVW/MOVT R2 := 0x80000000; CMP R0,R2; BNE +3 — and only when the
+    dividend IS INT_MIN — CMN R1,#1; BNE +1; UDF (INT_MIN/-1 overflow);
+    finally SDIV. [I32.divs v1 v2 = Some result] supplies both guard
+    discharges: the divisor is non-zero (first BNE taken), and NOT
+    (signed v1 = INT_MIN ∧ signed v2 = -1) — so when the second CMP finds
+    the dividend equal to 0x80000000 the CMN must find the divisor ≠ -1
+    (third BNE taken). Both paths land on the SDIV, whose model is
+    [I32.divs] itself.
+
+    [I32.valid_unsigned v2] is the same register-normalization hypothesis
+    as in [i32_divu_correct] (raw [v2 =? 0] model guard vs the CMP's
+    [v2 mod 2^32] Z-flag). The INT_MIN and -1 guard comparisons need no
+    such hypothesis: [I32.signed] already works mod 2^32, exactly like the
+    flags. This restatement is only provable because [I32.divs]'s overflow
+    guard now tests the signed interpretation (see Integers.v) — against
+    the old raw-representative guard the theorem was FALSE at
+    v1 = 0x80000000, v2 = 0xFFFFFFFF (model said Some, hardware traps). *)
 Theorem i32_divs_correct : forall wstate astate v1 v2 stack' result,
   wstate.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
   get_reg astate R0 = v1 ->
   get_reg astate R1 = v2 ->
+  I32.valid_unsigned v2 ->
   I32.divs v1 v2 = Some result ->
   exec_wasm_instr I32DivS wstate =
     Some (mkWasmState (VI32 result :: stack')
             wstate.(locals) wstate.(globals) wstate.(memory)) ->
   exists astate',
-    exec_program (compile_wasm_to_arm I32DivS) astate = Some astate' /\
+    exec_program_br (compile_wasm_to_arm I32DivS) astate = Some astate' /\
     get_reg astate' R0 = result.
 Proof.
-  (* Admitted: requires PC-relative branching model to skip UDF trap guard *)
-Admitted.
+  intros wstate astate v1 v2 stack' result Hstack HR0 HR1 Hval Hdivs Hwasm.
+  (* Peel the divs guards: the divisor is non-zero, and the INT_MIN/-1
+     overflow conjunction is false. *)
+  assert (Hnz : v2 <> 0).
+  { unfold I32.divs in Hdivs.
+    destruct (Z.eqb_spec v2 0); [discriminate | assumption]. }
+  assert (Hovf : (Z.eqb (I32.signed v1) I32.min_signed
+                  && Z.eqb (I32.signed v2) (-1))%bool = false).
+  { unfold I32.divs in Hdivs.
+    destruct (Z.eqb_spec v2 0); [discriminate |].
+    destruct ((Z.eqb (I32.signed v1) I32.min_signed
+               && Z.eqb (I32.signed v2) (-1))%bool) eqn:E;
+      [discriminate | reflexivity]. }
+  (* The Z flag latched by CMP R1,#0 is false (divu precedent). *)
+  assert (Hz : compute_z_flag (I32.sub v2 I32.zero) = false).
+  { rewrite z_flag_sub_eq.
+    unfold I32.eq.
+    replace (I32.unsigned I32.zero) with 0 by reflexivity.
+    apply Z.eqb_neq.
+    unfold I32.unsigned.
+    rewrite Z.mod_small; [exact Hnz |].
+    unfold I32.valid_unsigned, I32.max_unsigned, I32.modulus in *. lia. }
+  unfold exec_program_br.
+  change (length (compile_wasm_to_arm I32DivS)) with 11%nat.
+  (* pc = 0: CMP R1,#0 latches the flags, registers untouched. *)
+  erewrite (exec_program_pc_instr _ _ _ _ (CMP R1 (Imm I32.zero)));
+    [| reflexivity | exact I].
+  cbn [exec_instr eval_operand2].
+  (* pc = 1: BNE +1 — Z=0, branch TAKEN, skips the ÷0 UDF. *)
+  erewrite (exec_program_pc_bcond _ _ _ _ Cond_NE 1); [| reflexivity].
+  rewrite flags_set_flags.
+  cbn [eval_condition].
+  rewrite flag_z_update_flags_arith.
+  rewrite HR1, Hz.
+  cbn [negb].
+  (* pc = 3: MOVW R2,#0 — low half of INT_MIN. *)
+  erewrite (exec_program_pc_instr _ _ _ _ (MOVW R2 (I32.repr 0)));
+    [| reflexivity | exact I].
+  cbn [exec_instr].
+  (* pc = 4: MOVT R2,#0x8000 — R2 = 0x80000000 = 2147483648. *)
+  erewrite (exec_program_pc_instr _ _ _ _ (MOVT R2 (I32.repr 32768)));
+    [| reflexivity | exact I].
+  cbn [exec_instr].
+  rewrite get_set_reg_eq.
+  replace (I32.or (I32.and (I32.repr 0) (I32.repr 65535))
+             (I32.shl (I32.repr 32768) (I32.repr 16)))
+    with 2147483648 by reflexivity.
+  (* pc = 5: CMP R0,R2 — compares the dividend against INT_MIN. *)
+  erewrite (exec_program_pc_instr _ _ _ _ (CMP R0 (Reg R2)));
+    [| reflexivity | exact I].
+  cbn [exec_instr eval_operand2].
+  rewrite get_set_reg_eq.
+  rewrite !(get_set_reg_neq _ R2 R0) by discriminate.
+  rewrite !get_reg_set_flags.
+  rewrite HR0.
+  (* pc = 6: BNE +3 — case split on dividend = INT_MIN. *)
+  erewrite (exec_program_pc_bcond _ _ _ _ Cond_NE 3); [| reflexivity].
+  rewrite flags_set_flags.
+  cbn [eval_condition].
+  rewrite flag_z_update_flags_arith.
+  rewrite z_flag_sub_eq.
+  destruct (I32.eq v1 2147483648) eqn:Hmin; cbn [negb].
+  - (* Dividend IS INT_MIN: fall through to the CMN R1,#1 overflow guard,
+       which must find the divisor ≠ -1 (else divs would have trapped). *)
+    assert (Hsv1 : I32.signed v1 = I32.min_signed).
+    { unfold I32.eq in Hmin.
+      apply Z.eqb_eq in Hmin.
+      replace (I32.unsigned 2147483648) with 2147483648 in Hmin
+        by reflexivity.
+      unfold I32.signed. rewrite Hmin. reflexivity. }
+    assert (Hsv2 : Z.eqb (I32.signed v2) (-1) = false).
+    { rewrite Hsv1, Z.eqb_refl in Hovf. cbn [andb] in Hovf. exact Hovf. }
+    apply Z.eqb_neq in Hsv2.
+    (* The Z flag latched by CMN R1,#1 is therefore false. *)
+    assert (Hz3 : compute_z_flag (I32.add v2 I32.one) = false).
+    { unfold compute_z_flag, I32.eq.
+      replace (I32.unsigned I32.zero) with 0 by reflexivity.
+      apply Z.eqb_neq. intro Heq0.
+      apply Hsv2.
+      unfold I32.unsigned, I32.add, I32.repr in Heq0.
+      change I32.one with 1 in Heq0.
+      rewrite Zmod_mod in Heq0.
+      assert (Hu : v2 mod I32.modulus = I32.modulus - 1).
+      { assert (HM : 0 < I32.modulus) by (unfold I32.modulus; lia).
+        assert (Hb : 0 <= v2 mod I32.modulus < I32.modulus)
+          by (apply Z.mod_pos_bound; lia).
+        rewrite <- Zplus_mod_idemp_l in Heq0.
+        destruct (Z.eqb_spec (v2 mod I32.modulus) (I32.modulus - 1))
+          as [E | E]; [exact E |].
+        rewrite Z.mod_small in Heq0; lia. }
+      unfold I32.signed, I32.unsigned.
+      rewrite Hu.
+      reflexivity. }
+    (* pc = 7: CMN R1,#1 latches Z = (v2 + 1 == 0). *)
+    erewrite (exec_program_pc_instr _ _ _ _ (CMN R1 (Imm I32.one)));
+      [| reflexivity | exact I].
+    cbn [exec_instr eval_operand2].
+    rewrite !get_reg_set_flags.
+    rewrite !(get_set_reg_neq _ R2 R1) by discriminate.
+    rewrite !get_reg_set_flags.
+    rewrite HR1.
+    (* pc = 8: BNE +1 — divisor ≠ -1, branch TAKEN, skips the overflow UDF. *)
+    erewrite (exec_program_pc_bcond _ _ _ _ Cond_NE 1); [| reflexivity].
+    rewrite flags_set_flags.
+    cbn [eval_condition].
+    rewrite flag_z_update_flags_arith.
+    rewrite Hz3.
+    cbn [negb].
+    (* pc = 10: SDIV R0,R0,R1 — the model is I32.divs itself. *)
+    erewrite (exec_program_pc_instr _ _ _ _ (SDIV R0 R0 R1));
+      [| reflexivity | exact I].
+    cbn [exec_instr].
+    rewrite !get_reg_set_flags.
+    rewrite !(get_set_reg_neq _ R2 R0) by discriminate.
+    rewrite !(get_set_reg_neq _ R2 R1) by discriminate.
+    rewrite !get_reg_set_flags.
+    rewrite HR0, HR1, Hdivs.
+    cbn beta iota.
+    (* pc = 11: off the end — the program completed. *)
+    rewrite exec_program_pc_done; [| reflexivity].
+    eexists. split.
+    + reflexivity.
+    + apply get_set_reg_eq.
+  - (* Dividend ≠ INT_MIN: branch straight to the SDIV. *)
+    erewrite (exec_program_pc_instr _ _ _ _ (SDIV R0 R0 R1));
+      [| reflexivity | exact I].
+    cbn [exec_instr].
+    rewrite !get_reg_set_flags.
+    rewrite !(get_set_reg_neq _ R2 R0) by discriminate.
+    rewrite !(get_set_reg_neq _ R2 R1) by discriminate.
+    rewrite !get_reg_set_flags.
+    rewrite HR0, HR1, Hdivs.
+    cbn beta iota.
+    rewrite exec_program_pc_done; [| reflexivity].
+    eexists. split.
+    + reflexivity.
+    + apply get_set_reg_eq.
+Qed.
 
 (** i32.div_u — the FIRST trap-guard proof discharged against the
     branch-taking executor [exec_program_br] (#73): the compiled sequence
@@ -739,11 +894,10 @@ Qed.
 
 (** ** Summary
 
-    I32 theorems: 29 total — 28 Qed, 1 Admitted
-    - Arithmetic: 6 Qed (Add, Sub, Mul, DivU, RemS, RemU — DivU/RemS/RemU
-      against the branch-taking exec_program_br, #73), 1 Admitted (DivS —
-      trap-guard restatement against exec_program_br pending, extra
-      INT_MIN/-1 overflow guard)
+    I32 theorems: 29 total — 29 Qed, 0 Admitted
+    - Arithmetic: 7 Qed (Add, Sub, Mul, DivS, DivU, RemS, RemU — the four
+      div/rem trap-guard proofs against the branch-taking exec_program_br,
+      #73; DivS discharges the INT_MIN/-1 double guard)
     - Bitwise: 8 Qed (And, Or, Xor, Shl, ShrU, ShrS, Rotl, Rotr)
     - Comparison: 11 Qed (EQZ, EQ, NE, LtS, LtU, GtS, GtU, LeS, LeU, GeS, GeU)
     - Bit manipulation: 3 Qed (CLZ/CTZ/POPCNT using axiomatized I32.clz/ctz/popcnt)

--- a/crates/synth-verify/src/arm_semantics.rs
+++ b/crates/synth-verify/src/arm_semantics.rs
@@ -2373,6 +2373,15 @@ impl ArmSemantics {
                             // under the guard. Sound because these ops touch
                             // only registers/flags/VFP (the subset check in
                             // exec_trap_subset_op rejects everything else).
+                            //
+                            // Only components the op actually CHANGED are
+                            // merged — `ite(g, x, x) ≡ x`, and wrapping every
+                            // untouched register on every guarded step nests
+                            // the SDIV/UDIV operands in ite chains, blowing
+                            // the div/rem trap VC off a CDCL cliff (observed:
+                            // the div_s double-guard query ran 45+ min / 5 GB
+                            // with the unconditional merge, sub-second
+                            // without).
                             let regs_before = state.registers.clone();
                             let vfp_before = state.vfp_registers.clone();
                             let flags_before = ConditionFlags {
@@ -2383,15 +2392,28 @@ impl ArmSemantics {
                             };
                             self.exec_trap_subset_op(op, state)?;
                             for (r, before) in regs_before.iter().enumerate() {
-                                state.registers[r] = gb.ite(&state.registers[r], before);
+                                if !state.registers[r].same_term(before) {
+                                    state.registers[r] = gb.ite(&state.registers[r], before);
+                                }
                             }
                             for (r, before) in vfp_before.iter().enumerate() {
-                                state.vfp_registers[r] = gb.ite(&state.vfp_registers[r], before);
+                                if !state.vfp_registers[r].same_term(before) {
+                                    state.vfp_registers[r] =
+                                        gb.ite(&state.vfp_registers[r], before);
+                                }
                             }
-                            state.flags.n = bool_ite(gb, &state.flags.n, &flags_before.n);
-                            state.flags.z = bool_ite(gb, &state.flags.z, &flags_before.z);
-                            state.flags.c = bool_ite(gb, &state.flags.c, &flags_before.c);
-                            state.flags.v = bool_ite(gb, &state.flags.v, &flags_before.v);
+                            if !state.flags.n.same_term(&flags_before.n) {
+                                state.flags.n = bool_ite(gb, &state.flags.n, &flags_before.n);
+                            }
+                            if !state.flags.z.same_term(&flags_before.z) {
+                                state.flags.z = bool_ite(gb, &state.flags.z, &flags_before.z);
+                            }
+                            if !state.flags.c.same_term(&flags_before.c) {
+                                state.flags.c = bool_ite(gb, &state.flags.c, &flags_before.c);
+                            }
+                            if !state.flags.v.same_term(&flags_before.v) {
+                                state.flags.v = bool_ite(gb, &state.flags.v, &flags_before.v);
+                            }
                         }
                     }
                     merge_guard(&mut incoming, next, g);
@@ -2399,6 +2421,92 @@ impl ArmSemantics {
             }
         }
 
+        Ok(())
+    }
+
+    /// Whether the sequence's branch structure is VALUE-DEAD: every op inside
+    /// a branch-skipped span writes no register/VFP state (`Udf`, `Cmp`,
+    /// `Cmn`, nested `BCondOffset` only), and no op anywhere in the sequence
+    /// turns flags into a register value (`SetCond`).
+    ///
+    /// Under this condition the final REGISTER state is path-independent —
+    /// every register-writing op executes on every path, in program order —
+    /// so the straight-line value pass
+    /// [`Self::encode_sequence_value_straightline`] computes exactly the
+    /// registers any non-trapping real path produces. The flag writes a taken
+    /// branch skips (e.g. the div_s overflow guard's `CMN` behind `BNE +3`)
+    /// can only influence which PATH is taken — the trap side, which
+    /// [`Self::encode_sequence_br`] derives with full path sensitivity — and
+    /// never a register value, because `SetCond` (the only flag→register op
+    /// in the modeled subset) is excluded outright.
+    ///
+    /// This is what lets the div/rem trap VC keep its value clause
+    /// STRUCTURALLY aligned with the WASM side (`bvsdiv`/`MLS` terms
+    /// identical after canonicalization): an `ite(guard, …)` wrapper on an
+    /// SDIV/MLS operand un-shares the 32×32 multiplier/divider circuits and
+    /// sends the UNSAT proof off the CDCL cliff term.rs documents (observed:
+    /// rem_s value clause 15+ min with the ite, sub-second without).
+    pub fn branch_spans_are_value_dead(arm_ops: &[ArmOp]) -> bool {
+        use synth_synthesis::optimizer_bridge::estimate_arm_byte_size;
+
+        let mut offsets = Vec::with_capacity(arm_ops.len());
+        let mut off = 0usize;
+        for op in arm_ops {
+            offsets.push(off);
+            off += estimate_arm_byte_size(op);
+        }
+
+        // No flag→register materialization anywhere in the sequence.
+        if arm_ops.iter().any(|op| matches!(op, ArmOp::SetCond { .. })) {
+            return false;
+        }
+
+        for (i, op) in arm_ops.iter().enumerate() {
+            if let ArmOp::BCondOffset { offset, .. } = op {
+                if *offset < 0 {
+                    return false; // backward branch — not this subset at all
+                }
+                // Fall-through = next instruction; encoder rule for the
+                // target: branch_addr + 4 + 2*offset (same as
+                // `encode_sequence_br`). The skipped span is [fall-through,
+                // target).
+                let span_start = offsets[i] + estimate_arm_byte_size(op);
+                let span_end = offsets[i] + 4 + 2 * (*offset as usize);
+                for (j, skipped) in arm_ops.iter().enumerate() {
+                    if offsets[j] >= span_start && offsets[j] < span_end {
+                        match skipped {
+                            ArmOp::Udf { .. }
+                            | ArmOp::Cmp { .. }
+                            | ArmOp::Cmn { .. }
+                            | ArmOp::BCondOffset { .. } => {}
+                            _ => return false, // a register/VFP write is skippable
+                        }
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    /// Straight-line VALUE execution of a trap-guarded sequence: branches and
+    /// `UDF`s are register no-ops, every other op executes unconditionally
+    /// via the same modeled subset as the branch-taking executor.
+    ///
+    /// ONLY sound when [`Self::branch_spans_are_value_dead`] holds (see its
+    /// doc for the argument); callers must check it first. Produces ite-free
+    /// register terms, keeping the trap VC's value clause structurally
+    /// aligned with the WASM encoding.
+    pub fn encode_sequence_value_straightline(
+        &self,
+        arm_ops: &[ArmOp],
+        state: &mut ArmState,
+    ) -> Result<(), String> {
+        for op in arm_ops {
+            match op {
+                ArmOp::BCondOffset { .. } | ArmOp::Udf { .. } => {}
+                _ => self.exec_trap_subset_op(op, state)?,
+            }
+        }
         Ok(())
     }
 

--- a/crates/synth-verify/src/arm_semantics.rs
+++ b/crates/synth-verify/src/arm_semantics.rs
@@ -5,6 +5,7 @@
 //! captures its behavior, including register updates and condition flags.
 
 use crate::term::{BV, Bool};
+use std::collections::HashMap;
 use synth_synthesis::rules::{ArmOp, Operand2, Reg, VfpReg};
 
 /// ARM processor state representation in SMT
@@ -23,6 +24,13 @@ pub struct ArmState {
     pub locals: Vec<BV>,
     /// Global variables (for WASM verification)
     pub globals: Vec<BV>,
+    /// VCR-VER-002 (#166): the accumulated condition under which the executed
+    /// sequence TRAPS (reaches a `UDF`). `false` in a fresh state; `encode_op`
+    /// sets it unconditionally on a `Udf`, and the branch-taking executor
+    /// [`ArmSemantics::encode_sequence_br`] conditions it on the path guard the
+    /// `UDF` is reached under — this is the ARM-side trap term the
+    /// trap-preservation VC compares against the WASM op's trap condition.
+    pub may_trap: Bool,
 }
 
 /// ARM condition flags
@@ -70,6 +78,7 @@ impl ArmState {
             memory,
             locals,
             globals,
+            may_trap: Bool::from_bool(false),
         }
     }
 
@@ -1818,6 +1827,15 @@ impl ArmSemantics {
                 state.set_reg(rd, result);
             }
 
+            // VCR-VER-002 (#166): UDF is the WASM trap sink — executing it
+            // raises UsageFault. In the straight-line model (no path guards)
+            // reaching a UDF means the sequence traps unconditionally; the
+            // branch-taking executor [`Self::encode_sequence_br`] instead
+            // conditions this on the guard the UDF is reached under.
+            ArmOp::Udf { .. } => {
+                state.may_trap = Bool::from_bool(true);
+            }
+
             _ => {
                 // Unsupported operations - no state change
             }
@@ -2143,6 +2161,329 @@ impl ArmSemantics {
         x = x.bvlshr(BV::from_i64(24, 32));
 
         x
+    }
+}
+
+// ===========================================================================
+// VCR-VER-002 (#166): branch-taking guarded executor — DERIVES the ARM trap
+// condition from the emitted guard/branch/UDF structure
+// ===========================================================================
+
+/// Path guard: the condition under which an instruction executes. `Always`
+/// keeps the straight-line common case free of `ite` merging.
+#[derive(Clone)]
+enum Guard {
+    Always,
+    Cond(Bool),
+}
+
+impl Guard {
+    fn and_cond(&self, c: &Bool) -> Guard {
+        match self {
+            Guard::Always => Guard::Cond(c.clone()),
+            Guard::Cond(g) => Guard::Cond(Bool::and(&[g, c])),
+        }
+    }
+}
+
+/// Merge an incoming edge guard into the guard map at `at`.
+fn merge_guard(incoming: &mut HashMap<usize, Guard>, at: usize, g: Guard) {
+    match (incoming.get(&at), g) {
+        (Some(Guard::Always), _) => {}
+        (_, Guard::Always) => {
+            incoming.insert(at, Guard::Always);
+        }
+        (Some(Guard::Cond(a)), Guard::Cond(b)) => {
+            let merged = Bool::or(&[a, &b]);
+            incoming.insert(at, Guard::Cond(merged));
+        }
+        (None, g @ Guard::Cond(_)) => {
+            incoming.insert(at, g);
+        }
+    }
+}
+
+/// Boolean if-then-else (the term API only has BV ite).
+fn bool_ite(c: &Bool, t: &Bool, e: &Bool) -> Bool {
+    Bool::or(&[&Bool::and(&[c, t]), &Bool::and(&[&c.not(), e])])
+}
+
+/// IEEE 754 single-precision NaN test over the raw bit pattern:
+/// exponent all-ones with a non-zero fraction.
+fn f32_is_nan(x: &BV) -> Bool {
+    let exp_ones = x.extract(30, 23).eq(BV::from_u64(0xFF, 8));
+    let frac_nonzero = x.extract(22, 0).eq(BV::from_u64(0, 23)).not();
+    Bool::and(&[&exp_ones, &frac_nonzero])
+}
+
+/// Ordered `a < b` over IEEE 754 single-precision BIT PATTERNS, assuming
+/// neither operand is NaN (the callers conjoin the NaN exclusion). Uses the
+/// sign/magnitude case split; `+0.0 == -0.0` (neither is less).
+fn f32_ordered_lt(a: &BV, b: &BV) -> Bool {
+    let a_neg = a.extract(31, 31).eq(BV::from_u64(1, 1));
+    let b_neg = b.extract(31, 31).eq(BV::from_u64(1, 1));
+    let a_mag = a.extract(30, 0);
+    let b_mag = b.extract(30, 0);
+    let zero31 = BV::from_u64(0, 31);
+    let both_zero = Bool::and(&[&a_mag.eq(&zero31), &b_mag.eq(&zero31)]);
+    // (neg, neg): larger magnitude is smaller; (neg, pos): a < b unless both
+    // are zeros; (pos, neg): never; (pos, pos): magnitude order.
+    let neg_neg = b_mag.bvult(&a_mag);
+    let neg_pos = both_zero.not();
+    let pos_pos = a_mag.bvult(&b_mag);
+    bool_ite(
+        &a_neg,
+        &bool_ite(&b_neg, &neg_neg, &neg_pos),
+        &bool_ite(&b_neg, &Bool::from_bool(false), &pos_pos),
+    )
+}
+
+/// The three ordered VFP comparison results the trunc guards use, as total
+/// functions over the operands' bit patterns (result is 0 on any NaN — the
+/// unordered case — exactly the ARM `VCMP`+`VMRS`+`IT` materialization the
+/// `F32Lt`/`F32Gt`/`F32Ge` pseudo-ops stand for).
+fn f32_cmp_result(kind: F32CmpKind, a: &BV, b: &BV) -> Bool {
+    let ordered = Bool::and(&[&f32_is_nan(a).not(), &f32_is_nan(b).not()]);
+    let rel = match kind {
+        F32CmpKind::Lt => f32_ordered_lt(a, b),
+        F32CmpKind::Gt => f32_ordered_lt(b, a),
+        F32CmpKind::Ge => f32_ordered_lt(a, b).not(),
+    };
+    Bool::and(&[&ordered, &rel])
+}
+
+#[derive(Clone, Copy)]
+enum F32CmpKind {
+    Lt,
+    Gt,
+    Ge,
+}
+
+impl ArmSemantics {
+    /// Branch-taking guarded symbolic execution of an ARM sequence,
+    /// deriving `state.may_trap` from the emitted guard structure
+    /// (VCR-VER-002, #166).
+    ///
+    /// Forward-branch DAG execution over the op list: every instruction
+    /// carries the disjunction of the path conditions that reach it
+    /// (if-conversion), `BCondOffset` routes guards forward, and a `Udf`
+    /// accumulates its path guard into [`ArmState::may_trap`] — and does NOT
+    /// fall through (a trap halts execution, so the code after a guarded
+    /// `UDF` is reached only via the guard's skip branch). This makes the ARM
+    /// trap condition a DERIVED term: a lowering whose guard was dropped,
+    /// inverted, or aimed at the wrong register derives a trap condition that
+    /// fails the preservation VC — unlike the previous structural
+    /// `Udf`-presence proxy, which only saw that *some* trap existed.
+    ///
+    /// Branch targets are resolved in bytes via the shipped byte-size
+    /// estimator (`synth_synthesis::optimizer_bridge::estimate_arm_byte_size`,
+    /// the #511 estimator that CI pins against the encoder), matching the
+    /// encoder's `target = branch + 4 + 2*offset` halfword rule. A target
+    /// that lands mid-instruction, a backward branch (loop), an op outside
+    /// the modeled subset, or any label/call control flow is a loud `Err` —
+    /// never a silent accept.
+    pub fn encode_sequence_br(
+        &self,
+        arm_ops: &[ArmOp],
+        state: &mut ArmState,
+    ) -> Result<(), String> {
+        use synth_synthesis::optimizer_bridge::estimate_arm_byte_size;
+
+        // Byte offset of each op (the estimator is the pinned encoder mirror).
+        let mut offsets = Vec::with_capacity(arm_ops.len());
+        let mut off = 0usize;
+        for op in arm_ops {
+            offsets.push(off);
+            off += estimate_arm_byte_size(op);
+        }
+        let total_len = off;
+        let boundaries: std::collections::HashSet<usize> = offsets.iter().copied().collect();
+
+        let mut incoming: HashMap<usize, Guard> = HashMap::new();
+        incoming.insert(0, Guard::Always);
+
+        for (i, op) in arm_ops.iter().enumerate() {
+            let o = offsets[i];
+            // Unreached instruction (e.g. dead code behind an unconditional
+            // trap): no incoming edge, skip — it can never execute.
+            let Some(g) = incoming.get(&o).cloned() else {
+                continue;
+            };
+            let next = o + estimate_arm_byte_size(op);
+
+            match op {
+                ArmOp::BCondOffset { cond, offset } => {
+                    if *offset < 0 {
+                        return Err(
+                            "backward branch (loop) outside the trap-derivation subset — held out"
+                                .to_string(),
+                        );
+                    }
+                    // Encoder rule: offset is the halfword displacement,
+                    // target = branch_addr + 4 + 2*offset.
+                    let target = o + 4 + 2 * (*offset as usize);
+                    if target != total_len && !boundaries.contains(&target) {
+                        return Err(format!(
+                            "BCondOffset target {target} lands mid-instruction \
+                             (sequence len {total_len}) — estimator/encoder drift or \
+                             malformed guard"
+                        ));
+                    }
+                    let c = self.evaluate_condition(cond, &state.flags);
+                    merge_guard(&mut incoming, target, g.and_cond(&c));
+                    merge_guard(&mut incoming, next, g.and_cond(&c.not()));
+                }
+
+                ArmOp::Udf { .. } => {
+                    // The trap fires exactly under this path guard; execution
+                    // never continues past it (no fall-through edge).
+                    state.may_trap = match &g {
+                        Guard::Always => Bool::from_bool(true),
+                        Guard::Cond(gb) => Bool::or(&[&state.may_trap, gb]),
+                    };
+                }
+
+                // Label/relative/indirect control flow has no derivable local
+                // trap semantics here — loud decline, never a silent accept.
+                ArmOp::B { .. }
+                | ArmOp::BOffset { .. }
+                | ArmOp::Bcc { .. }
+                | ArmOp::Bhs { .. }
+                | ArmOp::Blo { .. }
+                | ArmOp::Bl { .. }
+                | ArmOp::Blx { .. }
+                | ArmOp::Bx { .. }
+                | ArmOp::Label { .. }
+                | ArmOp::Call { .. }
+                | ArmOp::CallIndirect { .. }
+                | ArmOp::BrTable { .. }
+                | ArmOp::Push { .. }
+                | ArmOp::Pop { .. } => {
+                    return Err(format!(
+                        "op {op:?} outside the trap-derivation subset — loud decline"
+                    ));
+                }
+
+                _ => {
+                    match &g {
+                        Guard::Always => self.exec_trap_subset_op(op, state)?,
+                        Guard::Cond(gb) => {
+                            // Guarded (if-converted) execution: snapshot the
+                            // register/flag/VFP state, execute, ite-merge
+                            // under the guard. Sound because these ops touch
+                            // only registers/flags/VFP (the subset check in
+                            // exec_trap_subset_op rejects everything else).
+                            let regs_before = state.registers.clone();
+                            let vfp_before = state.vfp_registers.clone();
+                            let flags_before = ConditionFlags {
+                                n: state.flags.n.clone(),
+                                z: state.flags.z.clone(),
+                                c: state.flags.c.clone(),
+                                v: state.flags.v.clone(),
+                            };
+                            self.exec_trap_subset_op(op, state)?;
+                            for (r, before) in regs_before.iter().enumerate() {
+                                state.registers[r] = gb.ite(&state.registers[r], before);
+                            }
+                            for (r, before) in vfp_before.iter().enumerate() {
+                                state.vfp_registers[r] = gb.ite(&state.vfp_registers[r], before);
+                            }
+                            state.flags.n = bool_ite(gb, &state.flags.n, &flags_before.n);
+                            state.flags.z = bool_ite(gb, &state.flags.z, &flags_before.z);
+                            state.flags.c = bool_ite(gb, &state.flags.c, &flags_before.c);
+                            state.flags.v = bool_ite(gb, &state.flags.v, &flags_before.v);
+                        }
+                    }
+                    merge_guard(&mut incoming, next, g);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Execute one non-branch op of the trap-derivation subset. Ops the
+    /// shipped trap-guarded lowerings use but `encode_op` leaves unmodeled
+    /// (`Cmn`, `Movw`, `Movt`, the ordered VFP compares) get explicit
+    /// semantics here; a WHITELIST of register-only value ops delegates to
+    /// `encode_op`; anything else is a loud `Err` — `encode_op`'s silent
+    /// `_ => {}` default must never green-wash a trap derivation.
+    fn exec_trap_subset_op(&self, op: &ArmOp, state: &mut ArmState) -> Result<(), String> {
+        match op {
+            // CMN: compare negated — flags from rn + op2.
+            ArmOp::Cmn { rn, op2 } => {
+                let a = state.get_reg(rn).clone();
+                let b = self.evaluate_operand2(op2, state);
+                let result = a.bvadd(&b);
+                self.update_flags_add(state, &a, &b, &result);
+                Ok(())
+            }
+            ArmOp::Movw { rd, imm16 } => {
+                state.set_reg(rd, BV::from_u64(*imm16 as u64, 32));
+                Ok(())
+            }
+            ArmOp::Movt { rd, imm16 } => {
+                let low = state.get_reg(rd).bvand(BV::from_u64(0xFFFF, 32));
+                let v = low.bvor(BV::from_u64((*imm16 as u64) << 16, 32));
+                state.set_reg(rd, v);
+                Ok(())
+            }
+            // Ordered VFP compares (the #709 trunc guards): real bit-pattern
+            // semantics — result register is 1 iff the ordered relation
+            // holds, 0 on NaN. encode_op models these as uninterpreted
+            // symbols, which cannot drive a trap derivation.
+            ArmOp::F32Lt { rd, sn, sm } => {
+                let a = state.get_vfp_reg(sn).clone();
+                let b = state.get_vfp_reg(sm).clone();
+                let r = self.bool_to_bv32(&f32_cmp_result(F32CmpKind::Lt, &a, &b));
+                state.set_reg(rd, r);
+                Ok(())
+            }
+            ArmOp::F32Gt { rd, sn, sm } => {
+                let a = state.get_vfp_reg(sn).clone();
+                let b = state.get_vfp_reg(sm).clone();
+                let r = self.bool_to_bv32(&f32_cmp_result(F32CmpKind::Gt, &a, &b));
+                state.set_reg(rd, r);
+                Ok(())
+            }
+            ArmOp::F32Ge { rd, sn, sm } => {
+                let a = state.get_vfp_reg(sn).clone();
+                let b = state.get_vfp_reg(sm).clone();
+                let r = self.bool_to_bv32(&f32_cmp_result(F32CmpKind::Ge, &a, &b));
+                state.set_reg(rd, r);
+                Ok(())
+            }
+            // Register/flag-only value ops the covered lowerings use:
+            // delegate to the existing encode_op semantics.
+            ArmOp::Cmp { .. }
+            | ArmOp::Add { .. }
+            | ArmOp::Sub { .. }
+            | ArmOp::Rsb { .. }
+            | ArmOp::Mov { .. }
+            | ArmOp::And { .. }
+            | ArmOp::Orr { .. }
+            | ArmOp::Eor { .. }
+            | ArmOp::Mul { .. }
+            | ArmOp::Mls { .. }
+            | ArmOp::Sdiv { .. }
+            | ArmOp::Udiv { .. }
+            | ArmOp::SetCond { .. }
+            | ArmOp::Nop
+            | ArmOp::F32Const { .. }
+            | ArmOp::I32TruncF32S { .. }
+            | ArmOp::I32TruncF32U { .. }
+            // Ldr/Str: the value model treats loads as fresh symbols and
+            // stores as no-ops (no memory-contents model) — fine for a trap
+            // derivation, where only the guard's flags/registers matter.
+            | ArmOp::Ldr { .. }
+            | ArmOp::Str { .. } => {
+                self.encode_op(op, state);
+                Ok(())
+            }
+            other => Err(format!(
+                "op {other:?} outside the trap-derivation subset — loud decline"
+            )),
+        }
     }
 }
 

--- a/crates/synth-verify/src/lib.rs
+++ b/crates/synth-verify/src/lib.rs
@@ -90,7 +90,9 @@ pub use fact_spec::{FactSpecResult, specialize_function};
 pub use solver::{BvSolver, CheckOutcome, OrdealSolver, new_solver};
 pub use term::{BV, Bool};
 #[cfg(feature = "arm")]
-pub use translation_validator::{TranslationValidator, ValidationResult, VerificationError};
+pub use translation_validator::{
+    CallIndirectSpec, TranslationValidator, ValidationResult, VerificationError,
+};
 #[cfg(feature = "arm")]
 pub use validator_pattern::{
     CertifiedSelection, SolverResultKind, ValidationError as PatternValidationError, Validator,

--- a/crates/synth-verify/src/term.rs
+++ b/crates/synth-verify/src/term.rs
@@ -343,6 +343,16 @@ impl BV {
         &self.term
     }
 
+    /// Structural equality of the underlying terms. Used by the guarded
+    /// (branch-taking) ARM executor to skip vacuous `ite(g, x, x)` state
+    /// merges: without it every guarded instruction wraps ALL untouched
+    /// registers in a fresh `ite`, nesting the SDIV/UDIV operands in ite
+    /// chains and pushing the div/rem trap VC off a CDCL cliff (a genuinely
+    /// solver-hard miter of two perturbed division circuits).
+    pub(crate) fn same_term(&self, other: &BV) -> bool {
+        self.width == other.width && ord_bv(&self.term, &other.term) == Ordering::Equal
+    }
+
     /// If this is a free variable, its name.
     pub(crate) fn var_name(&self) -> Option<&str> {
         match &self.term {
@@ -688,6 +698,11 @@ impl Bool {
     /// The underlying ordeal term.
     pub(crate) fn term(&self) -> &BoolTerm {
         &self.term
+    }
+
+    /// Structural equality of the underlying terms (see [`BV::same_term`]).
+    pub(crate) fn same_term(&self, other: &Bool) -> bool {
+        ord_bool(&self.term, &other.term) == Ordering::Equal
     }
 
     /// Wrap a raw `ordeal::BoolTerm` — used by the trap module (`trap.rs`),

--- a/crates/synth-verify/src/translation_validator.rs
+++ b/crates/synth-verify/src/translation_validator.rs
@@ -357,7 +357,10 @@ impl TranslationValidator {
             }
             WasmOp::Unreachable => {
                 let (_state, arm_trap) = self.derive_arm_state(arm_ops, &[], None)?;
-                Ok(Self::condition_verdict(&crate::trap::trap_always(), &arm_trap))
+                Ok(Self::condition_verdict(
+                    &crate::trap::trap_always(),
+                    &arm_trap,
+                ))
             }
             WasmOp::I32Load { offset, .. }
             | WasmOp::I32Load8S { offset, .. }
@@ -394,6 +397,18 @@ impl TranslationValidator {
     /// from the emitted guard structure by the branch-taking executor.
     /// Operands: dividend = `input_0` (R0), divisor = `input_1` (R1),
     /// result in R0.
+    ///
+    /// The VALUE term comes from the straight-line pass
+    /// ([`ArmSemantics::encode_sequence_value_straightline`]) whenever the
+    /// sequence's branch structure is value-dead
+    /// ([`ArmSemantics::branch_spans_are_value_dead`] — true for every
+    /// shipped div/rem guard shape): on such sequences every non-trapping
+    /// path produces the same registers as straight-line execution, and the
+    /// resulting ite-free SDIV/UDIV/MLS terms stay STRUCTURALLY aligned with
+    /// the WASM encoding — an `ite(guard, …)` wrapper on a divider/multiplier
+    /// operand un-shares the circuits and sends the UNSAT value proof off a
+    /// CDCL cliff. Non-conforming shapes fall back to the guarded
+    /// (if-converted) post-state value — sound, potentially slow.
     pub fn verify_div_rem_trap_preservation(
         &self,
         wasm_op: &WasmOp,
@@ -424,7 +439,18 @@ impl TranslationValidator {
 
         let wasm_value = self.wasm_encoder.encode_op(wasm_op, &inputs);
         let (state, arm_may_trap) = self.derive_arm_state(arm_ops, &inputs, None)?;
-        let arm_value = self.arm_encoder.extract_result(&state, &Reg::R0);
+        let arm_value = if ArmSemantics::branch_spans_are_value_dead(arm_ops) {
+            // Ite-free value term, structurally aligned with the WASM side
+            // (see the method doc for the soundness argument).
+            let mut vstate = ArmState::new_symbolic();
+            Self::seed_inputs(&mut vstate, &inputs)?;
+            self.arm_encoder
+                .encode_sequence_value_straightline(arm_ops, &mut vstate)
+                .map_err(VerificationError::UnsupportedOperation)?;
+            self.arm_encoder.extract_result(&vstate, &Reg::R0)
+        } else {
+            self.arm_encoder.extract_result(&state, &Reg::R0)
+        };
 
         let orig = crate::trap::DefineOrTrap {
             value: wasm_value,
@@ -1059,8 +1085,8 @@ mod tests {
     /// small value, the BLO guard passes, and the access escapes below the
     /// linear-memory base — WASM requires a trap. The derived gate exhibits
     /// exactly that dropped-trap counterexample. Pinned Invalid until the
-    /// selector's guard is made wraparound-safe (tracked as a #377/#651
-    /// follow-up filed with this gate).
+    /// selector's guard is made wraparound-safe — filed as #752 (the
+    /// #377/#651 follow-up).
     #[test]
     fn word_load_software_bounds_guard_wraps_at_address_top() {
         with_verification_context(|| {
@@ -1165,7 +1191,7 @@ mod tests {
             (4294967296.0_f32, -1.0_f32)
         };
         let mut ops = Vec::new();
-        let mut guard = |bound: f32, upper: bool| {
+        let guard = |ops: &mut Vec<ArmOp>, bound: f32, upper: bool| {
             ops.push(ArmOp::F32Const {
                 sd: VfpReg::S1,
                 value: bound,
@@ -1200,9 +1226,8 @@ mod tests {
             });
             ops.push(ArmOp::Udf { imm: 0 });
         };
-        guard(hi, true);
-        guard(lo, false);
-        drop(guard);
+        guard(&mut ops, hi, true);
+        guard(&mut ops, lo, false);
         if signed {
             ops.push(ArmOp::I32TruncF32S {
                 rd: Reg::R0,

--- a/crates/synth-verify/src/translation_validator.rs
+++ b/crates/synth-verify/src/translation_validator.rs
@@ -20,21 +20,11 @@
 
 use crate::arm_semantics::{ArmSemantics, ArmState};
 use crate::solver::{CheckOutcome, new_solver};
-use crate::term::BV;
+use crate::term::{BV, Bool};
 use crate::wasm_semantics::WasmSemantics;
 use synth_core::WasmOp;
 use synth_synthesis::{ArmOp, Reg, SynthesisRule};
 use thiserror::Error;
-
-/// Whether a div/rem ARM lowering carries its trap guard: synth guards a
-/// divide with a `Cmp`/branch/`Udf` sequence, so the presence of a `Udf`
-/// (the `undefined`/trap instruction) is the structural signal that the
-/// divide-by-zero (and, for signed, overflow) trap is still enforced. Its
-/// absence means the guard was dropped — the #633/#666/#642 shape.
-/// (VCR-VER-002, #166.)
-fn arm_sequence_has_trap_guard(arm_ops: &[ArmOp]) -> bool {
-    arm_ops.iter().any(|op| matches!(op, ArmOp::Udf { .. }))
-}
 
 /// Verification error types
 #[derive(Debug, Error)]
@@ -70,6 +60,23 @@ pub enum ValidationResult {
 
     /// Verification inconclusive (timeout or unsupported operations)
     Unknown { reason: String },
+}
+
+/// Module facts that define the WASM-side `call_indirect` trap condition
+/// (VCR-VER-002, #166): what the SPEC demands for the dispatched table, to be
+/// checked against the guards the selector actually resolved into the
+/// `ArmOp::CallIndirect` pseudo-op.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallIndirectSpec {
+    /// The dispatched table's element count (compile-time, per #642).
+    pub table_size: u32,
+    /// Whether the table may contain uninitialized (null) slots — if so, the
+    /// lowering MUST carry the #664 null check.
+    pub may_have_null_slot: bool,
+    /// `Some(expected_type_id)` when the table is heterogeneous and WASM's
+    /// §4.4.8 type check must be discharged at RUNTIME (#676); `None` when
+    /// the closed-world verdict discharges it at compile time.
+    pub heterogeneous_expected_type: Option<u32>,
 }
 
 /// Translation validator over the configured SMT engine (see
@@ -128,7 +135,40 @@ impl TranslationValidator {
             }
         };
 
+        // VCR-VER-002 (#166): PARTIAL ops (they trap on some inputs) MUST go
+        // through the trap-preservation VC — a value-only proof over a total
+        // model cannot see a dropped trap, and for div/rem the value-only
+        // query is not even well-posed (SMT bvsdiv is total where WASM
+        // traps). The trap VC subsumes the value obligation where the value
+        // is modeled (div/rem: trap clause AND guarded value clause).
+        if Self::is_trap_gated_op(wasm_op) {
+            return self.verify_trap_preservation(wasm_op, &arm_ops);
+        }
+
         self.verify_equivalence(wasm_op, &arm_ops)
+    }
+
+    /// The partial-op surface whose lowerings are MANDATORILY routed through
+    /// the trap-preservation VC by [`Self::verify_rule`].
+    fn is_trap_gated_op(wasm_op: &WasmOp) -> bool {
+        matches!(
+            wasm_op,
+            WasmOp::I32DivS
+                | WasmOp::I32DivU
+                | WasmOp::I32RemS
+                | WasmOp::I32RemU
+                | WasmOp::Unreachable
+                | WasmOp::I32Load { .. }
+                | WasmOp::I32Load8S { .. }
+                | WasmOp::I32Load8U { .. }
+                | WasmOp::I32Load16S { .. }
+                | WasmOp::I32Load16U { .. }
+                | WasmOp::I32Store { .. }
+                | WasmOp::I32Store8 { .. }
+                | WasmOp::I32Store16 { .. }
+                | WasmOp::I32TruncF32S
+                | WasmOp::I32TruncF32U
+        )
     }
 
     /// Verify equivalence between a WASM operation and ARM operations
@@ -277,34 +317,83 @@ impl TranslationValidator {
         Ok(ValidationResult::Verified)
     }
 
-    /// VCR-VER-002 (#166): mandatory **trap-preservation** obligation for a
-    /// div/rem lowering — that the ARM sequence preserves the WASM op's trap
-    /// (`÷0`, plus `INT_MIN/-1` for the signed ops) *and* its value, discharged
-    /// by [`crate::trap::prove_trap_equivalence`].
+    /// VCR-VER-002 (#166): mandatory **trap-preservation** obligation for the
+    /// partial-op lowerings whose ARM trap condition synth can DERIVE from the
+    /// emitted sequence. The ARM side is no longer a structural `Udf`-presence
+    /// proxy: [`ArmSemantics::encode_sequence_br`] threads a `may_trap` term
+    /// through the exec model — guard branches condition it, `UDF` execution
+    /// accumulates it — so a dropped, inverted, or wrong-register guard
+    /// derives a trap condition that fails the VC.
     ///
-    /// The WASM trap condition is derivable from the operands. The ARM
-    /// lowering's trap condition is derived **structurally** from `arm_ops`:
-    /// synth guards a divide with a `Cmp`/branch/`Udf` sequence (see
-    /// `synth_synthesis::contracts::division`), so a `Udf` in the sequence ⇒
-    /// the guard is present and the lowering traps on the same condition; its
-    /// absence ⇒ the guard was dropped (the #633/#666/#642 shape) and the
-    /// lowering never traps — which this gate reports `Invalid`.
+    /// # Covered classes (LIVE, derived ARM trap term)
     ///
-    /// # Soundness scope
+    /// | class | VC | operand convention |
+    /// |---|---|---|
+    /// | i32 div/rem | full ([`crate::trap::prove_trap_equivalence`]: trap AND guarded value) | dividend R0, divisor R1, result R0 |
+    /// | `unreachable` | trap-condition only | none |
+    /// | i32 load/store (all widths) | trap-condition only (no memory-contents model) | address R0 (+ store value R1), linear-memory size R10 |
+    /// | `i32.trunc_f32_s/u` | trap-condition only (no float→int value model) | operand S0, result R0 |
     ///
-    /// Sound in the **reject** direction: a div/rem lowering with no `Udf` is
-    /// reported `Invalid`, catching the whole trap-drop class. Presence of a
-    /// `Udf` is a *necessary* structural signal but does not by itself prove the
-    /// guard fires on *exactly* `÷0 ∨ overflow`.
+    /// `call_indirect` goes through
+    /// [`Self::verify_call_indirect_trap_preservation`] (it needs module
+    /// facts as the spec side).
     ///
-    // VCR-VER-002 follow-on: fully AUTO-deriving `opt.may_trap` from the shipped
-    // lowering (rather than the structural `Udf`-presence proxy) needs a
-    // `may_trap` flag threaded through the `ArmState` exec model so the
-    // encoder's `Cmp`/`Bne`/`Udf` expansion produces a derived trap term — or,
-    // equivalently, decoding the emitted guard bytes in `expansion_validator`.
-    // Until then the other partial-op classes (load/store, call_indirect,
-    // unreachable) have no ARM trap term on this value-only path and remain
-    // gated at the unit level (`tests/trap_preservation.rs`), not here.
+    /// # Held out, honestly
+    ///
+    /// - **i64 div/rem** — needs 64-bit operand terms + the register-pair ARM
+    ///   value model; still gated at the unit level
+    ///   (`tests/trap_preservation.rs`) and by the CI execution oracles.
+    /// - **`i32.trunc_f64_s/u`** — the guard drives f64 (D-register)
+    ///   compares, which the 32-bit VFP register model does not carry yet;
+    ///   unit-gated (`trap_trunc` classifier) + the m4f CI execution oracle.
+    pub fn verify_trap_preservation(
+        &self,
+        wasm_op: &WasmOp,
+        arm_ops: &[ArmOp],
+    ) -> Result<ValidationResult, VerificationError> {
+        match wasm_op {
+            WasmOp::I32DivS | WasmOp::I32DivU | WasmOp::I32RemS | WasmOp::I32RemU => {
+                self.verify_div_rem_trap_preservation(wasm_op, arm_ops)
+            }
+            WasmOp::Unreachable => {
+                let (_state, arm_trap) = self.derive_arm_state(arm_ops, &[], None)?;
+                Ok(Self::condition_verdict(&crate::trap::trap_always(), &arm_trap))
+            }
+            WasmOp::I32Load { offset, .. }
+            | WasmOp::I32Load8S { offset, .. }
+            | WasmOp::I32Load8U { offset, .. }
+            | WasmOp::I32Load16S { offset, .. }
+            | WasmOp::I32Load16U { offset, .. }
+            | WasmOp::I32Store { offset, .. }
+            | WasmOp::I32Store8 { offset, .. }
+            | WasmOp::I32Store16 { offset, .. } => {
+                let size: u64 = match wasm_op {
+                    WasmOp::I32Load8S { .. }
+                    | WasmOp::I32Load8U { .. }
+                    | WasmOp::I32Store8 { .. } => 1,
+                    WasmOp::I32Load16S { .. }
+                    | WasmOp::I32Load16U { .. }
+                    | WasmOp::I32Store16 { .. } => 2,
+                    _ => 4,
+                };
+                self.verify_mem_trap_preservation(arm_ops, *offset, size)
+            }
+            WasmOp::I32TruncF32S | WasmOp::I32TruncF32U => {
+                let signed = matches!(wasm_op, WasmOp::I32TruncF32S);
+                self.verify_trunc_f32_trap_preservation(arm_ops, signed)
+            }
+            other => Err(VerificationError::UnsupportedOperation(format!(
+                "trap-preservation gate does not cover {other:?} \
+                 (i64 div/rem and trunc_f64 are unit-gated — see method docs)"
+            ))),
+        }
+    }
+
+    /// i32 div/rem trap preservation (VCR-VER-002, #166): full VC — the trap
+    /// clause AND the guarded value clause — with the ARM trap term DERIVED
+    /// from the emitted guard structure by the branch-taking executor.
+    /// Operands: dividend = `input_0` (R0), divisor = `input_1` (R1),
+    /// result in R0.
     pub fn verify_div_rem_trap_preservation(
         &self,
         wasm_op: &WasmOp,
@@ -334,23 +423,215 @@ impl TranslationValidator {
         let inputs = vec![dividend.clone(), divisor.clone()];
 
         let wasm_value = self.wasm_encoder.encode_op(wasm_op, &inputs);
-        let arm_value = self.encode_arm_sequence(arm_ops, &inputs)?;
+        let (state, arm_may_trap) = self.derive_arm_state(arm_ops, &inputs, None)?;
+        let arm_value = self.arm_encoder.extract_result(&state, &Reg::R0);
 
         let orig = crate::trap::DefineOrTrap {
             value: wasm_value,
             may_trap: crate::trap::trap_div(div_op, &dividend, &divisor),
-        };
-        let arm_may_trap = if arm_sequence_has_trap_guard(arm_ops) {
-            crate::trap::trap_div(div_op, &dividend, &divisor)
-        } else {
-            crate::term::Bool::from_bool(false)
         };
         let opt = crate::trap::DefineOrTrap {
             value: arm_value,
             may_trap: arm_may_trap,
         };
 
-        Ok(match crate::trap::prove_trap_equivalence(&orig, &opt) {
+        Ok(Self::trap_verdict_to_result(
+            crate::trap::prove_trap_equivalence(&orig, &opt),
+        ))
+    }
+
+    /// i32 load/store OOB trap preservation (VCR-VER-002, #166 / #377):
+    /// trap-condition-only VC (synth models no memory contents). The WASM
+    /// side is ordeal's wraparound-safe bound check on the effective address
+    /// (`addr + offset + size >u mem_size`, exact 33-bit arithmetic); the ARM
+    /// side is DERIVED from the emitted software-bounds guard. Operand
+    /// convention: address = `input_0` (R0), store value (if any) = `input_1`
+    /// (R1), linear-memory size = R10 (the shipped ABI register).
+    pub fn verify_mem_trap_preservation(
+        &self,
+        arm_ops: &[ArmOp],
+        offset: u32,
+        access_size: u64,
+    ) -> Result<ValidationResult, VerificationError> {
+        let addr = BV::new_const("input_0", 32);
+        let value = BV::new_const("input_1", 32);
+        let inputs = vec![addr.clone(), value];
+
+        let mut state = ArmState::new_symbolic();
+        // The WASM-side bound is THE SAME symbol the ARM guard compares
+        // against: R10 = linear-memory size in bytes (shipped ABI).
+        let mem_bound = state.get_reg(&Reg::R10).clone();
+        Self::seed_inputs(&mut state, &inputs)?;
+        self.arm_encoder
+            .encode_sequence_br(arm_ops, &mut state)
+            .map_err(VerificationError::UnsupportedOperation)?;
+        let arm_trap = state.may_trap.clone();
+
+        // WASM Core: ea = addr + offset (exact), trap iff ea + size > bound.
+        // Folding the static offset into the size operand keeps ordeal's
+        // 33-bit zero-extended arithmetic exact: zext(addr) + zext(off+size).
+        let static_bytes = offset as u64 + access_size;
+        let wasm_trap = if static_bytes > u32::MAX as u64 {
+            // offset + size alone exceeds the 32-bit bound: every access traps.
+            crate::trap::trap_always()
+        } else {
+            crate::trap::trap_mem_oob(&addr, &BV::from_u64(static_bytes, 32), &mem_bound)
+        };
+
+        Ok(Self::condition_verdict(&wasm_trap, &arm_trap))
+    }
+
+    /// `i32.trunc_f32_s/u` trap preservation (VCR-VER-002, #166 / #709):
+    /// trap-condition-only VC (synth's QF_BV model carries no float→int
+    /// value function). The WASM side is ordeal 0.9.1's bit-pattern trunc
+    /// classifier (`NaN ∨ ±∞ ∨ out-of-range`); the ARM side is DERIVED from
+    /// the emitted domain guard (`F32Const` bound + ordered VFP compare +
+    /// `Cmp`/branch/`Udf`), with the ordered compares given real bit-pattern
+    /// semantics in the executor. Operand convention: float operand = S0.
+    pub fn verify_trunc_f32_trap_preservation(
+        &self,
+        arm_ops: &[ArmOp],
+        signed: bool,
+    ) -> Result<ValidationResult, VerificationError> {
+        use synth_synthesis::rules::VfpReg;
+        let bits = BV::new_const("input_0", 32);
+
+        let mut state = ArmState::new_symbolic();
+        state.set_vfp_reg(&VfpReg::S0, bits.clone());
+        self.arm_encoder
+            .encode_sequence_br(arm_ops, &mut state)
+            .map_err(VerificationError::UnsupportedOperation)?;
+        let arm_trap = state.may_trap.clone();
+
+        let wasm_trap = crate::trap::trap_trunc(
+            &bits,
+            crate::trap::FpFmt::F32,
+            crate::trap::IntTarget::I32,
+            signed,
+        );
+
+        Ok(Self::condition_verdict(&wasm_trap, &arm_trap))
+    }
+
+    /// `call_indirect` trap preservation (VCR-VER-002, #166 / #642 #664 #676):
+    /// trap-condition-only VC. The WASM-side spec comes from MODULE FACTS the
+    /// caller supplies ([`CallIndirectSpec`]); the ARM side is derived from
+    /// the `ArmOp::CallIndirect` pseudo-op's guard fields (`table_size`,
+    /// `null_check`, `type_check`) through the SAME pinned ordeal builder —
+    /// a selector that resolves the wrong table size, drops the null check on
+    /// a table with uninitialized slots (#664), or skips the runtime type
+    /// check on a heterogeneous table (#676) is reported `Invalid`.
+    ///
+    /// # Trust boundary
+    ///
+    /// This certifies the SELECTOR's guard resolution at the pseudo-op level;
+    /// the encoder's expansion of those fields into `CMP`/`BLO`/`UDF`/`BLX`
+    /// bytes is separately execution-gated (the unicorn call_indirect CI
+    /// jobs). Statically-discharged clauses are modeled by a provably
+    /// non-null slot term (`slot | 1`), keeping ordeal's builder the single
+    /// spec source.
+    pub fn verify_call_indirect_trap_preservation(
+        &self,
+        arm_op: &ArmOp,
+        spec: &CallIndirectSpec,
+    ) -> Result<ValidationResult, VerificationError> {
+        let ArmOp::CallIndirect {
+            table_size,
+            null_check,
+            type_check,
+            ..
+        } = arm_op
+        else {
+            return Err(VerificationError::UnsupportedOperation(format!(
+                "call_indirect trap gate needs the CallIndirect pseudo-op, got {arm_op:?}"
+            )));
+        };
+
+        let index = BV::new_const("input_0", 32);
+        let slot = BV::new_const("slot_ptr", 32);
+        let nonnull_slot = slot.bvor(BV::from_u64(1, 32));
+        let actual_ty = BV::new_const("slot_type_id", 32);
+
+        let build = |size: u32, may_null: bool, expected: Option<u32>| {
+            let expected_bv = expected.map(|e| BV::from_u64(e as u64, 32));
+            let size_bv = BV::from_u64(size as u64, 32);
+            let slot_term = if may_null { &slot } else { &nonnull_slot };
+            let type_trap = match &expected_bv {
+                Some(e) => crate::trap::TypeTrap::Runtime {
+                    actual_type_id: &actual_ty,
+                    expected_id: e,
+                },
+                None => crate::trap::TypeTrap::StaticallyDischarged,
+            };
+            crate::trap::trap_call_indirect(&crate::trap::CallIndirect {
+                index: &index,
+                table_size: &size_bv,
+                slot_ptr: slot_term,
+                type_trap,
+            })
+        };
+
+        let wasm_trap = build(
+            spec.table_size,
+            spec.may_have_null_slot,
+            spec.heterogeneous_expected_type,
+        );
+        let arm_trap = build(
+            *table_size,
+            *null_check,
+            type_check.as_ref().map(|(expected, _)| *expected),
+        );
+
+        Ok(Self::condition_verdict(&wasm_trap, &arm_trap))
+    }
+
+    /// Seed integer operand registers (R0..R2) and run the branch-taking
+    /// executor, returning the post-state and the DERIVED trap condition.
+    fn derive_arm_state(
+        &self,
+        arm_ops: &[ArmOp],
+        inputs: &[BV],
+        vfp_s0: Option<&BV>,
+    ) -> Result<(ArmState, Bool), VerificationError> {
+        let mut state = ArmState::new_symbolic();
+        Self::seed_inputs(&mut state, inputs)?;
+        if let Some(bits) = vfp_s0 {
+            state.set_vfp_reg(&synth_synthesis::rules::VfpReg::S0, bits.clone());
+        }
+        self.arm_encoder
+            .encode_sequence_br(arm_ops, &mut state)
+            .map_err(VerificationError::UnsupportedOperation)?;
+        let trap = state.may_trap.clone();
+        Ok((state, trap))
+    }
+
+    fn seed_inputs(state: &mut ArmState, inputs: &[BV]) -> Result<(), VerificationError> {
+        for (i, input) in inputs.iter().enumerate() {
+            let reg = match i {
+                0 => Reg::R0,
+                1 => Reg::R1,
+                2 => Reg::R2,
+                _ => {
+                    return Err(VerificationError::UnsupportedOperation(format!(
+                        "Too many inputs: {}",
+                        inputs.len()
+                    )));
+                }
+            };
+            state.set_reg(&reg, input.clone());
+        }
+        Ok(())
+    }
+
+    /// Run the trap-condition-only VC and map the verdict.
+    fn condition_verdict(wasm_trap: &Bool, arm_trap: &Bool) -> ValidationResult {
+        Self::trap_verdict_to_result(crate::trap::prove_trap_condition_equivalence(
+            wasm_trap, arm_trap,
+        ))
+    }
+
+    fn trap_verdict_to_result(verdict: crate::trap::TrapVerdict) -> ValidationResult {
+        match verdict {
             crate::trap::TrapVerdict::Preserved => ValidationResult::Verified,
             crate::trap::TrapVerdict::Dropped(model) => ValidationResult::Invalid {
                 counterexample: model
@@ -361,7 +642,7 @@ impl TranslationValidator {
             crate::trap::TrapVerdict::Unknown => ValidationResult::Unknown {
                 reason: "trap-preservation VC returned Unknown (conservative reject)".to_string(),
             },
-        })
+        }
     }
 
     /// Get number of inputs required for a WASM operation
@@ -417,6 +698,7 @@ impl TranslationValidator {
 mod tests {
     use super::*;
     use crate::with_verification_context;
+    use synth_synthesis::rules::Condition;
     use synth_synthesis::{Cost, Operand2, Pattern, Replacement};
 
     fn create_test_rule(wasm_op: WasmOp, arm_op: ArmOp) -> SynthesisRule {
@@ -464,37 +746,140 @@ mod tests {
         });
     }
 
+    /// The SHIPPED ÷0 guard shape (instruction_selector.rs I32DivU /
+    /// optimizer_bridge.rs DivU): CMP divisor,#0 ; BNE +0 (skip the UDF) ;
+    /// UDF ; UDIV. The derived trap term is (divisor == 0) — exactly WASM's.
+    fn shipped_divu_guard() -> Vec<ArmOp> {
+        vec![
+            ArmOp::Cmp {
+                rn: Reg::R1,
+                op2: Operand2::Imm(0),
+            },
+            ArmOp::BCondOffset {
+                cond: Condition::NE,
+                offset: 0,
+            },
+            ArmOp::Udf { imm: 0 },
+            ArmOp::Udiv {
+                rd: Reg::R0,
+                rn: Reg::R0,
+                rm: Reg::R1,
+            },
+        ]
+    }
+
+    /// The SHIPPED div_s DOUBLE guard (optimizer_bridge.rs DivS): the ÷0
+    /// guard plus the INT_MIN/-1 overflow guard (MOVW/MOVT 0x80000000 into
+    /// R12 ; CMP dividend ; BNE +3 ; CMN divisor,#1 ; BNE +0 ; UDF #1).
+    fn shipped_divs_double_guard() -> Vec<ArmOp> {
+        vec![
+            ArmOp::Cmp {
+                rn: Reg::R1,
+                op2: Operand2::Imm(0),
+            },
+            ArmOp::BCondOffset {
+                cond: Condition::NE,
+                offset: 0,
+            },
+            ArmOp::Udf { imm: 0 },
+            ArmOp::Movw {
+                rd: Reg::R12,
+                imm16: 0,
+            },
+            ArmOp::Movt {
+                rd: Reg::R12,
+                imm16: 0x8000,
+            },
+            ArmOp::Cmp {
+                rn: Reg::R0,
+                op2: Operand2::Reg(Reg::R12),
+            },
+            ArmOp::BCondOffset {
+                cond: Condition::NE,
+                offset: 3,
+            },
+            ArmOp::Cmn {
+                rn: Reg::R1,
+                op2: Operand2::Imm(1),
+            },
+            ArmOp::BCondOffset {
+                cond: Condition::NE,
+                offset: 0,
+            },
+            ArmOp::Udf { imm: 1 },
+            ArmOp::Sdiv {
+                rd: Reg::R0,
+                rn: Reg::R0,
+                rm: Reg::R1,
+            },
+        ]
+    }
+
     #[test]
     fn div_lowering_with_guard_preserves_the_trap() {
         with_verification_context(|| {
             let validator = TranslationValidator::new();
-            // Guarded divide: CMP divisor,#0 ; UDF (trap) ; UDIV. The structural
-            // Udf ⇒ the ÷0 trap is enforced; value matches WASM ⇒ Verified.
-            let arm_ops = [
-                ArmOp::Cmp {
-                    rn: Reg::R1,
-                    op2: Operand2::Imm(0),
-                },
-                ArmOp::Udf { imm: 0 },
-                ArmOp::Udiv {
-                    rd: Reg::R0,
-                    rn: Reg::R0,
-                    rm: Reg::R1,
-                },
-            ];
             let result = validator
-                .verify_div_rem_trap_preservation(&WasmOp::I32DivU, &arm_ops)
+                .verify_div_rem_trap_preservation(&WasmOp::I32DivU, &shipped_divu_guard())
                 .unwrap();
             assert_eq!(result, ValidationResult::Verified);
         });
     }
 
+    /// The derived gate is STRICTER than the retired Udf-presence proxy: a
+    /// guard with the branch polarity inverted (BEQ instead of BNE — the UDF
+    /// fires exactly when the divide is fine) still contains a Udf, so the
+    /// proxy called it Verified; the derived trap term is (divisor != 0),
+    /// which fails the VC.
     #[test]
-    fn signed_div_guard_preserves_both_zero_and_overflow_traps() {
+    fn div_guard_with_inverted_polarity_is_rejected() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let mut arm_ops = shipped_divu_guard();
+            arm_ops[1] = ArmOp::BCondOffset {
+                cond: Condition::EQ,
+                offset: 0,
+            };
+            let result = validator
+                .verify_div_rem_trap_preservation(&WasmOp::I32DivU, &arm_ops)
+                .unwrap();
+            assert!(
+                matches!(result, ValidationResult::Invalid { .. }),
+                "inverted guard polarity must be Invalid, got {result:?}"
+            );
+        });
+    }
+
+    #[test]
+    fn signed_div_double_guard_preserves_both_zero_and_overflow_traps() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let result = validator
+                .verify_div_rem_trap_preservation(&WasmOp::I32DivS, &shipped_divs_double_guard())
+                .unwrap();
+            assert_eq!(result, ValidationResult::Verified);
+        });
+    }
+
+    /// RED-FIRST for the div_s overflow class (#633-shape at i32): stripping
+    /// ONLY the INT_MIN/-1 overflow guard keeps a Udf in the sequence (the ÷0
+    /// guard), so the retired structural proxy called this Verified. The
+    /// derived trap term is only (divisor == 0), and the VC finds the dropped
+    /// overflow trap with the INT_MIN/-1 counterexample.
+    #[test]
+    fn signed_div_with_overflow_guard_stripped_is_rejected() {
         with_verification_context(|| {
             let validator = TranslationValidator::new();
             let arm_ops = [
-                ArmOp::Udf { imm: 0 }, // structural guard present
+                ArmOp::Cmp {
+                    rn: Reg::R1,
+                    op2: Operand2::Imm(0),
+                },
+                ArmOp::BCondOffset {
+                    cond: Condition::NE,
+                    offset: 0,
+                },
+                ArmOp::Udf { imm: 0 },
                 ArmOp::Sdiv {
                     rd: Reg::R0,
                     rn: Reg::R0,
@@ -504,7 +889,558 @@ mod tests {
             let result = validator
                 .verify_div_rem_trap_preservation(&WasmOp::I32DivS, &arm_ops)
                 .unwrap();
+            match result {
+                ValidationResult::Invalid { counterexample } => {
+                    let get = |n: &str| {
+                        counterexample
+                            .iter()
+                            .find(|(name, _)| name == n)
+                            .map(|(_, v)| *v)
+                    };
+                    assert_eq!(
+                        get("input_0"),
+                        Some(i32::MIN as u32 as i64),
+                        "dropped overflow trap must exhibit dividend INT_MIN: {counterexample:?}"
+                    );
+                    assert_eq!(
+                        get("input_1"),
+                        Some(u32::MAX as i64),
+                        "dropped overflow trap must exhibit divisor -1: {counterexample:?}"
+                    );
+                }
+                other => panic!("overflow-guard-stripped div_s must be Invalid, got {other:?}"),
+            }
+        });
+    }
+
+    /// rem_s carries ONLY the ÷0 guard — WASM rem_s(INT_MIN, -1) is 0, not a
+    /// trap — and the derived gate agrees.
+    #[test]
+    fn rems_single_zero_guard_is_exactly_right() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let arm_ops = [
+                ArmOp::Cmp {
+                    rn: Reg::R1,
+                    op2: Operand2::Imm(0),
+                },
+                ArmOp::BCondOffset {
+                    cond: Condition::NE,
+                    offset: 0,
+                },
+                ArmOp::Udf { imm: 0 },
+                ArmOp::Sdiv {
+                    rd: Reg::R2,
+                    rn: Reg::R0,
+                    rm: Reg::R1,
+                },
+                ArmOp::Mls {
+                    rd: Reg::R0,
+                    rn: Reg::R2,
+                    rm: Reg::R1,
+                    ra: Reg::R0,
+                },
+            ];
+            let result = validator
+                .verify_div_rem_trap_preservation(&WasmOp::I32RemS, &arm_ops)
+                .unwrap();
             assert_eq!(result, ValidationResult::Verified);
+        });
+    }
+
+    // --- unreachable (LIVE, #665 class) ---
+
+    #[test]
+    fn unreachable_udf_lowering_preserves_the_trap() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let result = validator
+                .verify_trap_preservation(&WasmOp::Unreachable, &[ArmOp::Udf { imm: 0 }])
+                .unwrap();
+            assert_eq!(result, ValidationResult::Verified);
+        });
+    }
+
+    #[test]
+    fn unreachable_lowered_to_nop_is_rejected() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            // The #665 shape: unreachable silently became a no-op.
+            let result = validator
+                .verify_trap_preservation(&WasmOp::Unreachable, &[ArmOp::Nop])
+                .unwrap();
+            assert!(
+                matches!(result, ValidationResult::Invalid { .. }),
+                "trap-dropping unreachable lowering must be Invalid, got {result:?}"
+            );
+        });
+    }
+
+    // --- i32 load/store OOB (LIVE, #377 class) ---
+
+    /// The SHIPPED software-bounds guard shape
+    /// (instruction_selector.rs generate_load_with_bounds_check):
+    /// ADD R12, addr, #(offset+size-1) ; CMP R12, R10 ; BLO +0 ; UDF ; LDR.
+    fn shipped_software_bounds_load(offset: i32, access_size: u32) -> Vec<ArmOp> {
+        use synth_synthesis::rules::MemAddr;
+        vec![
+            ArmOp::Add {
+                rd: Reg::R12,
+                rn: Reg::R0,
+                op2: Operand2::Imm(offset + access_size as i32 - 1),
+            },
+            ArmOp::Cmp {
+                rn: Reg::R12,
+                op2: Operand2::Reg(Reg::R10),
+            },
+            ArmOp::BCondOffset {
+                cond: Condition::LO,
+                offset: 0,
+            },
+            ArmOp::Udf { imm: 0 },
+            ArmOp::Ldr {
+                rd: Reg::R0,
+                addr: MemAddr::reg_imm(Reg::R11, Reg::R0, offset),
+            },
+        ]
+    }
+
+    /// RED-FIRST: a load with the bounds guard stripped derives trap = false
+    /// and is rejected against the WASM OOB condition.
+    #[test]
+    fn load_without_bounds_guard_is_rejected() {
+        use synth_synthesis::rules::MemAddr;
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let arm_ops = [ArmOp::Ldr {
+                rd: Reg::R0,
+                addr: MemAddr::reg_imm(Reg::R11, Reg::R0, 0),
+            }];
+            let result = validator
+                .verify_trap_preservation(
+                    &WasmOp::I32Load {
+                        offset: 0,
+                        align: 2,
+                    },
+                    &arm_ops,
+                )
+                .unwrap();
+            assert!(
+                matches!(result, ValidationResult::Invalid { .. }),
+                "guard-stripped load must be Invalid, got {result:?}"
+            );
+        });
+    }
+
+    /// A byte load's shipped guard (`end = addr + 0`) is EXACT: the 32-bit
+    /// end-address compute cannot wrap for size 1 / offset 0, so the derived
+    /// trap condition (addr >=u R10) matches WASM's (addr + 1 >u R10).
+    #[test]
+    fn byte_load_software_bounds_guard_preserves_the_trap() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let result = validator
+                .verify_trap_preservation(
+                    &WasmOp::I32Load8U {
+                        offset: 0,
+                        align: 0,
+                    },
+                    &shipped_software_bounds_load(0, 1),
+                )
+                .unwrap();
+            assert_eq!(result, ValidationResult::Verified);
+        });
+    }
+
+    /// FINDING (documented divergence): for multi-byte accesses the shipped
+    /// software-bounds guard computes `addr + (offset+size-1)` in WRAPPING
+    /// 32-bit arithmetic, while WASM's effective-address check is exact. At
+    /// `addr >= 0x1_0000_0000 - (offset+size-1)` the end-address wraps to a
+    /// small value, the BLO guard passes, and the access escapes below the
+    /// linear-memory base — WASM requires a trap. The derived gate exhibits
+    /// exactly that dropped-trap counterexample. Pinned Invalid until the
+    /// selector's guard is made wraparound-safe (tracked as a #377/#651
+    /// follow-up filed with this gate).
+    #[test]
+    fn word_load_software_bounds_guard_wraps_at_address_top() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let result = validator
+                .verify_trap_preservation(
+                    &WasmOp::I32Load {
+                        offset: 0,
+                        align: 2,
+                    },
+                    &shipped_software_bounds_load(0, 4),
+                )
+                .unwrap();
+            match result {
+                ValidationResult::Invalid { counterexample } => {
+                    let addr = counterexample
+                        .iter()
+                        .find(|(n, _)| n == "input_0")
+                        .map(|(_, v)| *v)
+                        .expect("counterexample must assign the address");
+                    assert!(
+                        addr >= 0xFFFF_FFFD,
+                        "the divergence is the 32-bit end-address wrap at the top \
+                         of the address space, got addr {addr:#x}"
+                    );
+                }
+                other => panic!(
+                    "expected the pinned wraparound divergence (Invalid), got {other:?} — \
+                     if this is now Verified the selector guard was fixed: \
+                     flip this test to Verified and close the finding"
+                ),
+            }
+        });
+    }
+
+    /// The gate is satisfiable by a correct guard: a wraparound-safe bound
+    /// check (trap iff bound < k, else iff addr >u bound - k, k = offset+size)
+    /// verifies for word accesses — proving the mem-OOB class gate is not
+    /// vacuously red.
+    #[test]
+    fn wraparound_safe_bounds_guard_verifies() {
+        use synth_synthesis::rules::MemAddr;
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let k = 4; // offset 0, size 4
+            let arm_ops = [
+                // CMP R10, #k ; BHS +0 ; UDF   — bound < k ⇒ every access traps
+                ArmOp::Cmp {
+                    rn: Reg::R10,
+                    op2: Operand2::Imm(k),
+                },
+                ArmOp::BCondOffset {
+                    cond: Condition::HS,
+                    offset: 0,
+                },
+                ArmOp::Udf { imm: 0 },
+                // SUB R12, R10, #k ; CMP addr, R12 ; BLS +0 ; UDF — exact on
+                // the bound >= k path (no wrap possible)
+                ArmOp::Sub {
+                    rd: Reg::R12,
+                    rn: Reg::R10,
+                    op2: Operand2::Imm(k),
+                },
+                ArmOp::Cmp {
+                    rn: Reg::R0,
+                    op2: Operand2::Reg(Reg::R12),
+                },
+                ArmOp::BCondOffset {
+                    cond: Condition::LS,
+                    offset: 0,
+                },
+                ArmOp::Udf { imm: 0 },
+                ArmOp::Ldr {
+                    rd: Reg::R0,
+                    addr: MemAddr::reg_imm(Reg::R11, Reg::R0, 0),
+                },
+            ];
+            let result = validator
+                .verify_trap_preservation(
+                    &WasmOp::I32Load {
+                        offset: 0,
+                        align: 2,
+                    },
+                    &arm_ops,
+                )
+                .unwrap();
+            assert_eq!(result, ValidationResult::Verified);
+        });
+    }
+
+    // --- i32.trunc_f32_s/u (LIVE, #709 class) ---
+
+    /// The SHIPPED trunc domain-guard shape (instruction_selector.rs
+    /// I32TruncF32S/U): per bound, F32Const scratch ; ordered compare into
+    /// R0 ; CMP R0,#0 ; BNE +0 (in-range skips) ; UDF — then the VCVT.
+    /// Operand in S0, bound scratch S1 (the gate's register convention).
+    fn shipped_trunc_f32_guard(signed: bool) -> Vec<ArmOp> {
+        use synth_synthesis::rules::VfpReg;
+        let (hi, lo) = if signed {
+            (2147483648.0_f32, -2147483648.0_f32)
+        } else {
+            (4294967296.0_f32, -1.0_f32)
+        };
+        let mut ops = Vec::new();
+        let mut guard = |bound: f32, upper: bool| {
+            ops.push(ArmOp::F32Const {
+                sd: VfpReg::S1,
+                value: bound,
+            });
+            let cmp = if upper {
+                ArmOp::F32Lt {
+                    rd: Reg::R0,
+                    sn: VfpReg::S0,
+                    sm: VfpReg::S1,
+                }
+            } else if signed {
+                ArmOp::F32Ge {
+                    rd: Reg::R0,
+                    sn: VfpReg::S0,
+                    sm: VfpReg::S1,
+                }
+            } else {
+                ArmOp::F32Gt {
+                    rd: Reg::R0,
+                    sn: VfpReg::S0,
+                    sm: VfpReg::S1,
+                }
+            };
+            ops.push(cmp);
+            ops.push(ArmOp::Cmp {
+                rn: Reg::R0,
+                op2: Operand2::Imm(0),
+            });
+            ops.push(ArmOp::BCondOffset {
+                cond: Condition::NE,
+                offset: 0,
+            });
+            ops.push(ArmOp::Udf { imm: 0 });
+        };
+        guard(hi, true);
+        guard(lo, false);
+        drop(guard);
+        if signed {
+            ops.push(ArmOp::I32TruncF32S {
+                rd: Reg::R0,
+                sm: VfpReg::S0,
+            });
+        } else {
+            ops.push(ArmOp::I32TruncF32U {
+                rd: Reg::R0,
+                sm: VfpReg::S0,
+            });
+        }
+        ops
+    }
+
+    #[test]
+    fn trunc_f32_s_domain_guard_preserves_the_trap() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let result = validator
+                .verify_trap_preservation(&WasmOp::I32TruncF32S, &shipped_trunc_f32_guard(true))
+                .unwrap();
+            assert_eq!(result, ValidationResult::Verified);
+        });
+    }
+
+    #[test]
+    fn trunc_f32_u_domain_guard_preserves_the_trap() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let result = validator
+                .verify_trap_preservation(&WasmOp::I32TruncF32U, &shipped_trunc_f32_guard(false))
+                .unwrap();
+            assert_eq!(result, ValidationResult::Verified);
+        });
+    }
+
+    /// RED-FIRST for the #709 class: the bare saturating VCVT (guards
+    /// stripped) never traps — rejected with a counterexample.
+    #[test]
+    fn trunc_f32_without_domain_guard_is_rejected() {
+        use synth_synthesis::rules::VfpReg;
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let arm_ops = [ArmOp::I32TruncF32S {
+                rd: Reg::R0,
+                sm: VfpReg::S0,
+            }];
+            let result = validator
+                .verify_trap_preservation(&WasmOp::I32TruncF32S, &arm_ops)
+                .unwrap();
+            assert!(
+                matches!(result, ValidationResult::Invalid { .. }),
+                "guard-stripped trunc must be Invalid, got {result:?}"
+            );
+        });
+    }
+
+    /// Half a domain guard (upper bound only) drops the lower-bound trap.
+    #[test]
+    fn trunc_f32_with_only_upper_guard_is_rejected() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let mut arm_ops = shipped_trunc_f32_guard(true);
+            // Strip the second (lower-bound) guard: 5 ops per guard block.
+            arm_ops.drain(5..10);
+            let result = validator
+                .verify_trap_preservation(&WasmOp::I32TruncF32S, &arm_ops)
+                .unwrap();
+            assert!(
+                matches!(result, ValidationResult::Invalid { .. }),
+                "upper-only trunc guard must be Invalid, got {result:?}"
+            );
+        });
+    }
+
+    // --- call_indirect (LIVE at the pseudo-op guard level, #642/#664/#676) ---
+
+    fn call_indirect_pseudo(
+        table_size: u32,
+        null_check: bool,
+        type_check: Option<(u32, u32)>,
+    ) -> ArmOp {
+        ArmOp::CallIndirect {
+            rd: Reg::R0,
+            type_idx: 0,
+            table_index_reg: Reg::R0,
+            table_size,
+            table_byte_offset: 0,
+            null_check,
+            type_check,
+        }
+    }
+
+    #[test]
+    fn call_indirect_matching_guards_preserve_the_traps() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            // Homogeneous table, all slots initialized: bounds clause only.
+            let result = validator
+                .verify_call_indirect_trap_preservation(
+                    &call_indirect_pseudo(8, false, None),
+                    &CallIndirectSpec {
+                        table_size: 8,
+                        may_have_null_slot: false,
+                        heterogeneous_expected_type: None,
+                    },
+                )
+                .unwrap();
+            assert_eq!(result, ValidationResult::Verified);
+            // Null-slot table + runtime type check, guards resolved.
+            let result = validator
+                .verify_call_indirect_trap_preservation(
+                    &call_indirect_pseudo(8, true, Some((3, 32))),
+                    &CallIndirectSpec {
+                        table_size: 8,
+                        may_have_null_slot: true,
+                        heterogeneous_expected_type: Some(3),
+                    },
+                )
+                .unwrap();
+            assert_eq!(result, ValidationResult::Verified);
+        });
+    }
+
+    /// RED-FIRST for the #664 class: table has uninitialized slots but the
+    /// selector resolved `null_check: false` — the null trap is dropped.
+    #[test]
+    fn call_indirect_dropped_null_check_is_rejected() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let result = validator
+                .verify_call_indirect_trap_preservation(
+                    &call_indirect_pseudo(8, false, None),
+                    &CallIndirectSpec {
+                        table_size: 8,
+                        may_have_null_slot: true,
+                        heterogeneous_expected_type: None,
+                    },
+                )
+                .unwrap();
+            assert!(
+                matches!(result, ValidationResult::Invalid { .. }),
+                "dropped null check must be Invalid, got {result:?}"
+            );
+        });
+    }
+
+    /// RED-FIRST for the #642 class: the selector resolved the WRONG table
+    /// size — indices in the gap escape the bounds trap.
+    #[test]
+    fn call_indirect_wrong_table_size_is_rejected() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let result = validator
+                .verify_call_indirect_trap_preservation(
+                    &call_indirect_pseudo(16, false, None),
+                    &CallIndirectSpec {
+                        table_size: 8,
+                        may_have_null_slot: false,
+                        heterogeneous_expected_type: None,
+                    },
+                )
+                .unwrap();
+            assert!(
+                matches!(result, ValidationResult::Invalid { .. }),
+                "wrong bounds size must be Invalid, got {result:?}"
+            );
+        });
+    }
+
+    /// RED-FIRST for the #676 class: heterogeneous table but the runtime
+    /// type check was dropped.
+    #[test]
+    fn call_indirect_dropped_type_check_is_rejected() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            let result = validator
+                .verify_call_indirect_trap_preservation(
+                    &call_indirect_pseudo(8, true, None),
+                    &CallIndirectSpec {
+                        table_size: 8,
+                        may_have_null_slot: true,
+                        heterogeneous_expected_type: Some(3),
+                    },
+                )
+                .unwrap();
+            assert!(
+                matches!(result, ValidationResult::Invalid { .. }),
+                "dropped type check must be Invalid, got {result:?}"
+            );
+        });
+    }
+
+    // --- verify_rule routes partial ops through the trap VC (mandatory) ---
+
+    #[test]
+    fn verify_rule_routes_partial_ops_through_the_trap_gate() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            // A bare-UDIV rule: value-plausible, trap-dropping. verify_rule
+            // must report Invalid (via the trap VC), not silently value-check.
+            let rule = SynthesisRule {
+                name: "i32.div_u → bare UDIV (trap-dropping)".into(),
+                priority: 0,
+                pattern: Pattern::WasmInstr(WasmOp::I32DivU),
+                replacement: Replacement::ArmInstr(ArmOp::Udiv {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R1,
+                }),
+                cost: Cost {
+                    cycles: 1,
+                    code_size: 4,
+                    registers: 2,
+                },
+            };
+            let result = validator.verify_rule(&rule).unwrap();
+            assert!(
+                matches!(result, ValidationResult::Invalid { .. }),
+                "verify_rule must reject the trap-dropping div rule, got {result:?}"
+            );
+
+            // The guarded shape goes green through the same entry point.
+            let rule = SynthesisRule {
+                name: "i32.div_u → guarded UDIV".into(),
+                priority: 0,
+                pattern: Pattern::WasmInstr(WasmOp::I32DivU),
+                replacement: Replacement::ArmSequence(shipped_divu_guard()),
+                cost: Cost {
+                    cycles: 4,
+                    code_size: 10,
+                    registers: 2,
+                },
+            };
+            assert_eq!(
+                validator.verify_rule(&rule).unwrap(),
+                ValidationResult::Verified
+            );
         });
     }
 

--- a/crates/synth-verify/src/trap.rs
+++ b/crates/synth-verify/src/trap.rs
@@ -127,9 +127,30 @@ pub fn div_op(op: &WasmOp) -> Option<DivOp> {
 }
 
 /// Trap condition for a div/rem op: divide-by-zero (all four) plus
-/// `INT_MIN / -1` signed overflow (`div_s`/`rem_s`). The width is taken from
+/// `INT_MIN / -1` signed overflow (`div_s` ONLY). The width is taken from
 /// `dividend` — pass 32-bit terms for i32 ops, 64-bit for i64.
+///
+/// # ordeal 0.9.1 divergence (upstream bug, reported as ordeal#72)
+///
+/// `ordeal::trap::trap_div(DivOp::RemS)` includes the `INT_MIN / -1`
+/// overflow clause, but WASM Core §4.4.1 `irem_s` does NOT trap there — it
+/// returns 0 (only `idiv_s` traps on overflow). synth's own models agree
+/// (`I32.rems` in `coq/Synth/Common/Integers.v` carries no overflow guard;
+/// the shipped `rem_s` lowering emits only the ÷0 guard). The divergence was
+/// invisible while BOTH sides of the VC used the builder (consistent
+/// wrongness); the #166 derived-ARM-trap gate exposed it by rejecting the
+/// CORRECT shipped `rem_s` lowering with an INT_MIN/-1 counterexample. Until
+/// the ordeal#72 fix ships, `RemS` is built through the zero-only path
+/// (`RemU`'s trap condition — the ÷0 test is a bit-pattern equality, so
+/// signedness does not change it).
 pub fn trap_div(op: DivOp, dividend: &BV, divisor: &BV) -> Bool {
+    // WASM rem_s traps ONLY on ÷0 — route around ordeal 0.9.1's spurious
+    // overflow clause (see the doc comment above).
+    let op = if matches!(op, DivOp::RemS) {
+        DivOp::RemU
+    } else {
+        op
+    };
     Bool::from_ordeal(ot::trap_div(
         op,
         dividend.term(),

--- a/crates/synth-verify/tests/comprehensive_verification.rs
+++ b/crates/synth-verify/tests/comprehensive_verification.rs
@@ -6,6 +6,7 @@
 //! `SYNTH_SOLVER_DIFF=1`.
 #![cfg(feature = "arm")]
 
+use synth_synthesis::rules::Condition;
 use synth_synthesis::{ArmOp, Operand2, Pattern, Reg, Replacement, SynthesisRule, WasmOp};
 use synth_verify::{
     ArmSemantics, ArmState, BV, TranslationValidator, ValidationResult, WasmSemantics,
@@ -25,6 +26,116 @@ fn create_rule(name: &str, wasm_op: WasmOp, arm_op: ArmOp) -> SynthesisRule {
             registers: 2,
         },
     }
+}
+
+/// Helper to create a multi-instruction test synthesis rule
+fn create_seq_rule(name: &str, wasm_op: WasmOp, arm_ops: Vec<ArmOp>) -> SynthesisRule {
+    SynthesisRule {
+        name: name.to_string(),
+        priority: 0,
+        pattern: Pattern::WasmInstr(wasm_op),
+        replacement: Replacement::ArmSequence(arm_ops),
+        cost: synth_synthesis::Cost {
+            cycles: 4,
+            code_size: 12,
+            registers: 3,
+        },
+    }
+}
+
+/// The SHIPPED ÷0 guard prefix: CMP divisor,#0 ; BNE +0 (skip the UDF) ; UDF.
+/// Since VCR-VER-002 (#166) wired the mandatory trap-preservation VC into
+/// `verify_rule`, every div/rem rule MUST carry its trap guard to verify —
+/// a bare SDIV/UDIV is the trap-dropping #633 bug shape and is Invalid.
+fn div_zero_guard() -> Vec<ArmOp> {
+    vec![
+        ArmOp::Cmp {
+            rn: Reg::R1,
+            op2: Operand2::Imm(0),
+        },
+        ArmOp::BCondOffset {
+            cond: Condition::NE,
+            offset: 0,
+        },
+        ArmOp::Udf { imm: 0 },
+    ]
+}
+
+/// The SHIPPED guarded div_u lowering: ÷0 guard + UDIV.
+fn guarded_div_u() -> Vec<ArmOp> {
+    let mut ops = div_zero_guard();
+    ops.push(ArmOp::Udiv {
+        rd: Reg::R0,
+        rn: Reg::R0,
+        rm: Reg::R1,
+    });
+    ops
+}
+
+/// The SHIPPED guarded div_s lowering: ÷0 guard + INT_MIN/-1 overflow guard
+/// (MOVW/MOVT 0x80000000 ; CMP dividend ; BNE +3 ; CMN divisor,#1 ; BNE +0 ;
+/// UDF) + SDIV.
+fn guarded_div_s() -> Vec<ArmOp> {
+    let mut ops = div_zero_guard();
+    ops.extend([
+        ArmOp::Movw {
+            rd: Reg::R12,
+            imm16: 0,
+        },
+        ArmOp::Movt {
+            rd: Reg::R12,
+            imm16: 0x8000,
+        },
+        ArmOp::Cmp {
+            rn: Reg::R0,
+            op2: Operand2::Reg(Reg::R12),
+        },
+        ArmOp::BCondOffset {
+            cond: Condition::NE,
+            offset: 3,
+        },
+        ArmOp::Cmn {
+            rn: Reg::R1,
+            op2: Operand2::Imm(1),
+        },
+        ArmOp::BCondOffset {
+            cond: Condition::NE,
+            offset: 0,
+        },
+        ArmOp::Udf { imm: 1 },
+        ArmOp::Sdiv {
+            rd: Reg::R0,
+            rn: Reg::R0,
+            rm: Reg::R1,
+        },
+    ]);
+    ops
+}
+
+/// The SHIPPED guarded rem lowering: ÷0 guard + SDIV/UDIV into R2 + MLS.
+/// (rem_s carries ONLY the ÷0 guard — WASM rem_s(INT_MIN,-1) is 0, no trap.)
+fn guarded_rem(signed: bool) -> Vec<ArmOp> {
+    let mut ops = div_zero_guard();
+    ops.push(if signed {
+        ArmOp::Sdiv {
+            rd: Reg::R2,
+            rn: Reg::R0,
+            rm: Reg::R1,
+        }
+    } else {
+        ArmOp::Udiv {
+            rd: Reg::R2,
+            rn: Reg::R0,
+            rm: Reg::R1,
+        }
+    });
+    ops.push(ArmOp::Mls {
+        rd: Reg::R0,
+        rn: Reg::R2,
+        rm: Reg::R1,
+        ra: Reg::R0,
+    });
+    ops
 }
 
 // ============================================================================
@@ -102,8 +213,10 @@ fn verify_i32_div_s() {
     with_verification_context(|| {
         let validator = TranslationValidator::new();
 
-        let rule = create_rule(
-            "i32.div_s",
+        // VCR-VER-002 (#166): a bare SDIV drops BOTH WASM traps (÷0 and
+        // INT_MIN/-1) — the mandatory trap gate must reject it.
+        let bare = create_rule(
+            "i32.div_s (bare, trap-dropping)",
             WasmOp::I32DivS,
             ArmOp::Sdiv {
                 rd: Reg::R0,
@@ -111,9 +224,16 @@ fn verify_i32_div_s() {
                 rm: Reg::R1,
             },
         );
-
         assert!(matches!(
-            validator.verify_rule(&rule),
+            validator.verify_rule(&bare),
+            Ok(ValidationResult::Invalid { .. })
+        ));
+
+        // The shipped double-guarded lowering verifies: traps preserved AND
+        // the quotient matches.
+        let guarded = create_seq_rule("i32.div_s", WasmOp::I32DivS, guarded_div_s());
+        assert!(matches!(
+            validator.verify_rule(&guarded),
             Ok(ValidationResult::Verified)
         ));
     });
@@ -124,8 +244,9 @@ fn verify_i32_div_u() {
     with_verification_context(|| {
         let validator = TranslationValidator::new();
 
-        let rule = create_rule(
-            "i32.div_u",
+        // VCR-VER-002 (#166): a bare UDIV drops the ÷0 trap — rejected.
+        let bare = create_rule(
+            "i32.div_u (bare, trap-dropping)",
             WasmOp::I32DivU,
             ArmOp::Udiv {
                 rd: Reg::R0,
@@ -133,9 +254,15 @@ fn verify_i32_div_u() {
                 rm: Reg::R1,
             },
         );
-
         assert!(matches!(
-            validator.verify_rule(&rule),
+            validator.verify_rule(&bare),
+            Ok(ValidationResult::Invalid { .. })
+        ));
+
+        // The shipped guarded lowering verifies.
+        let guarded = create_seq_rule("i32.div_u", WasmOp::I32DivU, guarded_div_u());
+        assert!(matches!(
+            validator.verify_rule(&guarded),
             Ok(ValidationResult::Verified)
         ));
     });
@@ -259,47 +386,26 @@ fn verify_i32_rem_s() {
     with_verification_context(|| {
         let validator = TranslationValidator::new();
 
-        let rule = SynthesisRule {
-            name: "i32.rem_s".to_string(),
-            priority: 0,
-            pattern: Pattern::WasmInstr(WasmOp::I32RemS),
-            replacement: Replacement::ArmSequence(vec![
-                // Step 1: Compute quotient
-                ArmOp::Sdiv {
-                    rd: Reg::R2, // quotient destination
-                    rn: Reg::R0, // dividend
-                    rm: Reg::R1, // divisor
-                },
-                // Step 2: Compute remainder using MLS
-                ArmOp::Mls {
-                    rd: Reg::R0, // remainder destination
-                    rn: Reg::R2, // quotient
-                    rm: Reg::R1, // divisor
-                    ra: Reg::R0, // dividend
-                },
-            ]),
-            cost: synth_synthesis::Cost {
-                cycles: 2,
-                code_size: 8,
-                registers: 3,
-            },
-        };
+        // VCR-VER-002 (#166): the guard-less SDIV+MLS sequence drops the ÷0
+        // trap — the mandatory trap gate must reject it.
+        let bare = create_seq_rule(
+            "i32.rem_s (guard-less, trap-dropping)",
+            WasmOp::I32RemS,
+            guarded_rem(true)[3..].to_vec(),
+        );
+        assert!(matches!(
+            validator.verify_rule(&bare),
+            Ok(ValidationResult::Invalid { .. })
+        ));
 
+        // The shipped ÷0-guarded SDIV+MLS verifies: trap preserved AND
+        // rem_s(a,b) = a - (a/b)*b.
+        let rule = create_seq_rule("i32.rem_s", WasmOp::I32RemS, guarded_rem(true));
         match validator.verify_rule(&rule) {
             Ok(ValidationResult::Verified) => {
                 println!("✓ I32RemS sequence verified: rem_s(a,b) = a - (a/b)*b");
             }
-            Ok(ValidationResult::Unknown { reason }) => {
-                // Complex arithmetic may timeout in SMT solver - concrete tests pass
-                println!(
-                    "⚠ I32RemS verification unknown (complex formula): {}",
-                    reason
-                );
-            }
-            other => panic!(
-                "Expected Verified or Unknown for REM_S sequence, got {:?}",
-                other
-            ),
+            other => panic!("Expected Verified for guarded REM_S sequence, got {other:?}"),
         }
     });
 }
@@ -318,47 +424,26 @@ fn verify_i32_rem_u() {
     with_verification_context(|| {
         let validator = TranslationValidator::new();
 
-        let rule = SynthesisRule {
-            name: "i32.rem_u".to_string(),
-            priority: 0,
-            pattern: Pattern::WasmInstr(WasmOp::I32RemU),
-            replacement: Replacement::ArmSequence(vec![
-                // Step 1: Compute quotient
-                ArmOp::Udiv {
-                    rd: Reg::R2, // quotient destination
-                    rn: Reg::R0, // dividend
-                    rm: Reg::R1, // divisor
-                },
-                // Step 2: Compute remainder using MLS
-                ArmOp::Mls {
-                    rd: Reg::R0, // remainder destination
-                    rn: Reg::R2, // quotient
-                    rm: Reg::R1, // divisor
-                    ra: Reg::R0, // dividend
-                },
-            ]),
-            cost: synth_synthesis::Cost {
-                cycles: 2,
-                code_size: 8,
-                registers: 3,
-            },
-        };
+        // VCR-VER-002 (#166): the guard-less UDIV+MLS sequence drops the ÷0
+        // trap — the mandatory trap gate must reject it.
+        let bare = create_seq_rule(
+            "i32.rem_u (guard-less, trap-dropping)",
+            WasmOp::I32RemU,
+            guarded_rem(false)[3..].to_vec(),
+        );
+        assert!(matches!(
+            validator.verify_rule(&bare),
+            Ok(ValidationResult::Invalid { .. })
+        ));
 
+        // The shipped ÷0-guarded UDIV+MLS verifies: trap preserved AND
+        // rem_u(a,b) = a - (a/b)*b.
+        let rule = create_seq_rule("i32.rem_u", WasmOp::I32RemU, guarded_rem(false));
         match validator.verify_rule(&rule) {
             Ok(ValidationResult::Verified) => {
                 println!("✓ I32RemU sequence verified: rem_u(a,b) = a - (a/b)*b");
             }
-            Ok(ValidationResult::Unknown { reason }) => {
-                // Complex arithmetic may timeout in SMT solver - concrete tests pass
-                println!(
-                    "⚠ I32RemU verification unknown (complex formula): {}",
-                    reason
-                );
-            }
-            other => panic!(
-                "Expected Verified or Unknown for REM_U sequence, got {:?}",
-                other
-            ),
+            other => panic!("Expected Verified for guarded REM_U sequence, got {other:?}"),
         }
     });
 }
@@ -1604,24 +1689,10 @@ fn batch_verify_all_arithmetic() {
                     rm: Reg::R1,
                 },
             ),
-            create_rule(
-                "i32.div_s",
-                WasmOp::I32DivS,
-                ArmOp::Sdiv {
-                    rd: Reg::R0,
-                    rn: Reg::R0,
-                    rm: Reg::R1,
-                },
-            ),
-            create_rule(
-                "i32.div_u",
-                WasmOp::I32DivU,
-                ArmOp::Udiv {
-                    rd: Reg::R0,
-                    rn: Reg::R0,
-                    rm: Reg::R1,
-                },
-            ),
+            // div rules carry their SHIPPED trap guards — the batch runs
+            // through the mandatory VCR-VER-002 trap gate (#166).
+            create_seq_rule("i32.div_s", WasmOp::I32DivS, guarded_div_s()),
+            create_seq_rule("i32.div_u", WasmOp::I32DivU, guarded_div_u()),
         ];
 
         let results = validator.verify_rules(&rules);
@@ -1693,9 +1764,11 @@ fn generate_verification_report() {
     with_verification_context(|| {
         let validator = TranslationValidator::new();
 
-        // Test all directly mappable operations
+        // Test all directly mappable operations; the div rules carry their
+        // SHIPPED trap guards (a bare SDIV/UDIV is Invalid under the
+        // mandatory VCR-VER-002 trap gate, #166).
         let test_cases = vec![
-            (
+            create_rule(
                 "i32.add → ADD",
                 WasmOp::I32Add,
                 ArmOp::Add {
@@ -1704,7 +1777,7 @@ fn generate_verification_report() {
                     op2: Operand2::Reg(Reg::R1),
                 },
             ),
-            (
+            create_rule(
                 "i32.sub → SUB",
                 WasmOp::I32Sub,
                 ArmOp::Sub {
@@ -1713,7 +1786,7 @@ fn generate_verification_report() {
                     op2: Operand2::Reg(Reg::R1),
                 },
             ),
-            (
+            create_rule(
                 "i32.mul → MUL",
                 WasmOp::I32Mul,
                 ArmOp::Mul {
@@ -1722,25 +1795,9 @@ fn generate_verification_report() {
                     rm: Reg::R1,
                 },
             ),
-            (
-                "i32.div_s → SDIV",
-                WasmOp::I32DivS,
-                ArmOp::Sdiv {
-                    rd: Reg::R0,
-                    rn: Reg::R0,
-                    rm: Reg::R1,
-                },
-            ),
-            (
-                "i32.div_u → UDIV",
-                WasmOp::I32DivU,
-                ArmOp::Udiv {
-                    rd: Reg::R0,
-                    rn: Reg::R0,
-                    rm: Reg::R1,
-                },
-            ),
-            (
+            create_seq_rule("i32.div_s → guarded SDIV", WasmOp::I32DivS, guarded_div_s()),
+            create_seq_rule("i32.div_u → guarded UDIV", WasmOp::I32DivU, guarded_div_u()),
+            create_rule(
                 "i32.and → AND",
                 WasmOp::I32And,
                 ArmOp::And {
@@ -1749,7 +1806,7 @@ fn generate_verification_report() {
                     op2: Operand2::Reg(Reg::R1),
                 },
             ),
-            (
+            create_rule(
                 "i32.or → ORR",
                 WasmOp::I32Or,
                 ArmOp::Orr {
@@ -1758,7 +1815,7 @@ fn generate_verification_report() {
                     op2: Operand2::Reg(Reg::R1),
                 },
             ),
-            (
+            create_rule(
                 "i32.xor → EOR",
                 WasmOp::I32Xor,
                 ArmOp::Eor {
@@ -1779,8 +1836,8 @@ fn generate_verification_report() {
         let mut invalid = 0;
         let mut unknown = 0;
 
-        for (name, wasm_op, arm_op) in test_cases {
-            let rule = create_rule(name, wasm_op, arm_op);
+        for rule in test_cases {
+            let name = rule.name.clone();
             let result = validator.verify_rule(&rule);
 
             let status = match &result {


### PR DESCRIPTION
Lane B of the v0.43.0 hub — verification-arc closure. Two halves, both landed.

## Half 1 — the trap-preservation VC is LIVE, with DERIVED ARM trap terms (#166 / VCR-VER-002)

The ARM-side trap condition is no longer the structural `Udf`-presence proxy: `ArmSemantics::encode_sequence_br` threads a `may_trap` term through a branch-taking guarded executor — `BCondOffset` routes path guards, executing a `UDF` accumulates its path guard, and everything else is if-converted. A **dropped, inverted, or wrong-register guard now derives a trap condition that fails the VC** (the proxy only saw that *some* trap existed). `verify_rule` routes partial ops through this gate **mandatorily**.

### Live class matrix

| class | VC | red-first evidence (guard-stripped ⇒ Invalid) |
|---|---|---|
| i32 div/rem (all four) | full (trap ∧ value) | bare `SDIV`/`UDIV`(±`MLS`) rejected; **inverted branch polarity** rejected (proxy passed it); div_s with ONLY the overflow guard stripped rejected with the INT_MIN/-1 counterexample |
| `unreachable` | trap-condition | `NOP` lowering rejected (#665 shape) |
| i32 load/store (1/2/4-byte) | trap-condition (no memory-contents model) | guard-stripped `LDR` rejected; wraparound-safe guard proven Verified (gate not vacuously red) |
| `i32.trunc_f32_s/u` | trap-condition (bit-pattern VFP compare semantics) | bare `VCVT` rejected; upper-bound-only guard rejected (#709 shape) |
| `call_indirect` | trap-condition at the pseudo-op guard level vs module-facts spec (`CallIndirectSpec`) | wrong table size (#642), dropped null check (#664), dropped runtime type check (#676) each rejected |

Held out honestly (unit-gated, doc'd in the method): i64 div/rem (needs 64-bit operands + register-pair value model), `trunc_f64` (no D-register model).

### Two genuine findings the derived gate produced

1. **ordeal#72** — ordeal 0.9.1 `trap_div(DivOp::RemS)` wrongly includes the INT_MIN/-1 overflow clause; WASM `rem_s` returns 0 there. Invisible while both VC sides used the same builder (consistent wrongness); the derived ARM side exposed it by **rejecting the CORRECT shipped rem_s lowering**. Workaround pinned in `trap.rs` until the upstream fix.
2. **#752** — the shipped `--safety-bounds software` guard computes the end address in wrapping 32-bit arithmetic: multi-byte accesses at the top of the i32 address space escape the OOB trap (WASM requires exact arithmetic). Pinned as a red test with the counterexample constrained to `addr >= 0xFFFF_FFFD`; a wraparound-safe guard shape is proven Verified.

### Solver-tractability work (required to make the gate green)

- `ite(g, x, x)` merges skipped via structural `same_term` — the unconditional 16-register if-conversion merge nested SDIV operands in ite chains: div_s double-guard VC ran **45+ min / 5.4 GB**, now 0.3 s.
- div/rem VALUE clause from a straight-line pass when `branch_spans_are_value_dead` (no register/VFP writes in branch-skipped spans, no `SetCond`) — true for every shipped div/rem shape, keeps the divider/multiplier circuits structurally shared with the WASM side (an ite-wrapped `MLS` miter is the term.rs CDCL cliff: rem_s UNSAT proof 15+ min → 0.3 s). Soundness argument in the doc comments; non-conforming shapes fall back to the guarded post-state.

`comprehensive_verification.rs` updated to the new reality: bare div/rem rules assert **Invalid** (the #633 trap-drop shape), shipped guarded shapes assert Verified through the same `verify_rule` entry.

## Half 2 — the LAST i32 div_s admit discharged (#73)

`i32_divs_correct` is **Qed** against `exec_program_br`: the full 11-instruction double-guard sequence with a case split on the dividend-is-INT_MIN compare (div_u/rem_s/rem_u precedent). **473 Qed / 5 Admitted** (was 472/6) — **0 division admits, #73 closed at i32**.

Enabling model fix (`Integers.v`): `I32.divs`'s overflow guard now tests the **signed interpretation** — the old raw-representative `Z.eqb x min_signed` (a negative constant) was vacuous for register-normalized values in `[0, 2^32)`, so the model under-trapped exactly where the compiled guard and the WASM spec trap; the theorem was FALSE as previously stated. `I32.signed` is invariant across representatives mod 2^32, so the new guard subsumes the old.

Docs + ledger bumped together, `claim_check` 18/18 green (README ×3, CLAUDE.md, coq/STATUS.md, claims.yaml incl. admit-breakdown i32 1→0).

## Gates

- `bazel test //coq:verify_proofs` PASSED (2/2)
- `cargo test --workspace` — 121 suites, all ok (synth-verify: 145 + 53 + 11)
- `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `python3 scripts/claim_check.py claims.yaml` — 18/18

Refs #166 #73 #242 ordeal#59 ordeal#72 #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L