### PR TITLE
chore(release): v0.45.0 — the Mega-Hub epic (all 3 North-Star tracks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.45.0] - 2026-07-16
+
+**The Mega-Hub epic — all three North-Star tracks advanced at once.** Five
+oracle-gated feature lanes plus an honest negative result on a shipped miscompile.
+Semantics (a WasmCert-Coq source anchor + 9 more verified-selector ops → 485 Qed),
+capability (AArch64 7→50 ops), performance (a proof-carrying 12× beat over clang),
+and assurance (MC/DC source-to-object provenance). Coordinator re-verified each
+lane's oracle before merge; cold-reviewed SAFE-TO-TAG.
+
+### Added (semantics — Track B)
+
+- **WASM source semantics anchored on WasmCert-Coq (VCR-WASM-001, #771).** New
+  `coq/Synth/WASM/WasmCertBridge.v` proves synth's `exec_wasm_instr I32Add`
+  refines the WasmCert-Coq operational rule — the WASM-side analogue of
+  `SailArmBridge.v`. Non-vacuous (the reference normalizes operands first; synth
+  adds raw representatives — the proof discharges the raw-vs-normalized gap via
+  `Zplus_mod`, not reflexivity). **Bounded first increment**: 1 op, establishes
+  the refinement pattern. The reference is a hand transcription with line-level
+  provenance to WasmCert-Coq/CompCert (importing the real dep drags mathcomp +
+  CompCert into the hermetic toolchain — the named follow-up).
+- **Verified-selector model extended 41 → 50 ops (VCR-ISA-001, #773).** Nine i64
+  pseudo-ops (`clz`, `ctz`, `popcnt`, `mul`, `shl`, `shr_u`, `shr_s`, `rotl`,
+  `rotr`) join the generate-not-mirror Rocq model. **476 → 485 Qed.** Byte-invisible
+  (bit-identical under `SYNTH_NO_SEL_DSL=1`); drift-guard holds (flipping a
+  generated rule breaks its Qed).
+
+### Added (capability — Track A)
+
+- **AArch64 backend milestone 2 — 7 → 50 covered ops (#769).** Full i32+i64 integer
+  ALU (24 i32 + 26 i64): arithmetic, bitwise, variable shifts/rotates, `clz`/`ctz`,
+  the compare family + `eqz`. Every new encoding clang-cross-verified; native
+  differential 175/175 vs wasmtime. **div/rem loud-declined** (A64 `SDIV`/`UDIV`
+  don't trap on `/0` or `INT_MIN÷-1` — the more-total-than-WASM soundness class,
+  deferred until explicit trap guards); popcnt/floats also declined (decline
+  matrix 10/10).
+
+### Added (performance — Track C)
+
+- **Proof-carrying specialization that beats LLVM (#770).** A const-divisor
+  `rem_u` identity elision: `x rem_u 1000` with the ingested fact `x ∈ [0,999]`
+  compiles to **2 B** (`bx lr`) vs **clang -Os 24 B** — a measured **12×** on
+  `gust_scale` (public cover target). Licensed by ordeal `UNSAT(P ∧
+  (x bvurem 1000) ≠ x)` with an LRAT certificate (proof-carrying, not heuristic);
+  absent/too-wide fact → loud decline. Flag-gated (`SYNTH_FACT_SPEC`); flag-off
+  byte-identical.
+
+### Added (assurance — Track C)
+
+- **MC/DC source-to-object provenance (#396 / VCR-DEC-003, #774).** The
+  `synth-provenance-v1` branch-transformation map (`--emit-provenance` JSON
+  sidecar; ELF byte-identical with/without the flag) records how each source WASM
+  branch/condition maps to object branches — `preserved`, `folded-predication`
+  (cmp→select), `split-into-object-branches` (br_table), `eliminated-constant`.
+  Closes the source-to-object gap that synth's branch folding/splitting opened for
+  witness MC/DC (witness#130). Reconciliation gate verified non-vacuous (RED under
+  an adversarial mislabel); uncovered object branches surfaced `resolved:false`,
+  never hidden. Bounded v1 — common transformations covered; i64-expansion /
+  trap-guard branches surfaced-unresolved as named follow-up.
+
+### Known issues (still open)
+
+- **#757 — accepted residual (second disproof).** The wide-static *copy* path
+  carries a miscompile confirmed on gale's silicon, re-characterized on 0.43.1 as
+  a multi-chunk memmove reading `data_base + small` instead of `data_base + 0x20`
+  in the RawVec-grow + memmove shape. **Seven faithful reconstructions of that
+  exact shape all compile byte-correct vs wasmtime** (#772) — the miscompile is
+  not reproducible from the description; it needs the reporter's exact
+  `loom.wasm`/`os-tl-cm3.o` (re-requested). #757 stays OPEN; this release lands the
+  7 shapes as regression guards but does NOT fix it.
+- **i64.trunc_f64 live trap-VC** — still not wireable (the selector loud-declines
+  the op ⇒ no shipped lowering to validate); blocked on selector support, not VC
+  work (carried from v0.44).
+- **#761 — latent self-contained linmem/globals overlap** (impact unverified).
+
 ## [0.44.0] - 2026-07-15
 
 **Five-lane hub: two more live trap classes, an extended verified-selector model,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,14 +1100,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1166,11 +1166,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.44.0"
+version = "0.45.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1225,14 +1225,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1240,11 +1240,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.44.0"
+version = "0.45.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.44.0"
+version = "0.45.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.44.0"
+version = "0.45.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.44.0",
+    version = "0.45.0",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.44.0" }
+synth-core = { path = "../synth-core", version = "0.45.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.44.0" }
+synth-core = { path = "../synth-core", version = "0.45.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.44.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.44.0" }
+synth-core = { path = "../synth-core", version = "0.45.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.45.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.44.0" }
+synth-core = { path = "../synth-core", version = "0.45.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.44.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.44.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.45.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.45.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.44.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.45.0", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -52,23 +52,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.44.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.44.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.44.0" }
-synth-backend = { path = "../synth-backend", version = "0.44.0" }
+synth-core = { path = "../synth-core", version = "0.45.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.45.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.45.0" }
+synth-backend = { path = "../synth-backend", version = "0.45.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.44.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.45.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.44.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.44.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.44.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.45.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.45.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.45.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.44.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.45.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.44.0" }
+synth-core = { path = "../synth-core", version = "0.45.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.44.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.45.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.44.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.44.0" }
-synth-opt = { path = "../synth-opt", version = "0.44.0" }
+synth-core = { path = "../synth-core", version = "0.45.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.45.0" }
+synth-opt = { path = "../synth-opt", version = "0.45.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.44.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.44.0" }
-synth-opt = { path = "../synth-opt", version = "0.44.0" }
+synth-core = { path = "../synth-core", version = "0.45.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.45.0" }
+synth-opt = { path = "../synth-opt", version = "0.45.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.44.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.45.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"


### PR DESCRIPTION
The Mega-Hub epic: 5 oracle-gated lanes across all three North-Star tracks, each coordinator-re-verified before merge.

| Lane | PR | Track | What |
|------|----|----|----|
| VCR-WASM-001 | #771 | B | WasmCert-Coq source anchor (i32.add refinement; 474→476 Qed) |
| VCR-ISA-001 | #773 | B | generate-not-mirror 41→50 ops (476→485 Qed, byte-invisible) |
| #538 | #769 | A | AArch64 m2 — 7→50 integer ops, 175/175 native diff, honest div/rem decline |
| #494 | #770 | C | proof-carrying rem_u elision — **12× beat over clang -Os** (2 B vs 24 B) |
| #396 | #774 | C | synth-provenance-v1 MC/DC source-to-object map (byte-identical ELF) |

**485 Qed / 50 rules / 19 claims.** Pin sweep 0.44.0→0.45.0 (workspace + path-deps + MODULE.bazel + npm). fmt clean.

## Documented residuals (honest)
- **#757** — accepted residual, second disproof: 7 faithful RawVec-grow+memmove reconstructions all byte-correct (#772 lands them as regression guards); needs the reporter's exact module. Stays OPEN, NOT fixed.
- **i64.trunc_f64** live-VC — still blocked on selector lowering (not VC work).
- **#761** — latent linmem/globals overlap, unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)