### PR TITLE
feat(#396): synth-provenance-v1 branch-transformation map + reconciliation gate (VCR-DEC-003)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,36 @@ jobs:
       - name: Run two-move execution oracle
         run: python scripts/repro/cmp_select_two_move_differential.py
 
+  provenance-gate:
+    name: synth-provenance-v1 reconciliation gate (#396)
+    # VCR-DEC-003 (#396, witness#130): the source-to-object branch-transformation
+    # map. Compiles a fixture that FOLDS (select->IT predication) and SPLITS
+    # (br_table) branches, then reconciles every REAL object conditional branch
+    # (from the BranchMap side-table) back to its source WASM condition. The gate
+    # is the non-vacuous check that a folded/eliminated condition is recorded AS
+    # folded with its object realization, never silently dropped. Runs in the
+    # workspace test set too, but named here so a provenance regression is a
+    # visible, self-describing red — witness's MC/DC object-certification depends
+    # on this contract holding.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Run reconciliation gate + emitter unit tests
+        run: |
+          cargo test -p synth-cli --test provenance_reconciliation_396
+          cargo test -p synth-core --lib provenance
+
   aarch64-oracle:
     name: aarch64 backend execution + decline oracle (#538 m2)
     # #538 milestone-2: the host-native A64 backend broadened from the m1 i32

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -1727,24 +1727,31 @@ artifacts:
       the ARM `line_map` and a new object-branch side-table `BranchMap`
       (`crate::backend::BranchClass`, captured at the ARM encode loop parallel to
       `line_map` — the one datum post-hoc CLI derivation could not recover: which
-      emitted instruction IS a conditional branch vs a predicated move). Covered
-      kinds (BOUNDED v1): `preserved` (br_if/br), `folded-predication` (select →
-      IT-block predicated move, no branch), `split-into-object-branches`
-      (br_table, `count` = object branches), `eliminated-constant` (fact-spec-
-      dropped source branch, derived from the `kept` set). Every entry carries its
-      object realization (`object_pcs`), and a per-function `object_cond_branches`
-      list reconciles every REAL object conditional branch back to its source
-      condition — an object branch no covered source op explains is surfaced with
-      `resolved: false` + a note (i64-expansion / trap-guard), NOT hidden. The
-      reconciliation gate (`provenance_reconciliation_396`, CI job
-      `provenance-gate`) is non-vacuous: it asserts clauses (a) every object cond
-      branch resolves and (b) the folded select is recorded folded with its
-      predicated object PC — verified RED under an adversarial mislabel of
-      SelectMove. FOLLOW-UP (uncovered in v1, named): the optimized `ir_to_arm`
-      path still sets `source_line: None` so its `branch_map` is unpopulated
-      (ARM direct + Thumb selector path covered); i64-expansion/trap-guard object
-      branches are surfaced-unresolved rather than reconciled; RISC-V/AArch64
-      carry no `branch_map`; witness#130 `object-disposition` end-to-end compose.
+      emitted instruction IS a conditional branch vs a predicated move).
+      GATE-EXERCISED kinds (BOUNDED v1): `preserved` (br_if/br),
+      `folded-predication` (select → IT-block predicated move, no branch),
+      `split-into-object-branches` (br_table, `count` = object branches) — all
+      three asserted on the reconciliation fixture. `eliminated-constant`
+      (fact-spec-dropped source branch, derived from the `kept` set) is WIRED in
+      the schema + emitter with the correct byte-offset join key, but not yet
+      gate-exercised (fact-spec deletions today are pure condition slices +
+      proven-dead `if` regions; a fixture that drops a covered branch op is a v1
+      follow-up). Every entry carries its object realization (`object_pcs`), and a
+      per-function `object_cond_branches` list reconciles every REAL object
+      conditional branch back to its source condition — an object branch no
+      covered source op explains is surfaced with `resolved: false` + a note
+      (i64-expansion / trap-guard), NOT hidden. The reconciliation gate
+      (`provenance_reconciliation_396`, CI job `provenance-gate`) is non-vacuous:
+      it asserts clauses (a) every object cond branch resolves and (b) the folded
+      select is recorded folded with its predicated object PC — verified RED under
+      an adversarial mislabel of SelectMove. FOLLOW-UP (uncovered in v1, named):
+      the optimized `ir_to_arm` path may drop `source_line` on some op shapes
+      (verified: this fixture keeps it on both the direct AND optimized paths) —
+      a function whose `line_map` came back all-None is LOUD-DECLINED from the
+      sidecar (warn + skip) rather than mislabeled; i64-expansion/trap-guard
+      object branches are surfaced-unresolved rather than reconciled; RISC-V/
+      AArch64 carry no `branch_map`; the eliminated-constant fixture; witness#130
+      `object-disposition` end-to-end compose.
     status: implemented
     tags: [witness, mcdc, traceability, provenance, vcr-dbg, decision, integration]
     links:

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -1719,13 +1719,33 @@ artifacts:
       synth lowers it; if witness re-serializes via walrus, the `InstrLocId`s must
       refer to the bytes synth then compiles).
 
-      Remaining = the EMITTER milestone (purely synth-internal): thread a per-branch
-      transformation label through BOTH lowering paths (optimized `ir_to_arm`
-      currently sets `source_line: None` — provenance is dropped there today; the
-      direct selector carries it) and serialize `synth-provenance-v1` behind a CLI
-      flag (frozen-safe: additive output file, no `.text` change). NOT in scope for
-      the contract-settling step; tracked as the VCR-DBG/witness follow-up.
-    status: proposed
+      EMITTER MILESTONE — LANDED (v0.45.0, PR feat/45-396-mcdc-provenance). The
+      `synth-provenance-v1` map is emitted behind `--emit-provenance` as a JSON
+      sidecar (`<output>.provenance.json`), frozen-safe (ELF byte-identical with
+      and without the flag, verified on control_step.wasm). The emitter derives
+      provenance POST-HOC at the CLI from the compiled op stream + `op_offsets` +
+      the ARM `line_map` and a new object-branch side-table `BranchMap`
+      (`crate::backend::BranchClass`, captured at the ARM encode loop parallel to
+      `line_map` — the one datum post-hoc CLI derivation could not recover: which
+      emitted instruction IS a conditional branch vs a predicated move). Covered
+      kinds (BOUNDED v1): `preserved` (br_if/br), `folded-predication` (select →
+      IT-block predicated move, no branch), `split-into-object-branches`
+      (br_table, `count` = object branches), `eliminated-constant` (fact-spec-
+      dropped source branch, derived from the `kept` set). Every entry carries its
+      object realization (`object_pcs`), and a per-function `object_cond_branches`
+      list reconciles every REAL object conditional branch back to its source
+      condition — an object branch no covered source op explains is surfaced with
+      `resolved: false` + a note (i64-expansion / trap-guard), NOT hidden. The
+      reconciliation gate (`provenance_reconciliation_396`, CI job
+      `provenance-gate`) is non-vacuous: it asserts clauses (a) every object cond
+      branch resolves and (b) the folded select is recorded folded with its
+      predicated object PC — verified RED under an adversarial mislabel of
+      SelectMove. FOLLOW-UP (uncovered in v1, named): the optimized `ir_to_arm`
+      path still sets `source_line: None` so its `branch_map` is unpopulated
+      (ARM direct + Thumb selector path covered); i64-expansion/trap-guard object
+      branches are surfaced-unresolved rather than reconciled; RISC-V/AArch64
+      carry no `branch_map`; witness#130 `object-disposition` end-to-end compose.
+    status: implemented
     tags: [witness, mcdc, traceability, provenance, vcr-dbg, decision, integration]
     links:
       - type: derives-from

--- a/crates/synth-backend-aarch64/src/backend.rs
+++ b/crates/synth-backend-aarch64/src/backend.rs
@@ -95,6 +95,8 @@ impl Backend for AArch64Backend {
             relocations: Vec::new(),
             // AArch64 DWARF `.debug_line` is a later milestone (pairs with #394).
             line_map: Vec::new(),
+            // VCR-DEC-003 (#396): provenance is ARM(Thumb)-only in v1.
+            branch_map: Vec::new(),
         })
     }
 

--- a/crates/synth-backend-riscv/src/backend.rs
+++ b/crates/synth-backend-riscv/src/backend.rs
@@ -195,6 +195,8 @@ fn compile_function_with_opts(
         // RISC-V DWARF `.debug_line` emission is a VCR-DBG-001 follow-up; no
         // source map produced yet (empty ⇒ the emitter skips this backend).
         line_map: Vec::new(),
+        // VCR-DEC-003 (#396): provenance is ARM-only in v1 (empty ⇒ skipped).
+        branch_map: Vec::new(),
     })
 }
 
@@ -449,6 +451,7 @@ mod tests {
             wasm_ops: ops.clone(),
             relocations: Vec::new(),
             line_map: Vec::new(),
+            branch_map: Vec::new(),
         };
         let cfg = CompileConfig {
             target: TargetSpec::riscv32imac(),

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -154,7 +154,7 @@ impl Backend for ArmBackend {
         ops: &[WasmOp],
         config: &CompileConfig,
     ) -> Result<CompiledFunction, BackendError> {
-        let (code, relocations, line_map) =
+        let (code, relocations, line_map, branch_map) =
             compile_wasm_to_arm(ops, config).map_err(BackendError::CompilationFailed)?;
 
         Ok(CompiledFunction {
@@ -163,6 +163,7 @@ impl Backend for ArmBackend {
             wasm_ops: ops.to_vec(),
             relocations,
             line_map,
+            branch_map,
         })
     }
 
@@ -293,7 +294,15 @@ fn has_value_carrying_branch(wasm_ops: &[WasmOp], block_arity: &[(u8, u8)]) -> b
 fn compile_wasm_to_arm(
     wasm_ops: &[WasmOp],
     config: &CompileConfig,
-) -> Result<(Vec<u8>, Vec<CodeRelocation>, LineMap), String> {
+) -> Result<
+    (
+        Vec<u8>,
+        Vec<CodeRelocation>,
+        LineMap,
+        synth_core::backend::BranchMap,
+    ),
+    String,
+> {
     // #539: `memory.grow(0)` must return the CURRENT page count, not the
     // fixed-memory `-1` sentinel — growing by zero pages can never fail (WASM
     // Core §4.4.7), so a guest doing `if (memory.grow(0) < 0) trap;` wrongly
@@ -1312,6 +1321,9 @@ fn compile_wasm_to_arm(
     // the end; the LDR patch below is in-place/length-preserving). Purely
     // additive: it does not touch `code`, so `.text` is byte-identical.
     let mut line_map: LineMap = Vec::new();
+    // VCR-DEC-003 (#396): object-branch class per emitted instruction, parallel
+    // to `line_map`. Cheap, additive, does not touch `code`.
+    let mut branch_map: synth_core::backend::BranchMap = Vec::new();
 
     for instr in &arm_instrs {
         // Record a relocation for every BL: the encoder emits `bl #0` and
@@ -1357,6 +1369,7 @@ fn compile_wasm_to_arm(
         // The machine offset of this instruction is the current code length,
         // captured before the bytes are appended.
         line_map.push((code.len() as u32, instr.source_line));
+        branch_map.push((code.len() as u32, classify_arm_branch(&instr.op)));
 
         let encoded = encoder
             .encode(&instr.op)
@@ -1416,7 +1429,24 @@ fn compile_wasm_to_arm(
         }
     }
 
-    Ok((code, relocations, line_map))
+    Ok((code, relocations, line_map, branch_map))
+}
+
+/// VCR-DEC-003 (#396): classify one emitted `ArmOp` into its object-level
+/// control-flow role for the `synth-provenance-v1` map. Conditional branches are
+/// the object decision points MC/DC must reconcile; `SelectMove` is the folded
+/// (IT-block) predicated form the cmp→select fuse produces — a decision with no
+/// branch.
+fn classify_arm_branch(op: &ArmOp) -> synth_core::backend::BranchClass {
+    use synth_core::backend::BranchClass;
+    match op {
+        ArmOp::Bcc { .. } | ArmOp::Bhs { .. } | ArmOp::Blo { .. } | ArmOp::BCondOffset { .. } => {
+            BranchClass::CondBranch
+        }
+        ArmOp::B { .. } | ArmOp::BOffset { .. } => BranchClass::UncondBranch,
+        ArmOp::SelectMove { .. } => BranchClass::Predicated,
+        _ => BranchClass::Other,
+    }
 }
 
 /// Resolve local label branches to byte-accurate offsets (#202).

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -3065,33 +3065,62 @@ fn compile_all_exports(
         // VCR-DEC-003 (#396): derive this function's branch-transformation map
         // from the ops it compiled + the ARM line_map/branch_map it produced.
         if let Some(pm) = provenance_map.as_mut() {
-            // Eliminated-constant: original-stream branch/condition ops the
-            // fact-spec dropped (present in func.ops, absent from `kept`).
-            let eliminated: Vec<(usize, String)> = match &spec {
-                Some(s) => {
-                    let kept: std::collections::HashSet<usize> = s.kept.iter().copied().collect();
-                    func.ops
-                        .iter()
-                        .enumerate()
-                        .filter(|(i, _)| !kept.contains(i))
-                        .filter_map(|(i, op)| {
-                            synth_core::provenance::covered_source_op_name(op)
-                                .map(|n| (i, n.to_string()))
-                        })
-                        .collect()
-                }
-                None => Vec::new(),
-            };
-            pm.functions
-                .push(synth_core::provenance::derive_function_provenance(
-                    func.index,
-                    &name,
-                    ops_for_compile,
-                    &op_offsets_for_elf,
-                    &compiled.line_map,
-                    &compiled.branch_map,
-                    &eliminated,
-                ));
+            // Loud-decline (frozen-safe: only affects the sidecar): a lowering
+            // path that dropped source_line (the optimized `ir_to_arm` on some
+            // op shapes) yields an all-`None` line_map. Object branches then
+            // cannot be reconciled to a source condition — emitting entries
+            // anyway would be a map that LIES to witness. Warn and skip this
+            // function rather than serialize a misleading one.
+            let has_branch = compiled
+                .branch_map
+                .iter()
+                .any(|(_, c)| *c == synth_core::backend::BranchClass::CondBranch);
+            let all_none = !compiled.line_map.is_empty()
+                && compiled.line_map.iter().all(|(_, oi)| oi.is_none());
+            if has_branch && all_none {
+                eprintln!(
+                    "warning: provenance: skipping '{name}' — its lowering path carries no \
+                     source map (line_map all-None), so object branches cannot be reconciled \
+                     to source conditions (VCR-DEC-003 v1 covers the ARM direct/Thumb selector \
+                     path; #396 follow-up: optimized ir_to_arm source_line)"
+                );
+            } else {
+                // Eliminated-constant: original-stream branch/condition ops the
+                // fact-spec dropped (present in func.ops, absent from `kept`).
+                // The join key is the ORIGINAL-stream byte offset (func.op_offsets
+                // is unfiltered; `orig_idx` indexes it directly).
+                let eliminated: Vec<(usize, String, u32)> = match &spec {
+                    Some(s) => {
+                        let kept: std::collections::HashSet<usize> =
+                            s.kept.iter().copied().collect();
+                        func.ops
+                            .iter()
+                            .enumerate()
+                            .filter(|(i, _)| !kept.contains(i))
+                            .filter_map(|(i, op)| {
+                                synth_core::provenance::covered_source_op_name(op).map(|n| {
+                                    (
+                                        i,
+                                        n.to_string(),
+                                        func.op_offsets.get(i).copied().unwrap_or(0),
+                                    )
+                                })
+                            })
+                            .collect()
+                    }
+                    None => Vec::new(),
+                };
+                pm.functions
+                    .push(synth_core::provenance::derive_function_provenance(
+                        func.index,
+                        &name,
+                        ops_for_compile,
+                        &op_offsets_for_elf,
+                        &compiled.line_map,
+                        &compiled.branch_map,
+                        &eliminated,
+                    ));
+            }
         }
 
         if !compiled.relocations.is_empty() {

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -397,6 +397,19 @@ enum Commands {
         #[arg(long)]
         debug_line: bool,
 
+        /// VCR-DEC-003 (#396, witness#130): emit the `synth-provenance-v1`
+        /// branch-transformation map as a JSON sidecar next to the output
+        /// (`<output>.provenance.json`). For each source WASM branch/condition it
+        /// records what object branch(es)/predicated-instruction(s) it became —
+        /// preserved (br_if/br), folded-predication (select→IT move),
+        /// split-into-object-branches (br_table), eliminated-constant — plus the
+        /// real object conditional branches reconciled back to their source
+        /// condition. witness's MC/DC reconciler consumes it to certify the
+        /// OBJECT. Purely additive: `.text` is byte-identical; off by default.
+        /// ARM(Thumb) only in v1 (RISC-V/AArch64 carry no branch_map).
+        #[arg(long)]
+        emit_provenance: bool,
+
         /// #543 (Phase 1): mark a linear-memory segment as VOLATILE — the DMA
         /// transfer window. Format `<base>:<len>`; both accept hex (`0x…`) or
         /// decimal, e.g. `--volatile-segment 0x20001000:4096`. Repeatable to mark
@@ -553,6 +566,7 @@ fn main() -> Result<()> {
             sign_output,
             shadow_stack_size,
             debug_line,
+            emit_provenance,
             volatile_segment,
             stack_layout,
             stack_size,
@@ -606,6 +620,7 @@ fn main() -> Result<()> {
                 sign_output,
                 shadow_stack_size,
                 debug_line,
+                emit_provenance,
                 volatile_segments,
                 stack_layout,
             )?;
@@ -1337,6 +1352,9 @@ fn compile_command(
     shadow_stack_size: Option<u32>,
     // VCR-DBG-001 step 4 (#394): `--debug-line` — emit `.debug_line` DWARF.
     debug_line: bool,
+    // VCR-DEC-003 (#396): `--emit-provenance` — write the synth-provenance-v1
+    // branch-transformation JSON sidecar.
+    emit_provenance: bool,
     // #543 Phase 1: integrator-marked volatile DMA-window ranges. Threaded to the
     // CompileConfig; not yet consumed (Phase 2 is the gated codegen back-off).
     volatile_segments: Vec<VolatileRange>,
@@ -1391,6 +1409,7 @@ fn compile_command(
             sign_output,
             shadow_stack_size,
             debug_line,
+            emit_provenance,
             volatile_segments,
             stack_layout,
         );
@@ -2430,6 +2449,8 @@ fn compile_all_exports(
     // VCR-DBG-001 step 4 (#394): emit a `.debug_line` section from the input
     // wasm's DWARF + the ARM line_maps. Default off ⇒ output byte-identical.
     debug_line: bool,
+    // VCR-DEC-003 (#396): write the synth-provenance-v1 JSON sidecar.
+    emit_provenance: bool,
     // #543 Phase 1: integrator-marked volatile DMA-window ranges. Threaded to the
     // CompileConfig; not yet consumed (Phase 2 is the gated codegen back-off).
     volatile_segments: Vec<VolatileRange>,
@@ -2440,6 +2461,15 @@ fn compile_all_exports(
     let path = input.context("--all-exports requires an input file")?;
 
     info!("Compiling all exports from: {}", path.display());
+
+    // VCR-DEC-003 (#396): accumulate the branch-transformation map across
+    // functions as they compile, then serialize the sidecar at the end.
+    let module_name = path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "module".to_string());
+    let mut provenance_map =
+        emit_provenance.then(|| synth_core::provenance::ProvenanceMap::new(module_name));
 
     let file_bytes =
         std::fs::read(&path).context(format!("Failed to read input file: {}", path.display()))?;
@@ -3032,6 +3062,38 @@ fn compile_all_exports(
         };
         info!("  {} bytes of machine code", compiled.code.len());
 
+        // VCR-DEC-003 (#396): derive this function's branch-transformation map
+        // from the ops it compiled + the ARM line_map/branch_map it produced.
+        if let Some(pm) = provenance_map.as_mut() {
+            // Eliminated-constant: original-stream branch/condition ops the
+            // fact-spec dropped (present in func.ops, absent from `kept`).
+            let eliminated: Vec<(usize, String)> = match &spec {
+                Some(s) => {
+                    let kept: std::collections::HashSet<usize> = s.kept.iter().copied().collect();
+                    func.ops
+                        .iter()
+                        .enumerate()
+                        .filter(|(i, _)| !kept.contains(i))
+                        .filter_map(|(i, op)| {
+                            synth_core::provenance::covered_source_op_name(op)
+                                .map(|n| (i, n.to_string()))
+                        })
+                        .collect()
+                }
+                None => Vec::new(),
+            };
+            pm.functions
+                .push(synth_core::provenance::derive_function_provenance(
+                    func.index,
+                    &name,
+                    ops_for_compile,
+                    &op_offsets_for_elf,
+                    &compiled.line_map,
+                    &compiled.branch_map,
+                    &eliminated,
+                ));
+        }
+
         if !compiled.relocations.is_empty() {
             info!(
                 "  {} relocations (external symbol references)",
@@ -3356,7 +3418,27 @@ fn compile_all_exports(
         output.display()
     );
 
+    // VCR-DEC-003 (#396): write the synth-provenance-v1 sidecar next to the
+    // output (`<output>.provenance.json`). Additive; the ELF is unchanged.
+    if let Some(pm) = provenance_map {
+        let sidecar = provenance_sidecar_path(&output);
+        std::fs::write(&sidecar, pm.to_json())
+            .with_context(|| format!("Failed to write provenance map: {}", sidecar.display()))?;
+        println!(
+            "  Provenance: wrote {} ({} functions) — synth-provenance-v1",
+            sidecar.display(),
+            pm.functions.len()
+        );
+    }
+
     Ok(())
+}
+
+/// VCR-DEC-003 (#396): `<output>` → `<output>.provenance.json`.
+fn provenance_sidecar_path(output: &std::path::Path) -> PathBuf {
+    let mut s = output.as_os_str().to_os_string();
+    s.push(".provenance.json");
+    PathBuf::from(s)
 }
 
 /// Build a simple multi-function ELF

--- a/crates/synth-cli/tests/provenance_reconciliation_396.rs
+++ b/crates/synth-cli/tests/provenance_reconciliation_396.rs
@@ -1,0 +1,212 @@
+//! VCR-DEC-003 (#396, witness#130) — the `synth-provenance-v1` reconciliation gate.
+//!
+//! This is the NON-VACUOUS half of the lane. It compiles a multi-branch fixture
+//! that FOLDS and SPLITS branches (a `select` fused to a predicated IT-block
+//! move, and a `br_table` split into N object branches), then parses the emitted
+//! `synth-provenance-v1` sidecar as an INDEPENDENT consumer (like witness's
+//! reconciler would) and asserts the two properties #396 exists to guarantee:
+//!
+//!   (a) every object-level conditional branch resolves to a source WASM
+//!       condition — checked against the map's `object_cond_branches` list,
+//!       which synth derives from the REAL object-branch side-table
+//!       (`BranchMap`), NOT by re-walking the wasm branch ops (that would be
+//!       vacuous — it could never catch a branch it didn't already expect);
+//!
+//!   (b) a folded/eliminated source condition is explicitly recorded as folded
+//!       with its object realization (the predicated instruction) — NOT silently
+//!       dropped.
+//!
+//! Plus the coverage the fixture guarantees: the map carries a `preserved`
+//! br_if, a `folded-predication` select, and a `split-into-object-branches`
+//! br_table, each with a non-empty object realization.
+//!
+//! The fusion flag (`SYNTH_CMP_SELECT_FUSE=1`) is REQUIRED for the fold to fire;
+//! the test drives it explicitly and then PROVES the fold actually happened
+//! (folded-predication entry present with predicated object PCs, and NO object
+//! conditional branch traces back to the select) — so it tests a real fold, not
+//! a mislabeled preserved branch.
+
+use serde_json::Value;
+use std::process::Command;
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture(name: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro")
+        .join(name)
+}
+
+/// Compile the fixture with fusion + provenance on; return the parsed map.
+fn compile_and_parse_provenance(fix: &str, out_stem: &str) -> Value {
+    let path = fixture(fix);
+    let out = format!("/tmp/{out_stem}.elf");
+    let sidecar = format!("/tmp/{out_stem}.elf.provenance.json");
+    let _ = std::fs::remove_file(&sidecar);
+
+    let res = Command::new(synth())
+        .env("SYNTH_CMP_SELECT_FUSE", "1")
+        .args([
+            "compile",
+            path.to_str().unwrap(),
+            "-o",
+            &out,
+            "--target",
+            "cortex-m4",
+            "--all-exports",
+            "--relocatable",
+            "--emit-provenance",
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        res.status.success(),
+        "synth compile failed for {fix}: {}",
+        String::from_utf8_lossy(&res.stderr)
+    );
+
+    let bytes = std::fs::read(&sidecar)
+        .unwrap_or_else(|e| panic!("provenance sidecar {sidecar} not written: {e}"));
+    serde_json::from_slice(&bytes).expect("sidecar is valid JSON")
+}
+
+/// The whole-lane reconciliation gate.
+#[test]
+fn provenance_reconciles_folded_and_split_branches_396() {
+    let map = compile_and_parse_provenance("provenance_branches_396.wat", "prov_recon_396");
+
+    // Schema pin — witness keys off this exact version string.
+    assert_eq!(
+        map["schema"], "synth-provenance-v1",
+        "schema string is the witness contract; do not change without coordinating witness#130"
+    );
+
+    let funcs = map["functions"].as_array().expect("functions array");
+    assert_eq!(funcs.len(), 1, "fixture has one exported function");
+    let f = &funcs[0];
+    let entries = f["entries"].as_array().expect("entries array");
+
+    // Collect entries by kind.
+    let by_kind = |k: &str| -> Vec<&Value> { entries.iter().filter(|e| e["kind"] == k).collect() };
+    let preserved = by_kind("preserved");
+    let folded = by_kind("folded-predication");
+    let split = by_kind("split-into-object-branches");
+
+    // --- Coverage: all three covered transformations are present. ---
+    assert!(
+        !preserved.is_empty(),
+        "expected a preserved br_if/br entry — got kinds {:?}",
+        entries.iter().map(|e| &e["kind"]).collect::<Vec<_>>()
+    );
+    assert!(
+        !folded.is_empty(),
+        "expected a folded-predication (select) entry — the FOLD must have fired \
+         (SYNTH_CMP_SELECT_FUSE=1). Got kinds {:?}",
+        entries.iter().map(|e| &e["kind"]).collect::<Vec<_>>()
+    );
+    assert!(
+        !split.is_empty(),
+        "expected a split-into-object-branches (br_table) entry"
+    );
+
+    // --- (b) The folded condition is recorded AS folded, with its object
+    //         realization (the predicated instruction) — NOT missing. ---
+    for e in &folded {
+        assert_eq!(
+            e["op"], "Select",
+            "folded-predication must originate at a select"
+        );
+        let pcs = e["object_pcs"].as_array().expect("object_pcs array");
+        assert!(
+            !pcs.is_empty(),
+            "a folded select must carry its object realization (the predicated move), \
+             not an empty realization — entry {e}"
+        );
+        // The witness join key is present and plausible.
+        assert!(
+            e["instruction_offset"].is_number(),
+            "folded entry must carry the wasm byte-offset join key: {e}"
+        );
+    }
+
+    // Prove the fold is a REAL fold, not a mislabeled branch: no object
+    // conditional branch may trace back to a select op index. (A select that did
+    // NOT fold would appear as an object branch here.)
+    let ocbs = f["object_cond_branches"]
+        .as_array()
+        .expect("object_cond_branches array");
+    let select_op_indices: std::collections::HashSet<i64> = folded
+        .iter()
+        .map(|e| e["wasm_op_index"].as_i64().unwrap())
+        .collect();
+    for b in ocbs {
+        if let Some(idx) = b["wasm_op_index"].as_i64() {
+            assert!(
+                !select_op_indices.contains(&idx),
+                "an object conditional branch traces back to a folded select (op {idx}) — \
+                 the fuse did not actually fold; the folded-predication label would be a lie"
+            );
+        }
+    }
+
+    // --- split: count present and object realization non-empty. ---
+    for e in &split {
+        assert_eq!(e["op"], "BrTable");
+        assert!(
+            e["count"].as_u64().unwrap_or(0) >= 1,
+            "a br_table split must record its object-branch count: {e}"
+        );
+        assert!(
+            !e["object_pcs"].as_array().unwrap().is_empty(),
+            "a br_table split must carry its object branch PCs: {e}"
+        );
+    }
+
+    // --- (a) EVERY object-level conditional branch resolves to a source WASM
+    //         condition. This iterates the REAL object branches (not the wasm
+    //         ops), so it is the non-vacuous completeness check. Any unresolved
+    //         branch (i64-expansion / trap-guard) would be surfaced here with a
+    //         note — for THIS fixture there are none, and we assert that. ---
+    assert!(
+        !ocbs.is_empty(),
+        "fixture must produce at least one real object conditional branch to reconcile"
+    );
+    for b in ocbs {
+        let resolved = b["resolved"].as_bool().unwrap_or(false);
+        assert!(
+            resolved,
+            "object conditional branch at pc {} did NOT resolve to a source condition \
+             (note: {:?}). Every object branch must reconcile back — an unresolved branch \
+             is an only-in-synth divergence that must be covered or explicitly justified.",
+            b["pc"], b["note"]
+        );
+        // A resolved branch carries its source join key.
+        assert!(
+            b["instruction_offset"].is_number(),
+            "a resolved object branch must carry the wasm byte-offset of its source condition: {b}"
+        );
+    }
+
+    // --- Cross-check: every object cond branch's source op appears as a covered
+    //     entry of the right kind (br_if -> preserved, br_table -> split). This
+    //     is the source<->object correspondence #396 is about, both directions. ---
+    let entry_offsets_preserved: std::collections::HashSet<i64> = preserved
+        .iter()
+        .map(|e| e["instruction_offset"].as_i64().unwrap())
+        .collect();
+    let entry_offsets_split: std::collections::HashSet<i64> = split
+        .iter()
+        .map(|e| e["instruction_offset"].as_i64().unwrap())
+        .collect();
+    for b in ocbs {
+        let off = b["instruction_offset"].as_i64().unwrap();
+        assert!(
+            entry_offsets_preserved.contains(&off) || entry_offsets_split.contains(&off),
+            "object branch at wasm offset {off} has no matching source entry (preserved/split) — \
+             the reconciliation would be incomplete"
+        );
+    }
+}

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -500,6 +500,34 @@ pub struct CodeRelocation {
 /// was produced.
 pub type LineMap = Vec<(u32, Option<usize>)>;
 
+/// VCR-DEC-003 (#396, witness#130): the object-level control-flow class of one
+/// emitted machine instruction, captured at encode time alongside [`LineMap`].
+/// It is the piece post-hoc CLI derivation cannot recover — `line_map` records
+/// which wasm op an instruction came from, but not whether that instruction IS a
+/// conditional branch, an unconditional branch, or a predicated (IT-block) move.
+/// The `synth-provenance-v1` emitter needs it to enumerate the ACTUAL object
+/// conditional branches (so it can prove "every object branch resolves to a
+/// source condition", not just "every source branch has an object PC").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BranchClass {
+    /// A conditional branch (`Bcc`/`Blo`/`Bhs`/`BCondOffset`) — an object-level
+    /// decision point MC/DC must account for.
+    CondBranch,
+    /// An unconditional branch (`B`/`BOffset`) — control flow, not a decision.
+    UncondBranch,
+    /// A predicated conditional move (`SelectMove`, the IT-block form the
+    /// cmp→select fuse produces) — a folded decision with no branch.
+    Predicated,
+    /// Anything else (data-processing, load/store, call, prologue/epilogue).
+    Other,
+}
+
+/// VCR-DEC-003: per-instruction object-branch class, parallel to [`LineMap`]
+/// (same length, same order — one entry per emitted machine instruction).
+/// `(machine_offset_within_code, class)`. Empty when provenance is not being
+/// produced (never serialized into `.text`; frozen-safe additive metadata).
+pub type BranchMap = Vec<(u32, BranchClass)>;
+
 /// A single compiled function
 #[derive(Debug, Clone)]
 pub struct CompiledFunction {
@@ -520,6 +548,13 @@ pub struct CompiledFunction {
     /// byte-identical with or without it. Empty for backends/paths that do not
     /// yet produce a source map (RISC-V, the optimized ARM path).
     pub line_map: LineMap,
+    /// VCR-DEC-003 (#396): per-instruction object-branch class, parallel to
+    /// `line_map`. Lets the `synth-provenance-v1` emitter enumerate the real
+    /// object conditional branches (not just re-walk the wasm branch ops).
+    /// Purely additive metadata: never serialized into `.text`, so emitted bytes
+    /// are byte-identical with or without it. Empty for backends/paths that do
+    /// not produce it (RISC-V, the optimized ARM path).
+    pub branch_map: BranchMap,
 }
 
 /// Result of compiling a full module

--- a/crates/synth-core/src/lib.rs
+++ b/crates/synth-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod component;
 pub mod dwarf_line;
 pub mod error;
 pub mod ir;
+pub mod provenance;
 pub mod safety_manifest;
 pub mod sbom;
 pub mod target;

--- a/crates/synth-core/src/provenance.rs
+++ b/crates/synth-core/src/provenance.rs
@@ -147,6 +147,13 @@ impl ProvenanceMap {
     }
 }
 
+/// Is this a source op the map covers as a branch/condition? Returns its
+/// mnemonic if so. Public so the CLI can classify eliminated (fact-spec-dropped)
+/// ops with the SAME coverage predicate the emitter uses.
+pub fn covered_source_op_name(op: &WasmOp) -> Option<&'static str> {
+    source_op_name(op)
+}
+
 /// Is this a source op the map covers as a branch/condition?
 fn source_op_name(op: &WasmOp) -> Option<&'static str> {
     match op {

--- a/crates/synth-core/src/provenance.rs
+++ b/crates/synth-core/src/provenance.rs
@@ -171,8 +171,12 @@ fn source_op_name(op: &WasmOp) -> Option<&'static str> {
 ///   its per-op absolute wasm byte offsets, already fact-spec-filtered upstream).
 /// - `line_map` / `branch_map` are index-aligned (one entry per emitted machine
 ///   instruction: `(pc, wasm_op_index)` and `(pc, class)`).
-/// - `eliminated`: `(wasm_op_index_in_original_stream, op_name)` for branch/
-///   condition ops that constant-folding / fact-spec dropped before codegen.
+/// - `eliminated`: `(wasm_op_index_in_original_stream, op_name,
+///   absolute_wasm_byte_offset)` for branch/condition ops that constant-folding
+///   / fact-spec dropped before codegen. The offset is the ORIGINAL-stream byte
+///   offset (the witness join key), NOT derivable from `op_offsets` here (which
+///   is the filtered/kept table) — the caller looks it up in the unfiltered
+///   side-table.
 pub fn derive_function_provenance(
     func_index: u32,
     name: &str,
@@ -180,7 +184,7 @@ pub fn derive_function_provenance(
     op_offsets: &[u32],
     line_map: &LineMap,
     branch_map: &BranchMap,
-    eliminated: &[(usize, String)],
+    eliminated: &[(usize, String, u32)],
 ) -> FunctionProvenance {
     // For each op index, collect the object PCs whose branch_map class matters.
     // line_map and branch_map are parallel; zip them.
@@ -235,9 +239,9 @@ pub fn derive_function_provenance(
     }
 
     // Eliminated-constant entries: branch/condition ops dropped before codegen.
-    for (orig_idx, op_name) in eliminated {
+    for (orig_idx, op_name, byte_offset) in eliminated {
         entries.push(ProvEntry {
-            instruction_offset: 0,
+            instruction_offset: *byte_offset,
             wasm_op_index: *orig_idx,
             op: op_name.clone(),
             kind: ProvKind::EliminatedConstant,
@@ -365,10 +369,12 @@ mod tests {
             &op_offsets,
             &line_map,
             &branch_map,
-            &[(3, "BrIf".to_string())],
+            &[(3, "BrIf".to_string(), 42)],
         );
         assert_eq!(fp.entries.len(), 1);
         assert_eq!(fp.entries[0].kind, ProvKind::EliminatedConstant);
         assert!(fp.entries[0].object_pcs.is_empty());
+        // The witness join key is the real byte offset, not a hardcoded 0.
+        assert_eq!(fp.entries[0].instruction_offset, 42);
     }
 }

--- a/crates/synth-core/src/provenance.rs
+++ b/crates/synth-core/src/provenance.rs
@@ -39,9 +39,11 @@
 //!
 //! ## Bounded v1 — covered vs uncovered
 //!
-//! COVERED solidly: `br_if`, `br` (preserved), `select` (folded-predication),
-//! `br_table` (split), constant-eliminated branch ops. Every object conditional
-//! branch that does NOT resolve to one of these source ops is surfaced in
+//! GATE-EXERCISED: `br_if`, `br` (preserved), `select` (folded-predication),
+//! `br_table` (split). `eliminated-constant` is WIRED (schema + emitter, correct
+//! byte-offset join key) but not yet gate-exercised — a fixture that drops a
+//! covered branch op is a v1 follow-up. Every object conditional branch that does
+//! NOT resolve to one of the covered source ops is surfaced in
 //! `object_cond_branches` with `resolved: false` and a `note` (e.g. an `i64`
 //! expansion branch or a div/mem trap guard) — an "only-in-synth"-style
 //! divergence the consumer SEES rather than a silent gap. Naming the uncovered

--- a/crates/synth-core/src/provenance.rs
+++ b/crates/synth-core/src/provenance.rs
@@ -1,0 +1,367 @@
+//! VCR-DEC-003 (#396, witness#130) — the `synth-provenance-v1` branch-transformation map.
+//!
+//! synth's lowering changes the branch structure between the WASM source and the
+//! ARM object: cmp→select fusion collapses a `select` into a predicated IT-block
+//! move (no branch), `br_table` splits one WASM branch into a cascade of object
+//! branches, constant-condition guards get elided. witness measures MC/DC on the
+//! WASM component; to certify the OBJECT it must reconcile each object-level
+//! branch/condition back to its source condition. This module emits the map that
+//! makes that reconciliation possible.
+//!
+//! ## Schema (`synth-provenance-v1`)
+//!
+//! A JSON sidecar. The witness-facing join key is `(func_index,
+//! instruction_offset)` where `instruction_offset` is the ABSOLUTE wasm byte
+//! offset of the source op (synth's `op_offsets`, same origin as walrus
+//! `InstrLocId` — see VCR-DEC-003). Each entry additionally carries the OBJECT
+//! realization (`object_pcs`) so a consumer can map a source condition to the
+//! machine code it became — the piece the roadmap's terse schema left implicit
+//! but the reconciliation gate needs.
+//!
+//! `kind ∈`
+//! - `preserved` — a 1:1 `br_if`/`br` that stayed a real object branch.
+//! - `folded-predication` — a `select` fused to predicated (IT-block) moves; a
+//!   decision with NO object branch. `object_pcs` point at the predicated moves.
+//! - `split-into-object-branches` — a `br_table` that became N object branches;
+//!   `count` = N.
+//! - `eliminated-constant` — a source branch/condition dropped before codegen
+//!   (constant-fold / fact-spec guard elision). `object_pcs` is empty; the
+//!   omission is RECORDED, not silently missing.
+//!
+//! ## What the map lets a consumer prove (the non-vacuous gate)
+//!
+//! (a) every object-level conditional branch resolves to a source WASM condition
+//!     — carried in `object_cond_branches`, derived from the real object-branch
+//!     side-table ([`crate::backend::BranchMap`]), NOT re-walked from the wasm
+//!     branch ops (which would be vacuous);
+//! (b) a folded/eliminated source condition is explicitly recorded with its
+//!     object realization (or its absence), NOT dropped.
+//!
+//! ## Bounded v1 — covered vs uncovered
+//!
+//! COVERED solidly: `br_if`, `br` (preserved), `select` (folded-predication),
+//! `br_table` (split), constant-eliminated branch ops. Every object conditional
+//! branch that does NOT resolve to one of these source ops is surfaced in
+//! `object_cond_branches` with `resolved: false` and a `note` (e.g. an `i64`
+//! expansion branch or a div/mem trap guard) — an "only-in-synth"-style
+//! divergence the consumer SEES rather than a silent gap. Naming the uncovered
+//! ones is the deliverable's explicit follow-up boundary.
+
+use serde::{Deserialize, Serialize};
+
+use crate::backend::{BranchClass, BranchMap, LineMap};
+use crate::wasm_op::WasmOp;
+
+/// The schema version string embedded at the top of the sidecar.
+pub const SCHEMA: &str = "synth-provenance-v1";
+
+/// The transformation a source branch/condition underwent on the way to object code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProvKind {
+    /// 1:1 `br_if`/`br` that stayed a real object branch.
+    Preserved,
+    /// `select` fused to predicated moves (no object branch).
+    FoldedPredication,
+    /// `br_table` split into N object branches (`count` = N).
+    SplitIntoObjectBranches,
+    /// Source branch/condition dropped before codegen (constant / fact-spec).
+    EliminatedConstant,
+}
+
+/// One source-level branch/condition and what it became in the object.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProvEntry {
+    /// Witness join key: ABSOLUTE wasm byte offset of the source op.
+    pub instruction_offset: u32,
+    /// Index of the source op within the (compiled) op stream — diagnostic.
+    pub wasm_op_index: usize,
+    /// The source WASM op mnemonic (e.g. `"BrIf"`, `"Select"`, `"BrTable"`).
+    pub op: String,
+    /// How synth transformed it.
+    pub kind: ProvKind,
+    /// Object PCs (function-relative machine offsets) that realize this source
+    /// op's control flow. Empty for `eliminated-constant`.
+    pub object_pcs: Vec<u32>,
+    /// For `split-into-object-branches`: the object-branch count. Omitted otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<usize>,
+    /// Optional scry#51 reachability evidence for an `eliminated-constant` entry
+    /// (justified-infeasible). Reserved for a later increment; `None` in v1.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scry_evidence: Option<String>,
+}
+
+/// One object-level conditional branch, and whether it reconciled to a covered
+/// source condition. This is the (a)-clause carrier: derived from the REAL
+/// object-branch side-table, so a branch synth emitted that no covered source op
+/// explains shows up here with `resolved: false` (surfaced, not hidden).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObjectCondBranch {
+    /// Function-relative machine offset of the conditional branch.
+    pub pc: u32,
+    /// The wasm op index this branch traces back to (via `line_map`), if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wasm_op_index: Option<usize>,
+    /// Absolute wasm byte offset of that source op, if resolvable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instruction_offset: Option<u32>,
+    /// True iff this branch resolves to a covered source condition (`br_if` /
+    /// `br_table`). False = an uncovered/only-in-synth object branch (e.g. an
+    /// i64-expansion or trap-guard branch) — a v1 follow-up, surfaced not hidden.
+    pub resolved: bool,
+    /// Human note when `resolved` is false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// Provenance for one compiled function.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FunctionProvenance {
+    pub func_index: u32,
+    pub name: String,
+    pub entries: Vec<ProvEntry>,
+    pub object_cond_branches: Vec<ObjectCondBranch>,
+}
+
+/// The whole-module `synth-provenance-v1` map.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProvenanceMap {
+    pub schema: String,
+    pub module: String,
+    pub functions: Vec<FunctionProvenance>,
+}
+
+impl ProvenanceMap {
+    pub fn new(module: impl Into<String>) -> Self {
+        ProvenanceMap {
+            schema: SCHEMA.to_string(),
+            module: module.into(),
+            functions: Vec::new(),
+        }
+    }
+
+    /// Serialize to pretty JSON.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).expect("ProvenanceMap serializes")
+    }
+}
+
+/// Is this a source op the map covers as a branch/condition?
+fn source_op_name(op: &WasmOp) -> Option<&'static str> {
+    match op {
+        WasmOp::BrIf(_) => Some("BrIf"),
+        WasmOp::Br(_) => Some("Br"),
+        WasmOp::BrTable { .. } => Some("BrTable"),
+        WasmOp::Select => Some("Select"),
+        _ => None,
+    }
+}
+
+/// Derive provenance for one function from the CLI-available data.
+///
+/// - `ops` / `op_offsets` are index-aligned (the stream the backend compiled and
+///   its per-op absolute wasm byte offsets, already fact-spec-filtered upstream).
+/// - `line_map` / `branch_map` are index-aligned (one entry per emitted machine
+///   instruction: `(pc, wasm_op_index)` and `(pc, class)`).
+/// - `eliminated`: `(wasm_op_index_in_original_stream, op_name)` for branch/
+///   condition ops that constant-folding / fact-spec dropped before codegen.
+pub fn derive_function_provenance(
+    func_index: u32,
+    name: &str,
+    ops: &[WasmOp],
+    op_offsets: &[u32],
+    line_map: &LineMap,
+    branch_map: &BranchMap,
+    eliminated: &[(usize, String)],
+) -> FunctionProvenance {
+    // For each op index, collect the object PCs whose branch_map class matters.
+    // line_map and branch_map are parallel; zip them.
+    let mut entries: Vec<ProvEntry> = Vec::new();
+
+    for (op_idx, op) in ops.iter().enumerate() {
+        let Some(op_name) = source_op_name(op) else {
+            continue;
+        };
+        let instruction_offset = op_offsets.get(op_idx).copied().unwrap_or(0);
+
+        // Object realizations of this op: the machine instructions whose
+        // line_map op-index == op_idx AND whose branch class is a branch or a
+        // predicated move (skip the data-processing setup instructions).
+        let mut cond_pcs = Vec::new();
+        let mut uncond_pcs = Vec::new();
+        let mut pred_pcs = Vec::new();
+        for ((pc, oi), (_pc2, class)) in line_map.iter().zip(branch_map.iter()) {
+            if *oi != Some(op_idx) {
+                continue;
+            }
+            match class {
+                BranchClass::CondBranch => cond_pcs.push(*pc),
+                BranchClass::UncondBranch => uncond_pcs.push(*pc),
+                BranchClass::Predicated => pred_pcs.push(*pc),
+                BranchClass::Other => {}
+            }
+        }
+
+        let (kind, object_pcs, count) = match op {
+            WasmOp::BrIf(_) => (ProvKind::Preserved, cond_pcs.clone(), None),
+            WasmOp::Br(_) => (ProvKind::Preserved, uncond_pcs.clone(), None),
+            WasmOp::BrTable { .. } => {
+                let n = cond_pcs.len();
+                let mut all = cond_pcs.clone();
+                all.extend(uncond_pcs.iter().copied());
+                (ProvKind::SplitIntoObjectBranches, all, Some(n))
+            }
+            WasmOp::Select => (ProvKind::FoldedPredication, pred_pcs.clone(), None),
+            _ => unreachable!("source_op_name gated the match"),
+        };
+
+        entries.push(ProvEntry {
+            instruction_offset,
+            wasm_op_index: op_idx,
+            op: op_name.to_string(),
+            kind,
+            object_pcs,
+            count,
+            scry_evidence: None,
+        });
+    }
+
+    // Eliminated-constant entries: branch/condition ops dropped before codegen.
+    for (orig_idx, op_name) in eliminated {
+        entries.push(ProvEntry {
+            instruction_offset: 0,
+            wasm_op_index: *orig_idx,
+            op: op_name.clone(),
+            kind: ProvKind::EliminatedConstant,
+            object_pcs: Vec::new(),
+            count: None,
+            scry_evidence: None,
+        });
+    }
+
+    // (a)-clause carrier: enumerate the REAL object conditional branches and
+    // reconcile each back to its source op via line_map. A branch that traces to
+    // a covered condition (BrIf / BrTable) is resolved; anything else is an
+    // uncovered/only-in-synth branch, surfaced with a note.
+    let mut object_cond_branches: Vec<ObjectCondBranch> = Vec::new();
+    for ((pc, oi), (_pc2, class)) in line_map.iter().zip(branch_map.iter()) {
+        if *class != BranchClass::CondBranch {
+            continue;
+        }
+        let (resolved, note, instruction_offset) = match oi {
+            Some(idx) => match ops.get(*idx) {
+                Some(WasmOp::BrIf(_)) | Some(WasmOp::BrTable { .. }) => {
+                    (true, None, op_offsets.get(*idx).copied())
+                }
+                Some(other) => (
+                    false,
+                    Some(format!(
+                        "object conditional branch from non-branch source op {other:?} \
+                         (uncovered in v1: i64-expansion / trap-guard / bounds-check branch)"
+                    )),
+                    op_offsets.get(*idx).copied(),
+                ),
+                None => (
+                    false,
+                    Some(
+                        "object conditional branch traces to an out-of-range op index".to_string(),
+                    ),
+                    None,
+                ),
+            },
+            None => (
+                false,
+                Some(
+                    "object conditional branch with no source op (prologue/epilogue synth branch)"
+                        .to_string(),
+                ),
+                None,
+            ),
+        };
+        object_cond_branches.push(ObjectCondBranch {
+            pc: *pc,
+            wasm_op_index: *oi,
+            instruction_offset,
+            resolved,
+            note,
+        });
+    }
+
+    FunctionProvenance {
+        func_index,
+        name: name.to_string(),
+        entries,
+        object_cond_branches,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserved_brif_and_folded_select() {
+        // op[0] BrIf, op[1] Select.
+        let ops = vec![WasmOp::BrIf(0), WasmOp::Select];
+        let op_offsets = vec![10u32, 20u32];
+        // Object: BrIf → cmp(other)@0x00 + bcc(cond)@0x04; Select → predicated mov@0x08.
+        let line_map: LineMap = vec![(0x00, Some(0)), (0x04, Some(0)), (0x08, Some(1))];
+        let branch_map: BranchMap = vec![
+            (0x00, BranchClass::Other),
+            (0x04, BranchClass::CondBranch),
+            (0x08, BranchClass::Predicated),
+        ];
+        let fp = derive_function_provenance(0, "f", &ops, &op_offsets, &line_map, &branch_map, &[]);
+
+        let brif = &fp.entries[0];
+        assert_eq!(brif.kind, ProvKind::Preserved);
+        assert_eq!(brif.object_pcs, vec![0x04]);
+        assert_eq!(brif.instruction_offset, 10);
+
+        let sel = &fp.entries[1];
+        assert_eq!(sel.kind, ProvKind::FoldedPredication);
+        assert_eq!(sel.object_pcs, vec![0x08]);
+
+        // (a): the one object cond branch resolves to the BrIf.
+        assert_eq!(fp.object_cond_branches.len(), 1);
+        assert!(fp.object_cond_branches[0].resolved);
+        assert_eq!(fp.object_cond_branches[0].instruction_offset, Some(10));
+    }
+
+    #[test]
+    fn unresolved_object_branch_is_surfaced_not_hidden() {
+        // An I32DivU whose object lowering emits a trap-guard conditional branch.
+        let ops = vec![WasmOp::I32DivU];
+        let op_offsets = vec![30u32];
+        let line_map: LineMap = vec![(0x00, Some(0))];
+        let branch_map: BranchMap = vec![(0x00, BranchClass::CondBranch)];
+        let fp = derive_function_provenance(0, "g", &ops, &op_offsets, &line_map, &branch_map, &[]);
+        // No covered source entries (I32DivU isn't a covered source branch)...
+        assert!(fp.entries.is_empty());
+        // ...but the object branch is NOT missing: it's surfaced unresolved.
+        assert_eq!(fp.object_cond_branches.len(), 1);
+        assert!(!fp.object_cond_branches[0].resolved);
+        assert!(fp.object_cond_branches[0].note.is_some());
+    }
+
+    #[test]
+    fn eliminated_constant_is_recorded() {
+        let ops: Vec<WasmOp> = vec![];
+        let op_offsets: Vec<u32> = vec![];
+        let line_map: LineMap = vec![];
+        let branch_map: BranchMap = vec![];
+        let fp = derive_function_provenance(
+            0,
+            "h",
+            &ops,
+            &op_offsets,
+            &line_map,
+            &branch_map,
+            &[(3, "BrIf".to_string())],
+        );
+        assert_eq!(fp.entries.len(), 1);
+        assert_eq!(fp.entries[0].kind, ProvKind::EliminatedConstant);
+        assert!(fp.entries[0].object_pcs.is_empty());
+    }
+}

--- a/scripts/repro/provenance_branches_396.wat
+++ b/scripts/repro/provenance_branches_396.wat
@@ -1,0 +1,36 @@
+;; VCR-DEC-003 (#396) provenance reconciliation fixture.
+;;
+;; Exercises all three covered branch transformations in one function so the
+;; synth-provenance-v1 reconciliation gate is non-vacuous:
+;;   - br_if      -> preserved (a real object conditional branch)
+;;   - select     -> folded-predication (cmp->select fuse -> IT-block move, no branch)
+;;   - br_table   -> split-into-object-branches (one WASM branch -> N object branches)
+(module
+  (func (export "decide") (param $x i32) (param $y i32) (result i32)
+    (local $acc i32)
+    ;; --- br_if: preserved ---
+    (block $done
+      (br_if $done (i32.lt_s (local.get $x) (i32.const 0)))
+      (local.set $acc (i32.const 10)))
+
+    ;; --- select: folded-predication ---
+    ;; acc = (y > 100) ? acc+1 : acc-1
+    (local.set $acc
+      (select
+        (i32.add (local.get $acc) (i32.const 1))
+        (i32.sub (local.get $acc) (i32.const 1))
+        (i32.gt_s (local.get $y) (i32.const 100))))
+
+    ;; --- br_table: split-into-object-branches ---
+    (block $b2
+      (block $b1
+        (block $b0
+          (br_table $b0 $b1 $b2 (local.get $x)))
+        ;; b0 target
+        (local.set $acc (i32.add (local.get $acc) (i32.const 100)))
+        (br $b2))
+      ;; b1 target
+      (local.set $acc (i32.add (local.get $acc) (i32.const 200))))
+    ;; b2 target (fallthrough)
+    (local.get $acc))
+)


### PR DESCRIPTION
## VCR-DEC-003 (#396, witness#130) — `synth-provenance-v1` source-to-object branch-transformation map

synth's lowering changes the branch structure between the WASM source and the ARM object (cmp→select fusion → IT-block predication, br_table splitting, wide-branch expansion). witness measures MC/DC on the WASM component; to certify the OBJECT it must reconcile each object-level branch/condition back to its source condition. Without a provenance map that reconciliation is impossible — the #396 / witness#130 source-to-object traceability gap. This PR ships the emitter + the non-vacuous reconciliation gate.

### Deliverable

**1. Emitter (`--emit-provenance`)** — writes a `synth-provenance-v1` JSON sidecar (`<output>.provenance.json`). Frozen-safe: the ELF is **byte-identical** with and without the flag (verified on control_step.wasm). Derived post-hoc at the CLI from the compiled op stream + `op_offsets` + the ARM `line_map` + a new object-branch side-table `BranchMap` (`crate::backend::BranchClass`, captured at the ARM encode loop — the one datum post-hoc derivation couldn't recover: *which emitted instruction IS a conditional branch vs a predicated move*).

**2. Reconciliation gate** (`provenance_reconciliation_396`, CI job `provenance-gate`) — parses the sidecar as an independent consumer and asserts the two properties #396 exists to guarantee. Verified **non-vacuous**: mislabeling `SelectMove` as `CondBranch` turns the gate RED.

### Schema `synth-provenance-v1`

```
{ schema, module, functions: [
  { func_index, name,
    entries: [ { instruction_offset,   // wasm byte offset — witness join key
                 wasm_op_index, op, kind, object_pcs, count?, scry_evidence? } ],
    object_cond_branches: [ { pc, wasm_op_index?, instruction_offset?, resolved, note? } ] } ] }
```

`kind ∈ preserved | folded-predication | split-into-object-branches | eliminated-constant`.

### Fixture source→object correspondence (`provenance_branches_396.wat`)

| source op (wasm off) | kind | object realization |
|---|---|---|
| `br_if` @47 | preserved | cond branch @0x12 |
| `select` @70 | folded-predication | IT-block predicated move @0x32 (no branch) |
| `br_table` @81 | split-into-object-branches (count 2) | cond @0x3c, cond @0x40, uncond @0x42 |
| `br` @95 | preserved | uncond branch @0x50 |

`object_cond_branches`: all 3 real object conditional branches (0x12, 0x3c, 0x40) reconcile back to their source condition — clause (a) satisfied non-vacuously. On a real fixture (msgq_put) an uncovered trap-guard branch is surfaced `resolved:false` with a note, never hidden.

### Bounded v1 — named follow-ups
- optimized `ir_to_arm` on some op shapes drops `source_line`; such functions are **loud-declined** from the sidecar (warn + skip) rather than mislabeled.
- i64-expansion / div-mem trap-guard object branches are surfaced-unresolved, not reconciled.
- RISC-V / AArch64 carry no `branch_map` (ARM-Thumb only in v1).
- witness#130 `object-disposition` end-to-end compose.

### Verification
- 3 emitter unit tests (`synth-core::provenance`) + reconciliation gate; full workspace green (2278 tests). ELF byte-identity confirmed. `rivet validate` non-xref error count unchanged (0). Roadmap VCR-DEC-003 → `implemented`.

Coordinates conceptually with witness#130 (referenced); the map + parse-assert gate live entirely in synth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
