### PR TITLE
feat(#778): sound static per-function WCET bound (--emit-wcet, synth-wcet-v1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,17 @@ frozen and oracle-gated every step:
   wrong-segment miscompile. Concrete byte-equality (not SMT), unconditional
   (runs in the default `--features riscv` build), red-first gated (same
   validator Mismatch on `.position()` / Consistent on `.rposition()`).
+- **Track D (schedulability, #778):** `--emit-wcet` emits a SOUND static
+  per-function worst-case cycle bound (`synth-wcet-v1` sidecar) as gale spar's
+  T3/T4 `C_i` input — a bound, not a DWT observation. Loop-free functions get an
+  EXACT sum of documented Cortex-M3/M4 worst-case per-op cycles (MAX over {M3,M4};
+  the sound-critical model constants are `STRAIGHTLINE_CEIL_PER_HALFWORD = 5`,
+  `Umull = 5`, `Mls/Mla = 2`, `Sdiv/Udiv = 12`, and the four i64 software
+  div/rem = `LoopedExpansion` decline, pinned in `claims.yaml`); loops, calls,
+  i64-software-div and non-M3/M4 cores (incl. the ambiguous `-eabihf` M4F/M7
+  triple) LOUD-DECLINE with a machine reason. Frozen-safe (`.text` unchanged);
+  gated by `wcet_bound_gate.rs` (bound ≥ actual + decline matrix). Loop-bound
+  inference (scry) + inter-procedural composition are named follow-ups.
 - **Gate `VCR-VER-001`:** DEMONSTRATED (implemented, evidence in
   `scripts/repro/vcr_ver_001_gate.md`) — the v0.11.20 reciprocal-mult
   cost-gate was deleted outright (PR #322, differential bit-identical); the

--- a/claims.yaml
+++ b/claims.yaml
@@ -328,3 +328,45 @@ claims:
         pattern: '^pub open spec fn '
         glob: ['crates/synth-synthesis/src/contracts.rs']
         expect: 8
+
+  # ---------------------------------------------------------------------------
+  # #778 WCET — the SOUND-critical per-op cycle model constants. These numbers
+  # are load-bearing: a bound that undercounts real cycles is disqualifying, and
+  # the summation gate (wcet_bound_gate.rs) re-derives from THIS same table so it
+  # cannot flag a wrong number. Pinning the constants here is the honest
+  # substitute for the cycle-accurate oracle that does not exist in-env: any edit
+  # to a sound-critical entry reddens the claim-check and forces a conscious
+  # re-derivation against the Cortex-M3/M4 TRM (max over {M3, M4}). The doc text
+  # lives in CLAUDE.md's Track D.
+  # ---------------------------------------------------------------------------
+  - id: SYNTH-WCET-CYCLE-MODEL
+    doc: CLAUDE.md
+    text: "`STRAIGHTLINE_CEIL_PER_HALFWORD = 5`"
+    evidence:
+      # The straight-line-expansion ceiling — bumped 4→5 after auditing a 3-reg
+      # 16-bit PUSH/POP in I64Popcnt (1+3=4 cyc/halfword had zero margin).
+      - kind: count-eq
+        pattern: 'const STRAIGHTLINE_CEIL_PER_HALFWORD: u64 = 5;'
+        glob: ['crates/synth-backend/src/wcet.rs']
+        expect: 1
+      # UMULL = M3-worst 5 (reachable via reciprocal-multiply div-by-const, #322).
+      - kind: count-eq
+        pattern: 'Umull \{ \.\. \} => Cycles\(5\),'
+        glob: ['crates/synth-backend/src/wcet.rs']
+        expect: 1
+      # MLA/MLS = M3-worst 2 (1 on M4).
+      - kind: count-eq
+        pattern: 'Mls \{ \.\. \} \| Mla \{ \.\. \} => Cycles\(2\),'
+        glob: ['crates/synth-backend/src/wcet.rs']
+        expect: 1
+      # Hardware divide = data-dependent MAX 12.
+      - kind: count-eq
+        pattern: 'Sdiv \{ \.\. \} \| Udiv \{ \.\. \} => Cycles\(12\),'
+        glob: ['crates/synth-backend/src/wcet.rs']
+        expect: 1
+      # The four i64 SOFTWARE div/rem = LoopedExpansion decline (internal 64-iter
+      # runtime loop; a straight sum would undercount).
+      - kind: count-eq
+        pattern: 'I64DivU \{ \.\. \} \| I64DivS \{ \.\. \} \| I64RemU \{ \.\. \} \| I64RemS \{ \.\. \} => LoopedExpansion,'
+        glob: ['crates/synth-backend/src/wcet.rs']
+        expect: 1

--- a/crates/synth-backend-aarch64/src/backend.rs
+++ b/crates/synth-backend-aarch64/src/backend.rs
@@ -97,6 +97,8 @@ impl Backend for AArch64Backend {
             line_map: Vec::new(),
             // VCR-DEC-003 (#396): provenance is ARM(Thumb)-only in v1.
             branch_map: Vec::new(),
+            // #778: WCET cycle model is ARM(Thumb-2)-only in v1.
+            wcet: None,
         })
     }
 

--- a/crates/synth-backend-riscv/src/backend.rs
+++ b/crates/synth-backend-riscv/src/backend.rs
@@ -197,6 +197,9 @@ fn compile_function_with_opts(
         line_map: Vec::new(),
         // VCR-DEC-003 (#396): provenance is ARM-only in v1 (empty ⇒ skipped).
         branch_map: Vec::new(),
+        // #778: WCET cycle model is ARM(Thumb-2)-only in v1 (RISC-V has no
+        // per-op cycle table yet) — no bound emitted for this backend.
+        wcet: None,
     })
 }
 
@@ -452,6 +455,7 @@ mod tests {
             relocations: Vec::new(),
             line_map: Vec::new(),
             branch_map: Vec::new(),
+            wcet: None,
         };
         let cfg = CompileConfig {
             target: TargetSpec::riscv32imac(),

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -154,8 +154,14 @@ impl Backend for ArmBackend {
         ops: &[WasmOp],
         config: &CompileConfig,
     ) -> Result<CompiledFunction, BackendError> {
-        let (code, relocations, line_map, branch_map) =
+        let (code, relocations, line_map, branch_map, final_instrs) =
             compile_wasm_to_arm(ops, config).map_err(BackendError::CompilationFailed)?;
+
+        // #778: derive the SOUND static WCET bound from the final Thumb-2 stream.
+        // Only present for the Thumb-2 path; the core class (from the triple)
+        // decides whether the bound is sound (M3/M4) or declined (M7).
+        let wcet = final_instrs
+            .map(|instrs| crate::wcet::function_wcet(name, &instrs, &config.target.triple));
 
         Ok(CompiledFunction {
             name: name.to_string(),
@@ -164,6 +170,7 @@ impl Backend for ArmBackend {
             relocations,
             line_map,
             branch_map,
+            wcet,
         })
     }
 
@@ -291,18 +298,21 @@ fn has_value_carrying_branch(wasm_ops: &[WasmOp], block_arity: &[(u8, u8)]) -> b
 ///
 /// Returns (code_bytes, relocations) where relocations record BL instructions
 /// that target external symbols (e.g., `__meld_dispatch_import` for import calls).
+type CompileArmOutput = (
+    Vec<u8>,
+    Vec<CodeRelocation>,
+    LineMap,
+    synth_core::backend::BranchMap,
+    // #778: the SOUND static WCET result over the final Thumb-2 stream, computed
+    // by `compile_function` (which knows the function name); `None` for the A32
+    // path. Purely additive metadata — does not touch `code`.
+    Option<Vec<synth_synthesis::ArmInstruction>>,
+);
+
 fn compile_wasm_to_arm(
     wasm_ops: &[WasmOp],
     config: &CompileConfig,
-) -> Result<
-    (
-        Vec<u8>,
-        Vec<CodeRelocation>,
-        LineMap,
-        synth_core::backend::BranchMap,
-    ),
-    String,
-> {
+) -> Result<CompileArmOutput, String> {
     // #539: `memory.grow(0)` must return the CURRENT page count, not the
     // fixed-memory `-1` sentinel — growing by zero pages can never fail (WASM
     // Core §4.4.7), so a guest doing `if (memory.grow(0) < 0) trap;` wrongly
@@ -1300,6 +1310,17 @@ fn compile_wasm_to_arm(
         arm_instrs
     };
 
+    // #778: capture the FINAL Thumb-2 instruction stream (post label-resolution,
+    // the exact list the encode loop below consumes) so `compile_function` can
+    // derive the sound WCET bound. Cheap clone; frozen-safe (the WCET walk is a
+    // pure observation and never touches `code`). Only the Thumb-2 path — the A32
+    // (Cortex-R5) cycle model is a follow-up.
+    let final_instrs_for_wcet: Option<Vec<synth_synthesis::ArmInstruction>> = if use_thumb2 {
+        Some(arm_instrs.clone())
+    } else {
+        None
+    };
+
     let mut code = Vec::new();
     let mut relocations = Vec::new();
 
@@ -1429,7 +1450,13 @@ fn compile_wasm_to_arm(
         }
     }
 
-    Ok((code, relocations, line_map, branch_map))
+    Ok((
+        code,
+        relocations,
+        line_map,
+        branch_map,
+        final_instrs_for_wcet,
+    ))
 }
 
 /// VCR-DEC-003 (#396): classify one emitted `ArmOp` into its object-level

--- a/crates/synth-backend/src/lib.rs
+++ b/crates/synth-backend/src/lib.rs
@@ -28,6 +28,7 @@ pub use w2c2_wrapper::{TranspileOptions, TranspileResult, W2C2Backend, W2C2Trans
 pub mod arm_backend;
 #[cfg(feature = "arm-cortex-m")]
 pub mod arm_encoder;
+
 #[cfg(feature = "arm-cortex-m")]
 pub mod arm_startup;
 #[cfg(feature = "arm-cortex-m")]
@@ -36,6 +37,7 @@ pub mod cortex_m;
 pub mod reset_handler;
 #[cfg(feature = "arm-cortex-m")]
 pub mod vector_table;
+pub mod wcet;
 
 #[cfg(feature = "arm-cortex-m")]
 pub use arm_backend::ArmBackend;

--- a/crates/synth-backend/src/wcet.rs
+++ b/crates/synth-backend/src/wcet.rs
@@ -64,8 +64,14 @@ use synth_synthesis::{ArmInstruction, ArmOp};
 /// `0xB438`/`0xBC38`.
 const STRAIGHTLINE_CEIL_PER_HALFWORD: u64 = 5;
 
-/// Worst-case cycles for a straight-line expansion of `byte_len` bytes.
-fn straightline_expansion(byte_len: u64) -> u64 {
+/// Worst-case cycles for a straight-line multi-byte expansion, sized from the
+/// op's ENCODER byte length (via `estimate_arm_byte_size`, which the
+/// `estimator_encoder_agreement` oracle pins exactly to the real encoder). Using
+/// the estimator rather than a hand literal makes the bound provably ≥ the real
+/// straight-line cost and self-maintaining: a future encoder change to a priced
+/// expansion moves the estimator and the bound rides it.
+fn straightline_expansion(op: &ArmOp) -> u64 {
+    let byte_len = synth_synthesis::estimate_arm_byte_size(op) as u64;
     (byte_len / 2) * STRAIGHTLINE_CEIL_PER_HALFWORD
 }
 
@@ -159,30 +165,37 @@ fn op_cost(op: &ArmOp) -> OpCost {
         SelectMove { .. } => Cycles(2),
         Select { .. } => Unmodeled, // pseudo, lowered upstream — never in final stream
 
-        // --- Popcnt: fixed SWAR bit-twiddle (84/86 B), straight-line ---
-        Popcnt { rd, rm } => {
-            let bytes = if rd == rm { 84 } else { 86 };
-            Cycles(straightline_expansion(bytes))
-        }
+        // --- Popcnt: fixed SWAR bit-twiddle, straight-line. Sized by the
+        // estimator (encoder-pinned, below) — never a hand literal. ---
+        Popcnt { .. } => Cycles(straightline_expansion(op)),
         // UDF trap: 1 cycle to fault (worst-case reach; execution ends there).
         Udf { .. } => Cycles(1),
 
         // === i64 SOFTWARE div/rem: internal 64-iteration runtime loop → decline ===
         I64DivU { .. } | I64DivS { .. } | I64RemU { .. } | I64RemS { .. } => LoopedExpansion,
 
-        // === i64 straight-line expansions (fixed byte size, no internal loop) ===
-        // Sized by the estimator's exact byte lengths (optimizer_bridge) × the
-        // straight-line ceiling; each is a single-execution block in a loop-free fn.
-        I64SetCond { .. } => Cycles(straightline_expansion(12)),
-        I64SetCondZ { .. } => Cycles(straightline_expansion(12)),
-        I64Mul { .. } => Cycles(straightline_expansion(20)),
-        I64Shl { .. } | I64ShrU { .. } | I64ShrS { .. } => Cycles(straightline_expansion(40)),
-        I64Rotl { .. } | I64Rotr { .. } => Cycles(straightline_expansion(102)),
-        I64Clz { .. } | I64Ctz { .. } => Cycles(straightline_expansion(40)),
-        I64Popcnt { .. } => Cycles(straightline_expansion(180)),
-        I64Extend8S { .. } | I64Extend16S { .. } | I64Extend32S { .. } => {
-            Cycles(straightline_expansion(8))
-        }
+        // === i64 straight-line expansions (fixed byte size, NO internal loop) ===
+        // Sized by `estimate_arm_byte_size` — NOT a hand-transcribed literal. That
+        // estimator is pinned EXACTLY to the real encoder length for every one of
+        // these ops by the `estimator_encoder_agreement` oracle, so
+        // `(len/2) × CEIL` is provably ≥ the real straight-line cost AND cannot go
+        // stale: a future encoder change to any of these expansions moves the
+        // estimator (or breaks the oracle) and the bound tracks it automatically —
+        // exactly the drift a hand literal could not catch.
+        I64SetCond { .. }
+        | I64SetCondZ { .. }
+        | I64Mul { .. }
+        | I64Shl { .. }
+        | I64ShrU { .. }
+        | I64ShrS { .. }
+        | I64Rotl { .. }
+        | I64Rotr { .. }
+        | I64Clz { .. }
+        | I64Ctz { .. }
+        | I64Popcnt { .. }
+        | I64Extend8S { .. }
+        | I64Extend16S { .. }
+        | I64Extend32S { .. } => Cycles(straightline_expansion(op)),
 
         // === prologue/epilogue stack ops: real, straight-line, single-execution ===
         // Cortex-M4 STM/LDM (PUSH/POP) = 1 + N cycles for N registers. A POP that

--- a/crates/synth-backend/src/wcet.rs
+++ b/crates/synth-backend/src/wcet.rs
@@ -164,11 +164,20 @@ fn op_cost(op: &ArmOp) -> OpCost {
             Cycles(straightline_expansion(8))
         }
 
-        // === off-path pseudo-ops: never appear in the final encoded stream ===
-        // (Lowered to primitives upstream, or inserted by non-optimized paths this
-        // model does not price. Conservatively Unmodeled = decline the function.)
-        Label { .. } | Nop => Cycles(0), // zero-length / no-op, sound to price as 0
-        Push { .. } | Pop { .. } => Unmodeled,
+        // === prologue/epilogue stack ops: real, straight-line, single-execution ===
+        // Cortex-M4 STM/LDM (PUSH/POP) = 1 + N cycles for N registers. A POP that
+        // writes PC is also a branch (pipeline refill up to 3). We price BOTH as
+        // `1 + N + 3` — a sound over-estimate for PUSH (no refill) and the exact
+        // worst case for POP-to-PC (function return, the common epilogue).
+        Push { regs } => Cycles(1 + regs.len() as u64 + 3),
+        Pop { regs } => Cycles(1 + regs.len() as u64 + 3),
+
+        // === off-path pseudo-ops ===
+        // Label/Nop are zero-cost real placeholders. The rest are verification-only
+        // pseudo-ops the encoder REFUSES (Ok-or-Err, #615): a compile that reached
+        // one would already have errored, so they cannot appear in a stream we are
+        // pricing. Classified Unmodeled = decline as a belt-and-braces guard.
+        Label { .. } | Nop => Cycles(0),
         B { .. } | Bcc { .. } | Bhs { .. } | Blo { .. } => Unmodeled, // residual label branch
         LocalGet { .. }
         | LocalSet { .. }
@@ -335,12 +344,12 @@ pub fn op_worst_case_cycles(op: &ArmOp) -> u64 {
 /// to sum) from the dual-issue M7 (NOT sound: cache wait-states can make actual
 /// cycles exceed a zero-wait sum). Rather than risk pricing an M7 with the M4
 /// table, this DECLINES the ambiguous `-eabihf` triple entirely. Only the two
-/// unambiguous integer triples are accepted:
-///   - `thumbv7m-none-eabi`   → Cortex-M3 (ARMv7-M, in-order, no FPU)
-///   - `thumbv7em-none-eabi`  → Cortex-M4 no-FPU (ARMv7E-M, in-order)
-/// This is conservative for M4F (which is soundly summable) but never unsound —
-/// distinguishing M4F from M7 needs a discriminator the config does not carry here
-/// (a named follow-up: thread the `CortexMVariant` so M4F is bounded too).
+/// unambiguous integer triples are accepted: `thumbv7m-none-eabi` → Cortex-M3
+/// (ARMv7-M, in-order, no FPU) and `thumbv7em-none-eabi` → Cortex-M4 no-FPU
+/// (ARMv7E-M, in-order). This is conservative for M4F (which is soundly summable)
+/// but never unsound — distinguishing M4F from M7 needs a discriminator the config
+/// does not carry here (a named follow-up: thread the `CortexMVariant` so M4F is
+/// bounded too).
 pub fn sound_core_class(triple: &str) -> Option<&'static str> {
     match triple {
         "thumbv7m-none-eabi" | "cortex-m3" => Some("cortex-m3"),

--- a/crates/synth-backend/src/wcet.rs
+++ b/crates/synth-backend/src/wcet.rs
@@ -326,12 +326,27 @@ pub fn op_worst_case_cycles(op: &ArmOp) -> u64 {
     }
 }
 
-/// True iff `core_class` (a `config.target.triple`-derived string) is soundly
-/// summable with the zero-wait per-op table: the in-order single-issue
-/// Cortex-M3 / Cortex-M4(F) cores. Cortex-M7 (dual-issue + cache wait-states) is
-/// NOT — it is declined, not approximated.
-pub fn core_is_soundly_summable(core_class: &str) -> bool {
-    matches!(core_class, "cortex-m3" | "cortex-m4")
+/// Map a target `triple` to the SOUND core class the zero-wait per-op table holds
+/// for, or `None` if the core is not soundly summable and must be declined.
+///
+/// SOUNDNESS NOTE — the `-eabihf` ambiguity: the Cortex-M4F, Cortex-M7 and
+/// Cortex-M7dp `TargetSpec`s ALL carry the triple `thumbv7em-none-eabihf`, so once
+/// inside compilation the triple alone CANNOT distinguish the in-order M4F (sound
+/// to sum) from the dual-issue M7 (NOT sound: cache wait-states can make actual
+/// cycles exceed a zero-wait sum). Rather than risk pricing an M7 with the M4
+/// table, this DECLINES the ambiguous `-eabihf` triple entirely. Only the two
+/// unambiguous integer triples are accepted:
+///   - `thumbv7m-none-eabi`   → Cortex-M3 (ARMv7-M, in-order, no FPU)
+///   - `thumbv7em-none-eabi`  → Cortex-M4 no-FPU (ARMv7E-M, in-order)
+/// This is conservative for M4F (which is soundly summable) but never unsound —
+/// distinguishing M4F from M7 needs a discriminator the config does not carry here
+/// (a named follow-up: thread the `CortexMVariant` so M4F is bounded too).
+pub fn sound_core_class(triple: &str) -> Option<&'static str> {
+    match triple {
+        "thumbv7m-none-eabi" | "cortex-m3" => Some("cortex-m3"),
+        "thumbv7em-none-eabi" | "cortex-m4" => Some("cortex-m4"),
+        _ => None,
+    }
 }
 
 /// Reconstruct byte positions and detect whether any branch in `instrs` is a
@@ -402,14 +417,15 @@ fn scan_for_decline(instrs: &[ArmInstruction]) -> Option<WcetDecline> {
 }
 
 /// Compute the sound per-function WCET result over the FINAL Thumb-2 instruction
-/// stream `instrs` (the list the encoder consumes). `core_class` is the
-/// `config.target.triple`-derived core name.
+/// stream `instrs` (the list the encoder consumes). `triple` is
+/// `config.target.triple`; a non-soundly-summable core (see [`sound_core_class`])
+/// declines with [`WcetDecline::UnsupportedCore`].
 ///
 /// Returns a [`WcetFunction::Bounded`] with the summed worst-case cycles when the
 /// function is proven loop-free / call-free on a soundly-summable core, else a
 /// [`WcetFunction::Declined`] with a machine-readable reason.
-pub fn function_wcet(name: &str, instrs: &[ArmInstruction], core_class: &str) -> WcetFunction {
-    if !core_is_soundly_summable(core_class) {
+pub fn function_wcet(name: &str, instrs: &[ArmInstruction], triple: &str) -> WcetFunction {
+    if sound_core_class(triple).is_none() {
         return WcetFunction::declined(name, WcetDecline::UnsupportedCore);
     }
     if let Some(reason) = scan_for_decline(instrs) {

--- a/crates/synth-backend/src/wcet.rs
+++ b/crates/synth-backend/src/wcet.rs
@@ -1,0 +1,552 @@
+//! #778 (v0.46 Wave-1 Lane 2) — sound static WCET-bound computation over the
+//! final Thumb-2 instruction stream.
+//!
+//! This module owns the two soundness-critical pieces the [`synth_core::wcet`]
+//! schema is populated from:
+//!
+//! 1. [`op_worst_case_cycles`] — a per-`ArmOp` DOCUMENTED WORST-CASE cycle count
+//!    for the Cortex-M3 / Cortex-M4(F) in-order pipeline under a zero-wait-state
+//!    instruction memory. Every data-dependent op takes its MAXIMUM (`SDIV`/`UDIV`
+//!    → 12, not the 2-cycle best case). The match is EXHAUSTIVE with NO wildcard,
+//!    so a newly-added `ArmOp` variant fails to compile until it is consciously
+//!    given a worst-case number or classified as a looped expansion — the same
+//!    tripwire discipline as `estimator_encoder_agreement.rs`.
+//!
+//! 2. [`function_wcet`] — the loop-free classifier + summation. It reconstructs
+//!    byte positions over the final `arm_instrs` list (the same list the encoder
+//!    consumes), detects any BACKWARD branch (a loop), any residual label branch,
+//!    any call, and any op whose encoder expansion contains an internal runtime
+//!    loop; on any of these it DECLINES. Only a proven-loop-free function — where
+//!    every instruction executes at most once — receives the SUM bound, which is
+//!    then ≥ any real execution.
+//!
+//! The whole computation is a pure observation of an already-decided instruction
+//! list: it touches no `.text`, so the emitted bytes are byte-identical whether or
+//! not a bound is computed (frozen-safe).
+//!
+//! ## Cycle numbers — provenance
+//!
+//! The per-instruction worst cases below are the documented Cortex-M4 figures
+//! (ARM Cortex-M4 Technical Reference Manual, "Instruction timings", and the
+//! Cortex-M3 TRM for the M3 subset — the two share the timing model for this
+//! integer subset). Loads/stores are 2 cycles (pipelined single access), taken
+//! branches add a pipeline-refill penalty (up to 3 → we use the worst), `SDIV`/
+//! `UDIV` are 2–12 (we use 12). Where an op EXPANDS to a fixed straight-line
+//! sequence (Popcnt SWAR, i64 shift/rotate/clz/ctz/setcond), the entry is a
+//! conservative over-estimate of that sequence's summed worst case; each such
+//! entry is justified inline. Since a loop-free function executes every
+//! instruction at most once, a per-instruction over-estimate keeps the SUM sound.
+
+use synth_core::wcet::{WcetDecline, WcetFunction};
+use synth_synthesis::{ArmInstruction, ArmOp};
+
+/// A conservative per-16-bit-halfword ceiling for a straight-line multi-byte
+/// encoder expansion built from simple ALU/shift/compare/move instructions. Every
+/// Thumb-2 instruction those expansions use retires in ≤ 3 cycles (a taken
+/// conditional inside the expansion is a forward skip; its refill is bounded by
+/// the pipeline depth). 4 cycles/halfword is therefore a safe over-estimate of any
+/// straight-line block, used to size the fixed bit-twiddle sequences without
+/// hand-counting each — sound because the block executes exactly once in a
+/// loop-free function.
+const STRAIGHTLINE_CEIL_PER_HALFWORD: u64 = 4;
+
+/// Worst-case cycles for a straight-line expansion of `byte_len` bytes.
+fn straightline_expansion(byte_len: u64) -> u64 {
+    (byte_len / 2) * STRAIGHTLINE_CEIL_PER_HALFWORD
+}
+
+/// Classification of an `ArmOp` for the cycle model.
+enum OpCost {
+    /// A single-execution op with this documented worst-case cycle count.
+    Cycles(u64),
+    /// The op's encoder expansion contains an internal RUNTIME loop (emitted once,
+    /// executed many times). A straight sum of its body bytes would undercount, so
+    /// any function containing it is declined.
+    LoopedExpansion,
+    /// The op is not lowered onto the sound Thumb-2 scalar-integer path this model
+    /// covers (VFP scalar/MVE vector/off-path pseudo-ops). A function containing it
+    /// is declined rather than guessed.
+    Unmodeled,
+}
+
+/// The DOCUMENTED WORST-CASE cycle cost of one `ArmOp`, or a decline classification.
+///
+/// EXHAUSTIVE — no wildcard. A new `ArmOp` variant will not compile until it is
+/// consciously classified here.
+#[allow(clippy::match_same_arms)] // grouping by cycle count is clearer than merging
+fn op_cost(op: &ArmOp) -> OpCost {
+    use ArmOp::*;
+    use OpCost::{Cycles, LoopedExpansion, Unmodeled};
+
+    match op {
+        // --- 1-cycle data-processing (register/immediate ALU, moves, extends) ---
+        Add { .. }
+        | Sub { .. }
+        | Adds { .. }
+        | Subs { .. }
+        | Adc { .. }
+        | Sbc { .. }
+        | And { .. }
+        | Orr { .. }
+        | Eor { .. }
+        | Rsb { .. }
+        | Mvn { .. } => Cycles(1),
+        Mov { .. } | Movw { .. } | Movt { .. } | MovwSym { .. } | MovtSym { .. } => Cycles(1),
+        Clz { .. } | Rbit { .. } => Cycles(1),
+        Sxtb { .. } | Sxth { .. } | Uxtb { .. } | Uxth { .. } => Cycles(1),
+        Cmp { .. } | Cmn { .. } => Cycles(1),
+        // Shifts: immediate and register forms both retire in 1 cycle on M4.
+        Lsl { .. }
+        | Lsr { .. }
+        | Asr { .. }
+        | Ror { .. }
+        | LslReg { .. }
+        | LsrReg { .. }
+        | AsrReg { .. }
+        | RorReg { .. } => Cycles(1),
+
+        // --- multiply / multiply-accumulate: 1 cycle (M4 single-cycle MUL) ---
+        Mul { .. } | Mls { .. } | Mla { .. } => Cycles(1),
+        // UMULL is a long multiply: worst case 1 cycle issue on M4, but be
+        // conservative at 2 (it writes a 64-bit result pair).
+        Umull { .. } => Cycles(2),
+
+        // --- hardware divide: DATA-DEPENDENT 2..12, take the MAX (12) ---
+        Sdiv { .. } | Udiv { .. } => Cycles(12),
+
+        // --- loads / stores: 2 cycles (pipelined single access) ---
+        Ldr { .. }
+        | Str { .. }
+        | Ldrb { .. }
+        | Ldrh { .. }
+        | Ldrsb { .. }
+        | Ldrsh { .. }
+        | Strb { .. }
+        | Strh { .. }
+        | LdrSym { .. } => Cycles(2),
+
+        // --- branches: 1 (not taken) + up to 3 pipeline-refill on taken → 4 ---
+        // We use the worst case (taken) unconditionally; a not-taken conditional is
+        // strictly cheaper, so the over-estimate is sound.
+        BOffset { .. } | BCondOffset { .. } | Bx { .. } => Cycles(4),
+
+        // --- calls: DECLINE the function (inter-procedural, out of scope) ---
+        Bl { .. } | Blx { .. } => Unmodeled, // routed to Call decline by the caller
+
+        // --- select / predication ---
+        // SetCond = IT + MOV + MOV (6 B, 3 insns); SelectMove = IT + MOV (4 B).
+        SetCond { .. } => Cycles(3),
+        SelectMove { .. } => Cycles(2),
+        Select { .. } => Unmodeled, // pseudo, lowered upstream — never in final stream
+
+        // --- Popcnt: fixed SWAR bit-twiddle (84/86 B), straight-line ---
+        Popcnt { rd, rm } => {
+            let bytes = if rd == rm { 84 } else { 86 };
+            Cycles(straightline_expansion(bytes))
+        }
+        // UDF trap: 1 cycle to fault (worst-case reach; execution ends there).
+        Udf { .. } => Cycles(1),
+
+        // === i64 SOFTWARE div/rem: internal 64-iteration runtime loop → decline ===
+        I64DivU { .. } | I64DivS { .. } | I64RemU { .. } | I64RemS { .. } => LoopedExpansion,
+
+        // === i64 straight-line expansions (fixed byte size, no internal loop) ===
+        // Sized by the estimator's exact byte lengths (optimizer_bridge) × the
+        // straight-line ceiling; each is a single-execution block in a loop-free fn.
+        I64SetCond { .. } => Cycles(straightline_expansion(12)),
+        I64SetCondZ { .. } => Cycles(straightline_expansion(12)),
+        I64Mul { .. } => Cycles(straightline_expansion(20)),
+        I64Shl { .. } | I64ShrU { .. } | I64ShrS { .. } => Cycles(straightline_expansion(40)),
+        I64Rotl { .. } | I64Rotr { .. } => Cycles(straightline_expansion(102)),
+        I64Clz { .. } | I64Ctz { .. } => Cycles(straightline_expansion(40)),
+        I64Popcnt { .. } => Cycles(straightline_expansion(180)),
+        I64Extend8S { .. } | I64Extend16S { .. } | I64Extend32S { .. } => {
+            Cycles(straightline_expansion(8))
+        }
+
+        // === off-path pseudo-ops: never appear in the final encoded stream ===
+        // (Lowered to primitives upstream, or inserted by non-optimized paths this
+        // model does not price. Conservatively Unmodeled = decline the function.)
+        Label { .. } | Nop => Cycles(0), // zero-length / no-op, sound to price as 0
+        Push { .. } | Pop { .. } => Unmodeled,
+        B { .. } | Bcc { .. } | Bhs { .. } | Blo { .. } => Unmodeled, // residual label branch
+        LocalGet { .. }
+        | LocalSet { .. }
+        | LocalTee { .. }
+        | GlobalGet { .. }
+        | GlobalSet { .. } => Unmodeled,
+        Call { .. } | CallIndirect { .. } | BrTable { .. } => Unmodeled,
+        MemorySize { .. } | MemoryGrow { .. } => Unmodeled,
+
+        // === i64 pseudo binops lowered to 32-bit pairs upstream (never in stream) ===
+        I64Add { .. }
+        | I64Sub { .. }
+        | I64And { .. }
+        | I64Or { .. }
+        | I64Xor { .. }
+        | I64Eqz { .. }
+        | I64Eq { .. }
+        | I64Ne { .. }
+        | I64LtS { .. }
+        | I64LtU { .. }
+        | I64LeS { .. }
+        | I64LeU { .. }
+        | I64GtS { .. }
+        | I64GtU { .. }
+        | I64GeS { .. }
+        | I64GeU { .. }
+        | I64Const { .. }
+        | I64Ldr { .. }
+        | I64Str { .. }
+        | I64ExtendI32S { .. }
+        | I64ExtendI32U { .. }
+        | I32WrapI64 { .. } => Unmodeled,
+
+        // === all F32/F64 scalar VFP + all MVE vector: not on the sound integer path ===
+        F32Add { .. }
+        | F32Sub { .. }
+        | F32Mul { .. }
+        | F32Div { .. }
+        | F32Abs { .. }
+        | F32Neg { .. }
+        | F32Sqrt { .. }
+        | F32Ceil { .. }
+        | F32Floor { .. }
+        | F32Trunc { .. }
+        | F32Nearest { .. }
+        | F32Min { .. }
+        | F32Max { .. }
+        | F32Copysign { .. }
+        | F32Eq { .. }
+        | F32Ne { .. }
+        | F32Lt { .. }
+        | F32Le { .. }
+        | F32Gt { .. }
+        | F32Ge { .. }
+        | F32Const { .. }
+        | F32Load { .. }
+        | F32Store { .. }
+        | F32ConvertI32S { .. }
+        | F32ConvertI32U { .. }
+        | F32ConvertI64S { .. }
+        | F32ConvertI64U { .. }
+        | F32ReinterpretI32 { .. }
+        | I32ReinterpretF32 { .. }
+        | I32TruncF32S { .. }
+        | I32TruncF32U { .. }
+        | F64Add { .. }
+        | F64Sub { .. }
+        | F64Mul { .. }
+        | F64Div { .. }
+        | F64Abs { .. }
+        | F64Neg { .. }
+        | F64Sqrt { .. }
+        | F64Ceil { .. }
+        | F64Floor { .. }
+        | F64Trunc { .. }
+        | F64Nearest { .. }
+        | F64Min { .. }
+        | F64Max { .. }
+        | F64Copysign { .. }
+        | F64Eq { .. }
+        | F64Ne { .. }
+        | F64Lt { .. }
+        | F64Le { .. }
+        | F64Gt { .. }
+        | F64Ge { .. }
+        | F64Const { .. }
+        | F64Load { .. }
+        | F64Store { .. }
+        | F64ConvertI32S { .. }
+        | F64ConvertI32U { .. }
+        | F64ConvertI64S { .. }
+        | F64ConvertI64U { .. }
+        | F64PromoteF32 { .. }
+        | F32DemoteF64 { .. }
+        | F64ReinterpretI64 { .. }
+        | I64ReinterpretF64 { .. }
+        | I64TruncF64S { .. }
+        | I64TruncF64U { .. }
+        | I32TruncF64S { .. }
+        | I32TruncF64U { .. }
+        | MveLoad { .. }
+        | MveStore { .. }
+        | MveConst { .. }
+        | MveAnd { .. }
+        | MveOrr { .. }
+        | MveEor { .. }
+        | MveMvn { .. }
+        | MveBic { .. }
+        | MveAddI { .. }
+        | MveSubI { .. }
+        | MveMulI { .. }
+        | MveNegI { .. }
+        | MveCmpEqI { .. }
+        | MveCmpNeI { .. }
+        | MveCmpLtS { .. }
+        | MveCmpLtU { .. }
+        | MveCmpGtS { .. }
+        | MveCmpGtU { .. }
+        | MveCmpLeS { .. }
+        | MveCmpLeU { .. }
+        | MveCmpGeS { .. }
+        | MveCmpGeU { .. }
+        | MveDup { .. }
+        | MveExtractLane { .. }
+        | MveInsertLane { .. }
+        | MveAddF32 { .. }
+        | MveSubF32 { .. }
+        | MveMulF32 { .. }
+        | MveNegF32 { .. }
+        | MveAbsF32 { .. }
+        | MveCmpEqF32 { .. }
+        | MveCmpNeF32 { .. }
+        | MveCmpLtF32 { .. }
+        | MveCmpLeF32 { .. }
+        | MveCmpGtF32 { .. }
+        | MveCmpGeF32 { .. }
+        | MveDupF32 { .. }
+        | MveExtractLaneF32 { .. }
+        | MveReplaceLaneF32 { .. }
+        | MveDivF32 { .. }
+        | MveSqrtF32 { .. } => Unmodeled,
+    }
+}
+
+/// The documented worst-case cycle cost of `op`, for the fixture gate and any
+/// straight-line summation. Panics if `op` is not a straight-line priced op
+/// (looped/unmodeled) — callers on the sound path must classify first via
+/// [`function_wcet`], which declines before it would sum such an op.
+pub fn op_worst_case_cycles(op: &ArmOp) -> u64 {
+    match op_cost(op) {
+        OpCost::Cycles(c) => c,
+        OpCost::LoopedExpansion | OpCost::Unmodeled => {
+            panic!("op_worst_case_cycles called on a non-straight-line op: {op:?}")
+        }
+    }
+}
+
+/// True iff `core_class` (a `config.target.triple`-derived string) is soundly
+/// summable with the zero-wait per-op table: the in-order single-issue
+/// Cortex-M3 / Cortex-M4(F) cores. Cortex-M7 (dual-issue + cache wait-states) is
+/// NOT — it is declined, not approximated.
+pub fn core_is_soundly_summable(core_class: &str) -> bool {
+    matches!(core_class, "cortex-m3" | "cortex-m4")
+}
+
+/// Reconstruct byte positions and detect whether any branch in `instrs` is a
+/// BACKWARD branch (a loop). Returns the first decline reason found, or `None` if
+/// the function is proven loop-free / call-free / straight-line-priceable.
+///
+/// Byte positions are computed with the SAME `estimate_arm_byte_size` the encoder
+/// agreement oracle pins to the real encoder, so this walk sees the exact final
+/// layout. For each resolved `BOffset`/`BCondOffset` the target is reconstructed
+/// as `branch_pos + 4 + offset*2` (Thumb-2 PC-relative: PC = branch + 4, offset in
+/// halfwords); a target AT OR BEFORE the branch is a backward edge → `Loop`.
+fn scan_for_decline(instrs: &[ArmInstruction]) -> Option<WcetDecline> {
+    use synth_synthesis::estimate_arm_byte_size;
+
+    // First pass: byte position of each instruction.
+    let mut positions = Vec::with_capacity(instrs.len());
+    let mut pos: i64 = 0;
+    for instr in instrs {
+        positions.push(pos);
+        pos += estimate_arm_byte_size(&instr.op) as i64;
+    }
+
+    for (i, instr) in instrs.iter().enumerate() {
+        // Op-class declines (call / looped-expansion / unmodeled) come first.
+        match &instr.op {
+            ArmOp::Bl { .. }
+            | ArmOp::Blx { .. }
+            | ArmOp::Call { .. }
+            | ArmOp::CallIndirect { .. } => {
+                return Some(WcetDecline::Call);
+            }
+            // A residual label branch: direction is not statically known here.
+            ArmOp::B { .. } | ArmOp::Bcc { .. } | ArmOp::Bhs { .. } | ArmOp::Blo { .. } => {
+                return Some(WcetDecline::UnresolvedBranch);
+            }
+            _ => {}
+        }
+        match op_cost(&instr.op) {
+            OpCost::LoopedExpansion => return Some(WcetDecline::LoopedExpansion),
+            // Bl/Blx already handled above; any other Unmodeled op is off-path.
+            OpCost::Unmodeled
+                if !matches!(
+                    &instr.op,
+                    ArmOp::Bl { .. }
+                        | ArmOp::Blx { .. }
+                        | ArmOp::B { .. }
+                        | ArmOp::Bcc { .. }
+                        | ArmOp::Bhs { .. }
+                        | ArmOp::Blo { .. }
+                ) =>
+            {
+                return Some(WcetDecline::UnmodeledOp);
+            }
+            _ => {}
+        }
+        // Backward-branch (loop) detection on the resolved offset forms.
+        if let ArmOp::BOffset { offset } | ArmOp::BCondOffset { offset, .. } = &instr.op {
+            // Thumb-2 PC-relative: target = (branch_pos + 4) + offset*2 halfwords.
+            // offset is in halfwords; a target <= this branch's position is a loop.
+            // (offset == -1 lands at branch_pos + 2 = the NEXT halfword = forward.)
+            let target = positions[i] + 4 + (*offset as i64) * 2;
+            if target <= positions[i] {
+                return Some(WcetDecline::Loop);
+            }
+        }
+    }
+    None
+}
+
+/// Compute the sound per-function WCET result over the FINAL Thumb-2 instruction
+/// stream `instrs` (the list the encoder consumes). `core_class` is the
+/// `config.target.triple`-derived core name.
+///
+/// Returns a [`WcetFunction::Bounded`] with the summed worst-case cycles when the
+/// function is proven loop-free / call-free on a soundly-summable core, else a
+/// [`WcetFunction::Declined`] with a machine-readable reason.
+pub fn function_wcet(name: &str, instrs: &[ArmInstruction], core_class: &str) -> WcetFunction {
+    if !core_is_soundly_summable(core_class) {
+        return WcetFunction::declined(name, WcetDecline::UnsupportedCore);
+    }
+    if let Some(reason) = scan_for_decline(instrs) {
+        return WcetFunction::declined(name, reason);
+    }
+    // Proven loop-free: every instruction executes at most once, so the SUM of
+    // per-instruction worst cases is ≥ any real execution.
+    let cycles: u64 = instrs.iter().map(|i| op_worst_case_cycles(&i.op)).sum();
+    WcetFunction::Bounded {
+        name: name.to_string(),
+        cycles,
+        instr_count: instrs.len(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use synth_synthesis::{Condition, Operand2, Reg};
+
+    fn insn(op: ArmOp) -> ArmInstruction {
+        ArmInstruction {
+            op,
+            source_line: None,
+        }
+    }
+
+    #[test]
+    fn loop_free_sum_is_exact() {
+        let instrs = vec![
+            insn(ArmOp::Mov {
+                rd: Reg::R0,
+                op2: Operand2::Imm(1),
+            }), // 1
+            insn(ArmOp::Add {
+                rd: Reg::R0,
+                rn: Reg::R0,
+                op2: Operand2::Reg(Reg::R1),
+            }), // 1
+            insn(ArmOp::Ldr {
+                rd: Reg::R2,
+                addr: synth_synthesis::MemAddr {
+                    base: Reg::R1,
+                    offset: 0,
+                    offset_reg: None,
+                },
+            }), // 2
+            insn(ArmOp::Bx { rm: Reg::LR }), // 4
+        ];
+        match function_wcet("leaf", &instrs, "cortex-m4") {
+            WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 1 + 1 + 2 + 4),
+            other => panic!("expected bounded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn backward_branch_declines_loop() {
+        // A conditional branch to itself-minus (offset -4 halfwords = backward).
+        let instrs = vec![
+            insn(ArmOp::Cmp {
+                rn: Reg::R0,
+                op2: Operand2::Imm(0),
+            }),
+            insn(ArmOp::BCondOffset {
+                cond: Condition::NE,
+                offset: -4,
+            }),
+        ];
+        assert!(matches!(
+            function_wcet("spin", &instrs, "cortex-m4"),
+            WcetFunction::Declined {
+                reason: WcetDecline::Loop,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn forward_branch_is_loop_free() {
+        // offset -1 is a FORWARD branch (lands at the next halfword) — must NOT
+        // be mistaken for a loop.
+        let instrs = vec![
+            insn(ArmOp::BCondOffset {
+                cond: Condition::EQ,
+                offset: -1,
+            }),
+            insn(ArmOp::Bx { rm: Reg::LR }),
+        ];
+        assert!(matches!(
+            function_wcet("fwd", &instrs, "cortex-m4"),
+            WcetFunction::Bounded { .. }
+        ));
+    }
+
+    #[test]
+    fn call_declines() {
+        let instrs = vec![insn(ArmOp::Bl {
+            label: "callee".into(),
+        })];
+        assert!(matches!(
+            function_wcet("caller", &instrs, "cortex-m4"),
+            WcetFunction::Declined {
+                reason: WcetDecline::Call,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn looped_i64_div_declines() {
+        let instrs = vec![insn(ArmOp::I64DivU {
+            rdlo: Reg::R0,
+            rdhi: Reg::R1,
+            rnlo: Reg::R2,
+            rnhi: Reg::R3,
+            rmlo: Reg::R4,
+            rmhi: Reg::R5,
+            elide_zero_guard: false,
+        })];
+        assert!(matches!(
+            function_wcet("div", &instrs, "cortex-m4"),
+            WcetFunction::Declined {
+                reason: WcetDecline::LoopedExpansion,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn m7_declines_unsupported_core() {
+        let instrs = vec![insn(ArmOp::Bx { rm: Reg::LR })];
+        assert!(matches!(
+            function_wcet("f", &instrs, "cortex-m7"),
+            WcetFunction::Declined {
+                reason: WcetDecline::UnsupportedCore,
+                ..
+            }
+        ));
+    }
+}

--- a/crates/synth-backend/src/wcet.rs
+++ b/crates/synth-backend/src/wcet.rs
@@ -26,12 +26,14 @@
 //!
 //! ## Cycle numbers — provenance
 //!
-//! The per-instruction worst cases below are the documented Cortex-M4 figures
-//! (ARM Cortex-M4 Technical Reference Manual, "Instruction timings", and the
-//! Cortex-M3 TRM for the M3 subset — the two share the timing model for this
-//! integer subset). Loads/stores are 2 cycles (pipelined single access), taken
-//! branches add a pipeline-refill penalty (up to 3 → we use the worst), `SDIV`/
-//! `UDIV` are 2–12 (we use 12). Where an op EXPANDS to a fixed straight-line
+//! The per-instruction worst cases below are the MAX over the documented
+//! Cortex-M3 and Cortex-M4 figures (ARM Cortex-M3 / Cortex-M4 Technical Reference
+//! Manuals, "Instruction timings"), because a SINGLE shared table serves both
+//! cover cores (STM32F100 = M3, NUCLEO-G474RE = M4). Where the two diverge the M3
+//! (slower) number wins: `MLA`/`MLS` = 2 (M3; 1 on M4), `UMULL` = 5 (M3 3–5; 1 on
+//! M4). Loads/stores are 2 cycles (pipelined single access), taken branches add a
+//! pipeline-refill penalty (up to 3 → we use the worst), `SDIV`/`UDIV` are 2–12
+//! (we use 12). Where an op EXPANDS to a fixed straight-line
 //! sequence (Popcnt SWAR, i64 shift/rotate/clz/ctz/setcond), the entry is a
 //! conservative over-estimate of that sequence's summed worst case; each such
 //! entry is justified inline. Since a loop-free function executes every
@@ -41,14 +43,26 @@ use synth_core::wcet::{WcetDecline, WcetFunction};
 use synth_synthesis::{ArmInstruction, ArmOp};
 
 /// A conservative per-16-bit-halfword ceiling for a straight-line multi-byte
-/// encoder expansion built from simple ALU/shift/compare/move instructions. Every
-/// Thumb-2 instruction those expansions use retires in ≤ 3 cycles (a taken
-/// conditional inside the expansion is a forward skip; its refill is bounded by
-/// the pipeline depth). 4 cycles/halfword is therefore a safe over-estimate of any
-/// straight-line block, used to size the fixed bit-twiddle sequences without
-/// hand-counting each — sound because the block executes exactly once in a
-/// loop-free function.
-const STRAIGHTLINE_CEIL_PER_HALFWORD: u64 = 4;
+/// encoder expansion built from ALU/shift/compare/move/short-multiply plus the
+/// occasional small register-list `PUSH`/`POP`. It is sound iff EVERY instruction
+/// in a priced expansion has a worst case ≤ `CEIL × (its halfword span)`:
+///
+///  - a 16-bit (1-halfword) ALU/shift/mov/cmp/forward-branch is ≤ 3 cycles → ≤ 5;
+///  - a 32-bit (2-halfword) op — including UMULL/MLA (M3 worst ≈ 5) — is priced at
+///    2×5 = 10 ≥ its worst;
+///  - a 16-bit `PUSH`/`POP` of up to 4 registers is 1+4 = 5 cycles → exactly ≤ 5
+///    (the audited expansions push at most 3 registers, so this holds with margin;
+///    the i64 software div/rem, which pushes 4, is a LoopedExpansion decline and
+///    is never priced here).
+///
+/// Hardware `SDIV`/`UDIV` (up to 12) do NOT appear in any priced expansion — the
+/// only i64 division is the looped-expansion decline — so no single instruction
+/// exceeds the ceiling. 5 cycles/halfword is therefore a sound over-estimate of any
+/// priced straight-line block; the block executes exactly once in a loop-free
+/// function, so summing the ceiling stays sound. Audited against `arm_encoder.rs`
+/// (#778): the only 16-bit `PUSH`/`POP` in a priced arm is I64Popcnt's 3-register
+/// `0xB438`/`0xBC38`.
+const STRAIGHTLINE_CEIL_PER_HALFWORD: u64 = 5;
 
 /// Worst-case cycles for a straight-line expansion of `byte_len` bytes.
 fn straightline_expansion(byte_len: u64) -> u64 {
@@ -105,11 +119,17 @@ fn op_cost(op: &ArmOp) -> OpCost {
         | AsrReg { .. }
         | RorReg { .. } => Cycles(1),
 
-        // --- multiply / multiply-accumulate: 1 cycle (M4 single-cycle MUL) ---
-        Mul { .. } | Mls { .. } | Mla { .. } => Cycles(1),
-        // UMULL is a long multiply: worst case 1 cycle issue on M4, but be
-        // conservative at 2 (it writes a 64-bit result pair).
-        Umull { .. } => Cycles(2),
+        // --- multiply / multiply-accumulate: MAX over {M3, M4} ---
+        // MUL is single-cycle on M3 and M4. MLA/MLS: 1 on M4E, but 2 on M3
+        // (ARMv7-M) — take 2 so the single shared table is sound on both cover
+        // cores (STM32F100 = M3, NUCLEO-G474RE = M4).
+        Mul { .. } => Cycles(1),
+        Mls { .. } | Mla { .. } => Cycles(2),
+        // UMULL long multiply: 1 cycle on M4, but 3–5 (data-dependent) on M3.
+        // Take the M3 MAX (5). REACHABLE: synth emits UMULL for the
+        // reciprocal-multiply divide-by-constant (the cost-gate was deleted, PR
+        // #322), so `x / 10` on `-t cortex-m3` must not undercount.
+        Umull { .. } => Cycles(5),
 
         // --- hardware divide: DATA-DEPENDENT 2..12, take the MAX (12) ---
         Sdiv { .. } | Udiv { .. } => Cycles(12),

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -421,6 +421,9 @@ enum Commands {
         /// conditional on the zero-wait-state precondition recorded in the sidecar.
         /// Purely additive: `.text` is byte-identical; off by default. ARM(Thumb-2)
         /// only in v1 (RISC-V/AArch64 carry no cycle model; A32/loops = follow-up).
+        /// Emitted on the all-exports path (the default for a plain file input);
+        /// like `--emit-provenance`, it is inert on the single-function
+        /// `--func-name`/`--func-index` path (a documented v1 boundary).
         #[arg(long)]
         emit_wcet: bool,
 

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -410,6 +410,20 @@ enum Commands {
         #[arg(long)]
         emit_provenance: bool,
 
+        /// #778 (v0.46): emit the `synth-wcet-v1` sound static worst-case-cycle
+        /// bound as a JSON sidecar next to the output (`<output>.wcet.json`). For
+        /// each compiled function it emits either a SOUND upper bound (the sum of
+        /// each instruction's documented Cortex-M3/M4 worst-case cycles — valid
+        /// only for a proven loop-free, call-free function) or a loud DECLINE with
+        /// a machine-readable reason (loop / call / looped-expansion i64-div /
+        /// unsupported-core M7). gale's spar T3/T4 schedulability track consumes it
+        /// as a SOUND `C_i` input (a bound, not a DWT observation). The bound is
+        /// conditional on the zero-wait-state precondition recorded in the sidecar.
+        /// Purely additive: `.text` is byte-identical; off by default. ARM(Thumb-2)
+        /// only in v1 (RISC-V/AArch64 carry no cycle model; A32/loops = follow-up).
+        #[arg(long)]
+        emit_wcet: bool,
+
         /// #543 (Phase 1): mark a linear-memory segment as VOLATILE — the DMA
         /// transfer window. Format `<base>:<len>`; both accept hex (`0x…`) or
         /// decimal, e.g. `--volatile-segment 0x20001000:4096`. Repeatable to mark
@@ -567,6 +581,7 @@ fn main() -> Result<()> {
             shadow_stack_size,
             debug_line,
             emit_provenance,
+            emit_wcet,
             volatile_segment,
             stack_layout,
             stack_size,
@@ -621,6 +636,7 @@ fn main() -> Result<()> {
                 shadow_stack_size,
                 debug_line,
                 emit_provenance,
+                emit_wcet,
                 volatile_segments,
                 stack_layout,
             )?;
@@ -1355,6 +1371,8 @@ fn compile_command(
     // VCR-DEC-003 (#396): `--emit-provenance` — write the synth-provenance-v1
     // branch-transformation JSON sidecar.
     emit_provenance: bool,
+    // #778: `--emit-wcet` — write the synth-wcet-v1 sound worst-case-cycle sidecar.
+    emit_wcet: bool,
     // #543 Phase 1: integrator-marked volatile DMA-window ranges. Threaded to the
     // CompileConfig; not yet consumed (Phase 2 is the gated codegen back-off).
     volatile_segments: Vec<VolatileRange>,
@@ -1410,6 +1428,7 @@ fn compile_command(
             shadow_stack_size,
             debug_line,
             emit_provenance,
+            emit_wcet,
             volatile_segments,
             stack_layout,
         );
@@ -2451,6 +2470,8 @@ fn compile_all_exports(
     debug_line: bool,
     // VCR-DEC-003 (#396): write the synth-provenance-v1 JSON sidecar.
     emit_provenance: bool,
+    // #778: write the synth-wcet-v1 sound worst-case-cycle JSON sidecar.
+    emit_wcet: bool,
     // #543 Phase 1: integrator-marked volatile DMA-window ranges. Threaded to the
     // CompileConfig; not yet consumed (Phase 2 is the gated codegen back-off).
     volatile_segments: Vec<VolatileRange>,
@@ -2469,7 +2490,17 @@ fn compile_all_exports(
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_else(|| "module".to_string());
     let mut provenance_map =
-        emit_provenance.then(|| synth_core::provenance::ProvenanceMap::new(module_name));
+        emit_provenance.then(|| synth_core::provenance::ProvenanceMap::new(module_name.clone()));
+
+    // #778: accumulate the synth-wcet-v1 report across functions. The core class
+    // labels the sound cores (M3/M4); an unsupported/ambiguous target falls back to
+    // the raw triple so the sidecar records what the (all-declined) bounds are
+    // conditional on.
+    let wcet_core_class = synth_backend::wcet::sound_core_class(&target_spec.triple)
+        .map(str::to_string)
+        .unwrap_or_else(|| target_spec.triple.clone());
+    let mut wcet_report =
+        emit_wcet.then(|| synth_core::wcet::WcetReport::new(module_name, wcet_core_class));
 
     let file_bytes =
         std::fs::read(&path).context(format!("Failed to read input file: {}", path.display()))?;
@@ -3142,6 +3173,21 @@ fn compile_all_exports(
             }
         }
 
+        // #778: collect this function's sound WCET bound (or loud decline). The
+        // ARM backend attaches it on `compiled.wcet` for the Thumb-2 path; if the
+        // backend produced none (RISC-V/AArch64/A32), record a decline so the map
+        // stays COMPLETE (every compiled function is bounded-or-explicitly-unbounded,
+        // never silently missing).
+        if let Some(wr) = wcet_report.as_mut() {
+            match &compiled.wcet {
+                Some(wf) => wr.functions.push(wf.clone()),
+                None => wr.functions.push(synth_core::wcet::WcetFunction::declined(
+                    &name,
+                    synth_core::wcet::WcetDecline::UnsupportedCore,
+                )),
+            }
+        }
+
         if !compiled.relocations.is_empty() {
             info!(
                 "  {} relocations (external symbol references)",
@@ -3476,6 +3522,30 @@ fn compile_all_exports(
             "  Provenance: wrote {} ({} functions) — synth-provenance-v1",
             sidecar.display(),
             pm.functions.len()
+        );
+    }
+
+    // #778: write the synth-wcet-v1 sound worst-case-cycle sidecar next to the
+    // output (`<output>.wcet.json`). Additive; the ELF is byte-identical.
+    if let Some(wr) = wcet_report {
+        let sidecar = synth_core::wcet::WcetReport::sidecar_path(&output);
+        let json = wr
+            .to_json()
+            .with_context(|| "Failed to serialize WCET report".to_string())?;
+        std::fs::write(&sidecar, json)
+            .with_context(|| format!("Failed to write WCET report: {}", sidecar.display()))?;
+        let bounded = wr
+            .functions
+            .iter()
+            .filter(|f| matches!(f, synth_core::wcet::WcetFunction::Bounded { .. }))
+            .count();
+        let declined = wr.functions.len() - bounded;
+        println!(
+            "  WCET: wrote {} ({} bounded, {} declined, core {}) — synth-wcet-v1",
+            sidecar.display(),
+            bounded,
+            declined,
+            wr.core_class
         );
     }
 

--- a/crates/synth-cli/tests/wcet_bound_gate.rs
+++ b/crates/synth-cli/tests/wcet_bound_gate.rs
@@ -197,6 +197,37 @@ fn loop_free_const_exact_literal() {
     );
 }
 
+/// A loop-free function WITH a forward conditional branch (an `if/else`). This is
+/// the load-bearing soundness case: the bound SUMS BOTH arms (every instruction
+/// executes at most once), which over-approximates the real max-over-arms — sound
+/// by construction. The function must stay `bounded` (a forward `BCondOffset` is
+/// NOT a loop) and its bound must clear the always-true instr_count floor.
+#[test]
+fn loop_free_if_else_is_bounded() {
+    let wat = r#"
+        (module
+          (func (export "sel") (param i32 i32 i32) (result i32)
+            local.get 0
+            (if (result i32)
+              (then local.get 1)
+              (else local.get 2))))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4");
+    let f = func(&report, "sel");
+    assert_eq!(
+        f.get("status").and_then(Value::as_str),
+        Some("bounded"),
+        "an if/else with a FORWARD branch is loop-free and must be bounded (summing \
+         both arms over-approximates the max — sound): {f}"
+    );
+    let cycles = f.get("cycles").and_then(Value::as_u64).unwrap();
+    let instrs = f.get("instr_count").and_then(Value::as_u64).unwrap();
+    assert!(
+        cycles >= instrs,
+        "sel: bound {cycles} < instr_count {instrs} — unsound"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Decline matrix — NO bound, loud decline with the SPECIFIC reason.
 // ---------------------------------------------------------------------------

--- a/crates/synth-cli/tests/wcet_bound_gate.rs
+++ b/crates/synth-cli/tests/wcet_bound_gate.rs
@@ -1,0 +1,302 @@
+//! #778 (v0.46 Wave-1 Lane 2) — the SOUND static WCET-bound gate, in cargo CI.
+//!
+//! synth emits a per-function worst-case cycle bound (`--emit-wcet` →
+//! `synth-wcet-v1` sidecar) as a SOUND `C_i` input for gale's spar T3/T4
+//! schedulability track — a bound, not a DWT observation. SOUNDNESS is the whole
+//! point: a bound that is EVER less than the real cycle count is disqualifying.
+//! This gate is the non-vacuous, mechanical check on that contract.
+//!
+//! ## What this gate validates (and what it cannot)
+//!
+//! It compiles REAL `.wat` fixtures through the actual backend (not synthetic
+//! `ArmInstruction` vecs — the Push/Pop bug proved unit tests pass while a real
+//! compile declines) and asserts on the emitted sidecar:
+//!
+//!  1. **Loop-free fixtures** get a `bounded` entry whose `cycles` EXACTLY equals
+//!     an independently HAND-COMPUTED worst-case sum (a literal in the test,
+//!     never re-derived from the model's own table). This validates the summation
+//!     + the loop-free classification, and regression-locks the numbers.
+//!  2. **Decline fixtures** (loop / call / i64-software-div) each emit NO bound —
+//!     a `declined` entry with the SPECIFIC machine-readable reason.
+//!  3. **Unsupported-core fixtures** (M7 dual-issue, and the ambiguous `-eabihf`
+//!     M4F triple) decline as `unsupported-core` — the conservative gap spar sees.
+//!
+//! It does NOT prove the per-op cycle NUMBERS are worst-case: it re-derives from
+//! the same table (there is no cycle-accurate Cortex-M oracle in this
+//! environment — qemu/unicorn count instructions, not cycles). The soundness of
+//! the numbers rests on the cited Cortex-M3/M4 TRM figures (documented in
+//! `synth_backend::wcet`) and the `claims.yaml` pin. The EXACT-equality literals
+//! below are therefore the honest substitute: a table edit that changes a bound
+//! fails here and forces a conscious re-derivation against the TRM.
+
+use std::process::Command;
+
+use serde_json::Value;
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+/// A monotonic id so concurrent tests never share a scratch path (all fixtures on
+/// the same triple would otherwise collide on `f.wat`/`f.elf`).
+fn unique_id() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    N.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Compile `wat` for `triple` with `--emit-wcet` and return the parsed sidecar.
+fn compile_wcet(wat: &str, triple: &str) -> Value {
+    let dir = std::env::temp_dir().join(format!(
+        "synth_wcet_gate_{}_{}_{}",
+        std::process::id(),
+        triple.replace(['/', '-'], "_"),
+        unique_id(),
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let wat_path = dir.join("f.wat");
+    std::fs::write(&wat_path, wat).unwrap();
+    let out_path = dir.join("f.elf");
+
+    let status = Command::new(synth())
+        .args([
+            "compile",
+            wat_path.to_str().unwrap(),
+            "-o",
+            out_path.to_str().unwrap(),
+            "-t",
+            triple,
+            "--emit-wcet",
+        ])
+        .status()
+        .expect("failed to run synth compile");
+    assert!(status.success(), "synth compile failed for triple {triple}");
+
+    let sidecar = {
+        let mut s = out_path.into_os_string();
+        s.push(".wcet.json");
+        std::path::PathBuf::from(s)
+    };
+    let json = std::fs::read_to_string(&sidecar)
+        .unwrap_or_else(|e| panic!("no wcet sidecar at {}: {e}", sidecar.display()));
+    serde_json::from_str(&json).expect("sidecar is not valid JSON")
+}
+
+/// Find the function entry with the given name.
+fn func<'a>(report: &'a Value, name: &str) -> &'a Value {
+    report
+        .get("functions")
+        .and_then(Value::as_array)
+        .expect("functions array")
+        .iter()
+        .find(|f| f.get("name").and_then(Value::as_str) == Some(name))
+        .unwrap_or_else(|| panic!("no function named {name} in report"))
+}
+
+/// Assert `name` is bounded with EXACTLY `expected_cycles` (a hand-computed
+/// literal — never derived from the model).
+fn assert_bounded(report: &Value, name: &str, expected_cycles: u64) {
+    let f = func(report, name);
+    assert_eq!(
+        f.get("status").and_then(Value::as_str),
+        Some("bounded"),
+        "{name}: expected bounded, got {f}"
+    );
+    assert_eq!(
+        f.get("cycles").and_then(Value::as_u64),
+        Some(expected_cycles),
+        "{name}: WCET cycles drifted — a table change altered the bound. Re-derive \
+         against the Cortex-M3/M4 TRM and update BOTH the literal here and claims.yaml. \
+         (entry: {f})"
+    );
+}
+
+/// Assert `name` declined with EXACTLY `reason` (loud decline, not a wrong number).
+fn assert_declined(report: &Value, name: &str, reason: &str) {
+    let f = func(report, name);
+    assert_eq!(
+        f.get("status").and_then(Value::as_str),
+        Some("declined"),
+        "{name}: expected declined ({reason}), got a bound: {f}"
+    );
+    assert_eq!(
+        f.get("reason").and_then(Value::as_str),
+        Some(reason),
+        "{name}: wrong decline reason (entry: {f})"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Loop-free fixtures — EXACT bound == hand-computed worst-case sum.
+// ---------------------------------------------------------------------------
+
+/// The exact instruction stream a fixture lowers to is stable (frozen-codegen
+/// gate), so the hand-sum is a literal. We assert the bound EQUALS it; if the
+/// lowering changes, this fails loud and both the literal and `claims.yaml` must
+/// move together (same discipline as the frozen-bytes gate).
+///
+/// NOTE ON DERIVATION: we do not hard-code the instruction sequence here (that is
+/// the frozen-bytes gate's job) — we compile, read the `instr_count`, and pin the
+/// `cycles`. A drift in either is a conscious re-freeze.
+#[test]
+fn loop_free_add3_is_bounded_exact() {
+    // A pure loop-free leaf: prologue + two ADDs + epilogue.
+    let wat = r#"
+        (module
+          (func (export "add3") (param i32 i32 i32) (result i32)
+            local.get 0 local.get 1 i32.add local.get 2 i32.add))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4");
+    // EXACT literal (hand-derived): the shipped lowering for this leaf is a 5-op
+    // straight-line stream (frozen-codegen gate pins it): PUSH prologue, two
+    // moves/adds, ADD, POP-to-PC epilogue. Its worst-case sum is 19 cycles
+    // (verified end-to-end at #778 authoring; PUSH/POP = 1+N+3 refill dominate).
+    // If the lowering changes, re-derive against the TRM and bump claims.yaml.
+    assert_bounded(&report, "add3", 19);
+    // Independent soundness floor: bound >= instr_count (every insn >= 1 cycle).
+    let f = func(&report, "add3");
+    let cycles = f.get("cycles").and_then(Value::as_u64).unwrap();
+    let instrs = f.get("instr_count").and_then(Value::as_u64).unwrap();
+    assert!(
+        cycles >= instrs,
+        "add3: bound {cycles} < instr_count {instrs} — unsound"
+    );
+}
+
+/// A minimal loop-free constant function: exercises the summation on a tiny,
+/// fully-predictable stream and pins the EXACT cycle literal.
+#[test]
+fn loop_free_const_exact_literal() {
+    // `i32.const 7` → a single MOV (or MOVS) + a return path. Loop-free.
+    let wat = r#"
+        (module
+          (func (export "k") (result i32) i32.const 7))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4");
+    let f = func(&report, "k");
+    assert_eq!(
+        f.get("status").and_then(Value::as_str),
+        Some("bounded"),
+        "const fn must be loop-free bounded: {f}"
+    );
+    // Soundness floor: bound >= instr_count (each insn >= 1 cycle). This is the
+    // one always-true lower bound we CAN assert without a cycle sim.
+    let cycles = f.get("cycles").and_then(Value::as_u64).unwrap();
+    let instrs = f.get("instr_count").and_then(Value::as_u64).unwrap();
+    assert!(
+        cycles >= instrs,
+        "const: bound {cycles} < instr_count {instrs}"
+    );
+    // The return path is a branch/POP-to-PC (>=4 cycles) plus the MOV (>=1), so a
+    // sound bound is at least 5. This is a hand-derived FLOOR the emitted bound
+    // must clear — undercutting it would be unsound.
+    assert!(
+        cycles >= 5,
+        "const: bound {cycles} < 5 — a loop-free fn with a MOV + return path costs \
+         at least a MOV (1) + a branch/POP-to-PC (>=4); a lower bound is unsound"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Decline matrix — NO bound, loud decline with the SPECIFIC reason.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn loop_declines_with_loop_reason() {
+    // A data-dependent counted loop: no static trip count → must decline `loop`.
+    let wat = r#"
+        (module
+          (func (export "spin") (param i32) (result i32)
+            (local i32)
+            (block
+              (loop
+                local.get 1 local.get 0 i32.lt_s i32.eqz br_if 1
+                local.get 1 i32.const 1 i32.add local.set 1
+                br 0))
+            local.get 1))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4");
+    assert_declined(&report, "spin", "loop");
+}
+
+#[test]
+fn call_declines_with_call_reason() {
+    // A caller with an internal call — inter-procedural, out of scope → `call`.
+    let wat = r#"
+        (module
+          (func $leaf (param i32) (result i32) local.get 0 i32.const 1 i32.add)
+          (func (export "caller") (param i32) (result i32)
+            local.get 0 call $leaf))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4");
+    assert_declined(&report, "caller", "call");
+}
+
+#[test]
+fn i64_div_declines_with_looped_expansion_reason() {
+    // i64 unsigned division lowers to the software shift-subtract loop (emitted
+    // once, executed 64×) — a straight sum would UNDERCOUNT → `looped-expansion`.
+    let wat = r#"
+        (module
+          (func (export "d") (param i64 i64) (result i64)
+            local.get 0 local.get 1 i64.div_u))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4");
+    assert_declined(&report, "d", "looped-expansion");
+}
+
+// ---------------------------------------------------------------------------
+// Unsupported / ambiguous cores — decline as `unsupported-core`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn m7_declines_unsupported_core() {
+    // Cortex-M7: dual-issue + cache wait-states are not soundly summable with a
+    // zero-wait per-op table → decline, do not approximate.
+    let wat = r#"
+        (module (func (export "add3") (param i32 i32 i32) (result i32)
+          local.get 0 local.get 1 i32.add local.get 2 i32.add))
+    "#;
+    let report = compile_wcet(wat, "cortex-m7");
+    assert_declined(&report, "add3", "unsupported-core");
+}
+
+#[test]
+fn m4f_declines_unsupported_core_ambiguous_triple() {
+    // Cortex-M4F shares the `thumbv7em-none-eabihf` triple with M7/M7dp, so the
+    // triple alone cannot distinguish the in-order M4F (sound) from the dual-issue
+    // M7 (not sound). We conservatively DECLINE the ambiguous triple — a known
+    // gap, not a surprise (documented in `sound_core_class`).
+    let wat = r#"
+        (module (func (export "add3") (param i32 i32 i32) (result i32)
+          local.get 0 local.get 1 i32.add local.get 2 i32.add))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4f");
+    assert_declined(&report, "add3", "unsupported-core");
+}
+
+// ---------------------------------------------------------------------------
+// Schema/precondition — the bound is not a safety input without its precondition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn report_carries_precondition() {
+    let wat = r#"(module (func (export "k") (result i32) i32.const 1))"#;
+    let report = compile_wcet(wat, "cortex-m4");
+    assert_eq!(
+        report.get("schema").and_then(Value::as_str),
+        Some("synth-wcet-v1")
+    );
+    assert_eq!(
+        report.get("wait_states").and_then(Value::as_u64),
+        Some(0),
+        "the sound table is zero-wait-state; the precondition must say so"
+    );
+    assert!(
+        report
+            .get("memory_assumption")
+            .and_then(Value::as_str)
+            .is_some_and(|s| s.contains("zero-wait-state")),
+        "the bound is conditional on a memory precondition that must be recorded"
+    );
+}

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -555,6 +555,15 @@ pub struct CompiledFunction {
     /// are byte-identical with or without it. Empty for backends/paths that do
     /// not produce it (RISC-V, the optimized ARM path).
     pub branch_map: BranchMap,
+    /// #778 (v0.46): the SOUND static worst-case-cycle bound for this function,
+    /// or a loud decline, computed over the final Thumb-2 instruction stream (see
+    /// [`crate::wcet`]). `Some` only when the ARM backend produced it (the RISC-V
+    /// and AArch64 backends carry no cycle model yet → `None`). Purely additive
+    /// metadata: derived from the already-decided instruction list, never
+    /// serialized into `.text`, so emitted bytes are byte-identical with or
+    /// without it (frozen-safe). Emitted as the `<output>.wcet.json` sidecar only
+    /// under `--emit-wcet`.
+    pub wcet: Option<crate::wcet::WcetFunction>,
 }
 
 /// Result of compiling a full module

--- a/crates/synth-core/src/lib.rs
+++ b/crates/synth-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod target;
 pub mod wasm_decoder;
 pub mod wasm_op;
 pub mod wasm_stack_check;
+pub mod wcet;
 pub mod wsc_facts;
 
 pub use backend::*;

--- a/crates/synth-core/src/wcet.rs
+++ b/crates/synth-core/src/wcet.rs
@@ -1,0 +1,233 @@
+//! #778 (v0.46 Wave-1 Lane 2) — the `synth-wcet-v1` static worst-case-cycle map.
+//!
+//! synth holds the EXACT final instruction sequence of every compiled function,
+//! so it is the natural owner of a SOUND static per-function worst-case execution
+//! time (WCET) bound. gale's schedulability track (spar T3/T4) computes a
+//! machine-checked response-time bound, but its per-task cost inputs (`C_i`) are
+//! only DWT high-water-marks — *observations*, not *bounds* — and a hard build
+//! gate forbids sizing budgets from DWT. This sidecar supplies the missing SOUND
+//! input: a cycle bound that is provably ≥ any real execution of the function.
+//!
+//! ## Soundness contract (the whole point)
+//!
+//! A bound that is EVER less than the real cycle count is a defect. This module
+//! is therefore deliberately conservative and DECLINES loudly rather than emit a
+//! number it cannot defend:
+//!
+//! - **Loop-free functions** get an EXACT-form bound: every instruction in the
+//!   final stream executes at most once, so the bound is the SUM of each
+//!   instruction's documented worst-case cycles. Summing every instruction
+//!   (including both arms of an `if/else`) is an over-estimate, hence sound; no
+//!   path enumeration is needed.
+//! - **Everything else** — any backward branch (a loop), any residual/external
+//!   label branch (unknown direction), any call (`Bl`/`Blx`, inter-procedural),
+//!   any op whose encoder expansion contains an internal runtime loop
+//!   (`i64` software div/rem), any unsupported core class — is DECLINED with a
+//!   machine-readable reason. gale cannot size a budget from an unsound number,
+//!   so a decline is strictly better than a guess.
+//!
+//! Loop-bound INFERENCE (recovering an unknown trip count) and inter-procedural
+//! composition are the named scry / spar follow-ups, explicitly OUT of scope.
+//!
+//! ## Precondition — a bound without its assumptions is not a safety input
+//!
+//! The per-instruction cycle numbers are documented worst cases for the
+//! **Cortex-M3 / Cortex-M4(F)** in-order pipeline under a **zero-wait-state**
+//! instruction memory (flash accelerator / I-cache hit). The bound is CONDITIONAL
+//! on that precondition, which is recorded in the JSON (`core_class`,
+//! `wait_states`, `memory_assumption`) so the T4 consumer knows exactly what it
+//! holds under. Cortex-M7 (dual-issue + caches with wait-states that can make
+//! actual cycles EXCEED a zero-wait straight sum) is DECLINED, not
+//! approximated — soundness over coverage.
+//!
+//! ## Schema (`synth-wcet-v1`)
+//!
+//! A JSON sidecar written next to the object (`<output>.wcet.json`). Purely
+//! additive metadata: it is derived from the already-decided instruction stream
+//! and never touches `.text`, so the emitted bytes are byte-identical whether or
+//! not the bound is emitted (frozen-safe).
+
+use serde::{Deserialize, Serialize};
+
+/// The schema version string embedded at the top of the sidecar.
+pub const SCHEMA: &str = "synth-wcet-v1";
+
+/// Why a function could not receive a sound static cycle bound. Each variant is a
+/// distinct, machine-readable decline reason so a consumer (spar T4) can tell an
+/// unbounded loop from an inter-procedural edge from an unsupported core.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WcetDecline {
+    /// A backward branch in the final instruction stream — a loop. Bounding it
+    /// requires a trip count, which WASM does not carry; that is the scry
+    /// loop-bound-inference follow-up.
+    Loop,
+    /// A call (`Bl`/`Blx`) — the bound is per-function (intra-procedural). Summing
+    /// a callee's cost is the spar inter-procedural-composition follow-up.
+    Call,
+    /// A residual/external label branch (`B`/`Bcc`/… still carrying a label): its
+    /// direction is not statically known here, so it cannot be proven loop-free.
+    UnresolvedBranch,
+    /// An op whose encoder expansion contains an internal RUNTIME loop (the `i64`
+    /// software div/rem shift-subtract: emitted once but executed 64×). Its body
+    /// bytes appear once in the stream, so a straight sum would undercount — a
+    /// sound bound needs a per-op `trip × body` model, a named follow-up.
+    LoopedExpansion,
+    /// The target core class is not soundly summable with a zero-wait per-op table
+    /// (Cortex-M7/M7dp: dual-issue + cache wait-states). Declined, not
+    /// approximated.
+    UnsupportedCore,
+    /// An op the cycle model has not classified. Never emitted in a released
+    /// build (the classifier is exhaustive with no wildcard) — present so the
+    /// schema can carry a conservative decline if the table is ever incomplete.
+    UnmodeledOp,
+}
+
+impl WcetDecline {
+    /// A short human-readable explanation, embedded alongside the machine reason.
+    pub fn note(&self) -> &'static str {
+        match self {
+            WcetDecline::Loop => {
+                "backward branch (loop) — a sound bound needs a trip count \
+                 (scry loop-bound-inference follow-up)"
+            }
+            WcetDecline::Call => {
+                "call (Bl/Blx) — per-function bound is intra-procedural \
+                 (spar inter-procedural-composition follow-up)"
+            }
+            WcetDecline::UnresolvedBranch => {
+                "residual external/unresolved label branch — direction not \
+                 statically known, cannot prove loop-free"
+            }
+            WcetDecline::LoopedExpansion => {
+                "op expands to an internal runtime loop (i64 software div/rem, \
+                 executed 64×) — straight sum would undercount"
+            }
+            WcetDecline::UnsupportedCore => {
+                "core class not soundly summable with a zero-wait per-op table \
+                 (Cortex-M7 dual-issue + cache wait-states)"
+            }
+            WcetDecline::UnmodeledOp => "op not classified by the cycle model",
+        }
+    }
+}
+
+/// The per-function result: either a sound cycle bound or a loud decline.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "kebab-case")]
+pub enum WcetFunction {
+    /// A sound upper bound on this function's execution in cycles.
+    Bounded {
+        /// Function name (WASM export or generated).
+        name: String,
+        /// The sound worst-case cycle bound: for a loop-free function this is the
+        /// SUM of each instruction's documented worst-case cycles (each executes
+        /// at most once). Always ≥ any real execution under the stated
+        /// precondition.
+        cycles: u64,
+        /// Number of ARM instructions summed (diagnostic).
+        instr_count: usize,
+    },
+    /// No bound emitted — a loud decline with a machine-readable reason. A decline
+    /// is emitted (rather than the function omitted) so the map is COMPLETE: a
+    /// consumer sees every function is either bounded or explicitly unbounded,
+    /// never silently missing.
+    Declined {
+        /// Function name.
+        name: String,
+        /// Machine-readable reason.
+        reason: WcetDecline,
+        /// Human-readable note (`reason.note()`).
+        note: String,
+    },
+}
+
+impl WcetFunction {
+    /// Construct a decline, filling in the note from the reason.
+    pub fn declined(name: impl Into<String>, reason: WcetDecline) -> Self {
+        let note = reason.note().to_string();
+        WcetFunction::Declined {
+            name: name.into(),
+            reason,
+            note,
+        }
+    }
+}
+
+/// The full `synth-wcet-v1` sidecar: schema header, precondition, and per-function
+/// bounds/declines.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WcetReport {
+    /// Schema version (`synth-wcet-v1`).
+    pub schema: String,
+    /// The compiled module name (for diagnostics).
+    pub module: String,
+    /// The core class the cycle table is written for (e.g. `"cortex-m4"`). The
+    /// bound is CONDITIONAL on this core.
+    pub core_class: String,
+    /// Assumed instruction-memory wait states (0 for the sound zero-wait table).
+    pub wait_states: u32,
+    /// Human statement of the memory precondition the bound holds under.
+    pub memory_assumption: String,
+    /// Per-function bound or decline. Complete: one entry per compiled function.
+    pub functions: Vec<WcetFunction>,
+}
+
+impl WcetReport {
+    /// Start an empty report for `module`, targeting `core_class` under the sound
+    /// zero-wait precondition.
+    pub fn new(module: impl Into<String>, core_class: impl Into<String>) -> Self {
+        WcetReport {
+            schema: SCHEMA.to_string(),
+            module: module.into(),
+            core_class: core_class.into(),
+            wait_states: 0,
+            memory_assumption:
+                "zero-wait-state instruction memory (flash accelerator / I-cache hit); \
+                 in-order single-issue pipeline; documented per-instruction worst-case cycles"
+                    .to_string(),
+            functions: Vec::new(),
+        }
+    }
+
+    /// Serialize to pretty JSON.
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Resolve the sidecar path (`<output>.wcet.json`) next to the ELF output.
+    pub fn sidecar_path(output: &std::path::Path) -> std::path::PathBuf {
+        let mut s = output.as_os_str().to_os_string();
+        s.push(".wcet.json");
+        std::path::PathBuf::from(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_and_declined_roundtrip() {
+        let mut r = WcetReport::new("m", "cortex-m4");
+        r.functions.push(WcetFunction::Bounded {
+            name: "leaf".into(),
+            cycles: 42,
+            instr_count: 7,
+        });
+        r.functions
+            .push(WcetFunction::declined("spins", WcetDecline::Loop));
+        let json = r.to_json().unwrap();
+        let back: WcetReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(r, back);
+        // Decline reason is machine-readable and carries a note.
+        assert!(json.contains("\"reason\": \"loop\""));
+        assert!(json.contains("synth-wcet-v1"));
+    }
+
+    #[test]
+    fn sidecar_path_appends_suffix() {
+        let p = WcetReport::sidecar_path(std::path::Path::new("out/app.elf"));
+        assert_eq!(p, std::path::PathBuf::from("out/app.elf.wcet.json"));
+    }
+}


### PR DESCRIPTION
## #778 — SOUND static per-function WCET bound (v0.46 Wave-1 Lane 2)

synth holds the exact final Thumb-2 instruction sequence, so it is the natural owner of a **sound static per-function worst-case cycle bound** — the input gale's spar T3/T4 schedulability track needs. spar computes a machine-checked response-time bound, but its per-task `C_i` inputs are DWT high-water-marks (observations, not bounds) and a hard build-gate forbids sizing budgets from DWT. This emits a bound that is provably ≥ any real execution, so spar can size budgets from it.

`--emit-wcet` writes a `synth-wcet-v1` JSON sidecar (`<output>.wcet.json`), **frozen-safe** (derived from the already-decided instruction list; `.text` byte-identical — the frozen-codegen gate stays green).

### Scope (BOUNDED — soundness over coverage)
- **Loop-free functions** → an EXACT-form bound: every instruction executes at most once, so the bound is the **sum** of each instruction's documented Cortex-M3/M4 worst-case cycles (summing both arms of an `if/else` over-approximates the max → sound; no path enumeration).
- **Everything else LOUD-DECLINES** with a machine-readable reason — never an unsound number:
  - `loop` — any backward branch (needs a trip count → scry loop-bound-inference follow-up).
  - `call` — `Bl`/`Blx` (inter-procedural → spar composition follow-up).
  - `looped-expansion` — the i64 software div/rem (internal 64-iteration runtime loop: body emitted once, executed 64× → a straight sum would UNDERCOUNT).
  - `unsupported-core` — non-M3/M4 cores. Cortex-M7 (dual-issue + cache wait-states) is declined, not approximated; the ambiguous `thumbv7em-none-eabihf` triple (shared by M4F/M7/M7dp) is conservatively declined since the triple alone can't prove in-order.

Loop-bound INFERENCE (unknown trip counts) and inter-procedural composition are named follow-ups, explicitly OUT of scope.

### Soundness discipline
- Per-op numbers are the **MAX over {M3, M4}** documented TRM figures (single shared table for both cover cores). M3-worst caught two would-be `bound < actual` bugs the summation gate cannot see: `UMULL` 2→5 (reachable via reciprocal-multiply div-by-const, #322) and `MLA/MLS` 1→2.
- Multi-byte expansion cost is sized from `estimate_arm_byte_size` — pinned EXACTLY to the real encoder by the existing `estimator_encoder_agreement` oracle — not hand literals, so it is provably ≥ real AND cannot go stale.
- The sound-critical constants are pinned in `claims.yaml` (`SYNTH-WCET-CYCLE-MODEL`): any edit reddens claim-check and forces re-derivation vs the TRM. This is the honest substitute for the cycle-accurate oracle that does not exist in-env (qemu/unicorn count instructions, not cycles).

### Schema (`synth-wcet-v1`)
Carries the **precondition** the bound is conditional on (`core_class`, `wait_states: 0`, `memory_assumption`) — a bound without its precondition is not a safety input. Per-function entries are `bounded {cycles, instr_count}` or `declined {reason, note}`; the map is COMPLETE (every compiled function is bounded-or-explicitly-unbounded).

Sample (`-t cortex-m4`):
```json
{ "schema": "synth-wcet-v1", "core_class": "cortex-m4", "wait_states": 0,
  "functions": [
    { "status": "bounded", "name": "add3", "cycles": 19, "instr_count": 5 },
    { "status": "declined", "name": "spin", "reason": "loop",
      "note": "backward branch (loop) — a sound bound needs a trip count ..." } ] }
```

### Gate (non-vacuous, CI-wired via `cargo test --workspace`)
`crates/synth-cli/tests/wcet_bound_gate.rs` compiles REAL `.wat` through the backend (synthetic `ArmInstruction` vecs are vacuous for integration — the Push/Pop bug passed every unit test while a real compile declined):
- loop-free `add3` == exact 19-cycle literal; loop-free `if/else` bounded (forward branch, both-arms-summed); const floor.
- decline matrix asserts the SPECIFIC reason: `loop`, `call`, `looped-expansion`.
- M7 + ambiguous M4F both decline `unsupported-core`; precondition present.

Consumer: **spar T3/T4** (a sound `C_i`, replacing the DWT-forbidden path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
