### PR TITLE
fix(claims): regenerate status.json + FEATURE_MATRIX for #803 trunc_sat ops (main is red)

### DIFF
--- a/artifacts/status.json
+++ b/artifacts/status.json
@@ -1,5 +1,5 @@
 {
-  "aarch64_selector_ops": 99,
+  "aarch64_selector_ops": 107,
   "backends": [
     "arm-thumb2-cortex-m",
     "arm-a32-cortex-r5",

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -33,7 +33,7 @@ soundness feature, not an absence.
 | ARM Thumb-2 (primary) | `synth-backend` | `cortex-m3`, `cortex-m4`, `cortex-m4f`, `cortex-m7`, `cortex-m7dp` (+ `cortex-m55` experimental MVE) | i32 + i64 (register pairs) complete; scalar f32/f64 via VFP on FPU targets; control flow (block/loop/if/br/br_table); memory incl. sub-word; direct calls; `call_indirect` in both relocatable and self-contained `--cortex-m` images (v0.47, #275) |
 | ARM A32 | `synth-backend` | `cortex-r5` | i32 + i64 integer family (221-variant no-wildcard tripwire, #615); self-contained `call_indirect` declines loudly (no flash-table builder) |
 | RISC-V RV32IMAC | `synth-backend-riscv` | `rv32imac`, `rv32imc`, `rv32im`, `rv32i`, `rv32gc`, `esp32c3` | i32 + i64 integer ops, control flow, calls incl. `call_indirect`, memory loads/stores; relocatable ELF; floats decline loudly |
-| AArch64 (A64, host-native) | `synth-backend-aarch64` | `cortex-a53` (host-linkable ET_REL, `-b aarch64`) | 99 distinct WASM ops handled by the selector: i32 + i64 integer core (no div/rem/popcnt yet), scalar f32/f64 incl. domain-guarded trapping float→int truncations, IEEE 754-2019 min/max, copysign (#538 milestone 4); straight-line function bodies only — control flow, memory, and everything else decline loudly |
+| AArch64 (A64, host-native) | `synth-backend-aarch64` | `cortex-a53` (host-linkable ET_REL, `-b aarch64`) | 107 distinct WASM ops handled by the selector: i32 + i64 integer core (no div/rem/popcnt yet), scalar f32/f64 incl. domain-guarded trapping float→int truncations, IEEE 754-2019 min/max, copysign (#538 milestone 4); straight-line function bodies only — control flow, memory, and everything else decline loudly |
 
 ---
 


### PR DESCRIPTION
Main's `claim-check` job is RED: `docs/status/FEATURE_MATRIX.md` + `artifacts/status.json` are stale.

**Root cause** — the two-generated-artifact merge-ordering hazard: #803 (trunc_sat) raised `aarch64_selector_ops` 99→107, and #804 (which ships the generated artifacts) snapshotted the pre-#803 count. #804 merged textually-clean on top of #803, so the semantic freshness gate — which GitHub's textual mergeability can't see — only failed once both were on `main`. The gate worked as designed: it caught a genuinely stale generated doc.

**Fix**: `python3 scripts/claim_check.py claims.yaml --emit-status`; 25/25 claims hold. Generated-artifact refresh only, no behavior change, `.text` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)