### PR TITLE
chore(release): v0.43.1 — self-contained data soundness fix (#758) + differential hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.1] - 2026-07-15
+
+**Soundness patch — the default `--cortex-m` path now ships its initialized data.**
+One pre-existing soundness fix, plus differential-harness hardening. This is a
+patch on v0.43.0, not a feature release.
+
+### Fixed (soundness)
+
+- **Default self-contained `--cortex-m` DROPPED active `(data)` segments (#758).**
+  The self-contained ELF builder emitted `.linear_memory` as NoBits (BSS) and the
+  generated `Reset_Handler` had no data-copy loop, so active `(data)` bytes never
+  reached RAM — every load from an initialized region read **zero**, silently. This
+  is a **pre-existing** bug (the self-contained builder never had a ROM→RAM copy),
+  NOT a v0.43.0 regression. Fixed by packing the data segments into a dense blob
+  appended to `.text` and emitting a byte-granular `ldrb`/`strb` crt0 copy loop in
+  the startup (src patched to the ROM flash address post-layout; dst =
+  `optimized_linmem_base()` so copy-dst == codegen-base by construction, tracking
+  `--stack-layout=low`); u64 bounds loud-decline; empty-data modules stay
+  byte-identical to the old NoBits path. Oracle `self_contained_data_758_differential.py`
+  (RED on base, 5 divergences → GREEN 6/6), CI-wired. `--relocatable` and
+  `--native-pointer-abi` paths byte-identical; frozen anchors 10/10.
+
+### Changed (test infrastructure)
+
+- **Wide-static-copy differential hardened against vacuous gates (#760).** Added a
+  multi-chunk static-copy control fixture and a differential harness that resolves
+  `R_ARM_THM_CALL` relocations and **hard-fails on any unhandled relocation type**
+  (an oracle that silently skips the call relocation is a vacuous gate). Wired into
+  the trap-semantics-oracle CI job.
+
+### Known issues (still open)
+
+- **#757 — wide-static *copy* path carries a confirmed-on-silicon miscompile that
+  is NOT reproducible from the issue text.** gale captured wrong bytes on gust:os
+  v0.4.0, but seven faithful reconstructions of the copy shape (including the
+  value-live-across-a-call and big-literal-pool variants) all compile
+  byte-identical to wasmtime — the reported symptom decodes to `base + 12` with the
+  *correct* relocation base, i.e. a wrong runtime offset, not a wrong relocation.
+  **#757 remains OPEN**, blocked on the reporter's reduced module. v0.43.1 does NOT
+  fix it; the control fixtures above are regression guards in the meantime.
+- **#761 — latent self-contained linmem/globals top-of-SRAM overlap** (impact
+  unverified), filed for investigation.
+
 ## [0.43.0] - 2026-07-15
 
 **Isolation + verification closure — and the biggest soundness yield of any hub

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,14 +1100,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1166,11 +1166,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.43.0"
+version = "0.43.1"
 
 [[package]]
 name = "synth-cli"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1225,14 +1225,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1240,11 +1240,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.43.0"
+version = "0.43.1"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.43.0"
+version = "0.43.1"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.43.0"
+version = "0.43.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.43.0",
+    version = "0.43.1",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.43.0" }
+synth-core = { path = "../synth-core", version = "0.43.1" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.43.0" }
+synth-core = { path = "../synth-core", version = "0.43.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.43.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.43.0" }
+synth-core = { path = "../synth-core", version = "0.43.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.43.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.43.0" }
+synth-core = { path = "../synth-core", version = "0.43.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.43.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.43.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.43.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.43.1", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.43.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.43.1", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -52,23 +52,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.43.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.43.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.43.0" }
-synth-backend = { path = "../synth-backend", version = "0.43.0" }
+synth-core = { path = "../synth-core", version = "0.43.1" }
+synth-frontend = { path = "../synth-frontend", version = "0.43.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.43.1" }
+synth-backend = { path = "../synth-backend", version = "0.43.1" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.43.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.43.1" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.43.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.43.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.43.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.43.1", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.43.1", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.43.1", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.43.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.43.1", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.43.0" }
+synth-core = { path = "../synth-core", version = "0.43.1" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.43.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.43.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.43.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.43.0" }
-synth-opt = { path = "../synth-opt", version = "0.43.0" }
+synth-core = { path = "../synth-core", version = "0.43.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.43.1" }
+synth-opt = { path = "../synth-opt", version = "0.43.1" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.43.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.43.0" }
-synth-opt = { path = "../synth-opt", version = "0.43.0" }
+synth-core = { path = "../synth-core", version = "0.43.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.43.1" }
+synth-opt = { path = "../synth-opt", version = "0.43.1" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.43.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.43.1", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"


### PR DESCRIPTION
Soundness patch on v0.43.0. Ships **#758 only**; **#757 remains open**.

## Fixed (soundness)
- **#758** — default self-contained `--cortex-m` DROPPED active `(data)` segments (NoBits + no crt0 copy loop → every initialized-region load read 0). **Pre-existing bug, not a v0.43.0 regression.** Fix = pack data into `.text` + byte-granular ROM→RAM copy loop; dst == `optimized_linmem_base()` by construction. Oracle `self_contained_data_758_differential.py` RED→GREEN 6/6, CI-wired. Relocatable/native-pointer byte-identical; frozen anchors 10/10. Verified by coordinator: oracle 6/6 + exact issue repro now ships the ROM image.

## Changed (test infra)
- **#760** — wide-static-copy differential now resolves `R_ARM_THM_CALL` and **hard-fails on any unhandled relocation** (kills the vacuous-gate class); 6-shape control fixture wired into trap-semantics-oracle.

## Known issues (NOT fixed here)
- **#757** — wide-static *copy* miscompile: real on gale's silicon, but 7 faithful reconstructions all byte-identical GREEN (`base+12` with correct reloc base = wrong runtime offset, not wrong relocation). Blocked on the reporter's reduced module. Control fixtures are regression guards.
- **#761** — latent self-contained linmem/globals top-of-SRAM overlap (impact unverified), filed for investigation.

Pin sweep: workspace + all path-dep pins + MODULE.bazel + npm → 0.43.1. Claim gate 18/18. fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)