### PR TITLE
feat(aarch64): milestone 4 — sound trapping float→int trunc + NaN-correct min/max + copysign (#538)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,14 +351,17 @@ jobs:
           cargo test -p synth-core --lib provenance
 
   aarch64-oracle:
-    name: aarch64 backend execution + decline oracle (#538 m2)
-    # #538 milestone-2: the host-native A64 backend broadened from the m1 i32
-    # add/sub/mul/and/or/xor core to the FULL i32 + i64 integer ALU (shifts,
-    # rotates, clz/ctz, the compare family, i64 x-forms + const). EXECUTE every
-    # covered op's emitted A64 `.text` under unicorn (UC_ARCH_ARM64) and diff vs
-    # wasmtime ground truth — the "third backend = third oracle" property — plus
-    # a decline-matrix probe asserting div/rem/popcnt/float still LOUD-decline
-    # (A64 SDIV/UDIV don't trap; a naive lowering would be a silent miscompile).
+    name: aarch64 backend execution + decline oracle (#538 m2–m4)
+    # #538: the host-native A64 backend, oracle-gated per milestone. EXECUTE
+    # every covered op's emitted A64 `.text` under unicorn (UC_ARCH_ARM64) and
+    # diff vs wasmtime ground truth — the "third backend = third oracle"
+    # property: m1 integer core, m2 full i32+i64 ALU, m3 scalar floats
+    # (NaN-ordering compares, promote/demote, converts, reinterprets), m4 the
+    # #709 boundary table (domain-guarded trapping trunc: every case where
+    # WASM traps must TRAP under emulation, in-range must match bit-exactly)
+    # + min/max NaN/±0 matrix + copysign. The decline-matrix probe asserts
+    # div/rem/popcnt/rounding/i64<->float still LOUD-decline (A64 SDIV/UDIV
+    # don't trap; a naive lowering would be a silent miscompile).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -384,7 +387,11 @@ jobs:
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_add_538_differential.py
       - name: Run m2 broadened i32+i64 ALU execution oracle
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_m2_538_differential.py
-      - name: Run m2 decline-matrix honesty oracle
+      - name: Run m3 scalar-float execution oracle
+        run: SYNTH=./target/debug/synth python scripts/repro/aarch64_m3_floats_538_differential.py
+      - name: Run m4 trunc boundary-table + min/max NaN/±0 execution oracle
+        run: SYNTH=./target/debug/synth python scripts/repro/aarch64_m4_trunc_minmax_538_differential.py
+      - name: Run decline-matrix honesty oracle
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_m2_decline_538.py
 
   trap-semantics-oracle:

--- a/crates/synth-backend-aarch64/src/encoder.rs
+++ b/crates/synth-backend-aarch64/src/encoder.rs
@@ -219,6 +219,13 @@ impl Cond {
             Cond::Mi => 0x5,
         }
     }
+
+    /// The ARCHITECTURAL condition encoding (`b.<cond>` bits [3:0]) — the
+    /// NON-inverted form, i.e. `cset_field() ^ 1`. Clang ground truth:
+    /// `b.mi` = cond 0x4, `b.ge` = 0xA, `b.gt` = 0xC.
+    fn bcond_field(self) -> u32 {
+        self.cset_field() ^ 1
+    }
 }
 
 /// `cmp wn, wm` — `subs wzr, wn, wm` (flags only).
@@ -251,6 +258,14 @@ pub fn movz(rd: Reg, imm16: u16) -> u32 {
     0x5280_0000 | ((imm16 as u32) << 5) | (rd as u32)
 }
 
+/// `movz wd, #imm16, lsl #(16*hw)` — zero the register and set the `hw`-th
+/// halfword. The shifted form the leading write of [`mov_imm64`] needs when the
+/// first non-zero halfword is NOT halfword 0 (e.g. f64 `-0.0` =
+/// `0x8000_0000_0000_0000`).
+pub fn movz_hw(rd: Reg, imm16: u16, hw: u8) -> u32 {
+    movz(rd, imm16) | ((hw as u32) << 21)
+}
+
 /// `movk wd, #imm16, lsl #(16*hw)` — keep other bits, set the `hw`-th halfword.
 pub fn movk(rd: Reg, imm16: u16, hw: u8) -> u32 {
     0x7280_0000 | ((hw as u32) << 21) | ((imm16 as u32) << 5) | (rd as u32)
@@ -261,11 +276,30 @@ pub fn ret() -> u32 {
     0xD65F_03C0
 }
 
-/// `brk #imm16` — A64 breakpoint/trap. Used for wasm `unreachable` (#665):
-/// WASM §4.4.5 requires an unconditional trap, the A64 analogue of Thumb-2
-/// `udf #0` / RV32 `ebreak`.
+/// `brk #imm16` — A64 breakpoint/trap. Used for wasm `unreachable` (#665) and
+/// the m4 trunc-guard trap path: WASM §4.4.5 requires an unconditional trap,
+/// the A64 analogue of Thumb-2 `udf #0` / RV32 `ebreak`.
 pub fn brk(imm16: u16) -> u32 {
     0xD420_0000 | ((imm16 as u32) << 5)
+}
+
+/// `b.<cond> #(imm19*4)` — conditional branch, PC-relative in words. Used by
+/// the m4 trunc domain guards to SKIP the `brk` trap when the operand is
+/// proven in-range (`b.mi +2` hops exactly over the following `brk`). Clang
+/// ground truth: `b.mi .+8` = 0x5400_0044 (imm19 = 2, cond = MI = 0x4).
+pub fn bcond(cond: Cond, imm19: i32) -> u32 {
+    0x5400_0000 | (((imm19 as u32) & 0x7FFFF) << 5) | cond.bcond_field()
+}
+
+/// `bic wd, wn, wm` — AND with complement (`wd = wn & !wm`). Used by the
+/// copysign lowering to clear the sign bit with the SAME mask register that
+/// isolates the source sign (one materialized mask instead of two).
+pub fn bic(rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    dp3(0x0A20_0000, rd, rn, rm)
+}
+/// `bic xd, xn, xm`
+pub fn bic64(rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    dp3_sf(0x0A20_0000, true, rd, rn, rm)
 }
 
 /// Materialize a 32-bit constant into `wd` with `movz` + optional `movk`.
@@ -291,9 +325,14 @@ pub fn mov_imm64(rd: Reg, value: u64) -> Vec<u32> {
         ((value >> 32) & 0xFFFF) as u16,
         ((value >> 48) & 0xFFFF) as u16,
     ];
-    // First non-zero halfword becomes the movz; if all zero, movz #0.
+    // First non-zero halfword becomes the movz; if all zero, movz #0. The movz
+    // MUST carry the halfword's shift (`lsl #(16*first)`) — a plain `movz`
+    // would deposit it in halfword 0 (the latent m3 bug that hit every constant
+    // whose low halfwords are all zero, e.g. f64 -0.0 = 0x8000_0000_0000_0000
+    // and the 2^31 trunc-guard boundary 0x41E0_0000_0000_0000; clang ground
+    // truth: `movz x0, #0x8000, lsl #48` = 0xD2F0_0000, not 0xD290_0000).
     let first = hw.iter().position(|&h| h != 0).unwrap_or(0);
-    let mut out = vec![movz(rd, hw[first]) | SF64];
+    let mut out = vec![movz_hw(rd, hw[first], first as u8) | SF64];
     for (i, &h) in hw.iter().enumerate() {
         if i != first && h != 0 {
             out.push(movk(rd, h, i as u8) | SF64);
@@ -403,6 +442,57 @@ pub fn fcmp_s(rn: FReg, rm: FReg) -> u32 {
 /// `fcmp dn, dm`
 pub fn fcmp_d(rn: FReg, rm: FReg) -> u32 {
     0x1E60_2000 | ((rm as u32) << 16) | ((rn as u32) << 5)
+}
+
+// ---------------------------------------------------------------------------
+// Milestone 4 — min/max + guarded trapping truncation.
+//
+// `FMIN`/`FMAX` (NOT the `NM` variants) implement IEEE 754-2019
+// minimum/maximum: either-NaN ⇒ NaN, and -0.0 < +0.0 — EXACTLY WASM
+// `f{32,64}.{min,max}` semantics (`FMINNM`/`FMAXNM` are minNum/maxNum, which
+// RETURN THE NUMBER when one operand is NaN — the wrong semantics). Verified
+// by execution against wasmtime in aarch64_m4_trunc_minmax_538_differential.py
+// (NaN + ±0 matrix), not assumed.
+//
+// `FCVTZS`/`FCVTZU` SATURATE on out-of-range/NaN where WASM TRAPS (#709), so
+// they are ONLY emitted behind the selector's fcmp+b.cond+brk domain guard —
+// on the guarded path every reachable input is in-range, where the two
+// semantics agree.
+// ---------------------------------------------------------------------------
+
+/// `fmin sd, sn, sm` — IEEE 754-2019 minimum (NaN-propagating, -0 < +0).
+pub fn fmin_s(rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    fp3(0x1E20_5800, rd, rn, rm)
+}
+/// `fmax sd, sn, sm` — IEEE 754-2019 maximum (NaN-propagating, -0 < +0).
+pub fn fmax_s(rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    fp3(0x1E20_4800, rd, rn, rm)
+}
+/// `fmin dd, dn, dm`
+pub fn fmin_d(rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    fp3(0x1E60_5800, rd, rn, rm)
+}
+/// `fmax dd, dn, dm`
+pub fn fmax_d(rd: FReg, rn: FReg, rm: FReg) -> u32 {
+    fp3(0x1E60_4800, rd, rn, rm)
+}
+
+/// `fcvtzs wd, sn` — f32 → signed i32, round-toward-zero. SATURATES: emit only
+/// behind the trunc domain guard.
+pub fn fcvtzs_w_from_s(rd: Reg, rn: FReg) -> u32 {
+    fp2(0x1E38_0000, rd, rn)
+}
+/// `fcvtzu wd, sn` — f32 → unsigned i32, round-toward-zero. Saturating; guarded.
+pub fn fcvtzu_w_from_s(rd: Reg, rn: FReg) -> u32 {
+    fp2(0x1E39_0000, rd, rn)
+}
+/// `fcvtzs wd, dn` — f64 → signed i32, round-toward-zero. Saturating; guarded.
+pub fn fcvtzs_w_from_d(rd: Reg, rn: FReg) -> u32 {
+    fp2(0x1E78_0000, rd, rn)
+}
+/// `fcvtzu wd, dn` — f64 → unsigned i32, round-toward-zero. Saturating; guarded.
+pub fn fcvtzu_w_from_d(rd: Reg, rn: FReg) -> u32 {
+    fp2(0x1E79_0000, rd, rn)
 }
 
 /// `fmov sd, wn` — reinterpret the 32-bit GP register `wn` into `sd` (no numeric
@@ -611,5 +701,48 @@ mod tests {
         );
         // zero → a single `movz x, #0`.
         assert_eq!(mov_imm64(0, 0), vec![movz(0, 0) | 0x8000_0000]);
+    }
+
+    #[test]
+    fn mov_imm64_leading_movz_carries_the_halfword_shift() {
+        // The latent m3 bug: when the FIRST non-zero halfword is not hw 0, the
+        // leading movz must be the SHIFTED form. Clang ground truth:
+        //   mov x0, #0x8000000000000000  →  movz x0, #0x8000, lsl #48 = 0xD2F0_0000
+        //   mov x0, #0x41e0000000000000  →  movz x0, #0x41e0, lsl #48 = 0xD2E8_3C00
+        // (f64 -0.0 and the 2^31 f64 trunc-guard boundary, respectively).
+        assert_eq!(mov_imm64(0, 0x8000_0000_0000_0000), vec![0xD2F0_0000]);
+        assert_eq!(mov_imm64(0, 0x41E0_0000_0000_0000), vec![0xD2E8_3C00]);
+        // Mixed: 0x0001_0000 → movz w/ hw=1 then nothing else.
+        assert_eq!(mov_imm64(3, 0x0001_0000), vec![movz_hw(3, 1, 1) | SF64]);
+    }
+
+    // Milestone 4 — trunc guards + min/max. Ground truth from `clang -target
+    // aarch64-linux-gnu` (assemble mnemonic, `objdump -d`, read the word).
+    #[test]
+    fn m4_fcvtz_encodings_match_clang() {
+        assert_eq!(fcvtzs_w_from_s(0, 1), 0x1E38_0020);
+        assert_eq!(fcvtzu_w_from_s(0, 1), 0x1E39_0020);
+        assert_eq!(fcvtzs_w_from_d(0, 1), 0x1E78_0020);
+        assert_eq!(fcvtzu_w_from_d(0, 1), 0x1E79_0020);
+        assert_eq!(fcvtzs_w_from_s(5, 6), 0x1E38_00C5);
+    }
+
+    #[test]
+    fn m4_fmin_fmax_encodings_match_clang() {
+        assert_eq!(fmin_s(0, 1, 2), 0x1E22_5820);
+        assert_eq!(fmax_s(3, 4, 5), 0x1E25_4883);
+        assert_eq!(fmin_d(0, 1, 2), 0x1E62_5820);
+        assert_eq!(fmax_d(3, 4, 5), 0x1E65_4883);
+    }
+
+    #[test]
+    fn m4_bcond_bic_encodings_match_clang() {
+        // b.mi .+8 / b.ge .+8 / b.gt .+8 / b.mi .+12
+        assert_eq!(bcond(Cond::Mi, 2), 0x5400_0044);
+        assert_eq!(bcond(Cond::Ge, 2), 0x5400_004A);
+        assert_eq!(bcond(Cond::Gt, 2), 0x5400_004C);
+        assert_eq!(bcond(Cond::Mi, 3), 0x5400_0064);
+        assert_eq!(bic(0, 1, 2), 0x0A22_0020);
+        assert_eq!(bic64(3, 4, 5), 0x8A25_0083);
     }
 }

--- a/crates/synth-backend-aarch64/src/lib.rs
+++ b/crates/synth-backend-aarch64/src/lib.rs
@@ -27,8 +27,20 @@
 //!   (`div`/`rem`), `popcnt`, and floats are DELIBERATELY still declined — A64
 //!   `SDIV`/`UDIV` don't trap, so a naive division lowering would be a silent
 //!   miscompile; those need explicit trap guards in a later milestone.
-//! - **later:** division-with-trap-guards, floats, spilling, memory, control
-//!   flow, calls, DWARF.
+//! - **3:** scalar floating point — f32/f64 const/add/sub/mul/div, abs/neg/sqrt,
+//!   the full compare family, promote/demote, i32→float converts, and the
+//!   f32↔i32 reinterprets, on a register-FILE-tagged value stack (GP vs FP).
+//! - **4 (this milestone):** the #709-class SOUNDNESS conversions — the
+//!   trapping float→int truncations (`i32.trunc_f32_{s,u}`,
+//!   `i32.trunc_f64_{s,u}`) lowered behind an explicit WASM §4.3.3 domain guard
+//!   (`fcmp` exact boundary + ordered `b.cond` + `brk`; A64 `FCVTZS`/`FCVTZU`
+//!   alone SATURATE where WASM traps), plus `f32/f64.min/max` (A64
+//!   `FMIN`/`FMAX` = IEEE 754-2019 minimum/maximum ≡ WASM NaN-propagation and
+//!   -0<+0, execution-verified vs wasmtime) and `f32/f64.copysign` (GP-file bit
+//!   surgery). Boundary-table execution differential:
+//!   `scripts/repro/aarch64_m4_trunc_minmax_538_differential.py`.
+//! - **later:** division-with-trap-guards, rounding ops, i64↔float converts,
+//!   spilling, memory, control flow, calls, DWARF.
 
 pub mod backend;
 pub mod elf;

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -35,12 +35,27 @@
 //! f32 param (delivered in `s0..` under AAPCS64, a counter INDEPENDENT of the
 //! GP arg registers) is never confused with a GP operand.
 //!
-//! **Still declined (loud-skip, never wrong code):** the trapping float→int
-//! truncations (`i32.trunc_f32_s`/`_u`, `i32.trunc_f64_*`): A64 `FCVTZS`/`FCVTZU`
-//! SATURATE on out-of-range/NaN whereas WASM traps — emitting them would be the
-//! #709 "more-total-than-WASM" silent miscompile, so they honest-reject. Also
-//! declined: `min`/`max`/`copysign`/rounding (`ceil`/`floor`/`trunc`/`nearest`)
-//! and the i64<->float conversions (a later increment).
+//! **Milestone 4 converts the #709-class declines into SOUND capabilities:**
+//!
+//! - The trapping float→int truncations (`i32.trunc_f32_{s,u}`,
+//!   `i32.trunc_f64_{s,u}`): A64 `FCVTZS`/`FCVTZU` SATURATE on out-of-range/NaN
+//!   whereas WASM traps (§4.3.3) — the #709 "more-total-than-WASM" silent
+//!   miscompile class. m4 lowers them with an EXPLICIT domain guard (the A64
+//!   twin of the Thumb-2 `f32_trunc_range_guard`): `fcmp` against the exact
+//!   WASM boundary constant, an ORDERED `b.cond` that skips a `brk #0` only
+//!   when the operand is proven in-range (NaN fails every ordered condition ⇒
+//!   falls into the trap), then the saturating convert on the proven-in-range
+//!   path where the two semantics agree.
+//! - `f32/f64.min/max`: A64 `FMIN`/`FMAX` (NOT `FMINNM`/`FMAXNM`) implement
+//!   IEEE 754-2019 minimum/maximum — either-NaN ⇒ NaN, `-0.0 < +0.0` — exactly
+//!   WASM's semantics; execution-verified against wasmtime (NaN/±0 matrix) in
+//!   `aarch64_m4_trunc_minmax_538_differential.py`, not assumed.
+//! - `f32/f64.copysign`: pure bit surgery through the GP file (`fmov` out,
+//!   one sign mask + `bic`/`and`/`orr`, `fmov` back).
+//!
+//! **Still declined (loud-skip, never wrong code):** the rounding ops
+//! (`ceil`/`floor`/`trunc`/`nearest`) and the i64<->float conversions
+//! (a later increment).
 
 use crate::encoder as enc;
 use crate::encoder::{Cond, FReg, Reg};
@@ -253,6 +268,121 @@ pub fn select_typed(
         stack.push(Val::fp(dst));
         Ok(())
     };
+    // m4: trapping float→int truncation with the #709 WASM domain guard
+    // (§4.3.3). A64 FCVTZS/FCVTZU SATURATE where WASM must TRAP, so the
+    // convert is emitted ONLY behind two fcmp + b.cond + brk range checks:
+    //
+    //   mov  dst, #hi_bits ; fmov bound, dst ; fcmp a, bound
+    //   b.mi +2                      // x < hi (ORDERED: NaN ⇒ fall through)
+    //   brk  #0                      // trap: NaN or too large
+    //   mov  dst, #lo_bits ; fmov bound, dst ; fcmp a, bound
+    //   b.<ge|gt> +2                 // x >= lo (signed f32) / x > lo (strict)
+    //   brk  #0                      // trap: too small
+    //   fcvtz[su] dst, a             // proven in-range: saturate == trunc
+    //
+    // Boundary table (WASM Core §4.3.3, mirrored from the Thumb-2 #709 guard):
+    //   f32→s: hi 2^31 (0x4F000000, exclusive), lo -2^31 (0xCF000000,
+    //          INCLUSIVE — -2^31 is representable and in-range; no f32 exists
+    //          strictly between -2^31-1 and -2^31, so `ge` is exact).
+    //   f32→u: hi 2^32 (0x4F800000, exclusive), lo -1.0 (0xBF800000, STRICT —
+    //          trunc(-0.5) = 0 is valid, trunc(-1.0) = -1 traps).
+    //   f64→s: hi 2^31 (0x41E0...0, exclusive), lo -(2^31)-1 (0xC1E0...0020_0000,
+    //          STRICT — f64 CAN represent values in (-2^31-1, -2^31), e.g.
+    //          -2147483648.5, which truncate to -2^31 and are IN-range; an
+    //          inclusive -2^31 bound would wrongly trap them).
+    //   f64→u: hi 2^32 (0x41F0...0, exclusive), lo -1.0 (0xBFF0...0, strict).
+    let trunc_guarded = |words: &mut Vec<u32>,
+                         stack: &mut Vec<Val>,
+                         is_f64: bool,
+                         signed: bool|
+     -> Result<(), SelectError> {
+        let a = pop_fp(stack, "trunc")?;
+        // Keep `a` live across temp allocation: it is read by both fcmps and
+        // the final convert, so the bound register must never alias it.
+        stack.push(Val::fp(a));
+        let dst = alloc_temp(stack)?; // GP: const scratch, then the result
+        let bound = alloc_ftemp(stack)?;
+        stack.pop();
+        let (hi_bits, lo_bits, lo_cond): (u64, u64, Cond) = match (is_f64, signed) {
+            (false, true) => (0x4F00_0000, 0xCF00_0000, Cond::Ge),
+            (false, false) => (0x4F80_0000, 0xBF80_0000, Cond::Gt),
+            (true, true) => (0x41E0_0000_0000_0000, 0xC1E0_0000_0020_0000, Cond::Gt),
+            (true, false) => (0x41F0_0000_0000_0000, 0xBFF0_0000_0000_0000, Cond::Gt),
+        };
+        let check = |words: &mut Vec<u32>, bits: u64, cond: Cond| {
+            if is_f64 {
+                for w in enc::mov_imm64(dst, bits) {
+                    words.push(w);
+                }
+                words.push(enc::fmov_d_from_x(bound, dst));
+                words.push(enc::fcmp_d(a, bound));
+            } else {
+                for w in enc::mov_imm32(dst, bits as u32) {
+                    words.push(w);
+                }
+                words.push(enc::fmov_s_from_w(bound, dst));
+                words.push(enc::fcmp_s(a, bound));
+            }
+            words.push(enc::bcond(cond, 2)); // skip the brk when in-range
+            words.push(enc::brk(0));
+        };
+        check(words, hi_bits, Cond::Mi);
+        check(words, lo_bits, lo_cond);
+        words.push(match (is_f64, signed) {
+            (false, true) => enc::fcvtzs_w_from_s(dst, a),
+            (false, false) => enc::fcvtzu_w_from_s(dst, a),
+            (true, true) => enc::fcvtzs_w_from_d(dst, a),
+            (true, false) => enc::fcvtzu_w_from_d(dst, a),
+        });
+        stack.push(Val::gp(dst));
+        Ok(())
+    };
+
+    // m4: copysign(z1, z2) — the magnitude of z1 with the sign of z2, a pure
+    // bit operation (WASM §4.3.3 fcopysign; NaN payloads pass through intact).
+    // Route both operands through the GP file, isolate the sign with ONE
+    // materialized mask (`and` for the sign, `bic` for the magnitude), merge,
+    // and move back.
+    let copysign =
+        |words: &mut Vec<u32>, stack: &mut Vec<Val>, is_f64: bool| -> Result<(), SelectError> {
+            let b = pop_fp(stack, "copysign")?; // z2: sign source
+            let a = pop_fp(stack, "copysign")?; // z1: magnitude
+            // Three DISTINCT free GP temps (a-bits, b-bits, mask).
+            let mut free = TEMPS
+                .iter()
+                .copied()
+                .filter(|t| !stack.iter().any(|v| v.file == File::Gp && v.reg == *t));
+            let (Some(ta), Some(tb), Some(tm)) = (free.next(), free.next(), free.next()) else {
+                return Err(SelectError(
+                    "value-stack too deep (copysign needs 3 GP temps)".into(),
+                ));
+            };
+            let dst = alloc_ftemp(stack)?; // may alias a/b: written last, from GP
+            if is_f64 {
+                words.push(enc::fmov_x_from_d(ta, a));
+                words.push(enc::fmov_x_from_d(tb, b));
+                for w in enc::mov_imm64(tm, 0x8000_0000_0000_0000) {
+                    words.push(w);
+                }
+                words.push(enc::and64(tb, tb, tm)); // sign of z2
+                words.push(enc::bic64(ta, ta, tm)); // magnitude of z1
+                words.push(enc::orr64(ta, ta, tb));
+                words.push(enc::fmov_d_from_x(dst, ta));
+            } else {
+                words.push(enc::fmov_w_from_s(ta, a));
+                words.push(enc::fmov_w_from_s(tb, b));
+                for w in enc::mov_imm32(tm, 0x8000_0000) {
+                    words.push(w);
+                }
+                words.push(enc::and(tb, tb, tm));
+                words.push(enc::bic(ta, ta, tm));
+                words.push(enc::orr(ta, ta, tb));
+                words.push(enc::fmov_s_from_w(dst, ta));
+            }
+            stack.push(Val::fp(dst));
+            Ok(())
+        };
+
     // reinterpret GP → FP (bit-cast, FMOV).
     let reinterpret_gp_to_fp = |words: &mut Vec<u32>,
                                 stack: &mut Vec<Val>,
@@ -484,6 +614,24 @@ pub fn select_typed(
             WasmOp::F64Le => fcmp_op(&mut words, &mut stack, enc::fcmp_d, Cond::Ls)?,
             WasmOp::F64Gt => fcmp_op(&mut words, &mut stack, enc::fcmp_d, Cond::Gt)?,
             WasmOp::F64Ge => fcmp_op(&mut words, &mut stack, enc::fcmp_d, Cond::Ge)?,
+
+            // --- f32/f64 min/max (m4): A64 FMIN/FMAX are IEEE 754-2019
+            // minimum/maximum — NaN-propagating, -0.0 < +0.0 — exactly WASM's
+            // semantics (execution-verified vs wasmtime, NaN/±0 matrix). ---
+            WasmOp::F32Min => fbinop(&mut words, &mut stack, enc::fmin_s)?,
+            WasmOp::F32Max => fbinop(&mut words, &mut stack, enc::fmax_s)?,
+            WasmOp::F64Min => fbinop(&mut words, &mut stack, enc::fmin_d)?,
+            WasmOp::F64Max => fbinop(&mut words, &mut stack, enc::fmax_d)?,
+
+            // --- copysign (m4): pure bit surgery through the GP file ---
+            WasmOp::F32Copysign => copysign(&mut words, &mut stack, false)?,
+            WasmOp::F64Copysign => copysign(&mut words, &mut stack, true)?,
+
+            // --- trapping float→int truncations (m4): domain-guarded #709 ---
+            WasmOp::I32TruncF32S => trunc_guarded(&mut words, &mut stack, false, true)?,
+            WasmOp::I32TruncF32U => trunc_guarded(&mut words, &mut stack, false, false)?,
+            WasmOp::I32TruncF64S => trunc_guarded(&mut words, &mut stack, true, true)?,
+            WasmOp::I32TruncF64U => trunc_guarded(&mut words, &mut stack, true, false)?,
 
             // --- float↔float precision conversions (total, never trap) ---
             WasmOp::F64PromoteF32 => funop(&mut words, &mut stack, enc::fcvt_d_from_s)?,
@@ -854,37 +1002,176 @@ mod tests {
         );
     }
 
+    // ---- milestone 4: guarded trunc, min/max, copysign ----
+
     #[test]
-    fn trapping_float_to_int_trunc_is_loud_declined() {
-        // A64 FCVTZS/FCVTZU SATURATE where WASM traps (#709) — must refuse.
-        for op in [
-            WasmOp::I32TruncF32S,
-            WasmOp::I32TruncF32U,
-            WasmOp::I32TruncF64S,
-            WasmOp::I32TruncF64U,
-        ] {
-            let ops = vec![WasmOp::LocalGet(0), op, WasmOp::End];
-            assert!(
-                select_typed(&ops, 1, &[true], &[]).is_err(),
-                "trapping float→int trunc must loud-decline"
-            );
-        }
+    fn i32_trunc_f32_s_emits_domain_guard_then_fcvtzs() {
+        // #709: the saturating FCVTZS must sit BEHIND the two-sided WASM
+        // range guard (fcmp bound; ordered b.cond skips the brk; NaN falls
+        // through every ordered condition into the trap).
+        let ops = vec![WasmOp::LocalGet(0), WasmOp::I32TruncF32S, WasmOp::End];
+        let w = select_typed(&ops, 1, &[true], &[]).unwrap();
+        let mut expect = Vec::new();
+        // hi bound: 2^31 (0x4F000000, exclusive, b.mi)
+        expect.extend(enc::mov_imm32(9, 0x4F00_0000));
+        expect.push(enc::fmov_s_from_w(16, 9));
+        expect.push(enc::fcmp_s(0, 16));
+        expect.push(enc::bcond(Cond::Mi, 2));
+        expect.push(enc::brk(0));
+        // lo bound: -2^31 (0xCF000000, INCLUSIVE, b.ge)
+        expect.extend(enc::mov_imm32(9, 0xCF00_0000));
+        expect.push(enc::fmov_s_from_w(16, 9));
+        expect.push(enc::fcmp_s(0, 16));
+        expect.push(enc::bcond(Cond::Ge, 2));
+        expect.push(enc::brk(0));
+        expect.push(enc::fcvtzs_w_from_s(9, 0));
+        expect.push(enc::mov_reg64(0, 9));
+        expect.push(enc::ret());
+        assert_eq!(w, expect);
     }
 
     #[test]
-    fn float_min_max_copysign_are_loud_declined() {
-        for op in [
+    fn i32_trunc_f64_s_lower_bound_is_strict_minus_2pow31_minus_1() {
+        // f64 CAN represent values in (-2^31-1, -2^31) (e.g. -2147483648.5)
+        // which truncate IN-range — the lower bound must be the STRICT
+        // -(2^31)-1 (0xC1E0_0000_0020_0000, b.gt), not an inclusive -2^31.
+        let ops = vec![WasmOp::LocalGet(0), WasmOp::I32TruncF64S, WasmOp::End];
+        let w = select_typed(&ops, 1, &[], &[true]).unwrap();
+        let lo = enc::mov_imm64(9, 0xC1E0_0000_0020_0000);
+        assert!(
+            w.windows(lo.len()).any(|win| win == lo.as_slice()),
+            "must materialize the strict -(2^31)-1 f64 bound; got {w:#010X?}"
+        );
+        assert!(w.contains(&enc::bcond(Cond::Gt, 2)));
+        assert!(w.contains(&enc::fcvtzs_w_from_d(9, 0)));
+        assert_eq!(w.iter().filter(|&&x| x == enc::brk(0)).count(), 2);
+    }
+
+    #[test]
+    fn i32_trunc_f32_u_uses_strict_minus_one_lower_bound_and_fcvtzu() {
+        let ops = vec![WasmOp::LocalGet(0), WasmOp::I32TruncF32U, WasmOp::End];
+        let w = select_typed(&ops, 1, &[true], &[]).unwrap();
+        // hi 2^32 = 0x4F800000; lo -1.0 = 0xBF800000 with STRICT b.gt.
+        assert!(w.contains(&enc::movz(9, 0)), "movz low half of 0x4F800000");
+        assert!(w.contains(&enc::movk(9, 0x4F80, 1)));
+        assert!(w.contains(&enc::movk(9, 0xBF80, 1)));
+        assert!(w.contains(&enc::bcond(Cond::Gt, 2)));
+        assert!(w.contains(&enc::fcvtzu_w_from_s(9, 0)));
+    }
+
+    #[test]
+    fn f32_min_max_use_fmin_fmax() {
+        // WASM min/max ≡ A64 FMIN/FMAX (IEEE 754-2019 minimum/maximum) — a
+        // single instruction each; FMINNM/FMAXNM would be the WRONG (minNum)
+        // NaN semantics.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
             WasmOp::F32Min,
-            WasmOp::F32Max,
-            WasmOp::F32Copysign,
-            WasmOp::F64Min,
+            WasmOp::End,
+        ];
+        let w = select_typed(&ops, 2, &[true, true], &[]).unwrap();
+        assert_eq!(
+            w,
+            vec![enc::fmin_s(16, 0, 1), enc::fmov_d(0, 16), enc::ret()]
+        );
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
             WasmOp::F64Max,
+            WasmOp::End,
+        ];
+        let w = select_typed(&ops, 2, &[], &[true, true]).unwrap();
+        assert_eq!(
+            w,
+            vec![enc::fmax_d(16, 0, 1), enc::fmov_d(0, 16), enc::ret()]
+        );
+    }
+
+    #[test]
+    fn f32_copysign_is_bit_surgery_through_gp() {
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::F32Copysign,
+            WasmOp::End,
+        ];
+        let w = select_typed(&ops, 2, &[true, true], &[]).unwrap();
+        let mut expect = vec![
+            enc::fmov_w_from_s(9, 0),  // z1 bits (magnitude)
+            enc::fmov_w_from_s(10, 1), // z2 bits (sign)
+        ];
+        expect.extend(enc::mov_imm32(11, 0x8000_0000));
+        expect.extend([
+            enc::and(10, 10, 11),
+            enc::bic(9, 9, 11),
+            enc::orr(9, 9, 10),
+            enc::fmov_s_from_w(16, 9),
+            enc::fmov_d(0, 16),
+            enc::ret(),
+        ]);
+        assert_eq!(w, expect);
+    }
+
+    #[test]
+    fn f64_copysign_uses_x_forms_and_shifted_movz_mask() {
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
             WasmOp::F64Copysign,
+            WasmOp::End,
+        ];
+        let w = select_typed(&ops, 2, &[], &[true, true]).unwrap();
+        // The 0x8000_0000_0000_0000 mask must be ONE shifted movz (the
+        // mov_imm64 halfword fix), clang: movz x11, #0x8000, lsl #48.
+        assert_eq!(
+            w,
+            vec![
+                enc::fmov_x_from_d(9, 0),
+                enc::fmov_x_from_d(10, 1),
+                0xD2F0_000B, // movz x11, #0x8000, lsl #48
+                enc::and64(10, 10, 11),
+                enc::bic64(9, 9, 11),
+                enc::orr64(9, 9, 10),
+                enc::fmov_d_from_x(16, 9),
+                enc::fmov_d(0, 16),
+                enc::ret()
+            ]
+        );
+    }
+
+    #[test]
+    fn rounding_and_i64_float_converts_are_loud_declined() {
+        // The m4 honesty frontier: rounding ops and i64<->float conversions
+        // stay DECLINED (never silent wrong code) until a later increment.
+        for op in [
+            WasmOp::F32Ceil,
+            WasmOp::F32Floor,
+            WasmOp::F32Trunc,
+            WasmOp::F32Nearest,
+            WasmOp::F64Ceil,
+            WasmOp::F64Floor,
+            WasmOp::F64Trunc,
+            WasmOp::F64Nearest,
         ] {
-            let ops = vec![WasmOp::LocalGet(0), WasmOp::LocalGet(1), op, WasmOp::End];
+            let ops = vec![WasmOp::LocalGet(0), op, WasmOp::End];
             assert!(
-                select_typed(&ops, 2, &[], &[true, true]).is_err(),
-                "min/max/copysign not yet supported — must loud-decline"
+                select_typed(&ops, 1, &[true], &[true]).is_err(),
+                "rounding ops not yet supported — must loud-decline"
+            );
+        }
+        for op in [WasmOp::I64TruncF64S, WasmOp::I64TruncF64U] {
+            let ops = vec![WasmOp::LocalGet(0), op, WasmOp::End];
+            assert!(
+                select_typed(&ops, 1, &[], &[true]).is_err(),
+                "i64<->float conversions not yet supported — must loud-decline"
+            );
+        }
+        for op in [WasmOp::F64ConvertI64S, WasmOp::F32ConvertI64U] {
+            let ops = vec![WasmOp::LocalGet(0), op, WasmOp::End];
+            assert!(
+                select_typed(&ops, 1, &[], &[]).is_err(),
+                "i64<->float conversions not yet supported — must loud-decline"
             );
         }
     }

--- a/crates/synth-backend/tests/f32_operations_test.rs
+++ b/crates/synth-backend/tests/f32_operations_test.rs
@@ -276,10 +276,21 @@ fn test_f32_floor_compiles_on_m4f() {
 }
 
 #[test]
-fn test_f32_min_compiles_on_m4f() {
-    let mut selector = selector_with_fpu();
-    let result = selector.select(&[WasmOp::F32Const(1.0), WasmOp::F32Const(2.0), WasmOp::F32Min]);
-    assert!(result.is_ok(), "f32.min should compile on cortex-m4f");
+fn test_f32_min_max_loud_declined_on_m4f() {
+    // #538 m4: f32.min/max are DECODED now (the aarch64 backend lowers them),
+    // but ARM32's legacy `ArmOp::F32Min/F32Max` compare-select pseudo-op is
+    // NOT WASM-correct (returns the wrong operand for NaN mixes and ±0
+    // pairs), so the ARM32 selector must LOUD-decline — never expose the
+    // latent miscompile — until the VMINNM+fix-up twin of F64Min/F64Max
+    // lands. This replaces the old test that pinned the wrong lowering as Ok.
+    for op in [WasmOp::F32Min, WasmOp::F32Max] {
+        let mut selector = selector_with_fpu();
+        let result = selector.select(&[WasmOp::F32Const(1.0), WasmOp::F32Const(2.0), op.clone()]);
+        assert!(
+            result.is_err(),
+            "{op:?} must loud-decline on ARM32 (NaN/±0-wrong legacy lowering)"
+        );
+    }
 }
 
 #[test]

--- a/crates/synth-cli/tests/aarch64_f32_loudskip_554.rs
+++ b/crates/synth-cli/tests/aarch64_f32_loudskip_554.rs
@@ -1,11 +1,13 @@
 //! synth#554 — `-b aarch64` must fail HONESTLY on an UNSUPPORTED float op, never
 //! emit a silent miscompile.
 //!
-//! m3 (#787) landed the non-trapping scalar floats, so this test now targets a
-//! float op that DELIBERATELY stays declined: `i32.trunc_f32_s`. A64 `FCVTZS`
-//! SATURATES where WASM TRAPS (out-of-range input) — the #709 more-total-than-WASM
-//! soundness class — so lowering it would silently return a wrong (saturated)
-//! value. The backend must loud-decline (`unsupported wasm op`) instead.
+//! m3 (#787) landed the non-trapping scalar floats; m4 (#538) landed the
+//! #709-class conversions (domain-guarded `i32.trunc_f32/f64_{s,u}`, FMIN/FMAX
+//! min/max, copysign), so this test now targets a float op that DELIBERATELY
+//! stays declined: `f64.floor` (rounding). It is DECODED (the ARM32 m7dp
+//! backend lowers it), so it reaches the aarch64 SELECTOR, which must
+//! loud-decline (`unsupported wasm op`) — the strongest form of the honesty
+//! check (nothing upstream masks it).
 //!
 //! These tests lock: (1) the declined-float function is REJECTED with a non-zero
 //! exit and an "unsupported" diagnostic; (2) a supported integer function still
@@ -32,7 +34,7 @@ fn aarch64_rejects_f32_function_instead_of_silent_miscompile_554() {
             "-b",
             "aarch64",
             "-n",
-            "f32trunc",
+            "f64floor",
             "-o",
             "/tmp/aarch64_f32_554.o",
         ])
@@ -40,7 +42,7 @@ fn aarch64_rejects_f32_function_instead_of_silent_miscompile_554() {
         .expect("run synth");
     assert!(
         !out.status.success(),
-        "expected a non-zero exit for a declined float op (i32.trunc_f32_s) on \
+        "expected a non-zero exit for a declined float op (f64.floor) on \
          -b aarch64; got success (silent miscompile). stdout={} stderr={}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr),

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -2160,6 +2160,17 @@ fn convert_operator(op: &wasmparser::Operator) -> Option<WasmOp> {
         F32Abs => Some(WasmOp::F32Abs),
         F32Neg => Some(WasmOp::F32Neg),
         F32Copysign => Some(WasmOp::F32Copysign),
+        // #538 m4: f32.sqrt / f32.min / f32.max un-dropped. sqrt is a single
+        // IEEE-754 VSQRT/FSQRT everywhere (sqrt of a negative ⇒ quiet NaN,
+        // never traps — exactly WASM). min/max lower on aarch64 (A64 FMIN/FMAX
+        // = IEEE 754-2019 minimum/maximum ≡ WASM NaN-propagation + -0<+0);
+        // ARM32 LOUD-declines them (its legacy compare-select pseudo-op is
+        // NaN/±0-wrong — see the selector's F32Min/F32Max reject arm) and
+        // RV32 loud-declines all floats. The f32 rounding ops stay at
+        // `_ => None` until a later increment.
+        F32Sqrt => Some(WasmOp::F32Sqrt),
+        F32Min => Some(WasmOp::F32Min),
+        F32Max => Some(WasmOp::F32Max),
         // #708 (phase 1b): the f32<->i32 bit-casts. Pure `VMOV` between a core
         // register and a single-precision S-register — no numeric conversion.
         F32ReinterpretI32 => Some(WasmOp::F32ReinterpretI32),

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -2431,6 +2431,23 @@ fn try_lower_f32(
             stack.push(StackVal::Float { sreg: sd });
             Ok(true)
         }
+        // #538 m4: `f32.sqrt` — a single `VSQRT.F32`, IEEE 754 square root
+        // (negative operand ⇒ quiet NaN, never traps), exactly WASM f32.sqrt.
+        // Previously dropped at decode; un-dropped alongside f32.min/max for
+        // the aarch64 m4 backend — ARM32 lowers it with the already-shipped
+        // clang-verified VSQRT encoder (execution-verified in
+        // scripts/repro/f32_ops_719_differential.py).
+        F32Sqrt => {
+            let sm = pop_float(stack)?;
+            let sd = alloc_vfp_temp(vfp_used)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::F32Sqrt { sd, sm },
+                source_line: Some(idx),
+            });
+            free_vfp_temp(vfp_used, vfp_home, sm);
+            stack.push(StackVal::Float { sreg: sd });
+            Ok(true)
+        }
         // #719 (phase 1b): `f32.copysign(a, b)` = magnitude of `a` with sign of
         // `b`. Stack order is `[a, b]` (b on top), so `sm` (popped first) is the
         // SIGN source `b` and `sn` is the MAGNITUDE source `a` — matching the
@@ -5766,18 +5783,22 @@ impl InstructionSelector {
                 let sm = self.alloc_vfp_reg();
                 vec![ArmOp::F32Nearest { sd, sm }]
             }
-            // F32 min/max — emit ArmOp variants, encoder expands to VCMP + conditional VMOV
-            F32Min if self.fpu.is_some() => {
-                let sd = self.alloc_vfp_reg();
-                let sn = self.alloc_vfp_reg();
-                let sm = self.alloc_vfp_reg();
-                vec![ArmOp::F32Min { sd, sn, sm }]
-            }
-            F32Max if self.fpu.is_some() => {
-                let sd = self.alloc_vfp_reg();
-                let sn = self.alloc_vfp_reg();
-                let sm = self.alloc_vfp_reg();
-                vec![ArmOp::F32Max { sd, sn, sm }]
+            // F32 min/max — LOUD-DECLINED on ARM32 (#538 m4): the legacy
+            // `ArmOp::F32Min/F32Max` pseudo-op encodes a naive VCMP +
+            // IT-conditional VMOV select, which returns the WRONG operand for
+            // NaN mixes (WASM requires NaN propagation) and for ±0 pairs
+            // (WASM: min(+0,-0) = -0). These ops were previously unreachable
+            // (dropped at decode); now that the decoder delivers them for the
+            // aarch64 backend, ARM32 must honest-reject rather than expose the
+            // latent miscompile. The fix is the f32 twin of
+            // `encode_thumb_f64_minmax` (VMINNM/VMAXNM + IT VS VADD fix-up) —
+            // a later increment.
+            op @ (F32Min | F32Max) if self.fpu.is_some() => {
+                return Err(synth_core::Error::synthesis(format!(
+                    "{op:?} not supported on ARM32: the available lowering is not \
+                     WASM NaN/±0-correct — declined until the VMINNM+fix-up twin \
+                     of F64Min/F64Max lands"
+                )));
             }
             // F32 copysign — emit ArmOp variant, encoder expands to VABS + sign extraction
             F32Copysign if self.fpu.is_some() => {

--- a/scripts/repro/aarch64_f32_unsupported_554.wat
+++ b/scripts/repro/aarch64_f32_unsupported_554.wat
@@ -1,12 +1,13 @@
 ;; #554 — `-b aarch64` must REJECT an UNSUPPORTED float op honestly, not silently
-;; miscompile it. m3 (#787) landed the non-trapping scalar floats (add/sub/mul/…),
-;; so the honesty test moves to a float op that DELIBERATELY stays declined:
-;; `i32.trunc_f32_s`. A64 FCVTZS SATURATES where WASM TRAPS (the #709
-;; more-total-than-WASM soundness class), so lowering it would be a silent wrong
-;; result — the backend must loud-decline instead. `i32add` is the control: a
-;; supported op that must still compile.
+;; miscompile it. m3 (#787) landed the non-trapping scalar floats and m4 (#538)
+;; landed the domain-guarded trapping truncations + min/max + copysign, so the
+;; honesty test moves to a float op that DELIBERATELY stays declined: `f64.floor`
+;; (rounding). It is DECODED (the ARM32 m7dp backend lowers it), so it reaches
+;; the aarch64 SELECTOR, which must loud-decline (`unsupported wasm op`) — the
+;; strongest form of the honesty check. `i32add` is the control: a supported op
+;; that must still compile.
 (module
-  (func (export "f32trunc") (param f32) (result i32)
-    (i32.trunc_f32_s (local.get 0)))
+  (func (export "f64floor") (param f64) (result f64)
+    (f64.floor (local.get 0)))
   (func (export "i32add") (param i32 i32) (result i32)
     (i32.add (local.get 0) (local.get 1))))

--- a/scripts/repro/aarch64_m2_decline_538.py
+++ b/scripts/repro/aarch64_m2_decline_538.py
@@ -41,16 +41,21 @@ DECLINED = [
                    '(i32.popcnt (local.get 0)))'),
     ("i64.popcnt", '(func (export "f") (param i64) (result i64) '
                    '(i64.popcnt (local.get 0)))'),
-    # m3 (#787) landed non-trapping scalar floats (add/sub/mul/div/cmp/convert/
-    # reinterpret) — those are now SUPPORTED, so the honesty gate moves to the
+    # m3 (#787) landed non-trapping scalar floats; m4 landed the #709-class
+    # conversions (domain-guarded i32.trunc_f32/f64_s/u, FMIN/FMAX min/max,
+    # copysign) — those are now SUPPORTED, so the honesty gate moves to the
     # floats that DELIBERATELY stay declined:
-    #   - trapping float→int truncation: A64 FCVTZS/FCVTZU SATURATE where WASM
-    #     TRAPS (the #709 more-total-than-WASM soundness class) — must NOT lower.
-    #   - min/max: WASM NaN-propagation semantics differ from A64 FMIN/FMAX.
-    ("i32.trunc_f32_s", '(func (export "f") (param f32) (result i32) '
-                        '(i32.trunc_f32_s (local.get 0)))'),
-    ("f32.min", '(func (export "f") (param f32 f32) (result f32) '
-                '(f32.min (local.get 0) (local.get 1)))'),
+    #   - rounding (ceil/floor/trunc/nearest): f64.floor is DECODED and must
+    #     loud-decline at the aarch64 SELECTOR; f32.floor is dropped at decode
+    #     (both paths must stay loud, never silent).
+    #   - i64<->float conversions: need i64-width FCVTZS/SCVTF forms + the
+    #     64-bit boundary guards (a later increment).
+    ("f64.floor", '(func (export "f") (param f64) (result f64) '
+                  '(f64.floor (local.get 0)))'),
+    ("f32.floor", '(func (export "f") (param f32) (result f32) '
+                  '(f32.floor (local.get 0)))'),
+    ("i64.trunc_f64_s", '(func (export "f") (param f64) (result i64) '
+                        '(i64.trunc_f64_s (local.get 0)))'),
 ]
 
 

--- a/scripts/repro/aarch64_m4_trunc_minmax_538.wat
+++ b/scripts/repro/aarch64_m4_trunc_minmax_538.wat
@@ -1,0 +1,47 @@
+;; #538 milestone-4 — the aarch64 SOUND-trapping-conversion acceptance module.
+;;
+;; Every export is a leaf function the m4 A64 selector lowers:
+;;   - the TRAPPING float->int truncations (i32.trunc_f32_s/u, i32.trunc_f64_s/u):
+;;     A64 FCVTZS/FCVTZU SATURATE where WASM TRAPS (#709), so the m4 lowering
+;;     range-guards the operand (fcmp exact WASM boundary + ordered b.cond + brk)
+;;     and converts ONLY on the proven-in-range path.
+;;   - f32/f64.min/max: A64 FMIN/FMAX = IEEE 754-2019 minimum/maximum, which is
+;;     exactly WASM's NaN-propagating, -0<+0 semantics (verified here, not assumed).
+;;   - f32/f64.copysign: pure bit surgery through the GP file.
+;;   - f32.sqrt: shipped in m3 but absent from the m3 differential's coverage.
+;;
+;; The differential (aarch64_m4_trunc_minmax_538_differential.py) executes each
+;; under unicorn UC_ARCH_ARM64 AND natively on the arm64 host (trap cases in a
+;; forked child so the SIGTRAP is observable), and diffs wasmtime ground truth —
+;; the full #709 boundary table: every case where WASM traps must TRAP (brk),
+;; every in-range case must match bit-exactly.
+(module
+  ;; ---- trapping float -> int truncations (#709 domain-guarded) ----
+  (func (export "i32_trunc_f32_s") (param f32) (result i32)
+    (i32.trunc_f32_s (local.get 0)))
+  (func (export "i32_trunc_f32_u") (param f32) (result i32)
+    (i32.trunc_f32_u (local.get 0)))
+  (func (export "i32_trunc_f64_s") (param f64) (result i32)
+    (i32.trunc_f64_s (local.get 0)))
+  (func (export "i32_trunc_f64_u") (param f64) (result i32)
+    (i32.trunc_f64_u (local.get 0)))
+
+  ;; ---- min/max (WASM NaN-propagation + -0 < +0) ----
+  (func (export "f32_min") (param f32 f32) (result f32)
+    (f32.min (local.get 0) (local.get 1)))
+  (func (export "f32_max") (param f32 f32) (result f32)
+    (f32.max (local.get 0) (local.get 1)))
+  (func (export "f64_min") (param f64 f64) (result f64)
+    (f64.min (local.get 0) (local.get 1)))
+  (func (export "f64_max") (param f64 f64) (result f64)
+    (f64.max (local.get 0) (local.get 1)))
+
+  ;; ---- copysign (bit-exact incl. NaN sign) ----
+  (func (export "f32_copysign") (param f32 f32) (result f32)
+    (f32.copysign (local.get 0) (local.get 1)))
+  (func (export "f64_copysign") (param f64 f64) (result f64)
+    (f64.copysign (local.get 0) (local.get 1)))
+
+  ;; ---- f32.sqrt (m3 op, m4 differential coverage) ----
+  (func (export "f32_sqrt") (param f32) (result f32)
+    (f32.sqrt (local.get 0))))

--- a/scripts/repro/aarch64_m4_trunc_minmax_538_differential.py
+++ b/scripts/repro/aarch64_m4_trunc_minmax_538_differential.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""#538 milestone-4 — the #709 boundary-table EXECUTION differential.
+
+m4 converts the aarch64 backend's #709-class declines into capabilities:
+  - i32.trunc_f32_s/u + i32.trunc_f64_s/u, lowered behind an explicit WASM
+    domain guard (fcmp exact boundary + ordered b.cond + brk) in front of the
+    otherwise-SATURATING A64 FCVTZS/FCVTZU;
+  - f32/f64.min/max via A64 FMIN/FMAX (claimed = IEEE 754-2019 minimum/maximum
+    = WASM semantics — VERIFIED here against wasmtime, not assumed);
+  - f32/f64.copysign (bit surgery; NaN sign must be preserved bit-exactly).
+
+The fatal class this gates: a saturating truncation where WASM traps. So the
+harness runs the FULL boundary table for every trunc op and requires the trap
+cases to ACTUALLY TRAP, execution-verified two ways:
+  (1) unicorn (UC_ARCH_ARM64): the guard's `brk #0` raises UC_ERR_EXCEPTION;
+  (2) natively on an arm64 host: EVERY native call runs in a forked child, so
+      an expected SIGTRAP is observed by the parent (and a surprise trap can't
+      kill the harness).
+In-range cases must match wasmtime bit-exactly. The static expect-trap column
+is itself validated against wasmtime first — if wasmtime disagrees with the
+table, the FIXTURE is declared wrong (loud), so the table can't drift vacuous.
+
+Run (needs wasmtime + unicorn + pyelftools; native path needs an arm64 host):
+  SYNTH=<target>/debug/synth python scripts/repro/aarch64_m4_trunc_minmax_538_differential.py
+"""
+
+import ctypes
+import math
+import os
+import platform
+import signal
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM64, UC_MODE_ARM, Uc, UcError
+from unicorn.arm64_const import (
+    UC_ARM64_REG_CPACR_EL1,
+    UC_ARM64_REG_D0,
+    UC_ARM64_REG_LR,
+    UC_ARM64_REG_S0,
+    UC_ARM64_REG_SP,
+    UC_ARM64_REG_V0,
+    UC_ARM64_REG_V1,
+    UC_ARM64_REG_W0,
+    UC_ARM64_REG_X0,
+    UC_ARM64_REG_X1,
+)
+
+WAT = Path(__file__).with_name("aarch64_m4_trunc_minmax_538.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+CODE, STK, RET = 0x100000, 0x200000, 0x300000
+V_ARGS = [UC_ARM64_REG_V0, UC_ARM64_REG_V1]
+X_ARGS = [UC_ARM64_REG_X0, UC_ARM64_REG_X1]
+
+M32 = (1 << 32) - 1
+M64 = (1 << 64) - 1
+INF = float("inf")
+NAN = float("nan")
+
+# Signatures: fn -> ([arg types], ret type).
+SIGS = {
+    "i32_trunc_f32_s": (["f32"], "i32"),
+    "i32_trunc_f32_u": (["f32"], "i32"),
+    "i32_trunc_f64_s": (["f64"], "i32"),
+    "i32_trunc_f64_u": (["f64"], "i32"),
+    "f32_min": (["f32", "f32"], "f32"),
+    "f32_max": (["f32", "f32"], "f32"),
+    "f64_min": (["f64", "f64"], "f64"),
+    "f64_max": (["f64", "f64"], "f64"),
+    "f32_copysign": (["f32", "f32"], "f32"),
+    "f64_copysign": (["f64", "f64"], "f64"),
+    "f32_sqrt": (["f32"], "f32"),
+}
+
+# ---------------------------------------------------------------------------
+# The #709 boundary table (WASM Core §4.3.3 trunc_s / trunc_u domains).
+# Key subtleties pinned:
+#   - trunc_f32_s(-2^31) is IN-range (exactly representable, lowest valid);
+#     trunc_f32_s(2^31) TRAPS (the largest valid f32 is 2147483520).
+#   - trunc_f64_s(-2147483648.5) is IN-range (truncates to -2^31): the f64
+#     lower bound is the STRICT -(2^31)-1, not an inclusive -2^31.
+#   - trunc_u(-0.9) -> 0 is IN-range (strict lower bound -1.0); trunc_u(-1.0)
+#     TRAPS.
+#   - NaN and ±inf ALWAYS trap.
+TRUNC_TABLE = {
+    "i32_trunc_f32_s": {
+        "in": [0.0, -0.0, 0.5, -0.5, 1.9, -1.9, 100.75,
+               2147483520.0, -2147483648.0, -2147483520.0],
+        "trap": [2147483648.0, 2147483904.0, -2147483904.0,
+                 1e10, -1e10, INF, -INF, NAN],
+    },
+    "i32_trunc_f32_u": {
+        "in": [0.0, -0.0, 0.5, -0.5, -0.9, 1.9, 42.0, 4294967040.0],
+        "trap": [-1.0, -1.5, 4294967296.0, 1e10, INF, -INF, NAN],
+    },
+    "i32_trunc_f64_s": {
+        "in": [0.0, -0.0, 0.5, -0.5, 1.9, -1.9,
+               2147483647.0, 2147483647.9,
+               -2147483648.0, -2147483648.5, -2147483648.999],
+        "trap": [2147483648.0, 2147483648.5, -2147483649.0, -2147483649.5,
+                 1e18, -1e18, INF, -INF, NAN],
+    },
+    "i32_trunc_f64_u": {
+        "in": [0.0, -0.0, 0.5, -0.5, -0.9, 1.9,
+               4294967295.0, 4294967295.9],
+        "trap": [-1.0, -1.5, 4294967296.0, 4294967296.5,
+                 1e18, INF, -INF, NAN],
+    },
+}
+
+# min/max NaN / ±0 matrix (WASM: either-NaN => NaN; min(-0,+0) = -0;
+# max(-0,+0) = +0).
+MINMAX_PAIRS = [
+    (NAN, 1.0), (1.0, NAN), (NAN, NAN),
+    (0.0, -0.0), (-0.0, 0.0), (0.0, 0.0), (-0.0, -0.0),
+    (1.0, 2.0), (2.0, 1.0), (-1.0, -2.0), (-2.0, -1.0),
+    (INF, 1.0), (-INF, 1.0), (INF, -INF), (-INF, INF),
+    (3.5, 3.5), (-1.5, 1.5),
+]
+
+# copysign is a PURE BIT operation — compared bit-exactly, including the sign
+# of a NaN result.
+COPYSIGN_PAIRS = [
+    (1.5, -2.0), (-1.5, 2.0), (1.5, -0.0), (-1.5, 0.0),
+    (0.0, -1.0), (-0.0, 1.0), (INF, -1.0), (-INF, 1.0),
+    (NAN, -1.0), (NAN, 1.0),
+]
+
+SQRT_VALS = [0.0, -0.0, 1.0, 2.0, 4.0, 0.25, -1.0, INF, NAN, 1e30]
+
+TRAP = "TRAP"
+
+
+def cases_for(fn):
+    """Yield (args, expect_trap) for a function. expect_trap is None when the
+    static table has no opinion (min/max/copysign/sqrt never trap)."""
+    if fn in TRUNC_TABLE:
+        for v in TRUNC_TABLE[fn]["in"]:
+            yield [v], False
+        for v in TRUNC_TABLE[fn]["trap"]:
+            yield [v], True
+    elif fn in ("f32_min", "f32_max", "f64_min", "f64_max"):
+        for a, b in MINMAX_PAIRS:
+            yield [a, b], False
+    elif fn in ("f32_copysign", "f64_copysign"):
+        for a, b in COPYSIGN_PAIRS:
+            yield [a, b], False
+    elif fn == "f32_sqrt":
+        for v in SQRT_VALS:
+            yield [v], False
+
+
+# --------------------------------------------------------------------------- #
+# encoding helpers
+def f32_bits(x):
+    return struct.unpack("<I", struct.pack("<f", x))[0]
+
+
+def f64_bits(x):
+    return struct.unpack("<Q", struct.pack("<d", x))[0]
+
+
+def as_i32(x):
+    return struct.unpack("<i", struct.pack("<I", int(x) & M32))[0]
+
+
+def arg_bits(ty, v):
+    return f32_bits(v) if ty == "f32" else f64_bits(v) if ty == "f64" else int(v) & M32
+
+
+def is_nan_bits(ty, bits):
+    if ty == "f32":
+        return math.isnan(struct.unpack("<f", struct.pack("<I", bits & M32))[0])
+    if ty == "f64":
+        return math.isnan(struct.unpack("<d", struct.pack("<Q", bits & M64))[0])
+    return False
+
+
+def results_match(ret, exp, got, bit_exact_nan):
+    if exp == TRAP or got == TRAP:
+        return exp == got
+    if is_nan_bits(ret, exp) and is_nan_bits(ret, got) and not bit_exact_nan:
+        return True  # NaN payload/sign not pinned for arithmetic min/max
+    return exp == got
+
+
+# --------------------------------------------------------------------------- #
+# wasmtime ground truth (TRAP on wasmtime.Trap)
+def wasmtime_run(fn, args, sig):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    f = wasmtime.Instance(store, module, []).exports(store)[fn]
+    types, ret = sig
+    call = [as_i32(v) if ty == "i32" else float(v) for ty, v in zip(types, args)]
+    try:
+        r = f(store, *call)
+    except wasmtime.Trap:
+        return TRAP
+    if ret == "f32":
+        return f32_bits(r)
+    if ret == "f64":
+        return f64_bits(r)
+    return int(r) & M32
+
+
+# --------------------------------------------------------------------------- #
+# ELF load
+def compile_aarch64(out):
+    cmd = [SYNTH, "compile", str(WAT), "-o", out, "-b", "aarch64", "--all-exports"]
+    r = subprocess.run(cmd, capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin"})
+    if r.returncode != 0:
+        sys.exit(f"aarch64 compile failed: {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for sy in sec.iter_symbols():
+                if sy.name:
+                    syms[sy.name] = sy["st_value"] & ~1
+    return code, base, syms
+
+
+# --------------------------------------------------------------------------- #
+# unicorn execution: value, or TRAP when the guard's brk raises an exception.
+def unicorn_run(code, base, faddr, sig, args):
+    off = faddr - base
+    types, ret = sig
+    mu = Uc(UC_ARCH_ARM64, UC_MODE_ARM)
+    mu.reg_write(UC_ARM64_REG_CPACR_EL1, 0x3 << 20)  # FPEN: enable V regs
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(STK - 0x10000, 0x20000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_ARM64_REG_SP, STK)
+    mu.reg_write(UC_ARM64_REG_LR, RET)
+    ngrn = nsrn = 0
+    for ty, v in zip(types, args):
+        b = arg_bits(ty, v)
+        if ty in ("f32", "f64"):
+            mu.reg_write(V_ARGS[nsrn], b)
+            nsrn += 1
+        else:
+            mu.reg_write(X_ARGS[ngrn], b)
+            ngrn += 1
+    try:
+        mu.emu_start(CODE + off, RET, count=2000)
+    except UcError:
+        # The domain guard's `brk #0` surfaces as an unmapped/exception stop —
+        # execution did NOT produce a value: a trap.
+        return TRAP
+    if ret == "f32":
+        return mu.reg_read(UC_ARM64_REG_S0) & M32
+    if ret == "f64":
+        return mu.reg_read(UC_ARM64_REG_D0) & M64
+    return mu.reg_read(UC_ARM64_REG_W0) & M32
+
+
+# --------------------------------------------------------------------------- #
+# native execution on an arm64 host — EVERY call in a forked child, so an
+# expected `brk #0` (SIGTRAP) is observable and a surprise one is survivable.
+_MAP_PRIVATE = 0x0002
+_MAP_ANON = 0x1000 if sys.platform == "darwin" else 0x20
+_MAP_JIT = 0x0800  # darwin only
+_PROT_RWX = 0x1 | 0x2 | 0x4
+
+
+def native_setup(code):
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.mmap.restype = ctypes.c_void_p
+    libc.mmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int,
+                          ctypes.c_int, ctypes.c_int, ctypes.c_long]
+    size = max(len(code), 4096)
+    flags = _MAP_PRIVATE | _MAP_ANON
+    if sys.platform == "darwin":
+        flags |= _MAP_JIT
+    addr = libc.mmap(None, size, _PROT_RWX, flags, -1, 0)
+    if addr in (ctypes.c_void_p(-1).value, 0, None):
+        err = ctypes.get_errno()
+        raise OSError(err, f"mmap(MAP_JIT) failed: {os.strerror(err)}")
+    if sys.platform == "darwin":
+        wp = ctypes.CDLL(None).pthread_jit_write_protect_np
+        wp(0)
+    ctypes.memmove(addr, code, len(code))
+    if sys.platform == "darwin":
+        wp(1)
+        libc.sys_icache_invalidate.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+        libc.sys_icache_invalidate(ctypes.c_void_p(addr), len(code))
+    return addr
+
+
+_CTY = {"f32": ctypes.c_float, "f64": ctypes.c_double, "i32": ctypes.c_int32}
+
+
+def native_run(code, faddr, code_base, sig, args):
+    """Fork; the child maps + calls the JIT'd function and pipes back the
+    result bits. A trap (SIGTRAP from `brk #0`) kills the CHILD; the parent
+    reports TRAP. The MAP_JIT region is created IN the child — an inherited
+    parent mapping sporadically faults (SIGBUS) after fork on macOS (the
+    per-thread jit-write-protect state does not reliably survive fork)."""
+    types, ret = sig
+    rd, wr = os.pipe()
+    pid = os.fork()
+    if pid == 0:  # child
+        try:
+            os.close(rd)
+            base_addr = native_setup(code)
+            fn_addr = base_addr + (faddr - code_base)
+            proto = ctypes.CFUNCTYPE(_CTY[ret], *[_CTY[t] for t in types])
+            fn = proto(fn_addr)
+            call = [as_i32(v) if ty == "i32" else float(v)
+                    for ty, v in zip(types, args)]
+            r = fn(*call)  # a brk #0 here delivers SIGTRAP -> child dies
+            if ret == "f32":
+                bits = f32_bits(r)
+            elif ret == "f64":
+                bits = f64_bits(r)
+            else:
+                bits = int(r) & M32
+            os.write(wr, struct.pack("<Q", bits))
+            os.close(wr)
+        finally:
+            os._exit(0)
+    os.close(wr)
+    _, status = os.waitpid(pid, 0)
+    data = os.read(rd, 8)
+    os.close(rd)
+    if os.WIFSIGNALED(status):
+        sig_no = os.WTERMSIG(status)
+        if sig_no in (signal.SIGTRAP, signal.SIGILL):
+            return TRAP
+        return f"ERR:signal {sig_no}"
+    if len(data) != 8:
+        return "ERR:no result"
+    return struct.unpack("<Q", data)[0]
+
+
+# --------------------------------------------------------------------------- #
+def main():
+    out = "/tmp/aarch64_m4_538.o"
+    compile_aarch64(out)
+    code, base, syms = load(out)
+    host_native = platform.machine() in ("arm64", "aarch64")
+
+    fails = 0
+    total = 0
+    trap_cases = 0
+    checked_native = 0
+    for fn, sig in SIGS.items():
+        if fn not in syms:
+            print(f"FAIL {fn}: symbol missing")
+            fails += 1
+            continue
+        _, ret = sig
+        bit_exact_nan = "copysign" in fn
+        for args, expect_trap in cases_for(fn):
+            total += 1
+            exp = wasmtime_run(fn, args, sig)
+            # Fixture-table sanity: wasmtime must agree with the static
+            # expect-trap column, or the boundary table itself is wrong.
+            if expect_trap != (exp == TRAP):
+                fails += 1
+                print(f"TABLE-BUG {fn}{args}: table says "
+                      f"{'trap' if expect_trap else 'value'}, wasmtime says "
+                      f"{exp if exp == TRAP else hex(exp)}")
+                continue
+            if exp == TRAP:
+                trap_cases += 1
+            oracles = [("unicorn", unicorn_run(code, base, syms[fn], sig, args))]
+            if host_native:
+                oracles.append(
+                    ("native", native_run(code, syms[fn], base, sig, args)))
+                checked_native += 1
+            for label, got in oracles:
+                if not results_match(ret, exp, got, bit_exact_nan):
+                    fails += 1
+                    e = exp if exp == TRAP else hex(exp)
+                    g = got if isinstance(got, str) else hex(got)
+                    print(f"BUG {fn}{args} [{label}] A64={g} wasmtime={e}")
+    print(f"\n{total} wasmtime cases ({trap_cases} trap cases), "
+          f"{checked_native} also run natively "
+          f"({'arm64 host' if host_native else 'unicorn-only host'})")
+    print("RESULT:", "PASS — aarch64 m4 trunc boundary table + min/max NaN/±0 "
+          "matrix match wasmtime (traps execution-verified)"
+          if not fails else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/f32_ops_719.wat
+++ b/scripts/repro/f32_ops_719.wat
@@ -20,6 +20,11 @@
     local.get 0 f32.reinterpret_i32 f32.abs i32.reinterpret_f32)
   (func (export "neg") (param i32) (result i32)
     local.get 0 f32.reinterpret_i32 f32.neg i32.reinterpret_f32)
+  ;; #538 m4: f32.sqrt un-dropped at decode (single VSQRT.F32; negative
+  ;; operand => quiet NaN, never traps). Bits-in/bits-out like abs/neg, but
+  ;; compared NaN-leniently (sqrt is ARITHMETIC: NaN payload not pinned).
+  (func (export "sqrt") (param i32) (result i32)
+    local.get 0 f32.reinterpret_i32 f32.sqrt i32.reinterpret_f32)
   ;; copysign(a, b) = |a| with sign of b. a=param0 (magnitude), b=param1 (sign).
   (func (export "copysign") (param i32 i32) (result i32)
     local.get 0 f32.reinterpret_i32

--- a/scripts/repro/f32_ops_719_differential.py
+++ b/scripts/repro/f32_ops_719_differential.py
@@ -202,6 +202,21 @@ def main():
             else:
                 print(f"[{fn}] 0x{b:08x} -> 0x{got:08x} (bit-exact) OK")
 
+    # ---- f32.sqrt (#538 m4 un-drop): bits in R0 -> bits in R0. NaN-LENIENT
+    # compare (sqrt is arithmetic — a negative operand's quiet-NaN payload is
+    # not pinned by WASM), every non-NaN result bit-exact. ----
+    if need("sqrt"):
+        for b in EDGE_BITS + [0x40800000, 0x40000000, 0x3E800000]:  # 4, 2, .25
+            uc = run(text, base, syms["sqrt"], r0=b)
+            got = uc.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+            want = exp["sqrt"](store, b) & 0xFFFFFFFF
+            checked += 1
+            if not f32_bits_eq(got, want):
+                nonlocal_fail(
+                    f"sqrt(0x{b:08x}) -> 0x{got:08x} != wasmtime 0x{want:08x}")
+            else:
+                print(f"[sqrt] 0x{b:08x} -> 0x{got:08x} OK")
+
     # ---- copysign(a, b): a=R0 (magnitude), b=R1 (sign) -> R0 ----
     if need("copysign"):
         for a in EDGE_BITS:


### PR DESCRIPTION
## #538 milestone 4 — the #709-class declines become SOUND capabilities

The A64 backend's remaining float declines existed for one reason: A64 is
**more total than WASM**. `FCVTZS`/`FCVTZU` SATURATE where WASM must trap
(the #709 silent-miscompile class), and naive min/max lowerings get NaN/±0
wrong. m4 converts them with explicit trap semantics, execution-gated.

### Ops landed (35 → 46, +11)

| op | lowering |
|---|---|
| `i32.trunc_f32_s/u`, `i32.trunc_f64_s/u` | two-sided domain guard: `fcmp` exact WASM §4.3.3 boundary + **ordered** `b.cond` (NaN fails every ordered condition → falls into `brk #0`) + convert only on the proven-in-range path |
| `f32/f64.min/max` | single `FMIN`/`FMAX` — IEEE 754-2019 minimum/maximum ≡ WASM NaN-propagation + -0<+0 (**verified vs wasmtime, not assumed**; `FMINNM`/`FMAXNM` would be the wrong minNum semantics) |
| `f32/f64.copysign` | GP-file bit surgery: one sign mask + `and`/`bic`/`orr` |
| `f32.sqrt` | m3 selector arm existed but the op was DROPPED at decode — un-dropped; now reachable on aarch64 **and** ARM32 |

Boundary-table subtlety worth review: the f64-signed **lower bound is the
STRICT −(2³¹)−1** (`0xC1E0_0000_0020_0000`, `b.gt`) — f64 represents values
in (−2³¹−1, −2³¹) (e.g. `-2147483648.5`) that truncate in-range; an
inclusive −2³¹ bound would wrongly trap them. (f32 uses inclusive `b.ge`
−2³¹: no f32 exists strictly between −2³¹−1 and −2³¹.)

### Two latent bugs found & fixed on the way

1. **`mov_imm64` halfword-shift bug (m3 latent):** the leading `movz` was
   emitted WITHOUT the halfword shift, so any constant whose low halfwords
   are all zero (f64 `-0.0` = `0x8000…0`, the 2³¹ guard bound `0x41E0…0`)
   materialized into halfword 0. Clang ground truth `0xD2F0_0000` vs the old
   `0xD290_0000`. Red-first encoder test.
2. **ARM32 `F32Min/F32Max` compare-select pseudo-op is NaN/±0-wrong** —
   previously unreachable dead code (decoder dropped f32.min/max). Now that
   the decoder delivers them, the ARM32 selector **loud-declines** them
   (never exposes the latent miscompile) until the `VMINNM` + `IT VS` fix-up
   twin of `F64Min/F64Max` lands. RV32 loud-declines all floats, unchanged.

### Gates (all green)

- **New m4 execution differential** `scripts/repro/aarch64_m4_trunc_minmax_538_differential.py`:
  **167 wasmtime cases, 32 trap cases** — every trunc op's full #709 boundary
  table run under **unicorn** (brk → exception) **and natively on arm64**
  (every call forked; expected SIGTRAP observed by the parent). The static
  expect-trap column is validated against wasmtime first, so the table can't
  drift vacuous. min/max NaN/±0 matrix; copysign bit-exact incl. NaN sign.
  (Native-fork note: the MAP_JIT region is mapped IN the child — an
  inherited parent mapping sporadically SIGBUSes after fork on macOS.)
- **m1/m2/m3 differentials still green**: 182/182 (m2), **513/513** (m3).
- **ARM32 f32 oracle extended + green**: `f32_ops_719_differential.py`
  238/238 (new `f32.sqrt` cases, NaN-lenient).
- **Encoder**: all new encodings (`fcvtzs/u` w←s/d, `fmin/fmax` s/d, `b.cond`,
  `bic`, shifted `movz`) clang-verified (`clang -target aarch64-linux-gnu`).
- **Decline gates MOVED, never deleted** (feature-loop rule):
  `aarch64_m2_decline_538.py` now pins `f64.floor` (selector-level decline),
  `f32.floor` (decode-drop) and `i64.trunc_f64_s` — 11/11 loud;
  `aarch64_f32_loudskip_554` targets `f64.floor`.
- **CI**: the m3 differential was never CI-wired — the `aarch64-oracle` job
  now runs m1→m4 + the decline matrix.
- `cargo test --workspace` green, clippy `-D warnings` clean, fmt clean,
  claim-check 21/21.

### Still declined (loud)

rounding (`ceil`/`floor`/`trunc`/`nearest`, f32+f64), i64↔float conversions,
div/rem, popcnt — pinned by the decline unit test + the decline-matrix oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L