### PR TITLE
feat(#275 finale): self-contained --cortex-m call_indirect — PC-relative flash funcref table (converts the #717 loud-decline)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -990,6 +990,55 @@ jobs:
           SYNTH: ./target/debug/synth
         run: python scripts/repro/call_indirect_676_differential.py
 
+  call-indirect-275-selfcontained-oracle:
+    name: self-contained call_indirect oracle (execution + residual declines)
+    # #275 finale (v0.47): the SELF-CONTAINED Thumb-2 `--cortex-m` image now
+    # lowers `call_indirect` through a flash-resident funcref table addressed
+    # PC-relative (`__synth_func_table` literal, patched post-layout) — never
+    # via R11, the linear-memory base the v0.42 #717 collision corrupted.
+    # Two gates:
+    #  1. EXECUTION differential (falcon shape): the default self-contained
+    #     image (its OWN Reset_Handler startup, nothing fabricated) runs a
+    #     heterogeneous 5-slot dispatch under unicorn vs the wasmtime oracle —
+    #     matching dispatches must return wasmtime's values (incl. a
+    #     linear-memory-reading target: the #717 non-collision proof), and
+    #     OOB / type-mismatch / null-slot cases must all stop AT A UDF
+    #     (§4.4.8). Red on <= v0.46: the dispatchers loud-declined (the #717
+    #     interim), so the harness fails at the symbol probe.
+    #  2. Emission + RESIDUAL declines: cortex-m emits the table; the
+    #     A32/Cortex-R5 self-contained path (no flash-table builder) still
+    #     LOUD-declines with #275; `--relocatable` stays untouched on both
+    #     ISAs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Run self-contained call_indirect EXECUTION differential
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/repro/call_indirect_275_selfcontained_execution_differential.py
+      - name: Run emission + residual-decline oracle
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/repro/call_indirect_275_selfcontained_differential.py
+
   block-brif-483-oracle:
     name: optimized-path block/br_if lowering oracle
     # VCR-ORACLE-001 (#242, #483): EXECUTE optimized-path functions with forward

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Self-contained `--cortex-m` `call_indirect` — the #275 finale (falcon's
+  blocker).** The v0.42 #717 loud-decline is converted into a real lowering:
+  the funcref table ships in FLASH (appended after the function code, the
+  #758 ROM-image pattern — pointer words with the Thumb bit set, null slots
+  as zero words, then the #676 type-id sidecar) and the dispatch reaches it
+  **PC-relative** through an `LdrSym` literal-pool pointer
+  (`__synth_func_table`, `Abs32` reloc patched post-layout by
+  `build_multi_func_cortex_m_elf`) — never via R11 (the linear-memory base
+  the #717 collision corrupted), R9/R10, or R12. Same WASM Core §4.4.8 trap
+  semantics as the relocatable R11 expansion: OOB index, #676 type mismatch,
+  and #664 null slot all `UDF`-trap. Gated by a red-first EXECUTION
+  differential (`call_indirect_275_selfcontained_execution_differential.py`):
+  the default image under unicorn vs wasmtime, 14/14 incl. a
+  linear-memory-reading dispatch target (non-collision proof) and every trap
+  class. Residual declines stay loud and gated: A32/Cortex-R5 self-contained
+  (no flash-table builder), imports present (ET_REL output), and the
+  `select_default` demo path. `--relocatable` output is byte-identical;
+  self-contained modules without `call_indirect` are byte-identical.
+
+### Found (tracked separately)
+
+- **#791: the optimized path miscompiles const-only-body functions** (result
+  materialized in r4, never moved to R0) — surfaced by the first execution
+  gate that runs dispatch targets in a default self-contained image; present
+  on main independent of this change (`--no-optimize` is correct).
+
 - **WCET phase 2 — statically-proven loop bounds + the `--wcet-hints` seam
   (#778).** `--emit-wcet` now BOUNDS canonical const-bound counted loops
   instead of declining them: a conservative symbolic walk over the final

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -441,13 +441,24 @@ fn compile_wasm_to_arm(
         // bounds guard + closed-world type verdicts). Without them, every
         // call_indirect lowering declines loudly.
         selector.set_call_indirect_guards(config.call_indirect_guards.clone());
-        // #275: on the self-contained image path (NOT --relocatable) decline
-        // call_indirect loudly — the R11 funcref-table region is only populated
-        // by an external runtime, which a self-contained ELF does not have, so
-        // the dispatch would read function pointers from linear-memory data (a
-        // silent miscompile). The host-linked (--relocatable) path keeps the
-        // guarded dispatch: there a runtime places the table region at R11.
-        selector.set_reject_self_contained_call_indirect(!config.relocatable);
+        // #275: on the self-contained image path (NOT --relocatable) the R11
+        // funcref-table dispatch is a silent miscompile — the region is only
+        // populated by an external runtime, which a self-contained ELF does
+        // not have, so the dispatch would read function pointers from
+        // linear-memory data. Two outcomes:
+        //  - the Thumb-2 `--cortex-m` image path (CLI-flagged: the builder
+        //    that emits and patches the flash-resident funcref table will
+        //    run) lowers call_indirect through that table, PC-relative,
+        //    never via R11;
+        //  - every OTHER self-contained configuration (A32/Cortex-R5, the
+        //    simple-ELF builder, imports present) keeps the loud decline.
+        // The host-linked (--relocatable) path keeps the guarded R11
+        // dispatch: there a runtime places the table region at R11.
+        let self_contained_table = config.self_contained_funcref_table
+            && matches!(config.target.isa, IsaVariant::Thumb2 | IsaVariant::Thumb);
+        selector
+            .set_reject_self_contained_call_indirect(!config.relocatable && !self_contained_table);
+        selector.set_self_contained_funcref_table(self_contained_table);
         // #237: native-pointer ABI — wasm statics become __synth_wasm_data-relative.
         selector.set_native_pointer_abi(config.native_pointer_abi, config.linear_memory_bytes);
         // VCR-MEM-002 phase 1 (#406): per-memory initial page counts — enables

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2587,6 +2587,7 @@ fn compile_all_exports(
         all_extra_memory_segments, // #406: (mem_idx>0, offset, bytes) init segments on non-default memories
         multi_memory_decline,      // #406: decode-level reason multi-memory must decline (if any)
         all_call_indirect_guards,  // #642: table size + closed-world type verdicts
+        all_funcref_slots, // #275: static funcref-region image (slot -> func index; None = null)
     ) = if path.extension().is_some_and(|ext| ext == "wast") {
         info!("Parsing WAST (extracting all modules)...");
         let contents = String::from_utf8(file_bytes).context("WAST file is not valid UTF-8")?;
@@ -2697,6 +2698,8 @@ fn compile_all_exports(
             // verify — the default guards DECLINE any call_indirect (the WAST
             // fixture suite carries none), never an unchecked branch.
             synth_core::CallIndirectGuards::default(),
+            // #275: no guards ⇒ no dispatch ⇒ no funcref-region image.
+            Vec::new(),
         )
     } else {
         let wasm_bytes = if path.extension().is_some_and(|ext| ext == "wat") {
@@ -2717,6 +2720,10 @@ fn compile_all_exports(
         // #642: call_indirect guard inputs — computed while the module is
         // still whole (before its vectors are moved out below).
         let guards = module.call_indirect_guards();
+        // #275: the static funcref-region image (slot -> initializing function
+        // index) — the self-contained image builder resolves these to laid-out
+        // function addresses and ships the table in flash.
+        let funcref_slots = module.funcref_region_slots();
         let func_arg_counts = module.func_arg_counts;
         let type_arg_counts = module.type_arg_counts;
         let memories = module.memories;
@@ -2818,7 +2825,8 @@ fn compile_all_exports(
             // decline reason (e.g. a non-const segment offset on memory k).
             module.extra_memory_data_segments,
             module.multi_memory_decline,
-            guards, // #642
+            guards,        // #642
+            funcref_slots, // #275
         )
     };
 
@@ -3016,6 +3024,14 @@ fn compile_all_exports(
         // #642: call_indirect guard inputs (compile-time table size for the
         // bounds guard + closed-world type verdicts). Default = decline.
         call_indirect_guards: all_call_indirect_guards,
+        // #275: self-contained funcref-table dispatch — enabled ONLY when the
+        // builder that emits and patches the flash-resident table
+        // (`build_multi_func_cortex_m_elf`) will run: Cortex-M image, not
+        // --relocatable, and no imported functions (imports force ET_REL
+        // output, whose host runtime owns the R11 table region instead). The
+        // ARM backend additionally gates on Thumb-2; every other
+        // configuration keeps the loud #275 decline.
+        self_contained_funcref_table: cortex_m && !relocatable && max_num_imported_funcs == 0,
         // #687: shift the optimized path's absolute linmem base up by the
         // reserved stack size under --stack-layout=low; default = 0x2000_0100
         // (byte-identical).
@@ -3321,6 +3337,14 @@ fn compile_all_exports(
     for label in &func_index_labels {
         internal_labels.insert(label.as_str());
     }
+    // #275: the self-contained funcref table is emitted and patched by the
+    // cortex-m image builder itself — a reloc against its base symbol is
+    // INTERNAL (it must not flip the output to ET_REL). Relocs against it
+    // exist only when `config.self_contained_funcref_table` enabled the
+    // lowering, which already required the cortex-m/self-contained path.
+    if config.self_contained_funcref_table {
+        internal_labels.insert(synth_core::backend::FUNC_TABLE_SYMBOL);
+    }
     let has_external_relocations = compiled_funcs
         .iter()
         .flat_map(|f| &f.relocations)
@@ -3490,6 +3514,14 @@ fn compile_all_exports(
             // now ships them in flash and copies ROM→RAM at reset. Empty ⇒ the
             // NoBits linear-memory path is byte-identical to before.
             &all_data_segments,
+            // #275: the static funcref-region image + the #676 type-id sidecar
+            // inputs — the builder ships the table in flash (after the function
+            // code) and patches every `FUNC_TABLE_SYMBOL` literal to its
+            // address. Consulted ONLY when a compiled function carries such a
+            // reloc; images without call_indirect are byte-identical.
+            &all_funcref_slots,
+            &config.call_indirect_guards.type_ids_image,
+            config.call_indirect_guards.type_ids_byte_offset,
         )?
     } else {
         build_multi_func_simple_elf(&compiled_funcs)?
@@ -5113,6 +5145,17 @@ fn build_multi_func_cortex_m_elf(
     // ROM→RAM at reset (the classic crt0 `.data` init). Empty ⇒ the linear
     // memory stays NoBits and the whole image is byte-identical to before.
     data_segments: &[(u32, Vec<u8>)],
+    // #275: the static funcref-region image — one slot per table entry across
+    // all tables in declaration order; `Some(func_index)` is resolved to the
+    // laid-out function address (Thumb bit set), `None` links as a ZERO word
+    // (null slot — the dispatch's runtime checks trap on it). Consulted ONLY
+    // when a compiled function carries a `FUNC_TABLE_SYMBOL` relocation.
+    funcref_slots: &[Option<u32>],
+    // #676/#275: the type-id sidecar words appended after the pointer words
+    // (one u32 structural class id per slot) and the sidecar's declared byte
+    // offset within the region — cross-checked against the pointer-word count.
+    type_ids_image: &[u32],
+    type_ids_byte_offset: Option<u32>,
 ) -> Result<Vec<u8>> {
     let flash_base: u32 = 0x0000_0000;
     let ram_base: u32 = 0x2000_0000;
@@ -5261,6 +5304,22 @@ fn build_multi_func_cortex_m_elf(
     // The caller routes here only when all relocations are internal (no
     // imports); we map each relocation symbol (export name or `func_{index}`)
     // to the callee's laid-out address and patch the 4 BL bytes.
+    //
+    // #275: a `call_indirect` dispatch additionally references the
+    // flash-resident funcref table through `Abs32` literal-pool relocations
+    // against `FUNC_TABLE_SYMBOL`. The table is laid out immediately after
+    // the function code (4-aligned, the #758 ROM-image pattern): one 4-byte
+    // code pointer per slot (Thumb bit set; null slots as ZERO words, #664),
+    // followed by the #676 type-id sidecar words. Its address is known here
+    // (`funcs_base + len(all_func_code)` rounded up), so the literal words
+    // are patched in place exactly like the internal BLs. Images without a
+    // `call_indirect` carry no such reloc and are byte-identical.
+    let needs_func_table = funcs
+        .iter()
+        .flat_map(|f| &f.relocations)
+        .any(|r| r.symbol == synth_core::backend::FUNC_TABLE_SYMBOL);
+    let func_table_addr = (funcs_base + all_func_code.len() as u32 + 3) & !3;
+    let mut func_table_blob: Vec<u8> = Vec::new();
     {
         use std::collections::HashMap;
         let mut label_to_addr: HashMap<&str, u32> = HashMap::new();
@@ -5283,8 +5342,110 @@ fn build_multi_func_cortex_m_elf(
             label_to_addr.insert(label.as_str(), *addr);
         }
 
+        // #275: build the funcref-table blob — every `Some(func_index)` slot
+        // must resolve to a COMPILED function (the #235 reachability walk
+        // pulls every table entry in once a call_indirect is reached); a
+        // missing one means the target was loud-skipped, and linking a zero
+        // word would silently turn a callable slot into a trap — refuse.
+        if needs_func_table {
+            if funcref_slots.is_empty() {
+                anyhow::bail!(
+                    "call_indirect compiled but the module has no statically \
+                     verifiable funcref-table image — refusing to emit an \
+                     unpopulated table (#275)"
+                );
+            }
+            for (slot, entry) in funcref_slots.iter().enumerate() {
+                let word: u32 = match entry {
+                    None => 0, // null slot — the dispatch's runtime checks trap
+                    Some(fidx) => {
+                        let label = format!("func_{fidx}");
+                        let Some(&addr) = label_to_addr.get(label.as_str()) else {
+                            anyhow::bail!(
+                                "funcref table slot {slot} references function \
+                                 {fidx}, which is not in the compiled output \
+                                 (loud-skipped or imported) — refusing to link \
+                                 a broken dispatch table (#275)"
+                            );
+                        };
+                        addr | 1 // Thumb bit — BLX to an even address faults
+                    }
+                };
+                func_table_blob.extend_from_slice(&word.to_le_bytes());
+            }
+            // #676: the type-id sidecar sits immediately after the pointer
+            // words. Cross-check the decoder-declared offset against the
+            // actual pointer-region size — a drift here would misplace every
+            // runtime type check.
+            match type_ids_byte_offset {
+                Some(off) if off as usize != func_table_blob.len() => {
+                    anyhow::bail!(
+                        "type-id sidecar offset {off} != pointer-region size {} \
+                         — funcref-region layout drift (#275/#676)",
+                        func_table_blob.len()
+                    );
+                }
+                None if !type_ids_image.is_empty() => {
+                    anyhow::bail!(
+                        "type-id sidecar image present without a declared \
+                         offset — funcref-region layout drift (#275/#676)"
+                    );
+                }
+                _ => {}
+            }
+            for id in type_ids_image {
+                func_table_blob.extend_from_slice(&id.to_le_bytes());
+            }
+            info!(
+                "  #275 funcref table: {} slot(s) + {} sidecar word(s) at 0x{:08x}",
+                funcref_slots.len(),
+                type_ids_image.len(),
+                func_table_addr
+            );
+        }
+
         for (i, func) in funcs.iter().enumerate() {
             for reloc in &func.relocations {
+                // #275: patch the funcref-table literal words (REL semantics:
+                // the in-place word is the addend, the final value is S + A).
+                if reloc.symbol == synth_core::backend::FUNC_TABLE_SYMBOL {
+                    if !matches!(reloc.kind, synth_core::backend::RelocKind::Abs32) {
+                        anyhow::bail!(
+                            "funcref-table relocation at offset {} in '{}' has \
+                             kind {:?}, expected Abs32 — unknown dispatch shape \
+                             (#275)",
+                            reloc.offset,
+                            func.name,
+                            reloc.kind
+                        );
+                    }
+                    let pos = (func_offsets[i] + reloc.offset) as usize;
+                    let addend =
+                        u32::from_le_bytes(all_func_code[pos..pos + 4].try_into().unwrap());
+                    let value = func_table_addr.wrapping_add(addend);
+                    all_func_code[pos..pos + 4].copy_from_slice(&value.to_le_bytes());
+                    info!(
+                        "  patched funcref-table literal at 0x{:08x} -> 0x{:08x}",
+                        funcs_base + func_offsets[i] + reloc.offset,
+                        value
+                    );
+                    continue;
+                }
+                // Every other relocation on this path is an internal BL call
+                // site. A non-ThmCall kind here would be silently corrupted by
+                // the BL patch below — refuse loudly instead (#275 hardening).
+                if !matches!(reloc.kind, synth_core::backend::RelocKind::ThmCall) {
+                    anyhow::bail!(
+                        "relocation against '{}' at offset {} in '{}' has kind \
+                         {:?}, which the standalone Cortex-M builder cannot \
+                         patch (only ThmCall BLs and funcref-table Abs32 \
+                         literals) — refusing a silent mis-patch",
+                        reloc.symbol,
+                        reloc.offset,
+                        func.name,
+                        reloc.kind
+                    );
+                }
                 let Some(&callee_addr) = label_to_addr.get(reloc.symbol.as_str()) else {
                     // Should not happen: the dispatcher only routes here when
                     // every relocation is internal. Be loud rather than emit a
@@ -5376,6 +5537,25 @@ fn build_multi_func_cortex_m_elf(
 
     // All function code
     flash_image.extend_from_slice(&all_func_code);
+
+    // #275: append the funcref table (4-aligned) immediately after the
+    // function code — the address every patched `FUNC_TABLE_SYMBOL` literal
+    // now carries. Empty for every image without a call_indirect dispatch
+    // (byte-identical). Placed BEFORE the #758 data ROM image, whose address
+    // is computed dynamically below and shifts harmlessly.
+    if !func_table_blob.is_empty() {
+        while !flash_image.len().is_multiple_of(4) {
+            flash_image.push(0);
+        }
+        let laid_out = flash_base + flash_image.len() as u32;
+        if laid_out != func_table_addr {
+            anyhow::bail!(
+                "funcref table laid out at 0x{laid_out:08x} but literals were \
+                 patched with 0x{func_table_addr:08x} — layout drift (#275)"
+            );
+        }
+        flash_image.extend_from_slice(&func_table_blob);
+    }
 
     // #758: append the data ROM init image (4-aligned) after the function
     // code. It lands INSIDE `.text` (the `.text` section IS `flash_image`), so

--- a/crates/synth-cli/tests/call_indirect_275_selfcontained.rs
+++ b/crates/synth-cli/tests/call_indirect_275_selfcontained.rs
@@ -1,23 +1,26 @@
-//! #275 — the self-contained `--cortex-m` `call_indirect` silent-miscompile
-//! close (outcome B: loud decline).
+//! #275 — self-contained `call_indirect`: emission + residual declines.
 //!
-//! The self-contained image path (`build_multi_func_cortex_m_elf`, i.e. no
-//! `--relocatable`) has no runtime to populate the contiguous R11 funcref-table
-//! region — R11 is the linear-memory base — so the guarded dispatch would load
-//! function pointers from linear-memory DATA (a silent miscompile: `entry`
-//! compiled to `exit 0, 0 skips` but stored garbage). Until the dedicated
-//! func-table fix (silicon-gated) lands, the self-contained path DECLINES
-//! `call_indirect` LOUDLY (AFD-008: an unlowerable op must `Err`, never
-//! silently continue).
+//! The v0.42 #717 interim (loud-decline on the whole self-contained path) was
+//! CONVERTED in v0.47: the Thumb-2 `--cortex-m` image path
+//! (`build_multi_func_cortex_m_elf`) lowers `call_indirect` through a
+//! flash-resident funcref table appended after the function code and
+//! addressed PC-RELATIVE (an `LdrSym` literal-pool word against
+//! `__synth_func_table`, patched post-layout) — NEVER via R11, the
+//! linear-memory base the #717 collision corrupted. Execution (incl. the
+//! §4.4.8 OOB / type-mismatch / null traps) is gated by
+//! `scripts/repro/call_indirect_275_selfcontained_execution_differential.py`.
 //!
 //! This locks:
-//!  1. self-contained: the `call_indirect` function is LOUD-skipped (a `#275`
-//!     diagnostic + a skip count) and is ABSENT from the output — no silent
-//!     colliding dispatch is emitted; the non-`call_indirect` functions still
-//!     compile;
-//!  2. `--relocatable`: the SAME module still emits `entry` with its guarded
-//!     dispatch — the host-linked path (a runtime places the table region at
-//!     R11) is untouched (the #642/#650/#664/#676 oracles gate its bytes).
+//!  1. self-contained `--cortex-m` (Thumb-2): the `call_indirect` function
+//!     now EMITS (with the `#275 funcref table` diagnostic) alongside the
+//!     other functions — no more #717 loud-skip;
+//!  2. RESIDUAL: A32/Cortex-R5 self-contained still LOUD-declines with a
+//!     `#275` diagnostic — its builder emits no funcref table, so a dispatch
+//!     would be the silent R11 collision;
+//!  3. `--relocatable`: the SAME module still emits `entry` with its guarded
+//!     R11 dispatch — the host-linked path (a runtime places the table
+//!     region at R11) is untouched (the #642/#650/#664/#676 oracles gate its
+//!     bytes).
 
 use std::process::Command;
 
@@ -39,11 +42,11 @@ fn has_symbol(bytes: &[u8], name: &str) -> bool {
     obj.symbols().any(|s| s.name() == Ok(name))
 }
 
-/// Outcome B: self-contained `--cortex-m` DECLINES `call_indirect` loudly —
-/// the function is skipped (named, counted) and absent from the ELF, never a
-/// silent colliding dispatch.
+/// #275 converted: the self-contained Thumb-2 `--cortex-m` image EMITS the
+/// `call_indirect` function, dispatching through the flash-resident funcref
+/// table (never R11).
 #[test]
-fn test_275_selfcontained_call_indirect_declines_loudly() {
+fn test_275_selfcontained_call_indirect_emits() {
     let path = fixture();
     let elf = "/tmp/ci275_selfcontained.elf";
     let out = Command::new(synth())
@@ -59,8 +62,52 @@ fn test_275_selfcontained_call_indirect_declines_loudly() {
         .output()
         .expect("run synth");
 
+    assert!(
+        out.status.success(),
+        "compile failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stderr.contains("skipping function 'entry'"),
+        "entry must compile now (regression to the #717 loud-decline), got:\n{stderr}"
+    );
+    assert!(
+        format!("{stdout}{stderr}").contains("#275 funcref table"),
+        "the flash funcref table must be emitted (diagnostic missing), got:\n{stdout}\n{stderr}"
+    );
+
+    let bytes = std::fs::read(elf).expect("read elf");
+    for f in ["entry", "func_1", "func_2", "func_3"] {
+        assert!(
+            has_symbol(&bytes, f),
+            "{f} must be in the self-contained image (#275)"
+        );
+    }
+}
+
+/// RESIDUAL decline: A32/Cortex-R5 self-contained (not the cortex-m image
+/// builder) still refuses `call_indirect` loudly — no funcref table is
+/// emitted there, so a dispatch would be the #717 silent R11 collision.
+#[test]
+fn test_275_selfcontained_a32_still_declines_loudly() {
+    let path = fixture();
+    let elf = "/tmp/ci275_selfcontained_r5.elf";
+    let out = Command::new(synth())
+        .args([
+            "compile",
+            path.to_str().unwrap(),
+            "--target",
+            "cortex-r5",
+            "-o",
+            elf,
+        ])
+        .output()
+        .expect("run synth");
+
     // The overall compile still succeeds (skip-and-continue), but the decline
-    // is LOUD — the diagnostic names #275 and the linear-memory collision.
+    // is LOUD — the diagnostic names #275.
     assert!(
         out.status.success(),
         "compile should skip-and-continue: {}",
@@ -69,7 +116,7 @@ fn test_275_selfcontained_call_indirect_declines_loudly() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         stderr.contains("skipping function 'entry'"),
-        "the call_indirect function must be a LOUD skip, got:\n{stderr}"
+        "the A32 self-contained call_indirect must stay a LOUD skip, got:\n{stderr}"
     );
     assert!(
         stderr.contains("#275"),
@@ -79,22 +126,12 @@ fn test_275_selfcontained_call_indirect_declines_loudly() {
         stderr.contains("were skipped"),
         "the skip must be surfaced in the summary count, got:\n{stderr}"
     );
-
-    // The declined function is ABSENT from the output — no silent dispatch.
     let bytes = std::fs::read(elf).expect("read elf");
     assert!(
         !has_symbol(&bytes, "entry"),
-        "`entry` must NOT be emitted — a declined function is absent, not a \
-         silent colliding dispatch (#275)"
+        "`entry` must NOT be emitted on the A32 self-contained path — a \
+         declined function is absent, not a silent colliding dispatch (#275)"
     );
-    // The non-call_indirect functions still compile (the decline is scoped to
-    // the call_indirect function, not the whole module).
-    for f in ["func_1", "func_2", "func_3"] {
-        assert!(
-            has_symbol(&bytes, f),
-            "{f} must still compile — only the call_indirect function declines"
-        );
-    }
 }
 
 /// The `--relocatable` (host-linked) path is UNTOUCHED: the same module still

--- a/crates/synth-cli/tests/call_indirect_275_selfcontained.rs
+++ b/crates/synth-cli/tests/call_indirect_275_selfcontained.rs
@@ -134,6 +134,82 @@ fn test_275_selfcontained_a32_still_declines_loudly() {
     );
 }
 
+/// RESIDUAL decline: a self-contained module with IMPORTED functions keeps
+/// the loud #275 decline — imports force ET_REL output, whose host runtime
+/// owns the R11 table region; the flash-table lowering must not fire there.
+#[test]
+fn test_275_selfcontained_with_imports_still_declines_loudly() {
+    let wat = r#"(module
+      (import "env" "ext" (func $ext (param i32) (result i32)))
+      (memory 1)
+      (type $un (func (param i32) (result i32)))
+      (func $easy (type $un) (i32.add (local.get 0) (i32.const 1)))
+      (func (export "go") (param i32 i32) (result i32)
+        (call_indirect (type $un) (local.get 0) (local.get 1)))
+      (table 1 funcref) (elem (i32.const 0) $easy))"#;
+    let src = "/tmp/ci275_imports.wat";
+    std::fs::write(src, wat).expect("write fixture");
+    let out = Command::new(synth())
+        .args([
+            "compile",
+            src,
+            "--cortex-m",
+            "--target",
+            "cortex-m3",
+            "-o",
+            "/tmp/ci275_imports.elf",
+        ])
+        .output()
+        .expect("run synth");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("skipping function 'go'") && stderr.contains("#275"),
+        "a self-contained module WITH imports must keep the loud #275 \
+         call_indirect decline (ET_REL output owns the table region), got:\n{stderr}"
+    );
+}
+
+/// LOUD bail (never a silent zero-linked slot): a funcref-table slot whose
+/// target function was loud-skipped (uncompilable) fails the whole compile
+/// with a named error — linking 0 would silently turn a callable slot into a
+/// trap.
+#[test]
+fn test_275_skipped_table_target_fails_loudly() {
+    let wat = r#"(module
+      (memory 1)
+      (type $un (func (param i32) (result i32)))
+      (func $hard (type $un)
+        (i32.trunc_f64_s (f64.sqrt (f64.convert_i32_s (local.get 0)))))
+      (func $easy (type $un) (i32.add (local.get 0) (i32.const 1)))
+      (func (export "go") (param i32 i32) (result i32)
+        (call_indirect (type $un) (local.get 0) (local.get 1)))
+      (table 2 funcref) (elem (i32.const 0) $easy $hard))"#;
+    let src = "/tmp/ci275_skiptarget.wat";
+    std::fs::write(src, wat).expect("write fixture");
+    let out = Command::new(synth())
+        .args([
+            "compile",
+            src,
+            "--cortex-m",
+            "--target",
+            "cortex-m3", // soft-float: the f64 target function loud-skips (#369)
+            "-o",
+            "/tmp/ci275_skiptarget.elf",
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        !out.status.success(),
+        "a dispatch table with a skipped target must FAIL the compile, not \
+         link a broken table"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("refusing to link a broken dispatch table"),
+        "the failure must name the broken-table refusal (#275), got:\n{stderr}"
+    );
+}
+
 /// The `--relocatable` (host-linked) path is UNTOUCHED: the same module still
 /// emits `entry` with its guarded dispatch — the runtime places the R11 table
 /// region there, so the dispatch is sound (the #642/#650/#664/#676 oracles

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -124,6 +124,17 @@ pub struct CompileConfig {
     /// instead of `__meld_dispatch_import`. (#197 — follow-up to #188/#171.)
     pub relocatable: bool,
 
+    /// #275: the SELF-CONTAINED Thumb-2 `--cortex-m` image path lowers
+    /// `call_indirect` through a flash-resident funcref table addressed
+    /// PC-RELATIVE (an `LdrSym` literal-pool pointer to
+    /// [`FUNC_TABLE_SYMBOL`]) — NEVER through R11, which is the linear-memory
+    /// base (the v0.42 #717 collision). Set by the CLI ONLY when the image
+    /// builder that emits and patches that table
+    /// (`build_multi_func_cortex_m_elf`) will run: Cortex-M family, not
+    /// `--relocatable`, no imported functions. Every other self-contained
+    /// configuration keeps the loud #275 decline. Default `false`.
+    pub self_contained_funcref_table: bool,
+
     /// #687 (`--stack-layout=low`): the absolute linear-memory base the
     /// OPTIMIZED ARM path materializes into user code. Defaults to
     /// [`OPTIMIZED_LINMEM_BASE`] (`0x2000_0100`, byte-identical to every
@@ -412,6 +423,9 @@ impl Default for CompileConfig {
             func_arg_counts: Vec::new(),
             type_arg_counts: Vec::new(),
             relocatable: false,
+            // #275: self-contained funcref-table dispatch is opt-in by the
+            // CLI's cortex-m image path; everything else keeps the decline.
+            self_contained_funcref_table: false,
             // #687: the historical optimized-path absolute base — every
             // default compile stays byte-identical.
             linmem_base: OPTIMIZED_LINMEM_BASE,
@@ -472,6 +486,18 @@ impl Default for CompileConfig {
         }
     }
 }
+
+/// #275: the base symbol of the SELF-CONTAINED funcref table — the
+/// flash-resident region `build_multi_func_cortex_m_elf` appends after the
+/// function code: one 4-byte code pointer per table slot across ALL tables in
+/// declaration order (the same contiguous layout the `--relocatable` R11
+/// contract uses — `TableGuards::base_byte_offset` stays valid verbatim),
+/// null slots as ZERO words (#664), followed by the #676 type-id sidecar at
+/// `type_ids_byte_offset` when a heterogeneous table needs it. The dispatch
+/// reaches it through an `LdrSym` literal-pool word (an `Abs32` reloc against
+/// this symbol) that the image builder patches post-layout — never through
+/// R11, which is the linear-memory base (the #717 collision).
+pub const FUNC_TABLE_SYMBOL: &str = "__synth_func_table";
 
 /// A relocation entry produced during compilation
 ///

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -515,6 +515,60 @@ impl DecodedModule {
         }
     }
 
+    /// #275: the STATIC image of the contiguous funcref region — one slot per
+    /// table entry across ALL tables in declaration order (the exact layout
+    /// [`CallIndirectGuards`]' `base_byte_offset` contract describes), each
+    /// `Some(full_function_index)` for a statically-known initialized slot
+    /// and `None` for a null (or not statically attributable) slot. The
+    /// self-contained image builder resolves each `Some` to the laid-out
+    /// function address (Thumb bit set) and links every `None` as a ZERO
+    /// word, which the dispatch's #664 null check / #676 id-0 compare traps.
+    ///
+    /// Mirrors the reconstruction in [`Self::call_indirect_guards`]:
+    ///  - stops at the first table with no compile-time size (later tables
+    ///    have no constant base offset, so no dispatch can reach them);
+    ///  - a table whose segments are not statically verifiable (non-const
+    ///    offset, non-`ref.func` entry, out-of-range write) contributes
+    ///    all-`None` slots — every dispatch into it declines at the lowering
+    ///    anyway, and a rogue read traps on the zero word rather than branch.
+    pub fn funcref_region_slots(&self) -> Vec<Option<u32>> {
+        let mut region: Vec<Option<u32>> = Vec::new();
+        for (n, &size) in self.table_sizes.iter().enumerate() {
+            let Some(size) = size else { break };
+            let mut slots: Vec<Option<u32>> = vec![None; size as usize];
+            let mut verifiable = true;
+            for seg in self
+                .elem_segments
+                .iter()
+                .filter(|s| s.table_index == n as u32)
+            {
+                let (Some(off), Some(funcs)) = (seg.offset, seg.funcs.as_ref()) else {
+                    verifiable = false;
+                    break;
+                };
+                for (k, &f) in funcs.iter().enumerate() {
+                    match slots.get_mut(off as usize + k) {
+                        Some(slot) => *slot = Some(f),
+                        None => {
+                            // Writes past the declared size: the guards
+                            // reject this table; ship all-null slots.
+                            verifiable = false;
+                            break;
+                        }
+                    }
+                }
+                if !verifiable {
+                    break;
+                }
+            }
+            if !verifiable {
+                slots = vec![None; size as usize];
+            }
+            region.extend(slots);
+        }
+        region
+    }
+
     /// #642/#650: the closed-world type verdicts for ONE table — `None` per
     /// expected type when every INITIALIZED slot of table `n` verifiably
     /// holds a function of that exact structural signature; `Some(reason)`

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -3293,6 +3293,17 @@ pub struct InstructionSelector {
     /// Set by the backend from `!config.relocatable`; the selector's own unit
     /// tests construct it directly (default `false`) and are unaffected.
     reject_self_contained_call_indirect: bool,
+    /// #275: lower `call_indirect` for the SELF-CONTAINED Thumb-2 image via
+    /// the flash-resident funcref table (`FUNC_TABLE_SYMBOL`), addressed
+    /// PC-relative through an `LdrSym` literal-pool pointer — NEVER via
+    /// R11/R9/R10/R12 base registers (R11 is the linear-memory base; the #717
+    /// collision this replaces). The backend sets it from
+    /// `config.self_contained_funcref_table` ONLY when the image builder that
+    /// emits and patches the table will run (Thumb-2 `--cortex-m`, no
+    /// imports, not `--relocatable`); it is mutually exclusive with
+    /// `reject_self_contained_call_indirect`. Only `select_with_stack`
+    /// implements this lowering — `select_default` declines it loudly.
+    self_contained_funcref_table: bool,
     /// #237: native-pointer ABI — wasm statics become `__synth_wasm_data`-
     /// relative (MOVW/MOVT), so a `base=0` host-pointer trampoline doesn't
     /// mis-address them.
@@ -3533,6 +3544,7 @@ impl InstructionSelector {
             num_imports: 0,
             relocatable: false,
             reject_self_contained_call_indirect: false,
+            self_contained_funcref_table: false,
             native_pointer_abi: false,
             memory_pages: Vec::new(),
             linear_memory_bytes: 0,
@@ -3583,6 +3595,7 @@ impl InstructionSelector {
             num_imports: 0,
             relocatable: false,
             reject_self_contained_call_indirect: false,
+            self_contained_funcref_table: false,
             native_pointer_abi: false,
             memory_pages: Vec::new(),
             linear_memory_bytes: 0,
@@ -3777,12 +3790,13 @@ impl InstructionSelector {
         if self.reject_self_contained_call_indirect {
             return Err(synth_core::Error::synthesis(format!(
                 "call_indirect (table {table_index}, expected type {type_index}): \
-                 the self-contained Cortex-M image has no runtime to populate the \
+                 this self-contained path has no runtime to populate the \
                  R11 funcref-table region (R11 is the linear-memory base), so the \
-                 dispatch would read function pointers from linear-memory data — a \
-                 silent miscompile. Declining (use --relocatable for a host-linked \
-                 object whose runtime places the table region, or await the \
-                 dedicated func-table fix) — #275"
+                 R11 dispatch would read function pointers from linear-memory data \
+                 — a silent miscompile. The dedicated flash-resident funcref table \
+                 covers only the Thumb-2 --cortex-m image path with no imported \
+                 functions; declining here (use --relocatable for a host-linked \
+                 object whose runtime places the table region) — #275"
             )));
         }
         let n_tables = self.call_indirect_guards.tables.len();
@@ -3920,6 +3934,171 @@ impl InstructionSelector {
         ))
     }
 
+    /// #275: emit the SELF-CONTAINED `call_indirect` dispatch — the funcref
+    /// table lives in FLASH (appended to `.text` by
+    /// `build_multi_func_cortex_m_elf`, the #758 ROM-image pattern) and is
+    /// reached PC-relative through an `LdrSym` literal-pool pointer carrying
+    /// an `Abs32` relocation against `FUNC_TABLE_SYMBOL`, which the image
+    /// builder patches to the table's laid-out address. No reserved base
+    /// register is touched: NOT R11 (linear-memory base — the #717 silent
+    /// miscompile this lowering replaces), NOT R9/R10 (globals / mem-size),
+    /// NOT R12 (encoder scratch, #212). Two callee-saved scratch registers
+    /// are taken via `free_callee_saved` (loud `Err` on exhaustion — an
+    /// honest decline, never a corrupted dispatch).
+    ///
+    /// The sequence (same WASM Core §4.4.8 trap semantics as the R11
+    /// expansion in `arm_encoder.rs`, same `UDF #0` trap idiom as the div
+    /// guards):
+    ///
+    /// ```text
+    ///   MOVW s_idx, #size_lo [; MOVT s_idx, #size_hi]
+    ///   CMP  idx, s_idx ; BLO +1 ; UDF #0            (OOB index trap, #642)
+    ///   LSL  s_idx, idx, #2                          (slot byte offset)
+    ///   [heterogeneous table (#676):
+    ///     LDR  s_addr, =__synth_func_table           (LdrSym literal)
+    ///     ADD  s_addr, s_addr, s_idx
+    ///     LDR  s_addr, [s_addr, #type_id_off]
+    ///     CMP  s_addr, #expected_id ; BEQ +1 ; UDF #0 (type-mismatch trap)]
+    ///   LDR  s_addr, =__synth_func_table             (LdrSym literal)
+    ///   ADD  s_addr, s_addr, s_idx
+    ///   LDR  s_addr, [s_addr, #table_byte_offset]
+    ///   [null slots (#664):
+    ///     CMP  s_addr, #0 ; BNE +1 ; UDF #0           (null-funcref trap)]
+    ///   BLX  s_addr
+    /// ```
+    ///
+    /// Returns the number of instructions pushed (for the caller's
+    /// control-flow bookkeeping).
+    #[allow(clippy::too_many_arguments)]
+    fn emit_self_contained_call_indirect(
+        &mut self,
+        instructions: &mut Vec<ArmInstruction>,
+        table_idx_reg: Reg,
+        live_regs: &[Reg],
+        local_to_reg: &std::collections::HashMap<u32, Reg>,
+        layout: &LocalLayout,
+        table_size: u32,
+        table_byte_offset: u32,
+        null_check: bool,
+        type_check: Option<(u32, u32)>,
+        idx: usize,
+    ) -> Result<usize> {
+        // Two callee-saved scratches, excluding everything live PLUS the
+        // table-index register (it must stay readable until the LSL).
+        let mut protected: Vec<Reg> = live_regs.to_vec();
+        protected.push(table_idx_reg);
+        let s_addr = self.free_callee_saved(&protected, local_to_reg, layout)?;
+        protected.push(s_addr);
+        let s_idx = self.free_callee_saved(&protected, local_to_reg, layout)?;
+
+        let before = instructions.len();
+        let mut push = |op: ArmOp| {
+            instructions.push(ArmInstruction {
+                op,
+                source_line: Some(idx),
+            });
+        };
+
+        // Bounds guard (#642): trap when index >= table size. MOVT only when
+        // the size exceeds 16 bits (mirrors the R11 expansion; never in
+        // practice, but the guard must not compare against a truncated size).
+        push(ArmOp::Movw {
+            rd: s_idx,
+            imm16: (table_size & 0xFFFF) as u16,
+        });
+        if table_size >> 16 != 0 {
+            push(ArmOp::Movt {
+                rd: s_idx,
+                imm16: (table_size >> 16) as u16,
+            });
+        }
+        push(ArmOp::Cmp {
+            rn: table_idx_reg,
+            op2: Operand2::Reg(s_idx),
+        });
+        // Skip the UDF when index < size — the div-guard `BCondOffset 0`
+        // idiom (offset 0 ⇒ target = branch + 4, one 16-bit insn).
+        push(ArmOp::BCondOffset {
+            cond: Condition::LO,
+            offset: 0,
+        });
+        push(ArmOp::Udf { imm: 0 });
+
+        // Slot byte offset — the index register is dead after this (both the
+        // sidecar and the pointer load index with s_idx).
+        push(ArmOp::Lsl {
+            rd: s_idx,
+            rn: table_idx_reg,
+            shift: 2,
+        });
+
+        // #676: heterogeneous table — runtime type check against the type-id
+        // sidecar (id 0 = null slot, subsuming the #664 null trap; the
+        // selector guards `expected_id <= 255` and `type_id_off <= 4095`).
+        if let Some((expected_id, type_id_off)) = type_check {
+            push(ArmOp::LdrSym {
+                rd: s_addr,
+                symbol: synth_core::backend::FUNC_TABLE_SYMBOL.to_string(),
+                addend: 0,
+            });
+            push(ArmOp::Add {
+                rd: s_addr,
+                rn: s_addr,
+                op2: Operand2::Reg(s_idx),
+            });
+            push(ArmOp::Ldr {
+                rd: s_addr,
+                addr: MemAddr::imm(s_addr, type_id_off as i32),
+            });
+            push(ArmOp::Cmp {
+                rn: s_addr,
+                op2: Operand2::Imm(expected_id as i32),
+            });
+            push(ArmOp::BCondOffset {
+                cond: Condition::EQ,
+                offset: 0,
+            });
+            push(ArmOp::Udf { imm: 0 });
+        }
+
+        // Pointer load: table base (PC-relative literal) + slot offset, then
+        // the #650 constant table base offset folded into the LDR immediate
+        // (the selector guards `table_byte_offset <= 4095`).
+        push(ArmOp::LdrSym {
+            rd: s_addr,
+            symbol: synth_core::backend::FUNC_TABLE_SYMBOL.to_string(),
+            addend: 0,
+        });
+        push(ArmOp::Add {
+            rd: s_addr,
+            rn: s_addr,
+            op2: Operand2::Reg(s_idx),
+        });
+        push(ArmOp::Ldr {
+            rd: s_addr,
+            addr: MemAddr::imm(s_addr, table_byte_offset as i32),
+        });
+
+        // #664: null-slot trap — the image builder links uninitialized slots
+        // as ZERO words; calling one must trap, not branch to address 0.
+        if null_check {
+            push(ArmOp::Cmp {
+                rn: s_addr,
+                op2: Operand2::Imm(0),
+            });
+            push(ArmOp::BCondOffset {
+                cond: Condition::NE,
+                offset: 0,
+            });
+            push(ArmOp::Udf { imm: 0 });
+        }
+
+        // Indirect call — the table words carry the Thumb bit (builder-set).
+        push(ArmOp::Blx { rm: s_addr });
+
+        Ok(instructions.len() - before)
+    }
+
     /// Enable relocatable host-link mode (#197): import calls emit a direct
     /// `BL func_N` (rewritten to the wasm field name by the relocatable-ELF
     /// builder) instead of dispatching through `__meld_dispatch_import`.
@@ -3936,6 +4115,15 @@ impl InstructionSelector {
     /// region) leaves it `false` and keeps emitting the guarded dispatch.
     pub fn set_reject_self_contained_call_indirect(&mut self, reject: bool) {
         self.reject_self_contained_call_indirect = reject;
+    }
+
+    /// #275: enable the SELF-CONTAINED funcref-table `call_indirect` lowering
+    /// (see the field doc). The backend sets this ONLY when the Thumb-2
+    /// `--cortex-m` image builder that emits and patches the
+    /// `FUNC_TABLE_SYMBOL` table will run; it replaces (and must be mutually
+    /// exclusive with) `reject_self_contained_call_indirect`.
+    pub fn set_self_contained_funcref_table(&mut self, enabled: bool) {
+        self.self_contained_funcref_table = enabled;
     }
 
     /// #237: enable the native-pointer ABI and supply the active data-segment
@@ -4918,6 +5106,19 @@ impl InstructionSelector {
                 // guard), a constant table base offset, and a verified
                 // closed-world type verdict for THAT table, decline loudly
                 // rather than emit an unchecked indirect branch.
+                // #275: the SELF-CONTAINED funcref-table lowering (PC-relative
+                // flash table) is implemented only by `select_with_stack` —
+                // this legacy/demo arm emits the R11 dispatch, which would be
+                // the #717 linear-memory collision on a self-contained image.
+                // Decline loudly rather than emit it.
+                if self.self_contained_funcref_table {
+                    return Err(synth_core::Error::synthesis(
+                        "call_indirect: the self-contained funcref-table dispatch \
+                         is a select_with_stack lowering; this selector path \
+                         would emit the colliding R11 dispatch — declining (#275)"
+                            .to_string(),
+                    ));
+                }
                 let (table_size, table_byte_offset, null_check, type_check) =
                     self.resolve_call_indirect_guards(*table_index, *type_index)?;
                 vec![ArmOp::CallIndirect {
@@ -12845,27 +13046,54 @@ impl InstructionSelector {
                         stack.pop();
                     }
 
-                    instructions.push(ArmInstruction {
-                        op: ArmOp::CallIndirect {
-                            rd: Reg::R0,
-                            type_idx: *type_index,
-                            table_index_reg: table_idx_reg,
-                            // #642: the encoder emits `CMP idx, size; BLO ok;
-                            // UDF #0` before the table load. #650: a non-zero
-                            // offset routes the load through the table's base
-                            // within the contiguous R11 region. #664: a table
-                            // with null slots gets a runtime null check on
-                            // the loaded pointer (zero-linked slot → trap).
-                            // #676: a heterogeneous table gets the runtime
-                            // type check against the type-id sidecar.
+                    if self.self_contained_funcref_table {
+                        // #275: SELF-CONTAINED image — dispatch through the
+                        // flash-resident funcref table (`FUNC_TABLE_SYMBOL`),
+                        // reached PC-relative via an `LdrSym` literal-pool
+                        // pointer the image builder patches post-layout.
+                        // NEVER via R11 (linear-memory base — the #717
+                        // collision), R9/R10 (globals / mem-size), or R12
+                        // (encoder scratch). Same §4.4.8 guard semantics as
+                        // the R11 expansion: OOB index → UDF, #676 type
+                        // mismatch → UDF, #664 null slot → UDF.
+                        let n = self.emit_self_contained_call_indirect(
+                            &mut instructions,
+                            table_idx_reg,
+                            &stack_live_regs(&stack),
+                            &local_to_reg,
+                            &layout,
                             table_size,
                             table_byte_offset,
                             null_check,
                             type_check,
-                        },
-                        source_line: Some(idx),
-                    });
-                    cf.add_instruction();
+                            idx,
+                        )?;
+                        for _ in 0..n {
+                            cf.add_instruction();
+                        }
+                    } else {
+                        instructions.push(ArmInstruction {
+                            op: ArmOp::CallIndirect {
+                                rd: Reg::R0,
+                                type_idx: *type_index,
+                                table_index_reg: table_idx_reg,
+                                // #642: the encoder emits `CMP idx, size; BLO ok;
+                                // UDF #0` before the table load. #650: a non-zero
+                                // offset routes the load through the table's base
+                                // within the contiguous R11 region. #664: a table
+                                // with null slots gets a runtime null check on
+                                // the loaded pointer (zero-linked slot → trap).
+                                // #676: a heterogeneous table gets the runtime
+                                // type check against the type-id sidecar.
+                                table_size,
+                                table_byte_offset,
+                                null_check,
+                                type_check,
+                            },
+                            source_line: Some(idx),
+                        });
+                        cf.add_instruction();
+                    }
                     // #311: tag an i64 result as the R0:R1 pair (static type).
                     let ret_i64 = self
                         .type_ret_i64

--- a/scripts/repro/call_indirect_275_selfcontained.wat
+++ b/scripts/repro/call_indirect_275_selfcontained.wat
@@ -1,18 +1,21 @@
-;; #275 — self-contained `--cortex-m` call_indirect silent-miscompile repro.
+;; #275 — self-contained call_indirect emission/decline fixture.
 ;;
 ;; `entry` dispatches through a constant table (index loaded from linmem[100]).
-;; wasmtime stores 100/200/300 to linmem[0] for table indices 0/1/2.
 ;;
-;; On the SELF-CONTAINED image path (build_multi_func_cortex_m_elf, i.e. NO
-;; --relocatable) the dispatch loads the function pointer from the contiguous
-;; R11 table region — but R11 is the LINEAR-MEMORY base and NOTHING populates
-;; that region in a self-contained image, so `ldr ip,[r11,idx*4]` reads
-;; function pointers from linear-memory DATA (a silent miscompile). Until the
-;; dedicated func-table fix (silicon-gated) lands, the self-contained path must
-;; DECLINE this loudly (AFD-008) rather than emit the colliding dispatch.
+;; HISTORY: the naive self-contained dispatch loaded the function pointer from
+;; the contiguous R11 table region — but R11 is the LINEAR-MEMORY base and
+;; NOTHING populates that region in a self-contained image, so
+;; `ldr ip,[r11,idx*4]` read function pointers from linear-memory DATA (a
+;; silent miscompile). v0.42 (#717) loud-declined; v0.47 CONVERTED the
+;; Thumb-2 `--cortex-m` path: the funcref table now ships in FLASH and the
+;; dispatch reaches it PC-relative (`__synth_func_table`), never via R11 —
+;; `entry` EMITS again. The A32/Cortex-R5 self-contained path (no flash-table
+;; builder) keeps the loud decline (AFD-008).
 ;;
 ;; The `--relocatable` path (where a runtime places the table region at R11)
 ;; keeps emitting the guarded dispatch — see the #642/#650/#664/#676 oracles.
+;; Execution semantics are gated by the companion
+;; call_indirect_275_selfcontained_execution_differential.py.
 (module
   (memory (export "memory") 1)
   (type $ret (func (result i32)))

--- a/scripts/repro/call_indirect_275_selfcontained_differential.py
+++ b/scripts/repro/call_indirect_275_selfcontained_differential.py
@@ -1,28 +1,30 @@
 #!/usr/bin/env python3
-"""#275 — self-contained `--cortex-m` call_indirect: LOUD-DECLINE oracle.
+"""#275 — self-contained call_indirect: emission + residual-decline oracle.
 
-Companion to the #642/#650/#664/#676 EXECUTION differentials, but this one
-gates outcome B (the sound interim): on the SELF-CONTAINED image path
-(`build_multi_func_cortex_m_elf`, no `--relocatable`) `call_indirect` must
-DECLINE LOUDLY rather than silently emit the R11-table dispatch that reads
-function pointers from linear-memory DATA (a silent miscompile).
-
-Root cause: the guarded dispatch loads the function pointer from the contiguous
-R11 funcref-table region, but R11 is the LINEAR-MEMORY base and a self-contained
-image has NO runtime to populate that region — so `ldr ip,[r11,idx*4]` reads
-whatever linear-memory data lives at that offset. Until the dedicated
-func-pointer table (silicon-gated, #275) lands, the self-contained path refuses
-(AFD-008: an unlowerable op must Err, never silently continue).
+The v0.42 #717 interim (loud-decline on the whole self-contained path) was
+CONVERTED in v0.47: the Thumb-2 `--cortex-m` image path now lowers
+`call_indirect` through a flash-resident funcref table addressed PC-RELATIVE
+(an `LdrSym` literal against `__synth_func_table`, patched post-layout) —
+never via R11, the linear-memory base the #717 collision corrupted. Execution
+(incl. every §4.4.8 trap) is gated by the companion
+`call_indirect_275_selfcontained_execution_differential.py`.
 
 This oracle asserts, using only `synth` + pyelftools (no unicorn/wasmtime):
-  1. self-contained: the `entry` (call_indirect) function is LOUD-skipped (a
-     `#275` diagnostic + a skip count) and is ABSENT from the ELF symtab — no
-     silent colliding dispatch — while `func_1/2/3` still compile;
-  2. `--relocatable`: the SAME module still emits `entry` (the host-linked path,
-     where a runtime places the table region at R11, is untouched).
+  1. self-contained `--cortex-m` (Thumb-2): the `entry` (call_indirect)
+     function now EMITS — with the `#275 funcref table` diagnostic — and the
+     non-call_indirect functions still compile;
+  2. RESIDUAL DECLINE — A32/Cortex-R5 self-contained (no `--relocatable`, not
+     the cortex-m image builder): `call_indirect` still LOUD-declines with a
+     `#275` diagnostic and `entry` stays ABSENT (the flash-table lowering is
+     Thumb-2 `--cortex-m` only; anything else would be the silent R11
+     collision);
+  3. `--relocatable`: the SAME module still emits `entry` on both Thumb-2 and
+     A32 (the host-linked path, where a runtime places the table region at
+     R11, is untouched).
 
 Run:  SYNTH=<path-to-synth> python scripts/repro/call_indirect_275_selfcontained_differential.py
-Exits nonzero on a silent emit (regression) or a declined relocatable path.
+Exits nonzero on a self-contained cortex-m decline (regression to #717), a
+SILENT emit on the residual A32 path, or a declined relocatable path.
 """
 
 import os
@@ -49,30 +51,53 @@ def run(args):
     return subprocess.run([SYNTH, "compile", str(WAT), *args], capture_output=True, text=True)
 
 
-def check_selfcontained() -> int:
+def check_selfcontained_cortex_m() -> int:
+    """#275 converted: the Thumb-2 cortex-m image EMITS the dispatch."""
     out = "/tmp/ci275_selfcontained_oracle.elf"
     r = run(["--cortex-m", "--target", "cortex-m3", "-o", out])
     fails = 0
     if r.returncode != 0:
-        print(f"self-contained: compile hard-failed (expected skip-and-continue):\n{r.stderr}")
+        print(f"self-contained cortex-m: compile failed:\n{r.stderr}")
         return 1
-    if "skipping function 'entry'" not in r.stderr or "#275" not in r.stderr:
-        print(f"self-contained: call_indirect was NOT loud-declined (#275):\n{r.stderr}")
+    if "skipping function 'entry'" in r.stderr:
+        print("self-contained cortex-m: entry LOUD-declined — regression to the "
+              f"#717 interim MISMATCH:\n{r.stderr}")
         fails += 1
-    else:
-        print("self-contained: entry LOUD-declined with a #275 diagnostic OK")
+    if "#275 funcref table" not in r.stdout + r.stderr:
+        print("self-contained cortex-m: no funcref-table diagnostic — the "
+              f"flash table was not emitted MISMATCH:\n{r.stdout}\n{r.stderr}")
+        fails += 1
     syms = symbols(out)
-    if "entry" in syms:
-        print("self-contained: `entry` EMITTED — a silent colliding dispatch (regression) MISMATCH")
-        fails += 1
-    else:
-        print("self-contained: `entry` absent from the ELF (no silent dispatch) OK")
-    for f in ("func_1", "func_2", "func_3"):
+    for f in ("entry", "func_1", "func_2", "func_3"):
         if f not in syms:
-            print(f"self-contained: {f} missing — decline must be scoped to call_indirect MISMATCH")
+            print(f"self-contained cortex-m: {f} missing from the image MISMATCH")
             fails += 1
     if fails == 0:
-        print("self-contained: non-call_indirect functions still compile OK")
+        print("self-contained cortex-m: entry emits the flash-table dispatch "
+              "(+ funcref table) OK")
+    return fails
+
+
+def check_selfcontained_a32_residual() -> int:
+    """The RESIDUAL decline: A32/Cortex-R5 self-contained must still refuse —
+    its builder emits no funcref table, so a dispatch would be the #717 R11
+    collision (a silent miscompile)."""
+    out = "/tmp/ci275_selfcontained_r5.elf"
+    r = run(["--target", "cortex-r5", "-o", out])
+    fails = 0
+    if r.returncode != 0:
+        print(f"self-contained cortex-r5: compile hard-failed (expected skip-and-continue):\n{r.stderr}")
+        return 1
+    if "skipping function 'entry'" not in r.stderr or "#275" not in r.stderr:
+        print("self-contained cortex-r5: call_indirect was NOT loud-declined — "
+              f"a silent R11 collision (#275) MISMATCH:\n{r.stderr}")
+        fails += 1
+    elif "entry" in symbols(out):
+        print("self-contained cortex-r5: `entry` EMITTED — silent colliding dispatch MISMATCH")
+        fails += 1
+    else:
+        print("self-contained cortex-r5: residual LOUD decline (A32 has no "
+              "flash-table lowering yet) OK")
     return fails
 
 
@@ -98,7 +123,11 @@ def check_relocatable() -> int:
 
 
 def main() -> int:
-    fails = check_selfcontained() + check_relocatable()
+    fails = (
+        check_selfcontained_cortex_m()
+        + check_selfcontained_a32_residual()
+        + check_relocatable()
+    )
     if fails == 0:
         print("ORACLE: PASS")
         return 0

--- a/scripts/repro/call_indirect_275_selfcontained_execution.wat
+++ b/scripts/repro/call_indirect_275_selfcontained_execution.wat
@@ -1,0 +1,28 @@
+;; #275 — self-contained `--cortex-m` call_indirect EXECUTION fixture (the
+;; falcon shape: an export dispatches through a funcref table).
+;;
+;; Heterogeneous 5-slot table: slots 0/2 = (i32,i32)->i32 ($add/$sub), slot 1 =
+;; (i32)->i32 ($ld), slots 3/4 null — so ONE image exercises every WASM Core
+;; §4.4.8 outcome: matching dispatch (values), type mismatch (trap via the #676
+;; type-id sidecar), null slot (trap, id 0), OOB index (trap, bounds guard).
+;;
+;; $ld reads LINEAR MEMORY (initialized by an active data segment, shipped via
+;; the #758 flash ROM image): via1(x,1) = x + 42 proves the dispatched
+;; function's R11 linmem addressing is INTACT — the funcref table lives in
+;; flash, PC-relative, never overlapping the R11 linear-memory region (the
+;; historical #717 collision read function "pointers" from linmem data).
+(module
+  (memory (export "memory") 1)
+  (data (i32.const 0) "\2a\00\00\00") ;; linmem[0] = 42
+  (type $bin (func (param i32 i32) (result i32)))
+  (type $un  (func (param i32) (result i32)))
+  (func $add (type $bin) (i32.add (local.get 0) (local.get 1)))
+  (func $sub (type $bin) (i32.sub (local.get 0) (local.get 1)))
+  (func $ld  (type $un)  (i32.add (local.get 0) (i32.load (i32.const 0))))
+  ;; via2(x, idx): dispatch expecting the 2-arg type — x and 7 are the args.
+  (func (export "via2") (param i32 i32) (result i32)
+    (call_indirect (type $bin) (local.get 0) (i32.const 7) (local.get 1)))
+  ;; via1(x, idx): dispatch expecting the 1-arg type.
+  (func (export "via1") (param i32 i32) (result i32)
+    (call_indirect (type $un) (local.get 0) (local.get 1)))
+  (table 5 funcref) (elem (i32.const 0) $add $ld $sub))

--- a/scripts/repro/call_indirect_275_selfcontained_execution_differential.py
+++ b/scripts/repro/call_indirect_275_selfcontained_execution_differential.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""#275 — self-contained `--cortex-m` call_indirect EXECUTION differential.
+
+The finale of #275: the falcon shape — a SELF-CONTAINED Cortex-M image whose
+exports dispatch through a funcref table — must EXECUTE correctly, including
+every WASM Core §4.4.8 trap. RED-FIRST: on the pre-fix main this fails at the
+symbol probe (`via1`/`via2` loud-declined, absent from the image — the #717
+interim); with the flash-resident funcref table (PC-relative dispatch, never
+R11) it is GREEN.
+
+For each (export, index) case both engines run:
+  - wasmtime (oracle): matching dispatches return values; wrong-class calls
+    trap ("indirect call type mismatch"); null slots trap ("uninitialized
+    element"); OOB indices trap ("undefined element").
+  - unicorn (the DEFAULT self-contained image, its OWN Reset_Handler startup —
+    the harness fabricates NOTHING: no table region, no RAM contents beyond
+    what the image's reset path copies): matching calls must equal wasmtime;
+    type-mismatch, null AND OOB cases must all stop AT A UDF (the deterministic
+    §4.4.8 trap idiom), never a stray fault or a wrong value.
+
+Non-collision proof (the #717 root cause): the `via1(x, 1)` dispatch target
+$ld READS LINEAR MEMORY initialized by an active data segment (`x + 42`) —
+correct values prove the funcref table lives outside the R11 linmem region and
+the dispatched function's linmem addressing survived the dispatch.
+
+Non-vacuity: a build without the type check BLXes the wrong-signature function
+and produces a wrong VALUE (via1(x,0) runs $add on one argument) — a mismatch,
+not a vacuous pass; a missing null check BLXes address 0 (fault, distinguished
+from UDF); a missing bounds guard reads past the table.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python \
+      scripts/repro/call_indirect_275_selfcontained_execution_differential.py
+Exits nonzero on a compile decline, missing export, value mismatch, or a trap
+that does not stop at a UDF.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_PC,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("call_indirect_275_selfcontained_execution.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+FLASH, RAM, RAM_SIZE = 0x0000_0000, 0x2000_0000, 0x40000
+RET = 0x000F_0000  # inside the flash map, far past any code
+X = 10
+# Per dispatcher: index -> expected wasmtime outcome category (§4.4.8).
+CASES = {
+    "via2": {"ok": [0, 2], "type": [1], "null": [3, 4], "oob": [5, 99]},
+    "via1": {"ok": [1], "type": [0, 2], "null": [3, 4], "oob": [5, 99]},
+}
+TRAP_REASON = {
+    "type": "indirect call type mismatch",
+    "null": "uninitialized element",
+    "oob": "undefined element",
+}
+
+
+def compile_synth(out: str) -> None:
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "--all-exports",
+         "-b", "arm", "--target", "cortex-m3"],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed: {r.stderr}")
+    if "skipping function" in r.stderr:
+        # The pre-fix #717 interim: call_indirect loud-declined. RED.
+        print(r.stderr)
+        print("\nORACLE: FAIL — dispatchers were loud-declined (the #717 "
+              "interim); self-contained call_indirect did not compile (#275)")
+        sys.exit(1)
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for sy in sec.iter_symbols():
+                if sy.name:
+                    syms[sy.name] = sy["st_value"]
+    return text.data(), text["sh_addr"], syms, f["e_type"]
+
+
+class ImageRunner:
+    """The DEFAULT self-contained image, startup included — one persistent
+    unicorn instance on ZEROED RAM (only the image's own reset path populates
+    it: R11/linmem init + the #758 ROM->RAM data copy)."""
+
+    def __init__(self, code, base, syms):
+        self.code, self.base, self.syms = code, base, syms
+        self.mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+        self.mu.mem_map(FLASH, 0x100000)
+        self.mu.mem_map(RAM, RAM_SIZE)
+        self.mu.mem_map(0xE000E000, 0x1000)  # SCS page
+        self.mu.mem_write(base, code)
+        self.sp = int.from_bytes(code[0:4], "little")
+        reset = syms.get("Reset_Handler")
+        if reset is None:
+            sys.exit("Reset_Handler missing from symtab")
+        # Execute the real startup UP TO the `LDR r0,[pc,#4]; BLX r0` scaffold.
+        stop = code.find(b"\x01\x48\x80\x47", (reset & ~1) - base)
+        if stop < 0:
+            sys.exit("startup call scaffold (LDR r0/BLX r0) not found")
+        self.mu.reg_write(UC_ARM_REG_SP, self.sp)
+        self.mu.emu_start(reset | 1, base + stop, count=100000)
+
+    def call(self, fn, a, b):
+        faddr = self.syms.get(fn)
+        if faddr is None:
+            return f"ERR:symbol {fn} missing"
+        self.mu.reg_write(UC_ARM_REG_SP, self.sp)
+        self.mu.reg_write(UC_ARM_REG_LR, RET | 1)
+        self.mu.reg_write(UC_ARM_REG_R0, a & 0xFFFFFFFF)
+        self.mu.reg_write(UC_ARM_REG_R1, b & 0xFFFFFFFF)
+        try:
+            self.mu.emu_start(faddr | 1, RET, count=100000)
+        except UcError:
+            # Distinguish the deterministic §4.4.8 UDF trap from a stray
+            # fault (e.g. a BLX to address 0 from a missing null check).
+            pc = self.mu.reg_read(UC_ARM_REG_PC)
+            lo = pc - self.base
+            if 0 <= lo < len(self.code) - 1 and self.code[lo:lo + 2] == b"\x00\xde":
+                return "trap:udf"
+            return f"ERR:fault pc={pc:#x}"
+        return self.mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def wasmtime_oracle():
+    """Ground truth: (export, idx) -> value or 'trap:udf'. The CASES table is
+    itself oracle-checked against the §4.4.8 trap reasons, not hand-trusted."""
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_text())
+    results = {}
+    for export, groups in CASES.items():
+        for why, idxs in groups.items():
+            for idx in idxs:
+                store = wasmtime.Store(engine)  # fresh instance per call
+                fn = wasmtime.Instance(store, module, []).exports(store)[export]
+                try:
+                    results[(export, idx)] = fn(store, X, idx) & 0xFFFFFFFF
+                    assert why == "ok", f"{export}({X},{idx}) must trap ({why})"
+                except wasmtime.Trap as t:
+                    reason = TRAP_REASON[why]
+                    assert reason in t.message, (
+                        f"{export}({X},{idx}): expected '{reason}', got {t.message}"
+                    )
+                    results[(export, idx)] = "trap:udf"
+    return results
+
+
+def main() -> int:
+    out = "/tmp/ci275_execution.elf"
+    compile_synth(out)
+    code, base, syms, etype = load(out)
+    print("=== #275 self-contained call_indirect EXECUTION differential ===")
+    if etype != "ET_EXEC":
+        print(f"  [BUG] output is {etype}, not ET_EXEC — not a self-contained image")
+        return 1
+    img = ImageRunner(code, base, syms)
+    gt = wasmtime_oracle()
+    fails = 0
+    for (export, idx), want in sorted(gt.items()):
+        got = img.call(export, X, idx)
+        ok = got == want
+        fails += 0 if ok else 1
+        print(f"  {export}({X},{idx}): wasmtime={want} synth={got} "
+              f"{'OK' if ok else 'MISMATCH'}")
+    if fails == 0:
+        print("ORACLE: PASS — self-contained call_indirect executes + traps "
+              "identically to wasmtime (#275)")
+        return 0
+    print(f"ORACLE: FAIL — {fails} divergence(s) (#275)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

The **last #275 residual** (falcon's blocker): `call_indirect` on the SELF-CONTAINED `--cortex-m` path. The v0.42 interim (#717) loud-declined because the naive dispatch placed the function table via **R11 — the linear-memory base** — a silent miscompile (function "pointers" read from linmem data). This PR converts the decline into a real, non-colliding lowering.

## Design (non-colliding table placement)

- **Table in FLASH**: `build_multi_func_cortex_m_elf` appends the funcref region after the function code (the #758 ROM-image pattern): one 4-byte pointer per slot across all tables in declaration order (**the same contiguous layout as the relocatable R11 contract** — `TableGuards::base_byte_offset` and the #676 sidecar offsets stay valid verbatim), Thumb bit set, null slots as ZERO words, the #676 type-id sidecar after the pointer words.
- **PC-relative dispatch**: the selector (`select_with_stack` only) emits `LdrSym →  __synth_func_table` literal-pool pointers (`Abs32` relocs the builder patches post-layout). **No reserved base register is touched** — not R11 (the #717 collision), not R9/R10, not R12 (encoder scratch, #212). Two callee-saved scratches via `free_callee_saved` (loud `Err` on exhaustion).
- **Trap semantics preserved** (WASM Core §4.4.8, mirroring the relocatable expansion + the div-guard `UDF #0` idiom):
  ```
  MOVW s2,#size [MOVT]; CMP idx,s2; BLO+1; UDF        ; OOB (#642)
  LSL s2,idx,#2
  [LDR s1,=table; ADD; LDR s1,[s1,#type_off]; CMP s1,#id; BEQ+1; UDF]  ; #676 type mismatch
  LDR s1,=table; ADD s1,s1,s2; LDR s1,[s1,#tbl_off]
  [CMP s1,#0; BNE+1; UDF]                              ; #664 null slot
  BLX s1
  ```
- **Enable condition** (never a silent widening): `cortex_m && !relocatable && no imported functions` (CLI) **and** Thumb-2 (backend) — exactly when the builder that emits + patches the table runs. Everything else keeps the loud #275 decline: A32/Cortex-R5 self-contained, the simple-ELF builder, imports (ET_REL), `select_default`.

## Gate (red-first, mechanical)

`scripts/repro/call_indirect_275_selfcontained_execution_differential.py` — the falcon shape (exports dispatching through a heterogeneous 5-slot funcref table), the DEFAULT self-contained image under unicorn (its OWN Reset_Handler; the harness fabricates nothing) vs the wasmtime oracle:

- **RED on origin/main** (verified against a main-built binary): dispatchers loud-skip → exit 1.
- **GREEN here: 14/14** — matching dispatches return wasmtime's values **including a linear-memory-reading target initialized by a #758 data segment (`via1(10,1) = 52`): the direct non-collision proof**; OOB, type-mismatch AND null-slot cases all stop **at a UDF** (never a stray fault / wrong value).
- Multi-table (non-zero base offset, the #650 aliasing canary) additionally hand-verified 10/10 vs wasmtime.

## Decline gates moved, never deleted

- `call_indirect_275_selfcontained_differential.py`: #717 loud-decline gate → emission gate (cortex-m emits table + `entry`) **plus residual-decline gate** (A32/Cortex-R5 self-contained still `#275`-declines loudly; `--relocatable` untouched on both ISAs).
- `crates/synth-cli/tests/call_indirect_275_selfcontained.rs`: same three-way split.
- CI: new `call-indirect-275-selfcontained-oracle` job (both scripts).
- The standalone builder's reloc patch loop is now **kind-dispatched** and loud-bails on anything it can't patch (previously it silently BL-patched every reloc).

## Frozen anchors

- All 110 `scripts/repro/*differential*.py` swept: 21 failures are **pre-existing host-dep** (bit-identical failure set against a main-built binary in the same environment), **0 regressions**.
- Byte-identity old-vs-new binary: self-contained + relocatable outputs for modules **without** call_indirect, and the relocatable call_indirect fixtures (650/664/676) — all identical. The relocatable R11 expansion is untouched.
- `cargo test --workspace` (125 suites) green; fmt + clippy `-D warnings` clean; `claim_check` 21/21.

## Closure status

- **#275 (closed since v0.11.33 for reachability) — its last functional residual, self-contained `--cortex-m` call_indirect, is now CLOSED**: the falcon shape compiles and executes correctly incl. all trap classes. 
- **Named residuals that remain loud declines** (documented + gated, not falcon-blocking): A32/Cortex-R5 self-contained (no flash-table builder there), and self-contained modules with imported functions (ET_REL output owns the table via its host runtime).
- **Found while gating, filed as #791**: the optimized path miscompiles const-only-body functions (result left in r4, never moved to R0) — pre-existing on main, surfaced by the first gate that *executes* dispatch targets in a default image; the new fixture uses param-computing targets so the gate isolates #275 behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L