### PR TITLE
feat(#798): RV32 active data segments SHIP — .wasm_data records + linker placement + startup copy, read-back hard gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **#798: RV32 active data segments SHIP — linker-script placement + startup
+  copy (the RV32 analogue of #758).** The single-base scheme
+  (`s11 = __linear_memory_base`, zeroed RAM) used to emit a `.text`-only
+  object: every nonzero active-segment byte read 0x00 at runtime (found by the
+  VCR-VER-003 phase-2 probe; v0.47 shipped a loud warning). Now `-b riscv`
+  packs the segments into sparse per-segment records
+  (`[u32 off][u32 len][bytes][pad4]`, declaration order —
+  `synth_core::static_data_addr::pack_segment_records`) emitted as a
+  `.wasm_data` PROGBITS section; the generated `linker.ld` places it in flash
+  (`__wasm_data_records_start/end`, before `_data_load`) and the generated
+  `startup.c` byte-copies each record to `__linear_memory_base + off` at
+  reset — record order preserves WASM's later-wins overlap semantics
+  (the #757 lesson). The warning became the VCR-VER-003 hard gate: the
+  emitted blob is READ BACK (`served_image_from_records`) and the compile
+  hard-errors on any served/runtime disagreement; a segment past the declared
+  linear memory is refused (`instantiation would trap`, #758 parity).
+  Regenerate `startup.c`/`linker.ld` via `synth riscv-runtime` — an old
+  script fails the link loudly (undefined `__wasm_data_records_*`) instead of
+  silently dropping data. Gated red-first: the control_step RV32 differential
+  was DE-VACUATED (linear memory now initialized from the SHIPPED records,
+  not wasmtime's instantiated memory — the pre-fix object fails loud,
+  `0x00000000` vs `0x00210a55`), and a new full-boot oracle
+  (`scripts/repro/rv32_data_798_boot_differential.py`: clang riscv32 +
+  ld.lld + unicorn booting `fw.elf` from `_reset`) proves the REAL startup
+  copy loop serves the later-wins image for overlapping segments. Data-free
+  modules ship no section and stay whole-object byte-identical; frozen RV32
+  fixtures' `.text` is unchanged (differentials re-run green, no re-pin
+  needed). The library `Backend::compile_module` path ships + validates the
+  records too.
+
 ## [0.47.0] - 2026-07-17
 
 **"Close the loops" — every v0.46 loud-decline converted to a proven capability

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,9 +166,13 @@ frozen and oracle-gated every step:
   the shipped init blob on the mixed split (the staggered-overlap straddle is
   refused with a span diagnostic); the self-contained `--cortex-m` #758 ROM
   image is packed by a shared later-wins packer and validated unconditionally;
-  RV32 (single-base s11, ships no initializer image) warns loudly on nonzero
-  dropped initializer bytes (hard decline + initializer shipping = named
-  follow-up, held on the frozen control_step fixture); AArch64 is N/A (no
+  RV32 active data segments SHIP since v0.48 (#798): sparse `.wasm_data`
+  records ([off][len][bytes], declaration order) placed in flash by the
+  generated linker.ld and byte-copied to `__linear_memory_base + off` by the
+  generated startup at reset — the emitted blob is READ BACK and
+  validate_served_image hard-errors the compile on any served/runtime
+  disagreement (the v0.47 warning is gone; the de-vacuated control_step
+  differential + a full-boot unicorn oracle gate it); AArch64 is N/A (no
   linear-memory ops in the integer subset).
 - **Track D (schedulability, #778):** `--emit-wcet` emits a SOUND static
   per-function worst-case cycle bound (`synth-wcet-v1` sidecar) as gale spar's

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -1301,17 +1301,28 @@ artifacts:
       the straddle fixture that the mixed split refuses compiles CORRECTLY
       here (e2e green gate).
       (7) RV32 single-base scheme (s11 = __linear_memory_base, zeroed RAM):
-      the object ships NO static-data initializer image at all — probing found
-      active nonzero data segments are silently DROPPED (loads read 0x00).
-      validate_served_image with an EMPTY image now runs unconditionally on
-      the RV32 emit path and WARNS LOUDLY per nonzero un-served byte
-      (all-zero / zero-overwritten runtime images genuinely ARE served by
-      zeroed RAM and stay silent — a later-wins check, not a bytes grep).
-      HELD AT WARNING, not a hard decline: the CI-pinned RV32 frozen fixture
-      (control_step.wasm carries a nonzero segment its differential never
-      reads) freezes compile-success on this path; the hard decline +
-      initializer shipping (the RV32 analogue of #758: linker-script
-      placement + startup copy) is the named follow-up.
+      the object used to ship NO static-data initializer image at all —
+      probing found active nonzero data segments were silently DROPPED (loads
+      read 0x00); v0.47 held a loud warning. SHIPPED in v0.48 (#798, the RV32
+      analogue of #758): active segments pack into sparse per-segment records
+      ([u32 off][u32 len][bytes][pad4], declaration order — synth_core::
+      static_data_addr::pack_segment_records) emitted as a `.wasm_data`
+      PROGBITS section; the generated linker.ld places it in flash
+      (__wasm_data_records_start/end, before _data_load) and the generated
+      startup.c byte-copies each record to `__linear_memory_base + off` at
+      reset (record order ⇒ later-wins). The VCR-VER-003 arm READS BACK the
+      emitted blob (served_image_from_records — never a recompute) and
+      hard-errors the compile on any served/runtime disagreement; a segment
+      past the declared memory is refused (instantiation would trap, #758
+      parity). Gated red-first: the control_step RV32 differential was
+      DE-VACUATED (linmem init now comes from the shipped records, not
+      wasmtime's memory image — pre-fix object FAILS loud, 0x00000000 vs
+      0x00210a55) and a full-boot oracle
+      (rv32_data_798_boot_differential.py: clang riscv32 + ld.lld + unicorn
+      from _reset) proves the REAL startup copy loop serves the later-wins
+      image for overlapping segments. Data-free modules ship no section and
+      stay byte-identical (frozen fixtures' .text unchanged — no re-pin
+      needed; a reversed-order pack is RED in the permanent unit gate).
       (8) AArch64: N/A, verified — the -b aarch64 integer subset has no
       linear-memory loads/stores (every memory op loud-declines at selection:
       "unsupported wasm op for aarch64 subset"), so compiled code cannot
@@ -1319,10 +1330,10 @@ artifacts:
 
       BOUNDED (named follow-ups after phase 2): recorded per-reloc access
       widths (removes the uncovered-span-byte tolerance and the conservative
-      8-byte widening); RV32 initializer shipping + hard decline (needs a
-      frozen-fixture refreeze ritual); all-addressing coverage (dynamic
-      base+index accesses that cross packed-segment boundaries at runtime are
-      out of static reach on the mixed split).
+      8-byte widening); all-addressing coverage (dynamic base+index accesses
+      that cross packed-segment boundaries at runtime are out of static reach
+      on the mixed split). RV32 initializer shipping landed v0.48 (#798,
+      item 7 above).
     status: implemented
     tags: [verification, addressing, relocation, soundness, mem757]
     links:
@@ -1343,6 +1354,7 @@ artifacts:
         - "Phase 2: spanned reloc check against the SHIPPED init blob (straddle refused e2e, owner access green)"
         - "Phase 2: #758 dense ROM image packed via pack_rom_image + validate_served_image (first-wins pack RED in the unit gate)"
         - "Phase 2: RV32 zero-served-image check — nonzero dropped initializers WARN loudly; zero-overwritten silent"
+        - "#798 (v0.48): RV32 ships .wasm_data records (linker placement + startup copy); read-back validate_served_image hard-errors; de-vacuated control_step differential + full-boot unicorn oracle"
       pass-criteria: >
         On any compiled relocatable object every static-data reloc resolves to
         the runtime-correct byte (segments later-wins), else the compile fails.
@@ -1353,9 +1365,12 @@ artifacts:
         staggered-overlap straddle fixture is REFUSED on the mixed split with
         a span diagnostic (and compiles CORRECTLY self-contained); the #758
         ROM image validates on every self-contained build (first-wins pack is
-        Mismatch in the unit gate); RV32 warns loudly on nonzero un-served
-        initializer bytes and stays silent on zero-served runtime images;
-        AArch64 is documented N/A (no linear-memory ops in the subset).
+        Mismatch in the unit gate); RV32 SHIPS its active segments as
+        .wasm_data records whose read-back served image must equal the
+        runtime image (hard error on mismatch; reversed-order pack is
+        Mismatch in the unit gate; de-vacuated control_step differential +
+        full-boot oracle green); AArch64 is documented N/A (no linear-memory
+        ops in the subset).
 
   # ---------------------------------------------------------------------------
   # Parallel ROI tracks (measured 2026-06-06): the allocator (VCR-RA-001) is the

--- a/claims.yaml
+++ b/claims.yaml
@@ -200,13 +200,16 @@ claims:
   # staggered-overlap straddle phase 1 silently miscompiled is now refused);
   # (b) the self-contained #758 ROM image is packed by the shared
   # declaration-order packer and validated unconditionally against the
-  # reconstructed runtime image; (c) the RV32 single-base path runs the
-  # zero-served-image check and WARNS LOUDLY on nonzero dropped initializer
-  # bytes (hard decline held on the CI-pinned RV32 frozen fixture — named
-  # follow-up); (d) AArch64 documented N/A (no linear-memory ops in the
-  # subset). The count-eq pins below hold the wiring UNCONDITIONAL: exactly
-  # one spanned-validator call on the mixed split, exactly one ROM-image and
-  # one RV32 served-image call.
+  # reconstructed runtime image; (c) RV32 active segments SHIP since v0.48
+  # (#798): packed as .wasm_data records (declaration order, startup copies
+  # to __linear_memory_base + off at reset), the emitted blob READ BACK via
+  # served_image_from_records and hard-error-validated against the runtime
+  # image (the v0.47 drop-warning is gone; de-vacuated control_step
+  # differential + full-boot unicorn oracle gate the runtime side);
+  # (d) AArch64 documented N/A (no linear-memory ops in the subset). The
+  # count-eq pins below hold the wiring UNCONDITIONAL: exactly one
+  # spanned-validator call on the mixed split, exactly one ROM-image and one
+  # RV32 served-image (read-back) call.
   - id: SYNTH-VCR-VER-003-STATUS
     doc: artifacts/verified-codegen-roadmap.yaml
     text: "Static-data addressing VC catches the overlapping-segment wrong-segment miscompile (#757) at compile time on every module"
@@ -224,10 +227,14 @@ claims:
         pattern: 'validate_reloc_resolutions_spanned\('
         glob: crates/synth-cli/src/main.rs
         expect: 1
-      - kind: count-eq                       # phase 2: #758 ROM image + RV32 zero-served checks
+      - kind: count-eq                       # phase 2: #758 ROM image + #798 RV32 read-back checks
         pattern: 'validate_served_image\('
         glob: crates/synth-cli/src/main.rs
         expect: 2
+      - kind: count-eq                       # #798: the RV32 served image is the EMITTED blob read back
+        pattern: 'served_image_from_records\('
+        glob: crates/synth-cli/src/main.rs
+        expect: 1
 
   - id: SYNTH-VCR-SEL-001-STATUS
     doc: README.md

--- a/crates/synth-backend-riscv/src/backend.rs
+++ b/crates/synth-backend-riscv/src/backend.rs
@@ -102,9 +102,43 @@ impl Backend for RiscVBackend {
             functions.push(compiled);
         }
 
+        // #798: ship the module's active data segments as `.wasm_data` records
+        // (declaration order — the startup's record-order copy preserves
+        // later-wins), then READ BACK the emitted blob and validate the image
+        // it serves against the declared segments. Empty segments ⇒ empty blob
+        // ⇒ byte-identical object.
+        let segments: Vec<synth_core::static_data_addr::DataSegment> = module
+            .data_segments
+            .iter()
+            .map(|(off, d)| synth_core::static_data_addr::DataSegment {
+                linmem_off: *off,
+                bytes: d.clone(),
+            })
+            .collect();
+        let wasm_data = synth_core::static_data_addr::pack_segment_records(&segments);
+        let served = synth_core::static_data_addr::served_image_from_records(&wasm_data)
+            .ok_or_else(|| {
+                BackendError::CompilationFailed(
+                    "VCR-VER-003 (#798): emitted .wasm_data records failed to parse back \
+                     — this is a compiler bug in the record packing"
+                        .into(),
+                )
+            })?;
+        if let synth_core::static_data_addr::ImageVerdict::Mismatch(m) =
+            synth_core::static_data_addr::validate_served_image(&segments, &served)
+        {
+            return Err(BackendError::CompilationFailed(format!(
+                "VCR-VER-003 (#798): the shipped .wasm_data records serve {} byte(s) that \
+                 disagree with the runtime linear-memory image (first: {}) — compiler bug \
+                 in the record packing",
+                m.len(),
+                m[0].describe()
+            )));
+        }
+
         let builder = RiscVElfBuilder::new_relocatable();
         let elf = builder
-            .build(&elf_funcs)
+            .build_with_data(&elf_funcs, &wasm_data)
             .map_err(|e| BackendError::CompilationFailed(format!("RISC-V ELF emit: {e}")))?;
 
         Ok(CompilationResult {

--- a/crates/synth-backend-riscv/src/elf_builder.rs
+++ b/crates/synth-backend-riscv/src/elf_builder.rs
@@ -87,6 +87,23 @@ impl RiscVElfBuilder {
     /// each function is independently resolved (no cross-function branch
     /// labels — those will need a second pass once we add `Call`).
     pub fn build(&self, functions: &[RiscVElfFunction]) -> Result<Vec<u8>, ElfBuildError> {
+        self.build_with_data(functions, &[])
+    }
+
+    /// Build the full ELF blob, shipping `wasm_data` (the #798 packed
+    /// active-data-segment records — see
+    /// `synth_core::static_data_addr::pack_segment_records`) as a `.wasm_data`
+    /// PROGBITS section. The generated linker script places it in flash and
+    /// the generated startup copies each record to
+    /// `__linear_memory_base + off` at reset. An EMPTY `wasm_data` omits the
+    /// section entirely, producing bytes identical to the pre-#798 layout —
+    /// data-free modules (and every frozen fixture without segments) are
+    /// untouched.
+    pub fn build_with_data(
+        &self,
+        functions: &[RiscVElfFunction],
+        wasm_data: &[u8],
+    ) -> Result<Vec<u8>, ElfBuildError> {
         let encoder = RiscVEncoder::new_rv32();
 
         // 1. Resolve labels per-function, accumulate code bytes & symbols.
@@ -104,12 +121,15 @@ impl RiscVElfBuilder {
             symbols.push((f.name.clone(), function_offset, function_size));
         }
 
-        // 2. Section ordering:
+        // 2. Section ordering (— entries marked § exist only when `wasm_data`
+        //    is non-empty; without it the layout is bit-identical to pre-#798):
         //    [0]  null
         //    [1]  .text (PROGBITS, AX)
-        //    [2]  .symtab (SYMTAB)
-        //    [3]  .strtab (STRTAB) — symbol names
-        //    [4]  .shstrtab (STRTAB) — section names
+        //    [2]§ .wasm_data (PROGBITS, A) — packed segment records
+        //    [·]  .symtab (SYMTAB)
+        //    [·]  .strtab (STRTAB) — symbol names
+        //    [·]  .shstrtab (STRTAB) — section names
+        let has_wasm_data = !wasm_data.is_empty();
         let mut elf = Vec::new();
         let ehsize = 52usize;
         let shentsize = 40usize;
@@ -121,9 +141,20 @@ impl RiscVElfBuilder {
         let text_offset = elf.len();
         elf.extend_from_slice(&text);
 
-        // Pad to 4-byte alignment for the symbol table.
+        // Pad to 4-byte alignment for what follows (.wasm_data / .symtab).
         while elf.len() % 4 != 0 {
             elf.push(0);
+        }
+
+        // .wasm_data — packed active-segment records (#798), 4-aligned.
+        let wasm_data_offset = elf.len();
+        if has_wasm_data {
+            elf.extend_from_slice(wasm_data);
+            // pack_segment_records pads each record to 4 bytes, but stay
+            // robust to arbitrary blobs: re-align for the symbol table.
+            while elf.len() % 4 != 0 {
+                elf.push(0);
+            }
         }
 
         // .strtab — built first so we know offsets for .symtab.
@@ -165,7 +196,7 @@ impl RiscVElfBuilder {
 
         // .shstrtab — fixed contents
         let shstrtab_offset = elf.len();
-        let shstrtab_data = build_shstrtab();
+        let shstrtab_data = build_shstrtab(has_wasm_data);
         elf.extend_from_slice(&shstrtab_data.bytes);
 
         // Pad to 4-byte for the section header table.
@@ -177,8 +208,11 @@ impl RiscVElfBuilder {
 
         // Section headers
         let text_size = text.len() as u32;
-        let symtab_link = 3u32; // index of .strtab
-        let shdrs = vec![
+        // .wasm_data (when present) sits between .text and .symtab, shifting
+        // the string/symbol-table indices up by one.
+        let wasm_data_shift = if has_wasm_data { 1u32 } else { 0 };
+        let symtab_link = 3u32 + wasm_data_shift; // index of .strtab
+        let mut shdrs = vec![
             // [0] null
             ShEntry::null(),
             // [1] .text
@@ -198,7 +232,26 @@ impl RiscVElfBuilder {
                 sh_addralign: 4,
                 sh_entsize: 0,
             },
-            // [2] .symtab
+        ];
+        if has_wasm_data {
+            // [2] .wasm_data — SHF_ALLOC only (a read-only flash image; the
+            // startup copies it into linear-memory RAM, code never executes
+            // or writes it in place).
+            shdrs.push(ShEntry {
+                sh_name: shstrtab_data.wasm_data_off,
+                sh_type: 1,    // SHT_PROGBITS
+                sh_flags: 0x2, // SHF_ALLOC
+                sh_addr: 0,
+                sh_offset: wasm_data_offset as u32,
+                sh_size: wasm_data.len() as u32,
+                sh_link: 0,
+                sh_info: 0,
+                sh_addralign: 4,
+                sh_entsize: 0,
+            });
+        }
+        shdrs.extend([
+            // [2/3] .symtab
             ShEntry {
                 sh_name: shstrtab_data.symtab_off,
                 sh_type: 2, // SHT_SYMTAB
@@ -211,7 +264,7 @@ impl RiscVElfBuilder {
                 sh_addralign: 4,
                 sh_entsize: 16,
             },
-            // [3] .strtab
+            // [3/4] .strtab
             ShEntry {
                 sh_name: shstrtab_data.strtab_off,
                 sh_type: 3, // SHT_STRTAB
@@ -224,7 +277,7 @@ impl RiscVElfBuilder {
                 sh_addralign: 1,
                 sh_entsize: 0,
             },
-            // [4] .shstrtab
+            // [4/5] .shstrtab
             ShEntry {
                 sh_name: shstrtab_data.shstrtab_off,
                 sh_type: 3, // SHT_STRTAB
@@ -237,7 +290,7 @@ impl RiscVElfBuilder {
                 sh_addralign: 1,
                 sh_entsize: 0,
             },
-        ];
+        ]);
 
         for sh in &shdrs {
             sh.write_into(&mut elf);
@@ -254,7 +307,7 @@ impl RiscVElfBuilder {
             shentsize as u16,
             ehsize as u16,
             phentsize as u16,
-            4u16, // shstrtab index
+            (4 + wasm_data_shift) as u16, // shstrtab index
         );
 
         Ok(elf)
@@ -398,15 +451,25 @@ impl ShEntry {
 struct ShstrtabData {
     bytes: Vec<u8>,
     text_off: u32,
+    wasm_data_off: u32,
     symtab_off: u32,
     strtab_off: u32,
     shstrtab_off: u32,
 }
 
-fn build_shstrtab() -> ShstrtabData {
+fn build_shstrtab(with_wasm_data: bool) -> ShstrtabData {
     let mut bytes = vec![0u8];
     let text_off = bytes.len() as u32;
     bytes.extend_from_slice(b".text\0");
+    // Only present when the object ships data (#798) — keeps data-free
+    // objects bit-identical to the pre-#798 layout.
+    let wasm_data_off = if with_wasm_data {
+        let off = bytes.len() as u32;
+        bytes.extend_from_slice(b".wasm_data\0");
+        off
+    } else {
+        0
+    };
     let symtab_off = bytes.len() as u32;
     bytes.extend_from_slice(b".symtab\0");
     let strtab_off = bytes.len() as u32;
@@ -416,6 +479,7 @@ fn build_shstrtab() -> ShstrtabData {
     ShstrtabData {
         bytes,
         text_off,
+        wasm_data_off,
         symtab_off,
         strtab_off,
         shstrtab_off,
@@ -616,6 +680,100 @@ mod tests {
             builder.build(&[f]),
             Err(ElfBuildError::UndefinedLabel(_))
         ));
+    }
+
+    /// #798: `build` (no data) and `build_with_data(&[], …)` are BYTE-identical
+    /// — the `.wasm_data` section, its shstrtab name, and the index shift only
+    /// exist when there are records to ship. Frozen data-free objects are
+    /// untouched by construction.
+    #[test]
+    fn empty_wasm_data_is_byte_identical_798() {
+        let builder = RiscVElfBuilder::new_relocatable();
+        let f = RiscVElfFunction {
+            name: "f".into(),
+            ops: vec![
+                nop_op(),
+                RiscVOp::Jalr {
+                    rd: Reg::ZERO,
+                    rs1: Reg::RA,
+                    imm: 0,
+                },
+            ],
+        };
+        let plain = builder.build(std::slice::from_ref(&f)).unwrap();
+        let with_empty = builder.build_with_data(&[f], &[]).unwrap();
+        assert_eq!(plain, with_empty, "empty wasm_data must not perturb bytes");
+        assert!(!plain.windows(10).any(|w| w == b".wasm_data"));
+    }
+
+    /// #798: a non-empty record blob ships as a `.wasm_data` PROGBITS section
+    /// (SHF_ALLOC, 4-aligned) holding the blob verbatim, `.text` unchanged,
+    /// and the trailing string/symbol sections still resolve (shstrndx shift).
+    #[test]
+    fn wasm_data_section_ships_records_verbatim_798() {
+        let builder = RiscVElfBuilder::new_relocatable();
+        let f = RiscVElfFunction {
+            name: "f".into(),
+            ops: vec![
+                nop_op(),
+                RiscVOp::Jalr {
+                    rd: Reg::ZERO,
+                    rs1: Reg::RA,
+                    imm: 0,
+                },
+            ],
+        };
+        let records = synth_core::static_data_addr::pack_segment_records(&[
+            synth_core::static_data_addr::DataSegment {
+                linmem_off: 16,
+                bytes: vec![1, 2, 3, 4],
+            },
+            synth_core::static_data_addr::DataSegment {
+                linmem_off: 0x10000,
+                bytes: vec![0xAA, 0xBB, 0xCC],
+            },
+        ]);
+        let plain = builder.build(std::slice::from_ref(&f)).unwrap();
+        let elf = builder.build_with_data(&[f], &records).unwrap();
+
+        // Walk the section headers by hand (mirrors what a linker does).
+        let shoff = u32::from_le_bytes(elf[32..36].try_into().unwrap()) as usize;
+        let shnum = u16::from_le_bytes(elf[48..50].try_into().unwrap()) as usize;
+        let shstrndx = u16::from_le_bytes(elf[50..52].try_into().unwrap()) as usize;
+        assert_eq!(shnum, 6, "null/.text/.wasm_data/.symtab/.strtab/.shstrtab");
+        assert_eq!(shstrndx, 5);
+        let shdr = |i: usize| &elf[shoff + i * 40..shoff + (i + 1) * 40];
+        let field =
+            |h: &[u8], o: usize| u32::from_le_bytes(h[o..o + 4].try_into().unwrap()) as usize;
+        let shstr = shdr(shstrndx);
+        let (stroff, strsz) = (field(shstr, 16), field(shstr, 20));
+        let names = &elf[stroff..stroff + strsz];
+        let name_of = |h: &[u8]| {
+            let n = field(h, 0);
+            let end = names[n..].iter().position(|&b| b == 0).unwrap() + n;
+            std::str::from_utf8(&names[n..end]).unwrap().to_string()
+        };
+        let wd = shdr(2);
+        assert_eq!(name_of(wd), ".wasm_data");
+        assert_eq!(field(wd, 4), 1, "SHT_PROGBITS");
+        assert_eq!(field(wd, 8), 0x2, "SHF_ALLOC only");
+        assert_eq!(field(wd, 32), 4, "sh_addralign");
+        let (off, sz) = (field(wd, 16), field(wd, 20));
+        assert_eq!(&elf[off..off + sz], &records[..], "records verbatim");
+        assert_eq!(off % 4, 0, "records 4-aligned in the file");
+        // .text bytes identical to the data-free build.
+        let text = shdr(1);
+        let plain_shoff = u32::from_le_bytes(plain[32..36].try_into().unwrap()) as usize;
+        let plain_text = &plain[plain_shoff + 40..plain_shoff + 80];
+        assert_eq!(
+            &elf[field(text, 16)..field(text, 16) + field(text, 20)],
+            &plain[field(plain_text, 16)..field(plain_text, 16) + field(plain_text, 20)],
+            ".text must be unchanged by shipping data"
+        );
+        // symtab still links to the (shifted) strtab: symbol 1 is "f".
+        let symtab = shdr(3);
+        assert_eq!(name_of(symtab), ".symtab");
+        assert_eq!(field(symtab, 24), 4, "sh_link -> .strtab at index 4");
     }
 
     #[test]

--- a/crates/synth-backend-riscv/src/linker_script.rs
+++ b/crates/synth-backend-riscv/src/linker_script.rs
@@ -122,6 +122,22 @@ impl RiscVLinkerScriptGenerator {
         out.push_str("    *(.text*)\n");
         out.push_str("  } > flash\n\n");
 
+        // ── .wasm_data — packed wasm active-segment records (#798) ──
+        // Flash-resident (XIP): repeated [u32 off][u32 len][bytes][pad4]
+        // records emitted by synth into the object's `.wasm_data` section.
+        // The startup walks them at reset and copies each to
+        // `__linear_memory_base + off` (record order = declaration order,
+        // so WASM's later-wins overlap semantics hold). A data-free object
+        // has no input section and the two symbols collapse (start == end,
+        // the copy loop no-ops).
+        out.push_str("  /* Wasm active data segments — copied to s11 + off at reset */\n");
+        out.push_str("  .wasm_data : {\n");
+        out.push_str("    . = ALIGN(4);\n");
+        out.push_str("    PROVIDE(__wasm_data_records_start = .);\n");
+        out.push_str("    KEEP(*(.wasm_data*))\n");
+        out.push_str("    PROVIDE(__wasm_data_records_end = .);\n");
+        out.push_str("  } > flash\n\n");
+
         // ── .rodata — read-only constants in flash ──────────────────
         out.push_str("  .rodata : {\n");
         out.push_str("    *(.rodata*)\n");
@@ -232,6 +248,25 @@ mod tests {
         let g = RiscVLinkerScriptGenerator::new(rv32imac_caps());
         let s = g.generate();
         assert!(s.contains(".data : AT(_data_load)"));
+    }
+
+    /// #798: the wasm active-segment records get a flash-resident output
+    /// section with start/end symbols for the startup copy loop, placed
+    /// BEFORE `_data_load` is pinned (so the `.data` flash load image cannot
+    /// overlap the records).
+    #[test]
+    fn wasm_data_records_in_flash_before_data_load_798() {
+        let g = RiscVLinkerScriptGenerator::new(rv32imac_caps());
+        let s = g.generate();
+        assert!(s.contains("KEEP(*(.wasm_data*))"));
+        assert!(s.contains("PROVIDE(__wasm_data_records_start = .);"));
+        assert!(s.contains("PROVIDE(__wasm_data_records_end = .);"));
+        let records = s.find(".wasm_data : {").unwrap();
+        let data_load = s.find("PROVIDE(_data_load = .);").unwrap();
+        assert!(
+            records < data_load,
+            ".wasm_data must be placed before _data_load is pinned"
+        );
     }
 
     #[test]

--- a/crates/synth-backend-riscv/src/startup.rs
+++ b/crates/synth-backend-riscv/src/startup.rs
@@ -82,6 +82,8 @@ impl RiscVStartupGenerator {
         out.push_str("extern uint32_t __linear_memory_base;\n");
         out.push_str("extern uint32_t _data_start, _data_end, _data_load;\n");
         out.push_str("extern uint32_t _bss_start, _bss_end;\n");
+        out.push_str("/* #798: wasm active-segment records (.wasm_data, flash) */\n");
+        out.push_str("extern uint32_t __wasm_data_records_start, __wasm_data_records_end;\n");
         out.push_str("extern int main(void);\n\n");
 
         out.push_str("/* Default trap handler — overridable by user code. */\n");
@@ -146,6 +148,36 @@ impl RiscVStartupGenerator {
         out.push_str("        \"addi t0, t0, 4\\n\"\n");
         out.push_str("        \"j 3b\\n\"\n");
         out.push_str("        \"4:\\n\"\n");
+        out.push('\n');
+        // #798: apply the wasm active data segments. The object's `.wasm_data`
+        // section (placed in flash by the generated linker script) holds
+        // repeated [u32 linmem_off][u32 len][len bytes][pad to 4] records in
+        // declaration order; copying them in record order preserves WASM's
+        // later-wins overlap semantics. Byte-granular copy — segment offsets
+        // and lengths have no alignment guarantee. A data-free object has
+        // start == end and the loop no-ops.
+        out.push_str("        /* Copy wasm data segments to __linear_memory_base + off (#798). */\n");
+        out.push_str("        \"la t0, __wasm_data_records_start\\n\"\n");
+        out.push_str("        \"la t1, __wasm_data_records_end\\n\"\n");
+        out.push_str("        \"6:\\n\"\n");
+        out.push_str("        \"bgeu t0, t1, 9f\\n\"\n");
+        out.push_str("        \"lw t2, 0(t0)\\n\"\n"); // linmem offset
+        out.push_str("        \"lw t3, 4(t0)\\n\"\n"); // byte length
+        out.push_str("        \"addi t0, t0, 8\\n\"\n");
+        out.push_str("        \"add t2, t2, s11\\n\"\n"); // dest = base + off
+        out.push_str("        \"7:\\n\"\n");
+        out.push_str("        \"beqz t3, 8f\\n\"\n");
+        out.push_str("        \"lbu t4, 0(t0)\\n\"\n");
+        out.push_str("        \"sb t4, 0(t2)\\n\"\n");
+        out.push_str("        \"addi t0, t0, 1\\n\"\n");
+        out.push_str("        \"addi t2, t2, 1\\n\"\n");
+        out.push_str("        \"addi t3, t3, -1\\n\"\n");
+        out.push_str("        \"j 7b\\n\"\n");
+        out.push_str("        \"8:\\n\"\n");
+        out.push_str("        \"addi t0, t0, 3\\n\"\n"); // 4-align to the
+        out.push_str("        \"andi t0, t0, -4\\n\"\n"); // next record header
+        out.push_str("        \"j 6b\\n\"\n");
+        out.push_str("        \"9:\\n\"\n");
         out.push('\n');
         out.push_str("        /* Jump to main. If main returns, spin. */\n");
         out.push_str("        \"call main\\n\"\n");
@@ -261,6 +293,26 @@ mod tests {
         assert!(code.contains("la t0, _data_load"));
         assert!(code.contains("_bss_start"));
         assert!(code.contains("_bss_end"));
+    }
+
+    /// #798: the reset path walks the `.wasm_data` records and byte-copies
+    /// each segment to `__linear_memory_base + off` BEFORE calling main —
+    /// record order (declaration order) preserves later-wins overlap
+    /// semantics.
+    #[test]
+    fn generates_wasm_data_segment_copy_loop_798() {
+        let g = RiscVStartupGenerator::new(rv32imac_caps());
+        let code = g.generate();
+        assert!(code.contains("la t0, __wasm_data_records_start"));
+        assert!(code.contains("la t1, __wasm_data_records_end"));
+        // dest = linmem base + record offset, byte-granular copy
+        assert!(code.contains("add t2, t2, s11"));
+        assert!(code.contains("lbu t4, 0(t0)"));
+        assert!(code.contains("sb t4, 0(t2)"));
+        // the copy must run BEFORE main
+        let copy = code.find("__wasm_data_records_start").unwrap();
+        let call_main = code.find("call main").unwrap();
+        assert!(copy < call_main, "segment copy must precede main");
     }
 
     #[test]

--- a/crates/synth-backend-riscv/src/startup.rs
+++ b/crates/synth-backend-riscv/src/startup.rs
@@ -156,7 +156,9 @@ impl RiscVStartupGenerator {
         // later-wins overlap semantics. Byte-granular copy — segment offsets
         // and lengths have no alignment guarantee. A data-free object has
         // start == end and the loop no-ops.
-        out.push_str("        /* Copy wasm data segments to __linear_memory_base + off (#798). */\n");
+        out.push_str(
+            "        /* Copy wasm data segments to __linear_memory_base + off (#798). */\n",
+        );
         out.push_str("        \"la t0, __wasm_data_records_start\\n\"\n");
         out.push_str("        \"la t1, __wasm_data_records_end\\n\"\n");
         out.push_str("        \"6:\\n\"\n");

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -3521,8 +3521,7 @@ fn compile_all_exports(
                 rv_mem_size
             );
         }
-        let rv_wasm_data =
-            synth_core::static_data_addr::pack_segment_records(&rv_segments);
+        let rv_wasm_data = synth_core::static_data_addr::pack_segment_records(&rv_segments);
         let rv_served = synth_core::static_data_addr::served_image_from_records(&rv_wasm_data)
             .ok_or_else(|| {
                 anyhow::anyhow!(

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -3480,19 +3480,26 @@ fn compile_all_exports(
         info!("Building AArch64 multi-function relocatable object (EM_AARCH64)");
         build_multi_func_aarch64_elf(&compiled_funcs)?
     } else if is_riscv {
-        // VCR-VER-003 phase 2 (#777): the RV32 single-base scheme (s11 =
-        // __linear_memory_base, zeroed RAM at reset) ships NO static-data
-        // initializer image — the object is `.text`-only, and neither the
-        // generated startup.c nor linker.ld carries the wasm data segments.
-        // Validate what zeroed RAM actually serves against the runtime image:
-        // any NONZERO later-wins byte is un-served (a load there returns 0x00
-        // instead of the initializer — the silent-drop analogue of #757).
-        // All-zero or zero-overwritten segments genuinely ARE served correctly
-        // and stay silent. This is a LOUD WARNING, not (yet) a hard error:
-        // the CI-pinned RV32 frozen fixture (control_step.wasm, which carries
-        // a nonzero active segment its differential never reads) freezes
-        // compile-success on this path; the hard-decline + initializer
-        // shipping (the RV32 analogue of #758) is the named follow-up.
+        // #798 (the RV32 analogue of #758; found by the VCR-VER-003 phase-2
+        // probe, #777): the RV32 single-base scheme (s11 =
+        // __linear_memory_base, zeroed RAM at reset) used to ship a
+        // `.text`-only object — active data segments were silently DROPPED
+        // (loads read 0x00; v0.47 warned loudly). Now the segments SHIP:
+        // packed into sparse per-segment records ([u32 off][u32 len][bytes]
+        // [pad4], declaration order) in a `.wasm_data` PROGBITS section; the
+        // generated linker.ld places it in flash and the generated startup.c
+        // byte-copies each record to `__linear_memory_base + off` at reset
+        // (record order ⇒ WASM later-wins overlap semantics). Regenerate the
+        // runtime scaffolding (`synth riscv-runtime`) alongside — an OLD
+        // linker script leaves `__wasm_data_records_*` undefined and the
+        // link fails loudly rather than dropping the data again.
+        //
+        // VCR-VER-003 gate (unconditional): READ BACK the emitted blob,
+        // reconstruct the image its record-order copy serves, and hard-error
+        // on any disagreement with the runtime image (segments applied
+        // declaration-order, later-wins) — the mixed-split-style hard error
+        // the v0.47 warning was held back from, now that the fixture's
+        // differential actually reads its segment.
         let rv_segments: Vec<synth_core::static_data_addr::DataSegment> = all_data_segments
             .iter()
             .map(|(off, d)| synth_core::static_data_addr::DataSegment {
@@ -3500,24 +3507,58 @@ fn compile_all_exports(
                 bytes: d.clone(),
             })
             .collect();
+        // Instantiation-trap guard (#758 parity): a segment past the declared
+        // linear memory would trap at wasm instantiation — refuse to ship a
+        // layout the semantics say cannot exist. u64 so off + len can't wrap.
+        let rv_mem_size = all_memories.first().map(|m| m.initial_bytes()).unwrap_or(0) as u64;
+        let rv_extent = synth_core::static_data_addr::image_extent(&rv_segments);
+        if rv_extent > rv_mem_size {
+            anyhow::bail!(
+                "active data segment extends to {} bytes but linear memory is only \
+                 {} bytes — instantiation would trap; refusing to truncate the \
+                 initializer (#798)",
+                rv_extent,
+                rv_mem_size
+            );
+        }
+        let rv_wasm_data =
+            synth_core::static_data_addr::pack_segment_records(&rv_segments);
+        let rv_served = synth_core::static_data_addr::served_image_from_records(&rv_wasm_data)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "VCR-VER-003 (#798): emitted .wasm_data records failed to parse \
+                     back — this is a compiler bug in the record packing"
+                )
+            })?;
         if let synth_core::static_data_addr::ImageVerdict::Mismatch(mismatches) =
-            synth_core::static_data_addr::validate_served_image(&rv_segments, &[])
+            synth_core::static_data_addr::validate_served_image(&rv_segments, &rv_served)
         {
-            let first = &mismatches[0];
-            warn!(
-                "VCR-VER-003 (#777 phase 2): the RISC-V object ships NO \
-                 static-data initializer image — {} nonzero initializer byte(s) \
-                 (first: {}) will read as 0x00 from zeroed RAM at runtime. Any \
-                 load from those addresses is a SILENT MISCOMPILE; use the ARM \
-                 relocatable (--native-pointer-abi) or self-contained \
-                 (--cortex-m) paths for modules whose code reads its data \
-                 segments.",
-                mismatches.len(),
-                first.describe()
+            let detail = mismatches
+                .iter()
+                .take(8)
+                .map(|m| format!("  {}", m.describe()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            anyhow::bail!(
+                "VCR-VER-003 (#798): RV32 .wasm_data record validation FAILED — {} \
+                 byte(s) the shipped records serve disagree with the runtime \
+                 linear-memory image (segments applied in declaration order, \
+                 later-wins). This is a compiler bug in the record packing:\n{detail}",
+                mismatches.len()
+            );
+        }
+        if !rv_segments.is_empty() {
+            info!(
+                "Shipping {} wasm data segment(s) ({} initializer byte(s)) as \
+                 .wasm_data records (#798) — the generated startup copies them to \
+                 __linear_memory_base + off at reset; regenerate startup.c/linker.ld \
+                 via `synth riscv-runtime` if yours predate v0.48",
+                rv_segments.len(),
+                rv_segments.iter().map(|s| s.bytes.len()).sum::<usize>()
             );
         }
         info!("Building RISC-V multi-function relocatable object (EM_RISCV)");
-        build_multi_func_riscv_elf(&compiled_funcs)?
+        build_multi_func_riscv_elf(&compiled_funcs, &rv_wasm_data)?
     } else if has_external_relocations || relocatable {
         let total_relocs: usize = compiled_funcs.iter().map(|f| f.relocations.len()).sum();
         if has_relocations {
@@ -6301,9 +6342,11 @@ fn build_riscv_elf(_code: &[u8], _func_name: &str) -> Result<Vec<u8>> {
     anyhow::bail!("RISC-V backend was not compiled in (rebuild with --features riscv)")
 }
 
-/// Build a multi-function RISC-V relocatable ELF.
+/// Build a multi-function RISC-V relocatable ELF. `wasm_data` is the #798
+/// packed active-data-segment record blob (`.wasm_data` section; empty ⇒
+/// the section is omitted and the object is byte-identical to pre-#798).
 #[cfg(feature = "riscv")]
-fn build_multi_func_riscv_elf(funcs: &[ElfFunction]) -> Result<Vec<u8>> {
+fn build_multi_func_riscv_elf(funcs: &[ElfFunction], wasm_data: &[u8]) -> Result<Vec<u8>> {
     use synth_backend_riscv::{Reg, RiscVElfBuilder, RiscVElfFunction, RiscVOp};
 
     // Same placeholder-then-overwrite approach as build_riscv_elf.
@@ -6339,7 +6382,7 @@ fn build_multi_func_riscv_elf(funcs: &[ElfFunction]) -> Result<Vec<u8>> {
 
     let builder = RiscVElfBuilder::new_relocatable();
     let mut elf = builder
-        .build(&placeholder_funcs)
+        .build_with_data(&placeholder_funcs, wasm_data)
         .context("RISC-V multi-function ELF generation failed")?;
 
     // .text starts immediately after the 52-byte ELF header.
@@ -6352,7 +6395,7 @@ fn build_multi_func_riscv_elf(funcs: &[ElfFunction]) -> Result<Vec<u8>> {
 }
 
 #[cfg(not(feature = "riscv"))]
-fn build_multi_func_riscv_elf(_funcs: &[ElfFunction]) -> Result<Vec<u8>> {
+fn build_multi_func_riscv_elf(_funcs: &[ElfFunction], _wasm_data: &[u8]) -> Result<Vec<u8>> {
     anyhow::bail!("RISC-V backend was not compiled in (rebuild with --features riscv)")
 }
 

--- a/crates/synth-cli/tests/vcr_ver_003_addr_777.rs
+++ b/crates/synth-cli/tests/vcr_ver_003_addr_777.rs
@@ -236,21 +236,33 @@ fn span_straddle_module_selfcontained_rom_image_validates() {
     );
 }
 
-/// RV32 class: the single-base scheme (s11, zeroed RAM) ships NO initializer
-/// image, so a module with NONZERO active data is a silent-drop risk — the
-/// (unconditional) zero-served-image validator must WARN LOUDLY. It is a
-/// warning, not a hard error: the CI-pinned RV32 frozen fixture
-/// (control_step.wasm) freezes compile-success on this path; the hard decline
-/// + initializer shipping is the named follow-up.
+/// Read a named section's bytes out of an ELF object on disk.
+fn section_bytes(path: &std::path::Path, name: &str) -> Option<Vec<u8>> {
+    use object::{Object, ObjectSection};
+    let bytes = std::fs::read(path).expect("read object");
+    let obj = object::File::parse(&*bytes).expect("parse object");
+    obj.section_by_name(name)
+        .map(|s| s.data().expect("section data").to_vec())
+}
+
+/// RV32 class (#798, SHIPPED in v0.48): the single-base scheme used to ship a
+/// `.text`-only object — nonzero active data was silently dropped (v0.47
+/// warned loudly). Now the segments ship as `.wasm_data` records
+/// ([u32 off][u32 len][bytes][pad4], declaration order) which the generated
+/// startup copies to `__linear_memory_base + off` at reset. The compile is
+/// GREEN, the old warning is GONE, and the object carries the exact record
+/// bytes for the segment.
 #[test]
-fn rv32_nonzero_data_segment_warns_loudly() {
+fn rv32_nonzero_data_segment_ships_wasm_data_records() {
     let wat = r#"(module
   (memory 1)
   (data (i32.const 16) "\01\02\03\04")
   (func (export "get") (result i32) i32.const 16 i32.load))"#;
     let fixture = wat_file("rv32_data_777.wat", wat);
+    let out_path = std::env::temp_dir()
+        .join("synth_vcr_ver_003_ph2")
+        .join("rv32_data_777.o");
     let out = compile(&fixture, "rv32_data_777.o", &["-b", "riscv"]);
-    // The warn! goes to stdout (tracing's default writer); scan both streams.
     let all = format!(
         "{}{}",
         String::from_utf8_lossy(&out.stdout),
@@ -258,22 +270,41 @@ fn rv32_nonzero_data_segment_warns_loudly() {
     );
     assert!(out.status.success(), "RV32 compile stays green:\n{all}");
     assert!(
-        all.contains("VCR-VER-003") && all.contains("read as 0x00"),
-        "nonzero dropped initializers must warn loudly:\n{all}"
+        !all.contains("read as 0x00"),
+        "the silent-drop warning must be gone — the data SHIPS now (#798):\n{all}"
+    );
+    assert!(
+        all.contains("Shipping 1 wasm data segment(s)"),
+        "the shipping info line names the segment count:\n{all}"
+    );
+    // The object carries the record verbatim: off=16, len=4, bytes 01020304.
+    let records = section_bytes(&out_path, ".wasm_data")
+        .expect("the object must ship a .wasm_data section");
+    assert_eq!(
+        records,
+        [16u32.to_le_bytes(), 4u32.to_le_bytes()].concat().iter().copied()
+            .chain([1u8, 2, 3, 4])
+            .collect::<Vec<u8>>(),
+        "record = [u32 off=16][u32 len=4][01 02 03 04]"
     );
 }
 
-/// RV32 non-vacuity: an all-zero runtime image (here a nonzero segment
-/// OVERWRITTEN to zero by a later one — later-wins, not a bytes-grep) IS
-/// served correctly by zeroed RAM, so the validator must stay silent.
+/// RV32 later-wins (#798 + the #757 lesson): overlapping segments ship BOTH
+/// records in declaration order — the startup's record-order copy leaves the
+/// LAST-declared bytes in linear memory, exactly WASM instantiation
+/// semantics. The read-back gate (validate_served_image over the emitted
+/// blob) is green, so the compile succeeds with no VCR-VER-003 error.
 #[test]
-fn rv32_zero_overwritten_data_stays_silent() {
+fn rv32_zero_overwritten_data_ships_both_records_in_order() {
     let wat = r#"(module
   (memory 1)
   (data (i32.const 16) "\01\02\03\04")
   (data (i32.const 16) "\00\00\00\00")
   (func (export "get") (result i32) i32.const 16 i32.load))"#;
     let fixture = wat_file("rv32_zero_777.wat", wat);
+    let out_path = std::env::temp_dir()
+        .join("synth_vcr_ver_003_ph2")
+        .join("rv32_zero_777.o");
     let out = compile(&fixture, "rv32_zero_777.o", &["-b", "riscv"]);
     let all = format!(
         "{}{}",
@@ -283,6 +314,65 @@ fn rv32_zero_overwritten_data_stays_silent() {
     assert!(out.status.success(), "RV32 compile stays green:\n{all}");
     assert!(
         !all.contains("VCR-VER-003"),
-        "zeroed RAM serves the all-zero runtime image — no warning:\n{all}"
+        "the read-back gate must be silent on a correct pack:\n{all}"
+    );
+    let records = section_bytes(&out_path, ".wasm_data").expect(".wasm_data present");
+    let mut expect = Vec::new();
+    for seg in [[1u8, 2, 3, 4], [0u8, 0, 0, 0]] {
+        expect.extend_from_slice(&16u32.to_le_bytes());
+        expect.extend_from_slice(&4u32.to_le_bytes());
+        expect.extend_from_slice(&seg);
+    }
+    assert_eq!(
+        records, expect,
+        "both records ship, declaration order (later-wins by copy order)"
+    );
+}
+
+/// RV32 data-free modules ship NO `.wasm_data` section and stay byte-stable:
+/// the empty-blob path is the pre-#798 layout exactly (the frozen RV32
+/// fixtures without segments are untouched by construction — also unit-gated
+/// in the ELF builder).
+#[test]
+fn rv32_data_free_module_has_no_wasm_data_section() {
+    let wat = r#"(module
+  (memory 1)
+  (func (export "get") (result i32) i32.const 16 i32.load))"#;
+    let fixture = wat_file("rv32_nodata_798.wat", wat);
+    let out_path = std::env::temp_dir()
+        .join("synth_vcr_ver_003_ph2")
+        .join("rv32_nodata_798.o");
+    let out = compile(&fixture, "rv32_nodata_798.o", &["-b", "riscv"]);
+    assert!(out.status.success());
+    assert!(
+        section_bytes(&out_path, ".wasm_data").is_none(),
+        "no segments => no .wasm_data section (byte-identical layout)"
+    );
+}
+
+/// RV32 instantiation-trap guard (#798, #758 parity): a segment extending
+/// past the declared linear memory can never be instantiated — refuse loudly
+/// instead of shipping a layout whose startup copy would scribble past the
+/// linear-memory window.
+#[test]
+fn rv32_segment_past_memory_is_refused() {
+    let wat = r#"(module
+  (memory 1)
+  (data (i32.const 65534) "\01\02\03\04")
+  (func (export "get") (result i32) i32.const 65534 i32.load))"#;
+    let fixture = wat_file("rv32_oob_798.wat", wat);
+    let out = compile(&fixture, "rv32_oob_798.o", &["-b", "riscv"]);
+    let all = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "segment past linear memory must be refused:\n{all}"
+    );
+    assert!(
+        all.contains("instantiation would trap"),
+        "the refusal names the reason:\n{all}"
     );
 }

--- a/crates/synth-cli/tests/vcr_ver_003_addr_777.rs
+++ b/crates/synth-cli/tests/vcr_ver_003_addr_777.rs
@@ -278,11 +278,14 @@ fn rv32_nonzero_data_segment_ships_wasm_data_records() {
         "the shipping info line names the segment count:\n{all}"
     );
     // The object carries the record verbatim: off=16, len=4, bytes 01020304.
-    let records = section_bytes(&out_path, ".wasm_data")
-        .expect("the object must ship a .wasm_data section");
+    let records =
+        section_bytes(&out_path, ".wasm_data").expect("the object must ship a .wasm_data section");
     assert_eq!(
         records,
-        [16u32.to_le_bytes(), 4u32.to_le_bytes()].concat().iter().copied()
+        [16u32.to_le_bytes(), 4u32.to_le_bytes()]
+            .concat()
+            .iter()
+            .copied()
             .chain([1u8, 2, 3, 4])
             .collect::<Vec<u8>>(),
         "record = [u32 off=16][u32 len=4][01 02 03 04]"

--- a/crates/synth-core/src/static_data_addr.rs
+++ b/crates/synth-core/src/static_data_addr.rs
@@ -68,11 +68,18 @@
 //!    (#758) serves linear memory from ONE dense flash blob copied to RAM at
 //!    reset — index = linmem offset, so spans/overlaps are structurally
 //!    preserved and the whole obligation reduces to "every blob byte equals
-//!    the runtime image byte (later-wins, zero elsewhere)". The same function
-//!    with an EMPTY image validates the RISC-V single-base scheme, where the
-//!    object ships NO initializer bytes at all and zeroed RAM serves every
-//!    address: any nonzero runtime-image byte is then a served/runtime
-//!    mismatch (the silent initializer-drop).
+//!    the runtime image byte (later-wins, zero elsewhere)". The RISC-V
+//!    single-base scheme (#798) ships its active segments as SPARSE
+//!    per-segment records ([`pack_segment_records`], a `.wasm_data` PROGBITS
+//!    section in flash) which the generated startup copies to `s11 + off` in
+//!    record order at reset; the emit path READS BACK the emitted blob
+//!    ([`served_image_from_records`] — never a recompute, that would
+//!    mirror-pin the check) into the dense served image and runs the same
+//!    gate, hard-erroring the compile on any served/runtime disagreement.
+//!    An EMPTY image models a target that ships no initializer bytes at all
+//!    (zeroed RAM serves every address): any nonzero runtime-image byte is
+//!    then a served/runtime mismatch (the silent initializer-drop this
+//!    validator caught on the pre-#798 RV32 path).
 //! 3. **AArch64: N/A** — the `-b aarch64` integer subset has no linear-memory
 //!    loads/stores (every memory op loud-declines at selection), so compiled
 //!    code cannot observe static data; there is nothing to validate.
@@ -493,6 +500,99 @@ pub fn validate_served_image(segments: &[DataSegment], image: &[u8]) -> ImageVer
     } else {
         ImageVerdict::Mismatch(bad)
     }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// #798: sparse per-segment records — the RV32 `.wasm_data` shipping format
+// ────────────────────────────────────────────────────────────────────
+
+/// Pack active data segments into the sparse per-segment record blob the RV32
+/// backend ships as its `.wasm_data` PROGBITS section (#798). Format, repeated
+/// per segment in DECLARATION order:
+///
+/// ```text
+///   u32 LE  linmem_off     (wasm i32.const segment offset)
+///   u32 LE  len            (initializer byte count)
+///   len     bytes          (the segment's initializer, verbatim)
+///   pad     0..3 zero bytes (4-align the next record header)
+/// ```
+///
+/// The generated startup (`synth riscv-runtime`) walks the records at reset
+/// and byte-copies each to `__linear_memory_base + linmem_off` in record
+/// order, so WASM's later-wins overlap semantics are preserved structurally
+/// by the copy order — iff the records are packed in declaration order (the
+/// red-first unit gate pins that: a reversed pack fails
+/// [`validate_served_image`] on overlapping segments).
+///
+/// Sparse-by-construction: a segment at linmem 1 MiB costs `8 + len` flash
+/// bytes, not a 1 MiB dense image. Zero segments ⇒ empty blob ⇒ the ELF
+/// builder omits the section entirely (byte-identical objects for data-free
+/// modules).
+pub fn pack_segment_records(segments: &[DataSegment]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for s in segments {
+        out.extend_from_slice(&s.linmem_off.to_le_bytes());
+        out.extend_from_slice(&(s.bytes.len() as u32).to_le_bytes());
+        out.extend_from_slice(&s.bytes);
+        while out.len() % 4 != 0 {
+            out.push(0);
+        }
+    }
+    out
+}
+
+/// Parse a `.wasm_data` record blob back into `(linmem_off, bytes)` records,
+/// in record order. Returns `None` on a malformed blob (truncated header or
+/// payload, misaligned trailing bytes) — the read-back side of the #798
+/// served-image gate must fail LOUDLY on garbage, never "best-effort" it.
+pub fn parse_segment_records(blob: &[u8]) -> Option<Vec<DataSegment>> {
+    let mut recs = Vec::new();
+    let mut i = 0usize;
+    while i < blob.len() {
+        let hdr = blob.get(i..i + 8)?;
+        let off = u32::from_le_bytes(hdr[0..4].try_into().unwrap());
+        let len = u32::from_le_bytes(hdr[4..8].try_into().unwrap()) as usize;
+        i += 8;
+        let bytes = blob.get(i..i + len)?.to_vec();
+        i += len;
+        // Consume the 4-align padding (must exist and be within the blob).
+        let aligned = i.next_multiple_of(4);
+        if aligned > blob.len() {
+            return None;
+        }
+        i = aligned;
+        recs.push(DataSegment {
+            linmem_off: off,
+            bytes,
+        });
+    }
+    Some(recs)
+}
+
+/// Reconstruct the dense image the shipped records SERVE: apply every record
+/// to `__linear_memory_base`-relative addresses in RECORD order (later
+/// overwrites earlier), exactly what the generated startup's copy loop does
+/// at reset. This is the read-back side of the #798 gate — it consumes the
+/// EMITTED blob, so feeding it to [`validate_served_image`] against the
+/// declared segment list cannot be satisfied by mirroring the packer.
+/// Returns `None` on a malformed blob, or when a record's `off + len`
+/// overflows `u32` (a hostile extent that could never be served).
+pub fn served_image_from_records(blob: &[u8]) -> Option<Vec<u8>> {
+    let recs = parse_segment_records(blob)?;
+    let extent = recs
+        .iter()
+        .map(|r| r.linmem_off as u64 + r.bytes.len() as u64)
+        .max()
+        .unwrap_or(0);
+    if extent > u32::MAX as u64 {
+        return None;
+    }
+    let mut image = vec![0u8; extent as usize];
+    for r in &recs {
+        let at = r.linmem_off as usize;
+        image[at..at + r.bytes.len()].copy_from_slice(&r.bytes);
+    }
+    Some(image)
 }
 
 #[cfg(test)]
@@ -977,5 +1077,108 @@ mod tests {
             validate_reloc_resolutions(&segs, &[bad]),
             Verdict::Mismatch(_)
         ));
+    }
+
+    // ─── #798 sparse per-segment records (RV32 `.wasm_data`) ───────────
+
+    /// Round trip: pack → parse recovers the declaration-order records
+    /// verbatim (offsets, lengths, bytes), across 4-align padding.
+    #[test]
+    fn segment_records_round_trip() {
+        let segs = vec![
+            DataSegment {
+                linmem_off: 16,
+                bytes: vec![1, 2, 3], // len 3 → 1 pad byte
+            },
+            DataSegment {
+                linmem_off: 0x10000,
+                bytes: vec![0xAA; 8],
+            },
+            DataSegment {
+                linmem_off: 4,
+                bytes: vec![9], // len 1 → 3 pad bytes
+            },
+        ];
+        let blob = pack_segment_records(&segs);
+        assert_eq!(blob.len() % 4, 0, "records blob is 4-aligned throughout");
+        let back = parse_segment_records(&blob).expect("well-formed blob parses");
+        assert_eq!(back.len(), 3);
+        for (a, b) in segs.iter().zip(back.iter()) {
+            assert_eq!(a.linmem_off, b.linmem_off);
+            assert_eq!(a.bytes, b.bytes);
+        }
+    }
+
+    /// RED-FIRST (#798 shipping gate, the #757 lesson applied to the copy
+    /// order): the startup copies records in RECORD order, so a pack that
+    /// stores overlapping segments in REVERSED declaration order serves the
+    /// FIRST-declared bytes (first-wins) — the served image read back from
+    /// that blob must FAIL validate_served_image, and the declaration-order
+    /// pack must PASS. Green on both would make the read-back gate vacuous.
+    #[test]
+    fn records_red_on_reversed_pack_green_on_declaration_order() {
+        let segs = overlapping_segments();
+        let mut reversed = segs.clone();
+        reversed.reverse();
+        let wrong_blob = pack_segment_records(&reversed);
+        let wrong_served = served_image_from_records(&wrong_blob).unwrap();
+        match validate_served_image(&segs, &wrong_served) {
+            ImageVerdict::Mismatch(m) => {
+                let at8 = m.iter().find(|x| x.addr == 0x100008).expect("addr 8");
+                assert_eq!(at8.served, 0xAA, "reversed pack serves seg_0's stale byte");
+                assert_eq!(at8.runtime, b'u', "runtime image owns seg_2's byte");
+            }
+            ImageVerdict::Consistent => {
+                panic!("VACUOUS: read-back gate accepted a reversed (first-wins) pack")
+            }
+        }
+        let right_blob = pack_segment_records(&segs);
+        let right_served = served_image_from_records(&right_blob).unwrap();
+        assert_eq!(
+            validate_served_image(&segs, &right_served),
+            ImageVerdict::Consistent,
+            "declaration-order records must serve the later-wins image"
+        );
+    }
+
+    /// The served image is SPARSE-tolerant: gaps between records read zero,
+    /// matching implicit-zero linear memory (zeroed RAM under the RV32
+    /// scheme), so a far-offset segment validates without a dense flash blob.
+    #[test]
+    fn records_far_offset_segment_served_correctly() {
+        let segs = vec![DataSegment {
+            linmem_off: 0x10000,
+            bytes: vec![7, 8, 9, 10],
+        }];
+        let blob = pack_segment_records(&segs);
+        assert_eq!(blob.len(), 12, "8-byte header + 4 bytes, no dense image");
+        let served = served_image_from_records(&blob).unwrap();
+        assert_eq!(served.len(), 0x10004);
+        assert_eq!(
+            validate_served_image(&segs, &served),
+            ImageVerdict::Consistent
+        );
+    }
+
+    /// Malformed blobs (truncated header, truncated payload, missing align
+    /// padding) parse to None — the read-back must fail loudly, not
+    /// best-effort.
+    #[test]
+    fn records_malformed_blobs_rejected() {
+        let segs = vec![DataSegment {
+            linmem_off: 4,
+            bytes: vec![1, 2, 3, 4, 5],
+        }];
+        let blob = pack_segment_records(&segs);
+        assert!(parse_segment_records(&blob[..4]).is_none(), "cut header");
+        assert!(parse_segment_records(&blob[..10]).is_none(), "cut payload");
+        assert!(
+            parse_segment_records(&blob[..blob.len() - 1]).is_none(),
+            "cut align padding"
+        );
+        assert!(served_image_from_records(&blob[..10]).is_none());
+        // Empty blob = zero segments: parses to nothing, serves nothing.
+        assert_eq!(parse_segment_records(&[]).unwrap().len(), 0);
+        assert_eq!(served_image_from_records(&[]).unwrap().len(), 0);
     }
 }

--- a/scripts/repro/control_step_riscv_differential.py
+++ b/scripts/repro/control_step_riscv_differential.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""#223 — control_step on RISC-V: correctness + ABI differential.
+"""#223 / #798 — control_step on RISC-V: correctness + ABI + shipped-data differential.
 
 After #218 (reachable) + #220 (callee-saved ABI) + #223 (Select, non-param
 locals, sign-extend), gale's `control_step_decide` compiles to RV32. This checks
@@ -7,12 +7,29 @@ it computes the SAME result as wasmtime (and the ARM backend — gale's referenc
 `(3000,50,40,0) = 0x00210a55`), reads its `.rodata` table via s11 (the linmem
 base), and preserves the caller's callee-saved registers.
 
+DE-VACUATED for #798: linear memory is initialized from the object's SHIPPED
+`.wasm_data` active-segment records (the exact bytes the generated startup's
+record-copy loop places at `s11 + off`), NOT from wasmtime's instantiated
+memory. The old harness copied wasmtime's memory image into unicorn, which
+masked the silent initializer drop the VCR-VER-003 phase-2 probe found — the
+object shipped `.text` only, every load of the 1200-byte decision table read
+0x00, and this differential stayed green anyway (a VACUOUS gate). Now:
+
+  - an object WITHOUT `.wasm_data` fails LOUDLY up front (the drop is visible);
+  - the emulated linmem holds exactly what the shipped records serve, so a
+    packing/offset bug diverges from wasmtime here.
+
+Record format (see synth_core::static_data_addr::pack_segment_records):
+repeated [u32 LE linmem_off][u32 LE len][len bytes][pad to 4], declaration
+order — the startup copies them in record order, so later-wins is preserved.
+
 Run:
   synth compile scripts/repro/control_step.wasm -b riscv -t rv32imac \
         --all-exports --relocatable -o /tmp/cs_rv.o
   /tmp/armv/bin/python scripts/repro/control_step_riscv_differential.py /tmp/cs_rv.o
 """
 import re
+import struct
 import subprocess
 import sys
 
@@ -46,6 +63,27 @@ SENTINELS = {
 VECTORS = [(3000, 50, 40, 0), (0, 0, 0, 0), (1500, 0, 0, 0), (2645, 10, 20, 0), (4000, 200, 30, 7)]
 
 
+def shipped_records(elffile):
+    """Parse the shipped `.wasm_data` active-segment records (#798).
+
+    Returns a declaration-order list of (linmem_off, bytes), or None when the
+    object ships no `.wasm_data` section at all (the pre-#798 silent drop).
+    """
+    sec = elffile.get_section_by_name(".wasm_data")
+    if sec is None:
+        return None
+    blob = sec.data()
+    recs, i = [], 0
+    while i + 8 <= len(blob):
+        off, ln = struct.unpack_from("<II", blob, i)
+        i += 8
+        assert i + ln <= len(blob), f"truncated .wasm_data record at {i}"
+        recs.append((off, blob[i:i + ln]))
+        i = (i + ln + 3) & ~3
+    assert i == len(blob), f".wasm_data has {len(blob) - i} trailing bytes"
+    return recs
+
+
 def main():
     engine = wasmtime.Engine()
     module = wasmtime.Module(engine, open(WASM, "rb").read())
@@ -53,24 +91,38 @@ def main():
     def wt(args):
         store = wasmtime.Store(engine)
         inst = wasmtime.Instance(store, module, [])
-        r = inst.exports(store)["control_step_decide"](store, *args) & 0xFFFFFFFF
-        rod = bytes(inst.exports(store)["memory"].read(store, 0x10000, 0x20000))
-        return r, rod
+        return inst.exports(store)["control_step_decide"](store, *args) & 0xFFFFFFFF
 
     dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
     syms = {m.group(2): int(m.group(1), 16)
             for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
     fa = syms["func_0"] if "func_0" in syms else syms["control_step_decide"]
-    code = ELFFile(open(ELF, "rb")).get_section_by_name(".text").data()
+    elffile = ELFFile(open(ELF, "rb"))
+    code = elffile.get_section_by_name(".text").data()
 
-    def run(args, rodata):
+    # #798 gate: the module carries a nonzero active data segment (the decision
+    # table at linmem 0x10000); an object that ships no .wasm_data records
+    # drops it silently — every table load reads 0x00. Fail LOUDLY up front.
+    recs = shipped_records(elffile)
+    if recs is None:
+        print("RISC-V control_step ORACLE: FAIL — object ships NO .wasm_data "
+              "records; the active data segment (decision table @ 0x10000) is "
+              "silently dropped (#798), linmem reads return 0x00")
+        sys.exit(1)
+    total = sum(len(b) for _, b in recs)
+    print(f"shipped .wasm_data: {len(recs)} record(s), {total} initializer byte(s)")
+
+    def run(args):
         mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
         mu.mem_map(CODE, 0x20000)
         mu.mem_map(LIN, 0x20000)
         mu.mem_map(STK - 0x8000, 0x10000)
         mu.mem_map(RET, 0x1000)
         mu.mem_write(CODE, code)
-        mu.mem_write(LIN + 0x10000, rodata)
+        # Linear memory init = the SHIPPED records, applied in record order
+        # (later-wins) — exactly what the generated startup copy loop does.
+        for off, b in recs:
+            mu.mem_write(LIN + off, bytes(b))
         mu.reg_write(UC_RISCV_REG_SP, STK)
         mu.reg_write(UC_RISCV_REG_S11, LIN)  # s11 = __linear_memory_base
         for r, v in zip((UC_RISCV_REG_A0, UC_RISCV_REG_A1, UC_RISCV_REG_A2, UC_RISCV_REG_A3), args):
@@ -88,15 +140,15 @@ def main():
 
     fails = 0
     for v in VECTORS:
-        gt, rodata = wt(v)
-        res, preserved, err = run(v, rodata)
+        gt = wt(v)
+        res, preserved, err = run(v)
         ok = res == gt and preserved
         fails += 0 if ok else 1
         shown = f"0x{res:08x}" if res is not None else f"ERR({err})"
         print(f"control_step{v} = {shown}  wasmtime=0x{gt:08x}  s-regs-preserved={preserved}"
               f"  {'OK' if ok else 'FAIL'}")
-    print("\nRISC-V control_step ORACLE: PASS (correct + ABI-compliant)" if not fails
-          else f"RISC-V control_step ORACLE: FAIL ({fails})")
+    print("\nRISC-V control_step ORACLE: PASS (correct + ABI-compliant + data shipped)"
+          if not fails else f"RISC-V control_step ORACLE: FAIL ({fails})")
     sys.exit(1 if fails else 0)
 
 

--- a/scripts/repro/rv32_data_798_boot_differential.py
+++ b/scripts/repro/rv32_data_798_boot_differential.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""#798 — RV32 active-data-segment shipping: FULL-BOOT differential.
+
+End-to-end over the REAL artifacts, not a model of them: synth compiles a
+module with OVERLAPPING active data segments to an RV32 object (`.wasm_data`
+records), `synth riscv-runtime` emits the startup.c + linker.ld, clang+lld
+build a bare-metal firmware, and unicorn boots it FROM `_reset` — so the
+generated startup's record-copy loop (byte-granular, record order ⇒
+later-wins) is what actually initializes linear memory. The exported reader's
+result must match wasmtime.
+
+This is the runtime half of the #798 gate; the compile-time half is the
+VCR-VER-003 read-back (validate_served_image over the emitted records) and
+the de-vacuated control_step differential.
+
+Requires: clang with the riscv32 target (brew llvm), ld.lld, wasmtime +
+unicorn + pyelftools in the venv. Missing tools are a LOUD failure, not a
+skip — a gate that skips on an assumption is vacuous.
+
+Run:
+  /tmp/armv/bin/python scripts/repro/rv32_data_798_boot_differential.py
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_RISCV, UC_MODE_RISCV32, Uc, UcError
+from unicorn.riscv_const import UC_RISCV_REG_PC
+
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+CLANG = os.environ.get("CLANG") or shutil.which("clang", path="/opt/homebrew/opt/llvm/bin") \
+    or shutil.which("clang")
+LLD = os.environ.get("LLD") or shutil.which("ld.lld")
+
+# Overlapping segments: seg1 overwrites seg0's tail — the runtime image at 16
+# is aa bb 11 22 ONLY if the startup copies records in declaration order.
+WAT = r"""(module
+  (memory 1)
+  (data (i32.const 16) "\aa\bb\cc\dd")
+  (data (i32.const 18) "\11\22")
+  (func (export "get") (result i32) i32.const 16 i32.load))"""
+
+MAIN_C = """extern unsigned get(void);
+volatile unsigned result;
+int main(void){ result = get(); return 0; }
+"""
+
+
+def run(cmd, **kw):
+    r = subprocess.run(cmd, capture_output=True, text=True, **kw)
+    if r.returncode != 0:
+        print(f"FAIL: {' '.join(str(c) for c in cmd)}\n{r.stdout}{r.stderr}")
+        sys.exit(1)
+    return r
+
+
+def main():
+    for tool, name in ((CLANG, "clang (riscv32-capable, e.g. brew llvm)"), (LLD, "ld.lld")):
+        if not tool or not os.path.exists(tool):
+            print(f"RV32 #798 BOOT ORACLE: FAIL — required tool missing: {name}")
+            sys.exit(1)
+
+    # wasmtime ground truth
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.encode())
+    store = wasmtime.Store(engine)
+    inst = wasmtime.Instance(store, module, [])
+    gt = inst.exports(store)["get"](store) & 0xFFFFFFFF
+
+    d = tempfile.mkdtemp(prefix="rv32_798_boot_")
+    wat = os.path.join(d, "module.wat")
+    open(wat, "w").write(WAT)
+    open(os.path.join(d, "main.c"), "w").write(MAIN_C)
+
+    out = run([SYNTH, "compile", wat, "-b", "riscv", "--target", "rv32imac",
+               "--all-exports", "--relocatable", "-o", os.path.join(d, "module.o")])
+    if "Shipping 2 wasm data segment(s)" not in out.stdout + out.stderr:
+        print("RV32 #798 BOOT ORACLE: FAIL — compile did not report shipping both segments")
+        sys.exit(1)
+    run([SYNTH, "riscv-runtime", "-o", d, "--linear-memory-size", "16384",
+         "--stack-size", "4096"])
+
+    cc = [CLANG, "-target", "riscv32-unknown-none-elf", "-march=rv32imac",
+          "-mabi=ilp32", "-O1", "-c"]
+    run(cc + [os.path.join(d, "startup.c"), "-o", os.path.join(d, "startup.o")])
+    run(cc + [os.path.join(d, "main.c"), "-o", os.path.join(d, "main.o")])
+    fw = os.path.join(d, "fw.elf")
+    run([LLD, "-T", os.path.join(d, "linker.ld"), os.path.join(d, "startup.o"),
+         os.path.join(d, "main.o"), os.path.join(d, "module.o"), "-o", fw])
+
+    ef = ELFFile(open(fw, "rb"))
+    syms = {s.name: s["st_value"]
+            for s in ef.get_section_by_name(".symtab").iter_symbols() if s.name}
+    mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+    mu.mem_map(0x0, 0x10000)          # flash
+    mu.mem_map(0x80000000, 0x10000)   # ram (presented zeroed — the scheme's assumption)
+    for seg in ef.iter_segments():
+        if seg["p_type"] == "PT_LOAD" and seg["p_filesz"]:
+            mu.mem_write(seg["p_paddr"], seg.data())  # LMA: flash-resident images
+    try:
+        mu.emu_start(ef.header.e_entry, 0xFFFFFFFC, count=100_000)
+    except UcError as e:
+        print(f"RV32 #798 BOOT ORACLE: FAIL — boot faulted: {e} "
+              f"pc=0x{mu.reg_read(UC_RISCV_REG_PC):x}")
+        sys.exit(1)
+
+    lin = bytes(mu.mem_read(syms["__linear_memory_base"] + 16, 4))
+    res = int.from_bytes(mu.mem_read(syms["result"], 4), "little")
+    print(f"linmem[16..20] after reset copy = {lin.hex()} (later-wins: aabb1122)")
+    print(f"get() via full boot = 0x{res:08x}  wasmtime = 0x{gt:08x}")
+    ok = lin == bytes.fromhex("aabb1122") and res == gt
+    print("RV32 #798 BOOT ORACLE: PASS — the generated startup's record-copy "
+          "loop serves the later-wins image" if ok
+          else "RV32 #798 BOOT ORACLE: FAIL")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #798. v0.48 Wave-1 Lane 3.

## What

The RV32 single-base scheme (`s11 = __linear_memory_base`, zeroed RAM) shipped a `.text`-only object: active data segments were **silently dropped** — every nonzero initializer byte read `0x00` at runtime (found by the VCR-VER-003 phase-2 probe #777; v0.47/#797 held a loud warning). This PR ships them — the real fix, not the decline:

- **Object**: segments pack into sparse per-segment records `[u32 off][u32 len][bytes][pad4]` (declaration order; `synth_core::static_data_addr::pack_segment_records`) emitted as a `.wasm_data` PROGBITS (SHF_ALLOC) section. A far segment costs `8 + len` flash bytes — no dense image. Data-free modules ship **no** section and are whole-object **byte-identical** (unit-gated).
- **Linker script** (`synth riscv-runtime`): flash-resident `.wasm_data` output section with `__wasm_data_records_start/end`, placed before `_data_load` is pinned. An old script + new startup fails the link **loudly** (undefined symbol) instead of dropping data again.
- **Startup**: the reset path walks the records and byte-copies each to `__linear_memory_base + off` before `main` — record order = declaration order, so WASM **later-wins** overlap semantics hold structurally (the #757 lesson).
- **VCR-VER-003 arm (hard gate)**: the emit path **reads the emitted blob back** (`served_image_from_records` — never a recompute, mirror-pinning structurally excluded) and `validate_served_image` hard-errors the compile on any served/runtime disagreement. A segment past the declared memory is refused (`instantiation would trap`, #758 parity). The v0.47 warning is **gone**; the library `Backend::compile_module` path ships + validates too.

## Red → green

- **De-vacuated `control_step_riscv_differential.py`**: the old harness copied *wasmtime's* instantiated memory into unicorn, masking the drop (a vacuous gate). It now initializes linmem **only from the shipped `.wasm_data` records**. On the pre-fix binary (ac79fb3): loud FAIL, and the semantic red is proven — zeroed-linmem execution returns `0x00000000` for `(3000,50,40,0)` where wasmtime returns `0x00210a55`. Post-fix: **5/5 vectors match** incl. gale's reference `0x00210a55`.
- **New full-boot oracle** `scripts/repro/rv32_data_798_boot_differential.py`: synth compile → `riscv-runtime` → clang(riscv32) + ld.lld → unicorn boots `fw.elf` **from `_reset`** — the REAL generated startup copy loop initializes linmem; overlapping segments serve the later-wins image (`aabb1122`) and `get()` equals wasmtime (`0x2211bbaa`). PASS locally.
- **Red-first unit gates**: a reversed (first-wins) record pack fails `validate_served_image` at the classic #757 byte; declaration order passes. Malformed blobs parse to `None` (loud).

## Refreeze ritual

All **12** `*_riscv_differential.py` scripts re-run **PASS** on the new bytes. Frozen RV32 `.text` is **unchanged** (control_step `.text` sha identical pre/post; data-free objects byte-identical) — `frozen_fixtures_rv32_text_is_bit_identical_oracle_001` green with **no re-pin needed**; the compile-success freeze that held the v0.47 warning is moot because the compile stays green *by shipping*, and its differential now actually reads the segment (de-vacuated per #797's finding).

## Gates

- `cargo test --workspace` green (126 suites), `cargo fmt --check`, `clippy -D warnings` clean
- `scripts/claim_check.py`: 21/21 — claims/roadmap updated to the shipped state + new count-eq pin holding the RV32 served image to the emitted blob read-back
- e2e tests: records-verbatim, both-records-in-order (overlap), no-section (data-free), instantiation-trap refusal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L