### PR TITLE
feat(#778): WCET phase 2 — statically-proven loop trip counts + the --wcet-hints sound-checker seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **WCET phase 2 — statically-proven loop bounds + the `--wcet-hints` seam
+  (#778).** `--emit-wcet` now BOUNDS canonical const-bound counted loops
+  instead of declining them: a conservative symbolic walk over the final
+  Thumb-2 stream (`synth-backend/src/wcet_loops.rs`) proves the counted-loop
+  induction — SP-slot counter written exactly once per iteration with a const
+  step, const init on the straight-line entry path, and an exit comparison
+  against a const bound that provably fires (exact i128 trip arithmetic with
+  static no-wrap checks) — and multiplies each region instruction's documented
+  worst-case cycles by the proven execution count (head-test `K+1`,
+  bottom-test `K`, nested regions multiplicative iff every level proves).
+  Byte layout comes from the REAL encoder (the same probe
+  `resolve_label_branches` uses), not `estimate_arm_byte_size` — the estimator
+  under-sizes a high-register `SetCond` (6 vs 10 bytes), which would shear
+  reconstructed branch targets (estimator gap left as a follow-up finding).
+  New `--wcet-hints <file>` (`synth-wcet-hints-v1`) accepts UNTRUSTED
+  per-function loop-bound hints (the scry oracle seam): each hint is verified
+  against synth's own derived trip count and otherwise REJECTED with a machine
+  reason in the sidecar (`hint-below-derived-trip`,
+  `hint-unverifiable-induction`, `hint-unknown-loop`) — never trusted into a
+  bound; equality-exit loops (the termination-brittle shape) bound only under
+  a verified hint, and the emitted trip count is always synth's derived value.
+  Data-dependent loops, non-canonical shapes, calls and i64-software-div keep
+  their loud declines. Sidecar additions are purely additive (`loops` +
+  `hint_rejections` per function); `.text` stays byte-identical with or
+  without `--emit-wcet`/`--wcet-hints`. Gated end-to-end in
+  `wcet_bound_gate.rs`: exact pinned literals + a trip-aware soundness floor
+  (`cycles ≥ trip × region_instr_count`), red-first wrong-hint rejection, and
+  the moved (never deleted) decline matrix; every bounded fixture was
+  additionally executed under unicorn at authoring time (result correct,
+  executed machine instructions ≤ bound).
+
 ## [0.46.0] - 2026-07-16
 
 **Qualification depth + capability breadth.** The sequel to the #757 arc: synth's
@@ -373,7 +406,6 @@ each now oracle-pinned.
   ValueRange premise on the index, the software bounds guard is proven dead and
   elided (ordeal-certified) — gust_poll's guarded path 184 → 104 B (−80 B, eight
   guards), bit-identical to the unguarded floor. Opt-in, flag-off byte-identical.
-
 
 ## [0.42.0] - 2026-07-15
 
@@ -2207,7 +2239,6 @@ Falsification: wrong if gale's mutex lane fails on silicon (native ref 124),
 any previously-compiling module's bytes change, or any pressure lane
 disagrees with wasmtime.
 
-
 ## [0.11.39] - 2026-06-11
 
 **The assurance carrier: a backward-dataflow translation validator now guards
@@ -2236,7 +2267,6 @@ is deleted (VCR-VER-001 executed).**
 Falsification: wrong if the validator accepts a rewrite that changes observable
 behavior (watched by the differential lanes + 98% mutant kill), or if any
 previously-compiling module's bytes change (all fixtures sha-verified).
-
 
 ## [0.11.38] - 2026-06-11
 
@@ -2270,7 +2300,6 @@ Falsification: wrong if any previously-compiling module's bytes change, or
 the high-pressure lane disagrees with wasmtime. The reciprocal-mult
 cost-gate revert experiment (VCR-VER-001 evidence) is now runnable.
 
-
 ## [0.11.37] - 2026-06-11
 
 **RV32 i64 locals + the per-op register-aliasing fix the behavioral oracle
@@ -2302,7 +2331,6 @@ signed-div-const, control_step); ARM fixtures cmp-bit-identical to v0.11.36;
 Falsification: wrong if gale's RV32 funccheck lane disagrees with wasmtime on
 the u64 family or any RV32 baseline regresses. Known + filed separately:
 pre-existing `i64.div_s/rem_s` sign clobber (#317, probe staged).
-
 
 ## [0.11.36] - 2026-06-11
 
@@ -2340,7 +2368,6 @@ unicorn check (count 0->1) and gmutex oracle on the G474RE are the decisive
 gates, plus cycle-neutrality on the rebaselined suite (241/150/151/37). New
 committed oracles: u64_unpack(+inlined).wat differentials,
 native_pointer_shadow_stack differential, test_311_* + shrink_saves_* tests.
-
 
 ## [0.11.35] - 2026-06-09
 
@@ -3190,7 +3217,6 @@ and the i64+calls `z_impl` shape now compile instead of being skipped.
 simultaneously-live i64 values fails to compile with a register-exhaustion error
 instead of spilling.
 
-
 ## [0.11.9] - 2026-05-30
 
 **Call argument marshalling (#195).** `select_with_stack`'s `Call` lowering
@@ -3214,7 +3240,6 @@ no-call param-register clobber class remains #193.
 **Falsification statement.** v0.11.9 is wrong if a call with i32 arguments
 (≤4) invokes the callee without those arguments in r0–r3, or if marshalling
 clobbers a caller-saved value the #188 preservation was meant to save.
-
 
 ## [0.11.8] - 2026-05-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,11 +165,23 @@ frozen and oracle-gated every step:
   EXACT sum of documented Cortex-M3/M4 worst-case per-op cycles (MAX over {M3,M4};
   the sound-critical model constants are `STRAIGHTLINE_CEIL_PER_HALFWORD = 5`,
   `Umull = 5`, `Mls/Mla = 2`, `Sdiv/Udiv = 12`, and the four i64 software
-  div/rem = `LoopedExpansion` decline, pinned in `claims.yaml`); loops, calls,
-  i64-software-div and non-M3/M4 cores (incl. the ambiguous `-eabihf` M4F/M7
-  triple) LOUD-DECLINE with a machine reason. Frozen-safe (`.text` unchanged);
-  gated by `wcet_bound_gate.rs` (bound ≥ actual + decline matrix). Loop-bound
-  inference (scry) + inter-procedural composition are named follow-ups.
+  div/rem = `LoopedExpansion` decline, pinned in `claims.yaml`). Phase 2
+  (v0.47): canonical const-bound counted loops (const init/step/bound, head- or
+  bottom-test, nested-multiplicative, memory-writing bodies) are PROVEN by a
+  conservative symbolic walk over the final stream (`wcet_loops.rs`, real-
+  encoder byte layout — NOT the estimator, whose high-reg `SetCond` sizes
+  drift) and bounded `trip × per-op worst cases`; `--wcet-hints`
+  (`synth-wcet-hints-v1`, UNTRUSTED scry seam) entries are verified against
+  synth's own derived trip and REJECTED with machine reasons
+  (`hint-below-derived-trip` / `hint-unverifiable-induction`) otherwise —
+  equality-exit shapes bound only under a verified hint. Data-dependent
+  loops, non-canonical shapes, calls, i64-software-div and non-M3/M4 cores
+  (incl. the ambiguous `-eabihf` M4F/M7 triple) still LOUD-DECLINE with a
+  machine reason. Frozen-safe (`.text` unchanged, hints byte-invisible);
+  gated by `wcet_bound_gate.rs` (bound ≥ actual + trip-aware floor +
+  red-first hint rejection + decline matrix). Richer hint certificates
+  (data-dependent bounds, scry) + inter-procedural composition are named
+  follow-ups.
 - **Gate `VCR-VER-001`:** DEMONSTRATED (implemented, evidence in
   `scripts/repro/vcr_ver_001_gate.md`) — the v0.11.20 reciprocal-mult
   cost-gate was deleted outright (PR #322, differential bit-identical); the

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -159,9 +159,16 @@ impl Backend for ArmBackend {
 
         // #778: derive the SOUND static WCET bound from the final Thumb-2 stream.
         // Only present for the Thumb-2 path; the core class (from the triple)
-        // decides whether the bound is sound (M3/M4) or declined (M7).
-        let wcet = final_instrs
-            .map(|instrs| crate::wcet::function_wcet(name, &instrs, &config.target.triple));
+        // decides whether the bound is sound (M3/M4) or declined (M7). Phase 2:
+        // any --wcet-hints entry for THIS function is verified (never trusted)
+        // by the loop analyzer.
+        let wcet = final_instrs.map(|instrs| {
+            let hints = config
+                .wcet_hints
+                .as_ref()
+                .and_then(|h| h.functions.get(name));
+            crate::wcet::function_wcet_with_hints(name, &instrs, &config.target.triple, hints)
+        });
 
         Ok(CompiledFunction {
             name: name.to_string(),

--- a/crates/synth-backend/src/lib.rs
+++ b/crates/synth-backend/src/lib.rs
@@ -38,6 +38,7 @@ pub mod reset_handler;
 #[cfg(feature = "arm-cortex-m")]
 pub mod vector_table;
 pub mod wcet;
+mod wcet_loops;
 
 #[cfg(feature = "arm-cortex-m")]
 pub use arm_backend::ArmBackend;

--- a/crates/synth-backend/src/wcet.rs
+++ b/crates/synth-backend/src/wcet.rs
@@ -12,13 +12,17 @@
 //!    given a worst-case number or classified as a looped expansion — the same
 //!    tripwire discipline as `estimator_encoder_agreement.rs`.
 //!
-//! 2. [`function_wcet`] — the loop-free classifier + summation. It reconstructs
-//!    byte positions over the final `arm_instrs` list (the same list the encoder
-//!    consumes), detects any BACKWARD branch (a loop), any residual label branch,
-//!    any call, and any op whose encoder expansion contains an internal runtime
-//!    loop; on any of these it DECLINES. Only a proven-loop-free function — where
-//!    every instruction executes at most once — receives the SUM bound, which is
-//!    then ≥ any real execution.
+//! 2. [`function_wcet`] — the classifier + summation. It reconstructs byte
+//!    positions over the final `arm_instrs` list (the same list the encoder
+//!    consumes), detects any residual label branch, any call, and any op whose
+//!    encoder expansion contains an internal runtime loop; on any of these it
+//!    DECLINES. Backward branches (loops) are handed to the
+//!    [`crate::wcet_loops`] analyzer (#778 phase 2): a loop whose trip count is
+//!    STATICALLY PROVEN (const-initialized counter, const step, const bound,
+//!    canonical single-backward-branch shape) multiplies its instructions'
+//!    worst cases by the proven execution count; anything unproven keeps the
+//!    loud `loop` decline. `--wcet-hints` entries are verified there (and
+//!    rejected with machine reasons when wrong/unverifiable — never trusted).
 //!
 //! The whole computation is a pure observation of an already-decided instruction
 //! list: it touches no `.text`, so the emitted bytes are byte-identical whether or
@@ -39,8 +43,10 @@
 //! entry is justified inline. Since a loop-free function executes every
 //! instruction at most once, a per-instruction over-estimate keeps the SUM sound.
 
-use synth_core::wcet::{WcetDecline, WcetFunction};
+use synth_core::wcet::{WcetDecline, WcetFunction, WcetFunctionHints};
 use synth_synthesis::{ArmInstruction, ArmOp};
+
+use crate::wcet_loops::{LoopAnalysis, analyze_loops};
 
 /// A conservative per-16-bit-halfword ceiling for a straight-line multi-byte
 /// encoder expansion built from ALU/shift/compare/move/short-multiply plus the
@@ -391,27 +397,12 @@ pub fn sound_core_class(triple: &str) -> Option<&'static str> {
     }
 }
 
-/// Reconstruct byte positions and detect whether any branch in `instrs` is a
-/// BACKWARD branch (a loop). Returns the first decline reason found, or `None` if
-/// the function is proven loop-free / call-free / straight-line-priceable.
-///
-/// Byte positions are computed with the SAME `estimate_arm_byte_size` the encoder
-/// agreement oracle pins to the real encoder, so this walk sees the exact final
-/// layout. For each resolved `BOffset`/`BCondOffset` the target is reconstructed
-/// as `branch_pos + 4 + offset*2` (Thumb-2 PC-relative: PC = branch + 4, offset in
-/// halfwords); a target AT OR BEFORE the branch is a backward edge → `Loop`.
+/// Scan for op-class declines: calls, residual label branches, looped
+/// expansions, unmodeled ops. Returns the first decline reason found, or `None`
+/// if every instruction is straight-line-priceable (backward branches — loops —
+/// are NOT a decline here; they are handed to [`crate::wcet_loops`]).
 fn scan_for_decline(instrs: &[ArmInstruction]) -> Option<WcetDecline> {
-    use synth_synthesis::estimate_arm_byte_size;
-
-    // First pass: byte position of each instruction.
-    let mut positions = Vec::with_capacity(instrs.len());
-    let mut pos: i64 = 0;
     for instr in instrs {
-        positions.push(pos);
-        pos += estimate_arm_byte_size(&instr.op) as i64;
-    }
-
-    for (i, instr) in instrs.iter().enumerate() {
         // Op-class declines (call / looped-expansion / unmodeled) come first.
         match &instr.op {
             ArmOp::Bl { .. }
@@ -444,16 +435,6 @@ fn scan_for_decline(instrs: &[ArmInstruction]) -> Option<WcetDecline> {
             }
             _ => {}
         }
-        // Backward-branch (loop) detection on the resolved offset forms.
-        if let ArmOp::BOffset { offset } | ArmOp::BCondOffset { offset, .. } = &instr.op {
-            // Thumb-2 PC-relative: target = (branch_pos + 4) + offset*2 halfwords.
-            // offset is in halfwords; a target <= this branch's position is a loop.
-            // (offset == -1 lands at branch_pos + 2 = the NEXT halfword = forward.)
-            let target = positions[i] + 4 + (*offset as i64) * 2;
-            if target <= positions[i] {
-                return Some(WcetDecline::Loop);
-            }
-        }
     }
     None
 }
@@ -464,22 +445,67 @@ fn scan_for_decline(instrs: &[ArmInstruction]) -> Option<WcetDecline> {
 /// declines with [`WcetDecline::UnsupportedCore`].
 ///
 /// Returns a [`WcetFunction::Bounded`] with the summed worst-case cycles when the
-/// function is proven loop-free / call-free on a soundly-summable core, else a
+/// function is proven loop-free / call-free — or when every loop's trip count is
+/// statically proven (#778 phase 2) — on a soundly-summable core, else a
 /// [`WcetFunction::Declined`] with a machine-readable reason.
 pub fn function_wcet(name: &str, instrs: &[ArmInstruction], triple: &str) -> WcetFunction {
+    function_wcet_with_hints(name, instrs, triple, None)
+}
+
+/// [`function_wcet`] with an optional UNTRUSTED `--wcet-hints` entry for this
+/// function (#778 phase 2, the scry seam). Every hint is soundly verified by
+/// [`crate::wcet_loops`] before use; wrong/unverifiable hints are rejected with
+/// machine reasons in the returned record — never trusted into a bound.
+pub fn function_wcet_with_hints(
+    name: &str,
+    instrs: &[ArmInstruction],
+    triple: &str,
+    hints: Option<&WcetFunctionHints>,
+) -> WcetFunction {
     if sound_core_class(triple).is_none() {
         return WcetFunction::declined(name, WcetDecline::UnsupportedCore);
     }
     if let Some(reason) = scan_for_decline(instrs) {
         return WcetFunction::declined(name, reason);
     }
-    // Proven loop-free: every instruction executes at most once, so the SUM of
-    // per-instruction worst cases is ≥ any real execution.
-    let cycles: u64 = instrs.iter().map(|i| op_worst_case_cycles(&i.op)).sum();
+    // Loop analysis: prove a trip count for every backward-branch region, or
+    // keep the loud `loop` decline.
+    let (multipliers, loops, hint_rejections) = match analyze_loops(instrs, hints) {
+        LoopAnalysis::NoLoops { hint_rejections } => (None, Vec::new(), hint_rejections),
+        LoopAnalysis::Proven {
+            multipliers,
+            loops,
+            hint_rejections,
+        } => (Some(multipliers), loops, hint_rejections),
+        LoopAnalysis::Unproven { hint_rejections } => {
+            return WcetFunction::declined_with_rejections(
+                name,
+                WcetDecline::Loop,
+                hint_rejections,
+            );
+        }
+    };
+    // Every instruction's documented worst case × its proven worst-case
+    // execution count (1 everywhere for a loop-free function). u128 through the
+    // sum so deep nesting cannot silently wrap; an astronomically large product
+    // declines rather than emitting a truncated (unsound) number.
+    let cycles_wide: u128 = instrs
+        .iter()
+        .enumerate()
+        .map(|(i, instr)| {
+            let mult = multipliers.as_ref().map_or(1u128, |m| m[i]);
+            (op_worst_case_cycles(&instr.op) as u128).saturating_mul(mult)
+        })
+        .fold(0u128, u128::saturating_add);
+    let Ok(cycles) = u64::try_from(cycles_wide) else {
+        return WcetFunction::declined_with_rejections(name, WcetDecline::Loop, hint_rejections);
+    };
     WcetFunction::Bounded {
         name: name.to_string(),
         cycles,
         instr_count: instrs.len(),
+        loops,
+        hint_rejections,
     }
 }
 

--- a/crates/synth-backend/src/wcet_loops.rs
+++ b/crates/synth-backend/src/wcet_loops.rs
@@ -1,0 +1,1306 @@
+//! #778 phase 2 (v0.47) — statically-evident loop trip counts + the `--wcet-hints`
+//! sound-checker seam, over the FINAL Thumb-2 instruction stream.
+//!
+//! Phase 1 declined EVERY backward branch. This module upgrades exactly the
+//! shapes it can PROVE and keeps declining everything else:
+//!
+//! - A **loop region** is `[head..=closer]` where `closer` is a backward
+//!   `BOffset`/`BCondOffset` targeting `head`. Regions must nest properly.
+//! - A region is **proven** when a tiny symbolic walk over its body shows the
+//!   canonical counted-loop induction: a counter living in an SP-relative word
+//!   slot, written EXACTLY once per iteration with `old + step` (const step),
+//!   and an exit comparison against a CONST bound that provably fires once the
+//!   counter reaches it (head-test `cmp; b<cond> → resume` or bottom-test
+//!   conditional backward branch). The counter's INIT must be a const store
+//!   found on the straight-line path into the head (function prologue for a
+//!   top-level loop, the parent body for a nested one).
+//! - Every instruction's worst-case cycle cost is then multiplied by its proven
+//!   worst-case execution count: `K+1` for a head-test region (the head check
+//!   runs once more than the body), `K` for a bottom-test region, multiplied
+//!   through nesting. Anything unproven → the function keeps the loud `loop`
+//!   decline.
+//!
+//! ## Soundness argument (why the multiplier is an upper bound)
+//!
+//! For a proven region entered with counter slot value `v`:
+//!
+//! 1. **Single entry**: the global branch discipline (below) guarantees control
+//!    enters the region only at `head` — every other branch in the function is
+//!    either a region closer (targeting its own head) or a region exit
+//!    (targeting exactly its innermost region's fall-through resume point).
+//! 2. **Monotone counter**: the walk proves the ONLY write to the counter slot
+//!    on the straight-line body is `old + step`, and no sub-word/dynamic store
+//!    can alias it (any such store taints the slot and fails the proof). SP
+//!    itself cannot move inside a region (`push`/`pop`/SP-writes decline), and
+//!    non-SP-based stores cannot alias the SP frame: WASM has no address-of-
+//!    local, so synth-generated non-SP stores address the linear-memory/global
+//!    image, which is layout-disjoint from the native stack frame (a sandbox-
+//!    respecting execution — the same precondition the bound already carries).
+//! 3. **Guaranteed exit**: the proven exit predicate `(v + a) REL bound` fires
+//!    by the K-th head evaluation, where `K` is computed from (init, step,
+//!    bound) in exact i64/u64 arithmetic WITH static no-overflow checks over
+//!    the whole counter walk (a wrap would break monotonicity, so any possible
+//!    wrap fails the proof). Early exits (extra conditional exits, traps) only
+//!    REDUCE iteration counts, so ignoring their predicates is conservative.
+//! 4. Anything the walk does not precisely model kills the affected symbolic
+//!    state (registers → Top, flags → unknown, slots → tainted), which can only
+//!    cause a DECLINE, never a smaller bound.
+//!
+//! **Equality exits are hint-gated**: a `(v + a) == bound` exit is the one shape
+//! where an off-by-one (step not dividing the distance) flips terminating into
+//! infinite. synth derives the trip count and verifies divisibility, but only
+//! CONSUMES it when an explicit `--wcet-hints` entry asserts a bound the derived
+//! count respects (`derived ≤ hint`) — the scry-oracle seam: the untrusted hint
+//! asserts intent, synth's checker re-derives and cross-checks, and the emitted
+//! trip count is always synth's own derived value, never the raw hint. A hint
+//! below the derived count, or on a loop whose induction synth cannot verify
+//! (data-dependent bound, non-canonical shape), is REJECTED with a machine
+//! reason and never trusted into a bound.
+
+use std::collections::BTreeMap;
+
+use synth_core::wcet::{
+    WcetFunctionHints, WcetHintReject, WcetHintRejection, WcetLoopBound, WcetLoopBoundSource,
+};
+use synth_synthesis::{ArmInstruction, ArmOp, Condition, Operand2, Reg};
+
+/// Result of the loop analysis over one function's final instruction stream.
+pub(crate) enum LoopAnalysis {
+    /// No backward branches — the plain loop-free sum applies (multiplier 1).
+    NoLoops {
+        hint_rejections: Vec<WcetHintRejection>,
+    },
+    /// EVERY loop region proved a trip count: per-instruction execution-count
+    /// multipliers (product of enclosing region factors, u128 to survive
+    /// nesting) plus the per-loop bound records for the sidecar.
+    Proven {
+        multipliers: Vec<u128>,
+        loops: Vec<WcetLoopBound>,
+        hint_rejections: Vec<WcetHintRejection>,
+    },
+    /// At least one region could not be proven — the function keeps the loud
+    /// `loop` decline; any offered hints that were rejected are recorded.
+    Unproven {
+        hint_rejections: Vec<WcetHintRejection>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Symbolic domain
+// ---------------------------------------------------------------------------
+
+/// Comparison relation of a predicate over the counter, by signedness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Rel {
+    Eq,
+    Ne,
+    LtS,
+    LeS,
+    GtS,
+    GeS,
+    LoU,
+    LsU,
+    HiU,
+    HsU,
+}
+
+impl Rel {
+    fn of(cond: Condition) -> Rel {
+        match cond {
+            Condition::EQ => Rel::Eq,
+            Condition::NE => Rel::Ne,
+            Condition::LT => Rel::LtS,
+            Condition::LE => Rel::LeS,
+            Condition::GT => Rel::GtS,
+            Condition::GE => Rel::GeS,
+            Condition::LO => Rel::LoU,
+            Condition::LS => Rel::LsU,
+            Condition::HI => Rel::HiU,
+            Condition::HS => Rel::HsU,
+        }
+    }
+
+    /// Logical negation over the same operands.
+    fn negate(self) -> Rel {
+        match self {
+            Rel::Eq => Rel::Ne,
+            Rel::Ne => Rel::Eq,
+            Rel::LtS => Rel::GeS,
+            Rel::GeS => Rel::LtS,
+            Rel::LeS => Rel::GtS,
+            Rel::GtS => Rel::LeS,
+            Rel::LoU => Rel::HsU,
+            Rel::HsU => Rel::LoU,
+            Rel::LsU => Rel::HiU,
+            Rel::HiU => Rel::LsU,
+        }
+    }
+}
+
+/// A boolean predicate over the counter slot's REGION-ENTRY value `v`:
+/// `(v + add) REL rhs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Pred {
+    /// SP-relative byte offset of the counter slot this predicate reads.
+    off: i64,
+    /// Constant added to the entry value before the comparison.
+    add: i64,
+    rel: Rel,
+    rhs: i32,
+}
+
+impl Pred {
+    fn negate(self) -> Pred {
+        Pred {
+            rel: self.rel.negate(),
+            ..self
+        }
+    }
+}
+
+/// Symbolic register/slot value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Sym {
+    /// Unknown.
+    Top,
+    /// A compile-time constant (i32 bit pattern).
+    Const(i32),
+    /// `(value of [sp,#off] at region entry) + add`.
+    Slot { off: i64, add: i64 },
+    /// A 0/1 boolean holding `pred`.
+    Bool(Pred),
+}
+
+/// Walk state: symbolic registers, slot writes since walk start, tainted slots
+/// (unreliable after a sub-word/unaligned store), and the last compare.
+#[derive(Clone)]
+struct WalkState {
+    regs: [Sym; 16],
+    /// Word-aligned SP-relative offsets written during THIS walk.
+    written: BTreeMap<i64, Sym>,
+    /// Offsets whose content is unreliable (sub-word overlap). A later full
+    /// word store un-taints (it fully replaces the slot).
+    tainted: std::collections::BTreeSet<i64>,
+    /// Operands of the last flag-setting compare, when precisely known.
+    flags: Option<(Sym, Sym)>,
+}
+
+impl WalkState {
+    fn fresh() -> Self {
+        WalkState {
+            regs: [Sym::Top; 16],
+            written: BTreeMap::new(),
+            tainted: std::collections::BTreeSet::new(),
+            flags: None,
+        }
+    }
+
+    fn reg(&self, r: Reg) -> Sym {
+        self.regs[r as usize]
+    }
+
+    fn set_reg(&mut self, r: Reg, v: Sym) {
+        self.regs[r as usize] = v;
+    }
+
+    fn kill_all_regs(&mut self) {
+        self.regs = [Sym::Top; 16];
+    }
+
+    fn op2(&self, op2: &Operand2) -> Sym {
+        match op2 {
+            Operand2::Imm(c) => Sym::Const(*c),
+            Operand2::Reg(r) => self.reg(*r),
+            Operand2::RegShift { .. } => Sym::Top,
+        }
+    }
+
+    /// Read a word slot `[sp,#off]`: the value written during this walk, else
+    /// the symbolic entry value `Slot{off,0}`.
+    fn read_slot(&self, off: i64) -> Sym {
+        if off % 4 != 0 || self.tainted.contains(&off) {
+            return Sym::Top;
+        }
+        self.written
+            .get(&off)
+            .copied()
+            .unwrap_or(Sym::Slot { off, add: 0 })
+    }
+
+    fn write_slot_word(&mut self, off: i64, v: Sym) {
+        if off % 4 == 0 {
+            // A full word store replaces the slot entirely — un-taint.
+            self.tainted.remove(&off);
+            self.written.insert(off, v);
+        } else {
+            // Unaligned word store touches two words: taint both.
+            self.taint_range(off, 4);
+        }
+    }
+
+    /// Mark every word overlapping `[off, off+width)` unreliable.
+    fn taint_range(&mut self, off: i64, width: i64) {
+        let first = off & !3;
+        let last = (off + width - 1) & !3;
+        let mut w = first;
+        while w <= last {
+            self.written.remove(&w);
+            self.tainted.insert(w);
+            w += 4;
+        }
+    }
+}
+
+/// Evaluate the predicate a condition computes over the last compare.
+fn eval_pred(cond: Condition, flags: &Option<(Sym, Sym)>) -> Option<Pred> {
+    let (a, b) = flags.as_ref()?;
+    match (a, b) {
+        (Sym::Slot { off, add }, Sym::Const(c)) => Some(Pred {
+            off: *off,
+            add: *add,
+            rel: Rel::of(cond),
+            rhs: *c,
+        }),
+        // `cmp <bool>, #0` — the eqz / br_if lowering shape.
+        (Sym::Bool(p), Sym::Const(0)) => match cond {
+            Condition::EQ => Some(p.negate()),
+            Condition::NE => Some(*p),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Regions
+// ---------------------------------------------------------------------------
+
+/// The exit shape a region's trip count is derived from.
+#[derive(Debug, Clone, Copy)]
+enum ExitShape {
+    /// Head-test: unconditional backward closer; `pred` (on some forward exit
+    /// branch) is TRUE ⇒ control leaves the region. Factor = K + 1.
+    HeadTest(Pred),
+    /// Bottom-test: conditional backward closer; `pred` TRUE ⇒ another
+    /// iteration. Factor = K.
+    BottomTest(Pred),
+}
+
+struct Region {
+    /// Instruction index of the loop head (backward-branch target).
+    head: usize,
+    /// Instruction index of the closing backward branch.
+    closer: usize,
+    /// `Some(cond)` when the closer is a conditional (bottom-test) branch.
+    closer_cond: Option<Condition>,
+    /// Immediate children (indices into the region vec), ascending head.
+    children: Vec<usize>,
+    /// Whether some other region directly contains this one.
+    has_parent: bool,
+    // --- proof results ---
+    /// Counter slot offset, step, and exit shape (from the structure walk).
+    proof: Option<(i64, i64, ExitShape)>,
+    /// Constant initial counter value (resolved by the enclosing walk).
+    init: Option<i32>,
+    /// Proven trip count (body executions) + whether it is hint-gated.
+    trip: Option<(u64, bool)>,
+    /// Per-iteration execution-count factor for instructions in this region.
+    factor: u128,
+}
+
+/// Analyze the loop structure of `instrs`. `hints` is the (already
+/// name-matched) UNTRUSTED per-function hint entry, if any.
+pub(crate) fn analyze_loops(
+    instrs: &[ArmInstruction],
+    hints: Option<&WcetFunctionHints>,
+) -> LoopAnalysis {
+    // Byte positions from the REAL encoder — the SAME source of truth
+    // `resolve_label_branches` computed the `BOffset`/`BCondOffset` halfword
+    // displacements against. (The `estimate_arm_byte_size` estimator is NOT
+    // exact for every op — e.g. a high-register `SetCond` widens its IT-block
+    // MOVs to 10 bytes where the estimate is 6 — and a drifted layout would
+    // reconstruct branch targets off-by-N, so the estimator must not be used
+    // here.) Any op the encoder refuses → conservatively unproven.
+    let n = instrs.len();
+    let encoder = crate::arm_encoder::ArmEncoder::new_thumb2();
+    let mut sizes: Vec<i64> = Vec::with_capacity(n);
+    for instr in instrs {
+        match encoder.encode(&instr.op) {
+            Ok(bytes) => sizes.push(bytes.len() as i64),
+            Err(_) => return unproven(hints, &[]),
+        }
+    }
+    let mut positions = Vec::with_capacity(n);
+    let mut pos: i64 = 0;
+    for &sz in &sizes {
+        positions.push(pos);
+        pos += sz;
+    }
+    // Byte offset → FIRST instruction index at that offset (labels are 0-size).
+    let mut idx_at: BTreeMap<i64, usize> = BTreeMap::new();
+    for (i, &p) in positions.iter().enumerate() {
+        idx_at.entry(p).or_insert(i);
+    }
+    let target_byte = |i: usize, offset: i32| positions[i] + 4 + (offset as i64) * 2;
+
+    // ---- collect regions from backward branches ----
+    let mut regions: Vec<Region> = Vec::new();
+    for (i, instr) in instrs.iter().enumerate() {
+        let (offset, cond) = match &instr.op {
+            ArmOp::BOffset { offset } => (*offset, None),
+            ArmOp::BCondOffset { cond, offset } => (*offset, Some(*cond)),
+            _ => continue,
+        };
+        let tgt = target_byte(i, offset);
+        if tgt > positions[i] {
+            continue; // forward — validated by the branch discipline below
+        }
+        let Some(&head) = idx_at.get(&tgt) else {
+            return unproven(hints, &[]); // target not at an instruction start
+        };
+        if head > i {
+            return unproven(hints, &[]);
+        }
+        regions.push(Region {
+            head,
+            closer: i,
+            closer_cond: cond,
+            children: Vec::new(),
+            has_parent: false,
+            proof: None,
+            init: None,
+            trip: None,
+            factor: 1,
+        });
+    }
+    if regions.is_empty() {
+        // Loop-free: any hints offered for this function address nonexistent
+        // loops — reject them loudly rather than silently ignoring them.
+        return LoopAnalysis::NoLoops {
+            hint_rejections: reject_extra_hints(hints, 0, &[]),
+        };
+    }
+
+    // Loop order for hint indexing + the sidecar: ascending head byte offset.
+    regions.sort_by_key(|r| (positions[r.head], r.closer));
+    let head_offsets: Vec<i64> = regions.iter().map(|r| positions[r.head]).collect();
+
+    // ---- structural sanity: distinct heads, proper nesting ----
+    for w in regions.windows(2) {
+        if w[0].head == w[1].head {
+            return unproven(hints, &head_offsets);
+        }
+    }
+    for a in 0..regions.len() {
+        for b in 0..regions.len() {
+            if a == b {
+                continue;
+            }
+            let (ra, rb) = (&regions[a], &regions[b]);
+            let disjoint = ra.closer < rb.head || rb.closer < ra.head;
+            let a_in_b = rb.head < ra.head && ra.closer < rb.closer;
+            let b_in_a = ra.head < rb.head && rb.closer < ra.closer;
+            if !(disjoint || a_in_b || b_in_a) {
+                return unproven(hints, &head_offsets);
+            }
+        }
+    }
+    // Parent/child links (immediate containment).
+    for a in 0..regions.len() {
+        let mut parent: Option<usize> = None;
+        for b in 0..regions.len() {
+            if b == a {
+                continue;
+            }
+            if regions[b].head < regions[a].head && regions[a].closer < regions[b].closer {
+                // b contains a; keep the tightest.
+                if parent.is_none_or(|p| {
+                    regions[b].closer - regions[b].head < regions[p].closer - regions[p].head
+                }) {
+                    parent = Some(b);
+                }
+            }
+        }
+        if let Some(p) = parent {
+            regions[a].has_parent = true;
+            regions[p].children.push(a);
+        }
+    }
+    for r in &mut regions {
+        r.children.sort_by_key(|&c| c); // regions vec is head-sorted already
+    }
+
+    // ---- global branch discipline ----
+    // Every branch must be (a) a region closer, or (b) a forward conditional
+    // branch inside a region targeting EXACTLY its innermost region's resume
+    // point (the byte after the closer). Anything else → unproven.
+    let innermost_of = |i: usize| -> Option<usize> {
+        regions
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| r.head <= i && i <= r.closer)
+            .min_by_key(|(_, r)| r.closer - r.head)
+            .map(|(k, _)| k)
+    };
+    for (i, instr) in instrs.iter().enumerate() {
+        let (offset, is_cond) = match &instr.op {
+            ArmOp::BOffset { offset } => (*offset, false),
+            ArmOp::BCondOffset { offset, .. } => (*offset, true),
+            _ => continue,
+        };
+        if regions.iter().any(|r| r.closer == i) {
+            continue; // a closer — backward to its own head by construction
+        }
+        let tgt = target_byte(i, offset);
+        if tgt <= positions[i] {
+            return unproven(hints, &head_offsets); // backward non-closer (unreachable)
+        }
+        if !is_cond {
+            return unproven(hints, &head_offsets); // forward unconditional (if/else) — non-canonical
+        }
+        let Some(rid) = innermost_of(i) else {
+            return unproven(hints, &head_offsets); // conditional CF outside any loop
+        };
+        let resume = positions[regions[rid].closer] + sizes[regions[rid].closer];
+        if tgt != resume {
+            return unproven(hints, &head_offsets); // mid-region or multi-level exit
+        }
+    }
+
+    // ---- per-region hard checks: nothing may move SP inside a region ----
+    for r in &regions {
+        for instr in &instrs[r.head..=r.closer] {
+            match &instr.op {
+                ArmOp::Push { .. } | ArmOp::Pop { .. } | ArmOp::Bx { .. } => {
+                    return unproven(hints, &head_offsets);
+                }
+                op => {
+                    if writes_sp(op) {
+                        return unproven(hints, &head_offsets);
+                    }
+                    // A dynamic or non-word-offset SP store inside a region is
+                    // handled by the walk (it taints), but a dynamic SP STORE
+                    // could alias ANY slot — refuse outright.
+                    if let ArmOp::Str { addr, .. }
+                    | ArmOp::Strb { addr, .. }
+                    | ArmOp::Strh { addr, .. } = op
+                        && addr.base == Reg::SP
+                        && addr.offset_reg.is_some()
+                    {
+                        return unproven(hints, &head_offsets);
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- structure walks, innermost first ----
+    let mut order: Vec<usize> = (0..regions.len()).collect();
+    order.sort_by_key(|&k| regions[k].closer - regions[k].head);
+    for k in order {
+        if !prove_region_structure(&mut regions, k, instrs) {
+            return unproven(hints, &head_offsets);
+        }
+    }
+
+    // ---- function-level walk: resolve top-level regions' inits ----
+    if !resolve_toplevel_inits(&mut regions, instrs) {
+        return unproven(hints, &head_offsets);
+    }
+
+    // ---- trip counts ----
+    for r in &mut regions {
+        let (Some((_, step, shape)), Some(init)) = (r.proof, r.init) else {
+            r.trip = None;
+            continue;
+        };
+        r.trip = match shape {
+            ExitShape::HeadTest(p) => exit_index(init, step, &p),
+            ExitShape::BottomTest(p) => {
+                // Body n (n ≥ 1) enters with v = init + (n−1)·step and repeats
+                // while `pred` holds. K = 1 + (first m ≥ 0 where ¬pred fires).
+                exit_index(init, step, &p.negate())
+                    .and_then(|(m, h)| m.checked_add(1).map(|k| (k, h)))
+            }
+        };
+    }
+
+    // ---- hints: verify / reject (the scry seam) ----
+    let mut rejections: Vec<WcetHintRejection> = Vec::new();
+    let empty = Vec::new();
+    let hint_list: &Vec<Option<u64>> = hints.map_or(&empty, |h| &h.loop_bounds);
+    let mut loops_out: Vec<WcetLoopBound> = Vec::new();
+    let mut all_proven = true;
+    for (idx, r) in regions.iter_mut().enumerate() {
+        let hint = hint_list.get(idx).copied().flatten();
+        let head_off = positions[r.head] as u64;
+        let (accepted, source): (Option<u64>, WcetLoopBoundSource) = match (r.trip, hint) {
+            // Fully static proof; no hint offered.
+            (Some((k, false)), None) => (Some(k), WcetLoopBoundSource::Static),
+            // Static proof + hint: the hint is cross-checked. A hint BELOW the
+            // derived trip is a wrong oracle claim — reject it loudly (the
+            // static bound stands on synth's own proof).
+            (Some((k, false)), Some(h)) => {
+                if h < k {
+                    rejections.push(rejection(
+                        idx,
+                        Some(head_off),
+                        h,
+                        WcetHintReject::HintBelowDerivedTrip,
+                    ));
+                }
+                (Some(k), WcetLoopBoundSource::Static)
+            }
+            // Equality-exit (hint-gated): unhinted → keep the decline.
+            (Some((_, true)), None) => (None, WcetLoopBoundSource::Static),
+            // Equality-exit with a hint: consume ONLY if derived ≤ hint.
+            (Some((k, true)), Some(h)) => {
+                if k <= h {
+                    (Some(k), WcetLoopBoundSource::HintVerified)
+                } else {
+                    rejections.push(rejection(
+                        idx,
+                        Some(head_off),
+                        h,
+                        WcetHintReject::HintBelowDerivedTrip,
+                    ));
+                    (None, WcetLoopBoundSource::Static)
+                }
+            }
+            // Unproven induction: any hint is unverifiable — never trusted.
+            (None, Some(h)) => {
+                rejections.push(rejection(
+                    idx,
+                    Some(head_off),
+                    h,
+                    WcetHintReject::HintUnverifiableInduction,
+                ));
+                (None, WcetLoopBoundSource::Static)
+            }
+            (None, None) => (None, WcetLoopBoundSource::Static),
+        };
+        match accepted {
+            Some(k) => {
+                r.factor = match r.closer_cond {
+                    // Head-test: the head check runs K+1 times.
+                    None => k as u128 + 1,
+                    // Bottom-test: every region instruction runs exactly K times.
+                    Some(_) => (k as u128).max(1),
+                };
+                loops_out.push(WcetLoopBound {
+                    head_offset: head_off,
+                    trip_count: k,
+                    region_instr_count: r.closer - r.head + 1,
+                    source,
+                    hint: match source {
+                        WcetLoopBoundSource::HintVerified => hint,
+                        WcetLoopBoundSource::Static => None,
+                    },
+                });
+            }
+            None => all_proven = false,
+        }
+    }
+    rejections.extend(reject_extra_hints(hints, regions.len(), &head_offsets));
+
+    if !all_proven {
+        return LoopAnalysis::Unproven {
+            hint_rejections: rejections,
+        };
+    }
+
+    // ---- per-instruction multipliers ----
+    let mut multipliers = vec![1u128; n];
+    for r in &regions {
+        for m in multipliers.iter_mut().take(r.closer + 1).skip(r.head) {
+            *m = m.saturating_mul(r.factor);
+        }
+    }
+    LoopAnalysis::Proven {
+        multipliers,
+        loops: loops_out,
+        hint_rejections: rejections,
+    }
+}
+
+fn rejection(
+    loop_index: usize,
+    head_offset: Option<u64>,
+    hint: u64,
+    reason: WcetHintReject,
+) -> WcetHintRejection {
+    let note = reason.note().to_string();
+    WcetHintRejection {
+        loop_index,
+        head_offset,
+        hint,
+        reason,
+        note,
+    }
+}
+
+/// Reject hint entries beyond the function's real loop count.
+fn reject_extra_hints(
+    hints: Option<&WcetFunctionHints>,
+    loop_count: usize,
+    _head_offsets: &[i64],
+) -> Vec<WcetHintRejection> {
+    let Some(h) = hints else {
+        return Vec::new();
+    };
+    h.loop_bounds
+        .iter()
+        .enumerate()
+        .skip(loop_count)
+        .filter_map(|(i, b)| b.map(|v| rejection(i, None, v, WcetHintReject::HintUnknownLoop)))
+        .collect()
+}
+
+/// Unproven WITHOUT any structure info: every offered hint is unverifiable.
+fn unproven(hints: Option<&WcetFunctionHints>, head_offsets: &[i64]) -> LoopAnalysis {
+    let rejections = hints
+        .map(|h| {
+            h.loop_bounds
+                .iter()
+                .enumerate()
+                .filter_map(|(i, b)| {
+                    b.map(|v| {
+                        rejection(
+                            i,
+                            head_offsets.get(i).map(|&o| o as u64),
+                            v,
+                            WcetHintReject::HintUnverifiableInduction,
+                        )
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    LoopAnalysis::Unproven {
+        hint_rejections: rejections,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Structure walk
+// ---------------------------------------------------------------------------
+
+/// Prove region `k`'s induction structure: counter slot, const step, exit
+/// predicate. Children must already be proven (innermost-first order); their
+/// inits are resolved here (a child's init store lives in THIS region's body).
+fn prove_region_structure(regions: &mut [Region], k: usize, instrs: &[ArmInstruction]) -> bool {
+    let (head, closer) = (regions[k].head, regions[k].closer);
+    let mut st = WalkState::fresh();
+    // (off, sym, order) of every word SP store on the region's own body.
+    let mut store_events: Vec<(i64, Sym)> = Vec::new();
+    // Exit predicates from forward conditional exits (branch TAKEN ⇒ leave).
+    let mut exits: Vec<Option<Pred>> = Vec::new();
+
+    let mut i = head;
+    while i <= closer {
+        // Child region: resolve its init from the current state, then skip it.
+        if let Some(&c) = regions[k].children.iter().find(|&&c| regions[c].head == i) {
+            let c_off = match regions[c].proof {
+                Some((off, _, _)) => off,
+                None => return false, // child unproven → parent unprovable
+            };
+            match st.read_slot(c_off) {
+                Sym::Const(init) => {
+                    // The same const init is stored on the straight-line path
+                    // before the child head on EVERY parent iteration.
+                    regions[c].init = Some(init);
+                }
+                _ => return false,
+            }
+            // Kill everything the child may change: registers (its body uses
+            // scratch freely), flags, and every slot it stores to.
+            st.kill_all_regs();
+            st.flags = None;
+            for instr in &instrs[regions[c].head..=regions[c].closer] {
+                match &instr.op {
+                    ArmOp::Str { addr, .. } if addr.base == Reg::SP => {
+                        st.taint_range(addr.offset as i64, 4);
+                    }
+                    ArmOp::Strb { addr, .. } if addr.base == Reg::SP => {
+                        st.taint_range(addr.offset as i64, 1);
+                    }
+                    ArmOp::Strh { addr, .. } if addr.base == Reg::SP => {
+                        st.taint_range(addr.offset as i64, 2);
+                    }
+                    _ => {}
+                }
+            }
+            i = regions[c].closer + 1;
+            continue;
+        }
+
+        let instr = &instrs[i];
+        match &instr.op {
+            ArmOp::BOffset { .. } if i == closer => break, // head-test closer
+            ArmOp::BCondOffset { cond, .. } if i == closer => {
+                // Bottom-test closer: TAKEN ⇒ another iteration.
+                let Some(p) = eval_pred(*cond, &st.flags) else {
+                    return false;
+                };
+                let Some((off, step, _)) = counter_candidate(&st, &store_events, &[Some(p)]) else {
+                    return false;
+                };
+                if p.off != off {
+                    return false;
+                }
+                regions[k].proof = Some((off, step, ExitShape::BottomTest(p)));
+                return true;
+            }
+            ArmOp::BCondOffset { cond, .. } => {
+                // Forward exit (global discipline verified the target). TAKEN ⇒
+                // leave the region; fall through otherwise. Unknown predicates
+                // are early exits — sound to ignore.
+                exits.push(eval_pred(*cond, &st.flags));
+            }
+            ArmOp::BOffset { .. } => return false, // forward BOffset inside region
+            op => sym_step(op, &mut st, &mut store_events),
+        }
+        i += 1;
+    }
+
+    // Head-test: pick the counter/exit pair.
+    let Some((off, step, pred)) = counter_candidate(&st, &store_events, &exits) else {
+        return false;
+    };
+    regions[k].proof = Some((off, step, ExitShape::HeadTest(pred)));
+    true
+}
+
+/// Find the counter slot: a word slot written EXACTLY once on the body with
+/// `entry + step` (step ≠ 0), still holding that value at the end of the walk
+/// (no child kill, no taint), that some usable exit predicate reads.
+fn counter_candidate(
+    st: &WalkState,
+    store_events: &[(i64, Sym)],
+    exits: &[Option<Pred>],
+) -> Option<(i64, i64, Pred)> {
+    for p in exits.iter().flatten() {
+        let off = p.off;
+        if st.tainted.contains(&off) {
+            continue;
+        }
+        let events: Vec<&Sym> = store_events
+            .iter()
+            .filter(|(o, _)| *o == off)
+            .map(|(_, s)| s)
+            .collect();
+        if events.len() != 1 {
+            continue;
+        }
+        let Sym::Slot { off: so, add: step } = *events[0] else {
+            continue;
+        };
+        if so != off || step == 0 {
+            continue;
+        }
+        // The final state must still show the increment (nothing killed it).
+        if st.written.get(&off) != Some(&Sym::Slot { off, add: step }) {
+            continue;
+        }
+        return Some((off, step, *p));
+    }
+    None
+}
+
+/// One symbolic step for a non-control op. Precisely models the ops the
+/// canonical counted-loop chain is built from; everything else conservatively
+/// kills exactly what it can define (or all registers for multi-instruction
+/// encoder expansions with scratch clobbers).
+fn sym_step(op: &ArmOp, st: &mut WalkState, store_events: &mut Vec<(i64, Sym)>) {
+    use ArmOp::*;
+    match op {
+        Mov { rd, op2 } => {
+            let v = st.op2(op2);
+            st.set_reg(*rd, v);
+            st.flags = None; // 16-bit MOVS immediate sets flags
+        }
+        Movw { rd, imm16 } => {
+            st.set_reg(*rd, Sym::Const(*imm16 as i32));
+            st.flags = None;
+        }
+        Add { rd, rn, op2 } | Adds { rd, rn, op2 } => {
+            let v = sym_add(st.reg(*rn), st.op2(op2), 1);
+            st.set_reg(*rd, v);
+            st.flags = None; // ADDS sets flags; we don't model add-flags
+        }
+        Sub { rd, rn, op2 } | Subs { rd, rn, op2 } => {
+            let v = sym_add(st.reg(*rn), st.op2(op2), -1);
+            st.set_reg(*rd, v);
+            st.flags = None;
+        }
+        Ldr { rd, addr } => {
+            let v = if addr.base == Reg::SP && addr.offset_reg.is_none() {
+                st.read_slot(addr.offset as i64)
+            } else {
+                Sym::Top
+            };
+            st.set_reg(*rd, v);
+            // Loads never set flags.
+        }
+        Ldrb { rd, addr } | Ldrh { rd, addr } | Ldrsb { rd, addr } | Ldrsh { rd, addr } => {
+            let _ = addr;
+            st.set_reg(*rd, Sym::Top);
+        }
+        LdrSym { rd, .. } => st.set_reg(*rd, Sym::Top),
+        Str { rd, addr } => {
+            if addr.base == Reg::SP {
+                if addr.offset_reg.is_none() {
+                    let off = addr.offset as i64;
+                    let v = st.reg(*rd);
+                    st.write_slot_word(off, v);
+                    if off % 4 == 0 {
+                        store_events.push((off, v));
+                    }
+                } else {
+                    // Dynamic SP store (pre-declined inside regions; harden
+                    // anyway): could alias anything.
+                    let offs: Vec<i64> = st.written.keys().copied().collect();
+                    for o in offs {
+                        st.taint_range(o, 4);
+                    }
+                }
+            }
+            // Non-SP stores address the linear-memory/global image — layout-
+            // disjoint from the SP frame (see module doc, soundness point 2).
+        }
+        Strb { rd: _, addr } => {
+            if addr.base == Reg::SP && addr.offset_reg.is_none() {
+                st.taint_range(addr.offset as i64, 1);
+            }
+        }
+        Strh { rd: _, addr } => {
+            if addr.base == Reg::SP && addr.offset_reg.is_none() {
+                st.taint_range(addr.offset as i64, 2);
+            }
+        }
+        Cmp { rn, op2 } => {
+            st.flags = Some((st.reg(*rn), st.op2(op2)));
+        }
+        Cmn { .. } => st.flags = None,
+        SetCond { rd, cond } => {
+            // IT + MOV + MOV: writes rd, PRESERVES the compare's flags.
+            let v = eval_pred(*cond, &st.flags).map_or(Sym::Top, Sym::Bool);
+            st.set_reg(*rd, v);
+        }
+        SelectMove { rd, .. } => {
+            st.set_reg(*rd, Sym::Top); // conditional write — value unknown
+        }
+        Label { .. } | Nop => {}
+        Udf { .. } => {
+            // Execution faults and never continues — over-approximating as a
+            // state kill is sound.
+            st.kill_all_regs();
+            st.flags = None;
+        }
+        // Single-register-destination ALU ops: kill exactly rd.
+        And { rd, .. }
+        | Orr { rd, .. }
+        | Eor { rd, .. }
+        | Rsb { rd, .. }
+        | Mvn { rd, .. }
+        | Adc { rd, .. }
+        | Sbc { rd, .. }
+        | Movt { rd, .. }
+        | MovwSym { rd, .. }
+        | MovtSym { rd, .. }
+        | Clz { rd, .. }
+        | Rbit { rd, .. }
+        | Sxtb { rd, .. }
+        | Sxth { rd, .. }
+        | Uxtb { rd, .. }
+        | Uxth { rd, .. }
+        | Lsl { rd, .. }
+        | Lsr { rd, .. }
+        | Asr { rd, .. }
+        | Ror { rd, .. }
+        | LslReg { rd, .. }
+        | LsrReg { rd, .. }
+        | AsrReg { rd, .. }
+        | RorReg { rd, .. }
+        | Mul { rd, .. }
+        | Mla { rd, .. }
+        | Mls { rd, .. }
+        | Sdiv { rd, .. }
+        | Udiv { rd, .. } => {
+            st.set_reg(*rd, Sym::Top);
+            st.flags = None;
+        }
+        Umull { rdlo, rdhi, .. } => {
+            st.set_reg(*rdlo, Sym::Top);
+            st.set_reg(*rdhi, Sym::Top);
+            st.flags = None;
+        }
+        // Everything else (multi-instruction encoder expansions clobber scratch
+        // registers not named in the op; off-path pseudos never reach here):
+        // kill all registers and flags. Slots survive — only Str*/Push write
+        // the SP frame, and Push/Pop are pre-declined inside regions.
+        _ => {
+            st.kill_all_regs();
+            st.flags = None;
+        }
+    }
+}
+
+/// Symbolic add/sub: `a + sign·b` when it stays exactly representable.
+fn sym_add(a: Sym, b: Sym, sign: i64) -> Sym {
+    match (a, b) {
+        (Sym::Const(x), Sym::Const(y)) => {
+            let r = x as i64 + sign * y as i64;
+            i32::try_from(r).map_or(Sym::Top, Sym::Const)
+        }
+        (Sym::Slot { off, add }, Sym::Const(y)) => {
+            match add.checked_add(sign * y as i64) {
+                // Keep the affine offset well inside i64 so later trip math in
+                // i128 cannot overflow.
+                Some(na) if na.abs() <= 1 << 33 => Sym::Slot { off, add: na },
+                _ => Sym::Top,
+            }
+        }
+        (Sym::Const(x), Sym::Slot { off, add }) if sign == 1 => match add.checked_add(x as i64) {
+            Some(na) if na.abs() <= 1 << 33 => Sym::Slot { off, add: na },
+            _ => Sym::Top,
+        },
+        _ => Sym::Top,
+    }
+}
+
+/// `writes_sp` — does this op define SP? (Loop regions refuse any SP motion;
+/// the function-level walk re-bases on the immediate push/pop/add/sub forms and
+/// gives up on anything else.) Exhaustive over every `rd`-carrying op the
+/// priced instruction set can contain; multi-instruction encoder expansions
+/// never target SP (audited: arithmetic scratch only, I64Popcnt's push/pop is
+/// SP-net-zero and it is a whole-function `LoopedExpansion` decline anyway).
+fn writes_sp(op: &ArmOp) -> bool {
+    use ArmOp::*;
+    match op {
+        Add { rd, .. }
+        | Sub { rd, .. }
+        | Adds { rd, .. }
+        | Subs { rd, .. }
+        | Adc { rd, .. }
+        | Sbc { rd, .. }
+        | Mov { rd, .. }
+        | Mvn { rd, .. }
+        | Movw { rd, .. }
+        | Movt { rd, .. }
+        | MovwSym { rd, .. }
+        | MovtSym { rd, .. }
+        | And { rd, .. }
+        | Orr { rd, .. }
+        | Eor { rd, .. }
+        | Rsb { rd, .. }
+        | Clz { rd, .. }
+        | Rbit { rd, .. }
+        | Sxtb { rd, .. }
+        | Sxth { rd, .. }
+        | Uxtb { rd, .. }
+        | Uxth { rd, .. }
+        | Lsl { rd, .. }
+        | Lsr { rd, .. }
+        | Asr { rd, .. }
+        | Ror { rd, .. }
+        | LslReg { rd, .. }
+        | LsrReg { rd, .. }
+        | AsrReg { rd, .. }
+        | RorReg { rd, .. }
+        | Mul { rd, .. }
+        | Mla { rd, .. }
+        | Mls { rd, .. }
+        | Sdiv { rd, .. }
+        | Udiv { rd, .. }
+        | Popcnt { rd, .. }
+        | Ldr { rd, .. }
+        | Ldrb { rd, .. }
+        | Ldrh { rd, .. }
+        | Ldrsb { rd, .. }
+        | Ldrsh { rd, .. }
+        | LdrSym { rd, .. }
+        | SetCond { rd, .. }
+        | SelectMove { rd, .. } => *rd == Reg::SP,
+        Umull { rdlo, rdhi, .. } => *rdlo == Reg::SP || *rdhi == Reg::SP,
+        Push { .. } | Pop { .. } => true,
+        _ => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Function-level walk (init resolution for top-level regions)
+// ---------------------------------------------------------------------------
+
+/// Walk the function linearly from index 0, tracking const stores into the SP
+/// frame, to resolve each TOP-LEVEL region's counter init; regions are skipped
+/// opaquely (their effects killed). SP motion outside regions (prologue
+/// push/sub) re-bases the tracked offsets. Returns false when an init cannot
+/// be proven const.
+fn resolve_toplevel_inits(regions: &mut [Region], instrs: &[ArmInstruction]) -> bool {
+    let mut st = WalkState::fresh();
+    let mut events: Vec<(i64, Sym)> = Vec::new();
+    let mut i = 0usize;
+    while i < instrs.len() {
+        // Top-level region head?
+        if let Some(k) =
+            (0..regions.len()).find(|&k| !regions[k].has_parent && regions[k].head == i)
+        {
+            let off = match regions[k].proof {
+                Some((off, _, _)) => off,
+                None => return false,
+            };
+            match st.read_slot(off) {
+                Sym::Const(init) => regions[k].init = Some(init),
+                _ => return false,
+            }
+            // Skip the region opaquely.
+            st.kill_all_regs();
+            st.flags = None;
+            for instr in &instrs[regions[k].head..=regions[k].closer] {
+                match &instr.op {
+                    ArmOp::Str { addr, .. } if addr.base == Reg::SP => {
+                        st.taint_range(addr.offset as i64, 4);
+                    }
+                    ArmOp::Strb { addr, .. } if addr.base == Reg::SP => {
+                        st.taint_range(addr.offset as i64, 1);
+                    }
+                    ArmOp::Strh { addr, .. } if addr.base == Reg::SP => {
+                        st.taint_range(addr.offset as i64, 2);
+                    }
+                    _ => {}
+                }
+            }
+            i = regions[k].closer + 1;
+            continue;
+        }
+
+        let instr = &instrs[i];
+        match &instr.op {
+            // SP motion outside regions: re-base tracked slot offsets. After
+            // `sub sp,#k` an address SP_old+off is SP_new+(off+k).
+            ArmOp::Push { regs } => shift_slots(&mut st, 4 * regs.len() as i64),
+            ArmOp::Pop { regs } => shift_slots(&mut st, -4 * (regs.len() as i64)),
+            ArmOp::Sub { rd, rn, op2 } | ArmOp::Subs { rd, rn, op2 }
+                if *rd == Reg::SP && *rn == Reg::SP =>
+            {
+                match op2 {
+                    Operand2::Imm(k) => shift_slots(&mut st, *k as i64),
+                    _ => return false, // dynamic SP adjust — give up
+                }
+            }
+            ArmOp::Add { rd, rn, op2 } | ArmOp::Adds { rd, rn, op2 }
+                if *rd == Reg::SP && *rn == Reg::SP =>
+            {
+                match op2 {
+                    Operand2::Imm(k) => shift_slots(&mut st, -(*k as i64)),
+                    _ => return false,
+                }
+            }
+            op if writes_sp(op) => return false, // any other SP write — give up
+            ArmOp::Bx { .. } => {
+                // A return: nothing after it can be reached by fallthrough, and
+                // all remaining region heads (if any) would be unreachable —
+                // their init can't be resolved.
+                if (0..regions.len()).any(|k| !regions[k].has_parent && regions[k].head > i) {
+                    return false;
+                }
+                break;
+            }
+            // Branches outside regions were rejected by the global discipline;
+            // region closers/exits are inside regions (skipped above).
+            op => sym_step(op, &mut st, &mut events),
+        }
+        i += 1;
+    }
+    true
+}
+
+/// Re-base every tracked slot offset by `delta` (SP moved down by `delta`).
+fn shift_slots(st: &mut WalkState, delta: i64) {
+    if delta == 0 {
+        return;
+    }
+    st.written = st
+        .written
+        .iter()
+        .map(|(&off, &v)| (off + delta, v))
+        .collect();
+    st.tainted = st.tainted.iter().map(|&off| off + delta).collect();
+    // Symbolic Slot{off} identities in registers refer to pre-shift offsets —
+    // drop them (registers holding loaded values stay valid as Const/Top, but a
+    // Slot identity is offset-relative).
+    for r in st.regs.iter_mut() {
+        if matches!(r, Sym::Slot { .. } | Sym::Bool(_)) {
+            *r = Sym::Top;
+        }
+    }
+    st.flags = None;
+}
+
+// ---------------------------------------------------------------------------
+// Trip-count arithmetic
+// ---------------------------------------------------------------------------
+
+/// Smallest `n ≥ 0` such that `(init + n·step + p.add) p.rel p.rhs` holds —
+/// i.e. the head evaluation index at which the exit predicate first fires —
+/// with STATIC no-overflow checks over the whole counter walk in the
+/// predicate's signedness domain. Returns `(n, requires_hint)`; equality exits
+/// set `requires_hint` (consumed only under a verified `--wcet-hints` entry).
+/// `None` = exit not statically guaranteed (or a possible wrap) → unproven.
+fn exit_index(init: i32, step: i64, p: &Pred) -> Option<(u64, bool)> {
+    let s = step;
+    debug_assert!(s != 0);
+    let signed = matches!(
+        p.rel,
+        Rel::LtS | Rel::LeS | Rel::GtS | Rel::GeS | Rel::Eq | Rel::Ne
+    );
+    // Counter values in the comparison domain.
+    let (v0, lo, hi): (i128, i128, i128) = if signed {
+        (init as i128, i32::MIN as i128, i32::MAX as i128)
+    } else {
+        (init as u32 as i128, 0, u32::MAX as i128)
+    };
+    let (rhs, add) = if signed {
+        (p.rhs as i128, p.add as i128)
+    } else {
+        (p.rhs as u32 as i128, p.add as i128)
+    };
+    let s = s as i128;
+
+    // Exit threshold as "counter value C where (C + add) rel rhs first holds
+    // along the walk direction", normalized to v ≥ T (for s > 0) or v ≤ T
+    // (for s < 0); equality handled separately.
+    let k: i128 = match p.rel {
+        Rel::Eq | Rel::Ne => {
+            let target = rhs - add;
+            if p.rel == Rel::Ne {
+                // Exit when v ≠ target: fires at n=0 unless v0 == target, in
+                // which case n=1 (one step moves off the target; no-wrap is
+                // checked below).
+                let n = if v0 == target { 1 } else { 0 };
+                return finish(n, v0, s, add, lo, hi, false);
+            }
+            // Exit when v == target: reachable iff the walk lands exactly on it.
+            let d = target - v0;
+            if d % s != 0 || d / s < 0 {
+                return None; // steps over or walks away — may never terminate
+            }
+            return finish(d / s, v0, s, add, lo, hi, true);
+        }
+        Rel::GeS | Rel::HsU => rhs - add,     // exit when v ≥ T
+        Rel::GtS | Rel::HiU => rhs - add + 1, // exit when v > T-  ⇔ v ≥ T+1
+        Rel::LeS | Rel::LsU => rhs - add,     // exit when v ≤ T
+        Rel::LtS | Rel::LoU => rhs - add - 1, // exit when v < T  ⇔ v ≤ T-1
+    };
+    let upward_exit = matches!(p.rel, Rel::GeS | Rel::GtS | Rel::HsU | Rel::HiU);
+    if upward_exit {
+        if v0 >= k {
+            return finish(0, v0, s, add, lo, hi, false);
+        }
+        if s <= 0 {
+            return None; // walking away from the exit threshold
+        }
+        let n = ceil_div_pos(k - v0, s);
+        finish(n, v0, s, add, lo, hi, false)
+    } else {
+        if v0 <= k {
+            return finish(0, v0, s, add, lo, hi, false);
+        }
+        if s >= 0 {
+            return None;
+        }
+        let n = ceil_div_pos(v0 - k, -s);
+        finish(n, v0, s, add, lo, hi, false)
+    }
+}
+
+/// `ceil(num / den)` for `num ≥ 0`, `den > 0` (i128 `div_ceil` is unstable).
+fn ceil_div_pos(num: i128, den: i128) -> i128 {
+    debug_assert!(num >= 0 && den > 0);
+    (num + den - 1) / den
+}
+
+/// Final static checks for exit index `n`: every counter value touched on the
+/// walk (`v0 .. v0+n·s`, monotone) and every compared value (`+add`) must stay
+/// exactly representable in the comparison domain — otherwise the hardware
+/// would wrap and the affine model would diverge from the machine.
+fn finish(
+    n: i128,
+    v0: i128,
+    s: i128,
+    add: i128,
+    lo: i128,
+    hi: i128,
+    requires_hint: bool,
+) -> Option<(u64, bool)> {
+    if n < 0 {
+        return None;
+    }
+    let vn = v0.checked_add(n.checked_mul(s)?)?;
+    for v in [v0, vn, v0 + add, vn + add] {
+        if v < lo || v > hi {
+            return None;
+        }
+    }
+    Some((u64::try_from(n).ok()?, requires_hint))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pred(rel: Rel, rhs: i32, add: i64) -> Pred {
+        Pred {
+            off: 0,
+            add,
+            rel,
+            rhs,
+        }
+    }
+
+    #[test]
+    fn head_test_up_count() {
+        // for v in 0..10 step 1, exit when v >= 10 → 10 full iterations.
+        assert_eq!(exit_index(0, 1, &pred(Rel::GeS, 10, 0)), Some((10, false)));
+        // init 3, step 2, exit when v >= 10 → v: 3,5,7,9,11 → n=4.
+        assert_eq!(exit_index(3, 2, &pred(Rel::GeS, 10, 0)), Some((4, false)));
+        // already at/above the bound → 0 iterations.
+        assert_eq!(exit_index(10, 1, &pred(Rel::GeS, 10, 0)), Some((0, false)));
+        // compared value is v+1 (bottom-test increment-then-compare shape).
+        assert_eq!(exit_index(0, 1, &pred(Rel::GeS, 10, 1)), Some((9, false)));
+    }
+
+    #[test]
+    fn down_count_and_unsigned() {
+        // v from 10 down to 0, exit when v <= 0 → n = 10.
+        assert_eq!(exit_index(10, -1, &pred(Rel::LeS, 0, 0)), Some((10, false)));
+        // unsigned: exit when v >=u 8, from 0 step 1 → 8.
+        assert_eq!(exit_index(0, 1, &pred(Rel::HsU, 8, 0)), Some((8, false)));
+        // step walks AWAY from the exit → not guaranteed.
+        assert_eq!(exit_index(0, -1, &pred(Rel::GeS, 10, 0)), None);
+    }
+
+    #[test]
+    fn equality_exit_is_hint_gated() {
+        // exact landing: 0,1,..,8 → n=8, requires_hint.
+        assert_eq!(exit_index(0, 1, &pred(Rel::Eq, 8, 0)), Some((8, true)));
+        // step 2 over an odd distance NEVER lands → None (may not terminate).
+        assert_eq!(exit_index(0, 2, &pred(Rel::Eq, 9, 0)), None);
+    }
+
+    #[test]
+    fn overflow_wraps_decline() {
+        // init MAX−1, step 2, exit when v ≥ MAX: the walk goes MAX−1 → MAX+1,
+        // i.e. the hardware would wrap past the threshold → None.
+        assert_eq!(
+            exit_index(i32::MAX - 1, 2, &pred(Rel::GeS, i32::MAX, 0)),
+            None
+        );
+        // Same shape one step earlier lands exactly on MAX → proven, 1 trip.
+        assert_eq!(
+            exit_index(i32::MAX - 2, 1, &pred(Rel::GeS, i32::MAX, 0)),
+            Some((2, false))
+        );
+    }
+}

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -427,6 +427,19 @@ enum Commands {
         #[arg(long)]
         emit_wcet: bool,
 
+        /// #778 phase 2 (v0.47): a `synth-wcet-hints-v1` JSON file of UNTRUSTED
+        /// per-function loop-trip-count hints (the scry oracle seam). Requires
+        /// `--emit-wcet`. Every hint is soundly CHECKED against synth's own
+        /// loop-induction proof over the final instruction stream: it is
+        /// consumed only when synth's derived trip count respects it, and
+        /// REJECTED with a machine-readable reason in the sidecar otherwise
+        /// (wrong hints — smaller than the derived trip — and unverifiable
+        /// hints — data-dependent bounds, non-canonical shapes — are NEVER
+        /// trusted into a bound). Hints never affect codegen: the emitted
+        /// bytes are byte-identical with or without them.
+        #[arg(long, value_name = "FILE")]
+        wcet_hints: Option<PathBuf>,
+
         /// #543 (Phase 1): mark a linear-memory segment as VOLATILE — the DMA
         /// transfer window. Format `<base>:<len>`; both accept hex (`0x…`) or
         /// decimal, e.g. `--volatile-segment 0x20001000:4096`. Repeatable to mark
@@ -585,12 +598,36 @@ fn main() -> Result<()> {
             debug_line,
             emit_provenance,
             emit_wcet,
+            wcet_hints,
             volatile_segment,
             stack_layout,
             stack_size,
         } => {
             // Resolve target spec: --target overrides, --cortex-m is backwards compat
             let target_spec = resolve_target_spec(target.as_deref(), cortex_m, &backend)?;
+
+            // #778 phase 2: parse + schema-validate the UNTRUSTED hints file up
+            // front so a malformed oracle input fails loudly, not mid-compile.
+            let wcet_hints = wcet_hints
+                .map(|p| -> Result<synth_core::wcet::WcetHints> {
+                    anyhow::ensure!(
+                        emit_wcet,
+                        "--wcet-hints requires --emit-wcet (hints only affect the WCET sidecar)"
+                    );
+                    let text = std::fs::read_to_string(&p)
+                        .context(format!("failed to read --wcet-hints file: {}", p.display()))?;
+                    let hints: synth_core::wcet::WcetHints = serde_json::from_str(&text)
+                        .context(format!("--wcet-hints {} is not valid JSON", p.display()))?;
+                    anyhow::ensure!(
+                        hints.schema == synth_core::wcet::HINTS_SCHEMA,
+                        "--wcet-hints {}: schema '{}' != required '{}'",
+                        p.display(),
+                        hints.schema,
+                        synth_core::wcet::HINTS_SCHEMA
+                    );
+                    Ok(hints)
+                })
+                .transpose()?;
             let is_cortex_m =
                 cortex_m || target_spec.family == synth_core::target::ArchFamily::ArmCortexM;
 
@@ -640,6 +677,7 @@ fn main() -> Result<()> {
                 debug_line,
                 emit_provenance,
                 emit_wcet,
+                wcet_hints,
                 volatile_segments,
                 stack_layout,
             )?;
@@ -1376,6 +1414,9 @@ fn compile_command(
     emit_provenance: bool,
     // #778: `--emit-wcet` — write the synth-wcet-v1 sound worst-case-cycle sidecar.
     emit_wcet: bool,
+    // #778 phase 2: parsed --wcet-hints (UNTRUSTED; verified per loop, never
+    // trusted). Only consulted by the WCET sidecar computation.
+    wcet_hints: Option<synth_core::wcet::WcetHints>,
     // #543 Phase 1: integrator-marked volatile DMA-window ranges. Threaded to the
     // CompileConfig; not yet consumed (Phase 2 is the gated codegen back-off).
     volatile_segments: Vec<VolatileRange>,
@@ -1432,6 +1473,7 @@ fn compile_command(
             debug_line,
             emit_provenance,
             emit_wcet,
+            wcet_hints,
             volatile_segments,
             stack_layout,
         );
@@ -2475,6 +2517,10 @@ fn compile_all_exports(
     emit_provenance: bool,
     // #778: write the synth-wcet-v1 sound worst-case-cycle JSON sidecar.
     emit_wcet: bool,
+    // #778 phase 2: parsed --wcet-hints (UNTRUSTED; verified per loop, never
+    // trusted into a bound). Threaded to the CompileConfig for the per-function
+    // WCET computation only — codegen never reads it.
+    wcet_hints: Option<synth_core::wcet::WcetHints>,
     // #543 Phase 1: integrator-marked volatile DMA-window ranges. Threaded to the
     // CompileConfig; not yet consumed (Phase 2 is the gated codegen back-off).
     volatile_segments: Vec<VolatileRange>,
@@ -2971,6 +3017,10 @@ fn compile_all_exports(
         // reserved stack size under --stack-layout=low; default = 0x2000_0100
         // (byte-identical).
         linmem_base: stack_layout.optimized_linmem_base(),
+        // #778 phase 2: UNTRUSTED --wcet-hints — consulted only by the WCET
+        // sidecar computation (each hint verified per loop, never trusted);
+        // codegen is byte-identical with or without it.
+        wcet_hints,
         ..CompileConfig::default()
     };
 

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -3584,6 +3584,30 @@ fn compile_all_exports(
     // #778: write the synth-wcet-v1 sound worst-case-cycle sidecar next to the
     // output (`<output>.wcet.json`). Additive; the ELF is byte-identical.
     if let Some(wr) = wcet_report {
+        // #778 phase 2: a --wcet-hints entry naming a function that does not
+        // exist in the module would otherwise vanish silently — an oracle typo
+        // must be LOUD (the per-loop rejections live in the sidecar; a missing
+        // function has no sidecar entry to carry one).
+        if let Some(hints) = &config.wcet_hints {
+            let compiled: std::collections::BTreeSet<&str> = wr
+                .functions
+                .iter()
+                .map(|f| match f {
+                    synth_core::wcet::WcetFunction::Bounded { name, .. }
+                    | synth_core::wcet::WcetFunction::Declined { name, .. } => name.as_str(),
+                })
+                .collect();
+            for unknown in hints
+                .functions
+                .keys()
+                .filter(|k| !compiled.contains(k.as_str()))
+            {
+                eprintln!(
+                    "warning: --wcet-hints names function '{unknown}' which is not in this \
+                     module — the hint was not consumed"
+                );
+            }
+        }
         let sidecar = synth_core::wcet::WcetReport::sidecar_path(&output);
         let json = wr
             .to_json()

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -410,17 +410,20 @@ enum Commands {
         #[arg(long)]
         emit_provenance: bool,
 
-        /// #778 (v0.46): emit the `synth-wcet-v1` sound static worst-case-cycle
-        /// bound as a JSON sidecar next to the output (`<output>.wcet.json`). For
-        /// each compiled function it emits either a SOUND upper bound (the sum of
-        /// each instruction's documented Cortex-M3/M4 worst-case cycles — valid
-        /// only for a proven loop-free, call-free function) or a loud DECLINE with
-        /// a machine-readable reason (loop / call / looped-expansion i64-div /
-        /// unsupported-core M7). gale's spar T3/T4 schedulability track consumes it
-        /// as a SOUND `C_i` input (a bound, not a DWT observation). The bound is
-        /// conditional on the zero-wait-state precondition recorded in the sidecar.
-        /// Purely additive: `.text` is byte-identical; off by default. ARM(Thumb-2)
-        /// only in v1 (RISC-V/AArch64 carry no cycle model; A32/loops = follow-up).
+        /// #778 (v0.46, phase 2 v0.47): emit the `synth-wcet-v1` sound static
+        /// worst-case-cycle bound as a JSON sidecar next to the output
+        /// (`<output>.wcet.json`). For each compiled function it emits either a
+        /// SOUND upper bound — the sum of each instruction's documented
+        /// Cortex-M3/M4 worst-case cycles, multiplied by PROVEN loop trip
+        /// counts for canonical const-bound counted loops (phase 2: const
+        /// init/step/bound, head-/bottom-test, nested-multiplicative) — or a
+        /// loud DECLINE with a machine-readable reason (statically-unproven
+        /// loop / call / looped-expansion i64-div / unsupported-core M7).
+        /// gale's spar T3/T4 schedulability track consumes it as a SOUND `C_i`
+        /// input (a bound, not a DWT observation). The bound is conditional on
+        /// the zero-wait-state precondition recorded in the sidecar. Purely
+        /// additive: `.text` is byte-identical; off by default. ARM(Thumb-2)
+        /// only in v1 (RISC-V/AArch64 carry no cycle model; A32 = follow-up).
         /// Emitted on the all-exports path (the default for a plain file input);
         /// like `--emit-provenance`, it is inert on the single-function
         /// `--func-name`/`--func-index` path (a documented v1 boundary).

--- a/crates/synth-cli/tests/wcet_bound_gate.rs
+++ b/crates/synth-cli/tests/wcet_bound_gate.rs
@@ -16,9 +16,22 @@
 //!     an independently HAND-COMPUTED worst-case sum (a literal in the test,
 //!     never re-derived from the model's own table). This validates the summation
 //!     + the loop-free classification, and regression-locks the numbers.
-//!  2. **Decline fixtures** (loop / call / i64-software-div) each emit NO bound —
-//!     a `declined` entry with the SPECIFIC machine-readable reason.
-//!  3. **Unsupported-core fixtures** (M7 dual-issue, and the ambiguous `-eabihf`
+//!  2. **Const-bound counted loops** (#778 phase 2) get a `bounded` entry with
+//!     the PROVEN trip count (head-test, bottom-test, nested-multiplicative,
+//!     memory-writing, zero-trip) — pinned exact literals + a trip-aware
+//!     soundness floor (`cycles ≥ trip × region_instr_count`).
+//!  3. **Decline fixtures** (data-dependent loop / non-canonical loop / call /
+//!     i64-software-div) each emit NO bound — a `declined` entry with the
+//!     SPECIFIC machine-readable reason. The phase-1 const-loop declines MOVED
+//!     to (2); the gate never deletes a decline, it converts it.
+//!  4. **The `--wcet-hints` seam** (#778 phase 2): RED-FIRST — a deliberately
+//!     WRONG hint (below the real trip count) is REJECTED
+//!     (`hint-below-derived-trip`) and the function stays declined; a correct
+//!     verifiable hint converts the equality-exit decline into a bound
+//!     (`hint-verified`, trip = synth's DERIVED count, never the raw hint); a
+//!     hint on a data-dependent loop is rejected `hint-unverifiable-induction`;
+//!     CLI misuse (no `--emit-wcet`, malformed JSON, wrong schema) fails loudly.
+//!  5. **Unsupported-core fixtures** (M7 dual-issue, and the ambiguous `-eabihf`
 //!     M4F triple) decline as `unsupported-core` — the conservative gap spar sees.
 //!
 //! It does NOT prove the per-op cycle NUMBERS are worst-case: it re-derives from
@@ -47,6 +60,11 @@ fn unique_id() -> u64 {
 
 /// Compile `wat` for `triple` with `--emit-wcet` and return the parsed sidecar.
 fn compile_wcet(wat: &str, triple: &str) -> Value {
+    compile_wcet_hinted(wat, triple, None)
+}
+
+/// Like [`compile_wcet`] but passing a `--wcet-hints` file (#778 phase 2).
+fn compile_wcet_hinted(wat: &str, triple: &str, hints_json: Option<&str>) -> Value {
     let dir = std::env::temp_dir().join(format!(
         "synth_wcet_gate_{}_{}_{}",
         std::process::id(),
@@ -58,16 +76,23 @@ fn compile_wcet(wat: &str, triple: &str) -> Value {
     std::fs::write(&wat_path, wat).unwrap();
     let out_path = dir.join("f.elf");
 
+    let mut args = vec![
+        "compile".to_string(),
+        wat_path.to_str().unwrap().to_string(),
+        "-o".to_string(),
+        out_path.to_str().unwrap().to_string(),
+        "-t".to_string(),
+        triple.to_string(),
+        "--emit-wcet".to_string(),
+    ];
+    if let Some(h) = hints_json {
+        let hints_path = dir.join("hints.json");
+        std::fs::write(&hints_path, h).unwrap();
+        args.push("--wcet-hints".to_string());
+        args.push(hints_path.to_str().unwrap().to_string());
+    }
     let status = Command::new(synth())
-        .args([
-            "compile",
-            wat_path.to_str().unwrap(),
-            "-o",
-            out_path.to_str().unwrap(),
-            "-t",
-            triple,
-            "--emit-wcet",
-        ])
+        .args(&args)
         .status()
         .expect("failed to run synth compile");
     assert!(status.success(), "synth compile failed for triple {triple}");
@@ -233,8 +258,12 @@ fn loop_free_if_else_is_bounded() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn loop_declines_with_loop_reason() {
-    // A data-dependent counted loop: no static trip count → must decline `loop`.
+fn data_dependent_loop_still_declines_with_loop_reason() {
+    // A DATA-DEPENDENT counted loop (bound = a runtime parameter): #778 phase 2
+    // proves const-bound counted loops, but a data-dependent bound has no
+    // statically-evident trip count → must STILL decline `loop`. (This is the
+    // decline the gate keeps — moved, never deleted: the const-bound shapes
+    // that used to sit here are now asserted BOUNDED below.)
     let wat = r#"
         (module
           (func (export "spin") (param i32) (result i32)
@@ -330,4 +359,398 @@ fn report_carries_precondition() {
             .is_some_and(|s| s.contains("zero-wait-state")),
         "the bound is conditional on a memory precondition that must be recorded"
     );
+}
+
+// ---------------------------------------------------------------------------
+// #778 phase 2 — statically-proven loop trip counts. These shapes were
+// asserted-DECLINED in phase 1; the gate MOVES here (never deletes): they must
+// now be BOUNDED with the exact derived trip count, and the bound must clear
+// the trip-aware soundness floor. Ground truth for every fixture was executed
+// under unicorn (Thumb-2 machine-instruction counting) at authoring time:
+// bound cycles >= executed machine instructions on every fixture, and each
+// function's RESULT matched the WASM semantics (a wrong trip count would have
+// changed both). In-CI the floor below is the analytic stand-in (no
+// cycle-accurate Cortex-M oracle exists in-env — same honesty note as phase 1).
+// ---------------------------------------------------------------------------
+
+/// The canonical `for i in 0..10` counted loop (const init 0, step 1, bound 10,
+/// head-test): must be BOUNDED with trip_count == 10 and the EXACT pinned
+/// cycle literal. unicorn ground truth at authoring: r0 == 45 (correct trips),
+/// 188 executed machine insns <= 349.
+#[test]
+fn const_bound_loop_is_bounded_with_static_trip() {
+    let wat = r#"
+        (module
+          (func (export "sum10") (result i32)
+            (local i32 i32)
+            (block
+              (loop
+                local.get 0 i32.const 10 i32.lt_s i32.eqz br_if 1
+                local.get 1 local.get 0 i32.add local.set 1
+                local.get 0 i32.const 1 i32.add local.set 0
+                br 0))
+            local.get 1))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4");
+    assert_bounded(&report, "sum10", 349);
+    assert_loop(&report, "sum10", 0, 10, "static");
+    assert_trip_floor(&report, "sum10");
+}
+
+/// Bottom-test form (`br_if 0` conditional backward branch): the body executes
+/// exactly trip_count times. unicorn: r0 == 45, 129 insns <= 229.
+#[test]
+fn bottom_test_loop_is_bounded() {
+    let wat = r#"
+        (module
+          (func (export "bottom") (result i32)
+            (local i32 i32)
+            (loop
+              local.get 1 local.get 0 i32.add local.set 1
+              local.get 0 i32.const 1 i32.add local.tee 0
+              i32.const 10 i32.lt_s br_if 0)
+            local.get 1))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4");
+    assert_bounded(&report, "bottom", 229);
+    assert_loop(&report, "bottom", 0, 10, "static");
+    assert_trip_floor(&report, "bottom");
+}
+
+/// Nested const-bound loops: BOTH levels prove → factors multiply (5 outer ×
+/// 3 inner; the inner counter is re-initialized inside the outer body and the
+/// analyzer proves that re-init). unicorn: r0 == 15, 377 insns <= 863.
+#[test]
+fn nested_const_loops_bound_multiplicatively() {
+    let wat = r#"
+        (module
+          (func (export "nested") (result i32)
+            (local i32 i32 i32)
+            (block
+              (loop
+                local.get 0 i32.const 5 i32.lt_s i32.eqz br_if 1
+                i32.const 0 local.set 1
+                (block
+                  (loop
+                    local.get 1 i32.const 3 i32.lt_s i32.eqz br_if 1
+                    local.get 2 i32.const 1 i32.add local.set 2
+                    local.get 1 i32.const 1 i32.add local.set 1
+                    br 0))
+                local.get 0 i32.const 1 i32.add local.set 0
+                br 0))
+            local.get 2))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4");
+    assert_bounded(&report, "nested", 863);
+    assert_loop(&report, "nested", 0, 5, "static");
+    assert_loop(&report, "nested", 1, 3, "static");
+    assert_trip_floor(&report, "nested");
+}
+
+/// A const-bound loop whose body WRITES linear memory: non-SP stores cannot
+/// alias the SP-frame counter (WASM has no address-of-local; the linear-memory
+/// image is layout-disjoint from the native stack), so the trip proof stands.
+/// unicorn: mem[44] == 11 after 16 trips, 304 insns <= 520.
+#[test]
+fn memory_writing_const_loop_is_bounded() {
+    let wat = r#"
+        (module
+          (func (export "memloop") (result i32)
+            (local i32)
+            (block
+              (loop
+                local.get 0 i32.const 16 i32.lt_s i32.eqz br_if 1
+                local.get 0 i32.const 4 i32.mul
+                local.get 0
+                i32.store
+                local.get 0 i32.const 1 i32.add local.set 0
+                br 0))
+            i32.const 44 i32.load)
+          (memory 1))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4");
+    let f = func(&report, "memloop");
+    assert_eq!(
+        f.get("status").and_then(Value::as_str),
+        Some("bounded"),
+        "memory-writing const-bound loop must bound: {f}"
+    );
+    assert_loop(&report, "memloop", 0, 16, "static");
+    assert_trip_floor(&report, "memloop");
+}
+
+/// A zero-trip loop (bound 0 < init 0 is false immediately): trip_count == 0,
+/// the head check still executes once, so the function stays bounded and the
+/// bound covers the single head evaluation. unicorn: r0 == 0, 18 insns <= 58.
+#[test]
+fn zero_trip_loop_is_bounded() {
+    let wat = r#"
+        (module
+          (func (export "trip0") (result i32)
+            (local i32 i32)
+            (block
+              (loop
+                local.get 0 i32.const 0 i32.lt_s i32.eqz br_if 1
+                local.get 1 i32.const 1 i32.add local.set 1
+                local.get 0 i32.const 1 i32.add local.set 0
+                br 0))
+            local.get 1))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4");
+    assert_loop(&report, "trip0", 0, 0, "static");
+    assert_trip_floor(&report, "trip0");
+}
+
+/// A loop whose body stores the counter TWICE on a conditional path (an `if`
+/// inside the body): the induction is NOT canonical → must stay declined. The
+/// decline-honesty counterpart to the bounded shapes above.
+#[test]
+fn conditional_counter_store_still_declines() {
+    let wat = r#"
+        (module
+          (func (export "condstore") (param i32) (result i32)
+            (local i32)
+            (block
+              (loop
+                local.get 1 i32.const 10 i32.lt_s i32.eqz br_if 1
+                (if (local.get 0)
+                  (then local.get 1 i32.const 5 i32.add local.set 1))
+                local.get 1 i32.const 1 i32.add local.set 1
+                br 0))
+            local.get 1))
+    "#;
+    let report = compile_wcet(wat, "cortex-m4");
+    assert_declined(&report, "condstore", "loop");
+}
+
+// ---------------------------------------------------------------------------
+// #778 phase 2 — the --wcet-hints seam (untrusted oracle + sound checker).
+// RED-FIRST: the wrong-hint rejection is asserted BEFORE the conversion.
+// ---------------------------------------------------------------------------
+
+/// The equality-exit fixture (`br_if (i32.eq i N)`): the ONE hint-gated shape —
+/// a step that misses the bound flips terminating into infinite, so synth
+/// derives the trip (8) + divisibility but only consumes it under an explicit
+/// verified hint.
+const EQEXIT_WAT: &str = r#"
+    (module
+      (func (export "eqexit") (result i32)
+        (local i32 i32)
+        (block
+          (loop
+            local.get 0 i32.const 8 i32.eq br_if 1
+            local.get 1 local.get 0 i32.add local.set 1
+            local.get 0 i32.const 1 i32.add local.set 0
+            br 0))
+        local.get 1))
+"#;
+
+/// RED: a deliberately-WRONG hint (3 < the real trip count 8) must be REJECTED
+/// with the machine reason `hint-below-derived-trip`, and the function must
+/// stay DECLINED — a wrong oracle claim is never trusted into a bound.
+#[test]
+fn wrong_hint_below_real_trip_is_rejected_red_first() {
+    let hints = r#"{"schema":"synth-wcet-hints-v1","functions":{"eqexit":{"loop_bounds":[3]}}}"#;
+    let report = compile_wcet_hinted(EQEXIT_WAT, "cortex-m4", Some(hints));
+    assert_declined(&report, "eqexit", "loop");
+    let f = func(&report, "eqexit");
+    let rej = f
+        .get("hint_rejections")
+        .and_then(Value::as_array)
+        .and_then(|a| a.first())
+        .unwrap_or_else(|| panic!("wrong hint must be RECORDED as rejected: {f}"));
+    assert_eq!(
+        rej.get("reason").and_then(Value::as_str),
+        Some("hint-below-derived-trip"),
+        "wrong hint must carry the specific machine rejection reason: {rej}"
+    );
+    assert_eq!(rej.get("hint").and_then(Value::as_u64), Some(3));
+}
+
+/// Unhinted, the equality-exit shape stays declined (the decline the hint
+/// seam converts — asserted so the conversion below is non-vacuous).
+#[test]
+fn equality_exit_unhinted_still_declines() {
+    let report = compile_wcet(EQEXIT_WAT, "cortex-m4");
+    assert_declined(&report, "eqexit", "loop");
+}
+
+/// GREEN: a correct, verifiable hint (8 >= derived 8) converts the decline into
+/// a bound. The emitted trip count is synth's DERIVED value (8) with source
+/// `hint-verified` — never the raw hint. unicorn ground truth at authoring:
+/// r0 == 28 (= 0+1+..+7), 126 executed machine insns <= 254.
+#[test]
+fn correct_hint_converts_decline_to_bound() {
+    let hints = r#"{"schema":"synth-wcet-hints-v1","functions":{"eqexit":{"loop_bounds":[8]}}}"#;
+    let report = compile_wcet_hinted(EQEXIT_WAT, "cortex-m4", Some(hints));
+    assert_bounded(&report, "eqexit", 254);
+    assert_loop(&report, "eqexit", 0, 8, "hint-verified");
+    assert_trip_floor(&report, "eqexit");
+}
+
+/// A hint on a DATA-DEPENDENT loop (bound = runtime parameter): synth cannot
+/// verify the induction against it → REJECTED `hint-unverifiable-induction`,
+/// function stays declined. The untrusted oracle cannot smuggle in a bound.
+#[test]
+fn data_dependent_hint_is_rejected_unverifiable() {
+    let wat = r#"
+        (module
+          (func (export "spin") (param i32) (result i32)
+            (local i32)
+            (block
+              (loop
+                local.get 1 local.get 0 i32.lt_s i32.eqz br_if 1
+                local.get 1 i32.const 1 i32.add local.set 1
+                br 0))
+            local.get 1))
+    "#;
+    let hints = r#"{"schema":"synth-wcet-hints-v1","functions":{"spin":{"loop_bounds":[100]}}}"#;
+    let report = compile_wcet_hinted(wat, "cortex-m4", Some(hints));
+    assert_declined(&report, "spin", "loop");
+    let f = func(&report, "spin");
+    let rej = f
+        .get("hint_rejections")
+        .and_then(Value::as_array)
+        .and_then(|a| a.first())
+        .unwrap_or_else(|| panic!("unverifiable hint must be RECORDED as rejected: {f}"));
+    assert_eq!(
+        rej.get("reason").and_then(Value::as_str),
+        Some("hint-unverifiable-induction"),
+        "data-dependent bound: hint must be rejected as unverifiable: {rej}"
+    );
+}
+
+/// `--wcet-hints` without `--emit-wcet` is a usage error (hints only affect the
+/// sidecar), and a malformed hints file fails LOUDLY before compiling.
+#[test]
+fn hints_cli_misuse_fails_loudly() {
+    let dir = std::env::temp_dir().join(format!(
+        "synth_wcet_gate_cli_{}_{}",
+        std::process::id(),
+        unique_id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let wat_path = dir.join("f.wat");
+    std::fs::write(
+        &wat_path,
+        r#"(module (func (export "k") (result i32) i32.const 1))"#,
+    )
+    .unwrap();
+    let hints_path = dir.join("hints.json");
+    std::fs::write(
+        &hints_path,
+        r#"{"schema":"synth-wcet-hints-v1","functions":{}}"#,
+    )
+    .unwrap();
+    let out = dir.join("f.elf");
+
+    // Without --emit-wcet → refused.
+    let status = Command::new(synth())
+        .args([
+            "compile",
+            wat_path.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+            "-t",
+            "cortex-m4",
+            "--wcet-hints",
+            hints_path.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+    assert!(
+        !status.success(),
+        "--wcet-hints without --emit-wcet must fail"
+    );
+
+    // Malformed JSON → refused loudly.
+    std::fs::write(&hints_path, "{not json").unwrap();
+    let status = Command::new(synth())
+        .args([
+            "compile",
+            wat_path.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+            "-t",
+            "cortex-m4",
+            "--emit-wcet",
+            "--wcet-hints",
+            hints_path.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+    assert!(!status.success(), "malformed --wcet-hints must fail loudly");
+
+    // Wrong schema string → refused loudly.
+    std::fs::write(&hints_path, r#"{"schema":"bogus-v9","functions":{}}"#).unwrap();
+    let status = Command::new(synth())
+        .args([
+            "compile",
+            wat_path.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+            "-t",
+            "cortex-m4",
+            "--emit-wcet",
+            "--wcet-hints",
+            hints_path.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+    assert!(!status.success(), "wrong hints schema must fail loudly");
+}
+
+// ---------------------------------------------------------------------------
+// Phase-2 assertion helpers.
+// ---------------------------------------------------------------------------
+
+/// Assert loop `idx` of `name` has EXACTLY `trip` and `source`.
+fn assert_loop(report: &Value, name: &str, idx: usize, trip: u64, source: &str) {
+    let f = func(report, name);
+    let l = f
+        .get("loops")
+        .and_then(Value::as_array)
+        .and_then(|a| a.get(idx))
+        .unwrap_or_else(|| panic!("{name}: no loop record #{idx} (entry: {f})"));
+    assert_eq!(
+        l.get("trip_count").and_then(Value::as_u64),
+        Some(trip),
+        "{name} loop {idx}: trip count drifted (record: {l})"
+    );
+    assert_eq!(
+        l.get("source").and_then(Value::as_str),
+        Some(source),
+        "{name} loop {idx}: wrong bound source (record: {l})"
+    );
+}
+
+/// The trip-aware soundness floor: every instruction costs at least 1 cycle
+/// and each loop's region instructions execute trip_count times, so the bound
+/// must satisfy both `cycles ≥ instr_count` and, per loop,
+/// `cycles ≥ trip_count × region_instr_count`. A bound below either is
+/// arithmetically impossible for a sound model — this floor is independent of
+/// the per-op cycle table (the phase-2 cross-check: instruction count × known
+/// trip count).
+fn assert_trip_floor(report: &Value, name: &str) {
+    let f = func(report, name);
+    let cycles = f.get("cycles").and_then(Value::as_u64).unwrap();
+    let instrs = f.get("instr_count").and_then(Value::as_u64).unwrap();
+    assert!(
+        cycles >= instrs,
+        "{name}: bound {cycles} < instr_count {instrs} — unsound"
+    );
+    for l in f
+        .get("loops")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let trip = l.get("trip_count").and_then(Value::as_u64).unwrap();
+        let region = l.get("region_instr_count").and_then(Value::as_u64).unwrap();
+        assert!(
+            cycles >= trip.saturating_mul(region),
+            "{name}: bound {cycles} < trip {trip} × region {region} — the loop's \
+             instructions alone execute more times than the bound allows: unsound"
+        );
+    }
 }

--- a/crates/synth-cli/tests/wcet_bound_gate.rs
+++ b/crates/synth-cli/tests/wcet_bound_gate.rs
@@ -588,6 +588,39 @@ fn correct_hint_converts_decline_to_bound() {
     assert_trip_floor(&report, "eqexit");
 }
 
+/// A wrong hint on a STATICALLY-PROVEN loop: synth's own proof stands (the
+/// bound does not depend on the oracle), but the contradicting hint is still
+/// RECORDED as rejected so the oracle learns its claim was wrong.
+#[test]
+fn wrong_hint_on_static_loop_bound_stands_rejection_recorded() {
+    let wat = r#"
+        (module
+          (func (export "sum10") (result i32)
+            (local i32 i32)
+            (block
+              (loop
+                local.get 0 i32.const 10 i32.lt_s i32.eqz br_if 1
+                local.get 1 local.get 0 i32.add local.set 1
+                local.get 0 i32.const 1 i32.add local.set 0
+                br 0))
+            local.get 1))
+    "#;
+    let hints = r#"{"schema":"synth-wcet-hints-v1","functions":{"sum10":{"loop_bounds":[5]}}}"#;
+    let report = compile_wcet_hinted(wat, "cortex-m4", Some(hints));
+    assert_bounded(&report, "sum10", 349); // static proof unaffected
+    assert_loop(&report, "sum10", 0, 10, "static");
+    let f = func(&report, "sum10");
+    let rej = f
+        .get("hint_rejections")
+        .and_then(Value::as_array)
+        .and_then(|a| a.first())
+        .unwrap_or_else(|| panic!("contradicting hint must be recorded: {f}"));
+    assert_eq!(
+        rej.get("reason").and_then(Value::as_str),
+        Some("hint-below-derived-trip")
+    );
+}
+
 /// A hint on a DATA-DEPENDENT loop (bound = runtime parameter): synth cannot
 /// verify the induction against it → REJECTED `hint-unverifiable-induction`,
 /// function stays declined. The untrusted oracle cannot smuggle in a bound.

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -303,6 +303,14 @@ pub struct CompileConfig {
     /// `VCR-DMA-001`.
     pub volatile_segments: Vec<VolatileRange>,
 
+    /// #778 phase 2 — the parsed `--wcet-hints` file (UNTRUSTED per-function
+    /// loop-bound hints, the scry seam). Consulted ONLY by the WCET sidecar
+    /// computation over the final instruction stream; NEVER by codegen — the
+    /// emitted bytes are byte-identical with or without hints. Every hint is
+    /// soundly verified before use and rejected with a machine reason
+    /// otherwise.
+    pub wcet_hints: Option<crate::wcet::WcetHints>,
+
     /// VCR-PERF-002 Phase 1 (#494) — proven invariants forwarded by loom in
     /// the `wsc.facts` custom section (encoding:
     /// `docs/design/wsc-facts-encoding.md`; program:
@@ -457,6 +465,10 @@ impl Default for CompileConfig {
             // loudly (never an unchecked indirect branch). Driver loops fill
             // this from the decoded module.
             call_indirect_guards: crate::wasm_decoder::CallIndirectGuards::default(),
+            // #778 phase 2: no --wcet-hints file ⇒ no hints. Consulted ONLY by
+            // the WCET sidecar computation — never by codegen (the emitted
+            // bytes are byte-identical with or without hints).
+            wcet_hints: None,
         }
     }
 }

--- a/crates/synth-core/src/wcet.rs
+++ b/crates/synth-core/src/wcet.rs
@@ -19,15 +19,26 @@
 //!   instruction's documented worst-case cycles. Summing every instruction
 //!   (including both arms of an `if/else`) is an over-estimate, hence sound; no
 //!   path enumeration is needed.
-//! - **Everything else** — any backward branch (a loop), any residual/external
+//! - **Loops with statically-evident trip counts** (#778 phase 2): a canonical
+//!   counted loop — const-initialized counter, const step, const bound, single
+//!   backward branch — whose trip count synth PROVES from the final instruction
+//!   stream gets `trip × body-worst + overhead` as an upper bound; every
+//!   instruction's cost is multiplied by its proven worst-case execution count.
+//!   Nested loops multiply only when EVERY level proves.
+//! - **Everything else** — any loop synth cannot prove a trip count for
+//!   (data-dependent bounds, non-canonical shapes), any residual/external
 //!   label branch (unknown direction), any call (`Bl`/`Blx`, inter-procedural),
 //!   any op whose encoder expansion contains an internal runtime loop
 //!   (`i64` software div/rem), any unsupported core class — is DECLINED with a
 //!   machine-readable reason. gale cannot size a budget from an unsound number,
 //!   so a decline is strictly better than a guess.
 //!
-//! Loop-bound INFERENCE (recovering an unknown trip count) and inter-procedural
-//! composition are the named scry / spar follow-ups, explicitly OUT of scope.
+//! `--wcet-hints` (#778 phase 2, the scry seam) supplies UNTRUSTED per-loop
+//! trip-count hints; each is soundly CHECKED against synth's own induction
+//! proof before use and REJECTED with a machine reason otherwise (see
+//! [`WcetHints`] / [`WcetHintReject`]). Richer hint certificates (data-dependent
+//! bounds) and inter-procedural composition remain the named scry / spar
+//! follow-ups, explicitly OUT of scope.
 //!
 //! ## Precondition — a bound without its assumptions is not a safety input
 //!
@@ -52,15 +63,20 @@ use serde::{Deserialize, Serialize};
 /// The schema version string embedded at the top of the sidecar.
 pub const SCHEMA: &str = "synth-wcet-v1";
 
+/// The schema string a `--wcet-hints` file must carry (#778 phase 2).
+pub const HINTS_SCHEMA: &str = "synth-wcet-hints-v1";
+
 /// Why a function could not receive a sound static cycle bound. Each variant is a
 /// distinct, machine-readable decline reason so a consumer (spar T4) can tell an
 /// unbounded loop from an inter-procedural edge from an unsupported core.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum WcetDecline {
-    /// A backward branch in the final instruction stream — a loop. Bounding it
-    /// requires a trip count, which WASM does not carry; that is the scry
-    /// loop-bound-inference follow-up.
+    /// A backward branch in the final instruction stream — a loop — whose trip
+    /// count synth could NOT statically prove (#778 phase 2 proves canonical
+    /// const-init/const-step/const-bound counted loops; equality-exit shapes
+    /// additionally need a verified `--wcet-hints` entry). Data-dependent
+    /// bounds remain the scry loop-bound-inference follow-up.
     Loop,
     /// A call (`Bl`/`Blx`) — the bound is per-function (intra-procedural). Summing
     /// a callee's cost is the spar inter-procedural-composition follow-up.
@@ -88,8 +104,10 @@ impl WcetDecline {
     pub fn note(&self) -> &'static str {
         match self {
             WcetDecline::Loop => {
-                "backward branch (loop) — a sound bound needs a trip count \
-                 (scry loop-bound-inference follow-up)"
+                "backward branch (loop) without a statically-proven trip count — \
+                 canonical const-bound counted loops are proven automatically; \
+                 equality-exit shapes need a verified --wcet-hints entry; \
+                 data-dependent bounds are the scry loop-bound-inference follow-up"
             }
             WcetDecline::Call => {
                 "call (Bl/Blx) — per-function bound is intra-procedural \
@@ -112,6 +130,100 @@ impl WcetDecline {
     }
 }
 
+/// How a loop's trip count was established (#778 phase 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WcetLoopBoundSource {
+    /// Fully static proof: const-initialized counter, const step, const bound,
+    /// exit-guaranteeing comparison — the trip count is derived by synth alone.
+    Static,
+    /// The loop is an equality-exit shape synth only bounds under an explicit
+    /// `--wcet-hints` assertion; the hint was CHECKED against synth's own derived
+    /// trip count (divisibility + monotonicity + derived ≤ hint) before use. The
+    /// emitted trip count is still synth's DERIVED value, never the raw hint.
+    HintVerified,
+}
+
+/// One proven-bounded loop inside a bounded function (#778 phase 2). Loops are
+/// listed in ascending `head_offset` order — the SAME order `--wcet-hints`
+/// `loop_bounds` entries are matched by.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WcetLoopBound {
+    /// Byte offset of the loop head (backward-branch target) within the function.
+    pub head_offset: u64,
+    /// The PROVEN maximum number of body executions (full iterations).
+    pub trip_count: u64,
+    /// Number of instructions inside the loop region (head..=backward branch),
+    /// so a consumer can cross-check `cycles ≥ trip_count × region_instr_count`
+    /// (every instruction costs ≥ 1 cycle).
+    pub region_instr_count: usize,
+    /// How the trip count was established.
+    pub source: WcetLoopBoundSource,
+    /// The hint value consumed (present iff `source == HintVerified` or a
+    /// redundant hint was cross-checked against a static proof).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hint: Option<u64>,
+}
+
+/// Machine-readable reason a `--wcet-hints` entry was REJECTED (#778 phase 2).
+/// The hint file is UNTRUSTED input: a hint is only ever consumed after synth
+/// verifies the loop's induction against it; everything else lands here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WcetHintReject {
+    /// The hint is SMALLER than synth's own derived trip count — a wrong hint.
+    /// Trusting it would emit a bound < a real execution (the fatal class).
+    HintBelowDerivedTrip,
+    /// synth could not verify the loop's induction against the hint (counter not
+    /// provably monotonic toward a statically-known bound ≤ hint — e.g. a
+    /// data-dependent bound register, a non-canonical shape, or an equality exit
+    /// whose step does not divide the distance). An unverifiable hint is never
+    /// trusted into a bound.
+    HintUnverifiableInduction,
+    /// The hint indexes a loop that does not exist in this function's final
+    /// instruction stream.
+    HintUnknownLoop,
+}
+
+impl WcetHintReject {
+    /// A short human-readable explanation, embedded alongside the machine reason.
+    pub fn note(&self) -> &'static str {
+        match self {
+            WcetHintReject::HintBelowDerivedTrip => {
+                "hint is below synth's derived trip count — a wrong hint; \
+                 trusting it would emit an unsound bound"
+            }
+            WcetHintReject::HintUnverifiableInduction => {
+                "loop induction not verifiable against the hint (counter not \
+                 provably monotonic toward a statically-known bound ≤ hint) — \
+                 an unverifiable hint is never trusted into a bound"
+            }
+            WcetHintReject::HintUnknownLoop => {
+                "hint indexes a loop that does not exist in the final \
+                 instruction stream"
+            }
+        }
+    }
+}
+
+/// One rejected hint, recorded in the sidecar so the oracle (scry) sees exactly
+/// which of its claims synth refused and why.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WcetHintRejection {
+    /// Index into the function's `loop_bounds` hint array (== loop order by
+    /// ascending head offset).
+    pub loop_index: usize,
+    /// Byte offset of the loop head this hint addressed, when the loop exists.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_offset: Option<u64>,
+    /// The rejected hint value.
+    pub hint: u64,
+    /// Machine-readable rejection reason.
+    pub reason: WcetHintReject,
+    /// Human-readable note (`reason.note()`).
+    pub note: String,
+}
+
 /// The per-function result: either a sound cycle bound or a loud decline.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "kebab-case")]
@@ -120,13 +232,21 @@ pub enum WcetFunction {
     Bounded {
         /// Function name (WASM export or generated).
         name: String,
-        /// The sound worst-case cycle bound: for a loop-free function this is the
+        /// The sound worst-case cycle bound. For a loop-free function this is the
         /// SUM of each instruction's documented worst-case cycles (each executes
-        /// at most once). Always ≥ any real execution under the stated
-        /// precondition.
+        /// at most once). For a function whose loops ALL have proven trip counts
+        /// (#778 phase 2) each instruction's cost is multiplied by its proven
+        /// worst-case execution count. Always ≥ any real execution under the
+        /// stated precondition.
         cycles: u64,
         /// Number of ARM instructions summed (diagnostic).
         instr_count: usize,
+        /// Proven loops (empty for a loop-free function), ascending head offset.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        loops: Vec<WcetLoopBound>,
+        /// Hints that were rejected (the static proof stands independently).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        hint_rejections: Vec<WcetHintRejection>,
     },
     /// No bound emitted — a loud decline with a machine-readable reason. A decline
     /// is emitted (rather than the function omitted) so the map is COMPLETE: a
@@ -139,6 +259,9 @@ pub enum WcetFunction {
         reason: WcetDecline,
         /// Human-readable note (`reason.note()`).
         note: String,
+        /// Hints that were offered for this function and rejected.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        hint_rejections: Vec<WcetHintRejection>,
     },
 }
 
@@ -150,8 +273,50 @@ impl WcetFunction {
             name: name.into(),
             reason,
             note,
+            hint_rejections: Vec::new(),
         }
     }
+
+    /// Construct a decline carrying rejected-hint records.
+    pub fn declined_with_rejections(
+        name: impl Into<String>,
+        reason: WcetDecline,
+        hint_rejections: Vec<WcetHintRejection>,
+    ) -> Self {
+        let note = reason.note().to_string();
+        WcetFunction::Declined {
+            name: name.into(),
+            reason,
+            note,
+            hint_rejections,
+        }
+    }
+}
+
+/// The parsed `--wcet-hints` file (`synth-wcet-hints-v1`) — an UNTRUSTED oracle
+/// input (#778 phase 2, the scry integration seam). Per function, an ordered
+/// array of claimed loop-trip-count upper bounds, matched to loops by ascending
+/// head offset (entry N = N-th loop head in the function; `null` skips a loop).
+/// Every entry is soundly CHECKED before use: synth re-derives the loop's trip
+/// count from its own induction proof and consumes the hint only when the
+/// derived count is ≤ the hint. A wrong or unverifiable hint is rejected with a
+/// machine reason ([`WcetHintReject`]) — never trusted into a bound.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WcetHints {
+    /// Must equal [`HINTS_SCHEMA`].
+    pub schema: String,
+    /// Per-function hint arrays, keyed by the compiled function name.
+    #[serde(default)]
+    pub functions: std::collections::BTreeMap<String, WcetFunctionHints>,
+}
+
+/// Per-function loop-bound hints.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WcetFunctionHints {
+    /// Claimed trip-count upper bounds, one per loop in ascending-head-offset
+    /// order; `null` leaves that loop unhinted.
+    #[serde(default)]
+    pub loop_bounds: Vec<Option<u64>>,
 }
 
 /// The full `synth-wcet-v1` sidecar: schema header, precondition, and per-function
@@ -214,6 +379,8 @@ mod tests {
             name: "leaf".into(),
             cycles: 42,
             instr_count: 7,
+            loops: Vec::new(),
+            hint_rejections: Vec::new(),
         });
         r.functions
             .push(WcetFunction::declined("spins", WcetDecline::Loop));

--- a/scripts/repro/wcet_phase2_778_unicorn_soundness.py
+++ b/scripts/repro/wcet_phase2_778_unicorn_soundness.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""#778 phase 2 soundness cross-check: execute compiled loop fixtures under
+unicorn (Thumb-2), count machine instructions, and check:
+
+  1. the functional result (r0) matches the WASM-semantics ground truth --
+     a wrong derived trip count would change it;
+  2. bound_cycles >= executed_instructions (every instruction costs >= 1
+     cycle, so a bound below the executed-instruction count is UNSOUND);
+  3. adversarial shapes (conditional counter store) stay DECLINED, and a
+     deliberately-wrong --wcet-hints entry (below the real trip count) is
+     REJECTED `hint-below-derived-trip` (red-first).
+
+This is the execution-side evidence the cargo gate (wcet_bound_gate.rs)
+cannot produce in-CI (no unicorn dependency there); the gate pins the same
+fixtures analytically (exact literals + trip-aware floor). Observed at
+authoring (v0.47 branch, debug build): sum10 r0=45 188<=349, bottom r0=45
+129<=229, nested r0=15 377<=863, eqexit(hint 8) r0=28 126<=254, step3 r0=7
+130<=254, memloop r0=11 304<=520, trip0 r0=0 18<=58; condstore declined;
+eqexit hint 3 rejected hint-below-derived-trip.
+
+Usage:
+    SYNTH=/path/to/synth python3 scripts/repro/wcet_phase2_778_unicorn_soundness.py
+Requires: pip install unicorn pyelftools
+"""
+import json
+import os
+import subprocess
+import sys
+
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_THUMB, UC_HOOK_CODE
+from unicorn.arm_const import (
+    UC_ARM_REG_R0, UC_ARM_REG_SP, UC_ARM_REG_LR, UC_ARM_REG_PC,
+    UC_ARM_REG_R10, UC_ARM_REG_R11,
+)
+from elftools.elf.elffile import ELFFile
+
+SYNTH = os.environ.get("SYNTH", "synth")
+RETURN_MAGIC = 0x0000FFFE  # even address outside .text: stop when PC reaches it
+
+
+def compile_wat(wat_path, elf_path, hints=None):
+    cmd = [SYNTH, "compile", wat_path, "-o", elf_path, "-t", "cortex-m4", "--emit-wcet"]
+    if hints:
+        cmd += ["--wcet-hints", hints]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    assert r.returncode == 0, r.stderr
+    return json.load(open(elf_path + ".wcet.json"))
+
+
+def load_elf(elf_path):
+    """Return (text_bytes, text_addr, {name: func_addr})."""
+    with open(elf_path, "rb") as f:
+        elf = ELFFile(f)
+        text = None
+        for seg in elf.iter_sections():
+            if seg.name == ".text":
+                text = (seg.data(), seg["sh_addr"])
+        syms = {}
+        for sec in elf.iter_sections():
+            if sec["sh_type"] == "SHT_SYMTAB":
+                for s in sec.iter_symbols():
+                    if s["st_info"]["type"] == "STT_FUNC":
+                        syms[s.name] = s["st_value"]
+        return text[0], text[1], syms
+
+
+def run_func(text, text_addr, addr, args=()):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    base = text_addr & ~0xFFF
+    size = ((text_addr + len(text) - base) + 0xFFF) & ~0xFFF
+    mu.mem_map(base, max(size, 0x1000))
+    mu.mem_write(text_addr, text)
+    mu.mem_map(0x20000000, 0x40000)  # linear memory + stack RAM
+    mu.mem_map(RETURN_MAGIC & ~0xFFF, 0x1000)
+    mu.reg_write(UC_ARM_REG_SP, 0x2003FF00)
+    mu.reg_write(UC_ARM_REG_LR, RETURN_MAGIC | 1)  # thumb return-to-magic
+    mu.reg_write(UC_ARM_REG_R10, 0x20000100)
+    mu.reg_write(UC_ARM_REG_R11, 0x20000100)
+    for i, v in enumerate(args):
+        mu.reg_write(UC_ARM_REG_R0 + i, v)
+
+    counted = {"n": 0}
+
+    def hook(mu_, addr_, size_, _):
+        counted["n"] += 1
+        if counted["n"] > 5_000_000:
+            mu_.emu_stop()
+
+    mu.hook_add(UC_HOOK_CODE, hook)
+    mu.emu_start(addr | 1, RETURN_MAGIC, timeout=10_000_000)
+    assert mu.reg_read(UC_ARM_REG_PC) & ~1 == RETURN_MAGIC, \
+        f"did not return: pc={mu.reg_read(UC_ARM_REG_PC):#x} after {counted['n']} insns"
+    return mu.reg_read(UC_ARM_REG_R0), counted["n"]
+
+
+def sidecar_entry(report, name):
+    for f in report["functions"]:
+        if f["name"] == name:
+            return f
+    raise KeyError(name)
+
+
+def check(name, report, elf_path, expect_r0, args=(), expect_status="bounded"):
+    f = sidecar_entry(report, name)
+    assert f["status"] == expect_status, f"{name}: {f}"
+    text, text_addr, syms = load_elf(elf_path)
+    r0, n_exec = run_func(text, text_addr, syms[name], args)
+    # unicorn's hook counts each IT-block micro-op and each 16/32-bit insn once;
+    # ArmOp-level instr counts differ (SetCond = 3 machine insns) — that's fine:
+    # the check direction only needs executed MACHINE insns vs cycle bound.
+    assert r0 == expect_r0 & 0xFFFFFFFF, f"{name}: r0={r0} expected {expect_r0}"
+    if expect_status == "bounded":
+        cyc = f["cycles"]
+        assert cyc >= n_exec, \
+            f"{name}: UNSOUND — bound {cyc} cycles < {n_exec} executed instructions"
+        print(f"  OK {name}: r0={r0}, executed {n_exec} machine insns <= bound {cyc} cycles"
+              f" (loops: {[(l['trip_count'], l['source']) for l in f.get('loops', [])]})")
+    else:
+        print(f"  OK {name}: r0={r0}, executed {n_exec}, status={f['status']} (decline honest)")
+
+
+WAT = r"""
+(module
+  (func (export "sum10") (result i32)
+    (local i32 i32)
+    (block (loop
+      local.get 0 i32.const 10 i32.lt_s i32.eqz br_if 1
+      local.get 1 local.get 0 i32.add local.set 1
+      local.get 0 i32.const 1 i32.add local.set 0
+      br 0))
+    local.get 1)
+  (func (export "bottom") (result i32)
+    (local i32 i32)
+    (loop
+      local.get 1 local.get 0 i32.add local.set 1
+      local.get 0 i32.const 1 i32.add local.tee 0
+      i32.const 10 i32.lt_s br_if 0)
+    local.get 1)
+  (func (export "nested") (result i32)
+    (local i32 i32 i32)
+    (block (loop
+      local.get 0 i32.const 5 i32.lt_s i32.eqz br_if 1
+      i32.const 0 local.set 1
+      (block (loop
+        local.get 1 i32.const 3 i32.lt_s i32.eqz br_if 1
+        local.get 2 i32.const 1 i32.add local.set 2
+        local.get 1 i32.const 1 i32.add local.set 1
+        br 0))
+      local.get 0 i32.const 1 i32.add local.set 0
+      br 0))
+    local.get 2)
+  (func (export "eqexit") (result i32)
+    (local i32 i32)
+    (block (loop
+      local.get 0 i32.const 8 i32.eq br_if 1
+      local.get 1 local.get 0 i32.add local.set 1
+      local.get 0 i32.const 1 i32.add local.set 0
+      br 0))
+    local.get 1)
+  (func (export "step3") (result i32)
+    (local i32 i32)
+    (block (loop
+      local.get 0 i32.const 20 i32.lt_s i32.eqz br_if 1
+      local.get 1 i32.const 1 i32.add local.set 1
+      local.get 0 i32.const 3 i32.add local.set 0
+      br 0))
+    local.get 1)
+  (func (export "memloop") (result i32)
+    (local i32)
+    (block (loop
+      local.get 0 i32.const 16 i32.lt_s i32.eqz br_if 1
+      local.get 0 i32.const 4 i32.mul
+      local.get 0
+      i32.store
+      local.get 0 i32.const 1 i32.add local.set 0
+      br 0))
+    i32.const 44 i32.load)
+  (func (export "trip0") (result i32)
+    (local i32 i32)
+    (block (loop
+      local.get 0 i32.const 0 i32.lt_s i32.eqz br_if 1
+      local.get 1 i32.const 1 i32.add local.set 1
+      local.get 0 i32.const 1 i32.add local.set 0
+      br 0))
+    local.get 1)
+  (memory 1))
+"""
+
+ADVERSARIAL_WAT = r"""
+(module
+  ;; conditional extra store to the counter inside the body (two stores) —
+  ;; the analyzer must NOT prove this shape
+  (func (export "condstore") (param i32) (result i32)
+    (local i32 i32)
+    (block (loop
+      local.get 1 i32.const 10 i32.lt_s i32.eqz br_if 1
+      (if (local.get 0) (then local.get 1 i32.const 5 i32.add local.set 1))
+      local.get 1 i32.const 1 i32.add local.set 1
+      br 0))
+    local.get 1)
+  ;; infinite loop shape (no exit) — must decline
+  ;; (kept commented: wasmtime/unicorn can't run it; the analyzer path is
+  ;;  covered by databound in the main gate)
+  (memory 1))
+"""
+
+
+def main():
+    d = os.environ.get("WCET_REPRO_DIR", "/tmp/wcet_phase2_778_repro")
+    os.makedirs(d, exist_ok=True)
+    os.chdir(d)
+    open("val.wat", "w").write(WAT)
+    open("adv.wat", "w").write(ADVERSARIAL_WAT)
+    open("val_hints.json", "w").write(json.dumps({
+        "schema": "synth-wcet-hints-v1",
+        "functions": {"eqexit": {"loop_bounds": [8]}},
+    }))
+
+    print("== main fixtures (with correct eqexit hint) ==")
+    report = compile_wat("val.wat", "val.elf", hints="val_hints.json")
+    check("sum10", report, "val.elf", 45)
+    check("bottom", report, "val.elf", 45)
+    check("nested", report, "val.elf", 15)
+    check("eqexit", report, "val.elf", 28)
+    check("step3", report, "val.elf", 7)      # v: 0,3,..,18 -> 7 trips
+    check("memloop", report, "val.elf", 11)   # mem[44] = 11 (11*4=44)
+    check("trip0", report, "val.elf", 0)      # 0 iterations, head runs once
+
+    print("== adversarial: must stay declined ==")
+    report = compile_wat("adv.wat", "adv.elf")
+    f = sidecar_entry(report, "condstore")
+    assert f["status"] == "declined" and f["reason"] == "loop", f
+    # execute it anyway to show the decline was honest, not vacuous
+    text, ta, syms = load_elf("adv.elf")
+    r0, n = run_func(text, ta, syms["condstore"], (1,))
+    print(f"  OK condstore: declined (two counter stores); runs fine r0={r0}")
+
+    print("== red-first: wrong hint rejected ==")
+    open("val_hints_wrong.json", "w").write(json.dumps({
+        "schema": "synth-wcet-hints-v1",
+        "functions": {"eqexit": {"loop_bounds": [3]}},
+    }))
+    report = compile_wat("val.wat", "val_wrong.elf", hints="val_hints_wrong.json")
+    f = sidecar_entry(report, "eqexit")
+    assert f["status"] == "declined", f
+    assert f["hint_rejections"][0]["reason"] == "hint-below-derived-trip", f
+    print("  OK eqexit with hint 3 (< real 8): REJECTED hint-below-derived-trip")
+
+    print("ALL SOUNDNESS CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part of #778 (v0.47 Wave-1 Lane 1). Converts the phase-1 blanket `loop` decline into proven bounds for canonical counted loops, and lands the scry hint seam: untrusted oracle + sound checker.

## Increment 1 — statically-evident trip counts

A new conservative analyzer (`crates/synth-backend/src/wcet_loops.rs`) works over the FINAL Thumb-2 instruction stream:

- **Loop regions** from resolved backward branches; must nest properly; a global branch discipline requires every branch to be a region closer or a conditional exit targeting exactly its region's fall-through resume point (anything else → decline).
- **Induction proof** by a symbolic walk: SP-slot counter written EXACTLY once per iteration with `old + const-step`, const init proven on the straight-line entry path (function prologue, or the parent body for nested loops), and an exit comparison against a const bound that provably fires — exact i128 trip arithmetic with static no-wrap checks over the whole counter walk.
- **Bound** = per-instruction documented worst case × proven execution count (`K+1` head-test, `K` bottom-test, multiplicative across nesting iff EVERY level proves; u128 internally, overflow → decline).
- **Byte layout from the real encoder** — the same probe `resolve_label_branches` uses — NOT `estimate_arm_byte_size`: the estimator under-sizes a high-register `SetCond` (6 vs 10 B), which sheared reconstructed branch targets in the nested fixture. Estimator gap filed as a follow-up finding below.

## Increment 2 — the `--wcet-hints` seam (scry integration, no scry dependency)

`--wcet-hints <file>` (`synth-wcet-hints-v1`) carries UNTRUSTED per-function loop-bound hints (ordered by loop head offset). Every hint is checked against synth's own derived trip count:

- **wrong hint** (below derived trip) → REJECTED `hint-below-derived-trip`, recorded in the sidecar; never trusted into a bound
- **unverifiable hint** (data-dependent bound, non-canonical shape) → REJECTED `hint-unverifiable-induction`
- **verified hint** on an equality-exit loop (the termination-brittle shape, deliberately hint-gated: a step that misses the bound flips terminating→infinite) → converts the decline into a bound whose trip count is synth's DERIVED value, never the raw hint (`source: hint-verified`)
- hints naming a nonexistent function warn loudly; malformed/mis-schema'd files and `--wcet-hints` without `--emit-wcet` fail the compile
- ELF verified byte-identical with/without hints (`cmp`)

## Decline matrix — before → after

Before = v0.46 shipped binary (observed: every backward branch declined `loop`).

| shape | v0.46 | v0.47 no hints | v0.47 with hints |
|---|---|---|---|
| head-test `for i in 0..10` | declined `loop` | **bounded 349 cyc, trip 10** | — |
| bottom-test (`br_if 0`) | declined `loop` | **bounded 229, trip 10** | — |
| nested 5×3 | declined `loop` | **bounded 863, trips 5·3** | — |
| memory-writing body (16 trips) | declined `loop` | **bounded 520** | — |
| step 3 (0..20) | declined `loop` | **bounded 254, trip 7** | — |
| zero-trip | declined `loop` | **bounded 58, trip 0** | — |
| equality-exit (`i32.eq`) | declined `loop` | declined `loop` | **bounded 254, trip 8, hint-verified**; wrong hint 3 → REJECTED |
| data-dependent bound (param) | declined `loop` | declined `loop` | declined + `hint-unverifiable-induction` |
| conditional counter store (`if` in body) | declined `loop` | declined `loop` | declined |
| call / i64 soft-div / M7 / M4F-eabihf | declined | declined (unchanged) | — |

## Evidence

- **Gate** (`wcet_bound_gate.rs`, 21 tests): decline assertions MOVED, never deleted — the now-bounded shapes assert exact pinned cycle literals + a trip-aware soundness floor (`cycles ≥ trip × region_instr_count`, independent of the cycle table); the still-declining shapes stay asserted; RED-FIRST wrong-hint rejection asserted before the conversion.
- **Unicorn execution** (authoring-time, Thumb-2 machine-instruction counting): every bounded fixture returns the semantically-correct result (a wrong trip count would change it) and executes ≤ bound machine instructions (sum10: 188 ≤ 349; nested: 377 ≤ 863; eqexit hinted: 126 ≤ 254; memloop: 304 ≤ 520; trip0: 18 ≤ 58).
- `cargo test --workspace` green (125 suites), clippy `-D warnings` clean, `claim_check` 21/21 (per-op cycle-model pins unchanged).
- Sidecar additions are purely additive (`loops`, `hint_rejections`); `.text` byte-identical.

## Follow-up findings (not in this PR)

- `estimate_arm_byte_size` under-sizes high-register `SetCond` (6 vs 10 B) and is therefore not layout-exact; the estimator↔encoder agreement oracle (#498/PR #511) does not cover this shape.
- Richer hint certificates for data-dependent bounds (the real scry payload) + inter-procedural composition remain the named follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L