### PR TITLE
proof(#166): close verify-what-ships proof residuals — 2 admits discharged, 3 pinned as honest T3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ cd coq && make proofs
 
 ### Proof Status
 
-See `coq/STATUS.md` for the complete coverage matrix. Current: 485 Qed / 5 Admitted
+See `coq/STATUS.md` for the complete coverage matrix. Current: 489 Qed / 3 Admitted
 (+2 `admit.` tactics) across `coq/Synth/`. The 50 selector-DSL rule theorems
 (`VcrSelRules.v`) are stated directly about the GENERATED model (VCR-ISA-001
 #667: `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v` emitted
@@ -99,9 +99,14 @@ reflexivity gate was retired as vacuous once the hand-written mirror was gone
 `scripts/claim_check.py` re-derive it on every commit — when a proof lands, update
 the docs AND `claims.yaml` in the same PR. Proofs are tiered:
 T1 (result-correspondence), T2 (existence-only), T3 (admitted). Remaining admits:
-2 Compilation.v, 1 CorrectnessSimple.v, 2 ArmRefinement.v — 0 division admits
+1 CorrectnessSimple.v, 2 ArmRefinement.v — 0 division admits
 (all four i32 div/rem trap guards discharged against `exec_program_br`, #73)
-and 0 i64 admits.
+and 0 i64 admits. (#166: the 2 Compilation.v example admits were discharged
+via `vm_compute`; the CorrectnessSimple.v `i32_const_correct` residual is a
+documented T3 — the MOVW+MOVT reconstruction arithmetic is now proven
+(`movw_movt_reconstruct_Z`, `i32_const_large_reconstruct`), the residual is the
+un-normalized-`Z` WASM-constant representation gap; the 2 ArmRefinement.v admits
+are opaque-`sail_exec_instr`-axiom placeholders superseded by `SailArmBridge.v`.)
 All i32 AND i64 operations have T1 proofs (i64 T1 parity since v0.11.0).
 
 ### Claim-verification gate

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 | ELF output with vector table | Implemented | Thumb bit set on symbols; not linked on real hardware |
 | Linker scripts (STM32, nRF52840, generic) | Implemented | Generated, not tested with real boards |
 | Cross-compilation (`--link` flag) | Implemented | Requires `arm-none-eabi-gcc` in PATH; not CI-tested |
-| Rocq mechanized proofs | 485 Qed / 5 Admitted | i32 + i64 T1 correctness proofs; the 50 selector-DSL rule theorems are stated directly about the GENERATED model (VCR-ISA-001 #667 — `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v`); all four i32 div/rem trap guards discharged against the branch-taking executor (#73) |
+| Rocq mechanized proofs | 489 Qed / 3 Admitted | i32 + i64 T1 correctness proofs; the 50 selector-DSL rule theorems are stated directly about the GENERATED model (VCR-ISA-001 #667 — `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v`); all four i32 div/rem trap guards discharged against the branch-taking executor (#73) |
 | SMT translation validation | ordeal (pure-Rust QF_BV) default | v0.27.0 (#553); Z3 demoted to feature-gated differential oracle — 141/141 agreement |
 | WebAssembly spec test suite | 227/257 compile | Compilation only — not executed on emulator |
 
@@ -194,7 +194,7 @@ Per the [PulseEngine Verification Guide](https://pulseengine.eu/guides/VERIFICAT
 
 | Track | Status | Coverage |
 |-------|--------|----------|
-| **Rocq** | Partial | 485 Qed / 5 Admitted (50 selector-DSL rule theorems stated directly about the GENERATED model, VCR-ISA-001 #667) — all four i32 div/rem trap guards discharged (#73) |
+| **Rocq** | Partial | 489 Qed / 3 Admitted (50 selector-DSL rule theorems stated directly about the GENERATED model, VCR-ISA-001 #667) — all four i32 div/rem trap guards discharged (#73) |
 | **Kani** | Starting | 18 bounded model checking harnesses for ARM encoder |
 | **Verus** | Starting | 8 spec functions in `synth-synthesis/src/contracts.rs`; Bazel integration via `rules_verus` |
 | **Lean** | Not started | — |
@@ -206,13 +206,18 @@ See `artifacts/verification-gaps.yaml` for the detailed gap analysis (VG-001 thr
 Mechanized proofs in Rocq 9 show that `compile_wasm_to_arm` preserves WASM semantics for each operation. The proof suite lives in `coq/Synth/` and covers ARM instruction semantics, WASM stack-machine semantics, and per-operation correctness theorems.
 
 ```
-485 Qed / 5 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
+489 Qed / 3 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
   T1 result-correspondence (ARM output = WASM result): all i32 ops and all
      i64 ops — i64 T1 parity since v0.11.0, 0 i64 admits (coq/STATUS.md)
   T2 existence-only: f32/f64 and remaining categories
-  T3 admitted (5): 2 Compilation.v, 1 CorrectnessSimple.v, 2 ArmRefinement.v
+  T3 admitted (3): 1 CorrectnessSimple.v, 2 ArmRefinement.v
      (0 division admits — all four i32 div/rem trap guards discharged against
-     exec_program_br, #73 closed at i32)
+     exec_program_br, #73 closed at i32; #166 discharged the 2 Compilation.v
+     example admits via vm_compute; the CorrectnessSimple.v i32_const_correct
+     residual is a documented modeling-gap T3 — the MOVW+MOVT reconstruction
+     arithmetic is proven, the gap is the un-normalized-Z WASM-constant
+     representation; the 2 ArmRefinement.v admits are opaque-sail_exec_instr-
+     axiom placeholders superseded by SailArmBridge.v)
   incl. 50 Qed selector-DSL rule theorems (Synth/VcrSelRules.v, 1:1 with
      coq/vcr_sel_rules.manifest) — stated directly about the GENERATED model
      (VCR-ISA-001 #667: rule_X := Gen.rule_X, single source

--- a/claims.yaml
+++ b/claims.yaml
@@ -29,20 +29,20 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-PROOF-COUNT-README
     doc: README.md
-    text: "485 Qed / 5 Admitted"
+    text: "489 Qed / 3 Admitted"
     evidence:
       - kind: count-eq                       # ALL THREE README spots must agree —
-        pattern: '485 Qed / 5 Admitted'      # a verbatim check alone greens if one
+        pattern: '489 Qed / 3 Admitted'      # a verbatim check alone greens if one
         glob: ['README.md']                  # of them drifts while another matches
         expect: 3
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 485
+        expect: 489
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 5
+        expect: 3
       - kind: count-eq                       # the "+2 admit. tactics" disclosure
         pattern: '^\s*admit\.'
         glob: ['coq/Synth/**/*.v']
@@ -50,33 +50,33 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-CLAUDE-MD
     doc: CLAUDE.md
-    text: "485 Qed / 5 Admitted"
+    text: "489 Qed / 3 Admitted"
     evidence:
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 485
+        expect: 489
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 5
+        expect: 3
 
   - id: SYNTH-PROOF-COUNT-STATUS-MD
     doc: coq/STATUS.md
-    text: "485 Qed / 5 Admitted"
+    text: "489 Qed / 3 Admitted"
     evidence:
       - kind: count-eq                       # headline + Total line must both agree
-        pattern: '485 Qed / 5 Admitted'
+        pattern: '489 Qed / 3 Admitted'
         glob: ['coq/STATUS.md']
         expect: 2
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 485
+        expect: 489
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 5
+        expect: 3
 
   # ---------------------------------------------------------------------------
   # The admit breakdown the docs disclose — per-file, so a new admit anywhere
@@ -93,7 +93,7 @@ claims:
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/Synth/Compilation.v']
-        expect: 2
+        expect: 0
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/Synth/CorrectnessSimple.v']

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -287,22 +287,27 @@ Named `*_executes` to distinguish from T1 `*_correct` proofs.
 | CorrectnessMemory.v | 8 | 4 i32/i64 + 4 f32/f64 load/store |
 | CorrectnessComplete.v | 1 | Master compilation theorem |
 
-## T3: Admitted (13)
+## T3: Admitted (3 Admitted + 2 admit., #166 recount)
 
-> v0.10.0 PR 1: `i64_add_correct` / `i64_sub_correct` moved out of T3 to T1
-> (Qed via the ADDS/ADC + SUBS/SBC carry/borrow-propagation lemmas). The
-> remaining i64 admits are the And/Or/Xor halves-distribute trio.
+> History (all now Qed, kept for the audit trail): v0.10.0 PR 1 lifted
+> `i64_add_correct` / `i64_sub_correct`; v0.10.0 PR 2 closed
+> `i64_to_i32_to_i64_wrap` (Integers.v); v0.11.0 closed the i64 And/Or/Xor
+> trio; #73 (v0.43) closed all four i32 div/rem trap guards including
+> `i32_divs_correct` against `exec_program_br`; #166 (v0.46) discharged the
+> 2 `Compilation.v` example admits. **No remaining control-flow-model or
+> division admits.** The 3 residuals below are one constant-representation
+> modeling gap and two Sail-axiom placeholders.
 
 | File | Count | Root Cause | Unblocking Strategy |
 |------|-------|------------|---------------------|
-| ArmRefinement.v | 2 | Needs Sail-generated ARM semantics | Phase 2: Import Sail specifications |
-| Integers.v | 1 | `i64_to_i32_to_i64_wrap` — Rocq 9 `Z.mod_mod` signature changed | Rework proof for new Z.mod_mod API |
-| CorrectnessI32.v | 1 | `i32_divs_correct` — the INT_MIN/-1 double-guard trap sequence; div_u/rem_s/rem_u discharged against `exec_program_br` (#697/#73) | Restate against `exec_program_br` (as div_u/rem_s/rem_u) with the second (INT_MIN/-1) guard |
 | CorrectnessSimple.v | 1 | `i32_const_correct` — **#166 DOCUMENTED MODELING-GAP T3, not a missing proof.** The MOVW+MOVT reconstruction arithmetic IS proven (`movw_movt_reconstruct_Z`, `i32_const_large_reconstruct`, both real Qed): the shipped large-constant path yields `I32.repr (I32.unsigned n) = I32.unsigned n`. The residual is a value-representation mismatch — `exec_wasm_instr (I32Const n)` pushes the RAW `Z` representative `n` (WasmSemantics does not normalize), so the theorem's `= n` is FALSE in the large branch for out-of-range `n` (concrete counterexample: `n = 2^32 + 0x10000`). | Change of contract (not a new proof): normalize `I32Const` at the WASM boundary (push `VI32 (I32.repr n)`), then `i32_const_large_reconstruct` discharges it; OR add the `I32.valid_unsigned n` register-normalization hypothesis (the #73 div_s precedent). Neither applied silently per the #166 no-weakening gate. |
-| CorrectnessSimple.v | 1 | `i64_const_correct` — v0.8.0 PR 1a aligned codegen to `I64ConstPseudo` (loads both halves); proof claimed R0 = low 16 bits via stale MOVW model | v0.8.0 PR 5: concrete `i64_const_lo`/`i64_const_hi` definitions |
-| CorrectnessI64.v | 3 | `i64_and/or/xor_correct` — halves-distribute-over-bitwise decomposition blocked by the same Rocq 9 `Z.mod_mod` rewrite issue as `i64_to_i32_to_i64_wrap` | Rework with new Z.mod_mod API (separate PR) |
-| Compilation.v | 0 | ~~`ex_compile_simple_add`, `ex_compile_increment_local`~~ — **#166 DISCHARGED** (Qed): `vm_compute` evaluates the `Z.leb (I32.unsigned n) 65535` constant-size guard that `simpl` could not reduce | (done) |
-| ArmRefinement.v | 2 | `arm_refines_sail`, `add_refines_sail` — **#166 confirmed GENUINE T3**: `SailARM.sail_exec_instr` is an opaque `Axiom` (no defining equation), so the required `= Some s_sail'` witness is not derivable | Replace the axiom with a real computational Sail semantics; the live per-instruction ADD/ADDS/CMP correspondence already exists in `SailArmBridge.v` (this placeholder is superseded) |
+| ArmRefinement.v | 2 (Admitted) + 2 (`admit.`) | `arm_refines_sail`, `add_refines_sail` — **#166 confirmed GENUINE T3**: `SailARM.sail_exec_instr` is an opaque `Axiom` (no defining equation), so the required `= Some s_sail'` witness is not derivable. Each theorem also carries one `admit.` tactic (the 2 disclosed `admit.`). | Replace the axiom with a real computational Sail semantics; the live per-instruction ADD/ADDS/CMP correspondence already exists in `SailArmBridge.v` (this placeholder file is superseded). |
+
+**Discharged since the table's original "(13)" snapshot** (all now Qed, no longer
+admitted): `Integers.v` `i64_to_i32_to_i64_wrap`; `CorrectnessI64.v`
+`i64_and/or/xor_correct`; `CorrectnessSimple.v` `i64_const_correct`;
+`CorrectnessI32.v` all four i32 div/rem trap guards (`i32_divs_correct` last, #73);
+`Compilation.v` `ex_compile_simple_add` + `ex_compile_increment_local` (#166).
 
 ## VFP Semantics (Phase 5 — New)
 

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -1,6 +1,6 @@
 # Rocq Proof Suite — Honest Status
 
-**Last Updated: 2026-07-15 (recount: 485 Qed / 5 Admitted, +2 admit., crude
+**Last Updated: 2026-07-16 (#166: recount 489 Qed / 3 Admitted, +2 admit., crude
 `grep "Qed\."` over `coq/Synth/**/*.v` — same method as prior recounts; the
 -40 vs the prior 512 are the retired VCR-ISA-001 #667 cross-check lemmas of
 `VcrSelRulesGenCheck.v`: `VcrSelRules.v` now DEFINES every `rule_X` as the
@@ -47,10 +47,16 @@ The flat-executor capability gap named by VCR-SEL-001 increment 4 is closed:
   model under-trapped exactly where the compiled guard and the WASM spec
   trap — the theorem was FALSE as previously stated).
 
-**Total admits: 5** (was 8) — 2 Compilation.v, 1 CorrectnessSimple.v,
-2 ArmRefinement.v; 0 division admits (#73 CLOSED at i32). The headline count grew 291 → 467 because the recount
-now includes everything landed since 2026-06-04 (SailArmBridge rounds 1–3,
-VcrSelRules increments, VcrSelExpansion, i64 certifying validation lemmas).
+**Total admits: 3** (was 5, #166) — 1 CorrectnessSimple.v, 2 ArmRefinement.v;
+0 division admits (#73 CLOSED at i32). #166 (v0.46 verify-what-ships) discharged
+the 2 `Compilation.v` example admits (`ex_compile_simple_add`,
+`ex_compile_increment_local`) via `vm_compute` on the constant-size guard, and
+proved the shipped MOVW+MOVT large-constant reconstruction
+(`movw_movt_reconstruct_Z`, `i32_const_large_reconstruct`, both real Qed) — see
+the #166 T3 section below for the remaining 3. The headline count grew 291 → 467
+because the recount now includes everything landed since 2026-06-04
+(SailArmBridge rounds 1–3, VcrSelRules increments, VcrSelExpansion, i64
+certifying validation lemmas).
 
 ## v0.11.0 outcome: true i64 T1 parity
 
@@ -159,7 +165,7 @@ umbrella #147).
 |------|---------|-------|
 | **T1: Result Correspondence** | ARM output register = WASM result value | 37¹ |
 | **T2: Existence-Only** | ARM execution succeeds (no result claim) | 139¹ |
-| **T3: Admitted / admit.** | Not yet proven | 7 (5 Admitted + 2 admit.) |
+| **T3: Admitted / admit.** | Not yet proven | 5 (3 Admitted + 2 admit.) |
 | **Infrastructure** | Properties of integers, states, flag lemmas | 65¹ |
 
 ¹ T1/T2/Infrastructure tier classification is the 2026-06-04 semantic recount
@@ -167,7 +173,7 @@ and predates the VcrSelRules (42), VcrSelPilot (7) and SailArmBridge (92) Qed;
 see the per-file breakdown below for current per-file counts. The T3 row and
 the headline total are re-derived by the claim gate.
 
-**Total: 485 Qed / 5 Admitted (+2 admit.) across all files** (recount 2026-07-15, CI-gated via `claims.yaml`)
+**Total: 489 Qed / 3 Admitted (+2 admit.) across all files** (recount 2026-07-15, CI-gated via `claims.yaml`)
 
 v0.10.0 PR 1: +2 T1 Qed (i64_add_correct, i64_sub_correct) and +9
 infrastructure Qed (combine_i32_unsigned, carry_split_add,
@@ -292,10 +298,11 @@ Named `*_executes` to distinguish from T1 `*_correct` proofs.
 | ArmRefinement.v | 2 | Needs Sail-generated ARM semantics | Phase 2: Import Sail specifications |
 | Integers.v | 1 | `i64_to_i32_to_i64_wrap` — Rocq 9 `Z.mod_mod` signature changed | Rework proof for new Z.mod_mod API |
 | CorrectnessI32.v | 1 | `i32_divs_correct` — the INT_MIN/-1 double-guard trap sequence; div_u/rem_s/rem_u discharged against `exec_program_br` (#697/#73) | Restate against `exec_program_br` (as div_u/rem_s/rem_u) with the second (INT_MIN/-1) guard |
-| CorrectnessSimple.v | 1 | `i32_const_correct` — compilation now branches on `I32.unsigned n <= 65535`; large-constant case requires Z.land/Z.shiftr lemmas | Prove MOVW+MOVT reconstruction lemma |
+| CorrectnessSimple.v | 1 | `i32_const_correct` — **#166 DOCUMENTED MODELING-GAP T3, not a missing proof.** The MOVW+MOVT reconstruction arithmetic IS proven (`movw_movt_reconstruct_Z`, `i32_const_large_reconstruct`, both real Qed): the shipped large-constant path yields `I32.repr (I32.unsigned n) = I32.unsigned n`. The residual is a value-representation mismatch — `exec_wasm_instr (I32Const n)` pushes the RAW `Z` representative `n` (WasmSemantics does not normalize), so the theorem's `= n` is FALSE in the large branch for out-of-range `n` (concrete counterexample: `n = 2^32 + 0x10000`). | Change of contract (not a new proof): normalize `I32Const` at the WASM boundary (push `VI32 (I32.repr n)`), then `i32_const_large_reconstruct` discharges it; OR add the `I32.valid_unsigned n` register-normalization hypothesis (the #73 div_s precedent). Neither applied silently per the #166 no-weakening gate. |
 | CorrectnessSimple.v | 1 | `i64_const_correct` — v0.8.0 PR 1a aligned codegen to `I64ConstPseudo` (loads both halves); proof claimed R0 = low 16 bits via stale MOVW model | v0.8.0 PR 5: concrete `i64_const_lo`/`i64_const_hi` definitions |
 | CorrectnessI64.v | 3 | `i64_and/or/xor_correct` — halves-distribute-over-bitwise decomposition blocked by the same Rocq 9 `Z.mod_mod` rewrite issue as `i64_to_i32_to_i64_wrap` | Rework with new Z.mod_mod API (separate PR) |
-| Compilation.v | 2 | `ex_compile_simple_add`, `ex_compile_increment_local` — `simpl` cannot reduce `Z.leb (I32.unsigned (I32.repr n)) 65535` | Use `vm_compute` or prove I32.unsigned reduction lemma |
+| Compilation.v | 0 | ~~`ex_compile_simple_add`, `ex_compile_increment_local`~~ — **#166 DISCHARGED** (Qed): `vm_compute` evaluates the `Z.leb (I32.unsigned n) 65535` constant-size guard that `simpl` could not reduce | (done) |
+| ArmRefinement.v | 2 | `arm_refines_sail`, `add_refines_sail` — **#166 confirmed GENUINE T3**: `SailARM.sail_exec_instr` is an opaque `Axiom` (no defining equation), so the required `= Some s_sail'` witness is not derivable | Replace the axiom with a real computational Sail semantics; the live per-instruction ADD/ADDS/CMP correspondence already exists in `SailArmBridge.v` (this placeholder is superseded) |
 
 ## VFP Semantics (Phase 5 — New)
 
@@ -421,7 +428,7 @@ Recount 2026-07-10 (`grep -oE 'Qed\.'` / `'Admitted\.'` per file):
 | File | Qed | Admitted | Tier |
 |------|-----|----------|------|
 | Correctness.v | 6 | 0 | T1 |
-| CorrectnessSimple.v | 28 | 1 | T2 + 1 admitted (i64_const_correct) |
+| CorrectnessSimple.v | 30 | 1 | T2 + 1 admitted (`i32_const_correct` — #166 documented modeling-gap T3; +2 real Qed added: `movw_movt_reconstruct_Z`, `i32_const_large_reconstruct`) |
 | CorrectnessI32.v | 31 | 0 | T1 — all four #73 div/rem trap-guard proofs discharged against `exec_program_br` (i32_divs_correct closed 2026-07-15 with the INT_MIN/-1 double-guard case split) |
 | CorrectnessI64.v | 46 | 0 | T1 (arith/bitwise/div/rem) + T2 (shifts/cmps/bit-manip) — 0 i64 admits since v0.11.0 |
 | CorrectnessI64Comparisons.v | 19 | 0 | T2 |
@@ -438,7 +445,7 @@ Recount 2026-07-10 (`grep -oE 'Qed\.'` / `'Admitted\.'` per file):
 | ArmSemantics.v | 8 | 0 | Infra |
 | SailArmBridge.v | 92 | 0 | Infra (VCR-ISA-001 Sail/ASL bridge: AddWithCarry family + ALU + shifts + moves) |
 | WasmSemantics.v | 6 | 0 | Infra |
-| Compilation.v | 3 | 2 | Infra + 2 admitted (`ex_compile_*` examples — Z.leb reduction) |
+| Compilation.v | 5 | 0 | Infra (#166: `ex_compile_simple_add` + `ex_compile_increment_local` discharged via `vm_compute`) |
 | Base.v | 4 | 0 | Infra |
 | StateMonad.v | 3 | 0 | Infra |
 | WasmValues.v | 2 | 0 | Infra |

--- a/coq/Synth/ARM/ArmRefinement.v
+++ b/coq/Synth/ARM/ArmRefinement.v
@@ -75,6 +75,31 @@ End SailARM.
    This is the key correctness property connecting our verification to
    the official ARM architecture specification.
 *)
+(**
+   T3 — GENUINELY UNPROVABLE AS STATED (opaque-axiom placeholder), NOT a
+   tractable residual. [SailARM.sail_exec_instr] (line 59) is declared as an
+   [Axiom], i.e. an opaque function symbol with NO computational content and NO
+   defining equations. The conclusion here requires exhibiting a concrete
+   witness [s_sail'] together with a proof that
+   [SailARM.sail_exec_instr instr s_sail = Some s_sail'] — but nothing in the
+   context can reduce or constrain an opaque axiom to [Some _], so no such
+   witness is derivable. This is a modeling-scaffold limitation, not a missing
+   arithmetic lemma: it cannot be closed without REPLACING the axiom with a
+   real, computational Sail semantics.
+
+   WHAT WOULD CLOSE IT / WHERE THE REAL WORK LIVES. The Sail anchoring the North
+   Star calls for (VCR-ISA-001, epic #242) has since landed as
+   [Synth.ARM.SailArmBridge] — a per-instruction hand-transcription of the
+   rems-project/sail-arm arm-v9.4-a execute clauses with line-level provenance,
+   plus BRIDGE lemmas proving [ArmSemantics.v]'s instruction equals the Sail
+   transcription on the shared state projection (92 Qed, real, actively
+   extended round by round). That file, not this placeholder, is the live Sail
+   correspondence; the spike (docs/design/vcr-isa-001-spike.md) measured that
+   importing the 42 MB Sail-generated Rocq model wholesale is infeasible at
+   synth's scale, which is exactly why [sail_exec_instr] here stays an opaque
+   axiom rather than a real definition. This theorem is retained only as the
+   historical statement of the intended global refinement shape; it is honestly
+   Admitted (T3), superseded by the SailArmBridge per-instruction bridges. *)
 Theorem arm_refines_sail : forall (instr : arm_instr) (s : arm_state) (s_sail : SailARM.sail_state),
   SailARM.state_corresponds s s_sail ->
   exists s_sail',
@@ -83,7 +108,10 @@ Theorem arm_refines_sail : forall (instr : arm_instr) (s : arm_state) (s_sail : 
                 exists s_sail'',
                   SailARM.state_corresponds s' s_sail'').
 Proof.
-  (* TODO: Prove after importing real Sail definitions *)
+  (* T3: [SailARM.sail_exec_instr] is an opaque Axiom (line 59) — the required
+     [= Some s_sail'] witness is not derivable. Superseded by the real
+     per-instruction bridges in [Synth.ARM.SailArmBridge]. See the block
+     comment above for the full rationale and closure path. *)
   admit.
 Admitted.
 
@@ -92,7 +120,19 @@ Admitted.
    We prove refinement for each instruction category.
 *)
 
-(** Arithmetic instructions refine Sail *)
+(** Arithmetic instructions refine Sail.
+
+    T3 — same opaque-axiom obstacle as [arm_refines_sail]. Unfolding [refines],
+    when [exec_instr (ADD ..) s = Some r] the goal reduces to
+    [Some r = match SailARM.sail_exec_instr (ADD ..) s_sail with
+              | Some _ => Some r | None => None end],
+    which holds iff [SailARM.sail_exec_instr (ADD ..) s_sail = Some _]. That is
+    again a claim about the opaque [Axiom] with no defining equation, so it is
+    not derivable. Closure requires replacing [sail_exec_instr] with a real
+    computational Sail semantics; the live per-instruction ADD/ADDS/CMP bridges
+    already exist in [Synth.ARM.SailArmBridge] (Round 1+), which is where the
+    genuine ADD↔Sail correspondence is proved. Honestly Admitted (T3),
+    superseded. *)
 Theorem add_refines_sail : forall rd rn op2 s s_sail,
   SailARM.state_corresponds s s_sail ->
   exec_instr (ADD rd rn op2) s ⊑
@@ -101,7 +141,8 @@ Theorem add_refines_sail : forall rd rn op2 s s_sail,
      | None => None
      end).
 Proof.
-  (* TODO: Prove after Sail integration *)
+  (* T3: opaque [SailARM.sail_exec_instr] Axiom; superseded by the real ADD/ADDS
+     bridges in [Synth.ARM.SailArmBridge]. See the comment above. *)
   admit.
 Admitted.
 

--- a/coq/Synth/Synth/Compilation.v
+++ b/coq/Synth/Synth/Compilation.v
@@ -546,25 +546,27 @@ Definition compile_wasm_program (prog : wasm_program) : arm_program :=
 (** ** Examples **)
 
 (** WASM: i32.const 5; i32.const 3; i32.add
-    Note: These examples are Admitted because compile_wasm_to_arm now branches
-    on [Z.leb (I32.unsigned n) 65535], and [simpl] cannot fully reduce
-    [I32.unsigned (I32.repr 5)] without unfolding the integer representation.
-    The compilation is still correct — the small-constant path produces [MOVW]. *)
+    [compile_wasm_to_arm] branches on [Z.leb (I32.unsigned n) 65535]; for the
+    small constants 5 and 3 the guard reduces to [true], selecting the [MOVW]
+    path. [simpl] cannot reduce [I32.unsigned (I32.repr 5) <=? 65535] because
+    the [mod 2^32] in [unsigned]/[repr] blocks it, but [vm_compute] evaluates
+    the guard to [true] and the whole program to the expected sequence. *)
 Example ex_compile_simple_add :
   compile_wasm_program ([I32Const (I32.repr 5); I32Const (I32.repr 3); I32Add]) =
   ([MOVW R0 (I32.repr 5);
    MOVW R0 (I32.repr 3);
    ADD R0 R0 (Reg R1)]).
-Proof. Admitted.
+Proof. vm_compute. reflexivity. Qed.
 
-(** WASM: local.get 0; i32.const 1; i32.add; local.set 0 *)
+(** WASM: local.get 0; i32.const 1; i32.add; local.set 0
+    [I32.one = I32.repr 1] is likewise in the small-constant branch. *)
 Example ex_compile_increment_local :
   compile_wasm_program ([LocalGet 0%nat; I32Const I32.one; I32Add; LocalSet 0%nat]) =
   ([MOV R0 (Reg R4);
    MOVW R0 I32.one;
    ADD R0 R0 (Reg R1);
    MOV R4 (Reg R0)]).
-Proof. Admitted.
+Proof. vm_compute. reflexivity. Qed.
 
 (** ** Compilation Invariants **)
 

--- a/coq/Synth/Synth/CorrectnessSimple.v
+++ b/coq/Synth/Synth/CorrectnessSimple.v
@@ -157,10 +157,125 @@ Qed.
 
 (** ** Constants *)
 
-(** i32.const now branches on the constant size (MOVW for <= 65535, MOVW+MOVT
-    for larger values). The small-constant case is straightforward; the
-    large-constant case requires showing MOVW+MOVT reconstructs the original
-    value via bitwise composition, which needs Z.land/Z.shiftr arithmetic. *)
+(** #166 verify-what-ships: the MOVW+MOVT large-constant reconstruction lemma.
+
+    The large-constant compilation path emits
+      MOVW R0 (repr (land u 65535))    (* low 16 bits *)
+      MOVT R0 (repr (shiftr u 16))     (* high 16 bits into bits 31..16 *)
+    where [u = I32.unsigned n]. This is the exact byte-level lowering the Rust
+    encoder ships (instruction_selector: split-immediate MOVW/MOVT). We prove,
+    by bit extensionality, that composing the two halves reconstructs [u]:
+
+      or (and (repr (land u 65535)) (repr 0xFFFF)) (shl (repr (shiftr u 16)) 16)
+        = repr u.
+
+    Everything on the left is [_ mod 2^32], so the reconstruction produces the
+    register-normalized value [repr u = repr (unsigned n) = unsigned n], NOT the
+    raw representative [n]. That distinction is the crux of the [i32_const_correct]
+    modeling gap documented below. *)
+
+Local Open Scope Z_scope.
+
+Lemma movw_movt_reconstruct_Z : forall u : Z,
+  Z.lor
+    (Z.land (Z.land u 65535 mod 2 ^ 32) (65535 mod 2 ^ 32) mod 2 ^ 32)
+    (Z.shiftl (Z.shiftr u 16 mod 2 ^ 32) 16 mod 2 ^ 32) mod 2 ^ 32
+  = u mod 2 ^ 32.
+Proof.
+  intros u.
+  change (65535 mod 2 ^ 32) with (Z.ones 16).
+  change 65535 with (Z.ones 16).
+  rewrite <- !Z.land_ones by lia.
+  apply Z.bits_inj'; intros i Hi.
+  (* Peel outer [land (ones32)] (final mod), the [lor], and the left operand's
+     [land]s down to [testbit u i]. The right operand's [shiftl] is handled per
+     half below (its argument's [land] only reduces after [Z.shiftl_spec]). *)
+  rewrite Z.land_spec, Z.lor_spec.
+  rewrite !Z.land_spec.
+  rewrite (Z.testbit_ones 32 i) by lia.
+  rewrite !(Z.testbit_ones 16 i) by lia.
+  (* Case on whether bit [i] lands in the low half (< 16) or high half (>= 16). *)
+  destruct (Z.ltb_spec i 16) as [Hlo | Hhi].
+  - (* low half: the shifted high part contributes 0 (bit index i-16 < 0). *)
+    rewrite Z.shiftl_spec by lia.
+    rewrite (Z.testbit_neg_r _ (i - 16)) by lia.
+    rewrite Bool.orb_false_r.
+    destruct (Z.testbit u i);
+      destruct (i <? 32) eqn:E32, (i <? 16) eqn:E16, (0 <=? i) eqn:E0;
+      cbn; try reflexivity;
+      (try (exfalso; apply Z.ltb_ge in E16; lia));
+      (try (exfalso; apply Z.leb_gt in E0; lia)).
+  - (* high half: the low-16 mask contributes 0 at bit i (i >= 16). *)
+    rewrite Z.shiftl_spec by lia.
+    rewrite Z.land_spec, (Z.testbit_ones 32 (i - 16)) by lia.
+    rewrite Z.shiftr_spec by lia.
+    replace (i - 16 + 16) with i by lia.
+    destruct (Z.testbit u i);
+      destruct (i <? 32) eqn:E32, (i <? 16) eqn:E16, (0 <=? i - 16) eqn:El,
+               (i - 16 <? 32) eqn:Eh, (0 <=? i) eqn:E0;
+      cbn; try reflexivity;
+      (try (exfalso; apply Z.ltb_lt in E16; lia));
+      (try (exfalso; apply Z.ltb_ge in E32; lia));
+      (try (exfalso; apply Z.leb_gt in El; lia));
+      (try (exfalso; apply Z.ltb_ge in Eh; lia)).
+Qed.
+
+(** ARM-level reconstruction: after the shipped MOVW+MOVT large-constant
+    sequence, R0 holds the register-normalized constant [I32.repr (I32.unsigned n)].
+    This is a real, unconditional Qed about the exact instructions that ship. *)
+Lemma i32_const_large_reconstruct : forall astate n,
+  I32.unsigned n > 65535 ->
+  exists astate',
+    exec_program (compile_wasm_to_arm (I32Const n)) astate = Some astate' /\
+    get_reg astate' R0 = I32.repr (I32.unsigned n).
+Proof.
+  intros astate n Hbig.
+  unfold compile_wasm_to_arm.
+  (* the guard [Z.leb (I32.unsigned n) 65535] is false *)
+  replace (Z.leb (I32.unsigned n) 65535) with false
+    by (symmetry; apply Z.leb_gt; lia).
+  (* Execute the two-instruction [MOVW; MOVT] program. *)
+  cbn [exec_program exec_instr].
+  eexists. split; [reflexivity|].
+  (* Reduce every [get_reg (set_reg _ R0 _) R0] (final get + MOVT's read). *)
+  rewrite !get_set_reg_eq.
+  unfold I32.or, I32.and, I32.shl, I32.repr, I32.unsigned.
+  (* shift amount: (16 mod 2^32) mod 32 = 16 *)
+  change ((16 mod 2 ^ 32) mod 32) with 16.
+  apply movw_movt_reconstruct_Z.
+Qed.
+
+Local Close Scope Z_scope.
+
+(** i32.const branches on the constant size: MOVW for [unsigned n <= 65535],
+    MOVW+MOVT otherwise.
+
+    T3 — DOCUMENTED MODELING GAP (NOT a division admit, NOT an unproven bit fact).
+    The reconstruction arithmetic IS proven (see [movw_movt_reconstruct_Z] and
+    [i32_const_large_reconstruct] above, both real Qed). The residual is a
+    value-representation mismatch, not a missing proof:
+
+    - [exec_wasm_instr (I32Const n)] pushes [VI32 n] with the RAW [Z]
+      representative [n] (WasmSemantics does not normalize constants).
+    - The MOVW+MOVT ship path (large branch) necessarily normalizes: it yields
+      [I32.repr (I32.unsigned n) = I32.unsigned n], proven above.
+
+    So [get_reg astate' R0 = n] holds UNCONDITIONALLY only in the small (MOVW)
+    branch; in the large branch it holds iff [n] is register-normalized
+    ([I32.valid_unsigned n], i.e. [n = I32.unsigned n]). The theorem as stated
+    (no normalization hypothesis) is therefore FALSE for out-of-range
+    representatives with [unsigned n > 65535] — a real counterexample exists
+    (e.g. [n = 2^32 + 0x10000]).
+
+    Two ways to close it, both a change of contract rather than a new proof:
+      (a) normalize [I32Const] at the WASM boundary in the model
+          (push [VI32 (I32.repr n)]), then [i32_const_large_reconstruct]
+          discharges it directly; or
+      (b) add the [I32.valid_unsigned n] register-normalization hypothesis
+          (the same explicit contract the #73 div_s proof adopted).
+    Per the #166 "never weaken a theorem to force a Qed" gate, neither is
+    applied here silently; the theorem stays honestly Admitted with the
+    reconstruction fact already discharged. *)
 Theorem i32_const_correct : forall wstate astate n,
   exec_wasm_instr (I32Const n) wstate =
     Some (mkWasmState
@@ -172,11 +287,9 @@ Theorem i32_const_correct : forall wstate astate n,
     exec_program (compile_wasm_to_arm (I32Const n)) astate = Some astate' /\
     get_reg astate' R0 = n.
 Proof.
-  (* Admitted: compilation now branches on I32.unsigned n <= 65535.
-     Small case: same as before (MOVW).
-     Large case: MOVW+MOVT reconstruct value from low/high halves.
-     Proving the large case requires: I32.or (I32.and (I32.repr low) 0xFFFF)
-       (I32.shl (I32.repr high) 16) = n, which needs Z.land/Z.shiftr lemmas. *)
+  (* See the T3 rationale above: false in the large branch for un-normalized
+     [n]; the reconstruction arithmetic itself is proven in
+     [i32_const_large_reconstruct]. *)
 Admitted.
 
 (** v0.9.0 PR 1 (precursor + discharge): I64Const compiles to


### PR DESCRIPTION
## #166 — "Arc: verify what ships" — control-flow / division-traps proof residuals

Audits the 5 Admitted + 2 `admit.` in `coq/Synth/`, discharges the tractable ones with **real** proofs, and pins the rest as precisely-documented T3 (no silent admits). **No theorem statement was weakened to force a Qed.**

### Headline: 485 Qed / 5 Admitted → **489 Qed / 3 Admitted** (+2 `admit.` unchanged)

The audit's real answer to the arc: **there are no remaining control-flow-model or division admits** — those were already closed by the `#73` / `exec_program_br` branch-taking-executor work. The 3 residuals are (1) one constant-representation modeling gap and (2) two Sail-axiom placeholders superseded by `SailArmBridge.v`.

### Discharged (Admitted → Qed, real proofs)
- **`Compilation.v` `ex_compile_simple_add` + `ex_compile_increment_local`** — `simpl` couldn't reduce the `Z.leb (I32.unsigned n) 65535` constant-size guard (the `mod 2^32` blocks it); `vm_compute` evaluates it. **2 admits → 0.**
- **New: `movw_movt_reconstruct_Z` + `i32_const_large_reconstruct` (`CorrectnessSimple.v`, +2 Qed)** — bit-extensional proof that the shipped `[MOVW; MOVT]` large-constant sequence reconstructs `I32.repr (I32.unsigned n)`. This is the actual "verify what ships" fact for the split-immediate lowering.

### Pinned as honest T3 (documented, not silently admitted)
- **`i32_const_correct` (`CorrectnessSimple.v`, 1 Admitted)** — DOCUMENTED MODELING GAP, not a missing proof. The reconstruction arithmetic is now proven (above). The residual is a value-representation mismatch: `exec_wasm_instr (I32Const n)` pushes the RAW `Z` representative `n` (WasmSemantics does not normalize), while the MOVW+MOVT ship path normalizes — so the theorem's `= n` is provably FALSE in the large branch for out-of-range `n` (counterexample `n = 2^32 + 0x10000`). Closing it is a change of contract (normalize `I32Const` at the WASM boundary, or add `I32.valid_unsigned n` — the #73 div_s precedent), which the #166 no-weakening gate forbids applying silently.
- **`arm_refines_sail` + `add_refines_sail` (`ArmRefinement.v`, 2 Admitted + 2 `admit.`)** — GENUINE T3. `SailARM.sail_exec_instr` is an opaque `Axiom` with no defining equation, so the required `= Some s_sail'` witness is not derivable. This placeholder file is superseded by `SailArmBridge.v` (the real per-instruction Sail/ASL bridge, 92 Qed). Statements unchanged; in-file rationale added.

### Gate
- `bazel test //coq:verify_proofs` — **GREEN** (both `rocq_proofs` + `vcr_sel_rules_coverage`).
- `python3 scripts/claim_check.py claims.yaml` — **20/20 hold** with updated counts.
- `claims.yaml` + `README.md` + `CLAUDE.md` + `coq/STATUS.md` bumped together (485→489 Qed, 5→3 Admitted, Compilation.v breakdown 2→0); STATUS T3 table de-staled.
- No Rust touched (no `cargo fmt` needed).

Refs #166. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L