### PR TITLE
investigate(#757): 7 faithful RawVec-grow+memmove reconstructions — all GREEN (bug needs gale's module; NO FIX)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,14 @@ jobs:
       # miscompile). Guards that the call-crossing static copy stays correct.
       - name: Run multi-chunk static-copy control oracle (#757, cortex-m3)
         run: SYNTH=./target/debug/synth python scripts/repro/wide_static_copy_757_differential.py
+      # #757 v0.45 investigation: a RawVec-grow + memmove reconstruction of gale's
+      # exact characterization (a >=9-byte static above wasm_data_base copied via a
+      # bump-allocator memmove reached through a grow-call spill/reload). Seven such
+      # faithful shapes ALL compile byte-correct vs wasmtime — the miscompile does
+      # NOT reproduce from the issue text; it needs gale's exact loom.wasm/os-tl-cm3.o.
+      # Kept as a regression guard that the RawVec-grow copy path stays correct.
+      - name: Run #757 RawVec-grow memmove reconstruction (cortex-m3)
+        run: SYNTH=./target/debug/synth python scripts/repro/mem757_rawvec_memcopy_differential.py
       # #740: the Thumb-2 B<cond>.W (T3) arm packed `halfword_offset >> 1`,
       # HALVING every conditional branch spanning > 254 bytes — gust_poll's
       # loop-head `br_if` to an outer block end landed mid-shape (spurious

--- a/scripts/repro/mem757_inlined_memmove.wat
+++ b/scripts/repro/mem757_inlined_memmove.wat
@@ -1,0 +1,42 @@
+(module
+  ;; #757 RED-FIRST repro attempt 5 — gale's INLINED memmove shape. loom inlines
+  ;; func_17 into the caller, so the source-relocation, the RawVec-grow `call`,
+  ;; the head+tail chunks, AND register pressure / const-CSE all live in ONE
+  ;; function. The head chunk routes through the #746 large-memarg arm
+  ;; (offset >= wasm_data_base), the overlapping i32 tail through a small-offset
+  ;; path — head and tail derive the source base DIFFERENTLY.
+  ;;
+  ;; Layout (wasm_data_base = sp_init = 0x100000), ONE segment:
+  ;;   0x100000: \02\00\00\00 \01\00\00\00 ...   low consts, 0x00..0x1f
+  ;;   0x100020: "gust:os up\n"                  the string at +0x20
+  ;;
+  ;; RED signature: copy_peek(0)==0x02, copy_peek(4)==0x01 (head read
+  ;; data_base + small = the low consts) while copy_peek(7..10) == " up\n".
+  ;;
+  ;; Compile: --target cortex-m3 --native-pointer-abi --all-exports
+  ;;          --relocatable --shadow-stack-size <B>
+  (memory (export "memory") 17)
+  (global $sp (mut i32) (i32.const 1048576))
+  (data (i32.const 1048576) "\02\00\00\00\01\00\00\00\03\00\00\00\04\00\00\00\05\00\00\00\06\00\00\00\07\00\00\00\08\00\00\00gust:os up\n\00\00\00\00\00")
+  (func $grow (param i32) (result i32)
+    (local $x i32)
+    (local.set $x (i32.const 0xdead))
+    (i32.add (local.get 0) (local.get $x))
+    drop
+    (i32.const 1052672))  ;; dst 0x101000
+  (func (export "copy_peek") (param i32) (result i32)
+    (local $idx i32)   ;; dynamic index (0) — forces the #746 dynamic-index arm
+    (local $dst i32)
+    (local.set $idx (i32.const 0))
+    (local.set $dst (call $grow (local.get 0)))
+    ;; HEAD wide i64 from static source via LARGE memarg (#746 arm):
+    ;;   source = __synth_wasm_data + 0x100020 + idx  (idx = 0)
+    ;;   dest   = dst
+    (i64.store (local.get $dst) (i64.load offset=1048608 (local.get $idx)))
+    ;; overlapping i32 TAIL from static source at offset 0x100027 (bytes 7..10),
+    ;; store to dst+7 — a DIFFERENT lowering path than the wide head.
+    local.get $dst
+    (i32.wrap_i64 (i64.load32_u offset=1048615 (local.get $idx)))
+    i32.store offset=7
+    ;; read dst byte (param 0) back
+    (i32.load8_u (i32.add (local.get $dst) (local.get 0)))))

--- a/scripts/repro/mem757_inlined_memmove_differential.py
+++ b/scripts/repro/mem757_inlined_memmove_differential.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""#757 RED-FIRST differential — memmove (`memory.copy`) from a STATIC pointer.
+
+gale's real mechanism: a RawVec-grow `call` followed by a `memory.copy` whose
+SOURCE operand is a static pointer const `data_base + 0x20` (a `&STATIC_STR`),
+relocated by the native-pointer ABI to `__synth_wasm_data + 0x20`. With low
+consts filling `[data_base, data_base+0x20)`, a wrong source addend reads the
+LOW consts [2,0,0,0,...] instead of "gust:os".
+
+This differs from the six 0.43.0 controls: those used i64.load/i64.store chunks
+with the offset folded into the MEMARG. gale's memmove passes the source as a
+relocated CONST POINTER through `memory.copy`.
+
+Unlike the separated-section harness, this maps linear memory as ONE contiguous
+region (R11 = 0 native deref, so wasm addr == absolute addr) and pins the
+`__synth_wasm_data` symbol at its wasm base 0x100000, so a runtime dst pointer
+(0x101000) and a relocated src pointer stay in the same address space — this is
+faithful to the deployed native-pointer image, where linear memory IS one block.
+Resolves R_ARM_ABS32 (2) and R_ARM_THM_CALL (10); an unresolved bl self-corrupts.
+
+Run:
+  SYNTH=./target/debug/synth python scripts/repro/mem757_memcopy_static_src_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("mem757_inlined_memmove.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+BUDGET = 2048
+ABS32 = 2
+THM_CALL = 10
+
+# One contiguous 8 MiB linear-memory image at LINBASE; .text placed just below
+# it. `__synth_wasm_data` symbol is pinned at DATABASE (= wasm data base 0x100000
+# offset into the image) so relocated static pointers and runtime dst pointers
+# share the address space, exactly as in the deployed native image.
+TEXT = 0x00080000
+LINBASE = 0x00100000  # wasm addr 0 -> here? No: native ABI uses R11=0, wasm addr == absolute.
+MAPSZ = 0x00400000
+
+
+def wasmtime_truth(fn, arg):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_text())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    return inst.exports(store)[fn](store, arg) & 0xFFFFFFFF
+
+
+def main():
+    obj = Path(tempfile.mkdtemp(prefix="mem757im_")) / "mem757im.o"
+    proc = subprocess.run(
+        [
+            SYNTH,
+            "compile",
+            str(WAT),
+            "-o",
+            str(obj),
+            "--target",
+            "cortex-m3",
+            "--native-pointer-abi",
+            "--all-exports",
+            "--relocatable",
+            "--shadow-stack-size",
+            str(BUDGET),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr.strip())
+        print("FAIL: compile declined")
+        return 1
+
+    e = ELFFile(open(obj, "rb"))
+    secname = {i: s.name for i, s in enumerate(e.iter_sections())}
+    text = bytearray(e.get_section_by_name(".text").data())
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: (s["st_shndx"], s["st_value"]) for s in symtab.iter_symbols()}
+
+    # Native-pointer image: wasm address A resolves to absolute A (R11 = 0).
+    # `__synth_wasm_data` and any `__synth_wasm_seg_*` region symbols are the
+    # wasm data base (0x100000) plus the symbol's st_value, so a relocated
+    # static pointer equals its wasm address.
+    WDB = 0x100000  # wasm data base
+
+    def sym_abs(name):
+        shndx, val = syms[name]
+        sn = secname.get(shndx, ".text")
+        if sn == ".text":
+            return TEXT + val
+        # data/rodata/bss region symbols: st_value is the wasm OFFSET into the
+        # linear image; absolute = wasm_data_base + offset (R11 = 0 native ABI).
+        return WDB + val
+
+    for r in e.get_section_by_name(".rel.text").iter_relocations():
+        t = r["r_info_type"]
+        sym = symtab.get_symbol(r["r_info_sym"])
+        off = r["r_offset"]
+        if t == ABS32:
+            (add,) = struct.unpack_from("<I", text, off)
+            struct.pack_into("<I", text, off, (sym_abs(sym.name) + add) & 0xFFFFFFFF)
+        elif t == THM_CALL:
+            P = TEXT + off + 4
+            S = sym_abs(sym.name) & ~1
+            disp = S - P
+            imm = (disp >> 1) & 0x3FFFFF
+            s = (imm >> 21) & 1
+            i1 = (imm >> 20) & 1
+            i2 = (imm >> 19) & 1
+            j1 = (~i1 & 1) ^ s
+            j2 = (~i2 & 1) ^ s
+            imm10 = (imm >> 11) & 0x3FF
+            imm11 = imm & 0x7FF
+            hi = 0xF000 | (s << 10) | imm10
+            lo = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+            struct.pack_into("<HH", text, off, hi, lo)
+        else:
+            print(f"FAIL: unhandled relocation type {t} at {off:#x}")
+            return 1
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(TEXT, 0x80000)  # code below linear memory
+    mu.mem_map(LINBASE, MAPSZ)  # one contiguous linear-memory image
+    mu.mem_write(TEXT, bytes(text))
+    RET = TEXT + 0x70000
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+    # Initialize the static data at its wasm addresses inside the linear image.
+    def init_lin():
+        mu.mem_write(LINBASE, b"\x00" * MAPSZ)
+        for nm in (".data", ".rodata"):
+            s = e.get_section_by_name(nm)
+            if s is None:
+                continue
+            # region symbol wasm offset for this section (0 default)
+            off = 0
+            for sname, (shndx, val) in syms.items():
+                if sname.startswith("__synth_wasm_seg") and secname.get(shndx) == nm:
+                    off = val
+                    break
+            mu.mem_write(WDB + off, bytes(s.data()))
+
+    def run_arm(fn, arg):
+        init_lin()
+        mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R11, 0)
+        mu.reg_write(UC_ARM_REG_SP, LINBASE + MAPSZ - 0x100)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        entry = TEXT + (syms[fn][1] & ~1)
+        mu.emu_start(entry | 1, RET, timeout=5_000_000)
+        return mu.reg_read(UC_ARM_REG_R0)
+
+    ok = True
+    for i in range(11):
+        exp = wasmtime_truth("copy_peek", i)
+        try:
+            got = run_arm("copy_peek", i)
+        except UcError as ex:
+            print(f"copy_peek({i}) = UNICORN FAULT {ex} (expect {exp:#x})")
+            ok = False
+            continue
+        match = "" if got == exp else "  <-- MISMATCH"
+        ec = chr(exp) if 32 <= exp < 127 else "."
+        print(f"copy_peek({i}) = {got:#x} (expect {exp:#x} {ec!r}){match}")
+        ok &= got == exp
+
+    print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repro/mem757_low_const_copy.wat
+++ b/scripts/repro/mem757_low_const_copy.wat
@@ -1,0 +1,58 @@
+(module
+  ;; #757 RED-FIRST repro (v0.45 Lane 1) — the shape the six 0.43.0 controls
+  ;; MISSED: the wide-head chunk-source addend miscomputation is MASKED unless
+  ;; there is initialized data BELOW the copied string inside the SAME
+  ;; `__synth_wasm_data` region.
+  ;;
+  ;; gale's mechanism-neutral 0.43.1 re-test: `.data` holds small consts at
+  ;; offsets 0x00..0x1f AND the string "gust:os up\n" at 0x20. The copy reads
+  ;; `data_base + small_offset` instead of `data_base + 0x20`, so output bytes
+  ;; 0..6 come back as the LOW-offset const region = [2,0,0,0,1,0,0], while
+  ;; bytes 7..10 (" up\n") are correct (the tail arm relocates right).
+  ;;
+  ;; Layout (wasm_data_base = sp_init = 0x100000):
+  ;;   0x100000: \02\00\00\00 \01\00\00\00 ...  small consts, 0x00..0x1f
+  ;;   0x100020: "gust:os up\n"                 the string, at +0x20
+  ;;
+  ;; The head i64 chunk is copied from a STATIC source at data_base+0x20 through
+  ;; the #746 i64 wide load/store arm, reached THROUGH a RawVec-grow `call`. If
+  ;; the wide arm folds the wrong addend, copy_peek(0..6) returns the low consts.
+  ;;
+  ;; Compile: --target cortex-m3 --native-pointer-abi --all-exports
+  ;;          --relocatable --shadow-stack-size <B>
+  (memory (export "memory") 17)
+  (global $sp (mut i32) (i32.const 1048576))
+  ;; ONE data segment (gale's real topology): consts at 0x00..0x1f AND the
+  ;; string "gust:os up\n" at +0x20, in the SAME `(data)` directive → the SAME
+  ;; `__synth_wasm_seg_0` symbol. The string's in-segment offset is a NONZERO
+  ;; 0x20. Two separate directives would give the string its own symbol with
+  ;; addend 0, MASKING a zeroed/mangled chunk-source addend — that is exactly
+  ;; why the six 0.43.0 controls stayed green. With one segment, a wrong head
+  ;; addend of 0 reads seg_0+0 = [2,0,0,0,1,0,0] = gale's leaked bytes.
+  (data (i32.const 1048576) "\02\00\00\00\01\00\00\00\03\00\00\00\04\00\00\00\05\00\00\00\06\00\00\00\07\00\00\00\08\00\00\00gust:os up\n\00\00\00\00\00")
+  ;; a callee that clobbers registers (grows a "vec": returns dst base)
+  (func $grow (param i32) (result i32)
+    (local $x i32)
+    (local.set $x (i32.const 0xdead))
+    (i32.add (local.get 0) (local.get $x))
+    drop
+    (i32.const 1048576))  ;; dst base 0x100000 (we overwrite the consts region,
+                          ;; but copy_peek reads back the DEST, which must equal
+                          ;; the STRING bytes if the copy sourced correctly)
+  (func (export "copy_peek") (param i32) (result i32)
+    (local $idx i32)
+    (local $dst i32)
+    (local.set $idx (i32.const 0))
+    (local.set $dst (call $grow (local.get 0)))
+    ;; HEAD wide i64 from static source at (idx) + static offset 0x100020 —
+    ;; idx live across the call above. Dest 0x100000 (dst base, the LOW region).
+    local.get $idx
+    local.get $idx
+    (i64.load offset=1048608)
+    (i64.store offset=1048576)
+    ;; TAIL bytes 8,9,10 (" up\n")
+    (i64.store8 offset=1048584 (local.get $idx) (i64.load8_u offset=1048616 (local.get $idx)))
+    (i64.store8 offset=1048585 (local.get $idx) (i64.load8_u offset=1048617 (local.get $idx)))
+    (i64.store8 offset=1048586 (local.get $idx) (i64.load8_u offset=1048618 (local.get $idx)))
+    ;; read byte (param 0) back from the DEST (0x100000)
+    (i32.wrap_i64 (i64.load8_u offset=1048576 (local.get 0)))))

--- a/scripts/repro/mem757_low_const_copy_differential.py
+++ b/scripts/repro/mem757_low_const_copy_differential.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""#757 RED-FIRST differential — the low-const-below-string chunked static copy.
+
+The six 0.43.0 reconstructions all found the wide-head source addend CORRECT,
+but every one of them placed the copied string AT the `__synth_wasm_data` base
+(or with only zeros below it), so a "reads base+0 instead of base+0x20"
+miscomputation was MASKED — reading zeros looks the same as reading nothing.
+
+gale's real gust:os module has small consts at data offsets 0x00..0x1f AND the
+string "gust:os up\\n" at 0x20 in the SAME region. This harness reproduces that
+layout: the head i64 chunk sources from `data_base + 0x20` through the #746 wide
+arm, reached THROUGH a RawVec-grow `call`, and the destination is the low-const
+region. copy_peek(i) copies then reads dest byte i back.
+
+If the wide arm folds the wrong per-chunk source addend, copy_peek(0..6) returns
+the LOW consts [2,0,0,0,1,0,0] instead of the string bytes "gust:os".
+
+Resolves BOTH R_ARM_ABS32 (type 2) and R_ARM_THM_CALL (type 10) — the copy is
+reached through a `bl` (RawVec-grow), and an unresolved bl self-corrupts (the
+memory-note vacuous-gate lesson). Separate section bases so a baked absolute
+linmem offset cannot accidentally resolve.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/mem757_low_const_copy_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("mem757_low_const_copy.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+BUDGET = 2048
+ABS32 = 2
+THM_CALL = 10
+BASES = {".text": 0x100000, ".bss": 0x200000, ".data": 0x300000, ".rodata": 0x400000}
+MAPSZ = 0x10000
+
+
+def wasmtime_truth(fn, arg):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_text())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    return inst.exports(store)[fn](store, arg) & 0xFFFFFFFF
+
+
+def main():
+    obj = Path(tempfile.mkdtemp(prefix="mem757lc_")) / "mem757lc.o"
+    proc = subprocess.run(
+        [
+            SYNTH,
+            "compile",
+            str(WAT),
+            "-o",
+            str(obj),
+            "--target",
+            "cortex-m3",
+            "--native-pointer-abi",
+            "--all-exports",
+            "--relocatable",
+            "--shadow-stack-size",
+            str(BUDGET),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr.strip())
+        print("FAIL: compile declined")
+        return 1
+
+    e = ELFFile(open(obj, "rb"))
+    secname = {i: s.name for i, s in enumerate(e.iter_sections())}
+    text = bytearray(e.get_section_by_name(".text").data())
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: (s["st_shndx"], s["st_value"]) for s in symtab.iter_symbols()}
+
+    def sym_addr(sym):
+        shndx, val = syms[sym.name]
+        sn = secname.get(shndx, ".text")
+        return BASES.get(sn, BASES[".text"]) + val
+
+    for r in e.get_section_by_name(".rel.text").iter_relocations():
+        t = r["r_info_type"]
+        sym = symtab.get_symbol(r["r_info_sym"])
+        off = r["r_offset"]
+        if t == ABS32:
+            shndx, val = syms[sym.name]
+            sn = secname[shndx]
+            (add,) = struct.unpack_from("<I", text, off)
+            struct.pack_into("<I", text, off, (BASES[sn] + val + add) & 0xFFFFFFFF)
+        elif t == THM_CALL:
+            P = BASES[".text"] + off + 4
+            S = sym_addr(sym) & ~1
+            disp = S - P
+            imm = (disp >> 1) & 0x3FFFFF
+            s = (imm >> 21) & 1
+            i1 = (imm >> 20) & 1
+            i2 = (imm >> 19) & 1
+            j1 = (~i1 & 1) ^ s
+            j2 = (~i2 & 1) ^ s
+            imm10 = (imm >> 11) & 0x3FF
+            imm11 = imm & 0x7FF
+            hi = 0xF000 | (s << 10) | imm10
+            lo = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+            struct.pack_into("<HH", text, off, hi, lo)
+        else:
+            print(f"FAIL: unhandled relocation type {t} at {off:#x} — vacuous-gate risk")
+            return 1
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    for _, base in BASES.items():
+        mu.mem_map(base, MAPSZ)
+    mu.mem_write(BASES[".text"], bytes(text))
+    for nm in (".data", ".rodata"):
+        s = e.get_section_by_name(nm)
+        if s is not None:
+            mu.mem_write(BASES[nm], bytes(s.data()))
+    bss = e.get_section_by_name(".bss")
+    bss_size = bss["sh_size"] if bss is not None else 0
+    RET = BASES[".text"] + 0xFF0
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+    def run_arm(fn, arg):
+        for nm in (".data", ".rodata"):
+            s = e.get_section_by_name(nm)
+            if s is not None:
+                mu.mem_write(BASES[nm], bytes(s.data()))
+        if bss_size:
+            mu.mem_write(BASES[".bss"], b"\x00" * bss_size)
+        mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R11, 0)
+        mu.reg_write(UC_ARM_REG_SP, BASES[".bss"] + MAPSZ - 0x100)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        entry = BASES[".text"] + (syms[fn][1] & ~1)
+        mu.emu_start(entry | 1, RET, timeout=5_000_000)
+        return mu.reg_read(UC_ARM_REG_R0)
+
+    ok = True
+    for i in range(11):
+        exp = wasmtime_truth("copy_peek", i)
+        try:
+            got = run_arm("copy_peek", i)
+        except UcError as ex:
+            print(f"copy_peek({i}) = UNICORN FAULT {ex} (expect {exp:#x})")
+            ok = False
+            continue
+        match = "" if got == exp else "  <-- MISMATCH"
+        print(f"copy_peek({i}) = {got:#x} (expect {exp:#x} {chr(exp) if 32<=exp<127 else '.'!r}){match}")
+        ok &= got == exp
+
+    print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repro/mem757_memcopy_static_src.wat
+++ b/scripts/repro/mem757_memcopy_static_src.wat
@@ -1,0 +1,41 @@
+(module
+  ;; #757 RED-FIRST repro attempt 2 — the actual gale MECHANISM: memmove
+  ;; (`memory.copy`) whose SOURCE is a static pointer const `data_base + 0x20`
+  ;; relocated by the native-pointer ABI, reached THROUGH a RawVec-grow `call`.
+  ;;
+  ;; Rust source shape: `dst.copy_from_slice(&STATIC_STR)` lowers to a
+  ;; `memory.copy (dst_ptr, src_ptr=data_base+0x20, len)`. Under
+  ;; --native-pointer-abi the `i32.const 0x100020` src pointer must relocate to
+  ;; `__synth_wasm_data + 0x20`. If instead it folds/relocates to
+  ;; `__synth_wasm_data + small` (e.g. the const-materialization path picks the
+  ;; wrong addend), the copy reads the LOW consts [2,0,0,0,1,0,0].
+  ;;
+  ;; Layout (wasm_data_base = sp_init = 0x100000):
+  ;;   0x100000: \02\00\00\00 \01\00\00\00 ...   low consts, 0x00..0x1f
+  ;;   0x100020: "gust:os up\n"                  the string at +0x20
+  ;;   dst = 0x101000 (a clear .bss-ish region above the statics)
+  ;;
+  ;; Compile: --target cortex-m3 --native-pointer-abi --all-exports
+  ;;          --relocatable --shadow-stack-size <B>
+  (memory (export "memory") 17)
+  (global $sp (mut i32) (i32.const 1048576))
+  ;; ONE data segment: consts at 0x00..0x1f AND the string at +0x20 → the SAME
+  ;; symbol, so the string source pointer has a NONZERO in-segment offset 0x20.
+  (data (i32.const 1048576) "\02\00\00\00\01\00\00\00\03\00\00\00\04\00\00\00\05\00\00\00\06\00\00\00\07\00\00\00\08\00\00\00gust:os up\n\00\00\00\00\00")
+  ;; RawVec-grow: clobbers caller-saved, returns the dst base 0x101000
+  (func $grow (param i32) (result i32)
+    (local $x i32)
+    (local.set $x (i32.const 0xdead))
+    (i32.add (local.get 0) (local.get $x))
+    drop
+    (i32.const 1052672))  ;; 0x101000 dst base
+  (func (export "copy_peek") (param i32) (result i32)
+    (local $dst i32)
+    (local.set $dst (call $grow (local.get 0)))
+    ;; memmove: copy 11 bytes of the string (src = 0x100020) into dst (0x101000)
+    (memory.copy
+      (local.get $dst)          ;; dst = 0x101000
+      (i32.const 1048608)       ;; src = data_base + 0x20 = 0x100020  (STATIC PTR)
+      (i32.const 11))           ;; len = 11 (>= 9 → multi-chunk)
+    ;; read dst byte (param 0) back
+    (i32.load8_u (i32.add (local.get $dst) (local.get 0)))))

--- a/scripts/repro/mem757_memcopy_static_src_differential.py
+++ b/scripts/repro/mem757_memcopy_static_src_differential.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""#757 RED-FIRST differential — memmove (`memory.copy`) from a STATIC pointer.
+
+gale's real mechanism: a RawVec-grow `call` followed by a `memory.copy` whose
+SOURCE operand is a static pointer const `data_base + 0x20` (a `&STATIC_STR`),
+relocated by the native-pointer ABI to `__synth_wasm_data + 0x20`. With low
+consts filling `[data_base, data_base+0x20)`, a wrong source addend reads the
+LOW consts [2,0,0,0,...] instead of "gust:os".
+
+This differs from the six 0.43.0 controls: those used i64.load/i64.store chunks
+with the offset folded into the MEMARG. gale's memmove passes the source as a
+relocated CONST POINTER through `memory.copy`.
+
+Unlike the separated-section harness, this maps linear memory as ONE contiguous
+region (R11 = 0 native deref, so wasm addr == absolute addr) and pins the
+`__synth_wasm_data` symbol at its wasm base 0x100000, so a runtime dst pointer
+(0x101000) and a relocated src pointer stay in the same address space — this is
+faithful to the deployed native-pointer image, where linear memory IS one block.
+Resolves R_ARM_ABS32 (2) and R_ARM_THM_CALL (10); an unresolved bl self-corrupts.
+
+Run:
+  SYNTH=./target/debug/synth python scripts/repro/mem757_memcopy_static_src_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("mem757_memcopy_static_src.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+BUDGET = 2048
+ABS32 = 2
+THM_CALL = 10
+
+# One contiguous 8 MiB linear-memory image at LINBASE; .text placed just below
+# it. `__synth_wasm_data` symbol is pinned at DATABASE (= wasm data base 0x100000
+# offset into the image) so relocated static pointers and runtime dst pointers
+# share the address space, exactly as in the deployed native image.
+TEXT = 0x00080000
+LINBASE = 0x00100000  # wasm addr 0 -> here? No: native ABI uses R11=0, wasm addr == absolute.
+MAPSZ = 0x00400000
+
+
+def wasmtime_truth(fn, arg):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_text())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    return inst.exports(store)[fn](store, arg) & 0xFFFFFFFF
+
+
+def main():
+    obj = Path(tempfile.mkdtemp(prefix="mem757mc_")) / "mem757mc.o"
+    proc = subprocess.run(
+        [
+            SYNTH,
+            "compile",
+            str(WAT),
+            "-o",
+            str(obj),
+            "--target",
+            "cortex-m3",
+            "--native-pointer-abi",
+            "--all-exports",
+            "--relocatable",
+            "--shadow-stack-size",
+            str(BUDGET),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr.strip())
+        print("FAIL: compile declined")
+        return 1
+
+    e = ELFFile(open(obj, "rb"))
+    secname = {i: s.name for i, s in enumerate(e.iter_sections())}
+    text = bytearray(e.get_section_by_name(".text").data())
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: (s["st_shndx"], s["st_value"]) for s in symtab.iter_symbols()}
+
+    # Native-pointer image: wasm address A resolves to absolute A (R11 = 0).
+    # `__synth_wasm_data` and any `__synth_wasm_seg_*` region symbols are the
+    # wasm data base (0x100000) plus the symbol's st_value, so a relocated
+    # static pointer equals its wasm address.
+    WDB = 0x100000  # wasm data base
+
+    def sym_abs(name):
+        shndx, val = syms[name]
+        sn = secname.get(shndx, ".text")
+        if sn == ".text":
+            return TEXT + val
+        # data/rodata/bss region symbols: st_value is the wasm OFFSET into the
+        # linear image; absolute = wasm_data_base + offset (R11 = 0 native ABI).
+        return WDB + val
+
+    for r in e.get_section_by_name(".rel.text").iter_relocations():
+        t = r["r_info_type"]
+        sym = symtab.get_symbol(r["r_info_sym"])
+        off = r["r_offset"]
+        if t == ABS32:
+            (add,) = struct.unpack_from("<I", text, off)
+            struct.pack_into("<I", text, off, (sym_abs(sym.name) + add) & 0xFFFFFFFF)
+        elif t == THM_CALL:
+            P = TEXT + off + 4
+            S = sym_abs(sym.name) & ~1
+            disp = S - P
+            imm = (disp >> 1) & 0x3FFFFF
+            s = (imm >> 21) & 1
+            i1 = (imm >> 20) & 1
+            i2 = (imm >> 19) & 1
+            j1 = (~i1 & 1) ^ s
+            j2 = (~i2 & 1) ^ s
+            imm10 = (imm >> 11) & 0x3FF
+            imm11 = imm & 0x7FF
+            hi = 0xF000 | (s << 10) | imm10
+            lo = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+            struct.pack_into("<HH", text, off, hi, lo)
+        else:
+            print(f"FAIL: unhandled relocation type {t} at {off:#x}")
+            return 1
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(TEXT, 0x80000)  # code below linear memory
+    mu.mem_map(LINBASE, MAPSZ)  # one contiguous linear-memory image
+    mu.mem_write(TEXT, bytes(text))
+    RET = TEXT + 0x70000
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+    # Initialize the static data at its wasm addresses inside the linear image.
+    def init_lin():
+        mu.mem_write(LINBASE, b"\x00" * MAPSZ)
+        for nm in (".data", ".rodata"):
+            s = e.get_section_by_name(nm)
+            if s is None:
+                continue
+            # region symbol wasm offset for this section (0 default)
+            off = 0
+            for sname, (shndx, val) in syms.items():
+                if sname.startswith("__synth_wasm_seg") and secname.get(shndx) == nm:
+                    off = val
+                    break
+            mu.mem_write(WDB + off, bytes(s.data()))
+
+    def run_arm(fn, arg):
+        init_lin()
+        mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R11, 0)
+        mu.reg_write(UC_ARM_REG_SP, LINBASE + MAPSZ - 0x100)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        entry = TEXT + (syms[fn][1] & ~1)
+        mu.emu_start(entry | 1, RET, timeout=5_000_000)
+        return mu.reg_read(UC_ARM_REG_R0)
+
+    ok = True
+    for i in range(11):
+        exp = wasmtime_truth("copy_peek", i)
+        try:
+            got = run_arm("copy_peek", i)
+        except UcError as ex:
+            print(f"copy_peek({i}) = UNICORN FAULT {ex} (expect {exp:#x})")
+            ok = False
+            continue
+        match = "" if got == exp else "  <-- MISMATCH"
+        ec = chr(exp) if 32 <= exp < 127 else "."
+        print(f"copy_peek({i}) = {got:#x} (expect {exp:#x} {ec!r}){match}")
+        ok &= got == exp
+
+    print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repro/mem757_memmove_param.wat
+++ b/scripts/repro/mem757_memmove_param.wat
@@ -1,0 +1,53 @@
+(module
+  ;; #757 RED-FIRST repro attempt 4 — gale's ACTUAL func_17 shape:
+  ;;   run -> func_20 -> func_16 (RawVec-grow) -> func_17 (memmove(dst,src,len))
+  ;; The memmove is a SEPARATE function taking (dst, src, len) as PARAMS; the
+  ;; caller applies `+0x20` to the source before the call. The body is the
+  ;; classic overlapping head-i64 + tail-i32 memmove (NOT the non-overlapping
+  ;; i64 + 3×i8 the six controls used):
+  ;;   head: i64.store(dst,   i64.load(src))        ;; dst[0..8]
+  ;;   tail: i32.store off=7(dst, i32.load off=7(src)) ;; dst[7..11], fixes byte 7
+  ;; Net for an 11-byte copy: bytes 0..6 from the HEAD source, 7..10 from the
+  ;; TAIL source. gale: 0..6 WRONG (low consts), 7..10 RIGHT — head and tail
+  ;; derive the source base DIFFERENTLY, so one is miscomputed.
+  ;;
+  ;; Layout (wasm_data_base = sp_init = 0x100000), ONE segment:
+  ;;   0x100000: \02\00\00\00 \01\00\00\00 ...   low consts, 0x00..0x1f
+  ;;   0x100020: "gust:os up\n"                  the string at +0x20
+  ;;
+  ;; RED signature: copy_peek(0)==0x02, copy_peek(4)==0x01 (head read
+  ;; data_base+0 = the low consts) while copy_peek(7..10) == " up\n".
+  ;;
+  ;; Compile: --target cortex-m3 --native-pointer-abi --all-exports
+  ;;          --relocatable --shadow-stack-size <B>
+  (memory (export "memory") 17)
+  (global $sp (mut i32) (i32.const 1048576))
+  (data (i32.const 1048576) "\02\00\00\00\01\00\00\00\03\00\00\00\04\00\00\00\05\00\00\00\06\00\00\00\07\00\00\00\08\00\00\00gust:os up\n\00\00\00\00\00")
+  ;; RawVec-grow: clobbers caller-saved, returns dst base 0x101000
+  (func $grow (param i32) (result i32)
+    (local $x i32)
+    (local.set $x (i32.const 0xdead))
+    (i32.add (local.get 0) (local.get $x))
+    drop
+    (i32.const 1052672))  ;; 0x101000
+  ;; func_17: overlapping head-i64 + tail-i32 memmove(dst, src, len)
+  (func $memmove (param $dst i32) (param $src i32) (param $len i32)
+    (local $t i32)
+    ;; some register pressure so the base temps don't trivially survive
+    (local.set $t (i32.add (local.get $len) (i32.const 3)))
+    (local.set $t (i32.and (local.get $t) (i32.const -4)))
+    ;; head: dst[0..8] = src[0..8]
+    (i64.store (local.get $dst) (i64.load (local.get $src)))
+    ;; tail: dst[7..11] = src[7..11]  (overlap fixes byte 7)
+    (i32.store offset=7 (local.get $dst) (i32.load offset=7 (local.get $src))))
+  (func (export "copy_peek") (param i32) (result i32)
+    (local $dst i32)
+    (local.set $dst (call $grow (local.get 0)))
+    ;; caller applies +0x20 to the source (the &STATIC[0] pointer) and calls
+    ;; the separate memmove — the +0x20 is applied HERE, not in func_17.
+    (call $memmove
+      (local.get $dst)
+      (i32.add (i32.const 1048576) (i32.const 32))  ;; src = data_base + 0x20
+      (i32.const 11))
+    ;; read dst byte (param 0) back
+    (i32.load8_u (i32.add (local.get $dst) (local.get 0)))))

--- a/scripts/repro/mem757_memmove_param_differential.py
+++ b/scripts/repro/mem757_memmove_param_differential.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""#757 RED-FIRST differential — memmove (`memory.copy`) from a STATIC pointer.
+
+gale's real mechanism: a RawVec-grow `call` followed by a `memory.copy` whose
+SOURCE operand is a static pointer const `data_base + 0x20` (a `&STATIC_STR`),
+relocated by the native-pointer ABI to `__synth_wasm_data + 0x20`. With low
+consts filling `[data_base, data_base+0x20)`, a wrong source addend reads the
+LOW consts [2,0,0,0,...] instead of "gust:os".
+
+This differs from the six 0.43.0 controls: those used i64.load/i64.store chunks
+with the offset folded into the MEMARG. gale's memmove passes the source as a
+relocated CONST POINTER through `memory.copy`.
+
+Unlike the separated-section harness, this maps linear memory as ONE contiguous
+region (R11 = 0 native deref, so wasm addr == absolute addr) and pins the
+`__synth_wasm_data` symbol at its wasm base 0x100000, so a runtime dst pointer
+(0x101000) and a relocated src pointer stay in the same address space — this is
+faithful to the deployed native-pointer image, where linear memory IS one block.
+Resolves R_ARM_ABS32 (2) and R_ARM_THM_CALL (10); an unresolved bl self-corrupts.
+
+Run:
+  SYNTH=./target/debug/synth python scripts/repro/mem757_memcopy_static_src_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("mem757_memmove_param.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+BUDGET = 2048
+ABS32 = 2
+THM_CALL = 10
+
+# One contiguous 8 MiB linear-memory image at LINBASE; .text placed just below
+# it. `__synth_wasm_data` symbol is pinned at DATABASE (= wasm data base 0x100000
+# offset into the image) so relocated static pointers and runtime dst pointers
+# share the address space, exactly as in the deployed native image.
+TEXT = 0x00080000
+LINBASE = 0x00100000  # wasm addr 0 -> here? No: native ABI uses R11=0, wasm addr == absolute.
+MAPSZ = 0x00400000
+
+
+def wasmtime_truth(fn, arg):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_text())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    return inst.exports(store)[fn](store, arg) & 0xFFFFFFFF
+
+
+def main():
+    obj = Path(tempfile.mkdtemp(prefix="mem757mm_")) / "mem757mm.o"
+    proc = subprocess.run(
+        [
+            SYNTH,
+            "compile",
+            str(WAT),
+            "-o",
+            str(obj),
+            "--target",
+            "cortex-m3",
+            "--native-pointer-abi",
+            "--all-exports",
+            "--relocatable",
+            "--shadow-stack-size",
+            str(BUDGET),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr.strip())
+        print("FAIL: compile declined")
+        return 1
+
+    e = ELFFile(open(obj, "rb"))
+    secname = {i: s.name for i, s in enumerate(e.iter_sections())}
+    text = bytearray(e.get_section_by_name(".text").data())
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: (s["st_shndx"], s["st_value"]) for s in symtab.iter_symbols()}
+
+    # Native-pointer image: wasm address A resolves to absolute A (R11 = 0).
+    # `__synth_wasm_data` and any `__synth_wasm_seg_*` region symbols are the
+    # wasm data base (0x100000) plus the symbol's st_value, so a relocated
+    # static pointer equals its wasm address.
+    WDB = 0x100000  # wasm data base
+
+    def sym_abs(name):
+        shndx, val = syms[name]
+        sn = secname.get(shndx, ".text")
+        if sn == ".text":
+            return TEXT + val
+        # data/rodata/bss region symbols: st_value is the wasm OFFSET into the
+        # linear image; absolute = wasm_data_base + offset (R11 = 0 native ABI).
+        return WDB + val
+
+    for r in e.get_section_by_name(".rel.text").iter_relocations():
+        t = r["r_info_type"]
+        sym = symtab.get_symbol(r["r_info_sym"])
+        off = r["r_offset"]
+        if t == ABS32:
+            (add,) = struct.unpack_from("<I", text, off)
+            struct.pack_into("<I", text, off, (sym_abs(sym.name) + add) & 0xFFFFFFFF)
+        elif t == THM_CALL:
+            P = TEXT + off + 4
+            S = sym_abs(sym.name) & ~1
+            disp = S - P
+            imm = (disp >> 1) & 0x3FFFFF
+            s = (imm >> 21) & 1
+            i1 = (imm >> 20) & 1
+            i2 = (imm >> 19) & 1
+            j1 = (~i1 & 1) ^ s
+            j2 = (~i2 & 1) ^ s
+            imm10 = (imm >> 11) & 0x3FF
+            imm11 = imm & 0x7FF
+            hi = 0xF000 | (s << 10) | imm10
+            lo = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+            struct.pack_into("<HH", text, off, hi, lo)
+        else:
+            print(f"FAIL: unhandled relocation type {t} at {off:#x}")
+            return 1
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(TEXT, 0x80000)  # code below linear memory
+    mu.mem_map(LINBASE, MAPSZ)  # one contiguous linear-memory image
+    mu.mem_write(TEXT, bytes(text))
+    RET = TEXT + 0x70000
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+    # Initialize the static data at its wasm addresses inside the linear image.
+    def init_lin():
+        mu.mem_write(LINBASE, b"\x00" * MAPSZ)
+        for nm in (".data", ".rodata"):
+            s = e.get_section_by_name(nm)
+            if s is None:
+                continue
+            # region symbol wasm offset for this section (0 default)
+            off = 0
+            for sname, (shndx, val) in syms.items():
+                if sname.startswith("__synth_wasm_seg") and secname.get(shndx) == nm:
+                    off = val
+                    break
+            mu.mem_write(WDB + off, bytes(s.data()))
+
+    def run_arm(fn, arg):
+        init_lin()
+        mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R11, 0)
+        mu.reg_write(UC_ARM_REG_SP, LINBASE + MAPSZ - 0x100)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        entry = TEXT + (syms[fn][1] & ~1)
+        mu.emu_start(entry | 1, RET, timeout=5_000_000)
+        return mu.reg_read(UC_ARM_REG_R0)
+
+    ok = True
+    for i in range(11):
+        exp = wasmtime_truth("copy_peek", i)
+        try:
+            got = run_arm("copy_peek", i)
+        except UcError as ex:
+            print(f"copy_peek({i}) = UNICORN FAULT {ex} (expect {exp:#x})")
+            ok = False
+            continue
+        match = "" if got == exp else "  <-- MISMATCH"
+        ec = chr(exp) if 32 <= exp < 127 else "."
+        print(f"copy_peek({i}) = {got:#x} (expect {exp:#x} {ec!r}){match}")
+        ok &= got == exp
+
+    print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repro/mem757_pressure_chunks.wat
+++ b/scripts/repro/mem757_pressure_chunks.wat
@@ -1,0 +1,52 @@
+(module
+  ;; #757 RED-FIRST repro attempt 7 — HIGH REGISTER PRESSURE multi-chunk copy.
+  ;; gale's func_17 lives in a 13-function module with real pressure; the six
+  ;; prior fixtures were low-pressure. Here many i64 chunks are copied with many
+  ;; live locals across the copy, forcing alloc_temp_or_spill / the #746 base
+  ;; temp to genuinely spill BETWEEN the head and tail chunks. If a chunk's base
+  ;; temp is spilled and the reload aliases a wrong slot, the head reads
+  ;; `data_base + small`.
+  ;;
+  ;; Layout (wasm_data_base = sp_init = 0x100000), ONE segment, 8 i64 chunks =
+  ;; 64 bytes of distinct content at +0x20:
+  ;;   0x100000: low consts 0x00..0x1f
+  ;;   0x100020..0x10005f: 8 distinct i64 words
+  ;;
+  ;; Compile: --target cortex-m3 --native-pointer-abi --all-exports
+  ;;          --relocatable --shadow-stack-size <B>
+  (memory (export "memory") 17)
+  (global $sp (mut i32) (i32.const 1048576))
+  (data (i32.const 1048576)
+    "\02\00\00\00\01\00\00\00\03\00\00\00\04\00\00\00\05\00\00\00\06\00\00\00\07\00\00\00\08\00\00\00\11\11\11\11\11\11\11\11\22\22\22\22\22\22\22\22\33\33\33\33\33\33\33\33\44\44\44\44\44\44\44\44\55\55\55\55\55\55\55\55\66\66\66\66\66\66\66\66\77\77\77\77\77\77\77\77\88\88\88\88\88\88\88\88")
+  (func $grow (param i32) (result i32)
+    (local $x i32)
+    (local.set $x (i32.const 0xdead))
+    (i32.add (local.get 0) (local.get $x))
+    drop
+    (i32.const 1052672))  ;; dst 0x101000
+  (func (export "copy_peek") (param i32) (result i32)
+    (local $idx i32)
+    (local $dst i32)
+    (local $a i32) (local $b i32) (local $c i32) (local $d i32)
+    (local.set $idx (i32.const 0))
+    (local.set $dst (call $grow (local.get 0)))
+    ;; keep many live values across the chunk copies to raise pressure
+    (local.set $a (i32.add (local.get 0) (i32.const 1)))
+    (local.set $b (i32.add (local.get 0) (i32.const 2)))
+    (local.set $c (i32.add (local.get 0) (i32.const 3)))
+    (local.set $d (i32.add (local.get 0) (i32.const 4)))
+    ;; 8 i64 chunks from static [idx + 0x100020 + k*8] into dst, #746 wide arm
+    (i64.store offset=0  (local.get $dst) (i64.load offset=1048608 (local.get $idx)))
+    (i64.store offset=8  (local.get $dst) (i64.load offset=1048616 (local.get $idx)))
+    (i64.store offset=16 (local.get $dst) (i64.load offset=1048624 (local.get $idx)))
+    (i64.store offset=24 (local.get $dst) (i64.load offset=1048632 (local.get $idx)))
+    (i64.store offset=32 (local.get $dst) (i64.load offset=1048640 (local.get $idx)))
+    (i64.store offset=40 (local.get $dst) (i64.load offset=1048648 (local.get $idx)))
+    (i64.store offset=48 (local.get $dst) (i64.load offset=1048656 (local.get $idx)))
+    (i64.store offset=56 (local.get $dst) (i64.load offset=1048664 (local.get $idx)))
+    ;; consume the pressure locals so they stay live across the copy
+    (i32.add (i32.add (local.get $a) (local.get $b))
+             (i32.add (local.get $c) (local.get $d)))
+    drop
+    ;; read dst byte (param 0) back
+    (i32.load8_u (i32.add (local.get $dst) (local.get 0)))))

--- a/scripts/repro/mem757_pressure_chunks_differential.py
+++ b/scripts/repro/mem757_pressure_chunks_differential.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""#757 RED-FIRST differential — memmove (`memory.copy`) from a STATIC pointer.
+
+gale's real mechanism: a RawVec-grow `call` followed by a `memory.copy` whose
+SOURCE operand is a static pointer const `data_base + 0x20` (a `&STATIC_STR`),
+relocated by the native-pointer ABI to `__synth_wasm_data + 0x20`. With low
+consts filling `[data_base, data_base+0x20)`, a wrong source addend reads the
+LOW consts [2,0,0,0,...] instead of "gust:os".
+
+This differs from the six 0.43.0 controls: those used i64.load/i64.store chunks
+with the offset folded into the MEMARG. gale's memmove passes the source as a
+relocated CONST POINTER through `memory.copy`.
+
+Unlike the separated-section harness, this maps linear memory as ONE contiguous
+region (R11 = 0 native deref, so wasm addr == absolute addr) and pins the
+`__synth_wasm_data` symbol at its wasm base 0x100000, so a runtime dst pointer
+(0x101000) and a relocated src pointer stay in the same address space — this is
+faithful to the deployed native-pointer image, where linear memory IS one block.
+Resolves R_ARM_ABS32 (2) and R_ARM_THM_CALL (10); an unresolved bl self-corrupts.
+
+Run:
+  SYNTH=./target/debug/synth python scripts/repro/mem757_memcopy_static_src_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("mem757_pressure_chunks.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+BUDGET = 2048
+ABS32 = 2
+THM_CALL = 10
+
+# One contiguous 8 MiB linear-memory image at LINBASE; .text placed just below
+# it. `__synth_wasm_data` symbol is pinned at DATABASE (= wasm data base 0x100000
+# offset into the image) so relocated static pointers and runtime dst pointers
+# share the address space, exactly as in the deployed native image.
+TEXT = 0x00080000
+LINBASE = 0x00100000  # wasm addr 0 -> here? No: native ABI uses R11=0, wasm addr == absolute.
+MAPSZ = 0x00400000
+
+
+def wasmtime_truth(fn, arg):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_text())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    return inst.exports(store)[fn](store, arg) & 0xFFFFFFFF
+
+
+def main():
+    obj = Path(tempfile.mkdtemp(prefix="mem757pc_")) / "mem757pc.o"
+    proc = subprocess.run(
+        [
+            SYNTH,
+            "compile",
+            str(WAT),
+            "-o",
+            str(obj),
+            "--target",
+            "cortex-m3",
+            "--native-pointer-abi",
+            "--all-exports",
+            "--relocatable",
+            "--shadow-stack-size",
+            str(BUDGET),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr.strip())
+        print("FAIL: compile declined")
+        return 1
+
+    e = ELFFile(open(obj, "rb"))
+    secname = {i: s.name for i, s in enumerate(e.iter_sections())}
+    text = bytearray(e.get_section_by_name(".text").data())
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: (s["st_shndx"], s["st_value"]) for s in symtab.iter_symbols()}
+
+    # Native-pointer image: wasm address A resolves to absolute A (R11 = 0).
+    # `__synth_wasm_data` and any `__synth_wasm_seg_*` region symbols are the
+    # wasm data base (0x100000) plus the symbol's st_value, so a relocated
+    # static pointer equals its wasm address.
+    WDB = 0x100000  # wasm data base
+
+    def sym_abs(name):
+        shndx, val = syms[name]
+        sn = secname.get(shndx, ".text")
+        if sn == ".text":
+            return TEXT + val
+        # data/rodata/bss region symbols: st_value is the wasm OFFSET into the
+        # linear image; absolute = wasm_data_base + offset (R11 = 0 native ABI).
+        return WDB + val
+
+    for r in e.get_section_by_name(".rel.text").iter_relocations():
+        t = r["r_info_type"]
+        sym = symtab.get_symbol(r["r_info_sym"])
+        off = r["r_offset"]
+        if t == ABS32:
+            (add,) = struct.unpack_from("<I", text, off)
+            struct.pack_into("<I", text, off, (sym_abs(sym.name) + add) & 0xFFFFFFFF)
+        elif t == THM_CALL:
+            P = TEXT + off + 4
+            S = sym_abs(sym.name) & ~1
+            disp = S - P
+            imm = (disp >> 1) & 0x3FFFFF
+            s = (imm >> 21) & 1
+            i1 = (imm >> 20) & 1
+            i2 = (imm >> 19) & 1
+            j1 = (~i1 & 1) ^ s
+            j2 = (~i2 & 1) ^ s
+            imm10 = (imm >> 11) & 0x3FF
+            imm11 = imm & 0x7FF
+            hi = 0xF000 | (s << 10) | imm10
+            lo = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+            struct.pack_into("<HH", text, off, hi, lo)
+        else:
+            print(f"FAIL: unhandled relocation type {t} at {off:#x}")
+            return 1
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(TEXT, 0x80000)  # code below linear memory
+    mu.mem_map(LINBASE, MAPSZ)  # one contiguous linear-memory image
+    mu.mem_write(TEXT, bytes(text))
+    RET = TEXT + 0x70000
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+    # Initialize the static data at its wasm addresses inside the linear image.
+    def init_lin():
+        mu.mem_write(LINBASE, b"\x00" * MAPSZ)
+        for nm in (".data", ".rodata"):
+            s = e.get_section_by_name(nm)
+            if s is None:
+                continue
+            # region symbol wasm offset for this section (0 default)
+            off = 0
+            for sname, (shndx, val) in syms.items():
+                if sname.startswith("__synth_wasm_seg") and secname.get(shndx) == nm:
+                    off = val
+                    break
+            mu.mem_write(WDB + off, bytes(s.data()))
+
+    def run_arm(fn, arg):
+        init_lin()
+        mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R11, 0)
+        mu.reg_write(UC_ARM_REG_SP, LINBASE + MAPSZ - 0x100)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        entry = TEXT + (syms[fn][1] & ~1)
+        mu.emu_start(entry | 1, RET, timeout=5_000_000)
+        return mu.reg_read(UC_ARM_REG_R0)
+
+    ok = True
+    for i in range(11):
+        exp = wasmtime_truth("copy_peek", i)
+        try:
+            got = run_arm("copy_peek", i)
+        except UcError as ex:
+            print(f"copy_peek({i}) = UNICORN FAULT {ex} (expect {exp:#x})")
+            ok = False
+            continue
+        match = "" if got == exp else "  <-- MISMATCH"
+        ec = chr(exp) if 32 <= exp < 127 else "."
+        print(f"copy_peek({i}) = {got:#x} (expect {exp:#x} {ec!r}){match}")
+        ok &= got == exp
+
+    print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repro/mem757_ptr_base_copy.wat
+++ b/scripts/repro/mem757_ptr_base_copy.wat
@@ -1,0 +1,45 @@
+(module
+  ;; #757 RED-FIRST repro attempt 3 — the RawVec/memmove POINTER-BASE shape:
+  ;; the copy source is a runtime pointer register holding `data_base`
+  ;; (== wasm_data_base == 0x100000), and the string is read as `[base + 0x20]`
+  ;; through small memarg offsets (the chunk offsets of a memmove loop). This is
+  ;; the else-branch / small-offset path the six 0.43.0 controls never hit —
+  ;; they all folded a LARGE static memarg (>= wasm_data_base) which routes to
+  ;; the #746 arm. Here the memarg offsets are SMALL (0x20, 0x28) and the base
+  ;; is a pointer, exactly like loom-inlined `Vec::extend_from_slice`.
+  ;;
+  ;; gale symptom: head reads `data_base + small` (the low consts
+  ;; [2,0,0,0,1,0,0]) instead of `data_base + 0x20` — i.e. the +0x20 base
+  ;; offset is dropped for the head chunk.
+  ;;
+  ;; Layout (wasm_data_base = sp_init = 0x100000), ONE segment:
+  ;;   0x100000: \02\00\00\00 \01\00\00\00 ...   low consts, 0x00..0x1f
+  ;;   0x100020: "gust:os up\n"                  the string at +0x20
+  ;;   dst = 0x101000
+  ;;
+  ;; Compile: --target cortex-m3 --native-pointer-abi --all-exports
+  ;;          --relocatable --shadow-stack-size <B>
+  (memory (export "memory") 17)
+  (global $sp (mut i32) (i32.const 1048576))
+  (data (i32.const 1048576) "\02\00\00\00\01\00\00\00\03\00\00\00\04\00\00\00\05\00\00\00\06\00\00\00\07\00\00\00\08\00\00\00gust:os up\n\00\00\00\00\00")
+  ;; RawVec-grow: clobbers caller-saved, returns dst base 0x101000
+  (func $grow (param i32) (result i32)
+    (local $x i32)
+    (local.set $x (i32.const 0xdead))
+    (i32.add (local.get 0) (local.get $x))
+    drop
+    (i32.const 1052672))  ;; 0x101000
+  (func (export "copy_peek") (param i32) (result i32)
+    (local $src i32)   ;; source POINTER (data_base), not a folded offset
+    (local $dst i32)
+    ;; src = data_base pointer 0x100000 (a runtime pointer register)
+    (local.set $src (i32.const 1048576))
+    (local.set $dst (call $grow (local.get 0)))
+    ;; HEAD wide i64 from [src + 0x20] (the string), store to [dst + 0]
+    (i64.store (local.get $dst) (i64.load offset=32 (local.get $src)))
+    ;; TAIL bytes 8,9,10 from [src + 0x28..0x2a], store to [dst + 8..10]
+    (i64.store8 offset=8 (local.get $dst) (i64.load8_u offset=40 (local.get $src)))
+    (i64.store8 offset=9 (local.get $dst) (i64.load8_u offset=41 (local.get $src)))
+    (i64.store8 offset=10 (local.get $dst) (i64.load8_u offset=42 (local.get $src)))
+    ;; read dst byte (param 0) back
+    (i32.load8_u (i32.add (local.get $dst) (local.get 0)))))

--- a/scripts/repro/mem757_ptr_base_copy_differential.py
+++ b/scripts/repro/mem757_ptr_base_copy_differential.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""#757 RED-FIRST differential — memmove (`memory.copy`) from a STATIC pointer.
+
+gale's real mechanism: a RawVec-grow `call` followed by a `memory.copy` whose
+SOURCE operand is a static pointer const `data_base + 0x20` (a `&STATIC_STR`),
+relocated by the native-pointer ABI to `__synth_wasm_data + 0x20`. With low
+consts filling `[data_base, data_base+0x20)`, a wrong source addend reads the
+LOW consts [2,0,0,0,...] instead of "gust:os".
+
+This differs from the six 0.43.0 controls: those used i64.load/i64.store chunks
+with the offset folded into the MEMARG. gale's memmove passes the source as a
+relocated CONST POINTER through `memory.copy`.
+
+Unlike the separated-section harness, this maps linear memory as ONE contiguous
+region (R11 = 0 native deref, so wasm addr == absolute addr) and pins the
+`__synth_wasm_data` symbol at its wasm base 0x100000, so a runtime dst pointer
+(0x101000) and a relocated src pointer stay in the same address space — this is
+faithful to the deployed native-pointer image, where linear memory IS one block.
+Resolves R_ARM_ABS32 (2) and R_ARM_THM_CALL (10); an unresolved bl self-corrupts.
+
+Run:
+  SYNTH=./target/debug/synth python scripts/repro/mem757_memcopy_static_src_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("mem757_ptr_base_copy.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+BUDGET = 2048
+ABS32 = 2
+THM_CALL = 10
+
+# One contiguous 8 MiB linear-memory image at LINBASE; .text placed just below
+# it. `__synth_wasm_data` symbol is pinned at DATABASE (= wasm data base 0x100000
+# offset into the image) so relocated static pointers and runtime dst pointers
+# share the address space, exactly as in the deployed native image.
+TEXT = 0x00080000
+LINBASE = 0x00100000  # wasm addr 0 -> here? No: native ABI uses R11=0, wasm addr == absolute.
+MAPSZ = 0x00400000
+
+
+def wasmtime_truth(fn, arg):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_text())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    return inst.exports(store)[fn](store, arg) & 0xFFFFFFFF
+
+
+def main():
+    obj = Path(tempfile.mkdtemp(prefix="mem757pb_")) / "mem757pb.o"
+    proc = subprocess.run(
+        [
+            SYNTH,
+            "compile",
+            str(WAT),
+            "-o",
+            str(obj),
+            "--target",
+            "cortex-m3",
+            "--native-pointer-abi",
+            "--all-exports",
+            "--relocatable",
+            "--shadow-stack-size",
+            str(BUDGET),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr.strip())
+        print("FAIL: compile declined")
+        return 1
+
+    e = ELFFile(open(obj, "rb"))
+    secname = {i: s.name for i, s in enumerate(e.iter_sections())}
+    text = bytearray(e.get_section_by_name(".text").data())
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: (s["st_shndx"], s["st_value"]) for s in symtab.iter_symbols()}
+
+    # Native-pointer image: wasm address A resolves to absolute A (R11 = 0).
+    # `__synth_wasm_data` and any `__synth_wasm_seg_*` region symbols are the
+    # wasm data base (0x100000) plus the symbol's st_value, so a relocated
+    # static pointer equals its wasm address.
+    WDB = 0x100000  # wasm data base
+
+    def sym_abs(name):
+        shndx, val = syms[name]
+        sn = secname.get(shndx, ".text")
+        if sn == ".text":
+            return TEXT + val
+        # data/rodata/bss region symbols: st_value is the wasm OFFSET into the
+        # linear image; absolute = wasm_data_base + offset (R11 = 0 native ABI).
+        return WDB + val
+
+    for r in e.get_section_by_name(".rel.text").iter_relocations():
+        t = r["r_info_type"]
+        sym = symtab.get_symbol(r["r_info_sym"])
+        off = r["r_offset"]
+        if t == ABS32:
+            (add,) = struct.unpack_from("<I", text, off)
+            struct.pack_into("<I", text, off, (sym_abs(sym.name) + add) & 0xFFFFFFFF)
+        elif t == THM_CALL:
+            P = TEXT + off + 4
+            S = sym_abs(sym.name) & ~1
+            disp = S - P
+            imm = (disp >> 1) & 0x3FFFFF
+            s = (imm >> 21) & 1
+            i1 = (imm >> 20) & 1
+            i2 = (imm >> 19) & 1
+            j1 = (~i1 & 1) ^ s
+            j2 = (~i2 & 1) ^ s
+            imm10 = (imm >> 11) & 0x3FF
+            imm11 = imm & 0x7FF
+            hi = 0xF000 | (s << 10) | imm10
+            lo = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+            struct.pack_into("<HH", text, off, hi, lo)
+        else:
+            print(f"FAIL: unhandled relocation type {t} at {off:#x}")
+            return 1
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(TEXT, 0x80000)  # code below linear memory
+    mu.mem_map(LINBASE, MAPSZ)  # one contiguous linear-memory image
+    mu.mem_write(TEXT, bytes(text))
+    RET = TEXT + 0x70000
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+    # Initialize the static data at its wasm addresses inside the linear image.
+    def init_lin():
+        mu.mem_write(LINBASE, b"\x00" * MAPSZ)
+        for nm in (".data", ".rodata"):
+            s = e.get_section_by_name(nm)
+            if s is None:
+                continue
+            # region symbol wasm offset for this section (0 default)
+            off = 0
+            for sname, (shndx, val) in syms.items():
+                if sname.startswith("__synth_wasm_seg") and secname.get(shndx) == nm:
+                    off = val
+                    break
+            mu.mem_write(WDB + off, bytes(s.data()))
+
+    def run_arm(fn, arg):
+        init_lin()
+        mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R11, 0)
+        mu.reg_write(UC_ARM_REG_SP, LINBASE + MAPSZ - 0x100)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        entry = TEXT + (syms[fn][1] & ~1)
+        mu.emu_start(entry | 1, RET, timeout=5_000_000)
+        return mu.reg_read(UC_ARM_REG_R0)
+
+    ok = True
+    for i in range(11):
+        exp = wasmtime_truth("copy_peek", i)
+        try:
+            got = run_arm("copy_peek", i)
+        except UcError as ex:
+            print(f"copy_peek({i}) = UNICORN FAULT {ex} (expect {exp:#x})")
+            ok = False
+            continue
+        match = "" if got == exp else "  <-- MISMATCH"
+        ec = chr(exp) if 32 <= exp < 127 else "."
+        print(f"copy_peek({i}) = {got:#x} (expect {exp:#x} {ec!r}){match}")
+        ok &= got == exp
+
+    print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repro/mem757_rawvec_memcopy.wat
+++ b/scripts/repro/mem757_rawvec_memcopy.wat
@@ -1,0 +1,45 @@
+(module
+  ;; #757 RED-FIRST repro attempt 6 — the RawVec call-graph shape on the RUNTIME
+  ;; -OFFSET axis (not the addend axis the five prior fixtures verified). gale:
+  ;;   run -> func_20 -> func_16 (RawVec-grow) -> func_17 (memmove)
+  ;; The `&STATIC[0]` source pointer (data_base + 0x20) is computed, held in a
+  ;; LOCAL ACROSS the RawVec-grow `call` (so it must spill/reload), THEN used as
+  ;; the `memory.copy` source after the grow returns. If the reload picks a
+  ;; stale slot or the source register is re-derived without the +0x20, the head
+  ;; chunk reads `data_base + small` (the low consts) — gale's exact symptom.
+  ;;
+  ;; This is the axis the prior fixtures MISSED: they verified the link-time
+  ;; relocation ADDEND (all correct, seg_0 + 0x20); this exercises the RUNTIME
+  ;; source-pointer VALUE surviving the call, which is a different bug class.
+  ;;
+  ;; Layout (wasm_data_base = sp_init = 0x100000), ONE segment:
+  ;;   0x100000: \02\00\00\00 \01\00\00\00 ...   low consts, 0x00..0x1f
+  ;;   0x100020: "gust:os up\n"                  the string at +0x20
+  ;;
+  ;; RED signature: copy_peek(0)==0x02 / low-const bytes for the head; the tail
+  ;; (bytes 7..10) reads " up\n" correctly.
+  ;;
+  ;; Compile: --target cortex-m3 --native-pointer-abi --all-exports
+  ;;          --relocatable --shadow-stack-size <B>
+  (memory (export "memory") 17)
+  (global $sp (mut i32) (i32.const 1048576))
+  (data (i32.const 1048576) "\02\00\00\00\01\00\00\00\03\00\00\00\04\00\00\00\05\00\00\00\06\00\00\00\07\00\00\00\08\00\00\00gust:os up\n\00\00\00\00\00")
+  (func $grow (param i32) (result i32)
+    (local $x i32)
+    (local.set $x (i32.const 0xdead))
+    (i32.add (local.get 0) (local.get $x))
+    drop
+    (i32.const 1052672))  ;; dst 0x101000
+  (func (export "copy_peek") (param i32) (result i32)
+    (local $src i32)
+    (local $dst i32)
+    (local $len i32)
+    ;; source pointer &STATIC[0] = data_base + 0x20, computed BEFORE the grow
+    (local.set $src (i32.add (i32.const 1048576) (i32.const 32)))
+    (local.set $len (i32.const 11))
+    ;; RawVec-grow — $src and $len are live ACROSS this call (must spill/reload)
+    (local.set $dst (call $grow (local.get 0)))
+    ;; memmove: copy from the reloaded $src into $dst
+    (memory.copy (local.get $dst) (local.get $src) (local.get $len))
+    ;; read dst byte (param 0) back
+    (i32.load8_u (i32.add (local.get $dst) (local.get 0)))))

--- a/scripts/repro/mem757_rawvec_memcopy_differential.py
+++ b/scripts/repro/mem757_rawvec_memcopy_differential.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""#757 RED-FIRST differential — memmove (`memory.copy`) from a STATIC pointer.
+
+gale's real mechanism: a RawVec-grow `call` followed by a `memory.copy` whose
+SOURCE operand is a static pointer const `data_base + 0x20` (a `&STATIC_STR`),
+relocated by the native-pointer ABI to `__synth_wasm_data + 0x20`. With low
+consts filling `[data_base, data_base+0x20)`, a wrong source addend reads the
+LOW consts [2,0,0,0,...] instead of "gust:os".
+
+This differs from the six 0.43.0 controls: those used i64.load/i64.store chunks
+with the offset folded into the MEMARG. gale's memmove passes the source as a
+relocated CONST POINTER through `memory.copy`.
+
+Unlike the separated-section harness, this maps linear memory as ONE contiguous
+region (R11 = 0 native deref, so wasm addr == absolute addr) and pins the
+`__synth_wasm_data` symbol at its wasm base 0x100000, so a runtime dst pointer
+(0x101000) and a relocated src pointer stay in the same address space — this is
+faithful to the deployed native-pointer image, where linear memory IS one block.
+Resolves R_ARM_ABS32 (2) and R_ARM_THM_CALL (10); an unresolved bl self-corrupts.
+
+Run:
+  SYNTH=./target/debug/synth python scripts/repro/mem757_memcopy_static_src_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("mem757_rawvec_memcopy.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+BUDGET = 2048
+ABS32 = 2
+THM_CALL = 10
+
+# One contiguous 8 MiB linear-memory image at LINBASE; .text placed just below
+# it. `__synth_wasm_data` symbol is pinned at DATABASE (= wasm data base 0x100000
+# offset into the image) so relocated static pointers and runtime dst pointers
+# share the address space, exactly as in the deployed native image.
+TEXT = 0x00080000
+LINBASE = 0x00100000  # wasm addr 0 -> here? No: native ABI uses R11=0, wasm addr == absolute.
+MAPSZ = 0x00400000
+
+
+def wasmtime_truth(fn, arg):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_text())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    return inst.exports(store)[fn](store, arg) & 0xFFFFFFFF
+
+
+def main():
+    obj = Path(tempfile.mkdtemp(prefix="mem757rv_")) / "mem757rv.o"
+    proc = subprocess.run(
+        [
+            SYNTH,
+            "compile",
+            str(WAT),
+            "-o",
+            str(obj),
+            "--target",
+            "cortex-m3",
+            "--native-pointer-abi",
+            "--all-exports",
+            "--relocatable",
+            "--shadow-stack-size",
+            str(BUDGET),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr.strip())
+        print("FAIL: compile declined")
+        return 1
+
+    e = ELFFile(open(obj, "rb"))
+    secname = {i: s.name for i, s in enumerate(e.iter_sections())}
+    text = bytearray(e.get_section_by_name(".text").data())
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: (s["st_shndx"], s["st_value"]) for s in symtab.iter_symbols()}
+
+    # Native-pointer image: wasm address A resolves to absolute A (R11 = 0).
+    # `__synth_wasm_data` and any `__synth_wasm_seg_*` region symbols are the
+    # wasm data base (0x100000) plus the symbol's st_value, so a relocated
+    # static pointer equals its wasm address.
+    WDB = 0x100000  # wasm data base
+
+    def sym_abs(name):
+        shndx, val = syms[name]
+        sn = secname.get(shndx, ".text")
+        if sn == ".text":
+            return TEXT + val
+        # data/rodata/bss region symbols: st_value is the wasm OFFSET into the
+        # linear image; absolute = wasm_data_base + offset (R11 = 0 native ABI).
+        return WDB + val
+
+    for r in e.get_section_by_name(".rel.text").iter_relocations():
+        t = r["r_info_type"]
+        sym = symtab.get_symbol(r["r_info_sym"])
+        off = r["r_offset"]
+        if t == ABS32:
+            (add,) = struct.unpack_from("<I", text, off)
+            struct.pack_into("<I", text, off, (sym_abs(sym.name) + add) & 0xFFFFFFFF)
+        elif t == THM_CALL:
+            P = TEXT + off + 4
+            S = sym_abs(sym.name) & ~1
+            disp = S - P
+            imm = (disp >> 1) & 0x3FFFFF
+            s = (imm >> 21) & 1
+            i1 = (imm >> 20) & 1
+            i2 = (imm >> 19) & 1
+            j1 = (~i1 & 1) ^ s
+            j2 = (~i2 & 1) ^ s
+            imm10 = (imm >> 11) & 0x3FF
+            imm11 = imm & 0x7FF
+            hi = 0xF000 | (s << 10) | imm10
+            lo = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+            struct.pack_into("<HH", text, off, hi, lo)
+        else:
+            print(f"FAIL: unhandled relocation type {t} at {off:#x}")
+            return 1
+
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(TEXT, 0x80000)  # code below linear memory
+    mu.mem_map(LINBASE, MAPSZ)  # one contiguous linear-memory image
+    mu.mem_write(TEXT, bytes(text))
+    RET = TEXT + 0x70000
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+    # Initialize the static data at its wasm addresses inside the linear image.
+    def init_lin():
+        mu.mem_write(LINBASE, b"\x00" * MAPSZ)
+        for nm in (".data", ".rodata"):
+            s = e.get_section_by_name(nm)
+            if s is None:
+                continue
+            # region symbol wasm offset for this section (0 default)
+            off = 0
+            for sname, (shndx, val) in syms.items():
+                if sname.startswith("__synth_wasm_seg") and secname.get(shndx) == nm:
+                    off = val
+                    break
+            mu.mem_write(WDB + off, bytes(s.data()))
+
+    def run_arm(fn, arg):
+        init_lin()
+        mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+        mu.reg_write(UC_ARM_REG_R11, 0)
+        mu.reg_write(UC_ARM_REG_SP, LINBASE + MAPSZ - 0x100)
+        mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        entry = TEXT + (syms[fn][1] & ~1)
+        mu.emu_start(entry | 1, RET, timeout=5_000_000)
+        return mu.reg_read(UC_ARM_REG_R0)
+
+    ok = True
+    for i in range(11):
+        exp = wasmtime_truth("copy_peek", i)
+        try:
+            got = run_arm("copy_peek", i)
+        except UcError as ex:
+            print(f"copy_peek({i}) = UNICORN FAULT {ex} (expect {exp:#x})")
+            ok = False
+            continue
+        match = "" if got == exp else "  <-- MISMATCH"
+        ec = chr(exp) if 32 <= exp < 127 else "."
+        print(f"copy_peek({i}) = {got:#x} (expect {exp:#x} {ec!r}){match}")
+        ok &= got == exp
+
+    print("ORACLE: PASS" if ok else "ORACLE: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
v0.45 Lane 1 — attempted to reproduce + fix #757 from gale's mechanism-neutral characterization. **Result: NO FIX — the miscompile does not reproduce on any synthetic reconstruction.** #757 stays OPEN, blocked on gale's exact `loom.wasm`/`os-tl-cm3.o`.

## What was tried
gale's 0.43.1 re-test characterized #757 as: garbage output bytes are the low-offset `.data` const region (0x00–0x1f), not string-adjacent → a **multi-chunk memmove reads `data_base + small` instead of `data_base + 0x20`**, in the **RawVec-grow + memmove copying a ≥9-byte static above `wasm_data_base`** shape (reached via a grow-call spill/reload). The direct-`i64.load` toy does NOT trigger it.

Built **7 faithful reconstructions** of that shape (`scripts/repro/mem757_*`): inlined memmove, low-const-copy, memcopy static-src, memmove-param, ptr-base-copy, **rawvec-memcopy** (the closest to gale's grow-call shape), pressure-chunks. **All 7 compile byte-correct vs wasmtime** — `src+0x20` survives the grow-call spill/reload in every case; the source offset is correct.

## Conclusion
Consistent with the v0.43.1 disproof (7 direct-load shapes also green): the exact ARM instruction shape that triggers the miscompile is **not reconstructable from the description**. It needs gale's exact reduced object. Re-requested `loom.wasm`/`os-tl-cm3.o` on #757.

## What lands here (investigation value, not a fix)
- 7 reconstruction harnesses as documented repro attempts.
- One (`mem757_rawvec_memcopy_differential.py`) CI-wired as a **regression guard** that the RawVec-grow copy path stays correct.

**#757 remains OPEN.** No source changed (scripts/repro + ci.yml only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)