### PR TITLE
chore(release): v0.46.1 — #791 const-only-body soundness patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.46.1] - 2026-07-17
+
+**Soundness patch — #791 closed (const-only-body exports returned garbage).**
+
+### Fixed (soundness)
+
+- **The optimized (default) path miscompiled functions whose body is a bare
+  constant (#791)** — `Opcode::Const` was the one value-producing arm that never
+  recorded its dest as `last_result_vreg`, so the epilogue's move-result-to-R0 had
+  nothing to move: `push {r4,lr}; movs r4,#K; pop {r4,pc}` — R0 never written, the
+  export returned caller residue. Found by the #275 lane's execution differential
+  (the first gate to run dispatch targets in a default self-contained image).
+  Fix: track the const's dest like every other producer. Side effect: void
+  functions whose final IR value is a stored const gain one harmless `mov r0,rX`
+  (+2 B, both flag arms consistently — the behavior every other producer always
+  had); `base_cse_flip_468` goldens re-pinned with rationale after a full
+  differential sweep on the new bytes. Red-first
+  `const_body_791_differential.py` (RED on 0.46.0, GREEN on fix); frozen anchors
+  10/10 unchanged.
+
 ## [0.46.0] - 2026-07-16
 
 **Qualification depth + capability breadth.** The sequel to the #757 arc: synth's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,14 +1100,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1166,11 +1166,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.46.0"
+version = "0.46.1"
 
 [[package]]
 name = "synth-cli"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1225,14 +1225,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1240,11 +1240,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.46.0"
+version = "0.46.1"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.46.0"
+version = "0.46.1"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.46.0"
+version = "0.46.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.46.0",
+    version = "0.46.1",
 )
 
 # Bazel dependencies

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.46.0" }
+synth-core = { path = "../synth-core", version = "0.46.1" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.46.0" }
+synth-core = { path = "../synth-core", version = "0.46.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.46.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.46.0" }
+synth-core = { path = "../synth-core", version = "0.46.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.46.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.46.0" }
+synth-core = { path = "../synth-core", version = "0.46.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.46.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.46.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.46.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.46.1", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.46.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.46.1", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -58,23 +58,23 @@ exports_only_275_probe = []
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.46.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.46.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.46.0" }
-synth-backend = { path = "../synth-backend", version = "0.46.0" }
+synth-core = { path = "../synth-core", version = "0.46.1" }
+synth-frontend = { path = "../synth-frontend", version = "0.46.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.46.1" }
+synth-backend = { path = "../synth-backend", version = "0.46.1" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.46.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.46.1" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.46.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.46.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.46.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.46.1", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.46.1", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.46.1", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.46.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.46.1", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-cli/tests/base_cse_flip_468.rs
+++ b/crates/synth-cli/tests/base_cse_flip_468.rs
@@ -136,20 +136,31 @@ fn func_sizes(elf: &[u8]) -> HashMap<String, usize> {
 /// previously appeared to read (−20 B): 342 → 326 B. New opt-out bytes
 /// execution-validated (spill_frame_499_differential.py +
 /// base_cse_differential.py, unicorn vs wasmtime) before re-pinning.
+///
+/// RE-PIN (#791): `Opcode::Const` now records its dest as `last_result_vreg`
+/// like every other value-producing arm (a const-only body previously never
+/// moved its result to R0 — the export returned caller residue from r4).
+/// Both fixtures here are single VOID functions whose final IR values are
+/// stored consts, so the epilogue now appends one spurious-but-harmless
+/// `mov r0, rX` (+2 B on BOTH arms) — the behavior void functions ending in
+/// any OTHER producer (Add, Select, ...) always had. Full scripts/repro
+/// differential sweep re-run green on the new bytes (incl.
+/// base_cse_differential.py + volatile_segment_543_differential.py, unicorn
+/// vs wasmtime) before re-pinning.
 const GOLDENS: [(&str, &str, usize, &str, usize); 2] = [
     (
         "scripts/repro/redundant_base_materialization.wat",
-        "a0f684bcfaaece182b55fdb2e98b94d54bbeab72243764ff354ed67b79a56aef",
-        224,
-        "b44084bebcc57701b39510d365a7e066d62f9bfae5a6f93a7860fe6e87f90a05",
-        326,
+        "5bba0a12d79c6bf9667f863afd4ca6127b52b5d859368904b8f2530b2a40a7f4",
+        226,
+        "7e4bbca6bc82dca2bd1fe1697baea4150a001561a605e3e5d48f78f038005e56",
+        328,
     ),
     (
         "scripts/repro/volatile_segment_543.wat",
-        "86af859f443eaaddf01a2a99811b81a60c66b6fe4118b53ceea121511c88070b",
-        194,
-        "eb9c8355416778fba8bedc26d1cf672a6f0334d915492f5cdffd95381d7572f7",
-        256,
+        "ca0da92e7d7328db90edcd250dbe568176358b0fc28d1b662205ceb3b928223d",
+        196,
+        "b63f4644cfeff637923230240ee665c8097055c56e4cca09f9ecfc7cfc247ecd",
+        258,
     ),
 ];
 

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.46.0" }
+synth-core = { path = "../synth-core", version = "0.46.1" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.46.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.46.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.46.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.46.0" }
-synth-opt = { path = "../synth-opt", version = "0.46.0" }
+synth-core = { path = "../synth-core", version = "0.46.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.46.1" }
+synth-opt = { path = "../synth-opt", version = "0.46.1" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -4041,6 +4041,14 @@ impl OptimizerBridge {
                             op2: Operand2::Imm(*value),
                         });
                     }
+                    // #791: a bare const can BE the function result. This was
+                    // the ONLY value-producing arm that did not record its
+                    // dest as `last_result_vreg`, so for a const-only body the
+                    // epilogue's move-result-to-R0 pass never fired — the
+                    // constant stayed in its callee-saved temp (r4) and the
+                    // export returned caller residue from R0. Track it like
+                    // every other producer (Load, Add, Select, Call, ...).
+                    last_result_vreg = Some(dest.0);
                 }
 
                 // Arithmetic operations

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.46.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.46.0" }
-synth-opt = { path = "../synth-opt", version = "0.46.0" }
+synth-core = { path = "../synth-core", version = "0.46.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.46.1" }
+synth-opt = { path = "../synth-opt", version = "0.46.1" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.46.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.46.1", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"

--- a/scripts/repro/const_body_791.wat
+++ b/scripts/repro/const_body_791.wat
@@ -1,0 +1,30 @@
+;; #791 — const-only-body exports on the OPTIMIZED (default self-contained) path.
+;;
+;; The optimized lowering (`optimizer_bridge::ir_to_arm`) materializes a bare
+;; `i32.const` result into a callee-saved temp (r4/r6/...) and never moves it
+;; to R0 — AAPCS callers read garbage (the caller's own saved r4, restored by
+;; the epilogue `pop {r4,pc}`). Every function here must return its constant.
+(module
+  ;; The minimal repro: body is a single i32.const.
+  (func (export "c100") (result i32) (i32.const 100))
+
+  ;; i64 const-only body (R0:R1 pair) — green pre-fix, pinned as a guard.
+  (func (export "c64") (result i64) (i64.const 0x1122334455667788))
+
+  ;; Declared-but-unused locals must not change the story.
+  (func (export "clocals") (result i32) (local i32 i32) (i32.const 42))
+
+  ;; WRONG-VALUE variant: an earlier op leaves a stale last-result vreg, the
+  ;; final const lands in a different temp — pre-fix this returns garbage
+  ;; instead of 100 (not even the stale 3).
+  (func (export "stale") (result i32) (local i32)
+    (local.set 0 (i32.add (i32.const 1) (i32.const 2)))
+    (i32.const 100))
+
+  ;; Tail-position explicit `return` of a const — same missing move.
+  (func (export "tailret") (result i32)
+    (return (i32.const 77)))
+
+  ;; local.get of a zero-init local — green pre-fix, pinned as a guard.
+  (func (export "getzero") (result i32) (local i32) (local.get 0))
+)

--- a/scripts/repro/const_body_791_differential.py
+++ b/scripts/repro/const_body_791_differential.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""#791 — EXECUTION-validate const-only-body returns on the optimized path.
+
+On the OPTIMIZED (default self-contained) ARM path, a function whose result is
+a bare `i32.const` materialized the constant into a callee-saved temp (r4) and
+never moved it to R0: `push {r4,lr}; movs r4,#100; pop {r4,pc}` — the export
+returns whatever the caller had in R0 (AAPCS reads R0). Root cause: the
+`Opcode::Const` arm in `optimizer_bridge::ir_to_arm` was the only
+value-producing arm that did not record its dest as `last_result_vreg`, so the
+epilogue's move-result-to-R0 pass never fired (and could fire on a STALE vreg
+from an earlier op — the `stale` case returns the wrong live value, not just
+caller residue).
+
+This harness compiles the fixture via the optimized path (default
+self-contained, `-b arm`), runs each export under unicorn (UC_ARCH_ARM /
+Thumb) with SENTINEL values pre-loaded in R0/R1 (so "R0 happened to be right"
+can't false-green), and asserts the returned R0 (R0:R1 for i64) matches
+wasmtime ground truth.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/const_body_791_differential.py
+Exits nonzero on any mismatch.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R4,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("const_body_791.wat")
+SYNTH = os.environ.get("SYNTH", "./target/release/synth")
+# (export, result kind) — every function is nullary; the observable is R0
+# (R0:R1 for i64).
+CASES = [
+    ("c100", "i32"),
+    ("c64", "i64"),
+    ("clocals", "i32"),
+    ("stale", "i32"),
+    ("tailret", "i32"),
+    ("getzero", "i32"),
+]
+SENTINEL_R0 = 0xDEADBEEF  # caller residue the bug leaks back
+SENTINEL_R1 = 0xCAFEF00D
+SENTINEL_R4 = 0x5A5A5A5A  # caller's saved r4 — restored by `pop {r4,pc}`
+
+
+def compile_optimized(out):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"},
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed: {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+    return data, base, syms
+
+
+def wasm_result(func):
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    return inst.exports(st)[func](st)
+
+
+def run_arm(code, base, addr, kind):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(base & ~0xFFFF, 0x20000)
+    mu.mem_write(base, code)
+    mu.mem_map(0x90000, 0x10000)
+    ret = 0x90100
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    mu.reg_write(UC_ARM_REG_R0, SENTINEL_R0)
+    mu.reg_write(UC_ARM_REG_R1, SENTINEL_R1)
+    mu.reg_write(UC_ARM_REG_R4, SENTINEL_R4)
+    mu.reg_write(UC_ARM_REG_SP, 0x98000)
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    mu.emu_start(addr | 1, ret, timeout=5_000_000)
+    r0 = mu.reg_read(UC_ARM_REG_R0)
+    if kind == "i64":
+        return r0 | (mu.reg_read(UC_ARM_REG_R1) << 32)
+    return r0
+
+
+def main():
+    if not os.path.exists(SYNTH):
+        sys.exit(f"{SYNTH} not found — build synth first")
+    elf = "/tmp/const_body_791.elf"
+    compile_optimized(elf)
+    code, base, syms = load(elf)
+
+    fails = 0
+    for func, kind in CASES:
+        mask = 0xFFFFFFFFFFFFFFFF if kind == "i64" else 0xFFFFFFFF
+        gt = wasm_result(func) & mask
+        got = run_arm(code, base, syms[func], kind) & mask
+        ok = got == gt
+        if not ok:
+            fails += 1
+        print(f"{'OK  ' if ok else 'FAIL'} {func}() = {got:#x}  (wasmtime: {gt:#x})")
+
+    print("ORACLE:", "PASS" if fails == 0 else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Pure patch: v0.46.0 + cherry-picked #794 (#791 fix: Opcode::Const never set last_result_vreg → const-only-body exports returned caller residue on the default path) + pins + CHANGELOG. NOTE: main is already AHEAD (m4 #790, WCET-ph2 #793) — this branch tags v0.46.1 from the v0.46.0 base; the PR is for CI + record, merge will be a no-op-ish union (main already has the fix via #794). Verified on-branch: const_body_791 ORACLE PASS, frozen 10/10, claims 21/21, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)