### PR TITLE
feat(VCR-ISA-001): extend generate-not-mirror Rocq ISA model to i32.eqz (40→41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,8 @@ cd coq && make proofs
 
 ### Proof Status
 
-See `coq/STATUS.md` for the complete coverage matrix. Current: 473 Qed / 5 Admitted
-(+2 `admit.` tactics) across `coq/Synth/`. The 40 selector-DSL rule theorems
+See `coq/STATUS.md` for the complete coverage matrix. Current: 474 Qed / 5 Admitted
+(+2 `admit.` tactics) across `coq/Synth/`. The 41 selector-DSL rule theorems
 (`VcrSelRules.v`) are stated directly about the GENERATED model (VCR-ISA-001
 #667: `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v` emitted
 from the shipped `sel_dsl::RULES`); the former 40-lemma `VcrSelRulesGenCheck.v`
@@ -127,18 +127,18 @@ frozen and oracle-gated every step:
 - **Track A (core):** `VCR-RA-001` allocator with Belady spilling — **verified,
   default-on since v0.24.0** (`SYNTH_SPILL_REALLOC`; `SYNTH_SPILL_ON_EXHAUST`
   built flag-off, silicon-gated #580). Next: `VCR-SEL-001` Rocq-discharged
-  verified selector DSL (increments 1–4 shipped **default-on**, 40 rules / 40 Qed,
+  verified selector DSL (increments 1–4 shipped **default-on**, 41 rules / 41 Qed,
   `SYNTH_SEL_DSL`; the Rocq-proved rules are the SHIPPED lowering path for their
-  40 covered ops, opt-out `SYNTH_NO_SEL_DSL=1`, byte-invisible flip) and
+  41 covered ops, opt-out `SYNTH_NO_SEL_DSL=1`, byte-invisible flip) and
   `VCR-PERF-002` proof-carrying specialization (#494,
   0.45× floor; phase 1 facts ingestion landed, PR #624).
 - **Track B (semantics):** `VCR-ISA-001` Sail-generated Rocq ISA model —
   approved, Sail/ASL bridge spike landed (92 Qed, `coq/Synth/ARM/SailArmBridge.v`);
   "generate, don't mirror" landed (#667): the shipped `sel_dsl::RULES` table
-  EMITS the 40 covered ops' Rocq lowerings
+  EMITS the 41 covered ops' Rocq lowerings
   (`coq/Synth/Synth/VcrSelRulesGenerated.v`, `Module Gen`), and `VcrSelRules.v`
   DEFINES `rule_X := Gen.rule_X` — the generated file is the single model
-  source, the 40 correctness Qed are stated directly about it, and a
+  source, the 41 correctness Qed are stated directly about it, and a
   selector-table change regenerates `Gen` and breaks the matching proof, so the
   #682 model↔selector drift is unrepresentable at the instruction-sequence level
   for those ops (the interim `VcrSelRulesGenCheck.v` reflexivity gate was

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -129,7 +129,7 @@
     "@@rules_renode~//renode:extensions.bzl%renode": {
       "general": {
         "bzlTransitiveDigest": "7Lnr806jnybahW/j3rYmzxDyIEILjiU3LTCqQKMBTAE=",
-        "usagesDigest": "k09BGJyWOyKalACFBPzTB3sNnounj9NxV9wXo1dYdS0=",
+        "usagesDigest": "xzMgAugBVf7dwP9q5aW+F8CkYeqeL3DoK5fgnVoatBM=",
         "recordedFileInputs": {
           "@@rules_renode~//renode/renode.BUILD.bazel": "92dbf0d95a2e56bfda1a31891f4d0b5f262d30b6546afb1b60cc48fdc09effac"
         },

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 | ELF output with vector table | Implemented | Thumb bit set on symbols; not linked on real hardware |
 | Linker scripts (STM32, nRF52840, generic) | Implemented | Generated, not tested with real boards |
 | Cross-compilation (`--link` flag) | Implemented | Requires `arm-none-eabi-gcc` in PATH; not CI-tested |
-| Rocq mechanized proofs | 473 Qed / 5 Admitted | i32 + i64 T1 correctness proofs; the 40 selector-DSL rule theorems are stated directly about the GENERATED model (VCR-ISA-001 #667 — `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v`); all four i32 div/rem trap guards discharged against the branch-taking executor (#73) |
+| Rocq mechanized proofs | 474 Qed / 5 Admitted | i32 + i64 T1 correctness proofs; the 41 selector-DSL rule theorems are stated directly about the GENERATED model (VCR-ISA-001 #667 — `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v`); all four i32 div/rem trap guards discharged against the branch-taking executor (#73) |
 | SMT translation validation | ordeal (pure-Rust QF_BV) default | v0.27.0 (#553); Z3 demoted to feature-gated differential oracle — 141/141 agreement |
 | WebAssembly spec test suite | 227/257 compile | Compilation only — not executed on emulator |
 
@@ -194,7 +194,7 @@ Per the [PulseEngine Verification Guide](https://pulseengine.eu/guides/VERIFICAT
 
 | Track | Status | Coverage |
 |-------|--------|----------|
-| **Rocq** | Partial | 473 Qed / 5 Admitted (40 selector-DSL rule theorems stated directly about the GENERATED model, VCR-ISA-001 #667) — all four i32 div/rem trap guards discharged (#73) |
+| **Rocq** | Partial | 474 Qed / 5 Admitted (41 selector-DSL rule theorems stated directly about the GENERATED model, VCR-ISA-001 #667) — all four i32 div/rem trap guards discharged (#73) |
 | **Kani** | Starting | 18 bounded model checking harnesses for ARM encoder |
 | **Verus** | Starting | 8 spec functions in `synth-synthesis/src/contracts.rs`; Bazel integration via `rules_verus` |
 | **Lean** | Not started | — |
@@ -206,14 +206,14 @@ See `artifacts/verification-gaps.yaml` for the detailed gap analysis (VG-001 thr
 Mechanized proofs in Rocq 9 show that `compile_wasm_to_arm` preserves WASM semantics for each operation. The proof suite lives in `coq/Synth/` and covers ARM instruction semantics, WASM stack-machine semantics, and per-operation correctness theorems.
 
 ```
-473 Qed / 5 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
+474 Qed / 5 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
   T1 result-correspondence (ARM output = WASM result): all i32 ops and all
      i64 ops — i64 T1 parity since v0.11.0, 0 i64 admits (coq/STATUS.md)
   T2 existence-only: f32/f64 and remaining categories
   T3 admitted (5): 2 Compilation.v, 1 CorrectnessSimple.v, 2 ArmRefinement.v
      (0 division admits — all four i32 div/rem trap guards discharged against
      exec_program_br, #73 closed at i32)
-  incl. 40 Qed selector-DSL rule theorems (Synth/VcrSelRules.v, 1:1 with
+  incl. 41 Qed selector-DSL rule theorems (Synth/VcrSelRules.v, 1:1 with
      coq/vcr_sel_rules.manifest) — stated directly about the GENERATED model
      (VCR-ISA-001 #667: rule_X := Gen.rule_X, single source
      Synth/VcrSelRulesGenerated.v emitted from the shipped sel_dsl::RULES, so
@@ -262,10 +262,10 @@ The one-sentence version: moving synth's correctness from *"we patched every bug
 
 | Track | Item | What it does | Status |
 |-------|------|--------------|--------|
-| **A — codegen core** | `VCR-SEL-001` | Rocq-discharged verified selector DSL — *"ISLE with a proof-assistant backend"*; a missing lowering rule becomes an enumerable coverage gap, not a silent miscompile | increments 1–4 shipped default-on (`SYNTH_SEL_DSL`, opt-out `SYNTH_NO_SEL_DSL=1`): 40 rules / 40 Qed theorems in `coq/Synth/Synth/VcrSelRules.v` (1:1 with `coq/vcr_sel_rules.manifest`, coverage-gated), plus 7 Qed pilot lemmas in `coq/Synth/Synth/VcrSelPilot.v`; the DSL is now the SHIPPED lowering path for its 40 covered ops (byte-invisible flip — every rule was mirror-pinned byte-identical to the hand-written arm it replaces, frozen anchors unmoved) |
+| **A — codegen core** | `VCR-SEL-001` | Rocq-discharged verified selector DSL — *"ISLE with a proof-assistant backend"*; a missing lowering rule becomes an enumerable coverage gap, not a silent miscompile | increments 1–4 shipped default-on (`SYNTH_SEL_DSL`, opt-out `SYNTH_NO_SEL_DSL=1`): 41 rules / 41 Qed theorems in `coq/Synth/Synth/VcrSelRules.v` (1:1 with `coq/vcr_sel_rules.manifest`, coverage-gated), plus 7 Qed pilot lemmas in `coq/Synth/Synth/VcrSelPilot.v`; the DSL is now the SHIPPED lowering path for its 41 covered ops (byte-invisible flip — every rule was mirror-pinned byte-identical to the hand-written arm it replaces, frozen anchors unmoved) |
 | | `VCR-PERF-002` | Proof-carrying specialization (#494): loom's `wsc.facts` invariants become premises for per-elision proof obligations, certificate-checked by the ordeal-backed validator — toward gale's measured **0.45× (below-native) floor** | design traced (v0.30.0); phase 1 (facts ingestion) landed ([PR #624](https://github.com/pulseengine/synth/pull/624), v0.31.0) |
 | | `SYNTH_SPILL_ON_EXHAUST` | Replace the register-exhaustion decline with allocation-time Belady spilling (#580) — the last piece of the exhaustion hard-fail | built, flag-off; default-on held for silicon cycle numbers |
-| **B — authoritative semantics** | `VCR-ISA-001` | Re-base ARM/RISC-V semantics on Sail-generated Rocq (the official ISA spec); generate the selector model, don't mirror it (#667) | approved — Sail/ASL bridge spike landed (92 Qed, `coq/Synth/ARM/SailArmBridge.v`); #667 "generate, don't mirror" landed: the shipped `sel_dsl::RULES` table emits the 40 covered ops' Rocq lowerings (`coq/Synth/Synth/VcrSelRulesGenerated.v`), and `VcrSelRules.v` DEFINES `rule_X := Gen.rule_X` — the generated file is the single model source, the 40 correctness Qed are stated directly about it, and a selector-table change breaks the matching proof (no hand-written copy left to drift) |
+| **B — authoritative semantics** | `VCR-ISA-001` | Re-base ARM/RISC-V semantics on Sail-generated Rocq (the official ISA spec); generate the selector model, don't mirror it (#667) | approved — Sail/ASL bridge spike landed (92 Qed, `coq/Synth/ARM/SailArmBridge.v`); #667 "generate, don't mirror" landed: the shipped `sel_dsl::RULES` table emits the 41 covered ops' Rocq lowerings (`coq/Synth/Synth/VcrSelRulesGenerated.v`), and `VcrSelRules.v` DEFINES `rule_X := Gen.rule_X` — the generated file is the single model source, the 41 correctness Qed are stated directly about it, and a selector-table change breaks the matching proof (no hand-written copy left to drift) |
 | | `VCR-WASM-001` | Anchor WASM source semantics on WasmCert-Coq | proposed |
 | **Gate** | `VCR-VER-001` | Success = a previously load-bearing greedy-fix becomes *revertable*, with the full differential bit-identical and cycles equal-or-better | **demonstrated** (implemented; [evidence](scripts/repro/vcr_ver_001_gate.md)): the v0.11.20 reciprocal-mult cost-gate deleted outright (PR #322, bit-identical); the #496 exhaustion decline revertable behind `SYNTH_SPILL_ON_EXHAUST` — red case green, anchors byte-identical, declines 14→8; flip held on a measured i32-shape cycle regression |
 

--- a/claims.yaml
+++ b/claims.yaml
@@ -29,16 +29,16 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-PROOF-COUNT-README
     doc: README.md
-    text: "473 Qed / 5 Admitted"
+    text: "474 Qed / 5 Admitted"
     evidence:
       - kind: count-eq                       # ALL THREE README spots must agree —
-        pattern: '473 Qed / 5 Admitted'      # a verbatim check alone greens if one
+        pattern: '474 Qed / 5 Admitted'      # a verbatim check alone greens if one
         glob: ['README.md']                  # of them drifts while another matches
         expect: 3
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 473
+        expect: 474
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -50,12 +50,12 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-CLAUDE-MD
     doc: CLAUDE.md
-    text: "473 Qed / 5 Admitted"
+    text: "474 Qed / 5 Admitted"
     evidence:
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 473
+        expect: 474
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -63,16 +63,16 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-STATUS-MD
     doc: coq/STATUS.md
-    text: "473 Qed / 5 Admitted"
+    text: "474 Qed / 5 Admitted"
     evidence:
       - kind: count-eq                       # headline + Total line must both agree
-        pattern: '473 Qed / 5 Admitted'
+        pattern: '474 Qed / 5 Admitted'
         glob: ['coq/STATUS.md']
         expect: 2
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 473
+        expect: 474
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -216,16 +216,16 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-SEL-DSL-RULES
     doc: README.md
-    text: "40 rules / 40 Qed theorems"
+    text: "41 rules / 41 Qed theorems"
     evidence:
       - kind: count-eq                       # rules in the manifest
         pattern: '^rule_'
         glob: ['coq/vcr_sel_rules.manifest']
-        expect: 40
+        expect: 41
       - kind: count-eq                       # 1:1 Qed theorems in VcrSelRules.v
         pattern: '^(?:Theorem|Lemma) rule_\w+_correct'
         glob: ['coq/Synth/Synth/VcrSelRules.v']
-        expect: 40
+        expect: 41
       - kind: count-max                      # the rule table carries no admits
         pattern: 'Admitted\.'
         glob: ['coq/Synth/Synth/VcrSelRules.v']
@@ -233,14 +233,14 @@ claims:
 
   - id: SYNTH-SEL-DSL-COVERAGE-STATUS-MD
     doc: coq/STATUS.md
-    text: "**40 (26%)**"                     # DSL-served column total, per-op-family table (#667)
+    text: "**41 (26%)**"                     # DSL-served column total, per-op-family table (#667)
     evidence:
       - kind: count-eq
         pattern: '^rule_'
         glob: ['coq/vcr_sel_rules.manifest']
-        expect: 40
+        expect: 41
       - kind: verbatim
-        text: "**40 Qed / 0 Admitted**"
+        text: "**41 Qed / 0 Admitted**"
 
   - id: SYNTH-SEL-DSL-PILOT
     doc: README.md

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -1,6 +1,6 @@
 # Rocq Proof Suite — Honest Status
 
-**Last Updated: 2026-07-15 (recount: 473 Qed / 5 Admitted, +2 admit., crude
+**Last Updated: 2026-07-15 (recount: 474 Qed / 5 Admitted, +2 admit., crude
 `grep "Qed\."` over `coq/Synth/**/*.v` — same method as prior recounts; the
 -40 vs the prior 512 are the retired VCR-ISA-001 #667 cross-check lemmas of
 `VcrSelRulesGenCheck.v`: `VcrSelRules.v` now DEFINES every `rule_X` as the
@@ -167,7 +167,7 @@ and predates the VcrSelRules (42), VcrSelPilot (7) and SailArmBridge (92) Qed;
 see the per-file breakdown below for current per-file counts. The T3 row and
 the headline total are re-derived by the claim gate.
 
-**Total: 473 Qed / 5 Admitted (+2 admit.) across all files** (recount 2026-07-15, CI-gated via `claims.yaml`)
+**Total: 474 Qed / 5 Admitted (+2 admit.) across all files** (recount 2026-07-15, CI-gated via `claims.yaml`)
 
 v0.10.0 PR 1: +2 T1 Qed (i64_add_correct, i64_sub_correct) and +9
 infrastructure Qed (combine_i32_unsigned, carry_split_add,
@@ -444,7 +444,7 @@ Recount 2026-07-10 (`grep -oE 'Qed\.'` / `'Admitted\.'` per file):
 | WasmValues.v | 2 | 0 | Infra |
 | VcrSelPilot.v | 7 | 0 | T1 (register-polymorphic; VCR-SEL-001 go/abandon measurement) |
 | VcrSelRules.v | 42 | 0 | T1 (register-polymorphic; the WIRED VCR-SEL-001 increment-1+2+3+4 rule table — 40 rule theorems 1:1 with `coq/vcr_sel_rules.manifest`, coverage-gated by `//coq:vcr_sel_rules_coverage`, + 2 mod-32 helper lemmas #683. VCR-ISA-001 #667 increment 2: every `rule_X` is DEFINED as the GENERATED `Gen.rule_X` of `VcrSelRulesGenerated.v` — emitted from the shipped `sel_dsl::RULES` — so the theorems are stated directly about the shipped sequences; a table change regenerates `Gen` and breaks the matching Qed. The former `VcrSelRulesGenCheck.v` 40-lemma `reflexivity` gate is retired as vacuous/subsumed) |
-| **Total** | **473** | **5** | (+2 `admit.`) |
+| **Total** | **474** | **5** | (+2 `admit.`) |
 
 ## VCR-SEL-001 increments 1 (2026-07-07) + 2 + 3 + 4 (2026-07-08): VcrSelRules.v
 
@@ -485,9 +485,9 @@ stepped proof closing with `I32.clz_rbit`;
 tier: the encoder's CMP-lo/SBCS-hi expansion is below the flat executor,
 see `docs/design/vcr-sel-001-increment-4.md`).
 
-**40 Qed / 0 Admitted**, same T1 bound as the pilot ("the ARM sequence
-computes the named result", not WASM refinement). These 47 Qed (pilot +
-rules) are included in the 2026-07-10 recount above.
+**41 Qed / 0 Admitted**, same T1 bound as the pilot ("the ARM sequence
+computes the named result", not WASM refinement). These 48 Qed (pilot +
+rules) are included in the recount above.
 
 ## DSL coverage vs model relevance (per-op-family metric, #667)
 
@@ -515,7 +515,7 @@ Every op family the shipped ARM selectors lower, as of increment 4
 | i32 ALU (add/sub/mul/and/or/xor) | 6 | **6** | 0 | 0 |
 | i32 shifts/rotates (shl/shr_s/shr_u/rotr/rotl) | 5 | **5** | 0 | 0 |
 | i32 binary comparisons (eq..ge_u) | 10 | **10** | 0 | 0 |
-| i32.eqz (CMP-imm shape) | 1 | 0 | 1 | 0 |
+| i32.eqz (CMP-imm shape) | 1 | **1** | 0 | 0 |
 | i32 bit-manip (clz/ctz/popcnt) | 3 | **3**¹ | 0 | 0 |
 | i32 div/rem (trap-guarded) | 4 | 0 | 4² | 0 |
 | i32 sign-extend (extend8_s/16_s) | 2 | 0 | 0 | 2 |
@@ -535,7 +535,7 @@ Every op family the shipped ARM selectors lower, as of increment 4
 | locals/globals (get/set/tee) | 5 | 0 | 5 | 0 |
 | parametric (drop/select/nop) | 3 | 0 | 3 | 0 |
 | control flow (block/loop/br/br_if/return/call/…) | ~10 | 0 | 0 | ~10 |
-| **Total (≈)** | **155** | **40 (26%)** | **96 (62%)** | **19 (12%)** |
+| **Total (≈)** | **155** | **41 (26%)** | **95 (61%)** | **19 (12%)** |
 
 ¹ pseudo-op tier: `popcnt`, `i64.eqz` and the ten binary i64 comparisons are
 proven at the `ArmOp` pseudo-op boundary (the selector's emission, which is

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -6,7 +6,7 @@
 `VcrSelRulesGenCheck.v`: `VcrSelRules.v` now DEFINES every `rule_X` as the
 GENERATED `Gen.rule_X` (`VcrSelRulesGenerated.v`, emitted from the shipped
 `sel_dsl::RULES`), so the generated-vs-hand-written `reflexivity` check
-became vacuous — its divergence gate is subsumed by the 40 rule correctness
+became vacuous — its divergence gate is subsumed by the rule correctness
 Qed themselves, which are now stated directly about the generated sequences)
 
 The headline count is CI-gated: `claims.yaml` + `scripts/claim_check.py`

--- a/coq/Synth/Synth/VcrSelRules.v
+++ b/coq/Synth/Synth/VcrSelRules.v
@@ -177,6 +177,16 @@ Definition rule_i32_le_u := Gen.rule_i32_le_u.
 Definition rule_i32_ge_s := Gen.rule_i32_ge_s.
 Definition rule_i32_ge_u := Gen.rule_i32_ge_u.
 
+(** i32.eqz — the unary compare-with-zero shape: the Rust rule emits
+    [Cmp {rn, Imm 0}; SetCond {rd, EQ}]; per the Compilation.v convention the
+    [SetCond] pseudo-op is modeled as [MOV rd #0; MOVEQ rd #1] over the flags
+    CMP latched. No aliasing side conditions: the flags transfer is through
+    NZCV, not a register, so the theorem holds for EVERY rd/rn assignment.
+    The immediate is modeled as [I32.zero] (definitionally [I32.repr 0]) to
+    match the fixed-register ancestor [i32_eqz_correct] (CorrectnessI32.v) and
+    reuse its [z_flag_sub_eq] flag lemma verbatim. *)
+Definition rule_i32_eqz  := Gen.rule_i32_eqz.
+
 (** ** The discharge tactic — verbatim [synth_binop_proof] (Tactics.v) modulo
     the lowering-unfold target, as measured by the pilot. *)
 Ltac synth_binop_proof_poly :=
@@ -577,6 +587,30 @@ Theorem rule_i32_ge_u_correct : forall wstate astate v1 v2 stack' rd rn rm,
     exec_program (rule_i32_ge_u rd rn rm) astate = Some astate' /\
     get_reg astate' rd = (if I32.geu v1 v2 then I32.one else I32.zero).
 Proof. synth_cmp_binop_proof_poly flags_geu. Qed.
+
+(** ** i32.eqz theorem — quantified over ARBITRARY rd rn (no side conditions:
+    CMP latches NZCV before rd is written, so every rd/rn aliasing is
+    admitted). The register-generalized form of the fixed-register ancestor
+    [i32_eqz_correct] (CorrectnessI32.v, [synth_cmp_unop_proof z_flag_sub_eq]),
+    with the two register binders replacing R0. *)
+Theorem rule_i32_eqz_correct : forall wstate astate v stack' rd rn,
+  wstate.(stack) = VI32 v :: stack' ->
+  get_reg astate rn = v ->
+  exec_wasm_instr I32Eqz wstate =
+    Some (mkWasmState
+            (VI32 (if I32.eq v I32.zero then I32.one else I32.zero) :: stack')
+            wstate.(locals) wstate.(globals) wstate.(memory)) ->
+  exists astate',
+    exec_program (rule_i32_eqz rd rn) astate = Some astate' /\
+    get_reg astate' rd = (if I32.eq v I32.zero then I32.one else I32.zero).
+Proof.
+  intros wstate astate v stack' rd rn Hstack HR0 Hwasm.
+  unfold rule_i32_eqz, Gen.rule_i32_eqz; simpl.
+  rewrite HR0; simpl.
+  rewrite z_flag_sub_eq.
+  destruct (I32.eq v I32.zero);
+  (eexists; split; [reflexivity | apply get_set_reg_eq]).
+Qed.
 
 (** ** Increment 3: the i64 register-pair rule lowerings — 1:1 with
     sel_dsl::RULES / sel_dsl::generated. An i64 value is a (lo, hi)

--- a/coq/Synth/Synth/VcrSelRulesGenerated.v
+++ b/coq/Synth/Synth/VcrSelRulesGenerated.v
@@ -92,6 +92,9 @@ Definition rule_i32_ge_s (rd rn rm : arm_reg) : arm_program :=
 Definition rule_i32_ge_u (rd rn rm : arm_reg) : arm_program :=
   [CMP rn (Reg rm); MOV rd (Imm I32.zero); MOVHS rd (Imm I32.one)].
 
+Definition rule_i32_eqz (rd rn : arm_reg) : arm_program :=
+  [CMP rn (Imm I32.zero); MOV rd (Imm I32.zero); MOVEQ rd (Imm I32.one)].
+
 Definition rule_i64_add (rdlo rdhi rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
   [ADDS rdlo rnlo (Reg rmlo); ADC rdhi rnhi (Reg rmhi)].
 

--- a/coq/vcr_sel_rules.manifest
+++ b/coq/vcr_sel_rules.manifest
@@ -24,6 +24,7 @@ rule_i32_le_s
 rule_i32_le_u
 rule_i32_ge_s
 rule_i32_ge_u
+rule_i32_eqz
 rule_i64_add
 rule_i64_sub
 rule_i64_and

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -14360,22 +14360,43 @@ impl InstructionSelector {
                             idx,
                         )?
                     };
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::Cmp {
-                            rn: a,
-                            op2: Operand2::Imm(0),
-                        },
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::SetCond {
-                            rd: dst,
-                            cond: Condition::EQ,
-                        },
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
+                    // VCR-SEL-001 (#242): behind SYNTH_SEL_DSL (default ON,
+                    // opt out SYNTH_NO_SEL_DSL) the CMP+SetCond pair comes from
+                    // the generated Rocq-proved rule — byte-identical to the
+                    // hand-written emission below (mirror-pinned). Same holdout
+                    // story as the i32 comparisons: select_with_stack owns the
+                    // materializing lowering, so the rule is wired here only.
+                    let dsl_ops = if self.sel_dsl {
+                        crate::sel_dsl::i32_eqz_rule(op, dst, a)
+                    } else {
+                        None
+                    };
+                    if let Some(rule_ops) = dsl_ops {
+                        for rule_op in rule_ops {
+                            instructions.push(ArmInstruction {
+                                op: rule_op,
+                                source_line: Some(idx),
+                            });
+                            cf.add_instruction();
+                        }
+                    } else {
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::Cmp {
+                                rn: a,
+                                op2: Operand2::Imm(0),
+                            },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::SetCond {
+                                rd: dst,
+                                cond: Condition::EQ,
+                            },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    }
                     stack.push(StackVal::i32(dst));
                 }
 
@@ -16203,6 +16224,12 @@ mod tests {
             if rule.name.starts_with("rule_i64_") {
                 continue;
             }
+            // i32.eqz is the sole UNARY compare-with-zero rule (CmpImm +
+            // SetCond); it needs a single-operand probe and a CmpImm window,
+            // pinned separately below.
+            if rule.name == "rule_i32_eqz" {
+                continue;
+            }
             probed += 1;
             let ops = vec![WasmOp::LocalGet(0), WasmOp::LocalGet(1), rule.op.clone()];
 
@@ -16348,6 +16375,60 @@ mod tests {
         assert_eq!(
             probed, 17,
             "unexpected select_with_stack-delegated rule count"
+        );
+
+        // i32.eqz — the unary compare-with-zero rule, probed with a single
+        // operand. OFF vs ON full-sequence equality, plus the CmpImm+SetCond
+        // window RMW-vacuity check for the registers the selector chose.
+        let eqz_ops = vec![WasmOp::LocalGet(0), WasmOp::I32Eqz];
+        let mut hw = InstructionSelector::new(vec![]);
+        hw.set_sel_dsl(false);
+        let eqz_baseline: Vec<ArmOp> = hw
+            .select_with_stack(&eqz_ops, 1)
+            .expect("i32.eqz hand-written arm failed")
+            .into_iter()
+            .map(|i| i.op)
+            .collect();
+        let mut dsl = InstructionSelector::new(vec![]);
+        dsl.set_sel_dsl(true);
+        let eqz_generated: Vec<ArmOp> = dsl
+            .select_with_stack(&eqz_ops, 1)
+            .expect("i32.eqz generated rule failed")
+            .into_iter()
+            .map(|i| i.op)
+            .collect();
+        assert_eq!(
+            eqz_baseline, eqz_generated,
+            "rule_i32_eqz: SYNTH_SEL_DSL=1 diverges from the hand-written \
+             select_with_stack arm"
+        );
+        let i = eqz_baseline
+            .iter()
+            .position(|o| {
+                matches!(
+                    o,
+                    ArmOp::Cmp {
+                        op2: Operand2::Imm(_),
+                        ..
+                    }
+                )
+            })
+            .expect("rule_i32_eqz: no CMP #imm in probe output");
+        let rn = match &eqz_baseline[i] {
+            ArmOp::Cmp { rn, .. } => *rn,
+            _ => unreachable!(),
+        };
+        let rd = match &eqz_baseline[i + 1] {
+            ArmOp::SetCond { rd, .. } => *rd,
+            other => panic!("rule_i32_eqz: no SetCond after CMP: {other:?}"),
+        };
+        let eqz_rule = crate::sel_dsl::i32_eqz_rule(&WasmOp::I32Eqz, rd, rn)
+            .expect("rule_i32_eqz: dispatch missing");
+        assert_eq!(
+            eqz_baseline[i..i + 2].to_vec(),
+            eqz_rule,
+            "rule_i32_eqz: the hand-written emission window does not equal the \
+             generated rule's output for the same registers"
         );
     }
 

--- a/crates/synth-synthesis/src/sel_dsl/generated.rs
+++ b/crates/synth-synthesis/src/sel_dsl/generated.rs
@@ -326,6 +326,22 @@ pub fn rule_i32_ge_u(rd: Reg, rn: Reg, rm: Reg) -> Vec<ArmOp> {
     ]
 }
 
+/// `i32.eqz`: rd = if rn == 0 {1} else {0}
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i32_eqz_correct` (Qed).
+pub fn rule_i32_eqz(rd: Reg, rn: Reg) -> Vec<ArmOp> {
+    vec![
+        ArmOp::Cmp {
+            rn,
+            op2: Operand2::Imm(0),
+        },
+        ArmOp::SetCond {
+            rd,
+            cond: Condition::EQ,
+        },
+    ]
+}
+
 /// `i64.add`: (rd_hi:rd_lo) = (rn_hi:rn_lo) + (rm_hi:rm_lo), carry via ADDS+ADC
 ///
 /// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_add_correct` (Qed).

--- a/crates/synth-synthesis/src/sel_dsl/mod.rs
+++ b/crates/synth-synthesis/src/sel_dsl/mod.rs
@@ -275,6 +275,9 @@ pub enum TemplateOp {
     AsrReg { rd: RegVar, rn: RegVar, rm: RegVar },
     /// `ArmOp::Cmp { rn, op2: Reg(rm) }` — flags only, no register written
     CmpReg { rn: RegVar, rm: RegVar },
+    /// `ArmOp::Cmp { rn, op2: Imm(imm) }` — flags only, no register written
+    /// (the `i32.eqz` compare-with-zero shape)
+    CmpImm { rn: RegVar, imm: u32 },
     /// `ArmOp::SetCond { rd, cond }` — rd = if cond over current NZCV {1} else {0}
     SetCond { rd: RegVar, cond: CondCode },
     /// `ArmOp::Adds { rd, rn, op2: Reg(rm) }` — ADD setting flags (C = carry-out)
@@ -708,6 +711,27 @@ pub const RULES: &[SelRule] = &[
         delegation: Delegation::SelectWithStack,
         doc: "`i32.ge_u`: rd = if rn >= rm (unsigned) {1} else {0}",
     },
+    // i32.eqz — the unary compare-with-zero shape: CMP rn, #0; SetCond rd, EQ.
+    // Same tier as the i32 comparisons (CMP latches NZCV before SetCond writes
+    // rd, so NO aliasing side conditions), and the same holdout story:
+    // select_default's I32Eqz arm is a *blind* bare-Cmp that never
+    // materializes the 0/1 result (production-unreachable — select_with_stack
+    // owns eqz), so this rule is delegated in select_with_stack ONLY.
+    SelRule {
+        name: "rule_i32_eqz",
+        op: WasmOp::I32Eqz,
+        params: &[Rd, Rn],
+        side_conditions: &[],
+        seq: &[
+            TemplateOp::CmpImm { rn: Rn, imm: 0 },
+            TemplateOp::SetCond {
+                rd: Rd,
+                cond: CondCode::Eq,
+            },
+        ],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i32.eqz`: rd = if rn == 0 {1} else {0}",
+    },
     // ---- increment 3: the i64 register-pair family. An i64 value lives in
     // a (lo, hi) register pair; each binary rule is parameterized over SIX
     // registers and emits the two-instruction pair shape. All carry the
@@ -1070,6 +1094,21 @@ pub fn i32_cmp_rule(
     })
 }
 
+/// Dispatch `i32.eqz` (unary compare-with-zero) to its generated Rocq-proved
+/// rule. Same contract as [`i32_cmp_rule`]: `None` for any other op so the
+/// caller's hand-written arm keeps ownership; no side conditions, so infallible
+/// where it fires.
+pub fn i32_eqz_rule(
+    op: &WasmOp,
+    rd: crate::rules::Reg,
+    rn: crate::rules::Reg,
+) -> Option<Vec<crate::rules::ArmOp>> {
+    Some(match op {
+        WasmOp::I32Eqz => generated::rule_i32_eqz(rd, rn),
+        _ => return None,
+    })
+}
+
 /// Dispatch an i32 register-shift/rotate op to its generated Rocq-proved rule
 /// (increment 2). Same contract as [`i32_cmp_rule`].
 pub fn i32_shift_rule(
@@ -1292,6 +1331,14 @@ fn template_expr(t: &TemplateOp, indent: usize) -> String {
                 rm.rust_name()
             )
         }
+        TemplateOp::CmpImm { rn, imm } => {
+            let ind = " ".repeat(indent);
+            let fld = " ".repeat(indent + 4);
+            format!(
+                "ArmOp::Cmp {{\n{fld}{},\n{fld}op2: Operand2::Imm({imm}),\n{ind}}}",
+                field("rn", rn)
+            )
+        }
         TemplateOp::SetCond { rd, cond } => {
             let ind = " ".repeat(indent);
             let fld = " ".repeat(indent + 4);
@@ -1478,6 +1525,17 @@ fn coq_instrs(t: &TemplateOp) -> Vec<String> {
             vec![format!("ASR_reg {} {} {}", r(rd), r(rn), r(rm))]
         }
         TemplateOp::CmpReg { rn, rm } => vec![format!("CMP {} (Reg {})", r(rn), r(rm))],
+        // The compare-with-zero shape models the immediate as [I32.zero]
+        // (definitionally [I32.repr 0]) to match the flat model's I32Eqz
+        // lowering and the [z_flag_sub_eq] flag lemma verbatim.
+        TemplateOp::CmpImm { rn, imm } => {
+            let operand = if imm == 0 {
+                "I32.zero".to_string()
+            } else {
+                format!("(I32.repr {imm})")
+            };
+            vec![format!("CMP {} (Imm {operand})", r(rn))]
+        }
         TemplateOp::SetCond { rd, cond } => vec![
             format!("MOV {} (Imm I32.zero)", r(rd)),
             format!("{} {} (Imm I32.one)", cond.coq_movcc(), r(rd)),


### PR DESCRIPTION
## Summary

Extends the #667 "generate, don't mirror" selector-DSL coverage past the 40
covered ops by adding **`i32.eqz`** — the 41st Rocq-discharged rule. The
shipped `sel_dsl::RULES` table now emits the eqz lowering into both the Rust
lowering (`generated.rs`) and the single-source Rocq model
(`VcrSelRulesGenerated.v`, `Module Gen`); `VcrSelRules.v` DEFINES
`rule_i32_eqz := Gen.rule_i32_eqz` and proves `rule_i32_eqz_correct` directly
about the generated sequence. Behavior-frozen, byte-invisible, oracle-gated.

**40 → 41 rules / 40 → 41 Qed; 473 → 474 total Qed / 5 Admitted (unchanged).**

## The op

`i32.eqz` is the unary compare-with-zero shape: `CMP rn, #0; SetCond rd, EQ`.
Same tier as the i32 comparisons — CMP latches NZCV before SetCond writes `rd`,
so **no aliasing side conditions** — and the same holdout story:
`select_default`'s `I32Eqz` arm is a *blind* bare-Cmp that never materializes
the 0/1 result (production-unreachable; `select_with_stack` owns eqz), so the
rule is wired in `select_with_stack` **only** (`Delegation::SelectWithStack`,
verbatim the i32-comparison precedent).

New `TemplateOp::CmpImm { rn, imm }` models the compare-with-zero. `coq_instrs`
emits `CMP rn (Imm I32.zero)` for imm 0 (definitionally `I32.repr 0`) to match
the flat model's `I32Eqz` lowering and reuse the `z_flag_sub_eq` flag lemma
verbatim — `rule_i32_eqz_correct` is the register-generalized form of the
fixed-register `i32_eqz_correct` ancestor (CorrectnessI32.v).

## Verification

- **Rocq proofs green:** `bazel test //coq:verify_proofs` → both
  `//coq:rocq_proofs` and `//coq:vcr_sel_rules_coverage` PASS. The 41st Qed
  (`rule_i32_eqz_correct`) compiles about the generated model.
- **Drift-guard demonstrated (not committed):** flipping `MOVEQ → MOVNE` in
  `Gen.rule_i32_eqz` (only that line) makes `bazel test //coq:rocq_proofs`
  fail at `VcrSelRules.v:612` with `Unable to unify "I32.one" with "I32.zero"`
  in the `exec_wasm_instr I32Eqz` environment — i.e. the correctness Qed IS the
  divergence gate for the new op. Restored to green.
- **Byte-invisibility confirmed:** frozen anchors
  (`cargo test -p synth-cli --test frozen_codegen_bytes`) unmoved; a module
  exercising `i32.eqz` (single + chained) compiles **bit-identically** under
  default (DSL on) and `SYNTH_NO_SEL_DSL=1` (same SHA256). The mirror-pin test
  gains a dedicated non-vacuity window check (extracts the selector's chosen
  registers, asserts the `CmpImm+SetCond` window equals `i32_eqz_rule`'s output).
- **Claim gate green:** `python3 scripts/claim_check.py claims.yaml` → 18/18
  hold. Counts bumped in `claims.yaml` + `README.md` + `CLAUDE.md` +
  `coq/STATUS.md` (per-op-family table: i32.eqz moves model-only → DSL-served).
- **Full workspace tests pass.**

## Scope note

`i32.eqz` was the one clean, model-supported, non-trapping op available to add.
The i32 sign-extend ops (`extend8_s`/`extend16_s`) were deliberately excluded —
they need new `SXTB`/`SXTH` templates *and* model-side `SXTB/SXTH` +
`I32.extend8_s/16_s` semantics that don't exist yet (out of scope; not a
trap-VC op). Trapping/partial lowerings are also out of scope here.

Refs #667 (VCR-ISA-001), #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L