### PR TITLE
chore(release): v0.45.1 — #757 soundness fix (overlapping-segment reloc miscompile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.45.1] - 2026-07-16
+
+**Soundness patch — #757 closed (root-caused + fixed on gale's exact module).**
+After surviving four releases as "unreproducible," gale delivered the exact fused
+`gust:os` node (`loom.wasm`) and it cracked immediately.
+
+### Fixed (soundness)
+
+- **Overlapping active data segments bound a static reloc to the wrong segment
+  (#757).** `loom.wasm` declares three active data segments **all at wasm linear
+  memory `0x100000`**. WASM applies active segments in declaration order, so a
+  later segment overwrites an earlier one — the last (`seg_2`, 24 B) owns those
+  bytes at runtime and holds `"gust:os up\n"` at linmem `0x100008`. The `#354`
+  mixed-split relocation retargeting resolved each `__synth_wasm_data + C` static
+  access to its owning `__synth_wasm_seg_K` via `.position()` (**first** match),
+  so the string source at `0x100008` bound to `__synth_wasm_seg_0 + 8` (seg_0's
+  stale const `0x02`) instead of `__synth_wasm_seg_2 + 8` (the string). Runtime:
+  `got=[2,0,0,0,1,0,0,32,…]` instead of `"gust:os up\n"` — a silent miscompile,
+  byte-identical across 0.43.0/0.43.1/0.44.0/0.45.0, and **not reproducible by
+  synthetic reconstructions** (v0.45.0 PR #772: 7 faithful shapes all green, because
+  a non-overlapping module has one segment per range where first==last match).
+  Fix: `.position()` → `.rposition()` — resolve overlapping addresses to the
+  last-declared owning segment, matching WASM overwrite semantics. **Byte-identical
+  for non-overlapping segments** (frozen anchors 10/10; `#739`/`#746`/`#758`/`#406`
+  static-data differentials all green). gale's `loom.wasm` is pinned as a permanent,
+  non-vacuous CI regression fixture (`mem757_gale_differential.py`, RED on the
+  pre-fix binary).
+
+### Note (North Star follow-up)
+
+- Filed **VCR-VER-003 (#777)** — per-compilation translation validation of
+  static-data addressing, to make the `#739`/`#746`/`#757`/`#758` patch-accretion
+  class unrepresentable by construction (the addressing analogue of VCR-VER-002's
+  trap validator). #757 slipped four releases because value-differential oracles
+  are coverage-limited; construction-based validation closes the gap.
+
 ## [0.45.0] - 2026-07-16
 
 **The Mega-Hub epic — all three North-Star tracks advanced at once.** Five

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,14 +1100,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1166,11 +1166,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.45.0"
+version = "0.45.1"
 
 [[package]]
 name = "synth-cli"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1225,14 +1225,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1240,11 +1240,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.45.0"
+version = "0.45.1"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.45.0"
+version = "0.45.1"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.45.0"
+version = "0.45.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.45.0",
+    version = "0.45.1",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.45.0" }
+synth-core = { path = "../synth-core", version = "0.45.1" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.45.0" }
+synth-core = { path = "../synth-core", version = "0.45.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.45.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.45.0" }
+synth-core = { path = "../synth-core", version = "0.45.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.45.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.45.0" }
+synth-core = { path = "../synth-core", version = "0.45.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.45.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.45.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.45.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.45.1", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.45.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.45.1", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -52,23 +52,23 @@ verify = ["synth-verify"]
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.45.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.45.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.45.0" }
-synth-backend = { path = "../synth-backend", version = "0.45.0" }
+synth-core = { path = "../synth-core", version = "0.45.1" }
+synth-frontend = { path = "../synth-frontend", version = "0.45.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.45.1" }
+synth-backend = { path = "../synth-backend", version = "0.45.1" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.45.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.45.1" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.45.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.45.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.45.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.45.1", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.45.1", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.45.1", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.45.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.45.1", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.45.0" }
+synth-core = { path = "../synth-core", version = "0.45.1" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.45.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.45.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.45.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.45.0" }
-synth-opt = { path = "../synth-opt", version = "0.45.0" }
+synth-core = { path = "../synth-core", version = "0.45.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.45.1" }
+synth-opt = { path = "../synth-opt", version = "0.45.1" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.45.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.45.0" }
-synth-opt = { path = "../synth-opt", version = "0.45.0" }
+synth-core = { path = "../synth-core", version = "0.45.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.45.1" }
+synth-opt = { path = "../synth-opt", version = "0.45.1" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.45.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.45.1", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.45.0",
+  "version": "0.45.1",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"


### PR DESCRIPTION
Soundness patch. Closes **#757** — root-caused + fixed on gale's exact `loom.wasm` (PR #779).

## Fixed
- **#757**: three active data segments overlapping at linmem `0x100000`; the `#354` reloc retargeting used `.position()` (first match), binding the string source to stale `seg_0` instead of the runtime-owning `seg_2`. Fix `.position()`→`.rposition()`. Verified red→green on gale's exact bytes; **byte-identical for non-overlapping segments** (frozen 10/10, `#739/#746/#758/#406` differentials green). `loom.wasm` pinned as a permanent CI regression fixture.

## Note
- **VCR-VER-003 (#777)** filed — per-compilation translation validation of static-data addressing, to make the `#739/#746/#757/#758` class unrepresentable by construction.

Pin sweep 0.45.0→0.45.1 (workspace + path-deps + MODULE.bazel + npm). Claim gate 19/19. fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)