### PR TITLE
feat(VCR-WASM-001): anchor WASM source semantics on WasmCert-Coq — i32.add bridge (bounded first increment)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ cd coq && make proofs
 
 ### Proof Status
 
-See `coq/STATUS.md` for the complete coverage matrix. Current: 474 Qed / 5 Admitted
+See `coq/STATUS.md` for the complete coverage matrix. Current: 476 Qed / 5 Admitted
 (+2 `admit.` tactics) across `coq/Synth/`. The 41 selector-DSL rule theorems
 (`VcrSelRules.v`) are stated directly about the GENERATED model (VCR-ISA-001
 #667: `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v` emitted

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 | ELF output with vector table | Implemented | Thumb bit set on symbols; not linked on real hardware |
 | Linker scripts (STM32, nRF52840, generic) | Implemented | Generated, not tested with real boards |
 | Cross-compilation (`--link` flag) | Implemented | Requires `arm-none-eabi-gcc` in PATH; not CI-tested |
-| Rocq mechanized proofs | 474 Qed / 5 Admitted | i32 + i64 T1 correctness proofs; the 41 selector-DSL rule theorems are stated directly about the GENERATED model (VCR-ISA-001 #667 — `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v`); all four i32 div/rem trap guards discharged against the branch-taking executor (#73) |
+| Rocq mechanized proofs | 476 Qed / 5 Admitted | i32 + i64 T1 correctness proofs; the 41 selector-DSL rule theorems are stated directly about the GENERATED model (VCR-ISA-001 #667 — `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v`); all four i32 div/rem trap guards discharged against the branch-taking executor (#73) |
 | SMT translation validation | ordeal (pure-Rust QF_BV) default | v0.27.0 (#553); Z3 demoted to feature-gated differential oracle — 141/141 agreement |
 | WebAssembly spec test suite | 227/257 compile | Compilation only — not executed on emulator |
 
@@ -194,7 +194,7 @@ Per the [PulseEngine Verification Guide](https://pulseengine.eu/guides/VERIFICAT
 
 | Track | Status | Coverage |
 |-------|--------|----------|
-| **Rocq** | Partial | 474 Qed / 5 Admitted (41 selector-DSL rule theorems stated directly about the GENERATED model, VCR-ISA-001 #667) — all four i32 div/rem trap guards discharged (#73) |
+| **Rocq** | Partial | 476 Qed / 5 Admitted (41 selector-DSL rule theorems stated directly about the GENERATED model, VCR-ISA-001 #667) — all four i32 div/rem trap guards discharged (#73) |
 | **Kani** | Starting | 18 bounded model checking harnesses for ARM encoder |
 | **Verus** | Starting | 8 spec functions in `synth-synthesis/src/contracts.rs`; Bazel integration via `rules_verus` |
 | **Lean** | Not started | — |
@@ -206,7 +206,7 @@ See `artifacts/verification-gaps.yaml` for the detailed gap analysis (VG-001 thr
 Mechanized proofs in Rocq 9 show that `compile_wasm_to_arm` preserves WASM semantics for each operation. The proof suite lives in `coq/Synth/` and covers ARM instruction semantics, WASM stack-machine semantics, and per-operation correctness theorems.
 
 ```
-474 Qed / 5 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
+476 Qed / 5 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
   T1 result-correspondence (ARM output = WASM result): all i32 ops and all
      i64 ops — i64 T1 parity since v0.11.0, 0 i64 admits (coq/STATUS.md)
   T2 existence-only: f32/f64 and remaining categories

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -688,7 +688,7 @@ artifacts:
       Sail at the bottom via VCR-ISA-001). The Component Model layer stays an
       open problem (no mechanized semantics yet) and is explicitly out of scope
       for this item. Independent of Track A.
-    status: proposed
+    status: implemented
     tags: [semantics, wasmcert, source, rocq, track-b]
     links:
       - type: derives-from
@@ -703,6 +703,21 @@ artifacts:
         GATE ADDED (deep-research 2026-06-10): WasmCert-Coq maintenance state
         is UNVERIFIED (no surviving claim) — same bounded feasibility spike
         required before release commitment.
+      status-note: >
+        BOUNDED FIRST INCREMENT LANDED (v0.45, VCR-WASM-001). The WASM-side
+        analogue of SailArmBridge.v (VCR-ISA-001): coq/Synth/WASM/
+        WasmCertReference.v transcribes WasmCert-Coq's i32.add operational rule
+        (= CompCert Int.add, repr(unsigned x + unsigned y)) into synth's I32
+        primitives with line-level provenance; WasmCertBridge.v proves (2 Qed,
+        real — not reflexivity) that synth's exec_wasm_instr I32Add refines
+        that INDEPENDENT reference. Non-vacuous: the reference is phrased only
+        in repr/unsigned/Z, never I32.add/exec_wasm_instr, so a wrong add
+        semantics fails the proof; the raw-vs-normalized (Zplus_mod) gap is
+        genuinely discharged. SCOPE: 1 op, establishing the pattern.
+        FOLLOW-UP (status stays implemented, not verified, until then): a real
+        external WasmCert-Coq/CompCert coq dependency into the hermetic
+        bazel/nix toolchain (the transcription is the bounded scaffold), plus
+        the full integer/control-flow fragment.
 
   # ---------------------------------------------------------------------------
   # Track C — validation methodology (can start now; feeds Tracks A and B)

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -703,7 +703,7 @@ artifacts:
         GATE ADDED (deep-research 2026-06-10): WasmCert-Coq maintenance state
         is UNVERIFIED (no surviving claim) — same bounded feasibility spike
         required before release commitment.
-      status-note: >
+
         BOUNDED FIRST INCREMENT LANDED (v0.45, VCR-WASM-001). The WASM-side
         analogue of SailArmBridge.v (VCR-ISA-001): coq/Synth/WASM/
         WasmCertReference.v transcribes WasmCert-Coq's i32.add operational rule

--- a/claims.yaml
+++ b/claims.yaml
@@ -29,16 +29,16 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-PROOF-COUNT-README
     doc: README.md
-    text: "474 Qed / 5 Admitted"
+    text: "476 Qed / 5 Admitted"
     evidence:
       - kind: count-eq                       # ALL THREE README spots must agree —
-        pattern: '474 Qed / 5 Admitted'      # a verbatim check alone greens if one
+        pattern: '476 Qed / 5 Admitted'      # a verbatim check alone greens if one
         glob: ['README.md']                  # of them drifts while another matches
         expect: 3
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 474
+        expect: 476
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -50,12 +50,12 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-CLAUDE-MD
     doc: CLAUDE.md
-    text: "474 Qed / 5 Admitted"
+    text: "476 Qed / 5 Admitted"
     evidence:
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 474
+        expect: 476
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -63,16 +63,16 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-STATUS-MD
     doc: coq/STATUS.md
-    text: "474 Qed / 5 Admitted"
+    text: "476 Qed / 5 Admitted"
     evidence:
       - kind: count-eq                       # headline + Total line must both agree
-        pattern: '474 Qed / 5 Admitted'
+        pattern: '476 Qed / 5 Admitted'
         glob: ['coq/STATUS.md']
         expect: 2
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 474
+        expect: 476
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -210,6 +210,28 @@ claims:
         pattern: 'Qed\.'
         glob: ['coq/Synth/ARM/SailArmBridge.v']
         expect: 92
+
+  # VCR-WASM-001 (Track B): WASM source semantics anchored on WasmCert-Coq.
+  # Bounded first increment — 1 op (i32.add), 2 real-Qed refinement lemmas
+  # (WasmCertBridge.v), establishing the pattern. The reference rule is a
+  # hand transcription of WasmCert-Coq/CompCert Int.add with line-level
+  # provenance (WasmCertReference.v); a real external dep + full fragment is
+  # the named follow-up. The WASM-side analogue of SailArmBridge.v (ISA-001).
+  - id: SYNTH-VCR-WASM-001-STATUS
+    doc: artifacts/verified-codegen-roadmap.yaml
+    text: "BOUNDED FIRST INCREMENT LANDED (v0.45, VCR-WASM-001)"
+    evidence:
+      - kind: yaml-field
+        path: artifacts/verified-codegen-roadmap.yaml
+        id: VCR-WASM-001
+        field: status
+        equals: implemented
+      - kind: count-eq                       # the 2 refinement bridge lemmas
+        pattern: 'Qed\.'
+        glob: ['coq/Synth/WASM/WasmCertBridge.v']
+        expect: 2
+      - kind: file-exists
+        path: coq/Synth/WASM/WasmCertReference.v
 
   # ---------------------------------------------------------------------------
   # Verified selector DSL coverage — the rule table, its manifest, and the

--- a/coq/BUILD.bazel
+++ b/coq/BUILD.bazel
@@ -116,6 +116,34 @@ rocq_library(
     deps = [":base", ":common", ":wasm_values", ":wasm_instructions"],
 )
 
+# VCR-WASM-001 (#242, Track B): WasmCert-Coq source-semantics anchor.
+# WasmCertReference.v transcribes WasmCert-Coq's i32.add rule (= CompCert
+# Int.add) into synth's I32 primitives with line-level provenance;
+# WasmCertBridge.v proves exec_wasm_instr I32Add refines that reference.
+# Bounded first increment — 1 op, 1 real-Qed refinement lemma (the WASM-side
+# analogue of SailArmBridge.v). Transcription to be replaced by a real
+# external dep — see file headers.
+rocq_library(
+    name = "wasm_cert_reference",
+    srcs = ["Synth/WASM/WasmCertReference.v"],
+    include_path = "Synth",
+    deps = [":base", ":common"],
+)
+
+rocq_library(
+    name = "wasm_cert_bridge",
+    srcs = ["Synth/WASM/WasmCertBridge.v"],
+    include_path = "Synth",
+    deps = [
+        ":base",
+        ":common",
+        ":wasm_values",
+        ":wasm_instructions",
+        ":wasm_semantics",
+        ":wasm_cert_reference",
+    ],
+)
+
 # ─── Compilation ──────────────────────────────────────────────────────────────
 # Bridges ARM and WASM: imports ArmInstructions + WasmSemantics (not ArmSemantics)
 
@@ -304,6 +332,7 @@ rocq_proof_test(
         ":extraction",
         ":arm_refinement",
         ":sail_arm_bridge",
+        ":wasm_cert_bridge",
         ":vcr_sel_pilot",
         ":vcr_sel_rules",
         ":vcr_sel_rules_generated",

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -1,6 +1,6 @@
 # Rocq Proof Suite — Honest Status
 
-**Last Updated: 2026-07-15 (recount: 474 Qed / 5 Admitted, +2 admit., crude
+**Last Updated: 2026-07-15 (recount: 476 Qed / 5 Admitted, +2 admit., crude
 `grep "Qed\."` over `coq/Synth/**/*.v` — same method as prior recounts; the
 -40 vs the prior 512 are the retired VCR-ISA-001 #667 cross-check lemmas of
 `VcrSelRulesGenCheck.v`: `VcrSelRules.v` now DEFINES every `rule_X` as the
@@ -167,7 +167,7 @@ and predates the VcrSelRules (42), VcrSelPilot (7) and SailArmBridge (92) Qed;
 see the per-file breakdown below for current per-file counts. The T3 row and
 the headline total are re-derived by the claim gate.
 
-**Total: 474 Qed / 5 Admitted (+2 admit.) across all files** (recount 2026-07-15, CI-gated via `claims.yaml`)
+**Total: 476 Qed / 5 Admitted (+2 admit.) across all files** (recount 2026-07-15, CI-gated via `claims.yaml`)
 
 v0.10.0 PR 1: +2 T1 Qed (i64_add_correct, i64_sub_correct) and +9
 infrastructure Qed (combine_i32_unsigned, carry_split_add,
@@ -444,7 +444,7 @@ Recount 2026-07-10 (`grep -oE 'Qed\.'` / `'Admitted\.'` per file):
 | WasmValues.v | 2 | 0 | Infra |
 | VcrSelPilot.v | 7 | 0 | T1 (register-polymorphic; VCR-SEL-001 go/abandon measurement) |
 | VcrSelRules.v | 42 | 0 | T1 (register-polymorphic; the WIRED VCR-SEL-001 increment-1+2+3+4 rule table — 40 rule theorems 1:1 with `coq/vcr_sel_rules.manifest`, coverage-gated by `//coq:vcr_sel_rules_coverage`, + 2 mod-32 helper lemmas #683. VCR-ISA-001 #667 increment 2: every `rule_X` is DEFINED as the GENERATED `Gen.rule_X` of `VcrSelRulesGenerated.v` — emitted from the shipped `sel_dsl::RULES` — so the theorems are stated directly about the shipped sequences; a table change regenerates `Gen` and breaks the matching Qed. The former `VcrSelRulesGenCheck.v` 40-lemma `reflexivity` gate is retired as vacuous/subsumed) |
-| **Total** | **474** | **5** | (+2 `admit.`) |
+| **Total** | **476** | **5** | (+2 `admit.`) |
 
 ## VCR-SEL-001 increments 1 (2026-07-07) + 2 + 3 + 4 (2026-07-08): VcrSelRules.v
 

--- a/coq/Synth/WASM/WasmCertBridge.v
+++ b/coq/Synth/WASM/WasmCertBridge.v
@@ -1,0 +1,80 @@
+(** * VCR-WASM-001 — WasmCert-Coq refinement bridge (BOUNDED first increment)
+
+    This file proves that synth's stack-machine executor [exec_wasm_instr]
+    AGREES with the WasmCert-Coq reference rule (WasmCertReference.v) for ONE
+    total operation: i32.add. It is the WASM-side analogue of SailArmBridge.v's
+    per-instruction bridge lemmas (VCR-ISA-001 / #667).
+
+    SCOPE (honest, named): bounded first increment — 1 op anchored, 1 real-Qed
+    refinement lemma, establishing the pattern. Full integer/control-flow
+    coverage and a real external WasmCert-Coq/CompCert coq dependency (this file
+    uses a hand transcription of the reference, see WasmCertReference.v) are the
+    named follow-up.
+
+    NON-VACUITY (why a WRONG synth semantics fails this file):
+    - [i32_add_refines_wasmcert_op] is NOT [reflexivity]: synth's [I32.add x y]
+      is [repr (x + y)] over RAW representatives, whereas the WasmCert/CompCert
+      reference [wasmcert_i32_add x y] is [repr (unsigned x + unsigned y)] —
+      operands normalized first. Equal mod 2^32, but definitionally distinct;
+      the proof discharges the raw-vs-normalized gap via [Zplus_mod].
+    - [i32_add_exec_refines_wasmcert] routes the claim through the REAL
+      [exec_wasm_instr I32Add]. If [exec_wasm_instr I32Add] were miswired to
+      compute [I32.sub]/[I32.mul] (or pushed the wrong value / wrong stack
+      shape), this theorem would be unprovable: the pushed result would not be
+      [wasmcert_i32_add v1 v2]. The reference pins the OPERATION, not the shape.
+*)
+
+From Stdlib Require Import ZArith.
+From Stdlib Require Import List.
+Require Import Synth.Common.Base.
+Require Import Synth.Common.Integers.
+Require Import Synth.WASM.WasmValues.
+Require Import Synth.WASM.WasmInstructions.
+Require Import Synth.WASM.WasmSemantics.
+Require Import Synth.WASM.WasmCertReference.
+
+Import List.ListNotations.
+Open Scope list_scope.
+Open Scope Z_scope.
+
+(** ** Algebraic core: synth's i32.add equals the WasmCert reference rule.
+
+    synth:      [I32.add x y      = repr (x + y)]            (raw operands)
+    WasmCert:   [wasmcert_i32_add = repr (unsigned x + unsigned y)]  (normalized)
+
+    These agree because [unsigned n = n mod 2^32] and addition commutes with
+    [mod] ([Zplus_mod]). This is the step that would break if synth added the
+    operands under a different operation. *)
+Theorem i32_add_refines_wasmcert_op : forall x y,
+  I32.add x y = wasmcert_i32_add x y.
+Proof.
+  intros x y.
+  unfold I32.add, wasmcert_i32_add, I32.repr, I32.unsigned.
+  (* Goal: (x + y) mod m = ((x mod m) + (y mod m)) mod m *)
+  rewrite Zplus_mod.
+  reflexivity.
+Qed.
+
+(** ** Executor-level refinement: [exec_wasm_instr I32Add] pushes exactly the
+       WasmCert reference result on top of the popped stack.
+
+    Mirrors the shape of [i32_add_type_preservation] in WasmSemantics.v, but
+    the pushed value is pinned to the INDEPENDENT reference
+    [wasmcert_i32_add v1 v2], not to synth's own [I32.add]. *)
+Theorem i32_add_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32Add s =
+  Some (mkWasmState
+          (VI32 (wasmcert_i32_add v1 v2) :: stack')
+          s.(locals)
+          s.(globals)
+          s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  simpl.
+  (* the executor pushes [VI32 (I32.add v1 v2)]; rewrite to the reference *)
+  rewrite i32_add_refines_wasmcert_op.
+  reflexivity.
+Qed.

--- a/coq/Synth/WASM/WasmCertReference.v
+++ b/coq/Synth/WASM/WasmCertReference.v
@@ -1,0 +1,75 @@
+(** * VCR-WASM-001 — WasmCert-Coq source-semantics reference (BOUNDED first increment)
+
+    GOAL (epic #242, VCR-WASM-001, roadmap Track B). WasmSemantics.v is a
+    HAND-WRITTEN stack-machine model: every source-side correctness statement
+    in this suite is "consistent with our own model" — a modeling bug in
+    [exec_wasm_instr] is invisible to the proofs. VCR-WASM-001 wants the WASM
+    source semantics ANCHORED on an INDEPENDENTLY derived reference:
+    WasmCert-Coq (Watt et al., FM'21), the community-standard mechanized
+    WebAssembly 1.0 semantics. This mirrors, on the WASM side, what
+    VCR-ISA-001 (#667 / SailArmBridge.v) does on the ARM/selector side:
+    "anchor/generate, don't mirror".
+
+    WHAT THIS FILE IS. Per the SailArmBridge.v spike precedent, importing the
+    external Rocq model WHOLESALE into synth's hermetic bazel/nix proof
+    toolchain is a no-go at this stage: WasmCert-Coq drags in mathcomp +
+    CompCert's Integers library as coq dependencies. So — exactly as
+    SailArmBridge transcribes the Sail [execute] clause BY HAND with line-level
+    provenance — this file TRANSCRIBES WasmCert-Coq's operational rule for ONE
+    total op (i32.add) into synth's own [I32] value primitives, with a verbatim
+    provenance citation to the WasmCert-Coq / CompCert source.
+
+    *** TRANSCRIPTION — to be replaced by a real external dependency. ***
+    This is a hand transcription, NOT the real WasmCert-Coq dependency. It is
+    the bounded-first-increment scaffolding that establishes the refinement
+    PATTERN for one op. Wiring the actual WasmCert-Coq/CompCert coq deps into
+    the hermetic toolchain, and extending to the full integer/control-flow
+    fragment, is the named follow-up (VCR-WASM-001 continuation).
+
+    PROVENANCE. The rule below is transcribed from:
+
+      - WasmCert/WasmCert-Coq @ master, theories/numerics.v:
+          Definition i32 : Type := Wasm_int.Int32.T.
+          (* within Wasm_int.Make, the Tmixin record: *)  int_add := iadd ;
+          Definition iadd : T -> T -> T := add.          (* aliases CompCert add *)
+        i.e. WasmCert's i32.add IS CompCert's Integers.Int.add.
+
+      - AbsInt/CompCert @ master, lib/Integers.v (Module Int):
+          Definition add (x y: int) : int := repr (unsigned x + unsigned y).
+          Definition unsigned (n: int) : Z := intval n.
+          Definition repr (x: Z) : int := mkint (Z_mod_modulus x) _.
+
+    The salient, deliberately-preserved feature of the reference is that
+    CompCert (hence WasmCert) NORMALIZES each operand with [unsigned] BEFORE
+    adding, then [repr]s the sum. Synth's [I32.add x y := repr (x + y)] adds
+    RAW representatives (its [int := Z] is unnormalized). The two are equal
+    mod 2^32 but DEFINITIONALLY DIFFERENT — so the bridge lemma in
+    WasmCertBridge.v is a genuine proof (not [reflexivity]), and it exercises
+    the raw-vs-normalized gap.
+
+    NON-VACUITY. [wasmcert_i32_add] is phrased ONLY in the value-encoding
+    primitives [I32.repr] / [I32.unsigned] / [Z] — it never mentions
+    [I32.add] or [exec_wasm_instr]. So the bridge lemma is not synth agreeing
+    with a copy of itself. A WRONG synth semantics for i32.add (e.g. if
+    [exec_wasm_instr I32Add] computed [I32.sub] or [I32.mul]) would FAIL to
+    satisfy the bridge theorem: the reference pins the OPERATION (addition mod
+    2^32), not merely the shape.
+*)
+
+From Stdlib Require Import ZArith.
+Require Import Synth.Common.Base.
+Require Import Synth.Common.Integers.
+
+Open Scope Z_scope.
+
+(** ** WasmCert-Coq reference rule for i32.add
+
+    Transcription of [Wasm_int.Int32.int_add] = CompCert [Int.add]:
+      [repr (unsigned x + unsigned y)].
+
+    Stated in synth's [I32] primitives. NOTE the [I32.unsigned] on each
+    operand — this is the CompCert/WasmCert normalize-then-add form, and is
+    what distinguishes this reference from synth's raw [I32.add x y :=
+    repr (x + y)]. *)
+Definition wasmcert_i32_add (x y : I32.int) : I32.int :=
+  I32.repr (I32.unsigned x + I32.unsigned y).

--- a/coq/_CoqProject
+++ b/coq/_CoqProject
@@ -23,6 +23,8 @@ Synth/ARM/SailArmBridge.v
 Synth/WASM/WasmValues.v
 Synth/WASM/WasmInstructions.v
 Synth/WASM/WasmSemantics.v
+Synth/WASM/WasmCertReference.v
+Synth/WASM/WasmCertBridge.v
 
 # Compilation and correctness
 Synth/Synth/Compilation.v


### PR DESCRIPTION
## VCR-WASM-001 (epic #242, Track B) — WasmCert-Coq source-semantics anchor

Anchors synth's hand-written `WasmSemantics.v` stack-machine model on an **independently derived reference** (WasmCert-Coq, Watt et al. FM'21), mirroring on the WASM side what VCR-ISA-001 / `SailArmBridge.v` (#667) does on the ARM/selector side. **Bounded first increment: 1 op (i32.add), 2 real-Qed refinement lemmas, establishing the pattern.**

### What landed
- **`coq/Synth/WASM/WasmCertReference.v`** — transcribes WasmCert-Coq's i32.add operational rule (`Wasm_int.Int32.int_add` = CompCert `Int.add` = `repr(unsigned x + unsigned y)`) into synth's `I32` primitives, with **line-level provenance** to the WasmCert-Coq / CompCert source. A bare `Definition` (0 Qed).
- **`coq/Synth/WASM/WasmCertBridge.v`** — 2 Qed:
  - `i32_add_refines_wasmcert_op : I32.add x y = wasmcert_i32_add x y` — the algebraic core, discharged via `Zplus_mod` (NOT `reflexivity`).
  - `i32_add_exec_refines_wasmcert` — routes the claim through the **real** `exec_wasm_instr I32Add`: the executor pushes exactly `wasmcert_i32_add v1 v2` on top of the popped stack.
- Wired into `coq/BUILD.bazel` (`wasm_cert_reference`, `wasm_cert_bridge`, both in `:rocq_proofs`) + `coq/_CoqProject`.

### Non-vacuity (why a wrong `exec_wasm_instr I32Add` fails this PR)
The reference `wasmcert_i32_add` is phrased **only** in `I32.repr` / `I32.unsigned` / `Z` — it never mentions `I32.add` or `exec_wasm_instr`, so the bridge is not synth agreeing with a copy of itself. synth's `I32.add x y := repr (x + y)` adds **raw** representatives; the WasmCert/CompCert reference normalizes each operand with `unsigned` **first**. Equal mod 2^32 but **definitionally distinct** — the proof genuinely discharges the raw-vs-normalized gap. A miswired add (e.g. `I32.sub`/`I32.mul`, wrong value, wrong stack shape) would be **unprovable**: the reference pins the OPERATION, not the shape.

### Verification
- `bazel test //coq:verify_proofs` — **GREEN** (both `rocq_proofs` and `vcr_sel_rules_coverage` PASSED with `WasmCertBridge.v` compiled).
- `python3 scripts/claim_check.py claims.yaml` — **19/19 claims hold**.

### Ledger (bumped doc + ledger together)
- Proof count 474 → **476 Qed** / 5 Admitted (claims.yaml, CLAUDE.md, README.md ×3, coq/STATUS.md ×3).
- New `SYNTH-VCR-WASM-001-STATUS` claim pins roadmap `status=implemented` + 2 Qed in `WasmCertBridge.v` + reference file exists.
- `artifacts/verified-codegen-roadmap.yaml`: VCR-WASM-001 `proposed` → **`implemented`** (not `verified` — 1 op) + `status-note`.

### Scope note (honest)
**Bounded first increment — 1 op, establishes the refinement pattern.** The reference is a **hand transcription** of the WasmCert-Coq/CompCert rule (importing the external model wholesale drags in mathcomp + CompCert Integers into the hermetic bazel/nix toolchain — a no-go at this stage, same as the `SailArmBridge.v` spike precedent). A **real external WasmCert-Coq/CompCert coq dependency** plus the **full integer/control-flow fragment** are the named follow-up (VCR-WASM-001 continuation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L