### PR TITLE
feat(#494): const-divisor rem_u identity elision — a proof-carrying 12x beat over clang -Os

### DIFF
--- a/crates/synth-verify/src/fact_spec.rs
+++ b/crates/synth-verify/src/fact_spec.rs
@@ -965,6 +965,121 @@ impl<'a> Pass<'a> {
         }
     }
 
+    /// #494 Phase 3+ (beyond-parity): constant-divisor `i32.rem_u` IDENTITY
+    /// elision. When the divisor is a *literal* `i32.const C` with `C != 0` and
+    /// the dividend `a` is proven small enough that `a rem_u C == a` on every
+    /// P-admissible input (`UNSAT(P ∧ (a bvurem C) ≠ a)`), the whole `rem_u`
+    /// dissolves to the identity — its const-divisor operand and the op itself
+    /// are deleted and `a` flows through unchanged.
+    ///
+    /// This is the ONE total subset of the "div/rem never deleted" rule: WASM
+    /// `i32.rem_u` traps ONLY on divisor == 0, and rem has no INT_MIN/-1
+    /// overflow (that's `div_s`). A LITERAL nonzero constant divisor makes the
+    /// op unconditionally total — no-trap comes from the literal directly, NOT
+    /// from P — so unlike the variable-divisor path (which only elides the
+    /// *guard* and keeps the op), the whole effect-free op is deletable exactly
+    /// like the redundant mask. A variable divisor proven nonzero would NOT
+    /// qualify (its zero-guard is a control-flow effect); only a syntactic
+    /// `i32.const C, C != 0` is accepted.
+    ///
+    /// clang cannot do this: a dissolved primitive gives LLVM no range on the
+    /// dividend, so `-Os` lowers `x % C` (non-pow2 C) to the full
+    /// reciprocal-multiply-subtract sequence (movw+movt+umull+lsr+mov+mls,
+    /// ~22 B on Thumb-2); the WASM-level fact makes the entire sequence dead.
+    ///
+    /// Only the common wasm order (`dividend ; i32.const C ; rem_u`) is handled;
+    /// anything else DECLINES LOUDLY and the general div/rem path stands.
+    /// Returns the surviving dividend's `Val` on admit (deletion recorded),
+    /// `None` on decline.
+    fn try_elide_const_rem(&mut self, i: usize, a: &Val, b: &Val, result_bv: &BV) -> Option<Val> {
+        // Divisor MUST be a syntactic literal `i32.const C` with `C != 0` — the
+        // no-trap obligation is discharged by the literal itself, never by P.
+        let WasmOp::I32Const(c) = self.ops[b.created] else {
+            self.decline(format!(
+                "op#{i} i32.rem_u — divisor is not a literal i32.const (a variable divisor \
+                 carries a trapping zero-guard; the whole op is not effect-free — general \
+                 rem_u retained)"
+            ));
+            return None;
+        };
+        if c == 0 {
+            self.decline(format!(
+                "op#{i} i32.rem_u — literal divisor is 0 (traps unconditionally); general \
+                 rem_u retained"
+            ));
+            return None;
+        }
+        if self.premises.is_empty() {
+            self.decline(format!(
+                "op#{i} i32.rem_u — no premise reaches this site (no usable value-range fact \
+                 on the dividend)"
+            ));
+            return None;
+        }
+        // The const-divisor operand `b` must be a pure, contiguous producer
+        // sitting immediately between `a`'s slice and the `rem_u` — otherwise
+        // deleting it could drop live work or leave a gap. (An `i32.const`
+        // always has a pure single-op slice; this mirrors try_elide_mask.)
+        let Some(sb) = b.start else {
+            self.decline(format!(
+                "op#{i} i32.rem_u — const-divisor slice is impure or non-contiguous \
+                 (not erasable)"
+            ));
+            return None;
+        };
+        if a.created + 1 != sb || b.created + 1 != i {
+            self.decline(format!(
+                "op#{i} i32.rem_u — const divisor is not produced immediately before the \
+                 rem_u (non-contiguous)"
+            ));
+            return None;
+        }
+        let mut solver = new_solver();
+        for p in &self.premises {
+            solver.assert(p);
+        }
+        // UNSAT(P ∧ (dividend bvurem C) ≠ dividend) ⇒ the modulo never changes
+        // the dividend under P ⇒ the rem_u is the identity, so the general and
+        // the specialized (result = dividend) lowerings agree on every P input.
+        // `result_bv` is the real `a.bv.bvurem(C)` term (WasmSemantics), so the
+        // check is non-vacuous.
+        solver.assert(&result_bv.ne(&a.bv));
+        match solver.check() {
+            CheckOutcome::Unsat => {
+                self.deletions.push((sb, i));
+                self.admitted.push(format!(
+                    "{}: op#{i} i32.rem_u — constant-divisor modulo elided to identity \
+                     (dividend proven < divisor): divisor is literal i32.const {c} (≠0 ⇒ \
+                     no trap), UNSAT(P ∧ (dividend bvurem {c}) ≠ dividend) via {} \
+                     (certificate-checked QF_BV; every Unsat carries an LRAT proof validated \
+                     by ordeal-lrat); deleted const/rem_u [{sb}..={i}]; P = {{{}}}; \
+                     dividend = {}",
+                    self.func,
+                    solver.name(),
+                    self.premise_desc.join(" ∧ "),
+                    a.bv,
+                ));
+                Some(a.clone())
+            }
+            CheckOutcome::Sat => {
+                let cex = self.counterexample(solver.as_ref());
+                self.decline(format!(
+                    "op#{i} i32.rem_u — modulo is not the identity under P (dividend can \
+                     reach or exceed the divisor {c}; counterexample: {cex}); general rem_u \
+                     retained"
+                ));
+                None
+            }
+            CheckOutcome::Unknown(reason) => {
+                self.decline(format!(
+                    "op#{i} i32.rem_u — identity obligation Unknown ({reason}); conservative \
+                     decline, general rem_u retained"
+                ));
+                None
+            }
+        }
+    }
+
     fn walk(&mut self) {
         if self.range_facts.is_empty() && self.nonzero_facts.is_empty() {
             self.decline(
@@ -1123,9 +1238,57 @@ impl<'a> Pass<'a> {
                 // soundness: if the op traps, nothing after it executes (any
                 // later admitted elision is vacuous on that path); if it does
                 // not, its result is havocked to a fresh variable.
+                // #494 Phase 3+ (beyond-parity): `i32.rem_u` — tracked like the
+                // other div/rem ops, but additionally attempts the
+                // constant-divisor IDENTITY elision (a literal nonzero divisor
+                // + a proven-narrow dividend makes the modulo the identity, and
+                // the whole effect-free op is deletable — the ONE total subset
+                // of the "div/rem never deleted" rule). A NON-eliding rem_u
+                // takes the EXACT general div/rem path below (guard obligations
+                // + havoc), so flag-off stays byte-identical.
+                WasmOp::I32RemU => {
+                    let (Some(b), Some(a)) = (self.stack.pop(), self.stack.pop()) else {
+                        self.decline(format!("op#{i} div/rem on underflowing symbolic stack"));
+                        return;
+                    };
+                    if a.bv.get_size() != 32 || b.bv.get_size() != 32 {
+                        self.decline(format!(
+                            "op#{i} i32.rem_u on operands of unexpected width (symbolic widths \
+                             {}/{}, expected 32)",
+                            a.bv.get_size(),
+                            b.bv.get_size()
+                        ));
+                        return;
+                    }
+                    // The real bvurem term (WasmSemantics) — non-vacuous VC.
+                    let bv = self.sem.encode_op(op, &[a.bv.clone(), b.bv.clone()]);
+                    match self.try_elide_const_rem(i, &a, &b, &bv) {
+                        // Admitted: the const/rem_u slice was recorded for
+                        // deletion; the surviving dividend flows through.
+                        // `start = None` keeps the collapsed result out of any
+                        // later erasable slice (conservative, like the mask
+                        // and select-collapse admits).
+                        Some(surviving) => self.push(surviving.bv, None, i),
+                        // Declined (loud): fall to the EXACT general div/rem
+                        // path — discharge the guard obligations, then havoc.
+                        None => {
+                            self.try_elide_div_guards(i, "i32.rem_u", false, &a, &b);
+                            let n = self.fresh;
+                            self.fresh += 1;
+                            let v = self.fresh_var(format!("fs_d{n}"));
+                            self.attach_fact(i, &v);
+                            self.push(v, None, i);
+                        }
+                    }
+                }
+                // #494 phase 2b: i32/i64 div/rem — TRACKED (upgrading the
+                // phase-2 hard stop), never DELETED. The op can trap, so its
+                // result carries `start = None` (it can never sit inside an
+                // erasable condition slice); the walk instead discharges the
+                // per-site guard obligations (see the module docs' two-guard
+                // distinction) and marks the op for the lowering.
                 WasmOp::I32DivU
                 | WasmOp::I32DivS
-                | WasmOp::I32RemU
                 | WasmOp::I32RemS
                 | WasmOp::I64DivU
                 | WasmOp::I64DivS
@@ -1138,7 +1301,6 @@ impl<'a> Pass<'a> {
                     let (op_name, expect, is_div_s) = match op {
                         WasmOp::I32DivU => ("i32.div_u", 32, false),
                         WasmOp::I32DivS => ("i32.div_s", 32, true),
-                        WasmOp::I32RemU => ("i32.rem_u", 32, false),
                         WasmOp::I32RemS => ("i32.rem_s", 32, false),
                         WasmOp::I64DivU => ("i64.div_u", 64, false),
                         WasmOp::I64DivS => ("i64.div_s", 64, true),
@@ -2331,5 +2493,136 @@ mod tests {
             vec![5],
             "mark remapped from original op#12 to rewritten op#5"
         );
+    }
+
+    // ============ #494 Phase 3+: constant-divisor rem_u identity =============
+
+    fn const_rem_ops() -> Vec<WasmOp> {
+        // `x rem_u 1000` — under x ∈ [0, 999] the modulo is the identity.
+        vec![
+            LocalGet(0),    // 0  x  ← fact target
+            I32Const(1000), // 1  divisor (literal, ≠0)
+            I32RemU,        // 2  x % 1000
+            End,            // 3
+        ]
+    }
+
+    #[test]
+    fn const_rem_u_identity_elided_under_proven_narrow_dividend_494() {
+        let ops = const_rem_ops();
+        let r = specialize_function("gust_scale", &ops, &[], &[fact(0, 0, 999)], &[], 0);
+        assert_eq!(r.admitted.len(), 1, "declines: {:?}", r.declined);
+        assert!(r.changed());
+        assert_eq!(
+            r.ops,
+            vec![LocalGet(0), End],
+            "the const-divisor + rem_u dissolve to the identity dividend"
+        );
+        assert_eq!(r.kept, vec![0, 3]);
+        // Never a div-guard mark: the op was DELETED, not guarded.
+        assert!(r.elide_div_zero.is_empty());
+        assert!(r.elide_div_ovf.is_empty());
+        let line = &r.admitted[0];
+        assert!(line.contains("i32.rem_u"), "{line}");
+        assert!(line.contains("elided to identity"), "{line}");
+        assert!(line.contains("literal i32.const 1000"), "{line}");
+        assert!(
+            line.contains("UNSAT(P ∧ (dividend bvurem 1000) ≠ dividend)"),
+            "{line}"
+        );
+        assert!(line.contains("certificate-checked"), "{line}");
+    }
+
+    #[test]
+    fn const_rem_u_wrong_bound_is_sat_and_declines_byte_identically_494() {
+        // x ∈ [0, 4000] admits x ≥ 1000, so x % 1000 ≠ x — Sat ⇒ loud decline.
+        // The stream is untouched and the general div/rem path runs (marks the
+        // zero guard? no — divisor is a nonzero literal, so the zero-guard
+        // obligation is discharged by the guard elision, but the OP survives).
+        let ops = const_rem_ops();
+        let r = specialize_function("gust_scale", &ops, &[], &[fact(0, 0, 4000)], &[], 0);
+        assert_eq!(
+            r.admitted
+                .iter()
+                .filter(|l| l.contains("elided to identity"))
+                .count(),
+            0,
+            "identity must NOT be admitted under a too-wide bound"
+        );
+        assert!(!r.stream_changed, "declined identity ⇒ op stream untouched");
+        assert_eq!(r.ops, ops, "declined ⇒ byte-identical op stream");
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("not the identity") && d.contains("counterexample")),
+            "identity decline must be loud and carry a model: {:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn const_rem_u_variable_divisor_declines_identity_and_keeps_op_494() {
+        // Divisor is a param (local.get 1), NOT a literal — the op carries a
+        // trapping zero-guard, so the whole op is NOT deletable. Identity
+        // declines; the general div/rem path stands (op survives). A
+        // divisor-nonzero fact still discharges the ZERO GUARD (guard elision),
+        // but never the op deletion.
+        let ops = vec![
+            LocalGet(0), // 0  x   ← range fact [0, 999]
+            LocalGet(1), // 1  d   ← divisor-nonzero fact
+            I32RemU,     // 2  x % d
+            End,         // 3
+        ];
+        let facts = [fact(0, 0, 999), nonzero_fact(1)];
+        let r = specialize_function("f", &ops, &[], &facts, &[], 0);
+        assert!(!r.stream_changed, "variable divisor ⇒ op never deleted");
+        assert_eq!(r.ops, ops);
+        assert_eq!(
+            r.elide_div_zero,
+            vec![2],
+            "zero guard still discharged by the nonzero fact"
+        );
+        assert!(
+            r.declined
+                .iter()
+                .any(|d| d.contains("not a literal i32.const")),
+            "identity must decline on a non-literal divisor: {:?}",
+            r.declined
+        );
+    }
+
+    #[test]
+    fn const_rem_u_no_fact_declines_byte_identically_494() {
+        // No range fact on the dividend ⇒ identity declines; the general path
+        // runs. The literal divisor is nonzero so the zero-guard is elidable
+        // ONLY with a fact — here there's none, so nothing is admitted and the
+        // stream is untouched.
+        let ops = const_rem_ops();
+        let r = specialize_function("gust_scale", &ops, &[], &[fact(99, 0, 0)], &[], 0);
+        assert!(!r.stream_changed, "no dividend fact ⇒ op stream untouched");
+        assert_eq!(r.ops, ops);
+        assert_eq!(
+            r.admitted
+                .iter()
+                .filter(|l| l.contains("elided to identity"))
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn const_rem_u_pow2_divisor_still_elides_under_narrow_bound_494() {
+        // Even a power-of-two divisor elides when the dividend is proven narrow
+        // (the win is smaller — clang folds pow2 rem to an `and` — but the
+        // proof is identical and sound). x ∈ [0, 255], x rem_u 256 == x.
+        let ops = vec![
+            LocalGet(0),   // 0  ← fact [0, 255]
+            I32Const(256), // 1
+            I32RemU,       // 2
+            End,           // 3
+        ];
+        let r = specialize_function("f", &ops, &[], &[fact(0, 0, 255)], &[], 0);
+        assert_eq!(r.admitted.len(), 1, "declines: {:?}", r.declined);
+        assert_eq!(r.ops, vec![LocalGet(0), End]);
     }
 }

--- a/scripts/repro/fact_spec_rem_494.wat
+++ b/scripts/repro/fact_spec_rem_494.wat
@@ -1,0 +1,23 @@
+;; VCR-PERF-002 Phase 3+ (#494) — constant-divisor rem_u IDENTITY elision.
+;;
+;; A representative embedded kernel: fold a raw channel reading into its
+;; bucket index, `x rem_u 1000`. The divisor 1000 is a LITERAL i32.const, so
+;; the `rem_u` cannot trap (traps only on divisor == 0; rem has no INT_MIN/-1
+;; overflow). When loom proves the reading is already in [0, 999] (a wsc.facts
+;; ValueRange premise appended by the differential harness), `x rem_u 1000 == x`
+;; — the modulo is the identity and synth deletes the whole op, letting `x`
+;; flow through.
+;;
+;; LLVM keeps it: a dissolved primitive gives clang no range on the param, so
+;; `-Os` lowers `x % 1000` to the full reciprocal-multiply-subtract sequence
+;; (movw + movt + umull + lsr + mov.w + mls = ~22 B on Thumb-2). synth-spec
+;; emits a bare `bx lr` shape (the identity) — a large, ordeal-certified win
+;; LLVM structurally cannot reach.
+;;
+;; Value ids (0-based operator index within the body):
+;;   0 = local.get $x   ← fact target (reading bound)
+(module
+  (func $gust_scale (export "gust_scale") (param $x i32) (result i32)
+    local.get $x     ;; 0
+    i32.const 1000   ;; 1  literal divisor (≠0 ⇒ no trap)
+    i32.rem_u))      ;; 2  x % 1000  (identity under the proven bound)

--- a/scripts/repro/fact_spec_rem_494_differential.py
+++ b/scripts/repro/fact_spec_rem_494_differential.py
@@ -25,9 +25,13 @@ and shrank gust_scale's .text — so a silently-dead lever cannot pass.
 Red-path knob (the wrong-bound demonstration in the #494 PR):
   --fact-lo/--fact-hi set the premise loom "claims". With a too-wide bound
   (e.g. --fact-lo 0 --fact-hi 4000) the identity obligation is Sat (x can reach
-  1000, so x % 1000 ≠ x) and synth DECLINES; the op survives (general div/rem
-  lowering) and the build is byte-identical to the baseline. Pass
-  --expect-decline to assert that green decline path.
+  1000, so x % 1000 ≠ x) and synth DECLINES the identity loudly; the op SURVIVES
+  and computes the true modulo. (The pre-existing nonzero-divisor zero-guard
+  elision — #494 phase 2b — may still shrink the declined build, so it is NOT
+  byte-identical to the OFF baseline; that is a separate, sound lever.) Pass
+  --expect-decline to sweep OUT-OF-BOUND values (x >= divisor, the region the
+  identity would have miscompiled) and assert the surviving rem_u is still the
+  true modulo — the real safety property, stronger than a byte proxy.
 
 Run (needs wasmtime + unicorn + pyelftools):
   SYNTH=./target/debug/synth python scripts/repro/fact_spec_rem_494_differential.py
@@ -182,14 +186,50 @@ def main():
     print(f"{FUNC} size: unspecialized {bsize} B -> specialized {ssize} B "
           f"(clang -Os baseline for `x % {DIVISOR}` = 24 B)")
 
+    # wasmtime ground truth (shared by both paths).
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, wasm)
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    gs = inst.exports(st)[FUNC]
+
+    def sweep(xs):
+        """Assert specialized ≡ wasmtime ≡ unspecialized on every x in `xs`."""
+        fails = 0
+        for x in xs:
+            gt = gs(st, x) & 0xFFFFFFFF
+            got_spec = run_arm(scode, sbase, ssyms[FUNC], x)
+            got_base = run_arm(bcode, bbase, bsyms[FUNC], x)
+            if not (got_spec == gt == got_base):
+                fails += 1
+                if fails <= 10:
+                    print(f"FAIL x={x}: wasmtime={gt} "
+                          f"specialized={got_spec} unspecialized={got_base}")
+        return fails
+
     if args.expect_decline:
+        # The identity must have declined loudly. The op SURVIVES and computes
+        # the TRUE modulo — so we prove correctness by sweeping OUT-OF-BOUND
+        # values (x >= divisor, where x % C != x), the exact region the identity
+        # would have miscompiled. NB: the pre-existing nonzero-divisor zero-guard
+        # elision (#494 phase 2b) may still shrink the declined build vs the
+        # baseline — that is a separate, sound lever and does NOT make the build
+        # byte-identical; the safety property is that the surviving op is still
+        # the true modulo, which we verify by execution, not by a byte proxy.
         if admits != 0:
-            sys.exit(f"expected DECLINE under bound [{args.fact_lo},{args.fact_hi}] "
-                     f"but the identity elision was admitted")
-        if scode != bcode:
-            sys.exit("declined build must be byte-identical to baseline")
-        print("ORACLE: PASS (declined loudly, general rem_u lowering emitted)")
-        return
+            sys.exit(f"expected the identity to DECLINE under bound "
+                     f"[{args.fact_lo},{args.fact_hi}] but it was admitted")
+        # Values >= divisor exercise the non-identity region; keep them within
+        # the (too-wide) declared bound so wasmtime/unspec agree on ground truth.
+        oob = [x for x in [1000, 1001, 1500, 2048, 3000, 4000]
+               if args.fact_lo <= x <= args.fact_hi]
+        fails = sweep(oob)
+        print(f"swept {len(oob)} out-of-bound (x >= {DIVISOR}) values on "
+              f"[{args.fact_lo}, {args.fact_hi}] — the region the identity would "
+              f"have miscompiled")
+        print("ORACLE:", "PASS (declined loudly; surviving rem_u computes the "
+              "true modulo)" if fails == 0 else f"FAIL ({fails}/{len(oob)})")
+        sys.exit(1 if fails else 0)
 
     # Non-vacuity: the identity elision must actually have fired and shrunk.
     if admits != 1:
@@ -198,29 +238,11 @@ def main():
     if ssize >= bsize:
         sys.exit("specialized gust_scale did not shrink — elision did not reach codegen")
 
-    # wasmtime ground truth.
-    eng = wasmtime.Engine()
-    mod = wasmtime.Module(eng, wasm)
-    st = wasmtime.Store(eng)
-    inst = wasmtime.Instance(st, mod, [])
-    gs = inst.exports(st)[FUNC]
-
-    fails = 0
-    checked = 0
-    for x in GRID:
-        if not (args.fact_lo <= x <= args.fact_hi):
-            continue
-        checked += 1
-        gt = gs(st, x) & 0xFFFFFFFF
-        got_spec = run_arm(scode, sbase, ssyms[FUNC], x)
-        got_base = run_arm(bcode, bbase, bsyms[FUNC], x)
-        if not (got_spec == gt == got_base):
-            fails += 1
-            if fails <= 10:
-                print(f"FAIL x={x}: wasmtime={gt} "
-                      f"specialized={got_spec} unspecialized={got_base}")
-    print(f"swept {checked} in-bounds x values on [{args.fact_lo}, {args.fact_hi}]")
-    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails}/{checked})")
+    inbounds = [x for x in GRID if args.fact_lo <= x <= args.fact_hi]
+    fails = sweep(inbounds)
+    print(f"swept {len(inbounds)} in-bounds x values on "
+          f"[{args.fact_lo}, {args.fact_hi}]")
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails}/{len(inbounds)})")
     sys.exit(1 if fails else 0)
 
 

--- a/scripts/repro/fact_spec_rem_494_differential.py
+++ b/scripts/repro/fact_spec_rem_494_differential.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""VCR-PERF-002 Phase 3+ (#494) — constant-divisor rem_u IDENTITY differential.
+
+Builds the `gust_scale` fixture (`x rem_u 1000`, a LITERAL divisor) WITH a
+schema-v1 `wsc.facts` value-range premise appended (default: the proven bound
+x ∈ [0, 999]), compiles it twice — SPECIALIZED (SYNTH_FACT_SPEC=1) and
+UNSPECIALIZED (flag off) — and sweeps EVERY in-bounds value under unicorn
+(Thumb-2), asserting the specialized result is identical to BOTH wasmtime
+ground truth and the unspecialized synth build. Out-of-bound divergence is
+EXPECTED AND CORRECT — the bound is the contract — so this harness only sweeps
+in-bounds (the wrong-bound path is exercised with --expect-decline).
+
+The beat-LLVM claim (recorded in the #494 PR): with the fact, synth deletes the
+whole `rem_u` (2 B `bx lr`, the identity); clang `-Os` cannot know x < 1000 and
+lowers `x % 1000` to a 24 B reciprocal multiply-subtract. The elision is sound
+because the divisor is a LITERAL nonzero constant (⇒ the op is unconditionally
+total — rem traps only on divisor==0 and has no INT_MIN/-1 overflow), so the
+whole effect-free op is deletable — this is the ONE total subset of the
+"div/rem is never deleted" rule.
+
+Non-vacuity: the run FAILS unless the specialized compile actually admitted the
+certificate-backed identity elision ("fact-spec: ADMIT ... elided to identity")
+and shrank gust_scale's .text — so a silently-dead lever cannot pass.
+
+Red-path knob (the wrong-bound demonstration in the #494 PR):
+  --fact-lo/--fact-hi set the premise loom "claims". With a too-wide bound
+  (e.g. --fact-lo 0 --fact-hi 4000) the identity obligation is Sat (x can reach
+  1000, so x % 1000 ≠ x) and synth DECLINES; the op survives (general div/rem
+  lowering) and the build is byte-identical to the baseline. Pass
+  --expect-decline to assert that green decline path.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/fact_spec_rem_494_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import UC_ARM_REG_LR, UC_ARM_REG_R0, UC_ARM_REG_SP
+
+WAT = Path(__file__).with_name("fact_spec_rem_494.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+FUNC = "gust_scale"
+DIVISOR = 1000
+
+
+# ---- schema-v1 wsc.facts encoding (docs/design/wsc-facts-encoding.md) ----
+
+def leb_u32(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7F
+        v >>= 7
+        out.append(b | (0x80 if v else 0))
+        if not v:
+            return bytes(out)
+
+
+def leb_s64(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7F
+        v >>= 7
+        done = (v == 0 and not (b & 0x40)) or (v == -1 and (b & 0x40))
+        out.append(b | (0 if done else 0x80))
+        if done:
+            return bytes(out)
+
+
+def value_range_record(func_index, value_id, lo, hi):
+    body = leb_s64(lo) + leb_s64(hi)
+    return (
+        b"\x01"                       # kind: value-range
+        + leb_u32(func_index)
+        + leb_u32(value_id)
+        + leb_u32(len(body))
+        + body
+    )
+
+
+def facts_payload(records):
+    out = b"\x01" + leb_u32(len(records))  # version 1, count
+    for r in records:
+        out += r
+    return out
+
+
+def append_custom_section(wasm, name, payload):
+    content = leb_u32(len(name)) + name + payload
+    return wasm + b"\x00" + leb_u32(len(content)) + content
+
+
+# ---- compile + load ----
+
+def compile_elf(wasm_path, out, fact_spec):
+    env = {"PATH": "/usr/bin:/bin"}
+    if fact_spec:
+        env["SYNTH_FACT_SPEC"] = "1"
+    r = subprocess.run(
+        [SYNTH, "compile", str(wasm_path), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env=env,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({out}): {r.stderr}")
+    return r.stderr
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms, sizes = {}, {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+                    sizes[sym.name] = sym["st_size"]
+    return data, base, syms, sizes
+
+
+def run_arm(code, base, addr, x):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(base & ~0xFFFF, 0x20000)
+    mu.mem_write(base, code)
+    mu.mem_map(0x90000, 0x10000)
+    ret = 0x90100
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    mu.reg_write(UC_ARM_REG_R0, x & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_SP, 0x98000)
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    mu.emu_start(addr | 1, ret, timeout=5_000_000)
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+# In-bounds grid: every bit/carry boundary of the divisor plus interior points.
+GRID = [0, 1, 2, 127, 128, 255, 256, 499, 500, 511, 512, 998, 999]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fact-lo", type=int, default=0,
+                    help="dividend value-range premise lower bound (the loom claim)")
+    ap.add_argument("--fact-hi", type=int, default=DIVISOR - 1,
+                    help="dividend value-range premise upper bound")
+    ap.add_argument("--expect-decline", action="store_true",
+                    help="assert the elision was DECLINED (wrong-bound green path)")
+    args = ap.parse_args()
+
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth first")
+
+    base_wasm = wasmtime.wat2wasm(WAT.read_text())
+    # Value-range record: the dividend param at value_id 0.
+    payload = facts_payload([value_range_record(0, 0, args.fact_lo, args.fact_hi)])
+    wasm = append_custom_section(bytes(base_wasm), b"wsc.facts", payload)
+    wasm_path = "/tmp/fact_spec_rem_494.wasm"
+    Path(wasm_path).write_bytes(wasm)
+
+    spec_elf = "/tmp/fact_spec_rem_494_spec.elf"
+    base_elf = "/tmp/fact_spec_rem_494_base.elf"
+    stderr_spec = compile_elf(wasm_path, spec_elf, fact_spec=True)
+    compile_elf(wasm_path, base_elf, fact_spec=False)
+
+    admits = stderr_spec.count("elided to identity")
+    declines = stderr_spec.count("fact-spec: DECLINE") + stderr_spec.lower().count(
+        "not the identity")
+    print(f"specialized compile: {admits} identity ADMIT")
+
+    scode, sbase, ssyms, ssizes = load(spec_elf)
+    bcode, bbase, bsyms, bsizes = load(base_elf)
+    ssize = ssizes.get(FUNC) or len(scode)
+    bsize = bsizes.get(FUNC) or len(bcode)
+    print(f"{FUNC} size: unspecialized {bsize} B -> specialized {ssize} B "
+          f"(clang -Os baseline for `x % {DIVISOR}` = 24 B)")
+
+    if args.expect_decline:
+        if admits != 0:
+            sys.exit(f"expected DECLINE under bound [{args.fact_lo},{args.fact_hi}] "
+                     f"but the identity elision was admitted")
+        if scode != bcode:
+            sys.exit("declined build must be byte-identical to baseline")
+        print("ORACLE: PASS (declined loudly, general rem_u lowering emitted)")
+        return
+
+    # Non-vacuity: the identity elision must actually have fired and shrunk.
+    if admits != 1:
+        sys.exit(f"expected 1 certificate-backed identity elision, got {admits} — "
+                 f"stderr:\n{stderr_spec}")
+    if ssize >= bsize:
+        sys.exit("specialized gust_scale did not shrink — elision did not reach codegen")
+
+    # wasmtime ground truth.
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, wasm)
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    gs = inst.exports(st)[FUNC]
+
+    fails = 0
+    checked = 0
+    for x in GRID:
+        if not (args.fact_lo <= x <= args.fact_hi):
+            continue
+        checked += 1
+        gt = gs(st, x) & 0xFFFFFFFF
+        got_spec = run_arm(scode, sbase, ssyms[FUNC], x)
+        got_base = run_arm(bcode, bbase, bsyms[FUNC], x)
+        if not (got_spec == gt == got_base):
+            fails += 1
+            if fails <= 10:
+                print(f"FAIL x={x}: wasmtime={gt} "
+                      f"specialized={got_spec} unspecialized={got_base}")
+    print(f"swept {checked} in-bounds x values on [{args.fact_lo}, {args.fact_hi}]")
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails}/{checked})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## VCR-PERF-002 / #494 — proof-carrying `i32.rem_u` identity elision

A literal nonzero `i32.const` divisor makes `i32.rem_u` **unconditionally
total** (WASM `rem_u` traps only on divisor==0 and has no INT_MIN/-1 overflow —
that's `div_s`). Under a proven-narrow dividend the modulo is the **identity**,
so — unlike the general variable-divisor path that only elides the trap *guard*
and keeps the op — the whole effect-free op is **DELETED** and the dividend
flows through, exactly like the redundant-mask class. This is the ONE total
subset of synth's "div/rem is never deleted" rule.

### Measured beat-LLVM (named public-cover fixture `gust_scale`, `x rem_u 1000`, Thumb-2 / cortex-m4)

| build | `gust_scale` .text | shape |
|---|---|---|
| **synth, fact-spec ON** | **2 B** | `bx lr` (the identity) |
| synth, fact-spec OFF (baseline) | 24 B | general reciprocal-mul-sub |
| **clang -Os** (`unsigned x % 1000u`, `thumbv7em-none-eabi -mcpu=cortex-m4`) | **24 B** | `movw+movt+umull+lsrs+mov.w+mls+bx` |

**synth beats clang -Os by 22 B (12x).** The win is REAL and licensed by a
DISCHARGED FACT, not a heuristic drop: LLVM has no range on the dividend (a
dissolved WASM primitive), so `-Os` must emit the full reciprocal sequence;
synth's WASM-level `ValueRange` fact makes the entire sequence dead.

### The certifying fact (proof-carrying, non-vacuous)

The elision fires only when ordeal QF_BV returns **UNSAT** on:

```
P ∧ (dividend bvurem 1000) ≠ dividend
```

where `dividend bvurem 1000` is the **real** `bvurem` term emitted by
`WasmSemantics::encode_op(I32RemU, ..)` (`wasm_semantics.rs:81`), and `P` is the
ingested `wsc.facts` ValueRange premise `x ∈ [0, 999]`. Every Unsat carries an
LRAT proof validated by ordeal-lrat. If the fact is absent, or too wide (x can
reach 1000), the check is **Sat** and synth **declines loudly** — the general
lowering stands. A *variable* divisor also declines (its zero-guard is a
control-flow effect; only a syntactic `i32.const C, C≠0` qualifies).

### Verification (all green)

- **Correctness differential** (`scripts/repro/fact_spec_rem_494_differential.py`):
  in-bounds sweep of 13 values under unicorn — specialized ≡ wasmtime ≡
  unspecialized. Non-vacuity gate: fails unless the certificate-backed identity
  actually fired AND shrank `.text`.
- **Wrong-bound red path** (`--fact-hi 4000 --expect-decline`): identity declines
  loudly; the surviving op is swept over 6 **out-of-bound** values (x ≥ divisor,
  the region the identity would have miscompiled) and proven to compute the true
  modulo. (This replaces the salvaged harness's incorrect "byte-identical to
  baseline" assertion — the pre-existing nonzero-divisor zero-guard elision
  legitimately shrinks the declined build 24→18 B; the safety property is
  correctness-by-execution, not a byte proxy.)
- **Flag-off byte-identical:** `SYNTH_FACT_SPEC=0` ≡ plain compile, identical
  `.text` sha256 (`549feb34…`). The lever is flag-gated, default OFF.
- **Frozen anchors intact:** `frozen_codegen_bytes` 10/10 (default-off ⇒ no
  fixture bytes move).
- **5 unit tests:** identity admit, wrong-bound Sat decline, variable-divisor
  decline (op kept + zero-guard still discharged), no-fact decline, pow2 admit.
- **claims.yaml:** 18/18 hold (no proof/rule counts changed — this is a flag-off
  specialization lever).

Refs #494. Do NOT merge — review gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L