### PR TITLE
chore(release): v0.43.0 — isolation + verification closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.0] - 2026-07-15
+
+**Isolation + verification closure — and the biggest soundness yield of any hub
+yet.** First multi-memory support, the last i32 division admit discharged (#73
+closed after five weeks open), the trap-preservation VC goes LIVE (a dropped trap
+now fails translation validation, not just a unit gate), the falcon float story
+completes, proof-carrying bounds elision hits the theoretical floor — and the
+derived trap gate + new execution coverage caught **six latent soundness bugs**,
+each now oracle-pinned.
+
+### Fixed (soundness)
+
+- **Wide conditional branches over 254 bytes were silently halved (#740).** The
+  Thumb-2 `B<cond>.W` (T3) encoder packed `halfword_offset >> 1` into the imm
+  field, which IS the halfword offset — so every conditional branch spanning
+  > 254 B landed at half its displacement (gust_poll's loop-head `br_if` landed
+  mid-shape). Fixed to pack directly (LLVM-cross-checked bytes) + loud-decline
+  out-of-range; the anti-vacuous xfail promoted to strict.
+- **Software bounds guard wrapped at the address-space top (#752).** The end
+  address was computed with a wrapping 32-bit `ADD`, so a multi-byte access near
+  `0xFFFFFFFF` wrapped small and escaped the OOB trap. Replaced with a
+  SUB-from-bound guard (borrow-check discharges the degenerate case; can't wrap)
+  on both ARM paths + the RV32 twin. Surfaced by the new live trap-VC.
+- **Three latent VFP bugs, caught before f64 shipped (#369):** f32.copysign
+  clobbered a live R0 (#615 class); the f64 `VCVT` signed/unsigned bases were
+  swapped; in-place trunc `VCVT` corrupted a param home. All pinned.
+- **i64/wide static-region accesses were baked, not relocated (#746).** The
+  #739 sub-word fix's wide-arm residual — i64 loads/stores above sp_init under
+  `--shadow-stack-size` now relocate; gale's dissolving buffer nodes unblock.
+
+### Added
+
+- **Multi-memory phase 1 (#406, VCR-MEM-002).** N wasm memories lower to N
+  distinct native base regions (`__synth_wasm_data_K`) on the relocatable path;
+  per-memory size/grow and reservation sections. Model A (distinct,
+  MPU/PMP-protectable), the #404 decision made real. Single-memory modules are
+  byte-identical; every unsupported combination (self-contained, native-pointer,
+  cross-memory copy, riscv/aarch64) is a typed loud-decline.
+- **The trap-preservation VC is LIVE (#166).** `translation_validator` now
+  DERIVES the ARM trap condition from a branch-taking guarded executor and
+  routes partial ops through it MANDATORILY — a guard-stripped, inverted, or
+  wrong-register lowering fails validation. Live for i32 div/rem, unreachable,
+  i32 load/store, i32 trunc_f32, and call_indirect (i64 div/rem and trunc_f64
+  held unit-gated, disclosed). The derived gate immediately caught the #752
+  wraparound and ordeal#72 (their RemS builder over-traps).
+- **The last i32 division admit is discharged — #73 closed at i32.** `div_s`
+  INT_MIN/-1 is now Qed against `exec_program_br` (a genuine model fix: the old
+  overflow guard tested the raw representative and the theorem was false as
+  stated). **473 Qed / 5 Admitted, 0 division admits.**
+- **The falcon float story completes (#369).** Call-boundary marshalling (float
+  args into S/D pools, results out), f64 hard-float params, and the f64 op tail
+  (VRINT rounding, VMINNM/VMAXNM, copysign, demote, i32↔f64 converts). Hard-float
+  is the shipped path end-to-end; every remaining gap is a loud decline.
+
+### Changed
+
+- **Proof-carrying bounds-check elision (#494 × #390).** Under a loom-proven
+  ValueRange premise on the index, the software bounds guard is proven dead and
+  elided (ordeal-certified) — gust_poll's guarded path 184 → 104 B (−80 B, eight
+  guards), bit-identical to the unguarded floor. Opt-in, flag-off byte-identical.
+
+
 ## [0.42.0] - 2026-07-15
 
 **The trap-preservation + float-completion + parity hub: dropping a WASM trap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,14 +1100,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1166,11 +1166,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.42.0"
+version = "0.43.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1225,14 +1225,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1240,11 +1240,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.42.0"
+version = "0.43.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.42.0"
+version = "0.43.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.42.0"
+version = "0.43.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.42.0",
+    version = "0.43.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.42.0" }
+synth-core = { path = "../synth-core", version = "0.43.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.42.0" }
+synth-core = { path = "../synth-core", version = "0.43.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.42.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.42.0" }
+synth-core = { path = "../synth-core", version = "0.43.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.43.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.42.0" }
+synth-core = { path = "../synth-core", version = "0.43.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.42.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.42.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.43.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.43.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.42.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.43.0", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -52,23 +52,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.42.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.42.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.42.0" }
-synth-backend = { path = "../synth-backend", version = "0.42.0" }
+synth-core = { path = "../synth-core", version = "0.43.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.43.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.43.0" }
+synth-backend = { path = "../synth-backend", version = "0.43.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.42.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.43.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.42.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.42.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.42.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.43.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.43.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.43.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.42.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.43.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.42.0" }
+synth-core = { path = "../synth-core", version = "0.43.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.42.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.43.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.42.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.42.0" }
-synth-opt = { path = "../synth-opt", version = "0.42.0" }
+synth-core = { path = "../synth-core", version = "0.43.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.43.0" }
+synth-opt = { path = "../synth-opt", version = "0.43.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.42.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.42.0" }
-synth-opt = { path = "../synth-opt", version = "0.42.0" }
+synth-core = { path = "../synth-core", version = "0.43.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.43.0" }
+synth-opt = { path = "../synth-opt", version = "0.43.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.42.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.43.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"


### PR DESCRIPTION
Seven-lane hub, all merged (#747/#748/#749/#750/#751/#753/#754), each lane's soundness-critical oracle re-verified by the coordinator before merge. Cold-agent clean-room review runs against this PR before tag.

## Headlines
- **#73 CLOSED** — the last i32 division admit (`div_s` INT_MIN/-1) discharged against `exec_program_br` via a genuine model fix. **473 Qed / 5 Admitted / 0 division admits.**
- **Live trap-preservation VC (#166)** — a dropped/inverted/wrong-register guard now fails `translation_validator` (derived ARM trap terms), not just a unit gate. Caught #752 + ordeal#72.
- **Multi-memory phase 1 (#406)** — N memories → N distinct native regions; single-memory byte-identical.
- **Falcon float complete (#369)** — marshalling + f64 params + op tail.
- **Bounds elision at the floor (#494×#390)** — gust_poll guarded path 184→104 B, ≡ unguarded floor.

## Six latent soundness bugs fixed (found by the derived gate + new coverage)
T3 encoder branch-halving (#740), bounds wraparound (#752), f32.copysign R0-clobber, f64 VCVT base swap, in-place VCVT home corruption, i64 static-region bake (#746).

Pin sweep incl. npm, claim gate 18/18, frozen anchors 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)