### PR TITLE
v0.44.0 Lane B: #406 multi-segment static-data coverage + honest MPU-isolation decline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,20 @@ jobs:
       # region (must stay 0). RED on v0.43.0 (4/5 read 0) -> GREEN.
       - name: Run self-contained data-segment oracle (#758, cortex-m3)
         run: SYNTH=./target/debug/synth python scripts/repro/self_contained_data_758_differential.py
+      # #406/#739-cluster coverage WIDENER: multi-chunk / multi-segment static
+      # data across BOTH the self-contained (--cortex-m) and --relocatable
+      # paths, segments at varied offsets — low, an UNALIGNED segment
+      # straddling a 4 KiB internal page boundary (0x1000), an overlapping
+      # later-wins pair, a HIGH segment near the top of a 2-page memory (0x1FF0,
+      # approaching the globals boundary), and a long multi-word ROM->RAM copy.
+      # Self-contained side runs the REAL reset path on ZEROED RAM (a dropped/
+      # short/mis-based copy — the #758/#746/#739 family — reads 0 and goes
+      # RED); relocatable side maps memory 0 at R11 with an embedder-populated
+      # init image and .text far away (baked-absolute offsets fault). Ground
+      # truth is wasmtime. WIDENS coverage only — #757 stays OPEN (blocked on
+      # the reporter's reduced module); a divergence here is a real find.
+      - name: Run multi-segment static-data oracle (#406, self-contained + relocatable)
+        run: SYNTH=./target/debug/synth python scripts/repro/multi_segment_static_data_differential.py
 
   fact-spec-oracle:
     name: fact-spec elision oracle (#494 phases 2 + 2b + 3+ + bounds)

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2756,6 +2756,34 @@ fn compile_all_exports(
                 all_memories.len()
             );
         }
+        // #406 / Lane B: per-memory MPU isolation is an architectural interlock,
+        // NOT yet realizable — refuse loudly rather than accept `--safety-bounds
+        // mpu` as a silent no-op (the #377 passthrough) on a multi-memory image.
+        // Programming an MPU region per memory needs synth to emit the startup
+        // that writes MPU_RBAR/RASR — i.e. the SELF-CONTAINED reset handler. But
+        // multi-memory only compiles on `--relocatable` (an ET_REL object whose
+        // startup the HOST linker/runtime owns, where synth writes no MPU
+        // programming), and the self-contained path DECLINES multi-memory above
+        // (one R11 base, every memory aliases). So there is no path today on
+        // which synth both emits its own startup AND lowers > 1 memory — the
+        // cross-memory OOB fault gate cannot be armed. Blocked on self-contained
+        // multi-memory (#406 phase 2). The single-memory `--safety-bounds mpu`
+        // remains the #377 hardware-enforcement passthrough.
+        if safety_bounds == SafetyBounds::Mpu {
+            anyhow::bail!(
+                "multi-memory (#406): per-memory MPU isolation (--safety-bounds \
+                 mpu) is not yet realizable for a module with {} linear \
+                 memories. Programming one MPU region per memory requires synth \
+                 to emit the startup that writes MPU_RBAR/RASR — the \
+                 self-contained reset handler — but multi-memory compiles ONLY \
+                 on --relocatable, where the host owns startup and synth emits \
+                 no MPU programming; the self-contained path in turn declines \
+                 multi-memory (one R11 base). Refusing rather than accepting a \
+                 silent MPU no-op. Blocked on self-contained multi-memory \
+                 (#406 phase 2)",
+                all_memories.len()
+            );
+        }
     }
 
     // Log import information

--- a/crates/synth-cli/tests/multi_memory_406.rs
+++ b/crates/synth-cli/tests/multi_memory_406.rs
@@ -17,6 +17,7 @@
 //! | multi-memory, self-contained --cortex-m| refuse (same)                  |
 //! | multi-memory × `--native-pointer-abi`  | refuse (static region is mem-0)|
 //! | multi-memory × `--shadow-stack-size`   | refuse (shrinks mem-0 geometry)|
+//! | multi-memory × `--safety-bounds mpu`   | refuse (MPU-startup interlock)  |
 //! | multi-memory on riscv / aarch64        | refuse (no per-memory base)    |
 //! | cross-/non-default memory.copy/fill    | loud-skip naming the op        |
 //! | i64/f32 access on memory k > 0         | loud-skip (i32 family only)    |
@@ -244,6 +245,33 @@ fn multi_memory_shadow_stack_refuses() {
     // The native-pointer-abi gate may fire first — either way it must be a
     // loud multi-memory refusal, and the flag combo must never compile.
     assert_refused(&out, &["multi-memory", "#406"], "--shadow-stack-size combo");
+}
+
+/// --safety-bounds mpu: per-memory MPU isolation is an architectural interlock
+/// (Lane B). Programming one MPU region per memory needs synth to emit the
+/// startup that writes MPU_RBAR/RASR — the SELF-CONTAINED reset handler — but
+/// multi-memory only compiles on --relocatable (host owns startup, synth emits
+/// no MPU programming), and the self-contained path declines multi-memory (one
+/// R11 base). So no path both emits synth's startup AND lowers > 1 memory; the
+/// cross-memory OOB fault gate cannot be armed. Refuse rather than accept a
+/// silent MPU no-op. Blocked on self-contained multi-memory (#406 phase 2).
+#[test]
+fn multi_memory_safety_bounds_mpu_refuses() {
+    let out = compile(
+        &two_mem_fixture(),
+        &[
+            "--relocatable",
+            "--safety-bounds",
+            "mpu",
+            "--target",
+            "cortex-m3",
+        ],
+    );
+    assert_refused(
+        &out,
+        &["multi-memory", "#406", "mpu"],
+        "per-memory MPU isolation interlock",
+    );
 }
 
 /// riscv / aarch64: no per-memory base lowering — refuse the module.

--- a/scripts/repro/multi_segment_static_data.wat
+++ b/scripts/repro/multi_segment_static_data.wat
@@ -1,0 +1,60 @@
+(module
+  ;; #406/#739-cluster coverage WIDENER — multi-chunk / multi-segment static
+  ;; data across BOTH the self-contained (`--cortex-m`, no --relocatable) and
+  ;; the --relocatable object paths. Segments live at VARIED offsets, including
+  ;; ones that straddle an internal 4 KiB page boundary and one placed near the
+  ;; top of a two-page linear memory (approaching the globals-table boundary the
+  ;; self-contained image lays out just above linmem). Single memory only —
+  ;; multi-memory self-contained is a loud decline (#406), so this exercises the
+  ;; static-data machinery both paths share.
+  ;;
+  ;; NOTE: this WIDENS coverage. It does NOT close #757 (blocked on the
+  ;; reporter's reduced module). If any case diverges from wasmtime that is a
+  ;; real find to report loudly, not to paper over.
+  (memory (export "mem") 2)  ;; 2 pages = 128 KiB — room for a high segment
+
+  ;; --- chunk A: small segment low in memory (word + high word) ---
+  (data (i32.const 0x40) "\11\22\33\44\55\66\77\88")           ;; @0x40
+
+  ;; --- chunk B: unaligned start, straddles a 4 KiB internal page boundary ---
+  ;; starts at 0x0FFE, so bytes land at 0x0FFE..0x1005 — across the 0x1000 line.
+  (data (i32.const 0x0FFE) "\a1\b2\c3\d4\e5\f6\07\18")          ;; @0x0FFE (straddles 0x1000)
+
+  ;; --- chunk C: overlapping pair — later segment wins (in-order semantics) ---
+  (data (i32.const 0x200) "\de\ad\be\ef")                       ;; @0x200
+  (data (i32.const 0x203) "\99\aa")                             ;; @0x203 overwrites 0x203..0x204
+
+  ;; --- chunk D: HIGH segment near the top of page 1 (0x1FF0), approaching the
+  ;; end of the 2-page reservation where the globals table is laid out just
+  ;; above linmem in the self-contained image. Wide + narrow reads. ---
+  (data (i32.const 0x1FF0) "\ca\fe\ba\be\0d\f0\ad\8b")          ;; @0x1FF0
+
+  ;; --- chunk E: a long (multi-word) segment to force a multi-word copy loop ---
+  (data (i32.const 0x800)
+    "\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f\20")
+
+  ;; ---- reads ----
+  (func (export "a_lo")  (result i32) (i32.load (i32.const 0x40)))    ;; 0x44332211
+  (func (export "a_hi")  (result i32) (i32.load (i32.const 0x44)))    ;; 0x88776655
+
+  ;; chunk B: read the word that straddles the page line (bytes 0x0FFE..0x1001)
+  (func (export "b_straddle") (result i32) (i32.load (i32.const 0x0FFE)))  ;; 0xd4c3b2a1
+  (func (export "b_after")    (result i32) (i32.load (i32.const 0x1002)))  ;; 0x1807f6e5
+
+  ;; chunk C overlap: byte @0x203 is 0x99 (later segment), @0x200 word head.
+  (func (export "c_head") (result i32) (i32.load8_u (i32.const 0x200)))    ;; 0xde
+  (func (export "c_ovl")  (result i32) (i32.load8_u (i32.const 0x203)))    ;; 0x99
+
+  ;; chunk D high segment (word + a byte mid-segment)
+  (func (export "d_lo")  (result i32) (i32.load (i32.const 0x1FF0)))       ;; 0xbebafeca
+  (func (export "d_hi")  (result i32) (i32.load (i32.const 0x1FF4)))       ;; 0x8badf00d
+  (func (export "d_byte") (result i32) (i32.load8_u (i32.const 0x1FF6)))   ;; 0xba
+
+  ;; chunk E: read three interior words of the long segment
+  (func (export "e_0")  (result i32) (i32.load (i32.const 0x800)))         ;; 0x04030201
+  (func (export "e_16") (result i32) (i32.load (i32.const 0x810)))         ;; 0x14131211
+  (func (export "e_28") (result i32) (i32.load (i32.const 0x81c)))         ;; 0x201f1e1d
+
+  ;; a load from a region NO segment initializes: must be zero
+  (func (export "gap") (result i32) (i32.load (i32.const 0x1800)))         ;; 0
+)

--- a/scripts/repro/multi_segment_static_data_differential.py
+++ b/scripts/repro/multi_segment_static_data_differential.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""#406 / #739-cluster COVERAGE WIDENER — multi-chunk / multi-segment static
+data across BOTH the self-contained (`--cortex-m`, no --relocatable) and the
+`--relocatable` object paths, with segments at varied offsets: a low segment, an
+UNALIGNED segment that STRADDLES a 4 KiB internal page boundary (0x1000), an
+overlapping pair (in-order "later wins"), a HIGH segment near the top of a two-
+page linear memory (0x1FF0 — approaching the globals-table boundary the self-
+contained image lays out just above linmem), and a long multi-word segment that
+forces a multi-word ROM->RAM copy.
+
+WHY BOTH PATHS
+  - Self-contained: the discriminating check. RAM is mapped ZEROED; whatever
+    ends up in linear memory is ONLY what the artifact's OWN Reset_Handler
+    copied there (ROM->RAM crt0 `.data` init). A dropped/short/mis-based copy
+    (the #758/#746/#739 failure family) reads 0 or garbage and diverges. This
+    is the path where the coverage bites.
+  - Relocatable: the addressing check. Memory 0 lives at the runtime R11 base
+    and the embedder populates its init segments (the object carries no ROM
+    image on this path). The harness maps memory 0 at R11 and writes the wasm
+    init image itself (the embedder's contract), then verifies every load's
+    ADDRESS arithmetic (R11 + offset, incl. the straddle and high-offset cases)
+    matches wasmtime. It cannot catch a dropped copy (there is none on this
+    path) — it catches a mis-computed offset.
+
+ANTI-VACUOUS
+  Ground truth is wasmtime (not a re-derivation of synth's own output). The
+  self-contained side executes the REAL reset path on ZEROED RAM, so a compiler
+  that ships no init data goes RED (reads 0). The relocatable side maps .text at
+  a base far from the R11 memory base so any baked-absolute static offset lands
+  in unmapped space (fault) rather than accidentally resolving.
+
+NOTE — this WIDENS coverage. It does NOT claim the #757 cluster closed (#757
+stays OPEN, blocked on the reporter's reduced module). If a case diverges, that
+is a real find to report LOUDLY, not to paper over.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/multi_segment_static_data_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R10,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("multi_segment_static_data.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+# Every export and the number of i32 args it takes (all take none here).
+EXPORTS = [
+    "a_lo", "a_hi", "b_straddle", "b_after", "c_head", "c_ovl",
+    "d_lo", "d_hi", "d_byte", "e_0", "e_16", "e_28", "gap",
+]
+
+PAGE = 0x10000
+
+
+def wasmtime_truth():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    return {fn: inst.exports(store)[fn](store) & 0xFFFFFFFF for fn in EXPORTS}
+
+
+def compile_synth(out, extra):
+    env = {"PATH": "/usr/bin:/bin"}
+    cmd = [SYNTH, "compile", str(WAT), "-o", out, "--all-exports",
+           "-b", "arm", "--target", "cortex-m3"] + extra
+    r = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({' '.join(extra) or 'self-contained'}): {r.stderr}")
+
+
+def load_syms(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for sy in sec.iter_symbols():
+                if sy.name and sy["st_info"]["type"] == "STT_FUNC":
+                    syms[sy.name] = sy["st_value"]
+    return f, text.data(), text["sh_addr"], syms
+
+
+# --- The wasm init image the embedder would map into memory 0 (relocatable
+# path). Built here from the SAME segments as the .wat so the relocatable side
+# checks addressing against a known-good memory, not against synth's own copy. ---
+def wasm_init_image(size):
+    img = bytearray(size)
+    for off, data in (
+        (0x40, b"\x11\x22\x33\x44\x55\x66\x77\x88"),
+        (0x0FFE, b"\xa1\xb2\xc3\xd4\xe5\xf6\x07\x18"),
+        (0x200, b"\xde\xad\xbe\xef"),
+        (0x203, b"\x99\xaa"),
+        (0x1FF0, b"\xca\xfe\xba\xbe\x0d\xf0\xad\x8b"),
+        (0x800, bytes(range(1, 0x21))),
+    ):
+        img[off:off + len(data)] = data
+    return bytes(img)
+
+
+# ---------------------------------------------------------------------------
+# Self-contained image: zeroed RAM, real reset path (ROM->RAM copy).
+# ---------------------------------------------------------------------------
+FLASH, RAM, RAM_SIZE = 0x0000_0000, 0x2000_0000, 0x40000
+RET = 0x000F_0000
+
+
+class SelfContainedRunner:
+    def __init__(self, code, base, syms):
+        self.base, self.syms = base, syms
+        self.mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+        self.mu.mem_map(FLASH, 0x100000)
+        self.mu.mem_map(RAM, RAM_SIZE)  # zeroed RAM: inits must come from startup
+        self.mu.mem_map(0xE000E000, 0x1000)  # SCS page
+        self.mu.mem_write(base, code)
+        self.sp = int.from_bytes(code[0:4], "little")
+        reset = syms.get("Reset_Handler")
+        if reset is None:
+            sys.exit("Reset_Handler missing from symtab")
+        stop = code.find(b"\x01\x48\x80\x47", (reset & ~1) - base)
+        if stop < 0:
+            sys.exit("startup call scaffold (LDR r0/BLX r0) not found")
+        self.mu.reg_write(UC_ARM_REG_SP, self.sp)
+        self.mu.emu_start(reset | 1, base + stop, count=200000)
+
+    def call(self, fn):
+        faddr = self.syms.get(fn)
+        if faddr is None:
+            return f"ERR:symbol {fn} missing"
+        self.mu.reg_write(UC_ARM_REG_SP, self.sp)
+        self.mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        try:
+            self.mu.emu_start(faddr | 1, RET, count=200000)
+        except UcError as e:
+            return f"ERR:{e}"
+        return self.mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+# ---------------------------------------------------------------------------
+# Relocatable object: memory 0 at the runtime R11 base, embedder-populated init.
+# .text mapped FAR from the memory base so a baked-absolute offset faults.
+# ---------------------------------------------------------------------------
+REL_TEXT = 0x0010_0000
+REL_MEM0 = 0x4000_0000  # R11 base — 2 wasm pages
+REL_STACK = 0x6000_0000
+
+
+class RelocatableRunner:
+    def __init__(self, code, base, syms):
+        self.syms = syms
+        self.mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+        self.mu.mem_map(REL_TEXT, 0x10000)
+        self.mu.mem_map(REL_MEM0, 2 * PAGE)
+        self.mu.mem_map(REL_STACK, PAGE)
+        self.mu.mem_write(REL_TEXT, code)
+        self.ret = REL_TEXT + 0x10000 - 0x10
+        self.mu.mem_write(self.ret, b"\x00\xbf\x00\xbf")
+        self.init = wasm_init_image(2 * PAGE)
+
+    def call(self, fn):
+        faddr = self.syms.get(fn)
+        if faddr is None:
+            return f"ERR:symbol {fn} missing"
+        # Fresh wasm instance: re-seed memory 0 from the embedder's init image.
+        self.mu.mem_write(REL_MEM0, self.init)
+        self.mu.reg_write(UC_ARM_REG_R10, 2 * PAGE)  # memory 0 size in bytes
+        self.mu.reg_write(UC_ARM_REG_R11, REL_MEM0)  # memory 0 base
+        self.mu.reg_write(UC_ARM_REG_SP, REL_STACK + PAGE - 0x100)
+        self.mu.reg_write(UC_ARM_REG_LR, self.ret | 1)
+        entry = REL_TEXT + (faddr & ~1)
+        try:
+            self.mu.emu_start(entry | 1, self.ret, count=200000)
+        except UcError as e:
+            return f"ERR:{e}"
+        return self.mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def run_path(label, runner, truth):
+    print(f"=== {label} ===")
+    fails = 0
+    for fn in EXPORTS:
+        exp = truth[fn]
+        got = runner.call(fn)
+        ok = isinstance(got, int) and got == exp
+        if not ok:
+            fails += 1
+        shown = hex(got) if isinstance(got, int) else got
+        print(f"  [{'ok ' if ok else 'BUG'}] {fn}() -> {shown}  (wasmtime {exp:#x})")
+    return fails
+
+
+def main():
+    truth = wasmtime_truth()
+    tmp = Path(tempfile.mkdtemp(prefix="mss_"))
+
+    sc_elf = str(tmp / "sc.elf")
+    compile_synth(sc_elf, [])
+    _, code, base, syms = load_syms(sc_elf)
+    sc_fails = run_path(
+        "self-contained --cortex-m (zeroed RAM, real reset ROM->RAM copy)",
+        SelfContainedRunner(code, base, syms), truth)
+
+    rel_o = str(tmp / "rel.o")
+    compile_synth(rel_o, ["--relocatable"])
+    _, code, base, syms = load_syms(rel_o)
+    rel_fails = run_path(
+        "relocatable (memory 0 at R11, embedder-populated init, .text far away)",
+        RelocatableRunner(code, base, syms), truth)
+
+    total = sc_fails + rel_fails
+    print(f"\nORACLE: {'PASS' if total == 0 else f'FAIL ({total} divergences)'}")
+    sys.exit(0 if total == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## v0.44.0 Lane B — multi-memory phase 2 (#406)

Honest-subset landing. States exactly what shipped vs. declined and why.

### Shipped: multi-segment static-data differential coverage hardening (Item 3)

New `scripts/repro/multi_segment_static_data_differential.py` + fixture, CI-wired, exercising multi-chunk / multi-segment static data across **BOTH** the self-contained (`--cortex-m`) and `--relocatable` paths, with segments at varied offsets:

- a low segment,
- an **unaligned** segment that **straddles a 4 KiB internal page boundary** (0x1000),
- an **overlapping** pair (in-order "later-wins"),
- a **high** segment near the top of a 2-page memory (0x1FF0 — approaching the globals-table boundary the self-contained image lays out just above linmem),
- a **long multi-word** segment (forces a multi-word ROM→RAM copy).

**Self-contained side** runs the REAL reset path on **zeroed RAM** — init must come from the artifact's own ROM→RAM crt0 `.data` copy, so a dropped/short/mis-based copy (the #758/#746/#739 failure family) reads 0 and goes RED. **Relocatable side** maps memory 0 at the runtime R11 base with an embedder-populated init image and `.text` mapped far away, so a baked-absolute static offset faults rather than accidentally resolving; it checks address arithmetic. Ground truth is wasmtime.

**Anti-vacuity proven**: neutering the reset copy's `strb` store makes every initialized read go to 0 (RED) — the gate is load-bearing, not a skip-vacuous check (the #712/#740 lesson).

**Finding: the new coverage is 26/26 green — it found NO miscompile.** This WIDENS coverage; it does **not** close the #757 cluster. **#757 stays OPEN**, blocked on the reporter's reduced module.

### Declined (honest): per-memory MPU isolation (Item 1)

The cross-memory OOB fault gate is **not realizable today** — an architectural interlock:

- Programming one MPU region per memory needs synth to emit the startup that writes `MPU_RBAR`/`RASR` — i.e. the **self-contained reset handler**.
- Multi-memory compiles **only** on `--relocatable` (an ET_REL object whose startup the **host** linker/runtime owns — synth emits no MPU programming).
- The self-contained path **declines** multi-memory (one R11 base, every memory aliases).

So there is **no path** on which synth both emits its own startup **and** lowers > 1 memory. Rather than accept `--safety-bounds mpu` as a silent no-op (the #377 passthrough) on a multi-memory image, `compile_all_exports` now **refuses loudly** and names the interlock. Matrix row + test added (`multi_memory_406.rs`, 14 green). Blocked on self-contained multi-memory (#406 phase 2).

*Why refuse `multi-memory + mpu` but keep `single-memory + mpu`, when both are codegen no-ops?* Multiple memories semantically imply isolation; `--safety-bounds mpu` on them **promises per-region protection synth cannot emit**, so refusing is honest. Single-memory `mpu` is the pre-existing #377 hardware-passthrough with **no cross-memory promise** — unchanged.

Renode (the only way to prove an actual MPU fault — unicorn does not emulate the Cortex-M MPU) is not runnable in this worktree, which reinforces the decline over an emit-without-execution claim.

### Confirmed honest (Item 2): self-contained multi-memory decline

The existing loud decline (`main.rs`, one R11 base ⇒ every memory aliases) is accurate; `multi_memory_406.rs` already tests it. Left as-is per the task's sanctioned "loud-decline the rest."

### Invariants

- **Single-memory bytes byte-identical** — `frozen_codegen_bytes` green; the MPU decline lives inside the `all_memories.len() > 1` branch only.
- Baseline differentials (#406, #758) still green.
- `cargo fmt` / `clippy -D warnings` clean; ci.yml parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
