### PR TITLE
investigate(#757): disprove the wide-static-copy triage mechanism + THM_CALL-aware oracle (NO FIX — #757 stays open)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,17 @@ jobs:
       # declines, nothing to emit) -> GREEN with the relocated arms.
       - name: Run i64/wide above-SP static shrink oracle (#746, cortex-m3)
         run: SYNTH=./target/debug/synth python scripts/repro/wide_static_746_differential.py
+      # #757: the multi-chunk static-copy CONTROL (gale's gust:os v0.4.0
+      # static-string copy shape). The triage claimed the #746 fix miscompiles
+      # the head chunk's source ADDRESS relocation; six faithful shapes — incl.
+      # the copy source/index LIVE ACROSS an internal `call` kept here — all
+      # copy "gust:os up\n" correctly on 0.43.0. The oracle resolves the
+      # R_ARM_THM_CALL relocation (the `bl` the copy loop is reached through)
+      # and HARD-FAILS on any unhandled relocation type — an oracle that skips
+      # the call relocation is a vacuous gate (the self-call masqueraded as a
+      # miscompile). Guards that the call-crossing static copy stays correct.
+      - name: Run multi-chunk static-copy control oracle (#757, cortex-m3)
+        run: SYNTH=./target/debug/synth python scripts/repro/wide_static_copy_757_differential.py
       # #740: the Thumb-2 B<cond>.W (T3) arm packed `halfword_offset >> 1`,
       # HALVING every conditional branch spanning > 254 bytes — gust_poll's
       # loop-head `br_if` to an outer block end landed mid-shape (spurious

--- a/scripts/repro/mem757_static_copy_controls.wat
+++ b/scripts/repro/mem757_static_copy_controls.wat
@@ -1,0 +1,52 @@
+(module
+  ;; #757 CONTROL (NOT a repro): value-live-across-call static i64 copy is
+  ;; CORRECT. This is one of six faithful reconstructions of gale's gust:os
+  ;; v0.4.0 static-string copy shape, ALL of which compile CORRECTLY on 0.43.0
+  ;; once the R_ARM_THM_CALL relocation is resolved in the differential harness
+  ;; (see wide_static_copy_757_differential.py).
+  ;;
+  ;; The #757 triage hypothesis — "the per-chunk SOURCE ADDRESS relocation is
+  ;; wrong for the HEAD chunk (addend uses the wrong chunk index)" — is
+  ;; EMPIRICALLY FALSE for every shape reproducible from the issue text:
+  ;;   * symmetric i64 head+tail, differing static memarg offsets
+  ;;   * asymmetric i64 wide head + i64 narrow tail bytes
+  ;;   * const-index and const-source-address chunks
+  ;;   * the `memory.copy` opcode from a static source
+  ;;   * a high-register-pressure loop copy
+  ;;   * THIS one: the copy source/index LIVE ACROSS an internal call
+  ;;     (gale's func_17 is reached through RawVec-grow func_16, a real `call`)
+  ;; In all of them the emitted relocation addend AND the runtime base register
+  ;; are correct, and execution matches wasmtime byte-for-byte.
+  ;;
+  ;; Kept as a REGRESSION CONTROL: the call-crossing shape (which the #746
+  ;; single-load fixtures never exercised) copies "gust:os up\n" correctly.
+  ;;
+  ;; Compile: --target cortex-m3 --native-pointer-abi --all-exports
+  ;;          --relocatable --shadow-stack-size <B>
+  (memory (export "memory") 17)
+  (global $sp (mut i32) (i32.const 1048576))
+  (data (i32.const 1048608) "gust:os up\n\00\00\00\00\00")
+  ;; a callee that clobbers registers (grows a "vec": returns dst base)
+  (func $grow (param i32) (result i32)
+    (local $x i32)
+    (local.set $x (i32.const 0xdead))
+    (i32.add (local.get 0) (local.get $x))
+    drop
+    (i32.const 1048576))  ;; dst base 0x100000
+  (func (export "copy_peek") (param i32) (result i32)
+    (local $idx i32)
+    (local $dst i32)
+    ;; establish a live index, then call grow (clobbers caller-saved)
+    (local.set $idx (i32.const 0))
+    (local.set $dst (call $grow (local.get 0)))
+    ;; HEAD wide i64 from static source at (idx) + static offset — idx live
+    ;; across the call above
+    local.get $idx
+    local.get $idx
+    (i64.load offset=1048608)
+    (i64.store offset=1048576)
+    ;; TAIL bytes 8,9,10
+    (i64.store8 offset=1048584 (local.get $idx) (i64.load8_u offset=1048616 (local.get $idx)))
+    (i64.store8 offset=1048585 (local.get $idx) (i64.load8_u offset=1048617 (local.get $idx)))
+    (i64.store8 offset=1048586 (local.get $idx) (i64.load8_u offset=1048618 (local.get $idx)))
+    (i32.wrap_i64 (i64.load8_u offset=1048576 (local.get 0)))))

--- a/scripts/repro/wide_static_copy_757_differential.py
+++ b/scripts/repro/wide_static_copy_757_differential.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""#757 investigation harness — the multi-chunk static-copy differential.
+
+#757 reported a SILENT MISCOMPILE regression from the #746 fix: a chunked copy
+of a static string (>= 9 bytes, above `wasm_data_base`, under
+`--native-pointer-abi --shadow-stack-size`) was claimed to copy the HEAD chunk
+wrong (source address offset past the string) while the TAIL read correctly —
+i.e. the per-chunk source-address RELOCATION addend was wrong for the first
+chunk.
+
+This harness runs the compiled object under unicorn (Thumb-2, R11 = 0 native
+deref, `.bss`/`.data`/`.rodata` at SEPARATE bases so a baked absolute linmem
+offset cannot accidentally resolve) against wasmtime ground truth, for a
+`copy_peek(i)` export that copies a static string into a dynamic `.bss` dest and
+reads byte `i` back.
+
+CRITICAL — it resolves R_ARM_THM_CALL (type 10) relocations, not just
+R_ARM_ABS32 (type 2). The gale shape reaches its copy loop THROUGH a `call`
+(RawVec-grow), so an object with an unresolved `bl` self-calls and corrupts
+state — an emulation artifact that MASQUERADES as a miscompile. An oracle that
+skips the call relocation is a vacuous gate (the memory-note lesson). Resolving
+it is what turned the apparent RED back to GREEN and disproved the triage
+mechanism.
+
+FINDING (0.43.0): every faithful reconstruction of the gale shape — symmetric
+i64 head+tail, asymmetric wide-head/narrow-tail, const-index, const-source,
+`memory.copy`, high-pressure loop, and the value-live-across-call control below
+— compiles CORRECTLY: the relocation addend AND the runtime base register are
+both right, execution matches wasmtime byte-for-byte. The triage's "head-chunk
+addend is wrong" hypothesis does not hold for any reproducible shape.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/wide_static_copy_757_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("mem757_static_copy_controls.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+BUDGET = 2048
+ABS32 = 2
+THM_CALL = 10
+BASES = {".text": 0x100000, ".bss": 0x200000, ".data": 0x300000, ".rodata": 0x400000}
+MAPSZ = 0x10000
+
+
+def wasmtime_truth(fn, arg):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_text())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    return inst.exports(store)[fn](store, arg) & 0xFFFFFFFF
+
+
+def main():
+    obj = Path(tempfile.mkdtemp(prefix="mem757_")) / "mem757.o"
+    proc = subprocess.run(
+        [
+            SYNTH,
+            "compile",
+            str(WAT),
+            "-o",
+            str(obj),
+            "--target",
+            "cortex-m3",
+            "--native-pointer-abi",
+            "--all-exports",
+            "--relocatable",
+            "--shadow-stack-size",
+            str(BUDGET),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr.strip())
+        print("FAIL: compile declined")
+        return 1
+
+    e = ELFFile(open(obj, "rb"))
+    secname = {i: s.name for i, s in enumerate(e.iter_sections())}
+    text = bytearray(e.get_section_by_name(".text").data())
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: (s["st_shndx"], s["st_value"]) for s in symtab.iter_symbols()}
+
+    def sym_addr(sym):
+        shndx, val = syms[sym.name]
+        sn = secname.get(shndx, ".text")
+        return BASES.get(sn, BASES[".text"]) + val
+
+    for r in e.get_section_by_name(".rel.text").iter_relocations():
+        t = r["r_info_type"]
+        sym = symtab.get_symbol(r["r_info_sym"])
+        off = r["r_offset"]
+        if t == ABS32:
+            shndx, val = syms[sym.name]
+            sn = secname[shndx]
+            (add,) = struct.unpack_from("<I", text, off)
+            struct.pack_into("<I", text, off, (BASES[sn] + val + add) & 0xFFFFFFFF)
+        elif t == THM_CALL:
+            # R_ARM_THM_CALL: encode a full Thumb BL to (S - P) — overwrite the
+            # f7ff fffe placeholder outright (do NOT re-add its -4 addend).
+            P = BASES[".text"] + off + 4
+            S = sym_addr(sym) & ~1
+            disp = S - P
+            imm = (disp >> 1) & 0x3FFFFF
+            s = (imm >> 21) & 1
+            i1 = (imm >> 20) & 1
+            i2 = (imm >> 19) & 1
+            j1 = (~i1 & 1) ^ s
+            j2 = (~i2 & 1) ^ s
+            imm10 = (imm >> 11) & 0x3FF
+            imm11 = imm & 0x7FF
+            hi = 0xF000 | (s << 10) | imm10
+            lo = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+            struct.pack_into("<HH", text, off, hi, lo)
+        else:
+            print(f"FAIL: unhandled relocation type {t} at {off:#x} — vacuous-gate risk")
+            return 1
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    for _, base in BASES.items():
+        mu.mem_map(base, MAPSZ)
+    mu.mem_write(BASES[".text"], bytes(text))
+    for nm in (".data", ".rodata"):
+        s = e.get_section_by_name(nm)
+        if s is not None:
+            mu.mem_write(BASES[nm], bytes(s.data()))
+    bss = e.get_section_by_name(".bss")
+    bss_size = bss["sh_size"] if bss is not None else 0
+    RET = BASES[".text"] + 0xFF0
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+    def run_arm(fn, arg):
+        if bss_size:
+            mu.mem_write(BASES[".bss"], b"\x00" * bss_size)
+        mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R11, 0)
+        mu.reg_write(UC_ARM_REG_SP, BASES[".bss"] + MAPSZ - 0x100)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        entry = BASES[".text"] + (syms[fn][1] & ~1)
+        mu.emu_start(entry | 1, RET, timeout=5_000_000)
+        return mu.reg_read(UC_ARM_REG_R0)
+
+    ok = True
+    for i in range(11):
+        exp = wasmtime_truth("copy_peek", i)
+        try:
+            got = run_arm("copy_peek", i)
+        except UcError as ex:
+            print(f"copy_peek({i}) = UNICORN FAULT {ex} (expect {exp:#x})")
+            ok = False
+            continue
+        match = "" if got == exp else "  <-- MISMATCH"
+        print(f"copy_peek({i}) = {got:#x} (expect {exp:#x}){match}")
+        ok &= got == exp
+
+    print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## #757 investigation — triage mechanism disproven, real reduction needed

**This is an INVESTIGATION PR, not a fix.** #757 reports a real silent miscompile (real qemu cortex-m3, real `os-tl-cm3.o`, real byte capture on gale's gust:os v0.4.0 seam). This PR does **not** resolve it — it disproves the *triaged mechanism* and lands durable investigation artifacts. **#757 stays OPEN.** No version bump (v0.43.1 was presumptive on a fix; there is no fix and no red→green to claim).

### What the triage said
The head chunk's **source ADDRESS relocation addend** is wrong (`__synth_wasm_data + C` uses the wrong chunk index), so a chunked copy of a static string reads `.data` bytes *after* the string for bytes 0–6 while bytes 7–10 read correctly.

### What I found (0.43.0, cortex-m3, `--native-pointer-abi --all-exports --relocatable --shadow-stack-size 2048`, unicorn vs wasmtime, byte-for-byte)
Every faithful reconstruction of the gale copy shape compiles **correctly** — the relocation addend AND the runtime base register are both right:

| shape | result |
|---|---|
| symmetric i64 head+tail, differing static memarg offsets | GREEN |
| asymmetric i64 **wide** head + i64 **narrow** tail bytes | GREEN |
| const-index / const-source-address chunks | GREEN |
| `memory.copy` opcode from a static source above `wasm_data_base` | GREEN |
| high-register-pressure loop copy | GREEN |
| copy source/index **live across an internal `call`** (RawVec-grow shape) | GREEN |
| **large function / big literal pool** (40 static i64 accesses, long `ldr [pc,#imm]`) | GREEN |

The reported `got = [2,0,0,0,1,0,0,32,...]` decodes to a single i64 load at **base + 12 with the *correct* base symbol** — a wrong runtime index/offset, **not** a wrong relocation addend. Nothing reconstructable from the issue text produces correct-base-plus-12.

### The process gap I closed (a real, durable win)
My first apparent RED was a **harness artifact**: the differential wasn't resolving the `R_ARM_THM_CALL` (type 10) relocation, so the object's `bl` (the call the copy loop is reached through) self-called and corrupted state. An oracle that skips the call relocation is a **vacuous gate**. `wide_static_copy_757_differential.py` now resolves THM_CALL and **hard-fails on any unhandled relocation type**. With the call resolved, the call-crossing shape is GREEN. (I retracted the false-root-cause commit `80c0522` via force-push before opening this PR.)

### Artifacts
- `scripts/repro/mem757_static_copy_controls.wat` — the value-live-across-call control (documents the disproven hypothesis + the six negative results)
- `scripts/repro/wide_static_copy_757_differential.py` — THM_CALL-aware differential, hard-fails on unhandled reloc types
- CI: wired into the `trap-semantics-oracle` job as a standing regression control

### Regressions re-verified green
- `wide_static_746_differential.py` — 25/25
- `static_above_sp_739_differential.py` — PASS
- `wide_static_copy_757_differential.py` — PASS (control)
- `cargo test -p synth-cli --test static_above_sp_739` — 5/5 (#739 + #746)

### Blocker
`feat/gust-v0.4.0-syscall-seam` @ `ef68c59` is not pushed (404 on the branch and SHA), so I cannot extract `func_17`'s wat or `os-tl-cm3.o`. Escalated on #757 requesting the reduced module. With the exact reduction the real class can be pinned; the controls guard the reconstructed shapes meanwhile. **Do not merge as a fix** — this closes no bug.

Refs #757 #746 #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
