### PR TITLE
fix(#776): aarch64 rotl clobbers a computed rotate operand (silent wrong result)

### DIFF
--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -123,14 +123,20 @@ pub fn select(ops: &[WasmOp], num_params: u32) -> Result<Vec<u32>, SelectError> 
             .pop()
             .ok_or_else(|| SelectError("rotl underflow".into()))?;
         let dst = alloc_temp(stack)?;
-        // `dst` is free of live entries here (n,k already popped); reuse it as
-        // the neg scratch, then as the result.
+        // #776: the `neg` scratch must NOT be `dst` — `alloc_temp` can hand back
+        // the register that held the computed operand `n` (n,k are already popped,
+        // so n's reg is free to reuse), and `neg(dst, k)` would then destroy `n`
+        // before `rorv` reads it (silent wrong result; param-only rotates escaped
+        // because their `n` sits in a distinct arg register). Compute `-k` in `k`'s
+        // own now-dead register instead; `rorv` then reads `n` (intact) + `-k` and
+        // writes `dst` safely — reads-before-write holds even if `dst` aliases an
+        // input, and n/k are distinct stack slots so `neg(k,k)` never touches `n`.
         if sf {
-            words.push(enc::neg64(dst, k));
-            words.push(enc::rorv64(dst, n, dst));
+            words.push(enc::neg64(k, k));
+            words.push(enc::rorv64(dst, n, k));
         } else {
-            words.push(enc::neg(dst, k));
-            words.push(enc::rorv(dst, n, dst));
+            words.push(enc::neg(k, k));
+            words.push(enc::rorv(dst, n, k));
         }
         stack.push(dst);
         Ok(())
@@ -427,11 +433,13 @@ mod tests {
             WasmOp::End,
         ];
         let w = select(&ops, 2).unwrap();
+        // #776: -k is computed in k's own register (1), NOT in dst (9) — so a
+        // computed `n` reused as dst is never clobbered before rorv reads it.
         assert_eq!(
             w,
             vec![
-                enc::neg(9, 1),
-                enc::rorv(9, 0, 9),
+                enc::neg(1, 1),
+                enc::rorv(9, 0, 1),
                 enc::mov_reg64(0, 9),
                 enc::ret()
             ]

--- a/scripts/repro/aarch64_m2_538.wat
+++ b/scripts/repro/aarch64_m2_538.wat
@@ -20,6 +20,11 @@
     (i32.rotr (local.get 0) (local.get 1)))
   (func (export "i32_rotl") (param i32 i32) (result i32)
     (i32.rotl (local.get 0) (local.get 1)))
+  ;; #776: rotate a COMPUTED value — n is a temp (add result). The pre-fix
+  ;; neg(dst,k);rorv(dst,n,dst) clobbered n when alloc_temp reused its register
+  ;; as dst. Param-only rotl (above) escaped this because n sits in an arg reg.
+  (func (export "i32_rotl_computed") (param i32 i32) (result i32)
+    (i32.rotl (i32.add (local.get 0) (local.get 0)) (local.get 1)))
 
   ;; ---- i32 clz / ctz ----
   (func (export "i32_clz") (param i32) (result i32)
@@ -76,6 +81,8 @@
     (i64.rotr (local.get 0) (local.get 1)))
   (func (export "i64_rotl") (param i64 i64) (result i64)
     (i64.rotl (local.get 0) (local.get 1)))
+  (func (export "i64_rotl_computed") (param i64 i64) (result i64)
+    (i64.rotl (i64.add (local.get 0) (local.get 0)) (local.get 1)))
 
   ;; ---- i64 clz / ctz ----
   (func (export "i64_clz") (param i64) (result i64)

--- a/scripts/repro/aarch64_m2_538_differential.py
+++ b/scripts/repro/aarch64_m2_538_differential.py
@@ -60,6 +60,9 @@ CASES += C32("i32_shr_u", (0x80000000, 4), (0xFFFFFFFF, 31), (1, 32))
 CASES += C32("i32_shr_s", (0x80000000, 4), (0xFFFFFFFF, 3), (0x7FFFFFFF, 1))
 CASES += C32("i32_rotr", (0x12345678, 4), (1, 1), (1, 0), (1, 33))
 CASES += C32("i32_rotl", (0x12345678, 4), (1, 31), (1, 0), (0x80000000, 1))
+# #776: computed rotate operand (n = a temp) — RED on the pre-fix binary
+# (neg scratch aliased n and destroyed it before rorv), GREEN after.
+CASES += C32("i32_rotl_computed", (0x12345678, 4), (1, 31), (0x80000000, 1), (3, 5))
 # i32 clz/ctz — zero input is the edge case (32).
 CASES += C32("i32_clz", (1,), (0x80000000,), (0,), (0xFFFFFFFF,))
 CASES += C32("i32_ctz", (1,), (0x80000000,), (0,), (8,))
@@ -78,6 +81,7 @@ CASES += C64("i64_shr_u", 64, (0x8000000000000000, 4), (M64, 63))
 CASES += C64("i64_shr_s", 64, (0x8000000000000000, 4), (M64, 3))
 CASES += C64("i64_rotr", 64, (0x0123456789ABCDEF, 8), (1, 0), (1, 65))
 CASES += C64("i64_rotl", 64, (0x0123456789ABCDEF, 8), (1, 63), (1, 0))
+CASES += C64("i64_rotl_computed", 64, (0x0123456789ABCDEF, 8), (1, 63), (3, 5))
 # i64 clz/ctz.
 CASES += C64("i64_clz", 64, (1,), (0x8000000000000000,), (0,))
 CASES += C64("i64_ctz", 64, (1,), (0x8000000000000000,), (0,), (256,))


### PR DESCRIPTION
Silent miscompile in `i32.rotl`/`i64.rotl` on the aarch64 backend when the rotated operand is **computed** — introduced by #769 (m2). Fix-first patch → v0.45.2.

## Root cause
`rotl` = `neg + rorv` (no native A64 rotate-left). The neg scratch reused `dst = alloc_temp()`: `neg(dst,k); rorv(dst,n,dst)`. For a computed `n`, alloc_temp can return n's freed register, so `neg(dst,k)` destroys `n` before `rorv` reads it. Param-only rotates escaped (n in a distinct arg reg).

## Fix
`neg(k,k); rorv(dst,n,k)` — compute `-k` in k's own dead register; `rorv` reads `n` intact + `-k`. One-line-equivalent, reads-before-write safe for any dst aliasing.

## Verification (red→green)
- New `i32_rotl_computed`/`i64_rotl_computed` cases (n = add temp) in the m2 differential.
- **RED on pre-fix**: 175/182 (`i32_rotl_computed(0x12345678,4) A64=-49 vs wasmtime=1183502082`, 7 fails).
- **GREEN after**: 182/182 vs wasmtime. Rides the CI-wired `aarch64-oracle` job.

Closes #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)