### PR TITLE
feat(VCR-ISA-001): extend generate-not-mirror Rocq ISA model to nine i64 pseudo-ops (41→50)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,8 @@ cd coq && make proofs
 
 ### Proof Status
 
-See `coq/STATUS.md` for the complete coverage matrix. Current: 476 Qed / 5 Admitted
-(+2 `admit.` tactics) across `coq/Synth/`. The 41 selector-DSL rule theorems
+See `coq/STATUS.md` for the complete coverage matrix. Current: 485 Qed / 5 Admitted
+(+2 `admit.` tactics) across `coq/Synth/`. The 50 selector-DSL rule theorems
 (`VcrSelRules.v`) are stated directly about the GENERATED model (VCR-ISA-001
 #667: `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v` emitted
 from the shipped `sel_dsl::RULES`); the former 40-lemma `VcrSelRulesGenCheck.v`
@@ -127,18 +127,18 @@ frozen and oracle-gated every step:
 - **Track A (core):** `VCR-RA-001` allocator with Belady spilling — **verified,
   default-on since v0.24.0** (`SYNTH_SPILL_REALLOC`; `SYNTH_SPILL_ON_EXHAUST`
   built flag-off, silicon-gated #580). Next: `VCR-SEL-001` Rocq-discharged
-  verified selector DSL (increments 1–4 shipped **default-on**, 41 rules / 41 Qed,
+  verified selector DSL (increments 1–4 shipped **default-on**, 50 rules / 50 Qed,
   `SYNTH_SEL_DSL`; the Rocq-proved rules are the SHIPPED lowering path for their
-  41 covered ops, opt-out `SYNTH_NO_SEL_DSL=1`, byte-invisible flip) and
+  50 covered ops, opt-out `SYNTH_NO_SEL_DSL=1`, byte-invisible flip) and
   `VCR-PERF-002` proof-carrying specialization (#494,
   0.45× floor; phase 1 facts ingestion landed, PR #624).
 - **Track B (semantics):** `VCR-ISA-001` Sail-generated Rocq ISA model —
   approved, Sail/ASL bridge spike landed (92 Qed, `coq/Synth/ARM/SailArmBridge.v`);
   "generate, don't mirror" landed (#667): the shipped `sel_dsl::RULES` table
-  EMITS the 41 covered ops' Rocq lowerings
+  EMITS the 50 covered ops' Rocq lowerings
   (`coq/Synth/Synth/VcrSelRulesGenerated.v`, `Module Gen`), and `VcrSelRules.v`
   DEFINES `rule_X := Gen.rule_X` — the generated file is the single model
-  source, the 41 correctness Qed are stated directly about it, and a
+  source, the 50 correctness Qed are stated directly about it, and a
   selector-table change regenerates `Gen` and breaks the matching proof, so the
   #682 model↔selector drift is unrepresentable at the instruction-sequence level
   for those ops (the interim `VcrSelRulesGenCheck.v` reflexivity gate was

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 | ELF output with vector table | Implemented | Thumb bit set on symbols; not linked on real hardware |
 | Linker scripts (STM32, nRF52840, generic) | Implemented | Generated, not tested with real boards |
 | Cross-compilation (`--link` flag) | Implemented | Requires `arm-none-eabi-gcc` in PATH; not CI-tested |
-| Rocq mechanized proofs | 476 Qed / 5 Admitted | i32 + i64 T1 correctness proofs; the 41 selector-DSL rule theorems are stated directly about the GENERATED model (VCR-ISA-001 #667 — `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v`); all four i32 div/rem trap guards discharged against the branch-taking executor (#73) |
+| Rocq mechanized proofs | 485 Qed / 5 Admitted | i32 + i64 T1 correctness proofs; the 50 selector-DSL rule theorems are stated directly about the GENERATED model (VCR-ISA-001 #667 — `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v`); all four i32 div/rem trap guards discharged against the branch-taking executor (#73) |
 | SMT translation validation | ordeal (pure-Rust QF_BV) default | v0.27.0 (#553); Z3 demoted to feature-gated differential oracle — 141/141 agreement |
 | WebAssembly spec test suite | 227/257 compile | Compilation only — not executed on emulator |
 
@@ -194,7 +194,7 @@ Per the [PulseEngine Verification Guide](https://pulseengine.eu/guides/VERIFICAT
 
 | Track | Status | Coverage |
 |-------|--------|----------|
-| **Rocq** | Partial | 476 Qed / 5 Admitted (41 selector-DSL rule theorems stated directly about the GENERATED model, VCR-ISA-001 #667) — all four i32 div/rem trap guards discharged (#73) |
+| **Rocq** | Partial | 485 Qed / 5 Admitted (50 selector-DSL rule theorems stated directly about the GENERATED model, VCR-ISA-001 #667) — all four i32 div/rem trap guards discharged (#73) |
 | **Kani** | Starting | 18 bounded model checking harnesses for ARM encoder |
 | **Verus** | Starting | 8 spec functions in `synth-synthesis/src/contracts.rs`; Bazel integration via `rules_verus` |
 | **Lean** | Not started | — |
@@ -206,14 +206,14 @@ See `artifacts/verification-gaps.yaml` for the detailed gap analysis (VG-001 thr
 Mechanized proofs in Rocq 9 show that `compile_wasm_to_arm` preserves WASM semantics for each operation. The proof suite lives in `coq/Synth/` and covers ARM instruction semantics, WASM stack-machine semantics, and per-operation correctness theorems.
 
 ```
-476 Qed / 5 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
+485 Qed / 5 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
   T1 result-correspondence (ARM output = WASM result): all i32 ops and all
      i64 ops — i64 T1 parity since v0.11.0, 0 i64 admits (coq/STATUS.md)
   T2 existence-only: f32/f64 and remaining categories
   T3 admitted (5): 2 Compilation.v, 1 CorrectnessSimple.v, 2 ArmRefinement.v
      (0 division admits — all four i32 div/rem trap guards discharged against
      exec_program_br, #73 closed at i32)
-  incl. 41 Qed selector-DSL rule theorems (Synth/VcrSelRules.v, 1:1 with
+  incl. 50 Qed selector-DSL rule theorems (Synth/VcrSelRules.v, 1:1 with
      coq/vcr_sel_rules.manifest) — stated directly about the GENERATED model
      (VCR-ISA-001 #667: rule_X := Gen.rule_X, single source
      Synth/VcrSelRulesGenerated.v emitted from the shipped sel_dsl::RULES, so
@@ -262,10 +262,10 @@ The one-sentence version: moving synth's correctness from *"we patched every bug
 
 | Track | Item | What it does | Status |
 |-------|------|--------------|--------|
-| **A — codegen core** | `VCR-SEL-001` | Rocq-discharged verified selector DSL — *"ISLE with a proof-assistant backend"*; a missing lowering rule becomes an enumerable coverage gap, not a silent miscompile | increments 1–4 shipped default-on (`SYNTH_SEL_DSL`, opt-out `SYNTH_NO_SEL_DSL=1`): 41 rules / 41 Qed theorems in `coq/Synth/Synth/VcrSelRules.v` (1:1 with `coq/vcr_sel_rules.manifest`, coverage-gated), plus 7 Qed pilot lemmas in `coq/Synth/Synth/VcrSelPilot.v`; the DSL is now the SHIPPED lowering path for its 41 covered ops (byte-invisible flip — every rule was mirror-pinned byte-identical to the hand-written arm it replaces, frozen anchors unmoved) |
+| **A — codegen core** | `VCR-SEL-001` | Rocq-discharged verified selector DSL — *"ISLE with a proof-assistant backend"*; a missing lowering rule becomes an enumerable coverage gap, not a silent miscompile | increments 1–4 shipped default-on (`SYNTH_SEL_DSL`, opt-out `SYNTH_NO_SEL_DSL=1`): 50 rules / 50 Qed theorems in `coq/Synth/Synth/VcrSelRules.v` (1:1 with `coq/vcr_sel_rules.manifest`, coverage-gated), plus 7 Qed pilot lemmas in `coq/Synth/Synth/VcrSelPilot.v`; the DSL is now the SHIPPED lowering path for its 50 covered ops (byte-invisible flip — every rule was mirror-pinned byte-identical to the hand-written arm it replaces, frozen anchors unmoved) |
 | | `VCR-PERF-002` | Proof-carrying specialization (#494): loom's `wsc.facts` invariants become premises for per-elision proof obligations, certificate-checked by the ordeal-backed validator — toward gale's measured **0.45× (below-native) floor** | design traced (v0.30.0); phase 1 (facts ingestion) landed ([PR #624](https://github.com/pulseengine/synth/pull/624), v0.31.0) |
 | | `SYNTH_SPILL_ON_EXHAUST` | Replace the register-exhaustion decline with allocation-time Belady spilling (#580) — the last piece of the exhaustion hard-fail | built, flag-off; default-on held for silicon cycle numbers |
-| **B — authoritative semantics** | `VCR-ISA-001` | Re-base ARM/RISC-V semantics on Sail-generated Rocq (the official ISA spec); generate the selector model, don't mirror it (#667) | approved — Sail/ASL bridge spike landed (92 Qed, `coq/Synth/ARM/SailArmBridge.v`); #667 "generate, don't mirror" landed: the shipped `sel_dsl::RULES` table emits the 41 covered ops' Rocq lowerings (`coq/Synth/Synth/VcrSelRulesGenerated.v`), and `VcrSelRules.v` DEFINES `rule_X := Gen.rule_X` — the generated file is the single model source, the 41 correctness Qed are stated directly about it, and a selector-table change breaks the matching proof (no hand-written copy left to drift) |
+| **B — authoritative semantics** | `VCR-ISA-001` | Re-base ARM/RISC-V semantics on Sail-generated Rocq (the official ISA spec); generate the selector model, don't mirror it (#667) | approved — Sail/ASL bridge spike landed (92 Qed, `coq/Synth/ARM/SailArmBridge.v`); #667 "generate, don't mirror" landed: the shipped `sel_dsl::RULES` table emits the 50 covered ops' Rocq lowerings (`coq/Synth/Synth/VcrSelRulesGenerated.v`), and `VcrSelRules.v` DEFINES `rule_X := Gen.rule_X` — the generated file is the single model source, the 50 correctness Qed are stated directly about it, and a selector-table change breaks the matching proof (no hand-written copy left to drift) |
 | | `VCR-WASM-001` | Anchor WASM source semantics on WasmCert-Coq | proposed |
 | **Gate** | `VCR-VER-001` | Success = a previously load-bearing greedy-fix becomes *revertable*, with the full differential bit-identical and cycles equal-or-better | **demonstrated** (implemented; [evidence](scripts/repro/vcr_ver_001_gate.md)): the v0.11.20 reciprocal-mult cost-gate deleted outright (PR #322, bit-identical); the #496 exhaustion decline revertable behind `SYNTH_SPILL_ON_EXHAUST` — red case green, anchors byte-identical, declines 14→8; flip held on a measured i32-shape cycle regression |
 

--- a/claims.yaml
+++ b/claims.yaml
@@ -29,16 +29,16 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-PROOF-COUNT-README
     doc: README.md
-    text: "476 Qed / 5 Admitted"
+    text: "485 Qed / 5 Admitted"
     evidence:
       - kind: count-eq                       # ALL THREE README spots must agree —
-        pattern: '476 Qed / 5 Admitted'      # a verbatim check alone greens if one
+        pattern: '485 Qed / 5 Admitted'      # a verbatim check alone greens if one
         glob: ['README.md']                  # of them drifts while another matches
         expect: 3
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 476
+        expect: 485
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -50,12 +50,12 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-CLAUDE-MD
     doc: CLAUDE.md
-    text: "476 Qed / 5 Admitted"
+    text: "485 Qed / 5 Admitted"
     evidence:
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 476
+        expect: 485
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -63,16 +63,16 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-STATUS-MD
     doc: coq/STATUS.md
-    text: "476 Qed / 5 Admitted"
+    text: "485 Qed / 5 Admitted"
     evidence:
       - kind: count-eq                       # headline + Total line must both agree
-        pattern: '476 Qed / 5 Admitted'
+        pattern: '485 Qed / 5 Admitted'
         glob: ['coq/STATUS.md']
         expect: 2
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 476
+        expect: 485
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -240,16 +240,16 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-SEL-DSL-RULES
     doc: README.md
-    text: "41 rules / 41 Qed theorems"
+    text: "50 rules / 50 Qed theorems"
     evidence:
       - kind: count-eq                       # rules in the manifest
         pattern: '^rule_'
         glob: ['coq/vcr_sel_rules.manifest']
-        expect: 41
+        expect: 50
       - kind: count-eq                       # 1:1 Qed theorems in VcrSelRules.v
         pattern: '^(?:Theorem|Lemma) rule_\w+_correct'
         glob: ['coq/Synth/Synth/VcrSelRules.v']
-        expect: 41
+        expect: 50
       - kind: count-max                      # the rule table carries no admits
         pattern: 'Admitted\.'
         glob: ['coq/Synth/Synth/VcrSelRules.v']
@@ -257,14 +257,14 @@ claims:
 
   - id: SYNTH-SEL-DSL-COVERAGE-STATUS-MD
     doc: coq/STATUS.md
-    text: "**41 (26%)**"                     # DSL-served column total, per-op-family table (#667)
+    text: "**50 (32%)**"                     # DSL-served column total, per-op-family table (#667)
     evidence:
       - kind: count-eq
         pattern: '^rule_'
         glob: ['coq/vcr_sel_rules.manifest']
-        expect: 41
+        expect: 50
       - kind: verbatim
-        text: "**41 Qed / 0 Admitted**"
+        text: "**50 Qed / 0 Admitted**"
 
   - id: SYNTH-SEL-DSL-PILOT
     doc: README.md

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -1,6 +1,6 @@
 # Rocq Proof Suite — Honest Status
 
-**Last Updated: 2026-07-15 (recount: 476 Qed / 5 Admitted, +2 admit., crude
+**Last Updated: 2026-07-15 (recount: 485 Qed / 5 Admitted, +2 admit., crude
 `grep "Qed\."` over `coq/Synth/**/*.v` — same method as prior recounts; the
 -40 vs the prior 512 are the retired VCR-ISA-001 #667 cross-check lemmas of
 `VcrSelRulesGenCheck.v`: `VcrSelRules.v` now DEFINES every `rule_X` as the
@@ -167,7 +167,7 @@ and predates the VcrSelRules (42), VcrSelPilot (7) and SailArmBridge (92) Qed;
 see the per-file breakdown below for current per-file counts. The T3 row and
 the headline total are re-derived by the claim gate.
 
-**Total: 476 Qed / 5 Admitted (+2 admit.) across all files** (recount 2026-07-15, CI-gated via `claims.yaml`)
+**Total: 485 Qed / 5 Admitted (+2 admit.) across all files** (recount 2026-07-15, CI-gated via `claims.yaml`)
 
 v0.10.0 PR 1: +2 T1 Qed (i64_add_correct, i64_sub_correct) and +9
 infrastructure Qed (combine_i32_unsigned, carry_split_add,
@@ -485,7 +485,7 @@ stepped proof closing with `I32.clz_rbit`;
 tier: the encoder's CMP-lo/SBCS-hi expansion is below the flat executor,
 see `docs/design/vcr-sel-001-increment-4.md`).
 
-**41 Qed / 0 Admitted**, same T1 bound as the pilot ("the ARM sequence
+**50 Qed / 0 Admitted**, same T1 bound as the pilot ("the ARM sequence
 computes the named result", not WASM refinement). These 48 Qed (pilot +
 rules) are included in the recount above.
 
@@ -522,9 +522,9 @@ Every op family the shipped ARM selectors lower, as of increment 4
 | i32.const | 1 | 0 | 1 | 0 |
 | i64 pair ALU (add/sub/and/or/xor) | 5 | **5** | 0 | 0 |
 | i64 comparisons (eqz + eq..ge_u) | 11 | **11**¹ | 0 | 0 |
-| i64 mul/div/rem | 4 | 0 | 4 | 0 |
-| i64 shifts/rotates (pair pseudo-ops) | 5 | 0 | 5 | 0 |
-| i64 bit-manip (clz/ctz/popcnt) | 3 | 0 | 3 | 0 |
+| i64 mul/div/rem | 4 | **1** | 3 | 0 |
+| i64 shifts/rotates (pair pseudo-ops) | 5 | **5**¹ | 0 | 0 |
+| i64 bit-manip (clz/ctz/popcnt) | 3 | **3**¹ | 0 | 0 |
 | i64 wrap/extend (wrap_i64, extend_i32_s/u) | 3 | 0 | 3 | 0 |
 | i64 sign-extend (extend8/16/32_s) | 3 | 0 | 0 | 3 |
 | i64.const | 1 | 0 | 1 | 0 |
@@ -535,13 +535,15 @@ Every op family the shipped ARM selectors lower, as of increment 4
 | locals/globals (get/set/tee) | 5 | 0 | 5 | 0 |
 | parametric (drop/select/nop) | 3 | 0 | 3 | 0 |
 | control flow (block/loop/br/br_if/return/call/…) | ~10 | 0 | 0 | ~10 |
-| **Total (≈)** | **155** | **41 (26%)** | **95 (61%)** | **19 (12%)** |
+| **Total (≈)** | **155** | **50 (32%)** | **86 (55%)** | **19 (12%)** |
 
-¹ pseudo-op tier: `popcnt`, `i64.eqz` and the ten binary i64 comparisons are
-proven at the `ArmOp` pseudo-op boundary (the selector's emission, which is
-what the DSL owns); the encoder expansions below that boundary
-(shift-and-add popcnt, the CMP-lo/SBCS-hi chain) are covered by the
-differential oracles, not Rocq — see `docs/design/vcr-sel-001-increment-4.md`.
+¹ pseudo-op tier: `i32.popcnt`, `i64.eqz`, the ten binary i64 comparisons, and
+the VCR-ISA-001 wave-2 i64 shapes (`clz`/`ctz`/`popcnt`, `mul`/`shl`/`shr_u`/
+`shr_s`, `rotl`/`rotr`) are proven at the `ArmOp` pseudo-op boundary (the
+selector's emission, which is what the DSL owns); the encoder expansions below
+that boundary (shift-and-add popcnt, the CMP-lo/SBCS-hi chain, the funnel-shift
+and UMULL+MLA sequences) are covered by the differential oracles, not Rocq —
+see `docs/design/vcr-sel-001-increment-4.md`.
 ² the 4 i32 div/rem model proofs are the T3 trap-guard admits (#73,
 `BCondOffset` executor gap).
 ³ the f32/f64 model rows ride the 21 VFP axioms; the shipped ARM path

--- a/coq/Synth/Synth/VcrSelRules.v
+++ b/coq/Synth/Synth/VcrSelRules.v
@@ -1093,3 +1093,239 @@ Theorem rule_i64_ge_u_correct :
       (if I64.geu (combine_i32 lo1 hi1) (combine_i32 lo2 hi2)
        then I32.one else I32.zero).
 Proof. synth_i64_setcond_proof_poly. Qed.
+
+(** ** VCR-ISA-001 wave-2 (v0.45): the single-pseudo-op i64 register-pair
+    shapes the selector already emits — DSL-covered here for the first time.
+
+    Each rule is ONE flat-model pseudo-op with a fixed-register ancestor in
+    CorrectnessI64.v (i64_{clz,ctz,popcnt,mul,shl,shru,shrs,rotl,rotr}_correct),
+    so — exactly like i64.eqz / the I64SetCond family — the DSL work is pure
+    register-generalization + re-export of the GENERATED [Gen.rule_X].
+
+    The pseudo-op semantics read EVERY operand half into a local BEFORE any
+    [set_reg] (ArmSemantics.v), so the value-correctness side conditions are
+    minimal:
+
+      - clz/ctz/popcnt (unary, single [rd] write): NONE — the selector's
+        [rd = rn_lo = R0] in-place emit is admitted;
+      - mul/shl/shr_u/shr_s/rotl/rotr (write the (lo, hi) result pair): a
+        SINGLE [rd_hi <> rd_lo] hypothesis — the high write must not destroy the
+        low result word. (The increment-3 three-condition pair set is NOT needed:
+        those were flags-COUPLED ADDS+ADC pairs where the low instruction wrote
+        before the high instruction re-read an operand; here one pseudo-op reads
+        all operands up front.)
+
+    Statements follow the ancestors' value-level shape (get_reg preconditions →
+    exec_program + result), with NO [exec_wasm_instr] hypothesis (the i64
+    ops are not in WasmSemantics.v, so such a hypothesis would be a
+    None-returning vacuity). The shift/rotate count is the low half only:
+    [combine_i32 cnt I32.zero], matching the [_bits_spec] axioms verbatim. *)
+
+Definition rule_i64_clz    := Gen.rule_i64_clz.
+Definition rule_i64_ctz    := Gen.rule_i64_ctz.
+Definition rule_i64_popcnt := Gen.rule_i64_popcnt.
+Definition rule_i64_mul    := Gen.rule_i64_mul.
+Definition rule_i64_shl    := Gen.rule_i64_shl.
+Definition rule_i64_shr_u  := Gen.rule_i64_shr_u.
+Definition rule_i64_shr_s  := Gen.rule_i64_shr_s.
+Definition rule_i64_rotl   := Gen.rule_i64_rotl.
+Definition rule_i64_rotr   := Gen.rule_i64_rotr.
+
+(** Unary bit counts — single pseudo-op, single [rd] write, NO side
+    condition. Discharge mirrors the fixed-register ancestors verbatim. *)
+
+Theorem rule_i64_clz_correct : forall astate lo hi rd rnlo rnhi,
+  get_reg astate rnlo = lo ->
+  get_reg astate rnhi = hi ->
+  exists astate',
+    exec_program (rule_i64_clz rd rnlo rnhi) astate = Some astate' /\
+    get_reg astate' rd = i64_to_i32 (I64.clz (combine_i32 lo hi)).
+Proof.
+  intros astate lo hi rd rnlo rnhi HR0 HR1.
+  unfold rule_i64_clz, Gen.rule_i64_clz; simpl.
+  rewrite HR0, HR1.
+  rewrite i64_clz_bits_spec.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
+
+Theorem rule_i64_ctz_correct : forall astate lo hi rd rnlo rnhi,
+  get_reg astate rnlo = lo ->
+  get_reg astate rnhi = hi ->
+  exists astate',
+    exec_program (rule_i64_ctz rd rnlo rnhi) astate = Some astate' /\
+    get_reg astate' rd = i64_to_i32 (I64.ctz (combine_i32 lo hi)).
+Proof.
+  intros astate lo hi rd rnlo rnhi HR0 HR1.
+  unfold rule_i64_ctz, Gen.rule_i64_ctz; simpl.
+  rewrite HR0, HR1.
+  rewrite i64_ctz_bits_spec.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
+
+Theorem rule_i64_popcnt_correct : forall astate lo hi rd rnlo rnhi,
+  get_reg astate rnlo = lo ->
+  get_reg astate rnhi = hi ->
+  exists astate',
+    exec_program (rule_i64_popcnt rd rnlo rnhi) astate = Some astate' /\
+    get_reg astate' rd = i64_to_i32 (I64.popcnt (combine_i32 lo hi)).
+Proof.
+  intros astate lo hi rd rnlo rnhi HR0 HR1.
+  unfold rule_i64_popcnt, Gen.rule_i64_popcnt; simpl.
+  rewrite HR0, HR1.
+  rewrite i64_popcnt_bits_spec.
+  eexists. split; [reflexivity | apply get_set_reg_eq].
+Qed.
+
+(** Binary register-pair shapes — single pseudo-op writing (lo, hi); the
+    lone [rd_hi <> rd_lo] hypothesis lets the low-result read past the
+    high write. Discharge mirrors [i64_mul_correct] etc., register-
+    generalized. *)
+
+Theorem rule_i64_mul_correct :
+  forall astate lo1 hi1 lo2 hi2 rdlo rdhi rnlo rnhi rmlo rmhi,
+  rdhi <> rdlo ->
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = lo2 ->
+  get_reg astate rmhi = hi2 ->
+  exists astate',
+    exec_program (rule_i64_mul rdlo rdhi rnlo rnhi rmlo rmhi) astate
+      = Some astate' /\
+    get_reg astate' rdlo = lo_of_i64 (I64.mul (combine_i32 lo1 hi1)
+                                              (combine_i32 lo2 hi2)) /\
+    get_reg astate' rdhi = hi_of_i64 (I64.mul (combine_i32 lo1 hi1)
+                                              (combine_i32 lo2 hi2)).
+Proof.
+  intros astate lo1 hi1 lo2 hi2 rdlo rdhi rnlo rnhi rmlo rmhi Hdd
+         HR0 HR1 HR2 HR3.
+  unfold rule_i64_mul, Gen.rule_i64_mul; simpl.
+  rewrite HR0, HR1, HR2, HR3.
+  rewrite i64_mul_lo_bits_spec, i64_mul_hi_bits_spec.
+  eexists. split; [reflexivity | split].
+  - rewrite get_set_reg_neq by exact Hdd. apply get_set_reg_eq.
+  - apply get_set_reg_eq.
+Qed.
+
+Theorem rule_i64_shl_correct :
+  forall astate lo1 hi1 cnt chi rdlo rdhi rnlo rnhi rmlo rmhi,
+  rdhi <> rdlo ->
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = cnt ->
+  get_reg astate rmhi = chi ->
+  exists astate',
+    exec_program (rule_i64_shl rdlo rdhi rnlo rnhi rmlo rmhi) astate
+      = Some astate' /\
+    get_reg astate' rdlo =
+      lo_of_i64 (I64.shl (combine_i32 lo1 hi1) (combine_i32 cnt I32.zero)) /\
+    get_reg astate' rdhi =
+      hi_of_i64 (I64.shl (combine_i32 lo1 hi1) (combine_i32 cnt I32.zero)).
+Proof.
+  intros astate lo1 hi1 cnt chi rdlo rdhi rnlo rnhi rmlo rmhi Hdd
+         HR0 HR1 HR2 HR3.
+  unfold rule_i64_shl, Gen.rule_i64_shl; simpl.
+  rewrite HR0, HR1, HR2.
+  rewrite i64_shl_lo_bits_spec, i64_shl_hi_bits_spec.
+  eexists. split; [reflexivity | split].
+  - rewrite get_set_reg_neq by exact Hdd. apply get_set_reg_eq.
+  - apply get_set_reg_eq.
+Qed.
+
+Theorem rule_i64_shr_u_correct :
+  forall astate lo1 hi1 cnt chi rdlo rdhi rnlo rnhi rmlo rmhi,
+  rdhi <> rdlo ->
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = cnt ->
+  get_reg astate rmhi = chi ->
+  exists astate',
+    exec_program (rule_i64_shr_u rdlo rdhi rnlo rnhi rmlo rmhi) astate
+      = Some astate' /\
+    get_reg astate' rdlo =
+      lo_of_i64 (I64.shru (combine_i32 lo1 hi1) (combine_i32 cnt I32.zero)) /\
+    get_reg astate' rdhi =
+      hi_of_i64 (I64.shru (combine_i32 lo1 hi1) (combine_i32 cnt I32.zero)).
+Proof.
+  intros astate lo1 hi1 cnt chi rdlo rdhi rnlo rnhi rmlo rmhi Hdd
+         HR0 HR1 HR2 HR3.
+  unfold rule_i64_shr_u, Gen.rule_i64_shr_u; simpl.
+  rewrite HR0, HR1, HR2.
+  rewrite i64_shru_lo_bits_spec, i64_shru_hi_bits_spec.
+  eexists. split; [reflexivity | split].
+  - rewrite get_set_reg_neq by exact Hdd. apply get_set_reg_eq.
+  - apply get_set_reg_eq.
+Qed.
+
+Theorem rule_i64_shr_s_correct :
+  forall astate lo1 hi1 cnt chi rdlo rdhi rnlo rnhi rmlo rmhi,
+  rdhi <> rdlo ->
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rmlo = cnt ->
+  get_reg astate rmhi = chi ->
+  exists astate',
+    exec_program (rule_i64_shr_s rdlo rdhi rnlo rnhi rmlo rmhi) astate
+      = Some astate' /\
+    get_reg astate' rdlo =
+      lo_of_i64 (I64.shrs (combine_i32 lo1 hi1) (combine_i32 cnt I32.zero)) /\
+    get_reg astate' rdhi =
+      hi_of_i64 (I64.shrs (combine_i32 lo1 hi1) (combine_i32 cnt I32.zero)).
+Proof.
+  intros astate lo1 hi1 cnt chi rdlo rdhi rnlo rnhi rmlo rmhi Hdd
+         HR0 HR1 HR2 HR3.
+  unfold rule_i64_shr_s, Gen.rule_i64_shr_s; simpl.
+  rewrite HR0, HR1, HR2.
+  rewrite i64_shrs_lo_bits_spec, i64_shrs_hi_bits_spec.
+  eexists. split; [reflexivity | split].
+  - rewrite get_set_reg_neq by exact Hdd. apply get_set_reg_eq.
+  - apply get_set_reg_eq.
+Qed.
+
+(** Rotates — single pseudo-op, single-register shift amount. Same
+    [rd_hi <> rd_lo] shape as the pair shifts. *)
+
+Theorem rule_i64_rotl_correct :
+  forall astate lo1 hi1 cnt rdlo rdhi rnlo rnhi rs,
+  rdhi <> rdlo ->
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rs = cnt ->
+  exists astate',
+    exec_program (rule_i64_rotl rdlo rdhi rnlo rnhi rs) astate
+      = Some astate' /\
+    get_reg astate' rdlo =
+      lo_of_i64 (I64.rotl (combine_i32 lo1 hi1) (combine_i32 cnt I32.zero)) /\
+    get_reg astate' rdhi =
+      hi_of_i64 (I64.rotl (combine_i32 lo1 hi1) (combine_i32 cnt I32.zero)).
+Proof.
+  intros astate lo1 hi1 cnt rdlo rdhi rnlo rnhi rs Hdd HR0 HR1 HR2.
+  unfold rule_i64_rotl, Gen.rule_i64_rotl; simpl.
+  rewrite HR0, HR1, HR2.
+  rewrite i64_rotl_lo_bits_spec, i64_rotl_hi_bits_spec.
+  eexists. split; [reflexivity | split].
+  - rewrite get_set_reg_neq by exact Hdd. apply get_set_reg_eq.
+  - apply get_set_reg_eq.
+Qed.
+
+Theorem rule_i64_rotr_correct :
+  forall astate lo1 hi1 cnt rdlo rdhi rnlo rnhi rs,
+  rdhi <> rdlo ->
+  get_reg astate rnlo = lo1 ->
+  get_reg astate rnhi = hi1 ->
+  get_reg astate rs = cnt ->
+  exists astate',
+    exec_program (rule_i64_rotr rdlo rdhi rnlo rnhi rs) astate
+      = Some astate' /\
+    get_reg astate' rdlo =
+      lo_of_i64 (I64.rotr (combine_i32 lo1 hi1) (combine_i32 cnt I32.zero)) /\
+    get_reg astate' rdhi =
+      hi_of_i64 (I64.rotr (combine_i32 lo1 hi1) (combine_i32 cnt I32.zero)).
+Proof.
+  intros astate lo1 hi1 cnt rdlo rdhi rnlo rnhi rs Hdd HR0 HR1 HR2.
+  unfold rule_i64_rotr, Gen.rule_i64_rotr; simpl.
+  rewrite HR0, HR1, HR2.
+  rewrite i64_rotr_lo_bits_spec, i64_rotr_hi_bits_spec.
+  eexists. split; [reflexivity | split].
+  - rewrite get_set_reg_neq by exact Hdd. apply get_set_reg_eq.
+  - apply get_set_reg_eq.
+Qed.

--- a/coq/Synth/Synth/VcrSelRulesGenerated.v
+++ b/coq/Synth/Synth/VcrSelRulesGenerated.v
@@ -152,4 +152,31 @@ Definition rule_i64_ge_s (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
 Definition rule_i64_ge_u (rd rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
   [I64SetCond rd rnlo rnhi rmlo rmhi Cond_CS].
 
+Definition rule_i64_clz (rd rnlo rnhi : arm_reg) : arm_program :=
+  [I64ClzPseudo rd rnlo rnhi].
+
+Definition rule_i64_ctz (rd rnlo rnhi : arm_reg) : arm_program :=
+  [I64CtzPseudo rd rnlo rnhi].
+
+Definition rule_i64_popcnt (rd rnlo rnhi : arm_reg) : arm_program :=
+  [I64PopcntPseudo rd rnlo rnhi].
+
+Definition rule_i64_mul (rdlo rdhi rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64MulPseudo rdlo rdhi rnlo rnhi rmlo rmhi].
+
+Definition rule_i64_shl (rdlo rdhi rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64ShlPseudo rdlo rdhi rnlo rnhi rmlo rmhi].
+
+Definition rule_i64_shr_u (rdlo rdhi rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64ShrUPseudo rdlo rdhi rnlo rnhi rmlo rmhi].
+
+Definition rule_i64_shr_s (rdlo rdhi rnlo rnhi rmlo rmhi : arm_reg) : arm_program :=
+  [I64ShrSPseudo rdlo rdhi rnlo rnhi rmlo rmhi].
+
+Definition rule_i64_rotl (rdlo rdhi rnlo rnhi rmlo : arm_reg) : arm_program :=
+  [I64RotlPseudo rdlo rdhi rnlo rnhi rmlo].
+
+Definition rule_i64_rotr (rdlo rdhi rnlo rnhi rmlo : arm_reg) : arm_program :=
+  [I64RotrPseudo rdlo rdhi rnlo rnhi rmlo].
+
 End Gen.

--- a/coq/vcr_sel_rules.manifest
+++ b/coq/vcr_sel_rules.manifest
@@ -44,3 +44,12 @@ rule_i64_le_s
 rule_i64_le_u
 rule_i64_ge_s
 rule_i64_ge_u
+rule_i64_clz
+rule_i64_ctz
+rule_i64_popcnt
+rule_i64_mul
+rule_i64_shl
+rule_i64_shr_u
+rule_i64_shr_s
+rule_i64_rotl
+rule_i64_rotr

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -13947,32 +13947,49 @@ impl InstructionSelector {
                         &live_params,
                         idx,
                     )?;
-                    let shift_op = match op {
-                        I64Shl => ArmOp::I64Shl {
-                            rd_lo: dst_lo,
-                            rd_hi: dst_hi,
-                            rn_lo: a_lo,
-                            rn_hi: a_hi,
-                            rm_lo: b_lo,
-                            rm_hi: b_hi,
-                        },
-                        I64ShrU => ArmOp::I64ShrU {
-                            rd_lo: dst_lo,
-                            rd_hi: dst_hi,
-                            rn_lo: a_lo,
-                            rn_hi: a_hi,
-                            rm_lo: b_lo,
-                            rm_hi: b_hi,
-                        },
-                        I64ShrS => ArmOp::I64ShrS {
-                            rd_lo: dst_lo,
-                            rd_hi: dst_hi,
-                            rn_lo: a_lo,
-                            rn_hi: a_hi,
-                            rm_lo: b_lo,
-                            rm_hi: b_hi,
-                        },
-                        _ => unreachable!(),
+                    // VCR-ISA-001 wave-2 (v0.45): behind SYNTH_SEL_DSL the
+                    // single i64 shift pseudo-op comes from the generated
+                    // Rocq-proved rule — byte-identical to the hand-written
+                    // emission below (mirror-pinned). The `rd_hi <> rd_lo` side
+                    // condition holds by construction: alloc_consecutive_pair
+                    // returns a distinct pair.
+                    let shift_op = if self.sel_dsl {
+                        crate::sel_dsl::i64_pair_bin_rule(
+                            op, dst_lo, dst_hi, a_lo, a_hi, b_lo, b_hi,
+                        )
+                        .expect("i64 shift op dispatch")
+                        .map_err(synth_core::Error::synthesis)?
+                        .into_iter()
+                        .next()
+                        .expect("i64 shift rule emits one op")
+                    } else {
+                        match op {
+                            I64Shl => ArmOp::I64Shl {
+                                rd_lo: dst_lo,
+                                rd_hi: dst_hi,
+                                rn_lo: a_lo,
+                                rn_hi: a_hi,
+                                rm_lo: b_lo,
+                                rm_hi: b_hi,
+                            },
+                            I64ShrU => ArmOp::I64ShrU {
+                                rd_lo: dst_lo,
+                                rd_hi: dst_hi,
+                                rn_lo: a_lo,
+                                rn_hi: a_hi,
+                                rm_lo: b_lo,
+                                rm_hi: b_hi,
+                            },
+                            I64ShrS => ArmOp::I64ShrS {
+                                rd_lo: dst_lo,
+                                rd_hi: dst_hi,
+                                rn_lo: a_lo,
+                                rn_hi: a_hi,
+                                rm_lo: b_lo,
+                                rm_hi: b_hi,
+                            },
+                            _ => unreachable!(),
+                        }
                     };
                     instructions.push(ArmInstruction {
                         op: shift_op,
@@ -14920,15 +14937,32 @@ impl InstructionSelector {
                         &live_params,
                         idx,
                     )?;
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::I64Mul {
+                    // VCR-ISA-001 wave-2 (v0.45): behind SYNTH_SEL_DSL the
+                    // single I64Mul pseudo-op comes from the generated
+                    // Rocq-proved rule — byte-identical to the hand-written
+                    // emission below (mirror-pinned; `rd_hi <> rd_lo` holds by
+                    // construction via alloc_consecutive_pair).
+                    let mul_op = if self.sel_dsl {
+                        crate::sel_dsl::i64_pair_bin_rule(
+                            op, dst_lo, dst_hi, a_lo, a_hi, b_lo, b_hi,
+                        )
+                        .expect("i64 mul op dispatch")
+                        .map_err(synth_core::Error::synthesis)?
+                        .into_iter()
+                        .next()
+                        .expect("i64 mul rule emits one op")
+                    } else {
+                        ArmOp::I64Mul {
                             rd_lo: dst_lo,
                             rd_hi: dst_hi,
                             rn_lo: a_lo,
                             rn_hi: a_hi,
                             rm_lo: b_lo,
                             rm_hi: b_hi,
-                        },
+                        }
+                    };
+                    instructions.push(ArmInstruction {
+                        op: mul_op,
                         source_line: Some(idx),
                     });
                     cf.add_instruction();
@@ -15064,22 +15098,35 @@ impl InstructionSelector {
                         &live_params,
                         idx,
                     )?;
-                    let arm_op = match op {
-                        I64Rotl => ArmOp::I64Rotl {
-                            rdlo: dst_lo,
-                            rdhi: dst_hi,
-                            rnlo: a_lo,
-                            rnhi: a_hi,
-                            shift: b_lo,
-                        },
-                        I64Rotr => ArmOp::I64Rotr {
-                            rdlo: dst_lo,
-                            rdhi: dst_hi,
-                            rnlo: a_lo,
-                            rnhi: a_hi,
-                            shift: b_lo,
-                        },
-                        _ => unreachable!(),
+                    // VCR-ISA-001 wave-2 (v0.45): behind SYNTH_SEL_DSL the
+                    // single i64 rotate pseudo-op comes from the generated
+                    // Rocq-proved rule — byte-identical (mirror-pinned;
+                    // `rd_hi <> rd_lo` holds by construction).
+                    let arm_op = if self.sel_dsl {
+                        crate::sel_dsl::i64_rot_rule(op, dst_lo, dst_hi, a_lo, a_hi, b_lo)
+                            .expect("i64 rotate op dispatch")
+                            .map_err(synth_core::Error::synthesis)?
+                            .into_iter()
+                            .next()
+                            .expect("i64 rotate rule emits one op")
+                    } else {
+                        match op {
+                            I64Rotl => ArmOp::I64Rotl {
+                                rdlo: dst_lo,
+                                rdhi: dst_hi,
+                                rnlo: a_lo,
+                                rnhi: a_hi,
+                                shift: b_lo,
+                            },
+                            I64Rotr => ArmOp::I64Rotr {
+                                rdlo: dst_lo,
+                                rdhi: dst_hi,
+                                rnlo: a_lo,
+                                rnhi: a_hi,
+                                shift: b_lo,
+                            },
+                            _ => unreachable!(),
+                        }
                     };
                     instructions.push(ArmInstruction {
                         op: arm_op,
@@ -15118,23 +15165,37 @@ impl InstructionSelector {
                         &live_params,
                         idx,
                     )?;
-                    let arm_op = match op {
-                        I64Clz => ArmOp::I64Clz {
-                            rd: dst_lo,
-                            rnlo: src_lo,
-                            rnhi: src_hi,
-                        },
-                        I64Ctz => ArmOp::I64Ctz {
-                            rd: dst_lo,
-                            rnlo: src_lo,
-                            rnhi: src_hi,
-                        },
-                        I64Popcnt => ArmOp::I64Popcnt {
-                            rd: dst_lo,
-                            rnlo: src_lo,
-                            rnhi: src_hi,
-                        },
-                        _ => unreachable!(),
+                    // VCR-ISA-001 wave-2 (v0.45): behind SYNTH_SEL_DSL the
+                    // single i64 bit-count pseudo-op comes from the generated
+                    // Rocq-proved rule — byte-identical (mirror-pinned). The
+                    // trailing `Movw dst_hi, 0` (hi-half zeroing) is outside the
+                    // rule's single-pseudo-op scope, exactly as the flat-model
+                    // ancestor proves only the count pseudo-op.
+                    let arm_op = if self.sel_dsl {
+                        crate::sel_dsl::i64_unary_count_rule(op, dst_lo, src_lo, src_hi)
+                            .expect("i64 count op dispatch")
+                            .into_iter()
+                            .next()
+                            .expect("i64 count rule emits one op")
+                    } else {
+                        match op {
+                            I64Clz => ArmOp::I64Clz {
+                                rd: dst_lo,
+                                rnlo: src_lo,
+                                rnhi: src_hi,
+                            },
+                            I64Ctz => ArmOp::I64Ctz {
+                                rd: dst_lo,
+                                rnlo: src_lo,
+                                rnhi: src_hi,
+                            },
+                            I64Popcnt => ArmOp::I64Popcnt {
+                                rd: dst_lo,
+                                rnlo: src_lo,
+                                rnhi: src_hi,
+                            },
+                            _ => unreachable!(),
+                        }
                     };
                     instructions.push(ArmInstruction {
                         op: arm_op,
@@ -16530,6 +16591,131 @@ mod tests {
                     crate::sel_dsl::i64_setcond_rule(&rule.op, rd, rn_lo, rn_hi, rm_lo, rm_hi)
                         .unwrap_or_else(|| panic!("{}: setcond dispatch missing", rule.name)),
                 )
+            } else if matches!(rule.op, WasmOp::I64Clz | WasmOp::I64Ctz | WasmOp::I64Popcnt) {
+                // VCR-ISA-001 wave-2: the unary bit-count single-pseudo-op
+                // window. Extract the three registers the hand-written arm
+                // chose (rd + operand pair).
+                let i = baseline
+                    .iter()
+                    .position(|o| {
+                        matches!(
+                            o,
+                            ArmOp::I64Clz { .. } | ArmOp::I64Ctz { .. } | ArmOp::I64Popcnt { .. }
+                        )
+                    })
+                    .unwrap_or_else(|| panic!("{}: no i64 count op in probe output", rule.name));
+                let (rd, rn_lo, rn_hi) = match &baseline[i] {
+                    ArmOp::I64Clz { rd, rnlo, rnhi }
+                    | ArmOp::I64Ctz { rd, rnlo, rnhi }
+                    | ArmOp::I64Popcnt { rd, rnlo, rnhi } => (*rd, *rnlo, *rnhi),
+                    _ => unreachable!(),
+                };
+                (
+                    baseline[i..i + 1].to_vec(),
+                    crate::sel_dsl::i64_unary_count_rule(&rule.op, rd, rn_lo, rn_hi)
+                        .unwrap_or_else(|| panic!("{}: count dispatch missing", rule.name)),
+                )
+            } else if matches!(rule.op, WasmOp::I64Rotl | WasmOp::I64Rotr) {
+                // VCR-ISA-001 wave-2: the i64 rotate single-pseudo-op window
+                // (five registers: result pair + operand pair + single shift).
+                let i = baseline
+                    .iter()
+                    .position(|o| matches!(o, ArmOp::I64Rotl { .. } | ArmOp::I64Rotr { .. }))
+                    .unwrap_or_else(|| panic!("{}: no i64 rotate op in probe output", rule.name));
+                let (rd_lo, rd_hi, rn_lo, rn_hi, shift) = match &baseline[i] {
+                    ArmOp::I64Rotl {
+                        rdlo,
+                        rdhi,
+                        rnlo,
+                        rnhi,
+                        shift,
+                    }
+                    | ArmOp::I64Rotr {
+                        rdlo,
+                        rdhi,
+                        rnlo,
+                        rnhi,
+                        shift,
+                    } => (*rdlo, *rdhi, *rnlo, *rnhi, *shift),
+                    _ => unreachable!(),
+                };
+                (
+                    baseline[i..i + 1].to_vec(),
+                    crate::sel_dsl::i64_rot_rule(&rule.op, rd_lo, rd_hi, rn_lo, rn_hi, shift)
+                        .unwrap_or_else(|| panic!("{}: rotate dispatch missing", rule.name))
+                        .unwrap_or_else(|e| {
+                            panic!(
+                                "{}: selector regs violate rotate side condition: {e}",
+                                rule.name
+                            )
+                        }),
+                )
+            } else if matches!(
+                rule.op,
+                WasmOp::I64Mul | WasmOp::I64Shl | WasmOp::I64ShrU | WasmOp::I64ShrS
+            ) {
+                // VCR-ISA-001 wave-2: the i64 binary register-pair
+                // single-pseudo-op window (six registers).
+                let i = baseline
+                    .iter()
+                    .position(|o| {
+                        matches!(
+                            o,
+                            ArmOp::I64Mul { .. }
+                                | ArmOp::I64Shl { .. }
+                                | ArmOp::I64ShrU { .. }
+                                | ArmOp::I64ShrS { .. }
+                        )
+                    })
+                    .unwrap_or_else(|| panic!("{}: no i64 pair-bin op in probe output", rule.name));
+                let (rd_lo, rd_hi, rn_lo, rn_hi, rm_lo, rm_hi) = match &baseline[i] {
+                    ArmOp::I64Mul {
+                        rd_lo,
+                        rd_hi,
+                        rn_lo,
+                        rn_hi,
+                        rm_lo,
+                        rm_hi,
+                    }
+                    | ArmOp::I64Shl {
+                        rd_lo,
+                        rd_hi,
+                        rn_lo,
+                        rn_hi,
+                        rm_lo,
+                        rm_hi,
+                    }
+                    | ArmOp::I64ShrU {
+                        rd_lo,
+                        rd_hi,
+                        rn_lo,
+                        rn_hi,
+                        rm_lo,
+                        rm_hi,
+                    }
+                    | ArmOp::I64ShrS {
+                        rd_lo,
+                        rd_hi,
+                        rn_lo,
+                        rn_hi,
+                        rm_lo,
+                        rm_hi,
+                    } => (*rd_lo, *rd_hi, *rn_lo, *rn_hi, *rm_lo, *rm_hi),
+                    _ => unreachable!(),
+                };
+                (
+                    baseline[i..i + 1].to_vec(),
+                    crate::sel_dsl::i64_pair_bin_rule(
+                        &rule.op, rd_lo, rd_hi, rn_lo, rn_hi, rm_lo, rm_hi,
+                    )
+                    .unwrap_or_else(|| panic!("{}: pair-bin dispatch missing", rule.name))
+                    .unwrap_or_else(|e| {
+                        panic!(
+                            "{}: selector regs violate pair-bin side condition: {e}",
+                            rule.name
+                        )
+                    }),
+                )
             } else {
                 // The pair window is the two-instruction sequence starting at
                 // the first lo-half data-processing op (the probe's constant
@@ -16632,8 +16818,10 @@ mod tests {
             );
         }
         // Five binary pair rules + i64.eqz + increment 4's ten binary
-        // I64SetCond comparison rules.
-        assert_eq!(probed, 16, "unexpected i64 pair rule count");
+        // I64SetCond comparison rules + VCR-ISA-001 wave-2's nine
+        // single-pseudo-op i64 shapes (clz/ctz/popcnt/mul/shl/shr_u/shr_s/
+        // rotl/rotr).
+        assert_eq!(probed, 25, "unexpected i64 pair rule count");
     }
 
     /// VCR-SEL-001 increment 2 (#242): the #258 imm-fold comparison peephole

--- a/crates/synth-synthesis/src/sel_dsl/generated.rs
+++ b/crates/synth-synthesis/src/sel_dsl/generated.rs
@@ -724,3 +724,194 @@ pub fn rule_i64_ge_u(rd: Reg, rn_lo: Reg, rn_hi: Reg, rm_lo: Reg, rm_hi: Reg) ->
         cond: Condition::HS,
     }]
 }
+
+/// `i64.clz`: rd = count-leading-zeros of (rn_hi:rn_lo), as i32
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_clz_correct` (Qed).
+pub fn rule_i64_clz(rd: Reg, rn_lo: Reg, rn_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64Clz {
+        rd,
+        rnlo: rn_lo,
+        rnhi: rn_hi,
+    }]
+}
+
+/// `i64.ctz`: rd = count-trailing-zeros of (rn_hi:rn_lo), as i32
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_ctz_correct` (Qed).
+pub fn rule_i64_ctz(rd: Reg, rn_lo: Reg, rn_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64Ctz {
+        rd,
+        rnlo: rn_lo,
+        rnhi: rn_hi,
+    }]
+}
+
+/// `i64.popcnt`: rd = population-count of (rn_hi:rn_lo), as i32
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_popcnt_correct` (Qed).
+pub fn rule_i64_popcnt(rd: Reg, rn_lo: Reg, rn_hi: Reg) -> Vec<ArmOp> {
+    vec![ArmOp::I64Popcnt {
+        rd,
+        rnlo: rn_lo,
+        rnhi: rn_hi,
+    }]
+}
+
+/// `i64.mul`: (rd_hi:rd_lo) = (rn_hi:rn_lo) * (rm_hi:rm_lo)
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_mul_correct` (Qed).
+///
+/// Side condition: `rd_hi` must not alias `rd_lo` (hypothesis of the theorem;
+/// violation is a loud `Err`, never a silent misassemble).
+pub fn rule_i64_mul(
+    rd_lo: Reg,
+    rd_hi: Reg,
+    rn_lo: Reg,
+    rn_hi: Reg,
+    rm_lo: Reg,
+    rm_hi: Reg,
+) -> Result<Vec<ArmOp>, &'static str> {
+    if rd_hi == rd_lo {
+        return Err("rule_i64_mul: side condition violated: rd_hi must not alias rd_lo");
+    }
+    Ok(vec![ArmOp::I64Mul {
+        rd_lo,
+        rd_hi,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+    }])
+}
+
+/// `i64.shl`: (rd_hi:rd_lo) = (rn_hi:rn_lo) << (rm_lo mod 64)
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_shl_correct` (Qed).
+///
+/// Side condition: `rd_hi` must not alias `rd_lo` (hypothesis of the theorem;
+/// violation is a loud `Err`, never a silent misassemble).
+pub fn rule_i64_shl(
+    rd_lo: Reg,
+    rd_hi: Reg,
+    rn_lo: Reg,
+    rn_hi: Reg,
+    rm_lo: Reg,
+    rm_hi: Reg,
+) -> Result<Vec<ArmOp>, &'static str> {
+    if rd_hi == rd_lo {
+        return Err("rule_i64_shl: side condition violated: rd_hi must not alias rd_lo");
+    }
+    Ok(vec![ArmOp::I64Shl {
+        rd_lo,
+        rd_hi,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+    }])
+}
+
+/// `i64.shr_u`: (rd_hi:rd_lo) = (rn_hi:rn_lo) >> (rm_lo mod 64) (logical)
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_shr_u_correct` (Qed).
+///
+/// Side condition: `rd_hi` must not alias `rd_lo` (hypothesis of the theorem;
+/// violation is a loud `Err`, never a silent misassemble).
+pub fn rule_i64_shr_u(
+    rd_lo: Reg,
+    rd_hi: Reg,
+    rn_lo: Reg,
+    rn_hi: Reg,
+    rm_lo: Reg,
+    rm_hi: Reg,
+) -> Result<Vec<ArmOp>, &'static str> {
+    if rd_hi == rd_lo {
+        return Err("rule_i64_shr_u: side condition violated: rd_hi must not alias rd_lo");
+    }
+    Ok(vec![ArmOp::I64ShrU {
+        rd_lo,
+        rd_hi,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+    }])
+}
+
+/// `i64.shr_s`: (rd_hi:rd_lo) = (rn_hi:rn_lo) >> (rm_lo mod 64) (arithmetic)
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_shr_s_correct` (Qed).
+///
+/// Side condition: `rd_hi` must not alias `rd_lo` (hypothesis of the theorem;
+/// violation is a loud `Err`, never a silent misassemble).
+pub fn rule_i64_shr_s(
+    rd_lo: Reg,
+    rd_hi: Reg,
+    rn_lo: Reg,
+    rn_hi: Reg,
+    rm_lo: Reg,
+    rm_hi: Reg,
+) -> Result<Vec<ArmOp>, &'static str> {
+    if rd_hi == rd_lo {
+        return Err("rule_i64_shr_s: side condition violated: rd_hi must not alias rd_lo");
+    }
+    Ok(vec![ArmOp::I64ShrS {
+        rd_lo,
+        rd_hi,
+        rn_lo,
+        rn_hi,
+        rm_lo,
+        rm_hi,
+    }])
+}
+
+/// `i64.rotl`: (rd_hi:rd_lo) = (rn_hi:rn_lo) rotate-left (shift mod 64)
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_rotl_correct` (Qed).
+///
+/// Side condition: `rd_hi` must not alias `rd_lo` (hypothesis of the theorem;
+/// violation is a loud `Err`, never a silent misassemble).
+pub fn rule_i64_rotl(
+    rd_lo: Reg,
+    rd_hi: Reg,
+    rn_lo: Reg,
+    rn_hi: Reg,
+    rm_lo: Reg,
+) -> Result<Vec<ArmOp>, &'static str> {
+    if rd_hi == rd_lo {
+        return Err("rule_i64_rotl: side condition violated: rd_hi must not alias rd_lo");
+    }
+    Ok(vec![ArmOp::I64Rotl {
+        rdlo: rd_lo,
+        rdhi: rd_hi,
+        rnlo: rn_lo,
+        rnhi: rn_hi,
+        shift: rm_lo,
+    }])
+}
+
+/// `i64.rotr`: (rd_hi:rd_lo) = (rn_hi:rn_lo) rotate-right (shift mod 64)
+///
+/// Rocq obligation: `Synth.Synth.VcrSelRules.rule_i64_rotr_correct` (Qed).
+///
+/// Side condition: `rd_hi` must not alias `rd_lo` (hypothesis of the theorem;
+/// violation is a loud `Err`, never a silent misassemble).
+pub fn rule_i64_rotr(
+    rd_lo: Reg,
+    rd_hi: Reg,
+    rn_lo: Reg,
+    rn_hi: Reg,
+    rm_lo: Reg,
+) -> Result<Vec<ArmOp>, &'static str> {
+    if rd_hi == rd_lo {
+        return Err("rule_i64_rotr: side condition violated: rd_hi must not alias rd_lo");
+    }
+    Ok(vec![ArmOp::I64Rotr {
+        rdlo: rd_lo,
+        rdhi: rd_hi,
+        rnlo: rn_lo,
+        rnhi: rn_hi,
+        shift: rm_lo,
+    }])
+}

--- a/crates/synth-synthesis/src/sel_dsl/mod.rs
+++ b/crates/synth-synthesis/src/sel_dsl/mod.rs
@@ -310,6 +310,65 @@ pub enum TemplateOp {
         rm_hi: RegVar,
         cond: CondCode,
     },
+    /// The single-pseudo-op i64 register-pair binary shapes
+    /// (`I64Mul` / `I64Shl` / `I64ShrU` / `I64ShrS`). Each is ONE ArmOp that
+    /// reads all four operand halves into locals BEFORE writing the (lo, hi)
+    /// destination pair, so — unlike the increment-3 ADDS+ADC pair rules — the
+    /// only aliasing constraint is `rd_hi <> rd_lo` (the high write must not
+    /// destroy the low result word). Modeled by the corresponding
+    /// `I64{Mul,Shl,ShrU,ShrS}Pseudo` constructor in the flat ARM model.
+    I64PairBin {
+        kind: I64PairBinKind,
+        rd_lo: RegVar,
+        rd_hi: RegVar,
+        rn_lo: RegVar,
+        rn_hi: RegVar,
+        rm_lo: RegVar,
+        rm_hi: RegVar,
+    },
+    /// The single-pseudo-op i64 rotate shapes (`I64Rotl` / `I64Rotr`). Like
+    /// [`TemplateOp::I64PairBin`] but the rotate amount is a SINGLE register
+    /// (`shift`, the low half of the i64 amount), matching the flat model's
+    /// `I64{Rotl,Rotr}Pseudo` (5-register) constructor. Only aliasing
+    /// constraint: `rd_hi <> rd_lo`.
+    I64PairRot {
+        left: bool,
+        rd_lo: RegVar,
+        rd_hi: RegVar,
+        rn_lo: RegVar,
+        rn_hi: RegVar,
+        shift: RegVar,
+    },
+    /// The single-pseudo-op i64 unary bit-count shapes (`I64Clz` / `I64Ctz` /
+    /// `I64Popcnt`). One ArmOp reads both operand halves and writes the single
+    /// i32 count into `rd` — NO aliasing side condition (`rd` may alias `rn_lo`,
+    /// the `R0, R0, R1` shape the selector emits). Modeled by the corresponding
+    /// `I64{Clz,Ctz,Popcnt}Pseudo` constructor.
+    I64UnaryCount {
+        kind: I64CountKind,
+        rd: RegVar,
+        rn_lo: RegVar,
+        rn_hi: RegVar,
+    },
+}
+
+/// The binary i64 register-pair pseudo-op families that share the
+/// [`TemplateOp::I64PairBin`] shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum I64PairBinKind {
+    Mul,
+    Shl,
+    ShrU,
+    ShrS,
+}
+
+/// The unary i64 bit-count pseudo-op families that share the
+/// [`TemplateOp::I64UnaryCount`] shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum I64CountKind {
+    Clz,
+    Ctz,
+    Popcnt,
 }
 
 /// One declarative lowering rule: `op → parameterized ARM sequence`.
@@ -1067,6 +1126,166 @@ pub const RULES: &[SelRule] = &[
         delegation: Delegation::Both,
         doc: "`i64.ge_u`: rd = if (rn_hi:rn_lo) >= (rm_hi:rm_lo) (unsigned) {1} else {0}",
     },
+    // ---- VCR-ISA-001 wave-2 (v0.45): the single-pseudo-op i64 register-pair
+    // shapes the selector already emits but were DSL-uncovered. Each is ONE
+    // ArmOp modeled by a dedicated flat-model pseudo-op
+    // (I64{Clz,Ctz,Popcnt,Mul,Shl,ShrU,ShrS,Rotl,Rotr}Pseudo), with a
+    // fixed-register ancestor in CorrectnessI64.v — so the DSL rule is a pure
+    // register-generalization + re-export, exactly like the increment-3/4
+    // i64.eqz / I64SetCond families. ----
+    //
+    // i64.clz / i64.ctz / i64.popcnt — unary bit counts: ONE pseudo-op reads
+    // both operand halves and writes the single i32 count into `rd`. NO
+    // aliasing side condition (the pseudo-op reads rn_lo/rn_hi before writing
+    // rd, so the selector's `rd = rn_lo = R0` in-place emit is admitted).
+    SelRule {
+        name: "rule_i64_clz",
+        op: WasmOp::I64Clz,
+        params: &[Rd, RnLo, RnHi],
+        side_conditions: &[],
+        seq: &[TemplateOp::I64UnaryCount {
+            kind: I64CountKind::Clz,
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+        }],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i64.clz`: rd = count-leading-zeros of (rn_hi:rn_lo), as i32",
+    },
+    SelRule {
+        name: "rule_i64_ctz",
+        op: WasmOp::I64Ctz,
+        params: &[Rd, RnLo, RnHi],
+        side_conditions: &[],
+        seq: &[TemplateOp::I64UnaryCount {
+            kind: I64CountKind::Ctz,
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+        }],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i64.ctz`: rd = count-trailing-zeros of (rn_hi:rn_lo), as i32",
+    },
+    SelRule {
+        name: "rule_i64_popcnt",
+        op: WasmOp::I64Popcnt,
+        params: &[Rd, RnLo, RnHi],
+        side_conditions: &[],
+        seq: &[TemplateOp::I64UnaryCount {
+            kind: I64CountKind::Popcnt,
+            rd: Rd,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+        }],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i64.popcnt`: rd = population-count of (rn_hi:rn_lo), as i32",
+    },
+    // i64.mul / i64.shl / i64.shr_u / i64.shr_s — binary register-pair shapes:
+    // ONE pseudo-op reads all four operand halves BEFORE writing the (lo, hi)
+    // destination pair, so the only aliasing constraint is `rd_hi <> rd_lo`.
+    SelRule {
+        name: "rule_i64_mul",
+        op: WasmOp::I64Mul,
+        params: I64_PAIR_PARAMS,
+        side_conditions: &[SideCondition::NotAlias(RdHi, RdLo)],
+        seq: &[TemplateOp::I64PairBin {
+            kind: I64PairBinKind::Mul,
+            rd_lo: RdLo,
+            rd_hi: RdHi,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+        }],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i64.mul`: (rd_hi:rd_lo) = (rn_hi:rn_lo) * (rm_hi:rm_lo)",
+    },
+    SelRule {
+        name: "rule_i64_shl",
+        op: WasmOp::I64Shl,
+        params: I64_PAIR_PARAMS,
+        side_conditions: &[SideCondition::NotAlias(RdHi, RdLo)],
+        seq: &[TemplateOp::I64PairBin {
+            kind: I64PairBinKind::Shl,
+            rd_lo: RdLo,
+            rd_hi: RdHi,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+        }],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i64.shl`: (rd_hi:rd_lo) = (rn_hi:rn_lo) << (rm_lo mod 64)",
+    },
+    SelRule {
+        name: "rule_i64_shr_u",
+        op: WasmOp::I64ShrU,
+        params: I64_PAIR_PARAMS,
+        side_conditions: &[SideCondition::NotAlias(RdHi, RdLo)],
+        seq: &[TemplateOp::I64PairBin {
+            kind: I64PairBinKind::ShrU,
+            rd_lo: RdLo,
+            rd_hi: RdHi,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+        }],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i64.shr_u`: (rd_hi:rd_lo) = (rn_hi:rn_lo) >> (rm_lo mod 64) (logical)",
+    },
+    SelRule {
+        name: "rule_i64_shr_s",
+        op: WasmOp::I64ShrS,
+        params: I64_PAIR_PARAMS,
+        side_conditions: &[SideCondition::NotAlias(RdHi, RdLo)],
+        seq: &[TemplateOp::I64PairBin {
+            kind: I64PairBinKind::ShrS,
+            rd_lo: RdLo,
+            rd_hi: RdHi,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            rm_lo: RmLo,
+            rm_hi: RmHi,
+        }],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i64.shr_s`: (rd_hi:rd_lo) = (rn_hi:rn_lo) >> (rm_lo mod 64) (arithmetic)",
+    },
+    // i64.rotl / i64.rotr — rotate shapes: the amount is a SINGLE register
+    // (`shift`, the low half of the i64 amount). Only aliasing constraint:
+    // `rd_hi <> rd_lo`.
+    SelRule {
+        name: "rule_i64_rotl",
+        op: WasmOp::I64Rotl,
+        params: &[RdLo, RdHi, RnLo, RnHi, RmLo],
+        side_conditions: &[SideCondition::NotAlias(RdHi, RdLo)],
+        seq: &[TemplateOp::I64PairRot {
+            left: true,
+            rd_lo: RdLo,
+            rd_hi: RdHi,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            shift: RmLo,
+        }],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i64.rotl`: (rd_hi:rd_lo) = (rn_hi:rn_lo) rotate-left (shift mod 64)",
+    },
+    SelRule {
+        name: "rule_i64_rotr",
+        op: WasmOp::I64Rotr,
+        params: &[RdLo, RdHi, RnLo, RnHi, RmLo],
+        side_conditions: &[SideCondition::NotAlias(RdHi, RdLo)],
+        seq: &[TemplateOp::I64PairRot {
+            left: false,
+            rd_lo: RdLo,
+            rd_hi: RdHi,
+            rn_lo: RnLo,
+            rn_hi: RnHi,
+            shift: RmLo,
+        }],
+        delegation: Delegation::SelectWithStack,
+        doc: "`i64.rotr`: (rd_hi:rd_lo) = (rn_hi:rn_lo) rotate-right (shift mod 64)",
+    },
 ];
 
 /// Dispatch an i32 comparison op to its generated Rocq-proved rule
@@ -1196,6 +1415,65 @@ pub fn i64_setcond_rule(
     })
 }
 
+/// Dispatch a unary i64 bit-count op (`i64.clz/ctz/popcnt`) to its generated
+/// Rocq-proved single-pseudo-op rule (VCR-ISA-001 wave-2). Same contract as
+/// [`i32_unary_rule`]: `None` for ops outside the family; no side conditions
+/// (the pseudo-op reads both operand halves before writing `rd`).
+pub fn i64_unary_count_rule(
+    op: &WasmOp,
+    rd: crate::rules::Reg,
+    rn_lo: crate::rules::Reg,
+    rn_hi: crate::rules::Reg,
+) -> Option<Vec<crate::rules::ArmOp>> {
+    Some(match op {
+        WasmOp::I64Clz => generated::rule_i64_clz(rd, rn_lo, rn_hi),
+        WasmOp::I64Ctz => generated::rule_i64_ctz(rd, rn_lo, rn_hi),
+        WasmOp::I64Popcnt => generated::rule_i64_popcnt(rd, rn_lo, rn_hi),
+        _ => return None,
+    })
+}
+
+/// Dispatch a binary i64 register-pair op (`i64.mul/shl/shr_u/shr_s`) to its
+/// generated Rocq-proved single-pseudo-op rule (VCR-ISA-001 wave-2). Each
+/// carries the single `rd_hi <> rd_lo` side condition (the high write must not
+/// destroy the low result word); violation is a loud `Err`.
+pub fn i64_pair_bin_rule(
+    op: &WasmOp,
+    rd_lo: crate::rules::Reg,
+    rd_hi: crate::rules::Reg,
+    rn_lo: crate::rules::Reg,
+    rn_hi: crate::rules::Reg,
+    rm_lo: crate::rules::Reg,
+    rm_hi: crate::rules::Reg,
+) -> Option<Result<Vec<crate::rules::ArmOp>, &'static str>> {
+    Some(match op {
+        WasmOp::I64Mul => generated::rule_i64_mul(rd_lo, rd_hi, rn_lo, rn_hi, rm_lo, rm_hi),
+        WasmOp::I64Shl => generated::rule_i64_shl(rd_lo, rd_hi, rn_lo, rn_hi, rm_lo, rm_hi),
+        WasmOp::I64ShrU => generated::rule_i64_shr_u(rd_lo, rd_hi, rn_lo, rn_hi, rm_lo, rm_hi),
+        WasmOp::I64ShrS => generated::rule_i64_shr_s(rd_lo, rd_hi, rn_lo, rn_hi, rm_lo, rm_hi),
+        _ => return None,
+    })
+}
+
+/// Dispatch an i64 rotate op (`i64.rotl/rotr`) to its generated Rocq-proved
+/// single-pseudo-op rule (VCR-ISA-001 wave-2). The rotate amount is a SINGLE
+/// register (`shift`, the low half of the i64 amount). Single `rd_hi <> rd_lo`
+/// side condition; violation is a loud `Err`.
+pub fn i64_rot_rule(
+    op: &WasmOp,
+    rd_lo: crate::rules::Reg,
+    rd_hi: crate::rules::Reg,
+    rn_lo: crate::rules::Reg,
+    rn_hi: crate::rules::Reg,
+    shift: crate::rules::Reg,
+) -> Option<Result<Vec<crate::rules::ArmOp>, &'static str>> {
+    Some(match op {
+        WasmOp::I64Rotl => generated::rule_i64_rotl(rd_lo, rd_hi, rn_lo, rn_hi, shift),
+        WasmOp::I64Rotr => generated::rule_i64_rotr(rd_lo, rd_hi, rn_lo, rn_hi, shift),
+        _ => return None,
+    })
+}
+
 /// Render a struct field, using field-init shorthand when the bound variable
 /// name matches the field name (keeps the generated file rustfmt/clippy-clean).
 fn field(name: &str, var: RegVar) -> String {
@@ -1272,6 +1550,78 @@ fn template_expr(t: &TemplateOp, indent: usize) -> String {
                 field("rm_lo", rm_lo),
                 field("rm_hi", rm_hi),
                 cond.rust_name()
+            )
+        }
+        TemplateOp::I64PairBin {
+            kind,
+            rd_lo,
+            rd_hi,
+            rn_lo,
+            rn_hi,
+            rm_lo,
+            rm_hi,
+        } => {
+            let variant = match kind {
+                I64PairBinKind::Mul => "I64Mul",
+                I64PairBinKind::Shl => "I64Shl",
+                I64PairBinKind::ShrU => "I64ShrU",
+                I64PairBinKind::ShrS => "I64ShrS",
+            };
+            let ind = " ".repeat(indent);
+            let fld = " ".repeat(indent + 4);
+            format!(
+                "ArmOp::{variant} {{\n{fld}{},\n{fld}{},\n{fld}{},\n{fld}{},\n{fld}{},\n\
+                 {fld}{},\n{ind}}}",
+                field("rd_lo", rd_lo),
+                field("rd_hi", rd_hi),
+                field("rn_lo", rn_lo),
+                field("rn_hi", rn_hi),
+                field("rm_lo", rm_lo),
+                field("rm_hi", rm_hi),
+            )
+        }
+        TemplateOp::I64PairRot {
+            left,
+            rd_lo,
+            rd_hi,
+            rn_lo,
+            rn_hi,
+            shift,
+        } => {
+            let variant = if left { "I64Rotl" } else { "I64Rotr" };
+            let ind = " ".repeat(indent);
+            let fld = " ".repeat(indent + 4);
+            format!(
+                "ArmOp::{variant} {{\n{fld}{},\n{fld}{},\n{fld}{},\n{fld}{},\n{fld}{},\n{ind}}}",
+                field("rdlo", rd_lo),
+                field("rdhi", rd_hi),
+                field("rnlo", rn_lo),
+                field("rnhi", rn_hi),
+                field("shift", shift),
+            )
+        }
+        TemplateOp::I64UnaryCount {
+            kind,
+            rd,
+            rn_lo,
+            rn_hi,
+        } => {
+            let variant = match kind {
+                I64CountKind::Clz => "I64Clz",
+                I64CountKind::Ctz => "I64Ctz",
+                I64CountKind::Popcnt => "I64Popcnt",
+            };
+            // The ArmOp field names (`rnlo`/`rnhi`) differ from the RegVar
+            // rust_names (`rn_lo`/`rn_hi`), so the fields render as
+            // `rnlo: rn_lo` (not shorthand) — rustfmt explodes the literal, so
+            // emit the exploded multi-line form directly to stay a fixpoint.
+            let ind = " ".repeat(indent);
+            let fld = " ".repeat(indent + 4);
+            format!(
+                "ArmOp::{variant} {{\n{fld}{},\n{fld}{},\n{fld}{},\n{ind}}}",
+                field("rd", rd),
+                field("rnlo", rn_lo),
+                field("rnhi", rn_hi),
             )
         }
         TemplateOp::Mul { rd, rn, rm } => format!(
@@ -1574,6 +1924,66 @@ fn coq_instrs(t: &TemplateOp) -> Vec<String> {
             r(rm_hi),
             cond.coq_condition()
         )],
+        TemplateOp::I64PairBin {
+            kind,
+            rd_lo,
+            rd_hi,
+            rn_lo,
+            rn_hi,
+            rm_lo,
+            rm_hi,
+        } => {
+            let ctor = match kind {
+                I64PairBinKind::Mul => "I64MulPseudo",
+                I64PairBinKind::Shl => "I64ShlPseudo",
+                I64PairBinKind::ShrU => "I64ShrUPseudo",
+                I64PairBinKind::ShrS => "I64ShrSPseudo",
+            };
+            vec![format!(
+                "{ctor} {} {} {} {} {} {}",
+                r(rd_lo),
+                r(rd_hi),
+                r(rn_lo),
+                r(rn_hi),
+                r(rm_lo),
+                r(rm_hi)
+            )]
+        }
+        TemplateOp::I64PairRot {
+            left,
+            rd_lo,
+            rd_hi,
+            rn_lo,
+            rn_hi,
+            shift,
+        } => {
+            let ctor = if left {
+                "I64RotlPseudo"
+            } else {
+                "I64RotrPseudo"
+            };
+            vec![format!(
+                "{ctor} {} {} {} {} {}",
+                r(rd_lo),
+                r(rd_hi),
+                r(rn_lo),
+                r(rn_hi),
+                r(shift)
+            )]
+        }
+        TemplateOp::I64UnaryCount {
+            kind,
+            rd,
+            rn_lo,
+            rn_hi,
+        } => {
+            let ctor = match kind {
+                I64CountKind::Clz => "I64ClzPseudo",
+                I64CountKind::Ctz => "I64CtzPseudo",
+                I64CountKind::Popcnt => "I64PopcntPseudo",
+            };
+            vec![format!("{ctor} {} {} {}", r(rd), r(rn_lo), r(rn_hi))]
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Wave-2 extension of the **VCR-ISA-001** "generate, don't mirror" Rocq ISA model (#667 lineage, #242 epic): add the nine single-pseudo-op i64 register-pair shapes the selector already emits but were DSL-uncovered — **41 → 50 rules / Qed**.

New ops (each a single flat-model pseudo-op with a fixed-register ancestor in `CorrectnessI64.v`, so the DSL work is pure register-generalization + re-export, exactly like `i64.eqz` #767):

| family | ops | pseudo-op |
|---|---|---|
| unary bit counts | `i64.clz` / `i64.ctz` / `i64.popcnt` | `I64{Clz,Ctz,Popcnt}Pseudo` |
| binary pairs | `i64.mul` / `i64.shl` / `i64.shr_u` / `i64.shr_s` | `I64{Mul,Shl,ShrU,ShrS}Pseudo` |
| rotates | `i64.rotl` / `i64.rotr` | `I64{Rotl,Rotr}Pseudo` |

## Architecture (#667)

The shipped `sel_dsl::RULES` table EMITS `VcrSelRulesGenerated.v` (`Module Gen`) + `generated.rs`; `VcrSelRules.v` DEFINES `rule_X := Gen.rule_X` and states the 9 new correctness Qed directly about the generated sequences. A table change regenerates `Gen` and breaks the matching proof — **drift is unrepresentable at the instruction-sequence level**. Demonstrated: flipping `Gen.rule_i64_mul` from `I64MulPseudo` to `I64ShlPseudo` makes `rule_i64_mul_correct` fail to compile (`//coq:rocq_proofs FAILED TO BUILD`); reverted.

## Side conditions (minimal, and correct)

Each pseudo-op reads every operand half into a local BEFORE any `set_reg`, so:
- unary counts: **none** (`rd` may alias `rn_lo` — the `R0,R0,R1` in-place emit is admitted);
- binary pairs / rotates: a **single** `rd_hi <> rd_lo` (the high write must not destroy the low result word).

NOT the increment-3 three-condition pair set — those were flags-coupled ADDS+ADC pairs. Every `select_with_stack` emit site uses `alloc_consecutive_pair`, so `rd_hi <> rd_lo` holds by construction. Statements are value-level like the `i64.eqz` ancestor (no `exec_wasm_instr` hypothesis — the i64 ops aren't in `WasmSemantics.v`); shift/rotate count is the low half only (`combine_i32 cnt I32.zero`), matching the `_bits_spec` axioms.

## Verification

- **Rocq green**: `bazel test //coq:verify_proofs` — `//coq:rocq_proofs` + `//coq:vcr_sel_rules_coverage` both PASS (all 50 rules, 50 Qed, 0 Admitted in the rule table).
- **Drift-guard**: flipping a generated rule breaks its Qed (shown above).
- **Byte-invisibility**: `SYNTH_NO_SEL_DSL=1` vs default is bit-identical for these ops — mirror-pinned by `sel_dsl_mirror_pin_i64_pair_rules_select_with_stack_242`, extended with dedicated count/rotate/pair-bin probe windows (probed 16→25, each a byte-equality assert). The nine `select_default` blind arms are the holdout, unchanged (`Delegation::SelectWithStack`).
- **No regression**: frozen anchors (`cargo test -p synth-cli --test frozen_codegen_bytes`) 10/10 intact; `cargo test -p synth-synthesis --lib` 624/624.
- **Claim gate**: `python3 scripts/claim_check.py claims.yaml` → **19/19 hold** (476→485 Qed, 41→50 rules, STATUS coverage 26%→32%).
- fmt + `clippy --workspace --all-targets -D warnings` clean.

Refs #667 (VCR-ISA-001), #242. Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L