### PR TITLE
chore(release): v0.48.0 — real modules, verified allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.0] - 2026-07-17
+
+**"Real modules, verified allocator" — the real falcon fused core drove the
+breadth (its skip classes became implemented ops or honest declines), and the
+register allocator (the North Star's last major unverified component) finally got
+a per-compilation validator.** Wave 1 closed the real-module frontier (trunc_sat,
+the float select/return class, RV32 data segments) and hardened the claim surface
+into machine-derived badges; Wave 2 deepened the verified core (an unconditional
+allocation validator, inter-procedural WCET, the WasmCert dep hook). Every lane
+oracle-gated red-first; frozen anchors byte-identical throughout.
+
 ### Added
 
+- **#782a: the WASM `trunc_sat` family — nontrapping saturating float→int.**
+  Un-dropped the decoder family (`i32/i64.trunc_sat_f32/f64_s/u`); i32 forms
+  lowered on ARM32 (bare round-toward-zero VCVT), all 8 forms on aarch64
+  (FCVTZS/FCVTZU — native saturation is the CORRECT semantics here, the guard-free
+  dual of the #709 trapping forms); ARM32 i64 forms loud-decline by name. Full
+  boundary table (NaN→0, ±inf→min/max, exact INT_MIN..MAX bounds, ±0.5) verified
+  bit-identical to wasmtime on m7dp+m4f+aarch64 — no traps anywhere. This gate
+  caught an optimized-path silent-NOP drop at land time.
+- **#782b: float `select` + explicit float `return` — the dominant falcon
+  fused-core skip class.** The "an integer operation popped an f32" reports were
+  NOT register pressure (that hypothesis was disproven by getting the real falcon
+  bytes) but two missing lowerings: `select` over two f32/f64 values (the clamp
+  idiom) and `return` of a float result. Getting the real bytes also surfaced two
+  soundness bugs fixed red-first: a **wide (i64) `select` hi-half SILENT
+  miscompile on every target** (cond==0 returned val2's lo paired with val1's hi;
+  soft-float f64 select rode the same path), and a **hard-float signature-only ABI
+  hole** (a float-signature function with no float op stayed on the float-naive
+  optimized path — callers marshalled S0/S1, the body read R0/R1). 702-case
+  differential vs wasmtime.
+- **VCR-RA-003 (#242): unconditional register-allocation validator** — the North
+  Star's last major unverified component gets a per-compilation checker
+  (`synth_synthesis::liveness::validate_final_allocation`, wired in `arm_backend`,
+  runs on every ARM compile in the default build, hard-errors on a violation).
+  Bounded first increment: straight-line segments + spill/reload discipline, with
+  two non-vacuous in-stream invariants — **callee-saved preservation (#490)** and
+  **spill-slot non-aliasing**. Red-first: a reverted #490 prologue / dropped
+  epilogue / aliased slot / unmodeled-op-no-prologue are CAUGHT; correct codegen
+  is silent (frozen 10/10 byte-identical is the silent-on-real-codegen proof).
+  CF-joins + calls are the named phase 2.
+- **WCET phase 3 (#778): inter-procedural composition over the direct call graph.**
+  A caller with a direct `BL func_N` to a LOCAL bounded callee is now BOUNDED (was
+  a blanket `call` decline): `total = own_cycles + Σ_site multiplier × callee_total`,
+  the per-site multiplier being the call site's proven execution count so a callee
+  inside a proven loop is counted `trip×`. New sound-critical constant
+  `BL_BLX_CALL_OVERHEAD_CYCLES = 4` (MAX{M3,M4}, pinned in `claims.yaml`).
+  Decline-honesty preserved (moved, never deleted): recursion / any call-graph
+  cycle → `recursion`, indirect → `indirect-call`, external import → `call`, a
+  declined callee → `callee-unbounded` (propagates up). Unicorn-verified bound ≥
+  actual; `.text` byte-identical (sidecar-only).
+- **VCR-WASM-001 phase 3 (#242): the `extra_coq_package` bzlmod hook** — a generic
+  mechanism to pull any `coqPackages.<attr>` into the hermetic toolchain without
+  forking rules_rocq_rust (closes named blocker 1). The real WasmCert-Coq dep
+  stays PENDING: the pinned nixpkgs ships wasmcert 2.2.0, which propagates unfree
+  CompCert 3.16; wasmcert ≥ 2.2.1 (which drops CompCert) is not yet in the pin, and
+  no unfree dep may enter CI. The 20-op transcription is unchanged (536 Qed held);
+  the hook is ready to flip to the real dep the moment the pin bumps.
 - **#798: RV32 active data segments SHIP — linker-script placement + startup
   copy (the RV32 analogue of #758).** The single-base scheme
   (`s11 = __linear_memory_base`, zeroed RAM) used to emit a `.text`-only

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,14 +1100,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1166,11 +1166,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.47.0"
+version = "0.48.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1226,14 +1226,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1241,11 +1241,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.47.0"
+version = "0.48.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.47.0"
+version = "0.48.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.47.0"
+version = "0.48.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.47.0",
+    version = "0.48.0",
 )
 
 # Bazel dependencies

--- a/artifacts/status.json
+++ b/artifacts/status.json
@@ -15,7 +15,7 @@
   "sel_dsl_pilot_qed": 7,
   "sel_dsl_rule_qed": 50,
   "sel_dsl_rules": 50,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "verus_spec_fns": 8,
   "wasmcert_bridge_qed": 49
 }

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.47.0" }
+synth-core = { path = "../synth-core", version = "0.48.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.47.0" }
+synth-core = { path = "../synth-core", version = "0.48.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.47.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.47.0" }
+synth-core = { path = "../synth-core", version = "0.48.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.48.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.47.0" }
+synth-core = { path = "../synth-core", version = "0.48.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.47.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.47.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.48.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.48.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.47.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.48.0", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -58,23 +58,23 @@ exports_only_275_probe = []
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.47.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.47.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.47.0" }
-synth-backend = { path = "../synth-backend", version = "0.47.0" }
+synth-core = { path = "../synth-core", version = "0.48.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.48.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.48.0" }
+synth-backend = { path = "../synth-backend", version = "0.48.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.47.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.48.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.47.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.47.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.47.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.48.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.48.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.48.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.47.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.48.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.47.0" }
+synth-core = { path = "../synth-core", version = "0.48.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.47.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.48.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.47.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.47.0" }
-synth-opt = { path = "../synth-opt", version = "0.47.0" }
+synth-core = { path = "../synth-core", version = "0.48.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.48.0" }
+synth-opt = { path = "../synth-opt", version = "0.48.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.47.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.47.0" }
-synth-opt = { path = "../synth-opt", version = "0.47.0" }
+synth-core = { path = "../synth-core", version = "0.48.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.48.0" }
+synth-opt = { path = "../synth-opt", version = "0.48.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.47.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.48.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -7,7 +7,7 @@
 > stale. All numbers come from [`artifacts/status.json`](../../artifacts/status.json),
 > which is re-derived from source on every run — never hand-edited.
 
-**Workspace version:** 0.47.0
+**Workspace version:** 0.48.0
 
 ---
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"


### PR DESCRIPTION
v0.48.0 release assembly. 8 lanes on main (#801–#808): Wave-1 (#782a trunc_sat, #782b float select/return + i64-select + ABI fixes, #798 RV32 data, docs claim-surface, #805 freshness fix) + Wave-2 (VCR-RA-003 alloc validator, WCET ph3, VCR-WASM ph3 hook).

This PR carries only the release mechanics: pin sweep 0.47.0→0.48.0 (workspace + path-deps + MODULE.bazel + npm), CHANGELOG [Unreleased]→[0.48.0] with the 5 lane entries the lanes didn't write themselves, regenerated status.json/FEATURE_MATRIX. 25/25 claims, frozen 10/10, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)