### PR TITLE
VCR-WASM-001 phase 2: WasmCert-Coq real-dep feasibility verdict + 19-op i32 refinement batch (49 Qed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ cd coq && make proofs
 
 ### Proof Status
 
-See `coq/STATUS.md` for the complete coverage matrix. Current: 489 Qed / 3 Admitted
+See `coq/STATUS.md` for the complete coverage matrix. Current: 536 Qed / 3 Admitted
 (+2 `admit.` tactics) across `coq/Synth/`. The 50 selector-DSL rule theorems
 (`VcrSelRules.v`) are stated directly about the GENERATED model (VCR-ISA-001
 #667: `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v` emitted
@@ -148,7 +148,10 @@ frozen and oracle-gated every step:
   #682 model↔selector drift is unrepresentable at the instruction-sequence level
   for those ops (the interim `VcrSelRulesGenCheck.v` reflexivity gate was
   retired as vacuous/subsumed). `VCR-WASM-001` WasmCert-Coq source semantics —
-  proposed.
+  phases 1+2 landed: the i32 integer fragment (19 ops) transcribed from the
+  pinned coq9.0-wasm-2.2.0 sources with line-level provenance and proven
+  refined by `exec_wasm_instr` (49 Qed, `coq/Synth/WASM/WasmCertBridge.v`);
+  real external dep nix-feasible, bazel-deferred (roadmap entry).
 - **Track C (validation):** the differential oracles are CI-gated jobs
   (cmp-select, RV32 shift-fold/const-addr-fold, callee-saved, spill-frame,
   symtab-based frozen-fixture differentials). `VCR-VER-003` (#777, implemented

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 | ELF output with vector table | Implemented | Thumb bit set on symbols; not linked on real hardware |
 | Linker scripts (STM32, nRF52840, generic) | Implemented | Generated, not tested with real boards |
 | Cross-compilation (`--link` flag) | Implemented | Requires `arm-none-eabi-gcc` in PATH; not CI-tested |
-| Rocq mechanized proofs | 489 Qed / 3 Admitted | i32 + i64 T1 correctness proofs; the 50 selector-DSL rule theorems are stated directly about the GENERATED model (VCR-ISA-001 #667 — `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v`); all four i32 div/rem trap guards discharged against the branch-taking executor (#73) |
+| Rocq mechanized proofs | 536 Qed / 3 Admitted | i32 + i64 T1 correctness proofs; the 50 selector-DSL rule theorems are stated directly about the GENERATED model (VCR-ISA-001 #667 — `rule_X := Gen.rule_X`, single source `VcrSelRulesGenerated.v`); all four i32 div/rem trap guards discharged against the branch-taking executor (#73) |
 | SMT translation validation | ordeal (pure-Rust QF_BV) default | v0.27.0 (#553); Z3 demoted to feature-gated differential oracle — 141/141 agreement |
 | WebAssembly spec test suite | 227/257 compile | Compilation only — not executed on emulator |
 
@@ -194,7 +194,7 @@ Per the [PulseEngine Verification Guide](https://pulseengine.eu/guides/VERIFICAT
 
 | Track | Status | Coverage |
 |-------|--------|----------|
-| **Rocq** | Partial | 489 Qed / 3 Admitted (50 selector-DSL rule theorems stated directly about the GENERATED model, VCR-ISA-001 #667) — all four i32 div/rem trap guards discharged (#73) |
+| **Rocq** | Partial | 536 Qed / 3 Admitted (50 selector-DSL rule theorems stated directly about the GENERATED model, VCR-ISA-001 #667) — all four i32 div/rem trap guards discharged (#73) |
 | **Kani** | Starting | 18 bounded model checking harnesses for ARM encoder |
 | **Verus** | Starting | 8 spec functions in `synth-synthesis/src/contracts.rs`; Bazel integration via `rules_verus` |
 | **Lean** | Not started | — |
@@ -206,7 +206,7 @@ See `artifacts/verification-gaps.yaml` for the detailed gap analysis (VG-001 thr
 Mechanized proofs in Rocq 9 show that `compile_wasm_to_arm` preserves WASM semantics for each operation. The proof suite lives in `coq/Synth/` and covers ARM instruction semantics, WASM stack-machine semantics, and per-operation correctness theorems.
 
 ```
-489 Qed / 3 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
+536 Qed / 3 Admitted (+2 admit. tactics)   [CI-gated: claims.yaml + scripts/claim_check.py]
   T1 result-correspondence (ARM output = WASM result): all i32 ops and all
      i64 ops — i64 T1 parity since v0.11.0, 0 i64 admits (coq/STATUS.md)
   T2 existence-only: f32/f64 and remaining categories
@@ -271,7 +271,7 @@ The one-sentence version: moving synth's correctness from *"we patched every bug
 | | `VCR-PERF-002` | Proof-carrying specialization (#494): loom's `wsc.facts` invariants become premises for per-elision proof obligations, certificate-checked by the ordeal-backed validator — toward gale's measured **0.45× (below-native) floor** | design traced (v0.30.0); phase 1 (facts ingestion) landed ([PR #624](https://github.com/pulseengine/synth/pull/624), v0.31.0) |
 | | `SYNTH_SPILL_ON_EXHAUST` | Replace the register-exhaustion decline with allocation-time Belady spilling (#580) — the last piece of the exhaustion hard-fail | built, flag-off; default-on held for silicon cycle numbers |
 | **B — authoritative semantics** | `VCR-ISA-001` | Re-base ARM/RISC-V semantics on Sail-generated Rocq (the official ISA spec); generate the selector model, don't mirror it (#667) | approved — Sail/ASL bridge spike landed (92 Qed, `coq/Synth/ARM/SailArmBridge.v`); #667 "generate, don't mirror" landed: the shipped `sel_dsl::RULES` table emits the 50 covered ops' Rocq lowerings (`coq/Synth/Synth/VcrSelRulesGenerated.v`), and `VcrSelRules.v` DEFINES `rule_X := Gen.rule_X` — the generated file is the single model source, the 50 correctness Qed are stated directly about it, and a selector-table change breaks the matching proof (no hand-written copy left to drift) |
-| | `VCR-WASM-001` | Anchor WASM source semantics on WasmCert-Coq | proposed |
+| | `VCR-WASM-001` | Anchor WASM source semantics on WasmCert-Coq | phases 1+2 landed: the i32 integer fragment (19 ops — arithmetic/bitwise/shifts/eqz/comparisons) transcribed from the pinned coq9.0-wasm-2.2.0 sources with line-level provenance (`coq/Synth/WASM/WasmCertReference.v`) and proven refined by `exec_wasm_instr` (49 Qed, `WasmCertBridge.v`); the real external dep is nix-feasible, bazel-deferred on three named blockers (roadmap entry) |
 | **Gate** | `VCR-VER-001` | Success = a previously load-bearing greedy-fix becomes *revertable*, with the full differential bit-identical and cycles equal-or-better | **demonstrated** (implemented; [evidence](scripts/repro/vcr_ver_001_gate.md)): the v0.11.20 reciprocal-mult cost-gate deleted outright (PR #322, bit-identical); the #496 exhaustion decline revertable behind `SYNTH_SPILL_ON_EXHAUST` — red case green, anchors byte-identical, declines 14→8; flip held on a measured i32-shape cycle regression |
 
 Honest open items: the RV32 local-promotion flip is held on a failed no-grow gate (#601); f32/f64 remain loud-reject (#369); SIMD/Helium is untested on hardware.

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -719,6 +719,31 @@ artifacts:
         bazel/nix toolchain (the transcription is the bounded scaffold), plus
         the full integer/control-flow fragment.
 
+        PHASE 2 (v0.47): real-dependency FEASIBILITY SPIKE result — nix-level
+        FEASIBLE, bazel-level DEFERRED on three named blockers. Evidence:
+        coqPackages.wasmcert (coq9.0-wasm-2.2.0) EXISTS in the exact nixpkgs
+        commit the rules_rocq_rust toolchain pins (88d3861a) and nix-builds
+        GREEN against the same Rocq 9.0.1 (verified 2026-07-17), propagating
+        coq-ext-lib 0.13.0, mathcomp-boot 2.5.0, parseque 0.3.0, flocq 4.2.1,
+        compcert 3.16 — the phase-1 "drags mathcomp+CompCert, no-go" wording
+        is obsolete. Blockers for wiring it into bazel: (1) rules_rocq_rust
+        has NO generic extra-coq-package hook — coqutil/hammer/smpl are
+        hard-coded attrs across extensions.bzl + toolchain.bzl + rocq.bzl, so
+        a fork change (or a large MODULE.bazel patch) is required; (2)
+        LICENSE: nixpkgs wasmcert 2.2.0 depends on CompCert 3.16, license
+        inria-compcert (meta.license.free = false) — an unfree dep in the
+        default CI proof toolchain needs an explicit allowUnfree opt-in and a
+        project policy decision; (3) upstream WasmCert-Coq 2.2.1 (master,
+        coq >= 9.0 & < 9.2) DROPS the coq-compcert dependency entirely, so
+        waiting for the next nixpkgs wasmcert bump removes blocker (2) for
+        free. Verdict: land the ruleset extra-package hook + take the dep when
+        wasmcert >= 2.2.1 reaches nixpkgs. Meanwhile phase 2 batch-extends the
+        transcription bridge: the full i32 arithmetic/bitwise/shift + eqz +
+        compare family (19 ops), each transcribed from the PINNED
+        coq9.0-wasm-2.2.0 sources (numerics.v / operations.v line-level
+        provenance, CompCert 3.16 lib/Integers.v for the underlying ops) with
+        a real-Qed refinement lemma per op in WasmCertBridge.v.
+
   # ---------------------------------------------------------------------------
   # Track C — validation methodology (can start now; feeds Tracks A and B)
   # ---------------------------------------------------------------------------

--- a/claims.yaml
+++ b/claims.yaml
@@ -29,16 +29,16 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-PROOF-COUNT-README
     doc: README.md
-    text: "489 Qed / 3 Admitted"
+    text: "536 Qed / 3 Admitted"
     evidence:
       - kind: count-eq                       # ALL THREE README spots must agree —
-        pattern: '489 Qed / 3 Admitted'      # a verbatim check alone greens if one
+        pattern: '536 Qed / 3 Admitted'      # a verbatim check alone greens if one
         glob: ['README.md']                  # of them drifts while another matches
         expect: 3
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 489
+        expect: 536
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -50,12 +50,12 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-CLAUDE-MD
     doc: CLAUDE.md
-    text: "489 Qed / 3 Admitted"
+    text: "536 Qed / 3 Admitted"
     evidence:
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 489
+        expect: 536
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -63,16 +63,16 @@ claims:
 
   - id: SYNTH-PROOF-COUNT-STATUS-MD
     doc: coq/STATUS.md
-    text: "489 Qed / 3 Admitted"
+    text: "536 Qed / 3 Admitted"
     evidence:
       - kind: count-eq                       # headline + Total line must both agree
-        pattern: '489 Qed / 3 Admitted'
+        pattern: '536 Qed / 3 Admitted'
         glob: ['coq/STATUS.md']
         expect: 2
       - kind: count-eq
         pattern: 'Qed\.'
         glob: ['coq/Synth/**/*.v']
-        expect: 489
+        expect: 536
       - kind: count-eq
         pattern: 'Admitted\.'
         glob: ['coq/Synth/**/*.v']
@@ -232,24 +232,28 @@ claims:
         expect: 92
 
   # VCR-WASM-001 (Track B): WASM source semantics anchored on WasmCert-Coq.
-  # Bounded first increment — 1 op (i32.add), 2 real-Qed refinement lemmas
-  # (WasmCertBridge.v), establishing the pattern. The reference rule is a
-  # hand transcription of WasmCert-Coq/CompCert Int.add with line-level
-  # provenance (WasmCertReference.v); a real external dep + full fragment is
-  # the named follow-up. The WASM-side analogue of SailArmBridge.v (ISA-001).
+  # Phase 1 (v0.45): 1 op (i32.add), 2 real-Qed refinement lemmas. Phase 2
+  # (v0.47): the i32 integer fragment batch — 19 ops (add/sub/mul, and/or/
+  # xor, shl/shr_u/shr_s, eqz/eq/ne, lt/gt/le/ge u+s), 49 Qed in
+  # WasmCertBridge.v (op-level + executor-level per op, + encoding/bit-level
+  # helpers). The reference rules are hand transcriptions of the PINNED
+  # coq9.0-wasm-2.2.0 sources with line-level provenance
+  # (WasmCertReference.v); the real external dep is nix-FEASIBLE but
+  # bazel-deferred on three named blockers (see the roadmap entry). The
+  # WASM-side analogue of SailArmBridge.v (ISA-001).
   - id: SYNTH-VCR-WASM-001-STATUS
     doc: artifacts/verified-codegen-roadmap.yaml
-    text: "BOUNDED FIRST INCREMENT LANDED (v0.45, VCR-WASM-001)"
+    text: "PHASE 2 (v0.47): real-dependency FEASIBILITY SPIKE result"
     evidence:
       - kind: yaml-field
         path: artifacts/verified-codegen-roadmap.yaml
         id: VCR-WASM-001
         field: status
         equals: implemented
-      - kind: count-eq                       # the 2 refinement bridge lemmas
+      - kind: count-eq                       # the refinement bridge lemmas
         pattern: 'Qed\.'
         glob: ['coq/Synth/WASM/WasmCertBridge.v']
-        expect: 2
+        expect: 49
       - kind: file-exists
         path: coq/Synth/WASM/WasmCertReference.v
 

--- a/coq/STATUS.md
+++ b/coq/STATUS.md
@@ -1,7 +1,11 @@
 # Rocq Proof Suite — Honest Status
 
-**Last Updated: 2026-07-16 (#166: recount 489 Qed / 3 Admitted, +2 admit., crude
-`grep "Qed\."` over `coq/Synth/**/*.v` — same method as prior recounts; the
+**Last Updated: 2026-07-17 (VCR-WASM-001 phase 2: recount 536 Qed / 3 Admitted,
++2 admit., crude `grep "Qed\."` over `coq/Synth/**/*.v` — same method as prior
+recounts; +47 vs the prior 489 are the WasmCert-Coq i32 refinement batch in
+`WasmCertBridge.v` (19 ops transcribed from the pinned coq9.0-wasm-2.2.0
+sources, op-level + executor-level Qed per op, + encoding/bit-level helpers);
+prior recount context (#166): the
 -40 vs the prior 512 are the retired VCR-ISA-001 #667 cross-check lemmas of
 `VcrSelRulesGenCheck.v`: `VcrSelRules.v` now DEFINES every `rule_X` as the
 GENERATED `Gen.rule_X` (`VcrSelRulesGenerated.v`, emitted from the shipped
@@ -173,7 +177,7 @@ and predates the VcrSelRules (42), VcrSelPilot (7) and SailArmBridge (92) Qed;
 see the per-file breakdown below for current per-file counts. The T3 row and
 the headline total are re-derived by the claim gate.
 
-**Total: 489 Qed / 3 Admitted (+2 admit.) across all files** (recount 2026-07-15, CI-gated via `claims.yaml`)
+**Total: 536 Qed / 3 Admitted (+2 admit.) across all files** (recount 2026-07-17, CI-gated via `claims.yaml`)
 
 v0.10.0 PR 1: +2 T1 Qed (i64_add_correct, i64_sub_correct) and +9
 infrastructure Qed (combine_i32_unsigned, carry_split_add,
@@ -454,9 +458,11 @@ Recount 2026-07-10 (`grep -oE 'Qed\.'` / `'Admitted\.'` per file):
 | Base.v | 4 | 0 | Infra |
 | StateMonad.v | 3 | 0 | Infra |
 | WasmValues.v | 2 | 0 | Infra |
+| WasmCertReference.v | 0 | 0 | definitions only (VCR-WASM-001: WasmCert-Coq i32 rules transcribed from the pinned coq9.0-wasm-2.2.0 sources with line-level provenance) |
+| WasmCertBridge.v | 49 | 0 | Infra/T1-analogue (VCR-WASM-001 phases 1+2: 19 i32 ops — arithmetic/bitwise/shifts/eqz/comparisons — each with an op-level refinement Qed against the WasmCert reference AND an executor-level Qed through the real `exec_wasm_instr`, + 9 encoding/bit-level helper Qed) |
 | VcrSelPilot.v | 7 | 0 | T1 (register-polymorphic; VCR-SEL-001 go/abandon measurement) |
 | VcrSelRules.v | 42 | 0 | T1 (register-polymorphic; the WIRED VCR-SEL-001 increment-1+2+3+4 rule table — 40 rule theorems 1:1 with `coq/vcr_sel_rules.manifest`, coverage-gated by `//coq:vcr_sel_rules_coverage`, + 2 mod-32 helper lemmas #683. VCR-ISA-001 #667 increment 2: every `rule_X` is DEFINED as the GENERATED `Gen.rule_X` of `VcrSelRulesGenerated.v` — emitted from the shipped `sel_dsl::RULES` — so the theorems are stated directly about the shipped sequences; a table change regenerates `Gen` and breaks the matching Qed. The former `VcrSelRulesGenCheck.v` 40-lemma `reflexivity` gate is retired as vacuous/subsumed) |
-| **Total** | **476** | **5** | (+2 `admit.`) |
+| **Total** | **536** | **3** | (+2 `admit.`; headline re-derived by the claim gate) |
 
 ## VCR-SEL-001 increments 1 (2026-07-07) + 2 + 3 + 4 (2026-07-08): VcrSelRules.v
 

--- a/coq/Synth/WASM/WasmCertBridge.v
+++ b/coq/Synth/WASM/WasmCertBridge.v
@@ -1,30 +1,52 @@
-(** * VCR-WASM-001 — WasmCert-Coq refinement bridge (BOUNDED first increment)
+(** * VCR-WASM-001 — WasmCert-Coq refinement bridge (phase 2: i32 batch)
 
     This file proves that synth's stack-machine executor [exec_wasm_instr]
-    AGREES with the WasmCert-Coq reference rule (WasmCertReference.v) for ONE
-    total operation: i32.add. It is the WASM-side analogue of SailArmBridge.v's
+    AGREES with the WasmCert-Coq reference rules (WasmCertReference.v) for the
+    i32 integer fragment: add, sub, mul, and, or, xor, shl, shr_u, shr_s,
+    eqz, eq, ne, lt_u, lt_s, gt_u, gt_s, le_u, le_s, ge_u — 19 ops, each with
+    an op-level refinement theorem ([I32.op = wasmcert_i32_op]) and an
+    executor-level theorem routing the claim through the REAL
+    [exec_wasm_instr]. It is the WASM-side analogue of SailArmBridge.v's
     per-instruction bridge lemmas (VCR-ISA-001 / #667).
 
-    SCOPE (honest, named): bounded first increment — 1 op anchored, 1 real-Qed
-    refinement lemma, establishing the pattern. Full integer/control-flow
-    coverage and a real external WasmCert-Coq/CompCert coq dependency (this file
-    uses a hand transcription of the reference, see WasmCertReference.v) are the
-    named follow-up.
+    SCOPE (honest, named): the reference is still a hand TRANSCRIPTION of the
+    pinned coq9.0-wasm-2.2.0 sources, not the real external dependency — see
+    WasmCertReference.v's header for the phase-2 feasibility verdict
+    (nix-feasible, bazel-deferred on three named blockers). Remaining op
+    coverage (div/rem trap rules, clz/ctz/popcnt, rotl/rotr, i64, memory,
+    control flow) is the named follow-up.
 
     NON-VACUITY (why a WRONG synth semantics fails this file):
-    - [i32_add_refines_wasmcert_op] is NOT [reflexivity]: synth's [I32.add x y]
-      is [repr (x + y)] over RAW representatives, whereas the WasmCert/CompCert
-      reference [wasmcert_i32_add x y] is [repr (unsigned x + unsigned y)] —
-      operands normalized first. Equal mod 2^32, but definitionally distinct;
-      the proof discharges the raw-vs-normalized gap via [Zplus_mod].
-    - [i32_add_exec_refines_wasmcert] routes the claim through the REAL
-      [exec_wasm_instr I32Add]. If [exec_wasm_instr I32Add] were miswired to
-      compute [I32.sub]/[I32.mul] (or pushed the wrong value / wrong stack
-      shape), this theorem would be unprovable: the pushed result would not be
-      [wasmcert_i32_add v1 v2]. The reference pins the OPERATION, not the shape.
+    - No op-level lemma is [reflexivity]-only where a real gap exists:
+      * arithmetic: synth operates on RAW representatives ([I32.add x y :=
+        repr (x + y)]) vs the reference's normalize-then-operate
+        ([repr (unsigned x + unsigned y)]) — discharged via
+        [Zplus_mod]/[Zminus_mod]/[Zmult_mod];
+      * bitwise: raw-vs-normalized under [Z.land]/[Z.lor]/[Z.lxor] is a
+        BIT-LEVEL fact (low 32 bits of the op equal the op of the low 32
+        bits), discharged by [Z.bits_inj'] + [testbit] reasoning — not by any
+        mod-homomorphism rewrite;
+      * shifts: the reference's DOUBLE normalization of the shift count
+        ([unsigned (repr (unsigned y mod 32))]) is collapsed by a proved
+        range lemma, and for shl the raw-vs-normalized operand gap is
+        discharged via [Z.shiftl_mul_pow2] + [Zmult_mod_idemp_l];
+      * comparisons: the reference keeps CompCert's SUMBOOL decisions
+        ([Z.eq_dec]/[Z_lt_dec], = Coqlib zeq/zlt) and WasmCert's DERIVED
+        orientation (gt/le/ge from lt by swap+negation, numerics.v:974-979),
+        while synth uses [Z.gtb]/[Z.leb]/[Z.geb] directly — each lemma
+        discharges the boolean-vs-sumbool bridge and, for gt/le/ge, the
+        real orientation gap ([Z.gtb_ltb]/[Z.leb_antisym]/[Z.geb_leb]).
+    - Executor-level theorems route through the REAL [exec_wasm_instr]. If an
+      op were miswired (wrong operation, wrong operand ORDER — pinned because
+      sub/shl/comparisons are non-commutative — wrong stack shape, wrong
+      boolean encoding), the theorem would be unprovable: the pushed value is
+      pinned to the INDEPENDENT reference, with comparisons pinned to
+      WasmCert's [wasm_bool] shape (numerics.v:1952-1953:
+      [if b then one else zero]).
 *)
 
 From Stdlib Require Import ZArith.
+From Stdlib Require Import Lia.
 From Stdlib Require Import List.
 Require Import Synth.Common.Base.
 Require Import Synth.Common.Integers.
@@ -37,14 +59,106 @@ Import List.ListNotations.
 Open Scope list_scope.
 Open Scope Z_scope.
 
-(** ** Algebraic core: synth's i32.add equals the WasmCert reference rule.
+(** ** Encoding helpers: boolean tests vs CompCert's sumbool decisions *)
 
-    synth:      [I32.add x y      = repr (x + y)]            (raw operands)
-    WasmCert:   [wasmcert_i32_add = repr (unsigned x + unsigned y)]  (normalized)
+Lemma zeqb_eq_dec : forall a b : Z,
+  (a =? b) = if Z.eq_dec a b then true else false.
+Proof.
+  intros a b. destruct (Z.eq_dec a b) as [E | E].
+  - apply Z.eqb_eq; exact E.
+  - apply Z.eqb_neq; exact E.
+Qed.
 
-    These agree because [unsigned n = n mod 2^32] and addition commutes with
-    [mod] ([Zplus_mod]). This is the step that would break if synth added the
-    operands under a different operation. *)
+Lemma zltb_lt_dec : forall a b : Z,
+  (a <? b) = if Z_lt_dec a b then true else false.
+Proof.
+  intros a b. destruct (Z_lt_dec a b) as [L | L].
+  - apply Z.ltb_lt; exact L.
+  - apply Z.ltb_nlt; exact L.
+Qed.
+
+(** Synth's [I32.signed] (Z.ltb over the normalized representative) equals
+    the transcribed CompCert [signed] (zlt sumbool, Integers.v:137-139). *)
+Lemma signed_refines_wasmcert : forall n,
+  I32.signed n = wasmcert_i32_signed n.
+Proof.
+  intros n. unfold I32.signed, wasmcert_i32_signed. cbv zeta.
+  rewrite zltb_lt_dec. destruct (Z_lt_dec _ _); reflexivity.
+Qed.
+
+(** ** Normalization helpers *)
+
+Lemma unsigned_repr_small : forall k,
+  0 <= k < I32.modulus -> I32.unsigned (I32.repr k) = k.
+Proof.
+  intros k H. unfold I32.unsigned, I32.repr.
+  rewrite Z.mod_mod by (unfold I32.modulus; lia).
+  apply Z.mod_small. exact H.
+Qed.
+
+Lemma shift_count_range : forall y,
+  0 <= I32.unsigned y mod 32 < 32.
+Proof.
+  intros y. apply Z.mod_pos_bound. lia.
+Qed.
+
+(** The reference's DOUBLE normalization of the shift count collapses:
+    [unsigned (repr (unsigned y mod 32)) = unsigned y mod 32]. *)
+Lemma shift_count_collapse : forall y,
+  I32.unsigned (I32.repr (I32.unsigned y mod 32)) = I32.unsigned y mod 32.
+Proof.
+  intros y. apply unsigned_repr_small.
+  pose proof (shift_count_range y). unfold I32.modulus. lia.
+Qed.
+
+(** ** Bit-level helpers: low 32 bits of a bitwise op = op of low 32 bits.
+    These are the raw-vs-normalized discharges for and/or/xor — genuine
+    [Z.testbit] facts, not mod-homomorphism rewrites. *)
+
+Lemma land_mod_modulus : forall a b,
+  Z.land a b mod I32.modulus =
+  Z.land (a mod I32.modulus) (b mod I32.modulus) mod I32.modulus.
+Proof.
+  intros a b. change I32.modulus with (2 ^ 32).
+  apply Z.bits_inj'. intros n Hn.
+  destruct (Z_lt_dec n 32) as [H | H].
+  - rewrite !Z.mod_pow2_bits_low by lia.
+    rewrite !Z.land_spec.
+    rewrite !Z.mod_pow2_bits_low by lia.
+    reflexivity.
+  - rewrite !Z.mod_pow2_bits_high by lia. reflexivity.
+Qed.
+
+Lemma lor_mod_modulus : forall a b,
+  Z.lor a b mod I32.modulus =
+  Z.lor (a mod I32.modulus) (b mod I32.modulus) mod I32.modulus.
+Proof.
+  intros a b. change I32.modulus with (2 ^ 32).
+  apply Z.bits_inj'. intros n Hn.
+  destruct (Z_lt_dec n 32) as [H | H].
+  - rewrite !Z.mod_pow2_bits_low by lia.
+    rewrite !Z.lor_spec.
+    rewrite !Z.mod_pow2_bits_low by lia.
+    reflexivity.
+  - rewrite !Z.mod_pow2_bits_high by lia. reflexivity.
+Qed.
+
+Lemma lxor_mod_modulus : forall a b,
+  Z.lxor a b mod I32.modulus =
+  Z.lxor (a mod I32.modulus) (b mod I32.modulus) mod I32.modulus.
+Proof.
+  intros a b. change I32.modulus with (2 ^ 32).
+  apply Z.bits_inj'. intros n Hn.
+  destruct (Z_lt_dec n 32) as [H | H].
+  - rewrite !Z.mod_pow2_bits_low by lia.
+    rewrite !Z.lxor_spec.
+    rewrite !Z.mod_pow2_bits_low by lia.
+    reflexivity.
+  - rewrite !Z.mod_pow2_bits_high by lia. reflexivity.
+Qed.
+
+(** ** Op-level refinement: arithmetic (raw vs normalized, mod-homomorphism) *)
+
 Theorem i32_add_refines_wasmcert_op : forall x y,
   I32.add x y = wasmcert_i32_add x y.
 Proof.
@@ -55,12 +169,177 @@ Proof.
   reflexivity.
 Qed.
 
-(** ** Executor-level refinement: [exec_wasm_instr I32Add] pushes exactly the
+Theorem i32_sub_refines_wasmcert_op : forall x y,
+  I32.sub x y = wasmcert_i32_sub x y.
+Proof.
+  intros x y.
+  unfold I32.sub, wasmcert_i32_sub, I32.repr, I32.unsigned.
+  rewrite Zminus_mod.
+  reflexivity.
+Qed.
+
+Theorem i32_mul_refines_wasmcert_op : forall x y,
+  I32.mul x y = wasmcert_i32_mul x y.
+Proof.
+  intros x y.
+  unfold I32.mul, wasmcert_i32_mul, I32.repr, I32.unsigned.
+  rewrite Zmult_mod.
+  reflexivity.
+Qed.
+
+(** ** Op-level refinement: bitwise (raw vs normalized, bit-level) *)
+
+Theorem i32_and_refines_wasmcert_op : forall x y,
+  I32.and x y = wasmcert_i32_and x y.
+Proof.
+  intros x y.
+  unfold I32.and, wasmcert_i32_and, I32.repr, I32.unsigned.
+  apply land_mod_modulus.
+Qed.
+
+Theorem i32_or_refines_wasmcert_op : forall x y,
+  I32.or x y = wasmcert_i32_or x y.
+Proof.
+  intros x y.
+  unfold I32.or, wasmcert_i32_or, I32.repr, I32.unsigned.
+  apply lor_mod_modulus.
+Qed.
+
+Theorem i32_xor_refines_wasmcert_op : forall x y,
+  I32.xor x y = wasmcert_i32_xor x y.
+Proof.
+  intros x y.
+  unfold I32.xor, wasmcert_i32_xor, I32.repr, I32.unsigned.
+  apply lxor_mod_modulus.
+Qed.
+
+(** ** Op-level refinement: shifts *)
+
+Theorem i32_shl_refines_wasmcert_op : forall x y,
+  I32.shl x y = wasmcert_i32_shl x y.
+Proof.
+  intros x y. unfold wasmcert_i32_shl. cbv zeta.
+  rewrite shift_count_collapse.
+  pose proof (shift_count_range y) as Hk.
+  unfold I32.shl, I32.repr, I32.unsigned. unfold I32.unsigned in Hk.
+  (* Goal: Z.shiftl x k mod m = Z.shiftl (x mod m) k mod m, 0 <= k < 32 *)
+  rewrite !Z.shiftl_mul_pow2 by lia.
+  rewrite Zmult_mod_idemp_l.
+  reflexivity.
+Qed.
+
+Theorem i32_shr_u_refines_wasmcert_op : forall x y,
+  I32.shru x y = wasmcert_i32_shr_u x y.
+Proof.
+  intros x y. unfold wasmcert_i32_shr_u. cbv zeta.
+  rewrite shift_count_collapse.
+  reflexivity.
+Qed.
+
+Theorem i32_shr_s_refines_wasmcert_op : forall x y,
+  I32.shrs x y = wasmcert_i32_shr_s x y.
+Proof.
+  intros x y. unfold wasmcert_i32_shr_s. cbv zeta.
+  rewrite shift_count_collapse.
+  unfold I32.shrs. rewrite signed_refines_wasmcert.
+  reflexivity.
+Qed.
+
+(** ** Op-level refinement: equality tests *)
+
+Theorem i32_eq_refines_wasmcert_op : forall x y,
+  I32.eq x y = wasmcert_i32_eq x y.
+Proof.
+  intros x y. unfold I32.eq, wasmcert_i32_eq. apply zeqb_eq_dec.
+Qed.
+
+(** [int_eqz := eq zero] puts zero FIRST (numerics.v:970); synth's executor
+    tests [I32.eq v I32.zero] — the symmetry discharge pins that they agree. *)
+Theorem i32_eqz_refines_wasmcert_op : forall v,
+  I32.eq v I32.zero = wasmcert_i32_eqz v.
+Proof.
+  intros v. unfold I32.eq, wasmcert_i32_eqz, wasmcert_i32_eq, I32.zero.
+  rewrite Z.eqb_sym. apply zeqb_eq_dec.
+Qed.
+
+Theorem i32_ne_refines_wasmcert_op : forall x y,
+  I32.ne x y = wasmcert_i32_ne x y.
+Proof.
+  intros x y. unfold I32.ne, wasmcert_i32_ne.
+  rewrite i32_eq_refines_wasmcert_op. reflexivity.
+Qed.
+
+(** ** Op-level refinement: order comparisons.
+    gt/le/ge discharge a REAL orientation gap: synth uses Z.gtb/Z.leb/Z.geb
+    directly, the reference derives them from lt by swap+negation. *)
+
+Theorem i32_lt_u_refines_wasmcert_op : forall x y,
+  I32.ltu x y = wasmcert_i32_lt_u x y.
+Proof.
+  intros x y. unfold I32.ltu, wasmcert_i32_lt_u. apply zltb_lt_dec.
+Qed.
+
+Theorem i32_lt_s_refines_wasmcert_op : forall x y,
+  I32.lts x y = wasmcert_i32_lt_s x y.
+Proof.
+  intros x y. unfold I32.lts, wasmcert_i32_lt_s.
+  rewrite !signed_refines_wasmcert. apply zltb_lt_dec.
+Qed.
+
+Theorem i32_gt_u_refines_wasmcert_op : forall x y,
+  I32.gtu x y = wasmcert_i32_gt_u x y.
+Proof.
+  intros x y. unfold I32.gtu, wasmcert_i32_gt_u, wasmcert_i32_lt_u.
+  rewrite Z.gtb_ltb. apply zltb_lt_dec.
+Qed.
+
+Theorem i32_gt_s_refines_wasmcert_op : forall x y,
+  I32.gts x y = wasmcert_i32_gt_s x y.
+Proof.
+  intros x y. unfold I32.gts, wasmcert_i32_gt_s, wasmcert_i32_lt_s.
+  rewrite Z.gtb_ltb. rewrite !signed_refines_wasmcert. apply zltb_lt_dec.
+Qed.
+
+Theorem i32_le_u_refines_wasmcert_op : forall x y,
+  I32.leu x y = wasmcert_i32_le_u x y.
+Proof.
+  intros x y. unfold I32.leu, wasmcert_i32_le_u, wasmcert_i32_lt_u.
+  rewrite Z.leb_antisym. rewrite zltb_lt_dec. reflexivity.
+Qed.
+
+Theorem i32_le_s_refines_wasmcert_op : forall x y,
+  I32.les x y = wasmcert_i32_le_s x y.
+Proof.
+  intros x y. unfold I32.les, wasmcert_i32_le_s, wasmcert_i32_lt_s.
+  rewrite Z.leb_antisym. rewrite !signed_refines_wasmcert.
+  rewrite zltb_lt_dec. reflexivity.
+Qed.
+
+Theorem i32_ge_u_refines_wasmcert_op : forall x y,
+  I32.geu x y = wasmcert_i32_ge_u x y.
+Proof.
+  intros x y. unfold I32.geu, wasmcert_i32_ge_u, wasmcert_i32_lt_u.
+  rewrite Z.geb_leb. rewrite Z.leb_antisym. rewrite zltb_lt_dec. reflexivity.
+Qed.
+
+Theorem i32_ge_s_refines_wasmcert_op : forall x y,
+  I32.ges x y = wasmcert_i32_ge_s x y.
+Proof.
+  intros x y. unfold I32.ges, wasmcert_i32_ge_s, wasmcert_i32_lt_s.
+  rewrite Z.geb_leb. rewrite Z.leb_antisym. rewrite !signed_refines_wasmcert.
+  rewrite zltb_lt_dec. reflexivity.
+Qed.
+
+(** ** Executor-level refinement: [exec_wasm_instr] pushes exactly the
        WasmCert reference result on top of the popped stack.
 
     Mirrors the shape of [i32_add_type_preservation] in WasmSemantics.v, but
-    the pushed value is pinned to the INDEPENDENT reference
-    [wasmcert_i32_add v1 v2], not to synth's own [I32.add]. *)
+    the pushed value is pinned to the INDEPENDENT reference, not to synth's
+    own operation. Comparisons pin WasmCert's [wasm_bool] result shape
+    (numerics.v:1952-1953). Proof pattern: expose the stack, rewrite the
+    reference back to synth's op via the (real) op-level refinement theorem,
+    and close by conversion — the rewrite step IS the refinement content. *)
+
 Theorem i32_add_exec_refines_wasmcert : forall v1 v2 s stack',
   s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
   exec_wasm_instr I32Add s =
@@ -73,8 +352,276 @@ Proof.
   intros v1 v2 s stack' Hstack.
   unfold exec_wasm_instr, pop2_i32, pop2.
   rewrite Hstack.
-  simpl.
-  (* the executor pushes [VI32 (I32.add v1 v2)]; rewrite to the reference *)
-  rewrite i32_add_refines_wasmcert_op.
+  rewrite <- i32_add_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_sub_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32Sub s =
+  Some (mkWasmState
+          (VI32 (wasmcert_i32_sub v1 v2) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_sub_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_mul_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32Mul s =
+  Some (mkWasmState
+          (VI32 (wasmcert_i32_mul v1 v2) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_mul_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_and_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32And s =
+  Some (mkWasmState
+          (VI32 (wasmcert_i32_and v1 v2) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_and_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_or_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32Or s =
+  Some (mkWasmState
+          (VI32 (wasmcert_i32_or v1 v2) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_or_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_xor_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32Xor s =
+  Some (mkWasmState
+          (VI32 (wasmcert_i32_xor v1 v2) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_xor_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_shl_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32Shl s =
+  Some (mkWasmState
+          (VI32 (wasmcert_i32_shl v1 v2) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_shl_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_shr_u_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32ShrU s =
+  Some (mkWasmState
+          (VI32 (wasmcert_i32_shr_u v1 v2) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_shr_u_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_shr_s_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32ShrS s =
+  Some (mkWasmState
+          (VI32 (wasmcert_i32_shr_s v1 v2) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_shr_s_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+(** Executor-level: equality tests and comparisons pin WasmCert's
+    [wasm_bool] shape ([if b then one else zero], numerics.v:1952-1953)
+    with the reference boolean under the [if]. *)
+
+Theorem i32_eqz_exec_refines_wasmcert : forall v s stack',
+  s.(stack) = VI32 v :: stack' ->
+  exec_wasm_instr I32Eqz s =
+  Some (mkWasmState
+          (VI32 (if wasmcert_i32_eqz v then I32.one else I32.zero) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v s stack' Hstack.
+  unfold exec_wasm_instr, pop_i32, pop_value, pop.
+  rewrite Hstack.
+  rewrite <- i32_eqz_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_eq_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32Eq s =
+  Some (mkWasmState
+          (VI32 (if wasmcert_i32_eq v1 v2 then I32.one else I32.zero) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_eq_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_ne_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32Ne s =
+  Some (mkWasmState
+          (VI32 (if wasmcert_i32_ne v1 v2 then I32.one else I32.zero) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_ne_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_lt_u_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32LtU s =
+  Some (mkWasmState
+          (VI32 (if wasmcert_i32_lt_u v1 v2 then I32.one else I32.zero) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_lt_u_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_lt_s_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32LtS s =
+  Some (mkWasmState
+          (VI32 (if wasmcert_i32_lt_s v1 v2 then I32.one else I32.zero) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_lt_s_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_gt_u_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32GtU s =
+  Some (mkWasmState
+          (VI32 (if wasmcert_i32_gt_u v1 v2 then I32.one else I32.zero) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_gt_u_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_gt_s_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32GtS s =
+  Some (mkWasmState
+          (VI32 (if wasmcert_i32_gt_s v1 v2 then I32.one else I32.zero) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_gt_s_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_le_u_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32LeU s =
+  Some (mkWasmState
+          (VI32 (if wasmcert_i32_le_u v1 v2 then I32.one else I32.zero) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_le_u_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_le_s_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32LeS s =
+  Some (mkWasmState
+          (VI32 (if wasmcert_i32_le_s v1 v2 then I32.one else I32.zero) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_le_s_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_ge_u_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32GeU s =
+  Some (mkWasmState
+          (VI32 (if wasmcert_i32_ge_u v1 v2 then I32.one else I32.zero) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_ge_u_refines_wasmcert_op.
+  reflexivity.
+Qed.
+
+Theorem i32_ge_s_exec_refines_wasmcert : forall v1 v2 s stack',
+  s.(stack) = VI32 v2 :: VI32 v1 :: stack' ->
+  exec_wasm_instr I32GeS s =
+  Some (mkWasmState
+          (VI32 (if wasmcert_i32_ge_s v1 v2 then I32.one else I32.zero) :: stack')
+          s.(locals) s.(globals) s.(memory)).
+Proof.
+  intros v1 v2 s stack' Hstack.
+  unfold exec_wasm_instr, pop2_i32, pop2.
+  rewrite Hstack.
+  rewrite <- i32_ge_s_refines_wasmcert_op.
   reflexivity.
 Qed.

--- a/coq/Synth/WASM/WasmCertReference.v
+++ b/coq/Synth/WASM/WasmCertReference.v
@@ -1,4 +1,4 @@
-(** * VCR-WASM-001 — WasmCert-Coq source-semantics reference (BOUNDED first increment)
+(** * VCR-WASM-001 — WasmCert-Coq source-semantics reference (phase 2: i32 batch)
 
     GOAL (epic #242, VCR-WASM-001, roadmap Track B). WasmSemantics.v is a
     HAND-WRITTEN stack-machine model: every source-side correctness statement
@@ -10,50 +10,73 @@
     VCR-ISA-001 (#667 / SailArmBridge.v) does on the ARM/selector side:
     "anchor/generate, don't mirror".
 
-    WHAT THIS FILE IS. Per the SailArmBridge.v spike precedent, importing the
-    external Rocq model WHOLESALE into synth's hermetic bazel/nix proof
-    toolchain is a no-go at this stage: WasmCert-Coq drags in mathcomp +
-    CompCert's Integers library as coq dependencies. So — exactly as
-    SailArmBridge transcribes the Sail [execute] clause BY HAND with line-level
-    provenance — this file TRANSCRIBES WasmCert-Coq's operational rule for ONE
-    total op (i32.add) into synth's own [I32] value primitives, with a verbatim
-    provenance citation to the WasmCert-Coq / CompCert source.
+    WHAT THIS FILE IS. Exactly as SailArmBridge transcribes the Sail [execute]
+    clauses BY HAND with line-level provenance, this file TRANSCRIBES
+    WasmCert-Coq's operational rules for the i32 integer fragment (arithmetic,
+    bitwise, shifts, eqz, and the full comparison family — 19 ops) into
+    synth's own [I32] value primitives, with verbatim provenance citations to
+    the WasmCert-Coq / CompCert sources.
 
     *** TRANSCRIPTION — to be replaced by a real external dependency. ***
-    This is a hand transcription, NOT the real WasmCert-Coq dependency. It is
-    the bounded-first-increment scaffolding that establishes the refinement
-    PATTERN for one op. Wiring the actual WasmCert-Coq/CompCert coq deps into
-    the hermetic toolchain, and extending to the full integer/control-flow
-    fragment, is the named follow-up (VCR-WASM-001 continuation).
+    PHASE-2 FEASIBILITY VERDICT (v0.47, see the VCR-WASM-001 entry in
+    artifacts/verified-codegen-roadmap.yaml for the full evidence): the real
+    dependency is NIX-FEASIBLE — [coqPackages.wasmcert] (coq9.0-wasm-2.2.0)
+    exists in the exact nixpkgs commit the rules_rocq_rust toolchain pins
+    (88d3861a) and nix-builds green against the same Rocq 9.0.1 — but
+    bazel-wiring is DEFERRED on three named blockers: (1) rules_rocq_rust has
+    no generic extra-coq-package hook (fork change required); (2) nixpkgs
+    wasmcert 2.2.0 depends on CompCert 3.16, whose license (inria-compcert)
+    is unfree — a policy decision, not a code change; (3) upstream WasmCert
+    2.2.1 drops the CompCert dependency, so the next nixpkgs bump removes (2).
+    Until then this file remains a hand transcription, now pinned to the
+    EXACT nix-built sources.
 
-    PROVENANCE. The rule below is transcribed from:
+    PROVENANCE (pinned). All citations below refer to:
 
-      - WasmCert/WasmCert-Coq @ master, theories/numerics.v:
-          Definition i32 : Type := Wasm_int.Int32.T.
-          (* within Wasm_int.Make, the Tmixin record: *)  int_add := iadd ;
-          Definition iadd : T -> T -> T := add.          (* aliases CompCert add *)
-        i.e. WasmCert's i32.add IS CompCert's Integers.Int.add.
+      - WasmCert-Coq 2.2.0 as built by nixpkgs 88d3861a for Rocq 9.0.1
+        (derivation coq9.0-wasm-2.2.0), file [Wasm/numerics.v] and
+        [Wasm/operations.v] — line numbers from the installed sources.
+        The i32 type is instantiated at numerics.v:1034-1035
+        ([Module Int32. Include Make(Integers.Wordsize_32).]), so
+        [wordsize = 32] throughout, and [Module Make] includes CompCert's
+        [Integers.Make] (numerics.v:98-102): the primitive [add]/[sub]/…
+        below ARE CompCert's.
 
-      - AbsInt/CompCert @ master, lib/Integers.v (Module Int):
-          Definition add (x y: int) : int := repr (unsigned x + unsigned y).
-          Definition unsigned (n: int) : Z := intval n.
-          Definition repr (x: Z) : int := mkint (Z_mod_modulus x) _.
+      - CompCert 3.16, [lib/Integers.v] (functor [Make], shared by [Int]):
+          135: Definition unsigned (n: int) : Z := intval n.
+          137: Definition signed (n: int) : Z :=
+          138:   let x := unsigned n in
+          139:   if zlt x half_modulus then x else x - modulus.
+          144: Definition repr (x: Z) : int :=
+          145:   mkint (Z_mod_modulus x) (Z_mod_modulus_range' x).
+          147: Definition zero := repr 0.
+          148: Definition one  := repr 1.
+        and [lib/Coqlib.v]:
+          249: Definition zeq: forall (x y: Z), {x = y} + {x <> y} := Z.eq_dec.
+          269: Definition zlt: forall (x y: Z), {x < y} + {x >= y} := Z_lt_dec.
+        (so the transcriptions below use [Z.eq_dec] / [Z_lt_dec] verbatim).
 
     The salient, deliberately-preserved feature of the reference is that
     CompCert (hence WasmCert) NORMALIZES each operand with [unsigned] BEFORE
-    adding, then [repr]s the sum. Synth's [I32.add x y := repr (x + y)] adds
-    RAW representatives (its [int := Z] is unnormalized). The two are equal
-    mod 2^32 but DEFINITIONALLY DIFFERENT — so the bridge lemma in
-    WasmCertBridge.v is a genuine proof (not [reflexivity]), and it exercises
-    the raw-vs-normalized gap.
+    operating, then [repr]s the result. Synth's [I32] operates on RAW
+    representatives (its [int := Z] is unnormalized). The two agree mod 2^32
+    but are DEFINITIONALLY DIFFERENT — so the bridge lemmas in
+    WasmCertBridge.v are genuine proofs exercising the raw-vs-normalized gap
+    (Zplus_mod/Zminus_mod/Zmult_mod for arithmetic, bit-level [Z.testbit]
+    reasoning for the bitwise ops, shift-count double-normalization collapse
+    for the shifts). For the comparisons the reference keeps CompCert's
+    SUMBOOL decisions ([Z.eq_dec]/[Z_lt_dec] = Coqlib's zeq/zlt) and
+    WasmCert's ORIENTATION (gt/le/ge are DERIVED from [ltu]/[lt] by argument
+    swap and negation, numerics.v:974-979), whereas synth uses boolean
+    [Z.gtb]/[Z.leb]/[Z.geb] directly — the bridge discharges both gaps.
 
-    NON-VACUITY. [wasmcert_i32_add] is phrased ONLY in the value-encoding
-    primitives [I32.repr] / [I32.unsigned] / [Z] — it never mentions
-    [I32.add] or [exec_wasm_instr]. So the bridge lemma is not synth agreeing
-    with a copy of itself. A WRONG synth semantics for i32.add (e.g. if
-    [exec_wasm_instr I32Add] computed [I32.sub] or [I32.mul]) would FAIL to
-    satisfy the bridge theorem: the reference pins the OPERATION (addition mod
-    2^32), not merely the shape.
+    NON-VACUITY. Every reference rule is phrased ONLY in the value-encoding
+    primitives [I32.repr] / [I32.unsigned] / [Z] operators and stdlib decision
+    procedures — never in synth's [I32.add]/[I32.sub]/…/[I32.lts] operations
+    and never in [exec_wasm_instr]. So the bridge lemmas are not synth
+    agreeing with a copy of itself: a WRONG synth semantics (wrong operation,
+    wrong operand order, wrong shift masking, wrong comparison signedness or
+    orientation) FAILS the corresponding bridge theorem.
 *)
 
 From Stdlib Require Import ZArith.
@@ -62,14 +85,147 @@ Require Import Synth.Common.Integers.
 
 Open Scope Z_scope.
 
-(** ** WasmCert-Coq reference rule for i32.add
+(** ** Arithmetic (WasmCert numerics.v — Tmixin at 952-954)
 
-    Transcription of [Wasm_int.Int32.int_add] = CompCert [Int.add]:
-      [repr (unsigned x + unsigned y)].
+    numerics.v:698  Definition iadd : T -> T -> T := add.
+    numerics.v:701  Definition isub : T -> T -> T := sub.
+    numerics.v:704  Definition imul : T -> T -> T := mul.
+    CompCert Integers.v:
+      186: Definition add (x y: int) : int := repr (unsigned x + unsigned y).
+      188: Definition sub (x y: int) : int := repr (unsigned x - unsigned y).
+      190: Definition mul (x y: int) : int := repr (unsigned x * unsigned y).
 
-    Stated in synth's [I32] primitives. NOTE the [I32.unsigned] on each
-    operand — this is the CompCert/WasmCert normalize-then-add form, and is
-    what distinguishes this reference from synth's raw [I32.add x y :=
-    repr (x + y)]. *)
+    NOTE the [I32.unsigned] on each operand — the CompCert/WasmCert
+    normalize-then-operate form, distinct from synth's raw
+    [I32.add x y := repr (x + y)] etc. *)
 Definition wasmcert_i32_add (x y : I32.int) : I32.int :=
   I32.repr (I32.unsigned x + I32.unsigned y).
+
+Definition wasmcert_i32_sub (x y : I32.int) : I32.int :=
+  I32.repr (I32.unsigned x - I32.unsigned y).
+
+Definition wasmcert_i32_mul (x y : I32.int) : I32.int :=
+  I32.repr (I32.unsigned x * I32.unsigned y).
+
+(** ** Bitwise (WasmCert numerics.v — Tmixin at 960-962)
+
+    numerics.v:902  Definition iand : T -> T -> T := and.
+    numerics.v:905  Definition ior  : T -> T -> T := or.
+    numerics.v:908  Definition ixor : T -> T -> T := xor.
+    CompCert Integers.v:
+      205: Definition and (x y: int): int := repr (Z.land (unsigned x) (unsigned y)).
+      206: Definition or  (x y: int): int := repr (Z.lor  (unsigned x) (unsigned y)).
+      207: Definition xor (x y: int): int := repr (Z.lxor (unsigned x) (unsigned y)). *)
+Definition wasmcert_i32_and (x y : I32.int) : I32.int :=
+  I32.repr (Z.land (I32.unsigned x) (I32.unsigned y)).
+
+Definition wasmcert_i32_or (x y : I32.int) : I32.int :=
+  I32.repr (Z.lor (I32.unsigned x) (I32.unsigned y)).
+
+Definition wasmcert_i32_xor (x y : I32.int) : I32.int :=
+  I32.repr (Z.lxor (I32.unsigned x) (I32.unsigned y)).
+
+(** ** Shifts (WasmCert numerics.v:911-922 — Tmixin at 963-965)
+
+    numerics.v:911-913  Definition ishl (i1 i2 : T) : T :=
+                          let k := repr (unsigned i2 mod wordsize)%Z in
+                          shl i1 k.
+    numerics.v:916-918  Definition ishr_u (i1 i2: T) : T :=
+                          let k := repr (unsigned i2 mod wordsize)%Z in
+                          shru i1 k.
+    numerics.v:920-922  Definition ishr_s (i1 i2: T) : T :=
+                          let k := repr (unsigned i2 mod wordsize)%Z in
+                          shr i1 k.
+    with [wordsize = 32] (Wordsize_32, numerics.v:1034-1035).
+    CompCert Integers.v:
+      213: Definition shl  (x y: int): int := repr (Z.shiftl (unsigned x) (unsigned y)).
+      214: Definition shru (x y: int): int := repr (Z.shiftr (unsigned x) (unsigned y)).
+      215: Definition shr  (x y: int): int := repr (Z.shiftr (signed x) (unsigned y)).
+
+    The WasmCert shift count is DOUBLY normalized: [unsigned (repr (unsigned
+    i2 mod 32))] — the transcription preserves that faithfully. *)
+Definition wasmcert_i32_shl (x y : I32.int) : I32.int :=
+  let k := I32.repr (I32.unsigned y mod 32) in
+  I32.repr (Z.shiftl (I32.unsigned x) (I32.unsigned k)).
+
+Definition wasmcert_i32_shr_u (x y : I32.int) : I32.int :=
+  let k := I32.repr (I32.unsigned y mod 32) in
+  I32.repr (Z.shiftr (I32.unsigned x) (I32.unsigned k)).
+
+(** Transcription of CompCert [signed] (Integers.v:137-139), used by [shr]
+    and the signed comparisons. [zlt] is [Z_lt_dec] (Coqlib.v:269). *)
+Definition wasmcert_i32_signed (n : I32.int) : Z :=
+  let x := I32.unsigned n in
+  if Z_lt_dec x I32.half_modulus then x else x - I32.modulus.
+
+Definition wasmcert_i32_shr_s (x y : I32.int) : I32.int :=
+  let k := I32.repr (I32.unsigned y mod 32) in
+  I32.repr (Z.shiftr (wasmcert_i32_signed x) (I32.unsigned k)).
+
+(** ** Equality tests (WasmCert numerics.v — Tmixin at 969-970;
+       operations.v:452-455 [app_testop_i] routes Eqz to [int_eqz])
+
+    numerics.v:969  int_eq  := eq ;
+    numerics.v:970  int_eqz := eq zero ;
+    numerics.v:93-94 (generic, wired by operations.v:461)
+                    Definition int_ne … := fun x y => negb (int_eq mx x y).
+    CompCert Integers.v:
+      177: Definition eq (x y: int) : bool :=
+      178:   if zeq (unsigned x) (unsigned y) then true else false.
+      147: Definition zero := repr 0.
+    [zeq] is [Z.eq_dec] (Coqlib.v:249).
+
+    NOTE [int_eqz := eq zero]: zero is the FIRST argument — the transcription
+    preserves that orientation. *)
+Definition wasmcert_i32_eq (x y : I32.int) : bool :=
+  if Z.eq_dec (I32.unsigned x) (I32.unsigned y) then true else false.
+
+Definition wasmcert_i32_eqz (v : I32.int) : bool :=
+  wasmcert_i32_eq (I32.repr 0) v.
+
+Definition wasmcert_i32_ne (x y : I32.int) : bool :=
+  negb (wasmcert_i32_eq x y).
+
+(** ** Order comparisons (WasmCert numerics.v — Tmixin at 972-979;
+       operations.v:457-470 [app_relop_i] routes ROI_lt/gt/le/ge here)
+
+    numerics.v:972  int_lt_u := ltu ;
+    numerics.v:973  int_lt_s := lt ;
+    numerics.v:974  int_gt_u x y := ltu y x ;
+    numerics.v:975  int_gt_s x y := lt y x ;
+    numerics.v:976  int_le_u x y := negb (ltu y x) ;
+    numerics.v:977  int_le_s x y := negb (lt y x) ;
+    numerics.v:978  int_ge_u x y := negb (ltu x y) ;
+    numerics.v:979  int_ge_s x y := negb (lt x y) ;
+    CompCert Integers.v:
+      179: Definition lt (x y: int) : bool :=
+      180:   if zlt (signed x) (signed y) then true else false.
+      181: Definition ltu (x y: int) : bool :=
+      182:   if zlt (unsigned x) (unsigned y) then true else false.
+
+    gt/le/ge are DERIVED (argument swap + negation) — synth instead uses
+    [Z.gtb]/[Z.leb]/[Z.geb] directly, so the bridge lemmas discharge a real
+    orientation gap, not just an encoding one. *)
+Definition wasmcert_i32_lt_u (x y : I32.int) : bool :=
+  if Z_lt_dec (I32.unsigned x) (I32.unsigned y) then true else false.
+
+Definition wasmcert_i32_lt_s (x y : I32.int) : bool :=
+  if Z_lt_dec (wasmcert_i32_signed x) (wasmcert_i32_signed y) then true else false.
+
+Definition wasmcert_i32_gt_u (x y : I32.int) : bool :=
+  wasmcert_i32_lt_u y x.
+
+Definition wasmcert_i32_gt_s (x y : I32.int) : bool :=
+  wasmcert_i32_lt_s y x.
+
+Definition wasmcert_i32_le_u (x y : I32.int) : bool :=
+  negb (wasmcert_i32_lt_u y x).
+
+Definition wasmcert_i32_le_s (x y : I32.int) : bool :=
+  negb (wasmcert_i32_lt_s y x).
+
+Definition wasmcert_i32_ge_u (x y : I32.int) : bool :=
+  negb (wasmcert_i32_lt_u x y).
+
+Definition wasmcert_i32_ge_s (x y : I32.int) : bool :=
+  negb (wasmcert_i32_lt_s x y).


### PR DESCRIPTION
## Summary

**VCR-WASM-001 phase 2** (Track B, epic #242) — two deliverables:

### 1. Real-dependency feasibility spike (verdict: nix-feasible, bazel-deferred)

Phase 1 deferred the real WasmCert-Coq dep with "drags mathcomp + CompCert into the hermetic toolchain". That wording is now obsolete — the spike sharpened it to evidence:

- `coqPackages.wasmcert` (**coq9.0-wasm-2.2.0**) EXISTS in the exact nixpkgs commit the `rules_rocq_rust` toolchain pins (`88d3861a`) and **nix-builds green** against the same Rocq 9.0.1, propagating coq-ext-lib 0.13.0, mathcomp-boot 2.5.0, parseque 0.3.0, flocq 4.2.1, compcert 3.16.
- Bazel wiring is deferred on **three named blockers** (documented in the roadmap entry):
  1. `rules_rocq_rust` has no generic extra-coq-package hook — coqutil/hammer/smpl are hard-coded across `extensions.bzl`/`toolchain.bzl`/`rocq.bzl`; a fork change is required;
  2. **License**: nixpkgs wasmcert 2.2.0 depends on CompCert 3.16 (`inria-compcert`, `meta.license.free = false`) — an unfree dep in the default CI proof toolchain is a policy decision, not an agent-unilateral change;
  3. Upstream WasmCert-Coq **2.2.1** (master, `coq >= 9.0 & < 9.2`) drops the CompCert dependency entirely — the next nixpkgs bump removes blocker 2 for free.

Verdict: land the ruleset hook + take the dep when wasmcert ≥ 2.2.1 reaches nixpkgs.

### 2. Batch-extended transcription bridge: 19 i32 ops, 49 Qed

- `WasmCertReference.v`: WasmCert-Coq's operational rules for the full i32 integer fragment — add/sub/mul, and/or/xor, shl/shr_u/shr_s, eqz, eq/ne, lt/gt/le/ge (u+s) — transcribed into synth's `I32` primitives with **line-level provenance pinned to the nix-built coq9.0-wasm-2.2.0 sources** (`numerics.v`/`operations.v`) and CompCert 3.16 `lib/Integers.v` + `lib/Coqlib.v`.
- `WasmCertBridge.v` (**49 Qed, 0 Admitted**): per op an op-level refinement theorem (`I32.op = wasmcert_i32_op`) AND an executor-level theorem through the real `exec_wasm_instr`, plus encoding/bit-level helpers. Every discharge is real (phase-1 raw-vs-normalized discipline, no reflexivity-only where a gap exists):
  - arithmetic: `Zplus_mod`/`Zminus_mod`/`Zmult_mod`;
  - bitwise: bit-level `Z.testbit` facts (low-32-bits-commute), not mod-homomorphism rewrites;
  - shifts: proved collapse of the reference's double-normalized shift count + `Z.shiftl_mul_pow2`/`Zmult_mod_idemp_l` for shl;
  - comparisons: sumbool-vs-boolean (`Z.eq_dec`/`Z_lt_dec` = CompCert's zeq/zlt vs synth's `Z.eqb`/`Z.ltb`) AND the real orientation gap — WasmCert derives gt/le/ge from lt by swap+negation (numerics.v:974-979) while synth uses `Z.gtb`/`Z.leb`/`Z.geb` directly; results pinned to WasmCert's `wasm_bool` shape.

### Counts + gates

- Proof count 489 → **536 Qed / 3 Admitted** (+47); `claims.yaml` + README + CLAUDE.md + coq/STATUS.md bumped together (SYNTH-VCR-WASM-001-STATUS now expects the 49 bridge Qed).
- `bazel test //coq:verify_proofs` **GREEN** (2/2).
- `python3 scripts/claim_check.py claims.yaml` **21/21 claims hold**.

Honest scope: the reference remains a hand transcription (now source-pinned); div/rem trap rules, clz/ctz/popcnt, rotl/rotr, i64, memory, and control flow are the named follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L