### PR TITLE
feat(#782a): implement the WASM trunc_sat family — nontrapping saturating float→int (i32 forms on ARM32, all 8 on aarch64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,16 @@ jobs:
       # calls).
       - name: Run f64 const/promote/arith/compare/mem + across-call oracle (#369, m7dp)
         run: SYNTH=./target/debug/synth python scripts/repro/f64_369_differential.py
+      # #782a: the NONTRAPPING trunc_sat family (§4.3.2 — NaN→0, out-of-range
+      # saturates, NEVER traps). Full boundary table (NaN/±inf/exact
+      # INT_MIN-INT_MAX bounds/±0.5) vs wasmtime on BOTH prioritized backends:
+      # ARM32 m7dp+m4f (bare RZ VCVT — the guard-free dual of the #709 trapping
+      # forms) and aarch64 (bare FCVTZS/FCVTZU, all 8 forms incl. i64 targets).
+      # Also pins falcon's exact flags (-t cortex-m7dp --relocatable): the i32
+      # forms must NOT skip, the ARM32 i64 forms MUST decline loudly by name.
+      # This gate caught the optimized-path silent-NOP drop at land time.
+      - name: Run trunc_sat boundary oracle (#782a, m7dp+m4f+aarch64)
+        run: SYNTH=./target/debug/synth python scripts/repro/trunc_sat_782_differential.py
       # #739: static ABOVE sp_init under --shadow-stack-size — the sub-word
       # load/store arms previously BAKED the linmem offset as an un-relocated
       # MOVW/MOVT immediate (invisible to the #678 reloc-walking rebase AND to

--- a/crates/synth-backend-aarch64/src/encoder.rs
+++ b/crates/synth-backend-aarch64/src/encoder.rs
@@ -495,6 +495,27 @@ pub fn fcvtzu_w_from_d(rd: Reg, rn: FReg) -> u32 {
     fp2(0x1E79_0000, rd, rn)
 }
 
+// #782a: the 64-bit-destination (`x`) FCVTZ forms (sf=1). The saturating
+// behavior (NaN → 0, out-of-range → INT64_MIN/MAX / 0/UINT64_MAX) that the
+// TRAPPING trunc lowerings must guard against is EXACTLY the WASM §4.3.2
+// `trunc_sat` semantics, so the i64 trunc_sat lowerings emit these bare.
+/// `fcvtzs xd, sn` — f32 → signed i64, round-toward-zero, saturating.
+pub fn fcvtzs_x_from_s(rd: Reg, rn: FReg) -> u32 {
+    fp2(0x9E38_0000, rd, rn)
+}
+/// `fcvtzu xd, sn` — f32 → unsigned i64, round-toward-zero, saturating.
+pub fn fcvtzu_x_from_s(rd: Reg, rn: FReg) -> u32 {
+    fp2(0x9E39_0000, rd, rn)
+}
+/// `fcvtzs xd, dn` — f64 → signed i64, round-toward-zero, saturating.
+pub fn fcvtzs_x_from_d(rd: Reg, rn: FReg) -> u32 {
+    fp2(0x9E78_0000, rd, rn)
+}
+/// `fcvtzu xd, dn` — f64 → unsigned i64, round-toward-zero, saturating.
+pub fn fcvtzu_x_from_d(rd: Reg, rn: FReg) -> u32 {
+    fp2(0x9E79_0000, rd, rn)
+}
+
 /// `fmov sd, wn` — reinterpret the 32-bit GP register `wn` into `sd` (no numeric
 /// conversion). Bridges the GP→FP files; used for `f32.reinterpret_i32`, moving a
 /// materialized f32 const bit-pattern into an S register, and float param setup.
@@ -725,6 +746,18 @@ mod tests {
         assert_eq!(fcvtzs_w_from_d(0, 1), 0x1E78_0020);
         assert_eq!(fcvtzu_w_from_d(0, 1), 0x1E79_0020);
         assert_eq!(fcvtzs_w_from_s(5, 6), 0x1E38_00C5);
+    }
+
+    // #782a — the x-destination (i64-target) FCVTZ forms. Ground truth from
+    // `clang -target aarch64-none-elf` + objdump on this exact operand set.
+    #[test]
+    fn trunc_sat_782_fcvtz_x_encodings_match_clang() {
+        assert_eq!(fcvtzs_x_from_s(0, 1), 0x9E38_0020);
+        assert_eq!(fcvtzu_x_from_s(0, 1), 0x9E39_0020);
+        assert_eq!(fcvtzs_x_from_d(0, 1), 0x9E78_0020);
+        assert_eq!(fcvtzu_x_from_d(0, 1), 0x9E79_0020);
+        assert_eq!(fcvtzs_x_from_s(5, 6), 0x9E38_00C5);
+        assert_eq!(fcvtzu_x_from_d(9, 15), 0x9E79_01E9);
     }
 
     #[test]

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -1091,6 +1091,70 @@ mod tests {
     }
 
     #[test]
+    fn trunc_sat_782_i32_forms_are_one_bare_fcvtz() {
+        // §4.3.2 trunc_sat is TOTAL — A64 FCVTZS/FCVTZU already saturate and
+        // give 0 for NaN, so the lowering is ONE bare convert: no bound
+        // materialization, no b.cond, and above all NO brk (a guard would
+        // spuriously trap where WASM saturates).
+        for (op, f32_src, cvt) in [
+            (
+                WasmOp::I32TruncSatF32S,
+                true,
+                enc::fcvtzs_w_from_s as fn(Reg, FReg) -> u32,
+            ),
+            (WasmOp::I32TruncSatF32U, true, enc::fcvtzu_w_from_s),
+            (WasmOp::I32TruncSatF64S, false, enc::fcvtzs_w_from_d),
+            (WasmOp::I32TruncSatF64U, false, enc::fcvtzu_w_from_d),
+        ] {
+            let ops = vec![WasmOp::LocalGet(0), op.clone(), WasmOp::End];
+            let (f32s, f64s): (&[bool], &[bool]) = if f32_src {
+                (&[true], &[])
+            } else {
+                (&[], &[true])
+            };
+            let w = select_typed(&ops, 1, f32s, f64s).unwrap();
+            assert_eq!(
+                w,
+                vec![cvt(9, 0), enc::mov_reg64(0, 9), enc::ret()],
+                "{op:?} must be one bare saturating convert"
+            );
+            assert!(
+                !w.contains(&enc::brk(0)),
+                "{op:?} is total — a brk guard would spuriously trap"
+            );
+        }
+    }
+
+    #[test]
+    fn trunc_sat_782_i64_forms_use_x_destination_fcvtz() {
+        // A64 is 64-bit native: the i64-target forms are the same
+        // one-instruction shape with an x (sf=1) destination.
+        for (op, f32_src, cvt) in [
+            (
+                WasmOp::I64TruncSatF32S,
+                true,
+                enc::fcvtzs_x_from_s as fn(Reg, FReg) -> u32,
+            ),
+            (WasmOp::I64TruncSatF32U, true, enc::fcvtzu_x_from_s),
+            (WasmOp::I64TruncSatF64S, false, enc::fcvtzs_x_from_d),
+            (WasmOp::I64TruncSatF64U, false, enc::fcvtzu_x_from_d),
+        ] {
+            let ops = vec![WasmOp::LocalGet(0), op.clone(), WasmOp::End];
+            let (f32s, f64s): (&[bool], &[bool]) = if f32_src {
+                (&[true], &[])
+            } else {
+                (&[], &[true])
+            };
+            let w = select_typed(&ops, 1, f32s, f64s).unwrap();
+            assert_eq!(
+                w,
+                vec![cvt(9, 0), enc::mov_reg64(0, 9), enc::ret()],
+                "{op:?} must be one bare x-destination saturating convert"
+            );
+        }
+    }
+
+    #[test]
     fn f32_min_max_use_fmin_fmax() {
         // WASM min/max ≡ A64 FMIN/FMAX (IEEE 754-2019 minimum/maximum) — a
         // single instruction each; FMINNM/FMAXNM would be the WRONG (minNum)

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -338,6 +338,27 @@ pub fn select_typed(
         Ok(())
     };
 
+    // #782a: NONTRAPPING saturating float→int truncation (WASM §4.3.2
+    // trunc_sat — the 0xFC-prefixed family). A64 FCVTZS/FCVTZU already
+    // implement it EXACTLY: round-toward-zero, out-of-range saturates to the
+    // integer bound, NaN → 0 (FPToFixed) — the very "more-total-than-WASM"
+    // behavior the m4 `trunc_guarded` domain guard defends the TRAPPING forms
+    // against is the REQUIRED semantics here, so the lowering is one bare
+    // convert. All eight forms land (A64 is 64-bit native, so the i64 targets
+    // are the same one-instruction shape with an x destination).
+    // Execution-verified vs wasmtime (NaN/±inf/exact-boundary table) in
+    // `scripts/repro/trunc_sat_782_differential.py`.
+    let trunc_sat = |words: &mut Vec<u32>,
+                     stack: &mut Vec<Val>,
+                     f: fn(Reg, FReg) -> u32|
+     -> Result<(), SelectError> {
+        let a = pop_fp(stack, "trunc_sat")?;
+        let dst = alloc_temp(stack)?;
+        words.push(f(dst, a));
+        stack.push(Val::gp(dst));
+        Ok(())
+    };
+
     // m4: copysign(z1, z2) — the magnitude of z1 with the sign of z2, a pure
     // bit operation (WASM §4.3.3 fcopysign; NaN payloads pass through intact).
     // Route both operands through the GP file, isolate the sign with ONE
@@ -632,6 +653,16 @@ pub fn select_typed(
             WasmOp::I32TruncF32U => trunc_guarded(&mut words, &mut stack, false, false)?,
             WasmOp::I32TruncF64S => trunc_guarded(&mut words, &mut stack, true, true)?,
             WasmOp::I32TruncF64U => trunc_guarded(&mut words, &mut stack, true, false)?,
+
+            // --- nontrapping saturating truncations (#782a): bare FCVTZ ---
+            WasmOp::I32TruncSatF32S => trunc_sat(&mut words, &mut stack, enc::fcvtzs_w_from_s)?,
+            WasmOp::I32TruncSatF32U => trunc_sat(&mut words, &mut stack, enc::fcvtzu_w_from_s)?,
+            WasmOp::I32TruncSatF64S => trunc_sat(&mut words, &mut stack, enc::fcvtzs_w_from_d)?,
+            WasmOp::I32TruncSatF64U => trunc_sat(&mut words, &mut stack, enc::fcvtzu_w_from_d)?,
+            WasmOp::I64TruncSatF32S => trunc_sat(&mut words, &mut stack, enc::fcvtzs_x_from_s)?,
+            WasmOp::I64TruncSatF32U => trunc_sat(&mut words, &mut stack, enc::fcvtzu_x_from_s)?,
+            WasmOp::I64TruncSatF64S => trunc_sat(&mut words, &mut stack, enc::fcvtzs_x_from_d)?,
+            WasmOp::I64TruncSatF64U => trunc_sat(&mut words, &mut stack, enc::fcvtzu_x_from_d)?,
 
             // --- float↔float precision conversions (total, never trap) ---
             WasmOp::F64PromoteF32 => funop(&mut words, &mut stack, enc::fcvt_d_from_s)?,

--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -4973,6 +4973,32 @@ mod tests {
     }
 
     #[test]
+    fn trunc_sat_782_loud_declines_on_rv32() {
+        // #782a: the decoder now delivers the trunc_sat family; RV32 has no
+        // float lowering at all, so every form must LOUD-decline through the
+        // catch-all `Unsupported` arm — never silent wrong code.
+        for op in [
+            WasmOp::I32TruncSatF32S,
+            WasmOp::I32TruncSatF32U,
+            WasmOp::I32TruncSatF64S,
+            WasmOp::I32TruncSatF64U,
+            WasmOp::I64TruncSatF32S,
+            WasmOp::I64TruncSatF32U,
+            WasmOp::I64TruncSatF64S,
+            WasmOp::I64TruncSatF64U,
+        ] {
+            let ops = [WasmOp::LocalGet(0), op.clone(), WasmOp::End];
+            match select(&ops, 1) {
+                Ok(_) => panic!("{op:?} must decline on RV32, but compiled"),
+                Err(err) => assert!(
+                    matches!(err, SelectorError::Unsupported(_)),
+                    "{op:?} must surface as Unsupported, got: {err:?}"
+                ),
+            }
+        }
+    }
+
+    #[test]
     fn div_emits_zero_trap() {
         let out = s(
             &[

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -2233,6 +2233,19 @@ fn convert_operator(op: &wasmparser::Operator) -> Option<WasmOp> {
         F32ConvertI32U => Some(WasmOp::F32ConvertI32U),
         I32TruncF32S => Some(WasmOp::I32TruncF32S),
         I32TruncF32U => Some(WasmOp::I32TruncF32U),
+        // #782a: the nontrapping trunc_sat family (0xFC-prefixed,
+        // saturating-float-to-int proposal) — TOTAL ops (§4.3.2: NaN → 0,
+        // out-of-range saturates to INT_MIN/INT_MAX, no traps). Un-dropped so
+        // the selectors see them: ARM32 lowers the i32-target forms as a bare
+        // VCVT (round-toward-zero VCVT already saturates and gives 0 for NaN —
+        // exactly trunc_sat, the very behavior the #709 guard exists to keep
+        // away from the TRAPPING forms); aarch64 lowers all eight via
+        // FCVTZS/FCVTZU. The i64-target forms LOUD-decline on 32-bit ARM (no
+        // i64 register-pair conversion path) and RV32 (no floats at all).
+        I32TruncSatF32S => Some(WasmOp::I32TruncSatF32S),
+        I32TruncSatF32U => Some(WasmOp::I32TruncSatF32U),
+        I64TruncSatF32S => Some(WasmOp::I64TruncSatF32S),
+        I64TruncSatF32U => Some(WasmOp::I64TruncSatF32U),
 
         // === Scalar f64 (GI-FPU-002 phase 2, #369) ===
         // Un-dropped for the DOUBLE-precision FPU target (cortex-m7dp D0..D15);
@@ -2285,6 +2298,13 @@ fn convert_operator(op: &wasmparser::Operator) -> Option<WasmOp> {
         F64ConvertI32U => Some(WasmOp::F64ConvertI32U),
         I32TruncF64S => Some(WasmOp::I32TruncF64S),
         I32TruncF64U => Some(WasmOp::I32TruncF64U),
+        // #782a: f64-source trunc_sat twins (see the f32 group above). falcon
+        // v1.123 carries 7× i32.trunc_sat_f64_s — the m7dp double-precision
+        // VCVT twins lower the i32-target forms; i64 targets loud-decline.
+        I32TruncSatF64S => Some(WasmOp::I32TruncSatF64S),
+        I32TruncSatF64U => Some(WasmOp::I32TruncSatF64U),
+        I64TruncSatF64S => Some(WasmOp::I64TruncSatF64S),
+        I64TruncSatF64U => Some(WasmOp::I64TruncSatF64U),
 
         // f32x4
         F32x4Add => Some(WasmOp::F32x4Add),

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -2362,6 +2362,62 @@ mod tests {
         );
     }
 
+    /// #782a: the 0xFC-prefixed trunc_sat family must DECODE (it was
+    /// previously unmapped → the whole function loud-skipped as
+    /// "unsupported operator", the falcon #782 `ts32`/`ts64` class). All
+    /// eight forms must surface as their `WasmOp` variants so the selectors
+    /// can lower (ARM32 i32-targets, aarch64 all) or LOUD-decline (ARM32
+    /// i64-targets, RV32) per backend.
+    #[test]
+    fn test_decode_trunc_sat_family() {
+        let wat = r#"
+            (module
+                (func (export "ts") (param f32 f64) (result i32)
+                    (i32.trunc_sat_f32_s (local.get 0))
+                    (i32.trunc_sat_f32_u (local.get 0))
+                    i32.add
+                    (i32.trunc_sat_f64_s (local.get 1))
+                    i32.add
+                    (i32.trunc_sat_f64_u (local.get 1))
+                    i32.add
+                    (i32.wrap_i64 (i64.trunc_sat_f32_s (local.get 0)))
+                    i32.add
+                    (i32.wrap_i64 (i64.trunc_sat_f32_u (local.get 0)))
+                    i32.add
+                    (i32.wrap_i64 (i64.trunc_sat_f64_s (local.get 1)))
+                    i32.add
+                    (i32.wrap_i64 (i64.trunc_sat_f64_u (local.get 1)))
+                    i32.add
+                )
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
+        let functions = decode_wasm_functions(&wasm).expect("Failed to decode");
+        assert_eq!(functions.len(), 1);
+        let f = &functions[0];
+        assert!(
+            f.unsupported.is_none(),
+            "trunc_sat must decode, not loud-skip: {:?}",
+            f.unsupported
+        );
+        for want in [
+            WasmOp::I32TruncSatF32S,
+            WasmOp::I32TruncSatF32U,
+            WasmOp::I32TruncSatF64S,
+            WasmOp::I32TruncSatF64U,
+            WasmOp::I64TruncSatF32S,
+            WasmOp::I64TruncSatF32U,
+            WasmOp::I64TruncSatF64S,
+            WasmOp::I64TruncSatF64U,
+        ] {
+            assert!(
+                f.ops.contains(&want),
+                "decoded ops must contain {want:?}: {:?}",
+                f.ops
+            );
+        }
+    }
+
     /// #204 regression: `i64.extend_i32_u`, `i64.extend_i32_s` and
     /// `i32.wrap_i64` must DECODE (they were previously unmapped → silently
     /// dropped by `convert_operator`, leaving an i32 value as a 64-bit operand

--- a/crates/synth-core/src/wasm_op.rs
+++ b/crates/synth-core/src/wasm_op.rs
@@ -302,6 +302,16 @@ pub enum WasmOp {
     I32TruncF32S,      // Truncate f32 to signed i32
     I32TruncF32U,      // Truncate f32 to unsigned i32
 
+    // Nontrapping float→int (WASM saturating-float-to-int proposal, 0xFC
+    // prefix). TOTAL ops — never trap: NaN → 0, below INT_MIN → INT_MIN,
+    // above INT_MAX → INT_MAX, else truncate toward zero (§4.3.2 trunc_sat).
+    // Rust emits these for `as` casts, so real modules (falcon, #782) carry
+    // them even when the trapping forms are absent.
+    I32TruncSatF32S, // Saturating truncate f32 to signed i32
+    I32TruncSatF32U, // Saturating truncate f32 to unsigned i32
+    I64TruncSatF32S, // Saturating truncate f32 to signed i64
+    I64TruncSatF32U, // Saturating truncate f32 to unsigned i64
+
     // ========================================================================
     // f64 Operations
     // ========================================================================
@@ -355,6 +365,13 @@ pub enum WasmOp {
     I64TruncF64U,      // Truncate f64 to unsigned i64
     I32TruncF64S,      // Truncate f64 to signed i32
     I32TruncF64U,      // Truncate f64 to unsigned i32
+
+    // Nontrapping f64→int (saturating-float-to-int, §4.3.2 trunc_sat — see
+    // the f32 group above for the semantics).
+    I32TruncSatF64S, // Saturating truncate f64 to signed i32
+    I32TruncSatF64U, // Saturating truncate f64 to unsigned i32
+    I64TruncSatF64S, // Saturating truncate f64 to signed i64
+    I64TruncSatF64U, // Saturating truncate f64 to unsigned i64
 
     // ========================================================================
     // v128 SIMD Operations (WASM SIMD proposal)

--- a/crates/synth-core/src/wasm_stack_check.rs
+++ b/crates/synth-core/src/wasm_stack_check.rs
@@ -162,9 +162,9 @@ fn stack_effect_or_bail(op: &WasmOp) -> StackEffect {
         F32ConvertI32S | F32ConvertI32U | F32ConvertI64S | F32ConvertI64U | F32DemoteF64
         | F32ReinterpretI32 | I32ReinterpretF32 | I32TruncF32S | I32TruncF32U | F64ConvertI32S
         | F64ConvertI32U | F64ConvertI64S | F64ConvertI64U | F64PromoteF32 | F64ReinterpretI64
-        | I64ReinterpretF64 | I64TruncF64S | I64TruncF64U | I32TruncF64S | I32TruncF64U => {
-            modeled(1, 1)
-        }
+        | I64ReinterpretF64 | I64TruncF64S | I64TruncF64U | I32TruncF64S | I32TruncF64U
+        | I32TruncSatF32S | I32TruncSatF32U | I32TruncSatF64S | I32TruncSatF64U
+        | I64TruncSatF32S | I64TruncSatF32U | I64TruncSatF64S | I64TruncSatF64U => modeled(1, 1),
 
         // ---- pop-only ----------------------------------------------------
         LocalSet(_) | GlobalSet(_) | Drop => modeled(1, 0),

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -2005,8 +2005,9 @@ fn wasm_stack_effect(op: &WasmOp) -> (usize, usize) {
         F32ConvertI32S | F32ConvertI32U | F32ConvertI64S | F32ConvertI64U | F32DemoteF64
         | F64ConvertI32S | F64ConvertI32U | F64ConvertI64S | F64ConvertI64U | F64PromoteF32
         | I32TruncF32S | I32TruncF32U | I32TruncF64S | I32TruncF64U | I64TruncF64S
-        | I64TruncF64U | F32ReinterpretI32 | I32ReinterpretF32 | F64ReinterpretI64
-        | I64ReinterpretF64 => (1, 1),
+        | I64TruncF64U | I32TruncSatF32S | I32TruncSatF32U | I32TruncSatF64S | I32TruncSatF64U
+        | I64TruncSatF32S | I64TruncSatF32U | I64TruncSatF64S | I64TruncSatF64U
+        | F32ReinterpretI32 | I32ReinterpretF32 | F64ReinterpretI64 | I64ReinterpretF64 => (1, 1),
 
         // Constants: push 1
         I32Const(_) | I64Const(_) | F32Const(_) | F64Const(_) => (0, 1),
@@ -2286,6 +2287,14 @@ fn is_scope_f32_op(op: &WasmOp) -> bool {
             | F32ConvertI32U
             | I32TruncF32S
             | I32TruncF32U
+            // #782a: the nontrapping trunc_sat forms with an f32 SOURCE. The
+            // i32-target pair lowers (bare saturating VCVT); the i64-target
+            // pair is listed so the FPU gate + the loud i64 decline in
+            // `try_lower_f32` fire instead of the register-blind fallback.
+            | I32TruncSatF32S
+            | I32TruncSatF32U
+            | I64TruncSatF32S
+            | I64TruncSatF32U
             // #708 (phase 1b): un-dropped f32 memory-load + f32<->i32 bitcasts.
             // `F32Load` itself is lowered in the main `select_with_stack` match
             // (it needs `self`'s bounds/base-rewrite machinery); listing it here
@@ -2634,6 +2643,65 @@ fn try_lower_f32(
             stack.push(StackVal::i32(rd));
             Ok(true)
         }
+        I32TruncSatF32S | I32TruncSatF32U => {
+            // #782a: `i32.trunc_sat_f32_{s,u}` — the NONTRAPPING saturating
+            // truncation (WASM §4.3.2 trunc_sat: NaN → 0, out-of-range
+            // saturates to the integer bound, never traps). ARM
+            // `VCVT.{S32,U32}.F32` in its round-toward-zero form saturates on
+            // out-of-range AND yields 0 for NaN (FPToFixed, ARM ARM) — exactly
+            // trunc_sat's semantics, so the bare conversion (the very lowering
+            // the #709 guard forbids for the TRAPPING forms) is the correct,
+            // guard-free lowering here. Execution-verified against wasmtime
+            // over the full boundary table (NaN/±inf/exact bounds/±0.5) in
+            // `scripts/repro/trunc_sat_782_differential.py`.
+            let signed = matches!(op, I32TruncSatF32S);
+            let sm = pop_float(stack)?;
+            let rd = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+            // Same encoder hazard as the trapping twin: the encoder converts
+            // IN PLACE (`VCVT Sm, Sm` then `VMOV Rd, Sm`), so a pinned
+            // param/local HOME register must survive — convert from a fresh
+            // copy staged through `rd` (a safe round-trip scratch: the VCVT
+            // overwrites it with the result anyway).
+            let sm_is_home = vfp_s_index(sm).is_some_and(|s| vfp_home[s]);
+            let work = if sm_is_home {
+                let copy = alloc_vfp_temp(vfp_used)?;
+                instructions.push(ArmInstruction {
+                    op: ArmOp::I32ReinterpretF32 { rd, sm },
+                    source_line: Some(idx),
+                });
+                instructions.push(ArmInstruction {
+                    op: ArmOp::F32ReinterpretI32 { sd: copy, rm: rd },
+                    source_line: Some(idx),
+                });
+                copy
+            } else {
+                sm
+            };
+            let arm = if signed {
+                ArmOp::I32TruncF32S { rd, sm: work }
+            } else {
+                ArmOp::I32TruncF32U { rd, sm: work }
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_temp(vfp_used, vfp_home, work);
+            free_vfp_temp(vfp_used, vfp_home, sm);
+            stack.push(StackVal::i32(rd));
+            Ok(true)
+        }
+        op @ (I64TruncSatF32S | I64TruncSatF32U) => {
+            // #782a: the i64-target trunc_sat forms need an i64 register-pair
+            // conversion path that 32-bit ARM VFP does not provide (VCVT
+            // targets a single 32-bit register). LOUD-decline the function —
+            // decline > wrong (falcon needs only the i32-target forms, #782).
+            Err(synth_core::Error::synthesis(format!(
+                "{op:?} not supported on 32-bit ARM: no i64 register-pair \
+                 float→int conversion path — declining the function loudly \
+                 (#782a; the i32-target trunc_sat forms are lowered)"
+            )))
+        }
         F32ReinterpretI32 => {
             // #708: i32 bits → f32 (VMOV Sd, Rm). Pure bit-cast, no conversion.
             let rm = pop_operand(stack, next_temp, instructions, spill, reserved, idx)?;
@@ -2785,6 +2853,13 @@ fn is_scope_f64_op(op: &WasmOp) -> bool {
             | F64ConvertI32U
             | I32TruncF64S
             | I32TruncF64U
+            // #782a: the nontrapping trunc_sat forms with an f64 SOURCE (the
+            // i32-target pair lowers as a bare saturating VCVT.{S32,U32}.F64;
+            // the i64-target pair loud-declines in `try_lower_f64`).
+            | I32TruncSatF64S
+            | I32TruncSatF64U
+            | I64TruncSatF64S
+            | I64TruncSatF64U
     )
 }
 
@@ -3247,6 +3322,67 @@ fn try_lower_f64(
             }
             stack.push(StackVal::i32(rd));
             Ok(true)
+        }
+        I32TruncSatF64S | I32TruncSatF64U => {
+            // #782a: `i32.trunc_sat_f64_{s,u}` — the NONTRAPPING saturating
+            // truncation (§4.3.2 trunc_sat: NaN → 0, out-of-range saturates,
+            // never traps). ARM `VCVT.{S32,U32}.F64` (round-toward-zero)
+            // saturates on out-of-range and yields 0 for NaN — exactly
+            // trunc_sat, so the bare conversion needs NO #709-style domain
+            // guard (the guard exists to make the TRAPPING forms trap).
+            // falcon v1.123 carries 7× of the signed form (#782).
+            // Execution-verified vs wasmtime over the boundary table in
+            // `scripts/repro/trunc_sat_782_differential.py`.
+            let signed = matches!(op, I32TruncSatF64S);
+            let dm = pop_double(stack)?;
+            // Same encoder hazard as the trapping twin: the result is staged
+            // through the SOURCE's low S-alias, clobbering half of `dm` —
+            // convert a pinned param/local HOME from a fresh copy.
+            let dm_is_home = vfp_d_index(dm).is_some_and(|d| vfp_home[2 * d]);
+            let work = if dm_is_home {
+                let copy = alloc_vfp_dtemp(vfp_used)?;
+                emit_d_copy(
+                    copy,
+                    dm,
+                    idx,
+                    stack,
+                    next_temp,
+                    spill,
+                    instructions,
+                    reserved,
+                )?;
+                copy
+            } else {
+                dm
+            };
+            let rd = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+            let arm = if signed {
+                ArmOp::I32TruncF64S { rd, dm: work }
+            } else {
+                ArmOp::I32TruncF64U { rd, dm: work }
+            };
+            instructions.push(ArmInstruction {
+                op: arm,
+                source_line: Some(idx),
+            });
+            free_vfp_dtemp(vfp_used, vfp_home, work);
+            if dm_is_home {
+                // `work` was the fresh copy; the untouched home stays pinned.
+            } else {
+                free_vfp_dtemp(vfp_used, vfp_home, dm);
+            }
+            stack.push(StackVal::i32(rd));
+            Ok(true)
+        }
+        op @ (I64TruncSatF64S | I64TruncSatF64U) => {
+            // #782a: no i64 register-pair float→int conversion path on 32-bit
+            // ARM — LOUD-decline (decline > wrong; falcon needs only the
+            // i32-target forms, #782).
+            Err(synth_core::Error::synthesis(format!(
+                "{op:?} not supported on 32-bit ARM: no i64 register-pair \
+                 float→int conversion path — declining the function loudly \
+                 (#782a; the i32-target trunc_sat forms are lowered)"
+            )))
         }
         _ => Ok(false),
     }
@@ -5962,6 +6098,29 @@ impl InstructionSelector {
                 seq
             }
 
+            // #782a: the NONTRAPPING trunc_sat forms — bare saturating VCVT,
+            // deliberately WITHOUT the #709 range guard (§4.3.2 trunc_sat:
+            // NaN → 0, out-of-range saturates; VCVT round-toward-zero does
+            // exactly that). Guard-free is the CORRECT lowering here, not a
+            // soundness hole.
+            I32TruncSatF32S if self.fpu.is_some() => {
+                let sm = self.alloc_vfp_reg();
+                vec![ArmOp::I32TruncF32S { rd, sm }]
+            }
+            I32TruncSatF32U if self.fpu.is_some() => {
+                let sm = self.alloc_vfp_reg();
+                vec![ArmOp::I32TruncF32U { rd, sm }]
+            }
+
+            // #782a: i64-target trunc_sat from f32 — no i64 register-pair
+            // conversion path on 32-bit ARM. Loud decline (decline > wrong).
+            op @ (I64TruncSatF32S | I64TruncSatF32U) if self.fpu.is_some() => {
+                return Err(synth_core::Error::synthesis(format!(
+                    "{op:?} not supported on 32-bit ARM: no i64 register-pair \
+                     float→int conversion path (#782a)"
+                )));
+            }
+
             // F32 rounding pseudo-ops — emit ArmOp variants, encoder expands to
             // multi-instruction sequences using FPSCR rounding-mode manipulation
             F32Ceil if self.fpu.is_some() => {
@@ -6054,7 +6213,11 @@ impl InstructionSelector {
             | F32ReinterpretI32
             | I32ReinterpretF32
             | I32TruncF32S
-            | I32TruncF32U) => {
+            | I32TruncF32U
+            | I32TruncSatF32S
+            | I32TruncSatF32U
+            | I64TruncSatF32S
+            | I64TruncSatF32U) => {
                 return Err(synth_core::Error::synthesis(format!(
                     "target {} has no FPU; cannot compile {op:?}",
                     self.target_name
@@ -6204,6 +6367,18 @@ impl InstructionSelector {
                 vec![ArmOp::I32TruncF64U { rd, dm }]
             }
 
+            // #782a: nontrapping trunc_sat from f64 — bare saturating
+            // VCVT.{S32,U32}.F64, guard-free BY DESIGN (§4.3.2: NaN → 0,
+            // out-of-range saturates — exactly what the VCVT does).
+            I32TruncSatF64S if self.has_double_fpu() => {
+                let dm = self.alloc_vfp_dreg();
+                vec![ArmOp::I32TruncF64S { rd, dm }]
+            }
+            I32TruncSatF64U if self.has_double_fpu() => {
+                let dm = self.alloc_vfp_dreg();
+                vec![ArmOp::I32TruncF64U { rd, dm }]
+            }
+
             // F64 rounding pseudo-ops — emit ArmOp variants; encoder expands
             // them into FPSCR-rounding-mode + VCVT sequences.
             F64Ceil if self.has_double_fpu() => {
@@ -6249,7 +6424,9 @@ impl InstructionSelector {
 
             // F64 i64 conversions: VCVT.{F64,S32}.{S32,F64} with i64 register
             // pairs is not implemented in the backend. Surface a typed error.
-            op @ (F64ConvertI64S | F64ConvertI64U | I64TruncF64S | I64TruncF64U)
+            // (#782a: the i64-target trunc_sat forms decline identically.)
+            op @ (F64ConvertI64S | F64ConvertI64U | I64TruncF64S | I64TruncF64U
+            | I64TruncSatF64S | I64TruncSatF64U)
                 if self.has_double_fpu() =>
             {
                 return Err(synth_core::Error::synthesis(format!(
@@ -6295,7 +6472,11 @@ impl InstructionSelector {
             | I64TruncF64S
             | I64TruncF64U
             | I32TruncF64S
-            | I32TruncF64U) => {
+            | I32TruncF64U
+            | I32TruncSatF64S
+            | I32TruncSatF64U
+            | I64TruncSatF64S
+            | I64TruncSatF64U) => {
                 let msg = if self.fpu.is_some() {
                     // Single-precision FPU target (e.g., Cortex-M4F): VFP-D
                     // instructions exist as encodings but the hardware lacks

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -1044,6 +1044,17 @@ impl OptimizerBridge {
                 | WasmOp::I32ReinterpretF32
                 | WasmOp::I32TruncF32S
                 | WasmOp::I32TruncF32U
+                // #782a: the f32-source trunc_sat forms consume a float-typed
+                // value the optimized path cannot map — bail to
+                // `select_with_stack` (which lowers the i32 targets and
+                // loud-declines the i64 targets). Omitting these from this
+                // list let the optimized path silently DROP the op (a 2-byte
+                // `bx lr` stub — the #615 silent-NOP class), caught by the
+                // trunc_sat_782 differential before it ever shipped.
+                | WasmOp::I32TruncSatF32S
+                | WasmOp::I32TruncSatF32U
+                | WasmOp::I64TruncSatF32S
+                | WasmOp::I64TruncSatF32U
                 // f64 arithmetic
                 | WasmOp::F64Add
                 | WasmOp::F64Sub
@@ -1083,6 +1094,11 @@ impl OptimizerBridge {
                 | WasmOp::I64TruncF64U
                 | WasmOp::I32TruncF64S
                 | WasmOp::I32TruncF64U
+                // #782a: f64-source trunc_sat twins (see the f32 group above).
+                | WasmOp::I32TruncSatF64S
+                | WasmOp::I32TruncSatF64U
+                | WasmOp::I64TruncSatF64S
+                | WasmOp::I64TruncSatF64U
         )
     }
 

--- a/crates/synth-synthesis/tests/trunc_sat_782.rs
+++ b/crates/synth-synthesis/tests/trunc_sat_782.rs
@@ -1,0 +1,199 @@
+//! #782a — trunc_sat (nontrapping saturating float→int) lowering contracts on
+//! the ARM32 shipping path (`select_with_stack`, the path falcon's
+//! `--relocatable` cortex-m7dp compile takes).
+//!
+//! WASM §4.3.2 `trunc_sat` is TOTAL: NaN → 0, out-of-range saturates to the
+//! integer bound, never traps. ARM `VCVT.{S32,U32}.F32/F64` (round-toward-
+//! zero) implements exactly that, so the CORRECT lowering is the bare VCVT —
+//! deliberately WITHOUT the #709 domain guard whose whole job is to make the
+//! TRAPPING `trunc` forms trap. These tests pin both directions:
+//!
+//!  * sat forms emit NO `Udf` (a guard would turn saturation into a spurious
+//!    trap — a miscompile);
+//!  * the trapping twins KEEP their `Udf` guard (the #709 soundness surface
+//!    must not be eroded by the new arms);
+//!  * the i64-target sat forms LOUD-decline on 32-bit ARM (no i64
+//!    register-pair conversion path) — decline > wrong;
+//!  * everything f32/f64 honest-rejects without the required FPU.
+//!
+//! The execution truth (boundary table vs wasmtime under unicorn, ARM32 +
+//! aarch64 + native) lives in `scripts/repro/trunc_sat_782_differential.py`.
+
+use synth_core::target::FPUPrecision;
+use synth_synthesis::rules::ArmOp;
+use synth_synthesis::{InstructionSelector, RuleDatabase, WasmOp};
+
+fn selector(fpu: Option<FPUPrecision>, name: &str) -> InstructionSelector {
+    let db = RuleDatabase::with_standard_rules();
+    let mut sel = InstructionSelector::new(db.rules().to_vec());
+    sel.set_target(fpu, name);
+    sel
+}
+
+/// Lower `(param <f32|f64>) (result _) op(local.get 0)` on the given target.
+fn lower(
+    fpu: Option<FPUPrecision>,
+    name: &str,
+    op: WasmOp,
+    param_is_f64: bool,
+) -> Result<Vec<ArmOp>, String> {
+    let mut sel = selector(fpu, name);
+    if param_is_f64 {
+        sel.set_params_f64(vec![true]);
+    } else {
+        sel.set_params_f32(vec![true]);
+    }
+    let ops = vec![WasmOp::LocalGet(0), op, WasmOp::End];
+    sel.select_with_stack(&ops, 1)
+        .map(|instrs| instrs.into_iter().map(|i| i.op).collect())
+        .map_err(|e| e.to_string())
+}
+
+fn has_udf(ops: &[ArmOp]) -> bool {
+    ops.iter().any(|o| matches!(o, ArmOp::Udf { .. }))
+}
+
+fn has_vcvt_f32(ops: &[ArmOp], signed: bool) -> bool {
+    ops.iter().any(|o| {
+        if signed {
+            matches!(o, ArmOp::I32TruncF32S { .. })
+        } else {
+            matches!(o, ArmOp::I32TruncF32U { .. })
+        }
+    })
+}
+
+fn has_vcvt_f64(ops: &[ArmOp], signed: bool) -> bool {
+    ops.iter().any(|o| {
+        if signed {
+            matches!(o, ArmOp::I32TruncF64S { .. })
+        } else {
+            matches!(o, ArmOp::I32TruncF64U { .. })
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// sat forms: bare VCVT, NO guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn i32_trunc_sat_f32_is_bare_vcvt_no_guard() {
+    for (op, signed) in [
+        (WasmOp::I32TruncSatF32S, true),
+        (WasmOp::I32TruncSatF32U, false),
+    ] {
+        let ops = lower(Some(FPUPrecision::Single), "cortex-m4f", op.clone(), false)
+            .unwrap_or_else(|e| panic!("{op:?} must lower on cortex-m4f: {e}"));
+        assert!(
+            has_vcvt_f32(&ops, signed),
+            "{op:?} must emit the saturating VCVT, got {ops:?}"
+        );
+        assert!(
+            !has_udf(&ops),
+            "{op:?} is TOTAL (§4.3.2) — a Udf guard would spuriously trap \
+             where WASM saturates: {ops:?}"
+        );
+    }
+}
+
+#[test]
+fn i32_trunc_sat_f64_is_bare_vcvt_no_guard() {
+    for (op, signed) in [
+        (WasmOp::I32TruncSatF64S, true),
+        (WasmOp::I32TruncSatF64U, false),
+    ] {
+        let ops = lower(Some(FPUPrecision::Double), "cortex-m7dp", op.clone(), true)
+            .unwrap_or_else(|e| panic!("{op:?} must lower on cortex-m7dp: {e}"));
+        assert!(
+            has_vcvt_f64(&ops, signed),
+            "{op:?} must emit the saturating VCVT.F64, got {ops:?}"
+        );
+        assert!(!has_udf(&ops), "{op:?} is TOTAL — no Udf guard: {ops:?}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// the trapping twins KEEP the #709 guard (soundness surface unchanged)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn trapping_trunc_still_carries_the_709_udf_guard() {
+    let f32_ops = lower(
+        Some(FPUPrecision::Single),
+        "cortex-m4f",
+        WasmOp::I32TruncF32S,
+        false,
+    )
+    .expect("trapping trunc_f32_s must still lower");
+    assert!(
+        has_udf(&f32_ops),
+        "i32.trunc_f32_s must KEEP its #709 trap guard: {f32_ops:?}"
+    );
+
+    let f64_ops = lower(
+        Some(FPUPrecision::Double),
+        "cortex-m7dp",
+        WasmOp::I32TruncF64S,
+        true,
+    )
+    .expect("trapping trunc_f64_s must still lower");
+    assert!(
+        has_udf(&f64_ops),
+        "i32.trunc_f64_s must KEEP its #709 trap guard: {f64_ops:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// i64-target sat forms: LOUD decline on 32-bit ARM
+// ---------------------------------------------------------------------------
+
+#[test]
+fn i64_trunc_sat_forms_loud_decline_on_arm32() {
+    for (op, is_f64) in [
+        (WasmOp::I64TruncSatF32S, false),
+        (WasmOp::I64TruncSatF32U, false),
+        (WasmOp::I64TruncSatF64S, true),
+        (WasmOp::I64TruncSatF64U, true),
+    ] {
+        let err = lower(
+            Some(FPUPrecision::Double),
+            "cortex-m7dp",
+            op.clone(),
+            is_f64,
+        )
+        .expect_err(&format!("{op:?} must DECLINE on 32-bit ARM, not compile"));
+        assert!(
+            err.contains("register-pair"),
+            "{op:?} decline must NAME the missing capability (i64 \
+             register-pair conversion), got: {err}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// capability gates: no FPU / single-precision honest-reject
+// ---------------------------------------------------------------------------
+
+#[test]
+fn trunc_sat_honest_rejects_without_required_fpu() {
+    // f32-source sat forms on a no-FPU target (cortex-m3).
+    let err = lower(None, "cortex-m3", WasmOp::I32TruncSatF32S, false)
+        .expect_err("trunc_sat_f32 must honest-reject on cortex-m3 (no FPU)");
+    assert!(
+        err.contains("FPU"),
+        "no-FPU decline must name the capability: {err}"
+    );
+    // f64-source sat forms on a single-precision target (cortex-m4f).
+    let err = lower(
+        Some(FPUPrecision::Single),
+        "cortex-m4f",
+        WasmOp::I32TruncSatF64S,
+        true,
+    )
+    .expect_err("trunc_sat_f64 must honest-reject on cortex-m4f (single-precision)");
+    assert!(
+        err.contains("double-precision") || err.contains("f64"),
+        "single-precision decline must name the capability: {err}"
+    );
+}

--- a/scripts/repro/trunc_sat_782.wat
+++ b/scripts/repro/trunc_sat_782.wat
@@ -1,0 +1,38 @@
+;; #782a — the nontrapping saturating float->int truncation acceptance module
+;; (WASM saturating-float-to-int proposal, 0xFC prefix, Core §4.3.2 trunc_sat).
+;;
+;; Semantics under test (TOTAL — never traps):
+;;   NaN -> 0; x < INT_MIN -> INT_MIN; x > INT_MAX -> INT_MAX (for _u:
+;;   negatives -> 0, above UINT_MAX -> UINT_MAX); else truncate toward zero.
+;;
+;; The i32-target quartet is what falcon-flight-v1.123 carries (7x
+;; i32.trunc_sat_f64_s + 1x i32.trunc_sat_f32_s, #782) — Rust emits trunc_sat
+;; for `as` casts. The i64-target quartet lowers on aarch64 only (A64 is
+;; 64-bit native); 32-bit ARM LOUD-declines it (see trunc_sat_782_decline in
+;; the differential).
+;;
+;; The differential (trunc_sat_782_differential.py) executes each export under
+;; unicorn (Thumb-2 cortex-m7dp AND aarch64) and natively on an arm64 host,
+;; diffing wasmtime ground truth over the full boundary table: NaN, ±inf, the
+;; exact INT_MIN/INT_MAX boundaries, ±0.5 fractions, and in-range values. NO
+;; case may trap anywhere — a UDF/brk stop is a failure by construction.
+(module
+  ;; ---- i32-target trunc_sat (the falcon quartet) ----
+  (func (export "i32_trunc_sat_f32_s") (param f32) (result i32)
+    (i32.trunc_sat_f32_s (local.get 0)))
+  (func (export "i32_trunc_sat_f32_u") (param f32) (result i32)
+    (i32.trunc_sat_f32_u (local.get 0)))
+  (func (export "i32_trunc_sat_f64_s") (param f64) (result i32)
+    (i32.trunc_sat_f64_s (local.get 0)))
+  (func (export "i32_trunc_sat_f64_u") (param f64) (result i32)
+    (i32.trunc_sat_f64_u (local.get 0)))
+
+  ;; ---- i64-target trunc_sat (aarch64-only; ARM32 loud-declines) ----
+  (func (export "i64_trunc_sat_f32_s") (param f32) (result i64)
+    (i64.trunc_sat_f32_s (local.get 0)))
+  (func (export "i64_trunc_sat_f32_u") (param f32) (result i64)
+    (i64.trunc_sat_f32_u (local.get 0)))
+  (func (export "i64_trunc_sat_f64_s") (param f64) (result i64)
+    (i64.trunc_sat_f64_s (local.get 0)))
+  (func (export "i64_trunc_sat_f64_u") (param f64) (result i64)
+    (i64.trunc_sat_f64_u (local.get 0))))

--- a/scripts/repro/trunc_sat_782_differential.py
+++ b/scripts/repro/trunc_sat_782_differential.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""#782a — the trunc_sat (nontrapping saturating float->int) boundary
+EXECUTION differential.
+
+WASM §4.3.2 trunc_sat is TOTAL: NaN -> 0, below INT_MIN -> INT_MIN, above
+INT_MAX -> INT_MAX (unsigned: negatives -> 0, above UINT_MAX -> UINT_MAX),
+else truncate toward zero. NO traps — anywhere. The lowerings under test:
+
+  * ARM32 Thumb-2 (cortex-m7dp, falcon's #782 target): the i32-target quartet
+    as a BARE round-toward-zero VCVT (which saturates and yields 0 for NaN —
+    exactly trunc_sat; the very behavior the #709 guard keeps away from the
+    TRAPPING forms). The i64-target quartet LOUD-declines (no i64
+    register-pair conversion path) — asserted here, symbols must be absent
+    and the decline must be named.
+  * aarch64: all eight via bare FCVTZS/FCVTZU (w and x destinations).
+
+Every boundary case must match wasmtime bit-exactly AND must not trap on our
+side (a UDF/brk stop is a failure by construction); wasmtime itself is
+asserted total first, so the table cannot drift vacuous. The falcon repro
+flags (`-t cortex-m7dp --relocatable`) are compile-gated: the four i32-target
+exports must NOT be skipped (the #782 'skipping ts32/ts64' class), the four
+i64-target exports MUST still be skipped loudly (decline-honesty).
+
+Run (needs wasmtime + unicorn + pyelftools; native path needs an arm64 host):
+  SYNTH=<target>/debug/synth python scripts/repro/trunc_sat_782_differential.py
+"""
+
+import ctypes
+import os
+import platform
+import signal
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_ARCH_ARM64, UC_MODE_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm64_const import (
+    UC_ARM64_REG_CPACR_EL1,
+    UC_ARM64_REG_LR,
+    UC_ARM64_REG_SP,
+    UC_ARM64_REG_V0,
+    UC_ARM64_REG_X0,
+)
+from unicorn.arm_const import (
+    UC_ARM_REG_D0,
+    UC_ARM_REG_LR,
+    UC_ARM_REG_PC,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_S0,
+    UC_ARM_REG_SP,
+)
+
+try:
+    from unicorn.arm_const import UC_ARM_REG_C1_C0_2, UC_ARM_REG_FPEXC
+except ImportError:  # older unicorn naming
+    UC_ARM_REG_C1_C0_2 = None
+    UC_ARM_REG_FPEXC = None
+
+WAT = Path(__file__).with_name("trunc_sat_782.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+MEMBASE = 0x20000000  # ARM32 R11/fp linear-memory base at reset (cortex_m.rs)
+A64_CODE, A64_STK, A64_RET = 0x100000, 0x200000, 0x300000
+
+M32 = (1 << 32) - 1
+M64 = (1 << 64) - 1
+INF = float("inf")
+NAN = float("nan")
+
+I32_FNS = {
+    "i32_trunc_sat_f32_s": ("f32", "i32"),
+    "i32_trunc_sat_f32_u": ("f32", "i32"),
+    "i32_trunc_sat_f64_s": ("f64", "i32"),
+    "i32_trunc_sat_f64_u": ("f64", "i32"),
+}
+I64_FNS = {
+    "i64_trunc_sat_f32_s": ("f32", "i64"),
+    "i64_trunc_sat_f32_u": ("f32", "i64"),
+    "i64_trunc_sat_f64_s": ("f64", "i64"),
+    "i64_trunc_sat_f64_u": ("f64", "i64"),
+}
+SIGS = {**I32_FNS, **I64_FNS}
+
+# ---------------------------------------------------------------------------
+# The §4.3.2 boundary table. EVERY case is total (wasmtime asserted no-trap):
+# NaN, ±inf, the exact saturation boundaries on both sides, ±0.5 fractions,
+# and plain in-range values. Boundary subtleties pinned:
+#   - f32 can't represent 2^31-1: 2147483520.0 is the largest f32 < 2^31;
+#     2^31 itself (2147483648.0) saturates to INT32_MAX. -2^31 is exact and
+#     in-range; the next f32 below (-2147483904.0) saturates to INT32_MIN.
+#   - f64->i32: 2147483647.9 truncates to INT32_MAX in-range; 2147483648.0
+#     saturates. -2147483648.999 truncates to -2^31; -2147483649.0 saturates.
+#   - unsigned: (-1.0, -0.0] truncates to 0 in-range semantics anyway; any
+#     value <= -1.0 (and -inf, NaN) must yield 0.
+#   - f32/f64->i64: 2^63 saturates to INT64_MAX (no f32/f64 hits 2^63-1);
+#     -2^63 is exactly representable and in-range for _s.
+BOUNDARY = {
+    "f32": [
+        0.0, -0.0, 0.5, -0.5, 0.9, -0.9, 1.5, -1.5, 42.0, -42.0, 100.75,
+        2147483520.0, -2147483520.0, 2147483648.0, -2147483648.0,
+        2147483904.0, -2147483904.0, 4294967040.0, 4294967296.0,
+        -1.0, -1.5, 3e9, -3e9, 5e9, 1e10, -1e10,
+        9223371487098961920.0,   # largest f32 < 2^63
+        9223372036854775808.0,   # 2^63: i64_s saturates to INT64_MAX
+        -9223372036854775808.0,  # -2^63 exactly: i64_s in-range minimum
+        18446742974197923840.0,  # largest f32 < 2^64
+        18446744073709551616.0,  # 2^64: i64_u saturates to UINT64_MAX
+        1e30, -1e30, INF, -INF, NAN,
+    ],
+    "f64": [
+        0.0, -0.0, 0.5, -0.5, 0.9, -0.9, 1.5, -1.5, 42.0, -42.0, 100.75,
+        2147483647.0, 2147483647.9, 2147483648.0, 2147483648.5,
+        -2147483648.0, -2147483648.5, -2147483648.999,
+        -2147483649.0, -2147483649.5,
+        4294967295.0, 4294967295.9, 4294967296.0, 4294967296.5,
+        -1.0, -1.5, 1e18, -1e18,
+        9223372036854774784.0,   # largest f64 < 2^63
+        9223372036854775808.0,   # 2^63: i64_s saturates
+        -9223372036854775808.0,  # -2^63 exactly: i64_s in-range minimum
+        -9223372036854777856.0,  # first f64 below -2^63: i64_s saturates
+        18446744073709549568.0,  # largest f64 < 2^64
+        18446744073709551616.0,  # 2^64: i64_u saturates
+        1e300, -1e300, INF, -INF, NAN,
+    ],
+}
+
+
+def f32_bits(x):
+    return struct.unpack("<I", struct.pack("<f", x))[0]
+
+
+def f64_bits(x):
+    return struct.unpack("<Q", struct.pack("<d", x))[0]
+
+
+def arg_bits(ty, v):
+    return f32_bits(v) if ty == "f32" else f64_bits(v)
+
+
+# ---------------------------------------------------------------------------
+# wasmtime ground truth — trunc_sat is TOTAL, so a wasmtime trap is a
+# harness/fixture bug, not a data point.
+def wasmtime_expected():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    exports = wasmtime.Instance(store, module, []).exports(store)
+    table = {}
+    for fn, (aty, rty) in SIGS.items():
+        f = exports[fn]
+        rows = []
+        for v in BOUNDARY[aty]:
+            try:
+                r = f(store, float(v))
+            except wasmtime.Trap:
+                sys.exit(f"TABLE-BUG: wasmtime TRAPPED on {fn}({v!r}) — "
+                         f"trunc_sat must be total")
+            rows.append((v, int(r) & (M32 if rty == "i32" else M64)))
+        table[fn] = rows
+    return table
+
+
+# ---------------------------------------------------------------------------
+def compile_or_die(out, extra, what):
+    cmd = [SYNTH, "compile", str(WAT), "-o", out, *extra]
+    r = subprocess.run(cmd, capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin"})
+    if r.returncode != 0:
+        sys.exit(f"{what} compile failed: {r.stderr}")
+    return r.stderr + r.stdout
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":  # #489: symtab, not disasm text
+            for sy in sec.iter_symbols():
+                if sy.name:
+                    syms[sy.name] = sy["st_value"]
+    return code, base, syms
+
+
+# ---------------------------------------------------------------------------
+# ARM32 (Thumb-2) unicorn execution. Returns ('ok', r0) or ('trap', pc-info).
+def arm32_run(text, base, addr, aty, v):
+    uc = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    map_base = base & ~0xFFF
+    size = ((len(text) + (base - map_base)) + 0xFFF) & ~0xFFF
+    uc.mem_map(map_base, max(size, 0x1000))
+    uc.mem_write(base, text)
+    uc.mem_map(0x30000, 0x10000)  # stack
+    uc.mem_map(MEMBASE, 0x10000)  # linear-memory window (R11 base)
+    uc.reg_write(UC_ARM_REG_SP, 0x38000)
+    uc.reg_write(UC_ARM_REG_R11, MEMBASE)
+    if UC_ARM_REG_C1_C0_2 is not None:
+        uc.reg_write(UC_ARM_REG_C1_C0_2, 0x00F00000)  # CPACR CP10/CP11
+    if UC_ARM_REG_FPEXC is not None:
+        uc.reg_write(UC_ARM_REG_FPEXC, 0x40000000)  # FPEXC.EN
+    if aty == "f32":
+        uc.reg_write(UC_ARM_REG_S0, f32_bits(v))
+    else:
+        uc.reg_write(UC_ARM_REG_D0, f64_bits(v))
+    ret = 0x38000
+    uc.reg_write(UC_ARM_REG_LR, ret | 1)
+    try:
+        uc.emu_start(addr | 1, ret & ~1, count=500)
+    except UcError as e:
+        pc = uc.reg_read(UC_ARM_REG_PC)
+        kind = "fault"
+        if base <= pc < base + len(text):
+            hw = struct.unpack("<H", text[pc - base: pc - base + 2])[0]
+            if hw & 0xFF00 == 0xDE00:  # Thumb UDF
+                kind = "trap-udf"
+        return (kind, f"{e} at pc={pc:#x}")
+    return ("ok", uc.reg_read(UC_ARM_REG_R0) & M32)
+
+
+# ---------------------------------------------------------------------------
+# aarch64 unicorn execution. Returns ('ok', bits) or ('trap', msg).
+def a64_run(code, base, faddr, aty, rty, v):
+    mu = Uc(UC_ARCH_ARM64, UC_MODE_ARM)
+    mu.reg_write(UC_ARM64_REG_CPACR_EL1, 0x3 << 20)  # FPEN
+    mu.mem_map(A64_CODE, 0x20000)
+    mu.mem_map(A64_STK - 0x10000, 0x20000)
+    mu.mem_map(A64_RET & ~0xFFF, 0x1000)
+    mu.mem_write(A64_CODE, code)
+    mu.reg_write(UC_ARM64_REG_SP, A64_STK)
+    mu.reg_write(UC_ARM64_REG_LR, A64_RET)
+    mu.reg_write(UC_ARM64_REG_V0, arg_bits(aty, v))
+    try:
+        mu.emu_start(A64_CODE + (faddr - base), A64_RET, count=2000)
+    except UcError as e:
+        return ("trap", str(e))
+    x0 = mu.reg_read(UC_ARM64_REG_X0)
+    return ("ok", x0 & (M32 if rty == "i32" else M64))
+
+
+# ---------------------------------------------------------------------------
+# native aarch64 execution (arm64 host): forked child, SIGTRAP observable.
+_MAP_PRIVATE = 0x0002
+_MAP_ANON = 0x1000 if sys.platform == "darwin" else 0x20
+_MAP_JIT = 0x0800
+_PROT_RWX = 0x1 | 0x2 | 0x4
+_CTY = {"f32": ctypes.c_float, "f64": ctypes.c_double,
+        "i32": ctypes.c_int32, "i64": ctypes.c_int64}
+
+
+def native_setup(code):
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.mmap.restype = ctypes.c_void_p
+    libc.mmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int,
+                          ctypes.c_int, ctypes.c_int, ctypes.c_long]
+    size = max(len(code), 4096)
+    flags = _MAP_PRIVATE | _MAP_ANON
+    if sys.platform == "darwin":
+        flags |= _MAP_JIT
+    addr = libc.mmap(None, size, _PROT_RWX, flags, -1, 0)
+    if addr in (ctypes.c_void_p(-1).value, 0, None):
+        err = ctypes.get_errno()
+        raise OSError(err, f"mmap(MAP_JIT) failed: {os.strerror(err)}")
+    if sys.platform == "darwin":
+        wp = ctypes.CDLL(None).pthread_jit_write_protect_np
+        wp(0)
+    ctypes.memmove(addr, code, len(code))
+    if sys.platform == "darwin":
+        wp(1)
+        libc.sys_icache_invalidate.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+        libc.sys_icache_invalidate(ctypes.c_void_p(addr), len(code))
+    return addr
+
+
+def native_run(code, faddr, code_base, aty, rty, v):
+    rd, wr = os.pipe()
+    pid = os.fork()
+    if pid == 0:  # child
+        try:
+            os.close(rd)
+            base_addr = native_setup(code)
+            proto = ctypes.CFUNCTYPE(_CTY[rty], _CTY[aty])
+            fn = proto(base_addr + (faddr - code_base))
+            r = fn(float(v))  # any brk -> SIGTRAP -> child dies
+            bits = int(r) & (M32 if rty == "i32" else M64)
+            os.write(wr, struct.pack("<Q", bits))
+            os.close(wr)
+        finally:
+            os._exit(0)
+    os.close(wr)
+    _, status = os.waitpid(pid, 0)
+    data = os.read(rd, 8)
+    os.close(rd)
+    if os.WIFSIGNALED(status):
+        sig_no = os.WTERMSIG(status)
+        if sig_no in (signal.SIGTRAP, signal.SIGILL):
+            return ("trap", f"signal {sig_no}")
+        return ("trap", f"ERR:signal {sig_no}")
+    if len(data) != 8:
+        return ("trap", "ERR:no result")
+    return ("ok", struct.unpack("<Q", data)[0])
+
+
+# ---------------------------------------------------------------------------
+def main():
+    expected = wasmtime_expected()
+    fails = 0
+    total = 0
+
+    # ==== falcon repro flags (#782): -t cortex-m7dp --relocatable ==========
+    # The four i32-target exports must NOT skip; the four i64-target exports
+    # MUST still skip with the named ARM32 decline (decline-honesty).
+    log = compile_or_die("/tmp/trunc_sat_782_reloc.elf",
+                         ["-b", "arm", "--target", "cortex-m7dp",
+                          "--relocatable"],
+                         "ARM32 --relocatable (falcon flags)")
+    for fn in I32_FNS:
+        if fn in log and "kipping" in log:
+            # cheap guard; the authoritative check is the symbol table below
+            pass
+    _, _, reloc_syms = load("/tmp/trunc_sat_782_reloc.elf")
+    for fn in I32_FNS:
+        total += 1
+        if fn not in reloc_syms:
+            fails += 1
+            print(f"FAIL [falcon-flags] {fn}: SKIPPED under "
+                  f"-t cortex-m7dp --relocatable (the #782 class)")
+    for fn in I64_FNS:
+        total += 1
+        if fn in reloc_syms:
+            fails += 1
+            print(f"FAIL [falcon-flags] {fn}: compiled on 32-bit ARM — "
+                  f"expected a LOUD decline (no i64 pair conversion)")
+    if "register-pair" not in log:
+        fails += 1
+        print("FAIL [falcon-flags]: the i64 trunc_sat decline is not NAMED "
+              "in the compile log (decline-honesty)")
+
+    # ==== ARM32 self-contained (cortex-m7dp): execute the i32 quartet ======
+    compile_or_die("/tmp/trunc_sat_782_arm.elf",
+                   ["-b", "arm", "--target", "cortex-m7dp", "--all-exports"],
+                   "ARM32 cortex-m7dp")
+    text, base, syms = load("/tmp/trunc_sat_782_arm.elf")
+    for fn, (aty, rty) in I32_FNS.items():
+        if fn not in syms:
+            fails += 1
+            print(f"FAIL [arm32] {fn}: symbol missing")
+            continue
+        for v, want in expected[fn]:
+            total += 1
+            kind, got = arm32_run(text, base, syms[fn], aty, v)
+            if kind != "ok":
+                fails += 1
+                print(f"BUG [arm32] {fn}({v!r}) -> {kind}: {got} — trunc_sat "
+                      f"must NEVER trap (wasmtime: {want:#x})")
+            elif got != want:
+                fails += 1
+                print(f"BUG [arm32] {fn}({v!r}) = {got:#x} != wasmtime {want:#x}")
+    # i64-target forms must be absent (loud-declined) on ARM32 here too.
+    for fn in I64_FNS:
+        total += 1
+        if fn in syms:
+            fails += 1
+            print(f"FAIL [arm32] {fn}: compiled on 32-bit ARM — expected decline")
+
+    # ==== ARM32 single-precision (cortex-m4f): f32 quartet only ============
+    # trunc_sat_f32_* needs only single-precision VFP; the f64-source forms
+    # ride the existing double-FPU honest-reject.
+    compile_or_die("/tmp/trunc_sat_782_m4f.elf",
+                   ["-b", "arm", "--target", "cortex-m4f", "--all-exports"],
+                   "ARM32 cortex-m4f")
+    m4f_text, m4f_base, m4f_syms = load("/tmp/trunc_sat_782_m4f.elf")
+    for fn, (aty, rty) in I32_FNS.items():
+        if aty != "f32":
+            total += 1
+            if fn in m4f_syms:
+                fails += 1
+                print(f"FAIL [m4f] {fn}: f64 source compiled on a "
+                      f"single-precision target — expected decline")
+            continue
+        if fn not in m4f_syms:
+            fails += 1
+            print(f"FAIL [m4f] {fn}: symbol missing")
+            continue
+        for v, want in expected[fn]:
+            total += 1
+            kind, got = arm32_run(m4f_text, m4f_base, m4f_syms[fn], aty, v)
+            if kind != "ok":
+                fails += 1
+                print(f"BUG [m4f] {fn}({v!r}) -> {kind}: {got}")
+            elif got != want:
+                fails += 1
+                print(f"BUG [m4f] {fn}({v!r}) = {got:#x} != wasmtime {want:#x}")
+
+    # ==== aarch64: all eight, unicorn + native ==============================
+    compile_or_die("/tmp/trunc_sat_782_a64.o",
+                   ["-b", "aarch64", "--all-exports"], "aarch64")
+    a64_code, a64_base, a64_syms = load("/tmp/trunc_sat_782_a64.o")
+    host_native = platform.machine() in ("arm64", "aarch64")
+    checked_native = 0
+    for fn, (aty, rty) in SIGS.items():
+        if fn not in a64_syms:
+            fails += 1
+            print(f"FAIL [a64] {fn}: symbol missing")
+            continue
+        faddr = a64_syms[fn] & ~1
+        for v, want in expected[fn]:
+            total += 1
+            oracles = [("unicorn", a64_run(a64_code, a64_base, faddr, aty, rty, v))]
+            if host_native:
+                oracles.append(
+                    ("native", native_run(a64_code, faddr, a64_base, aty, rty, v)))
+                checked_native += 1
+            for label, (kind, got) in oracles:
+                if kind != "ok":
+                    fails += 1
+                    print(f"BUG [a64/{label}] {fn}({v!r}) -> TRAP ({got}) — "
+                          f"trunc_sat must NEVER trap (wasmtime: {want:#x})")
+                elif got != want:
+                    fails += 1
+                    print(f"BUG [a64/{label}] {fn}({v!r}) = {got:#x} != "
+                          f"wasmtime {want:#x}")
+
+    print(f"\n{total} checks ({checked_native} also run natively, "
+          f"{'arm64 host' if host_native else 'unicorn-only host'})")
+    print("RESULT:", "PASS — trunc_sat boundary table matches wasmtime on "
+          "ARM32(m7dp+m4f)+aarch64; no traps anywhere; ARM32 i64 forms "
+          "loud-declined" if not fails else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part **a** of #782 (v0.48 wave 1, lane 1): the 0xFC-prefixed saturating-float-to-int family (`i32/i64.trunc_sat_f32/f64_s/u`, WASM Core §4.3.2) was never implemented — the decoder dropped all 8 ops and every containing function loud-skipped (falcon's `skipping 'ts32'/'ts64'` class; falcon-flight-v1.123 carries 7× `i32.trunc_sat_f64_s` + 1× `i32.trunc_sat_f32_s`).

## Semantics (§4.3.2 — TOTAL, never traps)
NaN → 0; below INT_MIN → INT_MIN; above INT_MAX → INT_MAX (unsigned: negatives → 0, above UINT_MAX → UINT_MAX); else truncate toward zero.

## What lands where

| op | ARM32 Thumb-2 | aarch64 | RV32 |
|---|---|---|---|
| `i32.trunc_sat_f32_s/u` | ✅ bare RZ `VCVT.{S32,U32}.F32` (m4f/m7/m7dp) | ✅ bare `FCVTZS/FCVTZU wd` | loud-decline |
| `i32.trunc_sat_f64_s/u` | ✅ bare RZ `VCVT.{S32,U32}.F64` (m7dp) | ✅ bare `FCVTZS/FCVTZU wd, dn` | loud-decline |
| `i64.trunc_sat_*` (4) | **LOUD-decline** (no i64 register-pair conversion path — decline > wrong) | ✅ bare `FCVTZS/FCVTZU xd` (clang-verified sf=1 encodings) | loud-decline |

The key insight both ways: ARM RZ `VCVT` / A64 `FCVTZ` saturate out-of-range and give 0 for NaN — the exact "more-total-than-WASM" behavior the #709 domain guard exists to keep away from the **trapping** `trunc` forms is the **required** semantics for `trunc_sat`, so the correct lowering is the bare convert with **no** guard. Both selector paths covered (with-stack = falcon's `--relocatable` path, and `select_default` parity); the with-stack lowerings reuse the trapping twins' pinned-home copy dance.

## Bug the gate caught before it shipped
The **optimized path** silently compiled `trunc_sat` functions to 2-byte `bx lr` stubs (the #615 silent-NOP class): `is_unsupported_float_op` didn't list the new ops, so they fell through the IR bridge as no-ops. Fixed by bailing all 8 forms to `select_with_stack`; the boundary differential is what caught it.

## Gates (mechanical, non-vacuous)
- **`scripts/repro/trunc_sat_782_differential.py`** (CI-wired in `trap-semantics-oracle`): 536 checks vs wasmtime — NaN, ±inf, exact INT_MIN/INT_MAX boundaries (incl. the f32-can't-represent-2^31−1 and f64 −2147483648.999 edges), ±0.5 fractions, in-range values — executed under unicorn (Thumb-2 m7dp **and** m4f, aarch64) and natively on an arm64 host (forked child so a spurious `brk` is observable). **No case may trap anywhere.** Falcon's exact flags (`-t cortex-m7dp --relocatable`) are compile-gated: the i32 forms must not skip; the ARM32 i64 forms must decline loudly **by name**.
- **Rust gates**: ARM32 sat = bare-VCVT/no-`Udf` + the trapping twins **keep** their #709 `Udf` guard + i64 loud-declines + no-FPU/single-precision honest-rejects (`synth-synthesis/tests/trunc_sat_782.rs`); aarch64 one-bare-fcvtz w/x-form streams + clang-pinned x encodings; RV32 `Unsupported`; decoder un-drop test.
- **Existing trapping-trunc differentials green** (m4 trap guards untouched): f32 #708/#709 48/48, f64 #369 339/339, aarch64 m4 167 cases.
- **Frozen anchors bit-identical** (10/10), full workspace 2381 passed / 0 failed, clippy -D warnings clean, claim gate 21/21.

## Decline-honesty
No existing gate asserted "trunc_sat unsupported" (the drop was the decoder `_ => None`); the still-declining subset (ARM32 i64 targets, RV32 everything) now has **named** loud-decline gates in both the Rust tests and the differential.

## falcon relevance (#782)
Addresses the `GI-FPU-001 unsupported operator` class for `i32.trunc_sat_f32_s` / `i32.trunc_sat_f64_s` — 2 of the 3 functions in that skip class (the third is `f64.reinterpret_i64`, a separate lane). The dominant 12× "integer popped f32" class and the rest of the #782 breakdown are out of scope for part a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L