### PR TITLE
feat(aarch64): milestone 3 — scalar floating point (#538)

### DIFF
--- a/crates/synth-backend-aarch64/src/backend.rs
+++ b/crates/synth-backend-aarch64/src/backend.rs
@@ -85,8 +85,15 @@ impl Backend for AArch64Backend {
             Some(declared) => inferred.min(declared),
             None => inferred,
         };
-        let words = selector::select(ops, num_params)
-            .map_err(|e| BackendError::CompilationFailed(e.to_string()))?;
+        // m3: thread the per-param float masks so float params resolve to their
+        // AAPCS64 V registers (an independent counter from the GP arg registers).
+        let words = selector::select_typed(
+            ops,
+            num_params,
+            &config.current_func_params_f32,
+            &config.current_func_params_f64,
+        )
+        .map_err(|e| BackendError::CompilationFailed(e.to_string()))?;
         let code: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
         Ok(CompiledFunction {
             name: name.to_string(),

--- a/crates/synth-backend-aarch64/src/encoder.rs
+++ b/crates/synth-backend-aarch64/src/encoder.rs
@@ -195,6 +195,10 @@ pub enum Cond {
     Hi,
     Ls,
     Hs,
+    /// `mi` — N set. WASM float `lt` lowers to `cset mi` after `fcmp`: ordered
+    /// less-than sets N=1, while an unordered (NaN) compare sets C=1,V=1 ⇒ N=0,
+    /// so `mi` correctly yields 0 (matching clang's f32/f64 `<` lowering).
+    Mi,
 }
 
 impl Cond {
@@ -212,6 +216,7 @@ impl Cond {
             Cond::Lt => 0xA,
             Cond::Gt => 0xD,
             Cond::Le => 0xC,
+            Cond::Mi => 0x5,
         }
     }
 }
@@ -295,6 +300,165 @@ pub fn mov_imm64(rd: Reg, value: u64) -> Vec<u32> {
         }
     }
     out
+}
+
+// ===========================================================================
+// Milestone 3 — scalar floating point (V/D/S register file).
+//
+// A64 keeps floats in a SEPARATE register file (V0..V31; the `s`/`d` views are
+// the low 32/64 bits). Data-processing float ops name V registers by number in
+// the same [20:16]/[9:5]/[4:0] fields as the integer forms, but the opcode's
+// `ftype` field at bits [23:22] selects single (00) vs double (01) precision —
+// NOT the `sf` bit. `FMOV` between the GP and FP files is the only bridge.
+//
+// Every base below is derived from `clang -target aarch64-linux-gnu` ground
+// truth (see the `fp_*` tests): assemble the mnemonic, read the 32-bit word,
+// subtract the operand fields.
+//
+// SOUNDNESS: the float→int truncations that TRAP in WASM on out-of-range /NaN
+// (`i32.trunc_f32_s` and friends) are NOT encoded here — A64 `FCVTZS`/`FCVTZU`
+// SATURATE instead of trapping (the #709 "more-total-than-WASM" class), so the
+// selector loud-declines them rather than emit a silently-wrong saturating
+// result. Only the total, non-trapping float ops live here.
+// ===========================================================================
+
+/// A float register operand (`0..=31`; the `s`/`d` view is width-selected by the
+/// op's `ftype` field, not by the register number).
+pub type FReg = u8;
+
+/// A two-source float data-processing op (`Fd = Fn OP Fm`). `base` is the 32-bit
+/// single-precision opcode with all operand fields zero; the double-precision
+/// twin sets `ftype=01` (bit 22).
+fn fp3(base: u32, rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    base | ((rm as u32) << 16) | ((rn as u32) << 5) | (rd as u32)
+}
+/// A one-source float op (`Fd = OP Fn`).
+fn fp2(base: u32, rd: FReg, rn: FReg) -> u32 {
+    base | ((rn as u32) << 5) | (rd as u32)
+}
+
+/// `fadd sd, sn, sm`
+pub fn fadd_s(rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    fp3(0x1E20_2800, rd, rn, rm)
+}
+/// `fsub sd, sn, sm`
+pub fn fsub_s(rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    fp3(0x1E20_3800, rd, rn, rm)
+}
+/// `fmul sd, sn, sm`
+pub fn fmul_s(rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    fp3(0x1E20_0800, rd, rn, rm)
+}
+/// `fdiv sd, sn, sm`
+pub fn fdiv_s(rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    fp3(0x1E20_1800, rd, rn, rm)
+}
+/// `fadd dd, dn, dm`
+pub fn fadd_d(rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    fp3(0x1E60_2800, rd, rn, rm)
+}
+/// `fsub dd, dn, dm`
+pub fn fsub_d(rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    fp3(0x1E60_3800, rd, rn, rm)
+}
+/// `fmul dd, dn, dm`
+pub fn fmul_d(rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    fp3(0x1E60_0800, rd, rn, rm)
+}
+/// `fdiv dd, dn, dm`
+pub fn fdiv_d(rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    fp3(0x1E60_1800, rd, rn, rm)
+}
+
+/// `fabs sd, sn`
+pub fn fabs_s(rd: FReg, rn: FReg) -> u32 {
+    fp2(0x1E20_C000, rd, rn)
+}
+/// `fneg sd, sn`
+pub fn fneg_s(rd: FReg, rn: FReg) -> u32 {
+    fp2(0x1E21_4000, rd, rn)
+}
+/// `fsqrt sd, sn`
+pub fn fsqrt_s(rd: FReg, rn: FReg) -> u32 {
+    fp2(0x1E21_C000, rd, rn)
+}
+/// `fabs dd, dn`
+pub fn fabs_d(rd: FReg, rn: FReg) -> u32 {
+    fp2(0x1E60_C000, rd, rn)
+}
+/// `fneg dd, dn`
+pub fn fneg_d(rd: FReg, rn: FReg) -> u32 {
+    fp2(0x1E61_4000, rd, rn)
+}
+/// `fsqrt dd, dn`
+pub fn fsqrt_d(rd: FReg, rn: FReg) -> u32 {
+    fp2(0x1E61_C000, rd, rn)
+}
+
+/// `fcmp sn, sm` — sets NZCV (unordered ⇒ C=1,V=1). The WASM float predicate is
+/// then materialized with a `cset` of the clang-matched condition (see selector).
+pub fn fcmp_s(rn: FReg, rm: FReg) -> u32 {
+    0x1E20_2000 | ((rm as u32) << 16) | ((rn as u32) << 5)
+}
+/// `fcmp dn, dm`
+pub fn fcmp_d(rn: FReg, rm: FReg) -> u32 {
+    0x1E60_2000 | ((rm as u32) << 16) | ((rn as u32) << 5)
+}
+
+/// `fmov sd, wn` — reinterpret the 32-bit GP register `wn` into `sd` (no numeric
+/// conversion). Bridges the GP→FP files; used for `f32.reinterpret_i32`, moving a
+/// materialized f32 const bit-pattern into an S register, and float param setup.
+pub fn fmov_s_from_w(rd: FReg, rn: Reg) -> u32 {
+    fp2(0x1E27_0000, rd, rn)
+}
+/// `fmov wd, sn` — reinterpret `sn`'s 32 bits into GP `wd` (`i32.reinterpret_f32`,
+/// and funneling a float result to `w0`).
+pub fn fmov_w_from_s(rd: Reg, rn: FReg) -> u32 {
+    fp2(0x1E26_0000, rd, rn)
+}
+/// `fmov dd, xn` — reinterpret 64-bit GP `xn` into `dd` (`f64.reinterpret_i64`).
+pub fn fmov_d_from_x(rd: FReg, rn: Reg) -> u32 {
+    fp2(0x9E67_0000, rd, rn)
+}
+/// `fmov xd, dn` — reinterpret `dn` into GP `xd` (`i64.reinterpret_f64`, and
+/// funneling an f64 result to `x0`).
+pub fn fmov_x_from_d(rd: Reg, rn: FReg) -> u32 {
+    fp2(0x9E66_0000, rd, rn)
+}
+/// `fmov sd, sn` — copy between S registers.
+pub fn fmov_s(rd: FReg, rn: FReg) -> u32 {
+    fp2(0x1E20_4000, rd, rn)
+}
+/// `fmov dd, dn` — copy between D registers.
+pub fn fmov_d(rd: FReg, rn: FReg) -> u32 {
+    fp2(0x1E60_4000, rd, rn)
+}
+
+/// `fcvt dd, sn` — single→double (`f64.promote_f32`). Exact, never traps.
+pub fn fcvt_d_from_s(rd: FReg, rn: FReg) -> u32 {
+    fp2(0x1E22_C000, rd, rn)
+}
+/// `fcvt sd, dn` — double→single (`f32.demote_f64`). Round-to-nearest, never
+/// traps (overflow ⇒ ±inf, matching WASM demote).
+pub fn fcvt_s_from_d(rd: FReg, rn: FReg) -> u32 {
+    fp2(0x1E62_4000, rd, rn)
+}
+
+/// `scvtf sd, wn` — signed i32 → f32 (`f32.convert_i32_s`). Total.
+pub fn scvtf_s_from_w(rd: FReg, rn: Reg) -> u32 {
+    fp2(0x1E22_0000, rd, rn)
+}
+/// `ucvtf sd, wn` — unsigned i32 → f32 (`f32.convert_i32_u`). Total.
+pub fn ucvtf_s_from_w(rd: FReg, rn: Reg) -> u32 {
+    fp2(0x1E23_0000, rd, rn)
+}
+/// `scvtf dd, wn` — signed i32 → f64 (`f64.convert_i32_s`). Exact, total.
+pub fn scvtf_d_from_w(rd: FReg, rn: Reg) -> u32 {
+    fp2(0x1E62_0000, rd, rn)
+}
+/// `ucvtf dd, wn` — unsigned i32 → f64 (`f64.convert_i32_u`). Exact, total.
+pub fn ucvtf_d_from_w(rd: FReg, rn: Reg) -> u32 {
+    fp2(0x1E63_0000, rd, rn)
 }
 
 /// Append a 32-bit instruction word to a little-endian byte buffer.
@@ -382,6 +546,58 @@ mod tests {
         assert_eq!(cset(0, Cond::Hi), 0x1A9F_97E0);
         assert_eq!(cset(0, Cond::Ls), 0x1A9F_87E0);
         assert_eq!(cset(0, Cond::Hs), 0x1A9F_37E0);
+    }
+
+    // Milestone 3 — scalar float. Ground truth from `clang -target
+    // aarch64-linux-gnu` (assemble mnemonic, `objdump -d`, read the word).
+    #[test]
+    fn fp_arith_encodings_match_clang() {
+        assert_eq!(fadd_s(0, 1, 2), 0x1E22_2820);
+        assert_eq!(fsub_s(3, 4, 5), 0x1E25_3883);
+        assert_eq!(fmul_s(6, 7, 8), 0x1E28_08E6);
+        assert_eq!(fdiv_s(9, 10, 11), 0x1E2B_1949);
+        assert_eq!(fadd_d(0, 1, 2), 0x1E62_2820);
+        assert_eq!(fsub_d(3, 4, 5), 0x1E65_3883);
+        assert_eq!(fmul_d(6, 7, 8), 0x1E68_08E6);
+        assert_eq!(fdiv_d(9, 10, 11), 0x1E6B_1949);
+    }
+
+    #[test]
+    fn fp_unary_encodings_match_clang() {
+        assert_eq!(fabs_s(0, 1), 0x1E20_C020);
+        assert_eq!(fneg_s(2, 3), 0x1E21_4062);
+        assert_eq!(fsqrt_s(4, 5), 0x1E21_C0A4);
+        assert_eq!(fabs_d(0, 1), 0x1E60_C020);
+        assert_eq!(fneg_d(2, 3), 0x1E61_4062);
+        assert_eq!(fsqrt_d(4, 5), 0x1E61_C0A4);
+    }
+
+    #[test]
+    fn fp_cmp_and_mi_cond_match_clang() {
+        assert_eq!(fcmp_s(0, 1), 0x1E21_2000);
+        assert_eq!(fcmp_d(0, 1), 0x1E61_2000);
+        // WASM float `lt` → `cset mi` (clang f32/f64 `<` lowering).
+        assert_eq!(cset(0, Cond::Mi), 0x1A9F_57E0);
+    }
+
+    #[test]
+    fn fmov_bridge_encodings_match_clang() {
+        assert_eq!(fmov_s_from_w(0, 1), 0x1E27_0020);
+        assert_eq!(fmov_w_from_s(0, 1), 0x1E26_0020);
+        assert_eq!(fmov_d_from_x(0, 1), 0x9E67_0020);
+        assert_eq!(fmov_x_from_d(0, 1), 0x9E66_0020);
+        assert_eq!(fmov_s(5, 6), 0x1E20_40C5);
+        assert_eq!(fmov_d(5, 6), 0x1E60_40C5);
+    }
+
+    #[test]
+    fn fp_convert_encodings_match_clang() {
+        assert_eq!(fcvt_d_from_s(0, 1), 0x1E22_C020);
+        assert_eq!(fcvt_s_from_d(0, 1), 0x1E62_4020);
+        assert_eq!(scvtf_s_from_w(0, 1), 0x1E22_0020);
+        assert_eq!(ucvtf_s_from_w(0, 1), 0x1E23_0020);
+        assert_eq!(scvtf_d_from_w(0, 1), 0x1E62_0020);
+        assert_eq!(ucvtf_d_from_w(0, 1), 0x1E63_0020);
     }
 
     #[test]

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -25,15 +25,66 @@
 //!   naively is the "ARM more-total-than-WASM" silent-miscompile class; they are
 //!   left for a later milestone that adds the explicit trap guards.
 //! - `popcnt`: no scalar A64 popcount pre-SVE (needs SIMD `CNT`+`ADDV`).
-//! - floats, memory, calls, control flow, non-param locals, spilling.
+//! - memory, calls, control flow, non-param locals, spilling.
+//!
+//! **Milestone 3 adds scalar floating point** (the separate V/D/S register file):
+//! f32/f64 const, add/sub/mul/div, abs/neg/sqrt, the full compare family, the
+//! f32<->f64 conversions (promote/demote), the int->float conversions
+//! (`convert_i32_{s,u}` → SCVTF/UCVTF), and the reinterprets (FMOV GP<->FP).
+//! The value stack now tags each entry with its register FILE (GP vs FP) so an
+//! f32 param (delivered in `s0..` under AAPCS64, a counter INDEPENDENT of the
+//! GP arg registers) is never confused with a GP operand.
+//!
+//! **Still declined (loud-skip, never wrong code):** the trapping float→int
+//! truncations (`i32.trunc_f32_s`/`_u`, `i32.trunc_f64_*`): A64 `FCVTZS`/`FCVTZU`
+//! SATURATE on out-of-range/NaN whereas WASM traps — emitting them would be the
+//! #709 "more-total-than-WASM" silent miscompile, so they honest-reject. Also
+//! declined: `min`/`max`/`copysign`/rounding (`ceil`/`floor`/`trunc`/`nearest`)
+//! and the i64<->float conversions (a later increment).
 
 use crate::encoder as enc;
-use crate::encoder::{Cond, Reg};
+use crate::encoder::{Cond, FReg, Reg};
 use synth_core::WasmOp;
 
-/// The value-stack temp registers: caller-saved `w9/x9..w15/x15` (7 slots).
-/// `w0..w7` hold incoming params; results funnel back through `x0`.
+/// The GP value-stack temp registers: caller-saved `w9/x9..w15/x15` (7 slots).
+/// `w0..w7` hold incoming integer params; results funnel back through `x0`.
 const TEMPS: [Reg; 7] = [9, 10, 11, 12, 13, 14, 15];
+
+/// The FP value-stack temp registers: caller-saved `v16..v23` (the low `v0..v7`
+/// carry incoming float params, `v8..v15` are callee-saved). 8 scratch slots.
+const FTEMPS: [FReg; 8] = [16, 17, 18, 19, 20, 21, 22, 23];
+
+/// Which register file a value-stack entry lives in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum File {
+    /// General-purpose (`w`/`x`) — integers and 0/1 compare results.
+    Gp,
+    /// Floating-point (`s`/`d`) — f32/f64 values.
+    Fp,
+}
+
+/// A value-stack entry: a register number plus which file it lives in. Widths
+/// are carried by the op (as in m2), not the entry — an FP op knows whether it
+/// wants the `s` or `d` view.
+#[derive(Clone, Copy, Debug)]
+struct Val {
+    reg: u8,
+    file: File,
+}
+impl Val {
+    fn gp(reg: Reg) -> Self {
+        Val {
+            reg,
+            file: File::Gp,
+        }
+    }
+    fn fp(reg: FReg) -> Self {
+        Val {
+            reg,
+            file: File::Fp,
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct SelectError(pub String);
@@ -44,63 +95,190 @@ impl std::fmt::Display for SelectError {
     }
 }
 
-/// Lower a single function body (its wasm op stream + declared param count) to a
-/// vector of A64 instruction words. `num_params` params are assumed resident in
-/// `w0/x0..w7/x7` on entry (up to 8 register params).
+/// Lower a single function body to A64 words, assuming the integer subset (m2)
+/// param convention: params in `w0/x0..` with no float params. Thin wrapper over
+/// [`select_typed`] with empty float-param masks.
 pub fn select(ops: &[WasmOp], num_params: u32) -> Result<Vec<u32>, SelectError> {
+    select_typed(ops, num_params, &[], &[])
+}
+
+/// The parameter's assigned register + file under AAPCS64. Integer params take
+/// `x0,x1,…` in order; float params take `v0,v1,…` in order — the two counters
+/// are INDEPENDENT, so `(param i32 f32 i32)` is w0, s0, w1.
+fn param_map(num_params: u32, params_f32: &[bool], params_f64: &[bool]) -> Vec<Val> {
+    let mut out = Vec::with_capacity(num_params as usize);
+    let mut ngrn: u8 = 0; // next general (integer) arg register
+    let mut nsrn: u8 = 0; // next SIMD/FP arg register
+    for k in 0..num_params as usize {
+        let is_f32 = params_f32.get(k).copied().unwrap_or(false);
+        let is_f64 = params_f64.get(k).copied().unwrap_or(false);
+        if is_f32 || is_f64 {
+            out.push(Val::fp(nsrn));
+            nsrn += 1;
+        } else {
+            out.push(Val::gp(ngrn));
+            ngrn += 1;
+        }
+    }
+    out
+}
+
+/// Lower a single function body with per-param type info. `params_f32[k]` /
+/// `params_f64[k]` mark which params are float (delivered in V registers). The
+/// integer path (empty masks) is byte-identical to the m2 behavior.
+pub fn select_typed(
+    ops: &[WasmOp],
+    num_params: u32,
+    params_f32: &[bool],
+    params_f64: &[bool],
+) -> Result<Vec<u32>, SelectError> {
     if num_params > 8 {
         return Err(SelectError(format!(
             "{num_params} params — supports at most 8 register params"
         )));
     }
+    let params = param_map(num_params, params_f32, params_f64);
     let mut words: Vec<u32> = Vec::new();
-    let mut stack: Vec<Reg> = Vec::new();
+    let mut stack: Vec<Val> = Vec::new();
 
-    // Pick a temp register not currently holding a live value-stack entry.
-    let alloc_temp = |stack: &[Reg]| -> Result<Reg, SelectError> {
+    // Pick a GP temp not holding a live GP value-stack entry.
+    let alloc_temp = |stack: &[Val]| -> Result<Reg, SelectError> {
         TEMPS
             .iter()
             .copied()
-            .find(|t| !stack.contains(t))
-            .ok_or_else(|| SelectError("value-stack too deep (temp regs exhausted)".into()))
+            .find(|t| !stack.iter().any(|v| v.file == File::Gp && v.reg == *t))
+            .ok_or_else(|| SelectError("value-stack too deep (GP temp regs exhausted)".into()))
+    };
+    // Pick an FP temp not holding a live FP value-stack entry.
+    let alloc_ftemp = |stack: &[Val]| -> Result<FReg, SelectError> {
+        FTEMPS
+            .iter()
+            .copied()
+            .find(|t| !stack.iter().any(|v| v.file == File::Fp && v.reg == *t))
+            .ok_or_else(|| SelectError("value-stack too deep (FP temp regs exhausted)".into()))
     };
 
-    // A binary `dst = a OP b` where `f` is the width-specialized encoder fn.
+    // Pop a GP operand, erroring if the top value is actually an FP value (a
+    // type confusion that would otherwise silently read the wrong file).
+    fn pop_gp(stack: &mut Vec<Val>, ctx: &str) -> Result<Reg, SelectError> {
+        let v = stack
+            .pop()
+            .ok_or_else(|| SelectError(format!("{ctx} underflow")))?;
+        if v.file != File::Gp {
+            return Err(SelectError(format!("{ctx}: expected GP operand, got FP")));
+        }
+        Ok(v.reg)
+    }
+    fn pop_fp(stack: &mut Vec<Val>, ctx: &str) -> Result<FReg, SelectError> {
+        let v = stack
+            .pop()
+            .ok_or_else(|| SelectError(format!("{ctx} underflow")))?;
+        if v.file != File::Fp {
+            return Err(SelectError(format!("{ctx}: expected FP operand, got GP")));
+        }
+        Ok(v.reg)
+    }
+
+    // A GP binary `dst = a OP b`.
     let binop = |words: &mut Vec<u32>,
-                 stack: &mut Vec<Reg>,
+                 stack: &mut Vec<Val>,
                  f: fn(Reg, Reg, Reg) -> u32|
      -> Result<(), SelectError> {
-        let b = stack
-            .pop()
-            .ok_or_else(|| SelectError("binop underflow".into()))?;
-        let a = stack
-            .pop()
-            .ok_or_else(|| SelectError("binop underflow".into()))?;
+        let b = pop_gp(stack, "binop")?;
+        let a = pop_gp(stack, "binop")?;
         let dst = alloc_temp(stack)?;
         words.push(f(dst, a, b));
-        stack.push(dst);
+        stack.push(Val::gp(dst));
         Ok(())
     };
 
-    // A unary `dst = OP a`.
+    // A GP unary `dst = OP a`.
     let unop = |words: &mut Vec<u32>,
-                stack: &mut Vec<Reg>,
+                stack: &mut Vec<Val>,
                 f: fn(Reg, Reg) -> u32|
      -> Result<(), SelectError> {
-        let a = stack
-            .pop()
-            .ok_or_else(|| SelectError("unop underflow".into()))?;
+        let a = pop_gp(stack, "unop")?;
         let dst = alloc_temp(stack)?;
         words.push(f(dst, a));
-        stack.push(dst);
+        stack.push(Val::gp(dst));
+        Ok(())
+    };
+
+    // An FP binary `dst = a OP b` (both operands and result in the FP file).
+    let fbinop = |words: &mut Vec<u32>,
+                  stack: &mut Vec<Val>,
+                  f: fn(FReg, FReg, FReg) -> u32|
+     -> Result<(), SelectError> {
+        let b = pop_fp(stack, "fbinop")?;
+        let a = pop_fp(stack, "fbinop")?;
+        let dst = alloc_ftemp(stack)?;
+        words.push(f(dst, a, b));
+        stack.push(Val::fp(dst));
+        Ok(())
+    };
+    // An FP unary `dst = OP a` (FP → FP).
+    let funop = |words: &mut Vec<u32>,
+                 stack: &mut Vec<Val>,
+                 f: fn(FReg, FReg) -> u32|
+     -> Result<(), SelectError> {
+        let a = pop_fp(stack, "funop")?;
+        let dst = alloc_ftemp(stack)?;
+        words.push(f(dst, a));
+        stack.push(Val::fp(dst));
+        Ok(())
+    };
+    // An FP compare `dst(GP 0/1) = (a CMP b)` — `fcmp` + `cset cond`. The result
+    // is a GP boolean; `cond` is the clang-matched (NaN-correct) condition.
+    let fcmp_op = |words: &mut Vec<u32>,
+                   stack: &mut Vec<Val>,
+                   fcmp: fn(FReg, FReg) -> u32,
+                   cond: Cond|
+     -> Result<(), SelectError> {
+        let b = pop_fp(stack, "fcompare")?;
+        let a = pop_fp(stack, "fcompare")?;
+        let dst = alloc_temp(stack)?;
+        words.push(fcmp(a, b));
+        words.push(enc::cset(dst, cond));
+        stack.push(Val::gp(dst));
+        Ok(())
+    };
+    // int → float conversion: pop a GP operand, push an FP result.
+    let cvt_gp_to_fp = |words: &mut Vec<u32>,
+                        stack: &mut Vec<Val>,
+                        f: fn(FReg, Reg) -> u32|
+     -> Result<(), SelectError> {
+        let a = pop_gp(stack, "convert")?;
+        let dst = alloc_ftemp(stack)?;
+        words.push(f(dst, a));
+        stack.push(Val::fp(dst));
+        Ok(())
+    };
+    // reinterpret GP → FP (bit-cast, FMOV).
+    let reinterpret_gp_to_fp = |words: &mut Vec<u32>,
+                                stack: &mut Vec<Val>,
+                                f: fn(FReg, Reg) -> u32|
+     -> Result<(), SelectError> {
+        let a = pop_gp(stack, "reinterpret")?;
+        let dst = alloc_ftemp(stack)?;
+        words.push(f(dst, a));
+        stack.push(Val::fp(dst));
+        Ok(())
+    };
+    // reinterpret FP → GP (bit-cast, FMOV).
+    let reinterpret_fp_to_gp = |words: &mut Vec<u32>,
+                                stack: &mut Vec<Val>,
+                                f: fn(Reg, FReg) -> u32|
+     -> Result<(), SelectError> {
+        let a = pop_fp(stack, "reinterpret")?;
+        let dst = alloc_temp(stack)?;
+        words.push(f(dst, a));
+        stack.push(Val::gp(dst));
         Ok(())
     };
 
     // `ctz` = `rbit` then `clz` (A64 has no direct CTZ). `sf` selects width.
-    let ctz = |words: &mut Vec<u32>, stack: &mut Vec<Reg>, sf: bool| -> Result<(), SelectError> {
-        let a = stack
-            .pop()
-            .ok_or_else(|| SelectError("ctz underflow".into()))?;
+    let ctz = |words: &mut Vec<u32>, stack: &mut Vec<Val>, sf: bool| -> Result<(), SelectError> {
+        let a = pop_gp(stack, "ctz")?;
         let dst = alloc_temp(stack)?;
         if sf {
             words.push(enc::rbit64(dst, a));
@@ -109,19 +287,15 @@ pub fn select(ops: &[WasmOp], num_params: u32) -> Result<Vec<u32>, SelectError> 
             words.push(enc::rbit(dst, a));
             words.push(enc::clz(dst, dst));
         }
-        stack.push(dst);
+        stack.push(Val::gp(dst));
         Ok(())
     };
 
     // `rotl rd, rn, rk` = `neg rtmp, rk; rorv rd, rn, rtmp` (mod-width neg gives
     // the equivalent right-rotate; correct including k=0 → neg 0 = 0).
-    let rotl = |words: &mut Vec<u32>, stack: &mut Vec<Reg>, sf: bool| -> Result<(), SelectError> {
-        let k = stack
-            .pop()
-            .ok_or_else(|| SelectError("rotl underflow".into()))?;
-        let n = stack
-            .pop()
-            .ok_or_else(|| SelectError("rotl underflow".into()))?;
+    let rotl = |words: &mut Vec<u32>, stack: &mut Vec<Val>, sf: bool| -> Result<(), SelectError> {
+        let k = pop_gp(stack, "rotl")?;
+        let n = pop_gp(stack, "rotl")?;
         let dst = alloc_temp(stack)?;
         // #776: the `neg` scratch must NOT be `dst` — `alloc_temp` can hand back
         // the register that held the computed operand `n` (n,k are already popped,
@@ -138,34 +312,28 @@ pub fn select(ops: &[WasmOp], num_params: u32) -> Result<Vec<u32>, SelectError> 
             words.push(enc::neg(k, k));
             words.push(enc::rorv(dst, n, k));
         }
-        stack.push(dst);
+        stack.push(Val::gp(dst));
         Ok(())
     };
 
-    // A comparison `dst = (a CMP b)` as `cmp` + `cset cond`. `sf` selects width.
+    // A GP comparison `dst = (a CMP b)` as `cmp` + `cset cond`. `sf` selects width.
     let cmp_op = |words: &mut Vec<u32>,
-                  stack: &mut Vec<Reg>,
+                  stack: &mut Vec<Val>,
                   sf: bool,
                   cond: Cond|
      -> Result<(), SelectError> {
-        let b = stack
-            .pop()
-            .ok_or_else(|| SelectError("compare underflow".into()))?;
-        let a = stack
-            .pop()
-            .ok_or_else(|| SelectError("compare underflow".into()))?;
+        let b = pop_gp(stack, "compare")?;
+        let a = pop_gp(stack, "compare")?;
         let dst = alloc_temp(stack)?;
         words.push(if sf { enc::cmp64(a, b) } else { enc::cmp(a, b) });
         words.push(enc::cset(dst, cond));
-        stack.push(dst);
+        stack.push(Val::gp(dst));
         Ok(())
     };
 
     // `eqz`: `dst = (a == 0)` as `cmp a, zr` + `cset eq`.
-    let eqz = |words: &mut Vec<u32>, stack: &mut Vec<Reg>, sf: bool| -> Result<(), SelectError> {
-        let a = stack
-            .pop()
-            .ok_or_else(|| SelectError("eqz underflow".into()))?;
+    let eqz = |words: &mut Vec<u32>, stack: &mut Vec<Val>, sf: bool| -> Result<(), SelectError> {
+        let a = pop_gp(stack, "eqz")?;
         let dst = alloc_temp(stack)?;
         words.push(if sf {
             enc::cmp64(a, enc::XZR)
@@ -173,7 +341,7 @@ pub fn select(ops: &[WasmOp], num_params: u32) -> Result<Vec<u32>, SelectError> 
             enc::cmp(a, enc::WZR)
         });
         words.push(enc::cset(dst, Cond::Eq));
-        stack.push(dst);
+        stack.push(Val::gp(dst));
         Ok(())
     };
 
@@ -185,22 +353,43 @@ pub fn select(ops: &[WasmOp], num_params: u32) -> Result<Vec<u32>, SelectError> 
                         "local.get {i}: non-param locals not yet supported"
                     )));
                 }
-                // params are in w0/x0..w7/x7 — same architectural number.
-                stack.push(*i as Reg);
+                // Resolve the param to its AAPCS64 register + file (GP or FP).
+                stack.push(params[*i as usize]);
             }
             WasmOp::I32Const(c) => {
                 let dst = alloc_temp(&stack)?;
                 for w in enc::mov_imm32(dst, *c as u32) {
                     words.push(w);
                 }
-                stack.push(dst);
+                stack.push(Val::gp(dst));
             }
             WasmOp::I64Const(c) => {
                 let dst = alloc_temp(&stack)?;
                 for w in enc::mov_imm64(dst, *c as u64) {
                     words.push(w);
                 }
-                stack.push(dst);
+                stack.push(Val::gp(dst));
+            }
+            // f32/f64 const: materialize the bit-pattern in a GP temp, then FMOV
+            // it into an FP temp (there is no direct FP immediate for arbitrary
+            // constants). The GP temp is transient (freed before the push).
+            WasmOp::F32Const(c) => {
+                let gp = alloc_temp(&stack)?;
+                for w in enc::mov_imm32(gp, c.to_bits()) {
+                    words.push(w);
+                }
+                let dst = alloc_ftemp(&stack)?;
+                words.push(enc::fmov_s_from_w(dst, gp));
+                stack.push(Val::fp(dst));
+            }
+            WasmOp::F64Const(c) => {
+                let gp = alloc_temp(&stack)?;
+                for w in enc::mov_imm64(gp, c.to_bits()) {
+                    words.push(w);
+                }
+                let dst = alloc_ftemp(&stack)?;
+                words.push(enc::fmov_d_from_x(dst, gp));
+                stack.push(Val::fp(dst));
             }
             // #665: wasm `unreachable` traps unconditionally (WASM §4.4.5) —
             // `brk #0`, the A64 analogue of Thumb-2 `udf #0` / RV32 `ebreak`.
@@ -262,21 +451,65 @@ pub fn select(ops: &[WasmOp], num_params: u32) -> Result<Vec<u32>, SelectError> 
             WasmOp::I64GeS => cmp_op(&mut words, &mut stack, true, Cond::Ge)?,
             WasmOp::I64GeU => cmp_op(&mut words, &mut stack, true, Cond::Hs)?,
 
-            // End of the function body: move the result to x0 and return. The
-            // 64-bit `mov x0, xN` is correct for i32 results too — every w-form
-            // producer zeroes the upper half, so `w0` still reads the right
-            // low 32 bits.
+            // --- f32 arithmetic ---
+            WasmOp::F32Add => fbinop(&mut words, &mut stack, enc::fadd_s)?,
+            WasmOp::F32Sub => fbinop(&mut words, &mut stack, enc::fsub_s)?,
+            WasmOp::F32Mul => fbinop(&mut words, &mut stack, enc::fmul_s)?,
+            WasmOp::F32Div => fbinop(&mut words, &mut stack, enc::fdiv_s)?,
+            WasmOp::F32Abs => funop(&mut words, &mut stack, enc::fabs_s)?,
+            WasmOp::F32Neg => funop(&mut words, &mut stack, enc::fneg_s)?,
+            WasmOp::F32Sqrt => funop(&mut words, &mut stack, enc::fsqrt_s)?,
+
+            // --- f32 comparisons (result is a GP i32 0/1; NaN-correct conds) ---
+            WasmOp::F32Eq => fcmp_op(&mut words, &mut stack, enc::fcmp_s, Cond::Eq)?,
+            WasmOp::F32Ne => fcmp_op(&mut words, &mut stack, enc::fcmp_s, Cond::Ne)?,
+            WasmOp::F32Lt => fcmp_op(&mut words, &mut stack, enc::fcmp_s, Cond::Mi)?,
+            WasmOp::F32Le => fcmp_op(&mut words, &mut stack, enc::fcmp_s, Cond::Ls)?,
+            WasmOp::F32Gt => fcmp_op(&mut words, &mut stack, enc::fcmp_s, Cond::Gt)?,
+            WasmOp::F32Ge => fcmp_op(&mut words, &mut stack, enc::fcmp_s, Cond::Ge)?,
+
+            // --- f64 arithmetic ---
+            WasmOp::F64Add => fbinop(&mut words, &mut stack, enc::fadd_d)?,
+            WasmOp::F64Sub => fbinop(&mut words, &mut stack, enc::fsub_d)?,
+            WasmOp::F64Mul => fbinop(&mut words, &mut stack, enc::fmul_d)?,
+            WasmOp::F64Div => fbinop(&mut words, &mut stack, enc::fdiv_d)?,
+            WasmOp::F64Abs => funop(&mut words, &mut stack, enc::fabs_d)?,
+            WasmOp::F64Neg => funop(&mut words, &mut stack, enc::fneg_d)?,
+            WasmOp::F64Sqrt => funop(&mut words, &mut stack, enc::fsqrt_d)?,
+
+            // --- f64 comparisons ---
+            WasmOp::F64Eq => fcmp_op(&mut words, &mut stack, enc::fcmp_d, Cond::Eq)?,
+            WasmOp::F64Ne => fcmp_op(&mut words, &mut stack, enc::fcmp_d, Cond::Ne)?,
+            WasmOp::F64Lt => fcmp_op(&mut words, &mut stack, enc::fcmp_d, Cond::Mi)?,
+            WasmOp::F64Le => fcmp_op(&mut words, &mut stack, enc::fcmp_d, Cond::Ls)?,
+            WasmOp::F64Gt => fcmp_op(&mut words, &mut stack, enc::fcmp_d, Cond::Gt)?,
+            WasmOp::F64Ge => fcmp_op(&mut words, &mut stack, enc::fcmp_d, Cond::Ge)?,
+
+            // --- float↔float precision conversions (total, never trap) ---
+            WasmOp::F64PromoteF32 => funop(&mut words, &mut stack, enc::fcvt_d_from_s)?,
+            WasmOp::F32DemoteF64 => funop(&mut words, &mut stack, enc::fcvt_s_from_d)?,
+
+            // --- int → float conversions (total, never trap) ---
+            WasmOp::F32ConvertI32S => cvt_gp_to_fp(&mut words, &mut stack, enc::scvtf_s_from_w)?,
+            WasmOp::F32ConvertI32U => cvt_gp_to_fp(&mut words, &mut stack, enc::ucvtf_s_from_w)?,
+            WasmOp::F64ConvertI32S => cvt_gp_to_fp(&mut words, &mut stack, enc::scvtf_d_from_w)?,
+            WasmOp::F64ConvertI32U => cvt_gp_to_fp(&mut words, &mut stack, enc::ucvtf_d_from_w)?,
+
+            // --- bit-cast reinterprets (pure FMOV, no numeric change) ---
+            WasmOp::F32ReinterpretI32 => {
+                reinterpret_gp_to_fp(&mut words, &mut stack, enc::fmov_s_from_w)?
+            }
+            WasmOp::I32ReinterpretF32 => {
+                reinterpret_fp_to_gp(&mut words, &mut stack, enc::fmov_w_from_s)?
+            }
+
+            // End of the function body: funnel the result into x0/d0 and return.
             WasmOp::End => {
-                if let Some(top) = stack.last().copied()
-                    && top != 0
-                {
-                    words.push(enc::mov_reg64(0, top));
-                }
-                words.push(enc::ret());
+                epilogue(&mut words, stack.last().copied());
             }
             other => {
                 return Err(SelectError(format!(
-                    "unsupported wasm op for aarch64 integer subset: {other:?}"
+                    "unsupported wasm op for aarch64 subset: {other:?}"
                 )));
             }
         }
@@ -284,14 +517,33 @@ pub fn select(ops: &[WasmOp], num_params: u32) -> Result<Vec<u32>, SelectError> 
 
     // A body without a trailing `End` still needs an epilogue.
     if !matches!(ops.last(), Some(WasmOp::End)) {
-        if let Some(top) = stack.last().copied()
-            && top != 0
-        {
-            words.push(enc::mov_reg64(0, top));
-        }
-        words.push(enc::ret());
+        epilogue(&mut words, stack.last().copied());
     }
     Ok(words)
+}
+
+/// Emit the function epilogue: move the top-of-stack result into the ABI return
+/// register (`x0` for a GP result, `d0` for a float result) and `ret`. A GP
+/// result already in `x0` / an FP result already in `v0` skips the move. The
+/// 64-bit `mov x0, xN` is correct for i32 results too (w-form producers zero the
+/// upper half); the `fmov d0, dN` likewise carries an f32's low 32 bits intact.
+fn epilogue(words: &mut Vec<u32>, top: Option<Val>) {
+    match top {
+        Some(Val {
+            reg,
+            file: File::Gp,
+        }) if reg != 0 => {
+            words.push(enc::mov_reg64(0, reg));
+        }
+        Some(Val {
+            reg,
+            file: File::Fp,
+        }) if reg != 0 => {
+            words.push(enc::fmov_d(0, reg));
+        }
+        _ => {}
+    }
+    words.push(enc::ret());
 }
 
 #[cfg(test)]
@@ -466,5 +718,187 @@ mod tests {
     fn popcnt_is_loud_declined() {
         let ops = vec![WasmOp::LocalGet(0), WasmOp::I32Popcnt, WasmOp::End];
         assert!(select(&ops, 1).is_err());
+    }
+
+    // ---- milestone 3: scalar float ----
+
+    #[test]
+    fn f32_add_uses_v_registers_and_fmov_return() {
+        // (param f32 f32) → params in s0, s1. f32.add → fadd v16, s0, s1;
+        // fmov d0, d16; ret.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::F32Add,
+            WasmOp::End,
+        ];
+        let w = select_typed(&ops, 2, &[true, true], &[]).unwrap();
+        assert_eq!(
+            w,
+            vec![enc::fadd_s(16, 0, 1), enc::fmov_d(0, 16), enc::ret()]
+        );
+    }
+
+    #[test]
+    fn f64_mul_uses_d_forms() {
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::F64Mul,
+            WasmOp::End,
+        ];
+        let w = select_typed(&ops, 2, &[], &[true, true]).unwrap();
+        assert_eq!(
+            w,
+            vec![enc::fmul_d(16, 0, 1), enc::fmov_d(0, 16), enc::ret()]
+        );
+    }
+
+    #[test]
+    fn mixed_int_float_params_assign_independent_registers() {
+        // (param i32 f32 i32): AAPCS64 → w0, s0, w1. `local.get 1` (the f32)
+        // must resolve to s0, `local.get 2` (the 2nd i32) to w1.
+        let ops = vec![
+            WasmOp::LocalGet(1), // f32 → s0
+            WasmOp::F32Neg,
+            WasmOp::End,
+        ];
+        let w = select_typed(&ops, 3, &[false, true, false], &[]).unwrap();
+        // fneg v16, s0 ; fmov d0, d16 ; ret
+        assert_eq!(w, vec![enc::fneg_s(16, 0), enc::fmov_d(0, 16), enc::ret()]);
+    }
+
+    #[test]
+    fn f32_lt_uses_fcmp_and_mi_cond() {
+        // f32.lt → fcmp s0,s1 ; cset w9, mi (NaN-correct) → GP result.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::F32Lt,
+            WasmOp::End,
+        ];
+        let w = select_typed(&ops, 2, &[true, true], &[]).unwrap();
+        assert_eq!(
+            w,
+            vec![
+                enc::fcmp_s(0, 1),
+                enc::cset(9, Cond::Mi),
+                enc::mov_reg64(0, 9),
+                enc::ret()
+            ]
+        );
+    }
+
+    #[test]
+    fn f32_const_materializes_via_gp_then_fmov() {
+        // f32.const 1.0 = 0x3F800000 → movz/movk into a GP temp, fmov s16,w9.
+        let ops = vec![WasmOp::F32Const(1.0), WasmOp::End];
+        let w = select_typed(&ops, 0, &[], &[]).unwrap();
+        let bits = 1.0f32.to_bits();
+        let mut expect = enc::mov_imm32(9, bits);
+        expect.push(enc::fmov_s_from_w(16, 9));
+        expect.push(enc::fmov_d(0, 16));
+        expect.push(enc::ret());
+        assert_eq!(w, expect);
+    }
+
+    #[test]
+    fn convert_i32_s_to_f32_pops_gp_pushes_fp() {
+        let ops = vec![WasmOp::LocalGet(0), WasmOp::F32ConvertI32S, WasmOp::End];
+        // param 0 is i32 → w0; scvtf s16, w0 ; fmov d0, d16 ; ret
+        let w = select_typed(&ops, 1, &[], &[]).unwrap();
+        assert_eq!(
+            w,
+            vec![enc::scvtf_s_from_w(16, 0), enc::fmov_d(0, 16), enc::ret()]
+        );
+    }
+
+    #[test]
+    fn reinterpret_i32_to_f32_and_back() {
+        // i32 param → f32.reinterpret → i32.reinterpret round-trips through FMOV.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::F32ReinterpretI32,
+            WasmOp::I32ReinterpretF32,
+            WasmOp::End,
+        ];
+        let w = select_typed(&ops, 1, &[], &[]).unwrap();
+        assert_eq!(
+            w,
+            vec![
+                enc::fmov_s_from_w(16, 0),
+                enc::fmov_w_from_s(9, 16),
+                enc::mov_reg64(0, 9),
+                enc::ret()
+            ]
+        );
+    }
+
+    #[test]
+    fn promote_demote_round_trip() {
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::F64PromoteF32,
+            WasmOp::F32DemoteF64,
+            WasmOp::End,
+        ];
+        let w = select_typed(&ops, 1, &[true], &[]).unwrap();
+        assert_eq!(
+            w,
+            vec![
+                enc::fcvt_d_from_s(16, 0),
+                enc::fcvt_s_from_d(16, 16),
+                enc::fmov_d(0, 16),
+                enc::ret()
+            ]
+        );
+    }
+
+    #[test]
+    fn trapping_float_to_int_trunc_is_loud_declined() {
+        // A64 FCVTZS/FCVTZU SATURATE where WASM traps (#709) — must refuse.
+        for op in [
+            WasmOp::I32TruncF32S,
+            WasmOp::I32TruncF32U,
+            WasmOp::I32TruncF64S,
+            WasmOp::I32TruncF64U,
+        ] {
+            let ops = vec![WasmOp::LocalGet(0), op, WasmOp::End];
+            assert!(
+                select_typed(&ops, 1, &[true], &[]).is_err(),
+                "trapping float→int trunc must loud-decline"
+            );
+        }
+    }
+
+    #[test]
+    fn float_min_max_copysign_are_loud_declined() {
+        for op in [
+            WasmOp::F32Min,
+            WasmOp::F32Max,
+            WasmOp::F32Copysign,
+            WasmOp::F64Min,
+            WasmOp::F64Max,
+            WasmOp::F64Copysign,
+        ] {
+            let ops = vec![WasmOp::LocalGet(0), WasmOp::LocalGet(1), op, WasmOp::End];
+            assert!(
+                select_typed(&ops, 2, &[], &[true, true]).is_err(),
+                "min/max/copysign not yet supported — must loud-decline"
+            );
+        }
+    }
+
+    #[test]
+    fn type_confusion_gp_op_on_fp_value_errors() {
+        // An f32 value fed to an integer op must ERROR (never read the wrong
+        // register file) — the value-stack file tag guards this.
+        let ops = vec![
+            WasmOp::LocalGet(0), // f32 → s0
+            WasmOp::LocalGet(1), // f32 → s1
+            WasmOp::I32Add,      // GP op on FP operands → error
+            WasmOp::End,
+        ];
+        assert!(select_typed(&ops, 2, &[true, true], &[]).is_err());
     }
 }

--- a/crates/synth-cli/tests/aarch64_f32_loudskip_554.rs
+++ b/crates/synth-cli/tests/aarch64_f32_loudskip_554.rs
@@ -1,19 +1,15 @@
-//! synth#554 — `-b aarch64` must fail HONESTLY on a scalar f32 op, never emit a
-//! silent miscompile.
+//! synth#554 — `-b aarch64` must fail HONESTLY on an UNSUPPORTED float op, never
+//! emit a silent miscompile.
 //!
-//! Scalar `f32.*` is dropped by the wasm decoder (`_ => None`), so it is absent
-//! from the op stream the backend selector sees — it never reaches the selector's
-//! `unsupported wasm op` guard. Before the fix the aarch64 backend lowered the
-//! remaining `[LocalGet, LocalGet, End]` into `mov w0, w1 ; ret` (returns the 2nd
-//! operand instead of the sum) and reported success. That is strictly worse than
-//! the honest "unsupported milestone-1 op" error the integer ops produce.
+//! m3 (#787) landed the non-trapping scalar floats, so this test now targets a
+//! float op that DELIBERATELY stays declined: `i32.trunc_f32_s`. A64 `FCVTZS`
+//! SATURATES where WASM TRAPS (out-of-range input) — the #709 more-total-than-WASM
+//! soundness class — so lowering it would silently return a wrong (saturated)
+//! value. The backend must loud-decline (`unsupported wasm op`) instead.
 //!
-//! The fix honors the decoder's `func.unsupported` loud-skip marker (#369) at the
-//! single-function CLI boundary (and in `AArch64Backend::compile_module`). These
-//! tests lock: (1) the f32 function is REJECTED with a non-zero exit and an
-//! "unsupported" diagnostic; (2) a supported integer function still compiles (the
-//! guard does not over-reject); (3) `--all-exports` loud-skips f32 while still
-//! emitting the integer function.
+//! These tests lock: (1) the declined-float function is REJECTED with a non-zero
+//! exit and an "unsupported" diagnostic; (2) a supported integer function still
+//! compiles (the guard does not over-reject).
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -36,7 +32,7 @@ fn aarch64_rejects_f32_function_instead_of_silent_miscompile_554() {
             "-b",
             "aarch64",
             "-n",
-            "f32add",
+            "f32trunc",
             "-o",
             "/tmp/aarch64_f32_554.o",
         ])
@@ -44,8 +40,8 @@ fn aarch64_rejects_f32_function_instead_of_silent_miscompile_554() {
         .expect("run synth");
     assert!(
         !out.status.success(),
-        "expected a non-zero exit for an f32 function on -b aarch64; got success \
-         (silent miscompile). stdout={} stderr={}",
+        "expected a non-zero exit for a declined float op (i32.trunc_f32_s) on \
+         -b aarch64; got success (silent miscompile). stdout={} stderr={}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr),
     );

--- a/scripts/repro/aarch64_f32_unsupported_554.wat
+++ b/scripts/repro/aarch64_f32_unsupported_554.wat
@@ -1,11 +1,12 @@
-;; #554 — `-b aarch64` (milestone-1, integer-only) must REJECT scalar f32 ops
-;; honestly, not silently miscompile them. `f32.add` is dropped by the decoder
-;; (`_ => None`), so it never reaches the selector's unsupported-op guard; before
-;; the fix the backend lowered the remaining `[LocalGet, LocalGet, End]` into
-;; `mov w0, w1 ; ret` (returns the 2nd operand, no add). `i32add` is the control:
-;; a fully-supported milestone-1 op that must still compile.
+;; #554 — `-b aarch64` must REJECT an UNSUPPORTED float op honestly, not silently
+;; miscompile it. m3 (#787) landed the non-trapping scalar floats (add/sub/mul/…),
+;; so the honesty test moves to a float op that DELIBERATELY stays declined:
+;; `i32.trunc_f32_s`. A64 FCVTZS SATURATES where WASM TRAPS (the #709
+;; more-total-than-WASM soundness class), so lowering it would be a silent wrong
+;; result — the backend must loud-decline instead. `i32add` is the control: a
+;; supported op that must still compile.
 (module
-  (func (export "f32add") (param f32 f32) (result f32)
-    (f32.add (local.get 0) (local.get 1)))
+  (func (export "f32trunc") (param f32) (result i32)
+    (i32.trunc_f32_s (local.get 0)))
   (func (export "i32add") (param i32 i32) (result i32)
     (i32.add (local.get 0) (local.get 1))))

--- a/scripts/repro/aarch64_m2_decline_538.py
+++ b/scripts/repro/aarch64_m2_decline_538.py
@@ -41,10 +41,16 @@ DECLINED = [
                    '(i32.popcnt (local.get 0)))'),
     ("i64.popcnt", '(func (export "f") (param i64) (result i64) '
                    '(i64.popcnt (local.get 0)))'),
-    ("f32.add", '(func (export "f") (param f32 f32) (result f32) '
-                '(f32.add (local.get 0) (local.get 1)))'),
-    ("f64.mul", '(func (export "f") (param f64 f64) (result f64) '
-                '(f64.mul (local.get 0) (local.get 1)))'),
+    # m3 (#787) landed non-trapping scalar floats (add/sub/mul/div/cmp/convert/
+    # reinterpret) — those are now SUPPORTED, so the honesty gate moves to the
+    # floats that DELIBERATELY stay declined:
+    #   - trapping float→int truncation: A64 FCVTZS/FCVTZU SATURATE where WASM
+    #     TRAPS (the #709 more-total-than-WASM soundness class) — must NOT lower.
+    #   - min/max: WASM NaN-propagation semantics differ from A64 FMIN/FMAX.
+    ("i32.trunc_f32_s", '(func (export "f") (param f32) (result i32) '
+                        '(i32.trunc_f32_s (local.get 0)))'),
+    ("f32.min", '(func (export "f") (param f32 f32) (result f32) '
+                '(f32.min (local.get 0) (local.get 1)))'),
 ]
 
 

--- a/scripts/repro/aarch64_m3_floats_538.wat
+++ b/scripts/repro/aarch64_m3_floats_538.wat
@@ -1,0 +1,103 @@
+;; #538 milestone-3 — the aarch64 scalar-FLOAT acceptance module.
+;; Every export is a leaf float function the m3 A64 selector lowers: f32/f64
+;; add/sub/mul/div, abs/neg/sqrt, the full compare family (eq/ne/lt/le/gt/ge),
+;; the f32<->f64 promote/demote conversions, the i32->float conversions
+;; (convert_i32_s/u), and the f32<->i32 reinterprets. Params that are float
+;; arrive in V registers (s0.. / d0..) under AAPCS64 — an INDEPENDENT counter
+;; from the GP arg registers — which the file-tagged value stack tracks.
+;;
+;; The differential (aarch64_m3_floats_538_differential.py) runs each under
+;; unicorn UC_ARCH_ARM64 (FPEN enabled) AND natively on the arm64 host, and
+;; diffs wasmtime ground truth — including NaN inputs (the compare NaN-ordering
+;; and the sign-of-NaN / ±0 edge cases).
+;;
+;; NOTE: the TRAPPING float->int truncations (i32.trunc_f32_s/_u, i32.trunc_f64_*)
+;; are deliberately ABSENT — A64 FCVTZS/FCVTZU SATURATE where WASM traps (#709),
+;; so the m3 selector loud-declines them (asserted in the unit tests + decline
+;; matrix). min/max/copysign/rounding are likewise declined.
+(module
+  ;; ---- f32 arithmetic ----
+  (func (export "f32_add") (param f32 f32) (result f32)
+    (f32.add (local.get 0) (local.get 1)))
+  (func (export "f32_sub") (param f32 f32) (result f32)
+    (f32.sub (local.get 0) (local.get 1)))
+  (func (export "f32_mul") (param f32 f32) (result f32)
+    (f32.mul (local.get 0) (local.get 1)))
+  (func (export "f32_div") (param f32 f32) (result f32)
+    (f32.div (local.get 0) (local.get 1)))
+  (func (export "f32_abs") (param f32) (result f32)
+    (f32.abs (local.get 0)))
+  (func (export "f32_neg") (param f32) (result f32)
+    (f32.neg (local.get 0)))
+
+  ;; ---- f32 comparisons (result i32) ----
+  (func (export "f32_eq") (param f32 f32) (result i32)
+    (f32.eq (local.get 0) (local.get 1)))
+  (func (export "f32_ne") (param f32 f32) (result i32)
+    (f32.ne (local.get 0) (local.get 1)))
+  (func (export "f32_lt") (param f32 f32) (result i32)
+    (f32.lt (local.get 0) (local.get 1)))
+  (func (export "f32_le") (param f32 f32) (result i32)
+    (f32.le (local.get 0) (local.get 1)))
+  (func (export "f32_gt") (param f32 f32) (result i32)
+    (f32.gt (local.get 0) (local.get 1)))
+  (func (export "f32_ge") (param f32 f32) (result i32)
+    (f32.ge (local.get 0) (local.get 1)))
+
+  ;; ---- f64 arithmetic ----
+  (func (export "f64_add") (param f64 f64) (result f64)
+    (f64.add (local.get 0) (local.get 1)))
+  (func (export "f64_sub") (param f64 f64) (result f64)
+    (f64.sub (local.get 0) (local.get 1)))
+  (func (export "f64_mul") (param f64 f64) (result f64)
+    (f64.mul (local.get 0) (local.get 1)))
+  (func (export "f64_div") (param f64 f64) (result f64)
+    (f64.div (local.get 0) (local.get 1)))
+  (func (export "f64_abs") (param f64) (result f64)
+    (f64.abs (local.get 0)))
+  (func (export "f64_neg") (param f64) (result f64)
+    (f64.neg (local.get 0)))
+  (func (export "f64_sqrt") (param f64) (result f64)
+    (f64.sqrt (local.get 0)))
+
+  ;; ---- f64 comparisons (result i32) ----
+  (func (export "f64_eq") (param f64 f64) (result i32)
+    (f64.eq (local.get 0) (local.get 1)))
+  (func (export "f64_ne") (param f64 f64) (result i32)
+    (f64.ne (local.get 0) (local.get 1)))
+  (func (export "f64_lt") (param f64 f64) (result i32)
+    (f64.lt (local.get 0) (local.get 1)))
+  (func (export "f64_le") (param f64 f64) (result i32)
+    (f64.le (local.get 0) (local.get 1)))
+  (func (export "f64_gt") (param f64 f64) (result i32)
+    (f64.gt (local.get 0) (local.get 1)))
+  (func (export "f64_ge") (param f64 f64) (result i32)
+    (f64.ge (local.get 0) (local.get 1)))
+
+  ;; ---- precision conversions ----
+  (func (export "f64_promote_f32") (param f32) (result f64)
+    (f64.promote_f32 (local.get 0)))
+  (func (export "f32_demote_f64") (param f64) (result f32)
+    (f32.demote_f64 (local.get 0)))
+
+  ;; ---- int -> float conversions ----
+  (func (export "f32_convert_i32_s") (param i32) (result f32)
+    (f32.convert_i32_s (local.get 0)))
+  (func (export "f32_convert_i32_u") (param i32) (result f32)
+    (f32.convert_i32_u (local.get 0)))
+  (func (export "f64_convert_i32_s") (param i32) (result f64)
+    (f64.convert_i32_s (local.get 0)))
+  (func (export "f64_convert_i32_u") (param i32) (result f64)
+    (f64.convert_i32_u (local.get 0)))
+
+  ;; ---- reinterprets (bit-casts) ----
+  (func (export "f32_reinterpret_i32") (param i32) (result f32)
+    (f32.reinterpret_i32 (local.get 0)))
+  (func (export "i32_reinterpret_f32") (param f32) (result i32)
+    (i32.reinterpret_f32 (local.get 0)))
+
+  ;; ---- mixed int/float param register assignment (AAPCS64) ----
+  ;; (param i32 f32 i32) → w0, s0, w1. Return the f32 param negated to prove
+  ;; the f32 resolves to s0 (not a GP register).
+  (func (export "mixed_params") (param i32 f32 i32) (result f32)
+    (f32.neg (local.get 1))))

--- a/scripts/repro/aarch64_m3_floats_538_differential.py
+++ b/scripts/repro/aarch64_m3_floats_538_differential.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""#538 milestone-3 — validate the aarch64 SCALAR-FLOAT backend codegen.
+
+Compiles the m3 float acceptance module with `synth compile -b aarch64`, then
+executes each exported function's emitted A64 `.text` two ways —
+  (1) under unicorn (UC_ARCH_ARM64, with FPEN enabled so V-register ops run), and
+  (2) NATIVELY on the arm64 host (mmap+mprotect the `.text`, call it via a
+      ctypes CFUNCTYPE with the right float/int arg + return signature),
+and diffs BOTH against wasmtime ground truth. This is the "third backend = third
+oracle" property extended to scalar float: f32/f64 add/sub/mul/div, abs/neg/sqrt,
+the full compare family (with NaN inputs — the ordering edge cases), the
+f32<->f64 promote/demote conversions, the i32->float conversions, and the
+f32<->i32 reinterprets.
+
+Float results are compared BIT-EXACTLY (via the raw bit pattern), so a wrong sign
+of zero or a mis-rounded conversion is caught; NaN results compare equal iff both
+are NaN (WASM does not pin the NaN payload, and neither does the hardware, so a
+canonical-vs-arithmetic NaN payload difference is not a bug).
+
+SOUNDNESS: the trapping float->int truncations are NOT in the module — the m3
+selector loud-declines them (A64 saturates where WASM traps, #709). That decline
+is asserted in the backend unit tests, not here.
+
+Run (needs wasmtime + unicorn + pyelftools; native path needs an arm64 host):
+  SYNTH=<target>/debug/synth python scripts/repro/aarch64_m3_floats_538_differential.py
+"""
+import ctypes
+import math
+import mmap
+import os
+import platform
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM64, UC_MODE_ARM, Uc, UcError
+from unicorn.arm64_const import (
+    UC_ARM64_REG_CPACR_EL1,
+    UC_ARM64_REG_D0,
+    UC_ARM64_REG_LR,
+    UC_ARM64_REG_S0,
+    UC_ARM64_REG_SP,
+    UC_ARM64_REG_V0,
+    UC_ARM64_REG_V1,
+    UC_ARM64_REG_W0,
+    UC_ARM64_REG_X0,
+    UC_ARM64_REG_X1,
+)
+
+WAT = Path(__file__).with_name("aarch64_m3_floats_538.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+CODE, STK, RET = 0x100000, 0x200000, 0x300000
+V_ARGS = [UC_ARM64_REG_V0, UC_ARM64_REG_V1]
+X_ARGS = [UC_ARM64_REG_X0, UC_ARM64_REG_X1]
+
+M32 = (1 << 32) - 1
+M64 = (1 << 64) - 1
+
+# Signatures: (fn, [arg_types], ret_type). Types: "f32","f64","i32".
+SIGS = {
+    "f32_add": (["f32", "f32"], "f32"),
+    "f32_sub": (["f32", "f32"], "f32"),
+    "f32_mul": (["f32", "f32"], "f32"),
+    "f32_div": (["f32", "f32"], "f32"),
+    "f32_abs": (["f32"], "f32"),
+    "f32_neg": (["f32"], "f32"),
+    "f32_eq": (["f32", "f32"], "i32"),
+    "f32_ne": (["f32", "f32"], "i32"),
+    "f32_lt": (["f32", "f32"], "i32"),
+    "f32_le": (["f32", "f32"], "i32"),
+    "f32_gt": (["f32", "f32"], "i32"),
+    "f32_ge": (["f32", "f32"], "i32"),
+    "f64_add": (["f64", "f64"], "f64"),
+    "f64_sub": (["f64", "f64"], "f64"),
+    "f64_mul": (["f64", "f64"], "f64"),
+    "f64_div": (["f64", "f64"], "f64"),
+    "f64_abs": (["f64"], "f64"),
+    "f64_neg": (["f64"], "f64"),
+    "f64_sqrt": (["f64"], "f64"),
+    "f64_eq": (["f64", "f64"], "i32"),
+    "f64_ne": (["f64", "f64"], "i32"),
+    "f64_lt": (["f64", "f64"], "i32"),
+    "f64_le": (["f64", "f64"], "i32"),
+    "f64_gt": (["f64", "f64"], "i32"),
+    "f64_ge": (["f64", "f64"], "i32"),
+    "f64_promote_f32": (["f32"], "f64"),
+    "f32_demote_f64": (["f64"], "f32"),
+    "f32_convert_i32_s": (["i32"], "f32"),
+    "f32_convert_i32_u": (["i32"], "f32"),
+    "f64_convert_i32_s": (["i32"], "f64"),
+    "f64_convert_i32_u": (["i32"], "f64"),
+    "f32_reinterpret_i32": (["i32"], "f32"),
+    "i32_reinterpret_f32": (["f32"], "i32"),
+    "mixed_params": (["i32", "f32", "i32"], "f32"),
+}
+
+# Interesting float inputs (as python floats, or ints for i32 args).
+F32_PAIRS = [
+    (1.5, 2.25), (-3.0, 4.0), (0.0, -0.0), (1.0, 0.0), (-1.0, 0.0),
+    (float("inf"), 1.0), (float("nan"), 1.0), (1.0, float("nan")),
+    (float("nan"), float("nan")), (3.14159, 2.71828),
+    (1e30, 1e30), (-1e30, 2.0), (float("-inf"), float("inf")),
+]
+F64_PAIRS = F32_PAIRS
+I32_VALS = [0, 1, -1, 2147483647, -2147483648, 0x3F800000, 0xC0000000, 42]
+
+
+def cases_for(fn):
+    args, _ = SIGS[fn]
+    out = []
+    if args == ["f32", "f32"] or args == ["f64", "f64"]:
+        for a, b in (F32_PAIRS if args[0] == "f32" else F64_PAIRS):
+            out.append([a, b])
+    elif args == ["f32"] or args == ["f64"]:
+        vals = [x for p in F32_PAIRS for x in p]
+        for v in vals:
+            out.append([v])
+    elif args == ["i32"]:
+        for v in I32_VALS:
+            out.append([v])
+    elif args == ["i32", "f32", "i32"]:
+        for v in [1.5, -2.0, 0.0, float("nan"), float("inf")]:
+            out.append([7, v, 9])
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# encoding helpers
+def f32_bits(x):
+    return struct.unpack("<I", struct.pack("<f", x))[0]
+
+
+def f64_bits(x):
+    return struct.unpack("<Q", struct.pack("<d", x))[0]
+
+
+def i32_bits(x):
+    return x & M32
+
+
+def as_i32(x):
+    """Interpret x's low 32 bits as a signed int (wasmtime/ctypes want signed)."""
+    return struct.unpack("<i", struct.pack("<I", int(x) & M32))[0]
+
+
+def arg_bits(ty, v):
+    if ty == "f32":
+        return f32_bits(v)
+    if ty == "f64":
+        return f64_bits(v)
+    return i32_bits(int(v))
+
+
+def is_nan_result(ty, bits):
+    if ty == "f32":
+        return math.isnan(struct.unpack("<f", struct.pack("<I", bits & M32))[0])
+    if ty == "f64":
+        return math.isnan(struct.unpack("<d", struct.pack("<Q", bits & M64))[0])
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# wasmtime ground truth
+def wasmtime_run(fn, args, sig):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    f = wasmtime.Instance(store, module, []).exports(store)[fn]
+    types, ret = sig
+    call = []
+    for ty, v in zip(types, args):
+        call.append(as_i32(v) if ty == "i32" else float(v))
+    r = f(store, *call)
+    if ret == "f32":
+        return f32_bits(r)
+    if ret == "f64":
+        return f64_bits(r)
+    return i32_bits(r)
+
+
+# --------------------------------------------------------------------------- #
+# ELF load
+def compile_aarch64(out):
+    cmd = [SYNTH, "compile", str(WAT), "-o", out, "-b", "aarch64", "--all-exports"]
+    r = subprocess.run(cmd, capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin"})
+    if r.returncode != 0:
+        sys.exit(f"aarch64 compile failed: {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for sy in sec.iter_symbols():
+                if sy.name:
+                    syms[sy.name] = sy["st_value"] & ~1
+    return code, base, syms
+
+
+# --------------------------------------------------------------------------- #
+# unicorn execution (FPEN enabled)
+def unicorn_run(code, base, faddr, sig, args):
+    off = faddr - base
+    types, ret = sig
+    mu = Uc(UC_ARCH_ARM64, UC_MODE_ARM)
+    # Enable the FP/SIMD unit (FPEN = 0b11 at CPACR_EL1[21:20]); otherwise the
+    # first V-register instruction traps.
+    mu.reg_write(UC_ARM64_REG_CPACR_EL1, 0x3 << 20)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(STK - 0x10000, 0x20000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_ARM64_REG_SP, STK)
+    mu.reg_write(UC_ARM64_REG_LR, RET)
+    ngrn = 0
+    nsrn = 0
+    for ty, v in zip(types, args):
+        b = arg_bits(ty, v)
+        if ty in ("f32", "f64"):
+            mu.reg_write(V_ARGS[nsrn], b)  # low 32/64 bits of Vn
+            nsrn += 1
+        else:
+            mu.reg_write(X_ARGS[ngrn], b)
+            ngrn += 1
+    try:
+        mu.emu_start(CODE + off, RET, count=2000)
+    except UcError as e:
+        return f"ERR:{e}"
+    if ret == "f32":
+        return mu.reg_read(UC_ARM64_REG_S0) & M32
+    if ret == "f64":
+        return mu.reg_read(UC_ARM64_REG_D0) & M64
+    return mu.reg_read(UC_ARM64_REG_W0) & M32
+
+
+# --------------------------------------------------------------------------- #
+# native execution on an arm64 host.
+#
+# Apple Silicon (darwin/arm64) forbids a plain W+X mapping — JIT pages need
+# MAP_JIT plus the per-thread write-protect toggle. Linux/arm64 accepts the
+# straightforward RWX mmap. We go through libc mmap directly to pass MAP_JIT.
+_native_regions = []
+
+_MAP_PRIVATE = 0x0002
+_MAP_ANON = 0x1000 if sys.platform == "darwin" else 0x20
+_MAP_JIT = 0x0800  # darwin only
+_PROT_RWX = 0x1 | 0x2 | 0x4
+
+
+def native_setup(code):
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.mmap.restype = ctypes.c_void_p
+    libc.mmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int,
+                          ctypes.c_int, ctypes.c_int, ctypes.c_long]
+    size = max(len(code), 4096)
+    flags = _MAP_PRIVATE | _MAP_ANON
+    if sys.platform == "darwin":
+        flags |= _MAP_JIT
+    addr = libc.mmap(None, size, _PROT_RWX, flags, -1, 0)
+    if addr == ctypes.c_void_p(-1).value or addr == 0:
+        err = ctypes.get_errno()
+        raise OSError(err, f"mmap(MAP_JIT) failed: {os.strerror(err)}")
+    if sys.platform == "darwin":
+        # Enter write mode, copy, then flip to execute mode + flush I-cache.
+        wp = ctypes.CDLL(None).pthread_jit_write_protect_np
+        wp(0)  # writable
+    ctypes.memmove(addr, code, len(code))
+    if sys.platform == "darwin":
+        wp(1)  # executable
+        libc.sys_icache_invalidate.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+        libc.sys_icache_invalidate(ctypes.c_void_p(addr), len(code))
+    _native_regions.append((addr, size))
+    return addr
+
+
+_CTY = {"f32": ctypes.c_float, "f64": ctypes.c_double, "i32": ctypes.c_int32}
+
+
+def native_run(base_addr, faddr, code_base, sig, args):
+    types, ret = sig
+    fn_addr = base_addr + (faddr - code_base)
+    argtypes = [_CTY[t] for t in types]
+    restype = _CTY[ret]
+    proto = ctypes.CFUNCTYPE(restype, *argtypes)
+    fn = proto(fn_addr)
+    call = []
+    for ty, v in zip(types, args):
+        call.append(as_i32(v) if ty == "i32" else float(v))
+    r = fn(*call)
+    if ret == "f32":
+        return f32_bits(r)
+    if ret == "f64":
+        return f64_bits(r)
+    return i32_bits(r)
+
+
+# --------------------------------------------------------------------------- #
+def main():
+    out = "/tmp/aarch64_m3_538.o"
+    compile_aarch64(out)
+    code, base, syms = load(out)
+    host_native = platform.machine() in ("arm64", "aarch64")
+    native_base = native_setup(code) if host_native else None
+
+    fails = 0
+    total = 0
+    checked_native = 0
+    missing = set()
+    for fn, sig in SIGS.items():
+        if fn not in syms:
+            print(f"FAIL {fn}: symbol missing")
+            missing.add(fn)
+            fails += 1
+            continue
+        _, ret = sig
+        for args in cases_for(fn):
+            total += 1
+            exp = wasmtime_run(fn, args, sig)
+            uni = unicorn_run(code, base, syms[fn], sig, args)
+            oracles = [("unicorn", uni)]
+            if host_native:
+                nat = native_run(native_base, syms[fn], base, sig, args)
+                oracles.append(("native", nat))
+                checked_native += 1
+            for label, got in oracles:
+                if not isinstance(got, int):
+                    fails += 1
+                    print(f"BUG {fn}{args} [{label}] {got} wasmtime={exp:#x}")
+                    continue
+                exp_nan = is_nan_result(ret, exp)
+                got_nan = is_nan_result(ret, got)
+                ok = (exp_nan and got_nan) or (got == exp)
+                if not ok:
+                    fails += 1
+                    print(f"BUG {fn}{args} [{label}] A64={got:#x} "
+                          f"wasmtime={exp:#x}")
+    print(f"\n{total} wasmtime cases, {checked_native} also run natively "
+          f"({'arm64 host' if host_native else 'unicorn-only host'})")
+    print(f"{total - (fails if fails <= total else total)}/{total} matched")
+    print("RESULT:", "PASS — aarch64 m3 float codegen matches wasmtime "
+          "(native + unicorn, third oracle)"
+          if not fails else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## AArch64 backend milestone 3 — scalar floating point (#538)

v0.46 Wave-2 Lane 4. Extends the host-native A64 backend (`crates/synth-backend-aarch64`) from the integer-only m2 subset to **scalar floating point** — the separate V/D/S register file.

### Float op coverage: 0 → 35

m2 loud-declined every float op. m3 lands the high-value, **total** (non-trapping) scalar-float surface:

| Group | Ops |
|-------|-----|
| f32 arith | `add` `sub` `mul` `div` `abs` `neg` |
| f32 compare | `eq` `ne` `lt` `le` `gt` `ge` |
| f32 const | `f32.const` (materialize + FMOV) |
| f64 arith | `add` `sub` `mul` `div` `abs` `neg` `sqrt` |
| f64 compare | `eq` `ne` `lt` `le` `gt` `ge` |
| f64 const | `f64.const` |
| precision | `f64.promote_f32` `f32.demote_f64` |
| int→float | `f32/f64.convert_i32_s` `f32/f64.convert_i32_u` |
| reinterpret | `f32.reinterpret_i32` `i32.reinterpret_f32` |

### Register-file separation
A64 floats live in V0–V31, an ABI counter **independent** of the GP arg registers. The value stack now tags each entry with its file (`Gp`/`Fp`); `select_typed` threads the per-param `f32`/`f64` masks so `(param i32 f32 i32)` correctly resolves to `w0, s0, w1`. A GP op fed an FP operand **errors** (type-confusion guard) — never reads the wrong file.

### Soundness — honest decline matrix
Still loud-declined (no symbol emitted, honest error — never silent-wrong):
- **Trapping float→int truncations** (`i32.trunc_f32_s/_u`, `i32.trunc_f64_s/_u`): A64 `FCVTZS`/`FCVTZU` **saturate** where WASM traps on out-of-range/NaN — the #709 "more-total-than-WASM" class. Verified declined end-to-end.
- `min`/`max`/`copysign`/rounding (`ceil`/`floor`/`trunc`/`nearest`) and i64↔float conversions — a later increment.
- `f32.sqrt` is decode-dropped upstream (`_ => None`); the selector arm exists but isn't reached (kept out of the count).

### Verification
- **clang-cross-verified encodings**: every FP base (FADD/FSUB/FMUL/FDIV, FABS/FNEG/FSQRT, FCMP + NaN-correct `mi`/`ls`/`gt`/`ge` conds, the FMOV GP↔FP bridges, FCVT S↔D, SCVTF/UCVTF) checked against `clang -target aarch64-linux-gnu` ground truth (`fp_*` encoder tests).
- **Native + unicorn differential** (`aarch64_m3_floats_538_differential.py`): each function runs under unicorn (UC_ARCH_ARM64, FPEN on) AND natively on the arm64 host (MAP_JIT), diffed **bit-exactly** vs wasmtime — **513/513 cases**, including NaN/±0/±inf inputs and mixed int/float param assignment.
- 36 backend unit tests green; m2 differential still 182/182 (no regression from the value-stack refactor); workspace clippy/fmt clean.

Cover targets only. References #538 (milestone 3). Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
