### PR TITLE
feat(#77,#80): platform space-consistency invariant + P3 async error-context.drop lowering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,23 @@ jobs:
         # above; run explicitly so a WCET-soundness regression is unmissable in the
         # log (the #778 phase-3 inter-procedural-composition contract).
         run: cargo test -p synth-cli --test wcet_bound_gate
+      - name: Space-consistency invariant (#77 — execution+memory space)
+        # The #77 checked property: an inconsistent execution/memory-space
+        # pairing (bare-metal + OS-mapped, hosted + physical, FP-requiring space
+        # on an FPU-less core) is REJECTED by synth_memory::space::validate().
+        # Red-first unit tests (both directions of each invariant); covered by
+        # `cargo test --workspace` above, run explicitly so a regression in the
+        # space-consistency model is unmissable in the log.
+        run: cargo test -p synth-memory --features std space::
+      - name: P3 async intrinsic honest-degradation gate (#80)
+        # The #80 gate: the ONE lowered async op (error-context.drop) compiles
+        # to a field-name BL call site; every declined intrinsic (error-context.new
+        # /.debug-message, stream, future, waitable-set, task) LOUD-DECLINES the
+        # compile by name. Runs the classifier unit tests + the CLI end-to-end
+        # gate so an accidental silent-lower of a declined op is unmissable.
+        run: |
+          cargo test -p synth-core --lib async_intrinsics
+          cargo test -p synth-cli --features riscv --test async_intrinsics_gate
 
   clippy:
     name: Clippy

--- a/artifacts/kiln-builtins-api.yaml
+++ b/artifacts/kiln-builtins-api.yaml
@@ -387,3 +387,78 @@ artifacts:
         MOV R11, R0; weak symbol default returns 0x20000000 when
         kiln-builtins is not linked; Renode test verifies R11 is set
         correctly at user code entry.
+
+  # ---------------------------------------------------------------------------
+  # #80: P3 async host-intrinsic compilation (honest degradation)
+  # ---------------------------------------------------------------------------
+
+  - id: KB-010
+    type: system-req
+    title: P3 async intrinsic compilation with honest degradation
+    description: >
+      When Meld lowers a P3 (Component Model async) component, the core module
+      imports RFC #46 async host intrinsics under the `pulseengine:async`
+      module (error-context.*, stream.*, future.*, waitable-set.*, task.*).
+      Synth shall compile the call sites it can lower CORRECTLY and LOUD-DECLINE
+      the rest by name, rather than emit a call that silently miscompiles.
+      Bounded initial scope (#80): synth lowers exactly ONE op —
+      error-context.drop, a pure scalar handle op (one i32 handle in, nothing
+      out) that marshals as an ordinary AAPCS C call through the existing
+      relocatable field-name BL host-link path (#197), producing an UNDEF
+      `error-context.drop` symbol the host linker resolves against
+      kiln-builtins. The lowering decision is PER OP, not per family:
+      error-context.new and error-context.debug-message carry a linmem message
+      pointer (canonical ABI) and are DECLINED alongside the buffer families —
+      lowering them as if scalar would silently miscompile the pointer
+      argument. The `stream`, `future`, and `waitable-set`/`task` families are
+      DECLINED with a machine reason naming the missing capability
+      (bounds-checked linear-memory buffer layout for stream / future /
+      error-context.new / .debug-message; register save/restore across the
+      scheduler yield for waitable-set/task). An unknown intrinsic in the async
+      namespace is also declined rather than blindly called. Non-async imports
+      are untouched (byte-invisible). The declined ops are named follow-ups
+      once the buffer/yield capabilities land.
+    status: implemented
+    tags: [p3-async, rfc46, honest-degradation, kiln-builtins, error-context]
+    links:
+      - type: derives-from
+        target: BR-003
+      - type: refines
+        target: FR-003
+      - type: traces-to
+        target: KB-001
+    fields:
+      req-type: functional
+      priority: should
+      verification-criteria: >
+        synth_core::async_intrinsics::classify() returns Lowered ONLY for
+        error-context.drop, Declined (naming the family/reason) for
+        error-context.new / .debug-message / stream / future / waitable-set /
+        task and unknown async intrinsics, NotAsync for non-async imports; the
+        CLI end-to-end gate compiles async_error_context.wat to a relocatable
+        ELF carrying the `error-context.drop` BL target symbol and FAILS the
+        compile on each declined-op fixture with the #80 machine reason.
+
+  - id: KB-VER-001
+    type: sys-verification
+    title: "P3 async intrinsic gate: error-context.drop lowered, other intrinsics declined"
+    description: >
+      Machine-checked verification of the #80 honest-degradation gate (KB-010).
+      Unit tests (synth-core async_intrinsics, 7 tests) assert the
+      classification of every op, including the soundness case that
+      error-context.new / .debug-message are DECLINED (linmem buffer) and NOT
+      lowered as if scalar. The CLI integration test (async_intrinsics_gate,
+      2 tests) exercises the real `synth compile` binary: (a) the lowered op
+      compiles to a relocatable ELF whose symbol table carries
+      `error-context.drop` as the AAPCS BL target the host linker resolves (the
+      executes-vs-reference ABI contract, checked via the ELF symtab); (b) each
+      declined-op fixture (stream / future / waitable-set / task /
+      error-context.new) FAILS the compile with a diagnostic carrying the "#80
+      async-intrinsic decline" machine reason. Frozen fixtures unchanged (the
+      gate fires only on the pulseengine:async namespace). CI oracle step
+      "P3 async intrinsic honest-degradation gate (#80)" runs both.
+    status: implemented
+    tags: [p3-async, red-first, symtab-oracle, honest-degradation]
+    links:
+      - type: verifies
+        target: KB-010

--- a/artifacts/target-platforms.yaml
+++ b/artifacts/target-platforms.yaml
@@ -269,3 +269,74 @@ artifacts:
       verification-criteria: >
         MemoryLayout::generic() returns correct values;
         Renode cortex_m_test.robot passes with synth_cortex_m.repl platform.
+
+  # ---------------------------------------------------------------------------
+  # #77: Platform space-consistency model (RAJA/Kokkos execution+memory space)
+  # ---------------------------------------------------------------------------
+
+  - id: TP-009
+    type: system-req
+    title: Execution-space / memory-space consistency invariant
+    description: >
+      Synth shall model the target's execution space (where code runs — the
+      Cortex-M core / bare-metal vs hosted) and its memory spaces (where data
+      lives — Flash / SRAM / TCM / ExternalRAM / OS-mapped) as first-class
+      concepts (RAJA/Kokkos pattern, #77), and shall CHECK — not merely
+      assume by convention — that a selected execution space and the memory
+      spaces it is asked to use are mutually consistent. Two consistency
+      invariants are enforced (bounded initial scope): (1) OS-mapping
+      consistency — a bare-metal execution space cannot be paired with an
+      OS-mapped (Linux-only) memory space, and a hosted execution space cannot
+      claim a physical on-silicon space (Flash/TCM/ExternalRAM); (2) FPU
+      capability consistency — a memory space that declares an FP working set
+      cannot be hosted by a core with no FPU (Cortex-M0). An inconsistent
+      configuration is REJECTED with a machine reason naming the offending
+      space, rather than producing a silently miscompiled or unbootable image.
+      Geometry consistency (linmem base vs globals region, static-data
+      addressing) is OUT of scope here — it is owned by the static-data
+      addressing validator (synth_core::static_data_addr). This is a
+      standalone model in
+      synth-memory (synth_memory::space); wiring it into the live target
+      selection path is a named follow-up.
+    status: implemented
+    tags: [platform-abstraction, memory-space, execution-space, kokkos, raja]
+    links:
+      - type: derives-from
+        target: BR-003
+      - type: refines
+        target: FR-002
+    fields:
+      req-type: functional
+      priority: should
+      verification-criteria: >
+        synth_memory::space::PlatformSpaces::validate() returns Err for every
+        inconsistent execution/memory-space pairing (bare-metal + OS-mapped;
+        hosted + physical; FP-requiring space + FPU-less core) and Ok for
+        consistent ones; red-first unit tests in crates/synth-memory/src/space.rs
+        (7 tests) enforce both directions of each invariant.
+
+  - id: TP-VER-001
+    type: sys-verification
+    title: "Space-consistency invariant: violating configs rejected, consistent accepted"
+    description: >
+      Machine-checked verification of the #77 execution/memory-space
+      consistency invariant (TP-009). The Rust validator
+      synth_memory::space::PlatformSpaces::validate() is exercised by
+      red-first unit tests that assert: (a) a bare-metal execution space
+      paired with an OS-mapped memory space is rejected with
+      SpaceError::BareMetalCannotUseOsSpace naming the space; (b) a hosted
+      execution space paired with a physical (Flash/TCM/ExternalRAM) space is
+      rejected with HostedCannotUsePhysicalSpace; (c) an FP-requiring memory
+      space on a Cortex-M0 (no FPU) is rejected with FpuRequiredButAbsent;
+      (d) the corresponding well-formed configurations validate Ok (invariant
+      is non-vacuous in both directions); (e) the first violation in
+      declaration order is reported deterministically. Red-first evidence:
+      neutering validate() to always-Ok fails four rejection tests.
+      Covered by crates/synth-memory/src/space.rs::tests (7 tests); CI oracle
+      step "space-consistency (#77)" runs
+      `cargo test -p synth-memory --features std space::`.
+    status: implemented
+    tags: [space-consistency, red-first, unit-test]
+    links:
+      - type: verifies
+        target: TP-009

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2783,6 +2783,27 @@ fn compile_all_exports(
         let memories = module.memories;
         let imports = module.imports;
         let num_imports = module.num_imported_funcs;
+        // #80: P3 async host-intrinsic honest-degradation gate. Meld lowers P3
+        // async components with imports under the `pulseengine:async` module
+        // (RFC #46). Synth lowers exactly ONE op — `error-context.drop` (a
+        // scalar handle op that marshals like any AAPCS C call through the
+        // existing field-name BL path) — and LOUD-DECLINES the rest
+        // (`error-context.new`/`.debug-message`, `stream`, `future`,
+        // `waitable-set`, `task`) by name, because they need bounds-checked
+        // linmem buffer layout or register save/restore across a scheduler
+        // yield that synth does not yet generate. A blind BL would silently
+        // miscompile; refusing is the #275-style honest degradation.
+        // Non-async imports classify NotAsync and are untouched (byte-invisible).
+        for imp in &imports {
+            if !matches!(imp.kind, synth_core::wasm_decoder::ImportKind::Function(_)) {
+                continue;
+            }
+            if let synth_core::async_intrinsics::AsyncClassification::Declined(d) =
+                synth_core::async_intrinsics::classify(&imp.module, &imp.name)
+            {
+                anyhow::bail!("{d}");
+            }
+        }
         let data_segs = module.data_segments; // #237: capture before `functions` is moved
         let elem_func_indices = module.elem_func_indices; // #275: call_indirect targets
         // #237: identify the stack-pointer global for native-pointer promotion.

--- a/crates/synth-cli/tests/async_intrinsics_gate.rs
+++ b/crates/synth-cli/tests/async_intrinsics_gate.rs
@@ -1,0 +1,124 @@
+//! #80 P3 async intrinsic honest-degradation gate (CLI end-to-end).
+//!
+//! Synth lowers exactly ONE async intrinsic family — `error-context` — and
+//! LOUD-DECLINES the rest by name. This test exercises the real `synth compile`
+//! binary:
+//!
+//! - the LOWERED family (`error-context.drop`) compiles to a relocatable ELF
+//!   whose symtab carries the field-name as an UNDEFINED symbol — the AAPCS
+//!   `BL` call site the host linker resolves against kiln-builtins (the
+//!   "executes vs reference" ABI contract, checked via symtab per the
+//!   read-symtab-not-disasm lesson);
+//! - each DECLINED family (`stream`, `future`, `waitable-set`, `task`) makes
+//!   the compile FAIL with a machine reason naming the family.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn synth_binary() -> PathBuf {
+    let mut path = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    path.push("synth");
+    path
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn fixture(name: &str) -> PathBuf {
+    workspace_root()
+        .join("tests")
+        .join("integration")
+        .join(name)
+}
+
+/// The LOWERED family compiles and emits a field-name BL call site.
+#[test]
+fn error_context_family_is_lowered_and_emits_field_name_symbol() {
+    let wat = fixture("async_error_context.wat");
+    assert!(wat.exists(), "fixture missing: {}", wat.display());
+    let out = std::env::temp_dir().join("synth_async_ec.o");
+
+    let result = Command::new(synth_binary())
+        .args([
+            "compile",
+            wat.to_str().unwrap(),
+            "--no-optimize",
+            "--relocatable",
+            "-o",
+            out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run synth");
+
+    assert!(
+        result.status.success(),
+        "error-context should compile; stderr={}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    // The field-name `error-context.drop` must appear as the BL target symbol
+    // in the ELF (the host-link contract). We scan the raw bytes for the
+    // symbol string — the relocatable path records it as an UNDEF symbol.
+    let data = std::fs::read(&out).unwrap();
+    assert_eq!(&data[0..4], b"\x7fELF", "not an ELF");
+    let sym = b"error-context.drop";
+    assert!(
+        data.windows(sym.len()).any(|w| w == sym),
+        "field-name BL target 'error-context.drop' must be in the ELF symbol \
+         table (the AAPCS call site the host linker resolves)"
+    );
+}
+
+/// Every DECLINED family fails the compile with a named machine reason.
+#[test]
+fn declined_families_reject_loudly() {
+    // (fixture, family substring the diagnostic must name)
+    let cases = [
+        ("async_stream_declined.wat", "stream"),
+        ("async_future_declined.wat", "future"),
+        ("async_waitable_declined.wat", "waitable"),
+        ("async_task_declined.wat", "task"),
+    ];
+    for (fixture_name, family) in cases {
+        let wat = fixture(fixture_name);
+        assert!(wat.exists(), "fixture missing: {}", wat.display());
+        let out = std::env::temp_dir().join(format!("synth_async_decl_{family}.o"));
+
+        let result = Command::new(synth_binary())
+            .args([
+                "compile",
+                wat.to_str().unwrap(),
+                "--no-optimize",
+                "-o",
+                out.to_str().unwrap(),
+            ])
+            .output()
+            .expect("run synth");
+
+        assert!(
+            !result.status.success(),
+            "{fixture_name}: declined family must FAIL the compile"
+        );
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        assert!(
+            stderr.contains("#80 async-intrinsic decline"),
+            "{fixture_name}: decline must carry the #80 machine reason; got: {stderr}"
+        );
+        assert!(
+            stderr.contains(family),
+            "{fixture_name}: decline must name the '{family}' family; got: {stderr}"
+        );
+    }
+}

--- a/crates/synth-cli/tests/async_intrinsics_gate.rs
+++ b/crates/synth-cli/tests/async_intrinsics_gate.rs
@@ -1,8 +1,9 @@
 //! #80 P3 async intrinsic honest-degradation gate (CLI end-to-end).
 //!
-//! Synth lowers exactly ONE async intrinsic family — `error-context` — and
-//! LOUD-DECLINES the rest by name. This test exercises the real `synth compile`
-//! binary:
+//! Synth lowers exactly ONE async intrinsic op — `error-context.drop` (a
+//! scalar handle op) — and LOUD-DECLINES the rest by name, INCLUDING the other
+//! error-context ops (`.new`/`.debug-message`) which carry a linmem message
+//! pointer. This test exercises the real `synth compile` binary:
 //!
 //! - the LOWERED family (`error-context.drop`) compiles to a relocatable ELF
 //!   whose symtab carries the field-name as an UNDEFINED symbol — the AAPCS
@@ -90,6 +91,9 @@ fn declined_families_reject_loudly() {
         ("async_future_declined.wat", "future"),
         ("async_waitable_declined.wat", "waitable"),
         ("async_task_declined.wat", "task"),
+        // SOUNDNESS: error-context.new carries a linmem message pointer — it is
+        // NOT the scalar op error-context.drop, so it is declined (buffer class).
+        ("async_error_context_new_declined.wat", "buffer"),
     ];
     for (fixture_name, family) in cases {
         let wat = fixture(fixture_name);

--- a/crates/synth-core/src/async_intrinsics.rs
+++ b/crates/synth-core/src/async_intrinsics.rs
@@ -17,18 +17,19 @@
 //!
 //! ## Bounded scope (#80)
 //!
-//! - **Lowered family: `error-context`.** Its intrinsics are pure scalar
-//!   handle operations (`error-context.new`, `error-context.debug-message`,
-//!   `error-context.drop`) — no linear-memory buffer transfer, no scheduler
-//!   yield, no callback trampoline. They marshal like any AAPCS C call
-//!   (handle in `r0`, result in `r0`), so the existing field-name `BL` path
-//!   compiles them correctly today. This is the ONE family we can honestly
-//!   claim.
-//! - **Declined families:** `stream` (needs bounds-checked buffer memory
-//!   layout — issue §3), `future` (needs the readable/writable-end buffer
-//!   protocol), `waitable`/`task` (needs register save/restore across the
-//!   `waitable-set.wait` yield — issue §4). Each is refused with a named
-//!   [`AsyncDecline`] carrying the exact reason.
+//! - **Lowered op: `error-context.drop`.** This is a pure scalar handle
+//!   operation — it takes one error-context handle (`i32`) and returns nothing,
+//!   touching no linear-memory buffer and never yielding. It marshals like any
+//!   AAPCS C call (handle in `r0`), so the existing field-name `BL` path
+//!   compiles it correctly today. This is the ONE op we can honestly claim.
+//!   The lowering decision is made PER OP, not per family (see
+//!   [`LOWERED_FIELDS`]).
+//! - **Declined (everything else), each with a named [`AsyncDecline`]:**
+//!   `error-context.new` / `.debug-message` (they pass a linmem message
+//!   pointer — the SAME bounds-checked buffer class as stream, NOT scalar),
+//!   `stream` (bounds-checked buffer memory layout — issue §3), `future`
+//!   (readable/writable-end buffer protocol), `waitable`/`task` (register
+//!   save/restore across the `waitable-set.wait` yield — issue §4).
 //!
 //! The intrinsic namespace and per-family field prefixes are the CONTRACT
 //! synth compiles against; they are pinned here (single source) citing
@@ -43,9 +44,16 @@
 pub const ASYNC_MODULE: &str = "pulseengine:async";
 
 /// The async intrinsic families synth distinguishes (#80).
+///
+/// The lowered/declined decision is made PER OP (field name), not per family
+/// — within `error-context` only `.drop` is a scalar handle op; `.new` and
+/// `.debug-message` transfer a message string through linear memory (canonical
+/// ABI) and are declined alongside the buffer families. See [`is_lowered_field`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AsyncFamily {
-    /// `error-context.*` — pure scalar handle ops. **Lowered.**
+    /// `error-context.*` — error-context resource ops. Only `.drop` (scalar
+    /// handle) is lowered; `.new` / `.debug-message` are declined (linmem
+    /// message buffer, same class as stream).
     ErrorContext,
     /// `stream.*` — typed stream read/write over linear-memory buffers.
     /// **Declined** (buffer memory layout + bounds checks unimplemented).
@@ -55,6 +63,21 @@ pub enum AsyncFamily {
     /// `waitable-set.*` / `task.*` — scheduler yield points. **Declined**
     /// (register save/restore across yield unimplemented).
     WaitableTask,
+}
+
+/// The exact intrinsic FIELDS synth lowers today (#80). Deliberately a single
+/// unambiguously-scalar op: `error-context.drop` takes one error-context handle
+/// (i32) and returns nothing — it touches no linear-memory buffer and does not
+/// yield, so the existing AAPCS field-name BL path compiles it correctly. Every
+/// other async intrinsic (including `error-context.new` /
+/// `error-context.debug-message`, which pass a linmem message pointer) is
+/// declined. Widening this set requires an end-to-end test proving the pointer
+/// arguments lower against the linmem base — a named follow-up.
+pub const LOWERED_FIELDS: &[&str] = &["error-context.drop"];
+
+/// Whether synth currently lowers this exact intrinsic field to native ARM.
+pub fn is_lowered_field(field: &str) -> bool {
+    LOWERED_FIELDS.contains(&field)
 }
 
 impl AsyncFamily {
@@ -73,11 +96,6 @@ impl AsyncFamily {
             "waitable-set" | "waitable" | "task" => Some(AsyncFamily::WaitableTask),
             _ => None,
         }
-    }
-
-    /// Whether synth can currently lower this family to native ARM.
-    pub const fn is_lowered(self) -> bool {
-        matches!(self, AsyncFamily::ErrorContext)
     }
 
     /// A stable machine-readable family tag for diagnostics.
@@ -141,11 +159,18 @@ pub fn classify(module: &str, field: &str) -> AsyncClassification {
     if module != ASYNC_MODULE {
         return AsyncClassification::NotAsync;
     }
-    match AsyncFamily::from_field(field) {
-        Some(fam) if fam.is_lowered() => AsyncClassification::Lowered {
-            family: fam,
+    // Lowering is decided PER OP, not per family: only the exact scalar ops in
+    // LOWERED_FIELDS pass; a recognized family with an unlowered field (e.g.
+    // error-context.new, which carries a linmem message pointer) is declined.
+    if is_lowered_field(field) {
+        let family = AsyncFamily::from_field(field)
+            .expect("a LOWERED_FIELDS entry must classify into a family");
+        return AsyncClassification::Lowered {
+            family,
             field: field.to_string(),
-        },
+        };
+    }
+    match AsyncFamily::from_field(field) {
         Some(fam) => AsyncClassification::Declined(AsyncDecline {
             field: field.to_string(),
             family: Some(fam),
@@ -168,26 +193,31 @@ pub fn classify(module: &str, field: &str) -> AsyncClassification {
 fn decline_reason(family: AsyncFamily, field: &str) -> String {
     let ns = ASYNC_MODULE;
     match family {
-        AsyncFamily::ErrorContext => {
-            // Unreachable — error-context is lowered — but keep total.
-            format!("'{ns}::{field}' unexpectedly declined (error-context is lowered)")
-        }
+        AsyncFamily::ErrorContext => format!(
+            "'{ns}::{field}' (error-context family) not compiled: only \
+             error-context.drop (a scalar handle op) is lowered. This op \
+             transfers a message string through linear memory (canonical ABI), \
+             which needs the same bounds-checked linmem-base-relative buffer \
+             lowering as the stream family that synth does not yet generate \
+             (#80). Use error-context.drop, or link this op against a host that \
+             owns the buffer protocol."
+        ),
         AsyncFamily::Stream => format!(
             "'{ns}::{field}' (stream family) not compiled: synth does not yet \
              generate the bounds-checked linear-memory buffer layout the stream \
-             read/write intrinsics require (#80 §3). Lower only error-context \
+             read/write intrinsics require (#80 §3). Lower only error-context.drop \
              for now, or link the stream intrinsic against a host that owns the \
              buffer protocol."
         ),
         AsyncFamily::Future => format!(
             "'{ns}::{field}' (future family) not compiled: the readable/writable-\
              end buffer transfer protocol is unimplemented (#80 §3). Only \
-             error-context is lowered."
+             error-context.drop is lowered."
         ),
         AsyncFamily::WaitableTask => format!(
             "'{ns}::{field}' (waitable/task family) not compiled: synth does not \
              yet save/restore register state across the scheduler yield at \
-             waitable-set.wait (#80 §4). Only error-context is lowered."
+             waitable-set.wait (#80 §4). Only error-context.drop is lowered."
         ),
     }
 }
@@ -196,23 +226,35 @@ fn decline_reason(family: AsyncFamily, field: &str) -> String {
 mod tests {
     use super::*;
 
-    /// The lowered family: error-context intrinsics are recognized and pass
-    /// through to the field-name BL path.
+    /// The lowered op: `error-context.drop` (scalar handle) is recognized and
+    /// passes through to the field-name BL path.
     #[test]
-    fn error_context_is_lowered() {
-        for field in [
-            "error-context.new",
-            "error-context.debug-message",
-            "error-context.drop",
-        ] {
-            assert_eq!(
-                classify(ASYNC_MODULE, field),
-                AsyncClassification::Lowered {
-                    family: AsyncFamily::ErrorContext,
-                    field: field.to_string(),
-                },
-                "{field} should be lowered"
-            );
+    fn error_context_drop_is_lowered() {
+        assert_eq!(
+            classify(ASYNC_MODULE, "error-context.drop"),
+            AsyncClassification::Lowered {
+                family: AsyncFamily::ErrorContext,
+                field: "error-context.drop".to_string(),
+            }
+        );
+        assert!(is_lowered_field("error-context.drop"));
+    }
+
+    /// RED-FIRST soundness (#80): the OTHER error-context ops carry a linmem
+    /// message pointer and are DECLINED with the buffer reason — NOT lowered as
+    /// if scalar (would silently miscompile the pointer arg).
+    #[test]
+    fn error_context_buffer_ops_are_declined() {
+        for field in ["error-context.new", "error-context.debug-message"] {
+            match classify(ASYNC_MODULE, field) {
+                AsyncClassification::Declined(d) => {
+                    assert_eq!(d.family, Some(AsyncFamily::ErrorContext));
+                    assert!(d.reason.contains("buffer"), "{field}: {}", d.reason);
+                    assert!(d.reason.contains("linear memory"), "{field}: {}", d.reason);
+                }
+                other => panic!("{field} must be declined (linmem buffer), got {other:?}"),
+            }
+            assert!(!is_lowered_field(field));
         }
     }
 
@@ -278,12 +320,21 @@ mod tests {
         );
     }
 
-    /// The lowered family flips the is_lowered predicate; declined ones do not.
+    /// The per-op lowered set is exactly `error-context.drop` and nothing
+    /// else — non-vacuous in both directions.
     #[test]
-    fn is_lowered_predicate_is_non_vacuous() {
-        assert!(AsyncFamily::ErrorContext.is_lowered());
-        assert!(!AsyncFamily::Stream.is_lowered());
-        assert!(!AsyncFamily::Future.is_lowered());
-        assert!(!AsyncFamily::WaitableTask.is_lowered());
+    fn lowered_field_set_is_exact() {
+        assert_eq!(LOWERED_FIELDS, &["error-context.drop"]);
+        assert!(is_lowered_field("error-context.drop"));
+        for f in [
+            "error-context.new",
+            "error-context.debug-message",
+            "stream.read",
+            "future.read",
+            "waitable-set.wait",
+            "task.return",
+        ] {
+            assert!(!is_lowered_field(f), "{f} must not be lowered");
+        }
     }
 }

--- a/crates/synth-core/src/async_intrinsics.rs
+++ b/crates/synth-core/src/async_intrinsics.rs
@@ -1,0 +1,289 @@
+//! P3 async host-intrinsic classification and honest degradation (#80).
+//!
+//! When Meld lowers a P3 (Component Model async) component to a core module,
+//! the output imports RFC #46 async host intrinsics (`stream.read`,
+//! `stream.write`, `waitable-set.wait`, `task.return`, `error-context.new`,
+//! `future.read`, …). Synth compiles each import *call site* to a native
+//! `BL <field-name>` into kiln-builtins via the existing relocatable host-link
+//! path (#197) — the raw call lowering already exists and is unchanged.
+//!
+//! What this module adds is the missing *semantic gate* (#80): a compiler that
+//! blindly emits `BL stream.read` would silently miscompile — the intrinsic
+//! needs bounds-checked linear-memory buffers and register save/restore across
+//! a scheduler yield, none of which synth generates yet. The #275-style honest
+//! degradation is: LOWER exactly the ONE family we can compile correctly, and
+//! LOUD-DECLINE every other family BY NAME with a machine reason, rather than
+//! emitting a call that will misbehave at runtime.
+//!
+//! ## Bounded scope (#80)
+//!
+//! - **Lowered family: `error-context`.** Its intrinsics are pure scalar
+//!   handle operations (`error-context.new`, `error-context.debug-message`,
+//!   `error-context.drop`) — no linear-memory buffer transfer, no scheduler
+//!   yield, no callback trampoline. They marshal like any AAPCS C call
+//!   (handle in `r0`, result in `r0`), so the existing field-name `BL` path
+//!   compiles them correctly today. This is the ONE family we can honestly
+//!   claim.
+//! - **Declined families:** `stream` (needs bounds-checked buffer memory
+//!   layout — issue §3), `future` (needs the readable/writable-end buffer
+//!   protocol), `waitable`/`task` (needs register save/restore across the
+//!   `waitable-set.wait` yield — issue §4). Each is refused with a named
+//!   [`AsyncDecline`] carrying the exact reason.
+//!
+//! The intrinsic namespace and per-family field prefixes are the CONTRACT
+//! synth compiles against; they are pinned here (single source) citing
+//! RFC #46 until Meld's lowering fixes the canonical strings cross-repo
+//! (meld#94).
+
+/// The import module namespace P3-async intrinsics are imported under.
+///
+/// Meld lowers P3 async components with imports in this module (RFC #46 async
+/// ABI). Only imports in this namespace are subject to async classification;
+/// every other import is untouched (so non-async modules stay byte-identical).
+pub const ASYNC_MODULE: &str = "pulseengine:async";
+
+/// The async intrinsic families synth distinguishes (#80).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AsyncFamily {
+    /// `error-context.*` — pure scalar handle ops. **Lowered.**
+    ErrorContext,
+    /// `stream.*` — typed stream read/write over linear-memory buffers.
+    /// **Declined** (buffer memory layout + bounds checks unimplemented).
+    Stream,
+    /// `future.*` — single-shot readable/writable ends. **Declined.**
+    Future,
+    /// `waitable-set.*` / `task.*` — scheduler yield points. **Declined**
+    /// (register save/restore across yield unimplemented).
+    WaitableTask,
+}
+
+impl AsyncFamily {
+    /// Classify an intrinsic field name into its family. Returns `None` for a
+    /// field name that is not a recognized P3-async intrinsic (an unknown
+    /// import in the async namespace — also a decline, see [`classify`]).
+    ///
+    /// Matching is by the `.`-separated resource prefix, matching the RFC #46
+    /// `resource.method` naming (`stream.read`, `error-context.new`, …).
+    pub fn from_field(field: &str) -> Option<Self> {
+        let resource = field.split('.').next().unwrap_or(field);
+        match resource {
+            "error-context" => Some(AsyncFamily::ErrorContext),
+            "stream" => Some(AsyncFamily::Stream),
+            "future" => Some(AsyncFamily::Future),
+            "waitable-set" | "waitable" | "task" => Some(AsyncFamily::WaitableTask),
+            _ => None,
+        }
+    }
+
+    /// Whether synth can currently lower this family to native ARM.
+    pub const fn is_lowered(self) -> bool {
+        matches!(self, AsyncFamily::ErrorContext)
+    }
+
+    /// A stable machine-readable family tag for diagnostics.
+    pub const fn tag(self) -> &'static str {
+        match self {
+            AsyncFamily::ErrorContext => "error-context",
+            AsyncFamily::Stream => "stream",
+            AsyncFamily::Future => "future",
+            AsyncFamily::WaitableTask => "waitable-task",
+        }
+    }
+}
+
+/// A refused P3-async import — the machine reason it cannot be compiled (#80).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AsyncDecline {
+    /// The offending import field (e.g. `stream.read`).
+    pub field: String,
+    /// The classified family, if recognized (`None` = unknown async import).
+    pub family: Option<AsyncFamily>,
+    /// The machine reason string.
+    pub reason: String,
+}
+
+impl core::fmt::Display for AsyncDecline {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "#80 async-intrinsic decline: {}", self.reason)
+    }
+}
+
+/// The outcome of classifying a single import against the async contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AsyncClassification {
+    /// Not a P3-async import (wrong module namespace). Untouched by #80.
+    NotAsync,
+    /// A P3-async import in a family synth lowers. The call flows through the
+    /// existing field-name `BL` path unchanged; the carried field is the
+    /// symbol name that path relocates against.
+    Lowered {
+        /// The lowered family (always [`AsyncFamily::ErrorContext`] today).
+        family: AsyncFamily,
+        /// The import field / `BL` target symbol.
+        field: String,
+    },
+    /// A P3-async import synth refuses to compile (a declined family or an
+    /// unknown async intrinsic).
+    Declined(AsyncDecline),
+}
+
+/// Classify one import (`module` / `field`) against the P3-async contract (#80).
+///
+/// - Import module != [`ASYNC_MODULE`] → [`AsyncClassification::NotAsync`]
+///   (byte-invisible: non-async modules are completely unaffected).
+/// - `error-context.*` → [`AsyncClassification::Lowered`].
+/// - a recognized-but-unlowered family (`stream`/`future`/`waitable`/`task`) →
+///   [`AsyncClassification::Declined`] naming the family and the missing
+///   capability.
+/// - an unrecognized field in the async namespace → `Declined` (unknown
+///   intrinsic — refuse rather than blindly `BL` an unspecified contract).
+pub fn classify(module: &str, field: &str) -> AsyncClassification {
+    if module != ASYNC_MODULE {
+        return AsyncClassification::NotAsync;
+    }
+    match AsyncFamily::from_field(field) {
+        Some(fam) if fam.is_lowered() => AsyncClassification::Lowered {
+            family: fam,
+            field: field.to_string(),
+        },
+        Some(fam) => AsyncClassification::Declined(AsyncDecline {
+            field: field.to_string(),
+            family: Some(fam),
+            reason: decline_reason(fam, field),
+        }),
+        None => AsyncClassification::Declined(AsyncDecline {
+            field: field.to_string(),
+            family: None,
+            reason: format!(
+                "unknown P3-async intrinsic '{ASYNC_MODULE}::{field}' — synth \
+                 will not emit a call against an unspecified async contract \
+                 (RFC #46); recognized families: error-context (lowered), \
+                 stream / future / waitable-set / task (declined)"
+            ),
+        }),
+    }
+}
+
+/// The per-family machine reason for a declined intrinsic.
+fn decline_reason(family: AsyncFamily, field: &str) -> String {
+    let ns = ASYNC_MODULE;
+    match family {
+        AsyncFamily::ErrorContext => {
+            // Unreachable — error-context is lowered — but keep total.
+            format!("'{ns}::{field}' unexpectedly declined (error-context is lowered)")
+        }
+        AsyncFamily::Stream => format!(
+            "'{ns}::{field}' (stream family) not compiled: synth does not yet \
+             generate the bounds-checked linear-memory buffer layout the stream \
+             read/write intrinsics require (#80 §3). Lower only error-context \
+             for now, or link the stream intrinsic against a host that owns the \
+             buffer protocol."
+        ),
+        AsyncFamily::Future => format!(
+            "'{ns}::{field}' (future family) not compiled: the readable/writable-\
+             end buffer transfer protocol is unimplemented (#80 §3). Only \
+             error-context is lowered."
+        ),
+        AsyncFamily::WaitableTask => format!(
+            "'{ns}::{field}' (waitable/task family) not compiled: synth does not \
+             yet save/restore register state across the scheduler yield at \
+             waitable-set.wait (#80 §4). Only error-context is lowered."
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The lowered family: error-context intrinsics are recognized and pass
+    /// through to the field-name BL path.
+    #[test]
+    fn error_context_is_lowered() {
+        for field in [
+            "error-context.new",
+            "error-context.debug-message",
+            "error-context.drop",
+        ] {
+            assert_eq!(
+                classify(ASYNC_MODULE, field),
+                AsyncClassification::Lowered {
+                    family: AsyncFamily::ErrorContext,
+                    field: field.to_string(),
+                },
+                "{field} should be lowered"
+            );
+        }
+    }
+
+    /// RED-FIRST (#80): the stream family is declined BY NAME with the buffer
+    /// reason.
+    #[test]
+    fn stream_is_declined_by_name() {
+        let c = classify(ASYNC_MODULE, "stream.read");
+        match c {
+            AsyncClassification::Declined(d) => {
+                assert_eq!(d.family, Some(AsyncFamily::Stream));
+                assert!(d.reason.contains("stream"));
+                assert!(d.reason.contains("buffer"));
+                assert!(d.to_string().contains("stream.read"));
+            }
+            other => panic!("stream.read should be declined, got {other:?}"),
+        }
+    }
+
+    /// RED-FIRST (#80): future and waitable/task families are declined.
+    #[test]
+    fn future_and_waitable_are_declined() {
+        assert!(matches!(
+            classify(ASYNC_MODULE, "future.read"),
+            AsyncClassification::Declined(d) if d.family == Some(AsyncFamily::Future)
+        ));
+        assert!(matches!(
+            classify(ASYNC_MODULE, "waitable-set.wait"),
+            AsyncClassification::Declined(d) if d.family == Some(AsyncFamily::WaitableTask)
+        ));
+        assert!(matches!(
+            classify(ASYNC_MODULE, "task.return"),
+            AsyncClassification::Declined(d) if d.family == Some(AsyncFamily::WaitableTask)
+        ));
+    }
+
+    /// An unknown intrinsic in the async namespace is declined (not blindly
+    /// lowered).
+    #[test]
+    fn unknown_async_intrinsic_is_declined() {
+        match classify(ASYNC_MODULE, "quantum.entangle") {
+            AsyncClassification::Declined(d) => {
+                assert_eq!(d.family, None);
+                assert!(d.reason.contains("unknown"));
+            }
+            other => panic!("unknown intrinsic should decline, got {other:?}"),
+        }
+    }
+
+    /// Byte-invisibility: a NON-async import is untouched (NotAsync). This is
+    /// what keeps frozen fixtures / ordinary modules bit-identical.
+    #[test]
+    fn non_async_import_is_untouched() {
+        assert_eq!(classify("env", "print_i32"), AsyncClassification::NotAsync);
+        assert_eq!(
+            classify("wasi:cli/stdout", "write"),
+            AsyncClassification::NotAsync
+        );
+        // Same field names under a DIFFERENT module are NOT async either.
+        assert_eq!(
+            classify("env", "stream.read"),
+            AsyncClassification::NotAsync
+        );
+    }
+
+    /// The lowered family flips the is_lowered predicate; declined ones do not.
+    #[test]
+    fn is_lowered_predicate_is_non_vacuous() {
+        assert!(AsyncFamily::ErrorContext.is_lowered());
+        assert!(!AsyncFamily::Stream.is_lowered());
+        assert!(!AsyncFamily::Future.is_lowered());
+        assert!(!AsyncFamily::WaitableTask.is_lowered());
+    }
+}

--- a/crates/synth-core/src/lib.rs
+++ b/crates/synth-core/src/lib.rs
@@ -5,6 +5,7 @@
 //! representation (IR) used for synthesis.
 
 pub mod arena_bind;
+pub mod async_intrinsics;
 pub mod backend;
 pub mod component;
 pub mod dwarf_line;

--- a/crates/synth-memory/src/lib.rs
+++ b/crates/synth-memory/src/lib.rs
@@ -16,6 +16,9 @@ pub mod table;
 #[cfg(feature = "std")]
 pub mod platform;
 
+#[cfg(feature = "std")]
+pub mod space;
+
 pub use bounds::{BoundsChecker, MaskingBoundsChecker, SoftwareBoundsChecker};
 pub use descriptor::{MemoryDescriptor, MemoryFlags, ProtectionStrategy};
 pub use table::{MAX_MEMORIES, MemoryTable};

--- a/crates/synth-memory/src/space.rs
+++ b/crates/synth-memory/src/space.rs
@@ -1,0 +1,402 @@
+//! Platform space-consistency model (#77 — RAJA/Kokkos execution-space +
+//! memory-space pattern).
+//!
+//! LLNL RAJA and Sandia Kokkos model *where code runs* (execution space) and
+//! *where data lives* (memory space) as first-class concepts. Synth today
+//! chooses a target's memory layout by informal convention (linker scripts +
+//! `synth-memory` descriptors). This module gives ONE concrete slice of that
+//! choice a *checked* property instead of a convention: the selected
+//! execution space and the memory spaces it is asked to use must be mutually
+//! consistent, and an inconsistent pairing is REJECTED (red-first) rather than
+//! silently miscompiled.
+//!
+//! ## Scope (deliberately bounded, #77)
+//!
+//! This is NOT the full three-layer Platform Package from the issue. It
+//! formalizes exactly two consistency invariants — the ones that turn a
+//! "wrong config" from a runtime mystery into a compile-time `Err`:
+//!
+//! 1. **OS-mapping consistency.** A bare-metal execution space (no operating
+//!    system underneath) cannot be paired with a memory space whose backing is
+//!    an OS/host mapping (e.g. an `mmap`-backed Linux region). Conversely a
+//!    hosted execution space cannot claim a physical on-chip space (Flash / TCM)
+//!    that only exists on real silicon. This is the issue's own worked example
+//!    ("a bare-metal target cannot request a Linux-only space").
+//!
+//! 2. **FPU-capability consistency.** A memory space may declare that it holds
+//!    floating-point working data that requires hardware FP (a `RequiresFpu`
+//!    flag). An execution space with `Fpu::None` cannot host such a space —
+//!    the core has no FP unit to touch it.
+//!
+//! Geometry (linmem base vs globals region overlap, static-data addressing) is
+//! deliberately OUT of scope here — that lives in `synth_core::static_data_addr`
+//! (VCR-VER-003). This module owns only the *space-kind* consistency relation.
+//!
+//! The invariant is machine-checked by [`PlatformSpaces::validate`] and its
+//! unit tests: a violating configuration returns [`SpaceError`], a consistent
+//! one returns `Ok(())`.
+
+#![allow(clippy::result_unit_err)]
+
+/// Where compiled code executes — the *execution space* (Kokkos terminology).
+///
+/// The distinction that matters for consistency is whether an operating system
+/// sits underneath (a hosted process) or whether this is bare silicon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionSpace {
+    /// Bare-metal ARM Cortex-M core — no OS, physical memory map, MPU-based
+    /// isolation. This is synth's primary deployment shape (i.MX RT1062,
+    /// STM32H743, NUCLEO boards, qemu bare-metal).
+    BareMetal {
+        /// Which Cortex-M variant — gates FP and SIMD capability.
+        core: CortexM,
+    },
+    /// Hosted process on an OS (Linux/desktop). Memory is virtual, spaces are
+    /// OS mappings. This is the desktop test / `HostPlatform` shape.
+    Hosted,
+}
+
+/// Cortex-M core variant — the capability axis relevant to space consistency
+/// is the FPU. (SIMD/MPU are modeled elsewhere; this enum carries only what
+/// the two invariants need.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CortexM {
+    /// Cortex-M0 / M0+ — integer only, no FPU.
+    M0,
+    /// Cortex-M4F — single-precision FPv4 FPU.
+    M4F,
+    /// Cortex-M33 — single-precision FPU (FPv5), TrustZone.
+    M33,
+    /// Cortex-M55 — Helium (MVE) + double-precision FPU.
+    M55,
+}
+
+impl CortexM {
+    /// The FPU capability this core provides.
+    pub const fn fpu(self) -> Fpu {
+        match self {
+            CortexM::M0 => Fpu::None,
+            CortexM::M4F | CortexM::M33 => Fpu::Single,
+            CortexM::M55 => Fpu::Double,
+        }
+    }
+}
+
+impl ExecutionSpace {
+    /// Whether an operating system sits underneath this execution space.
+    pub const fn is_os_hosted(self) -> bool {
+        matches!(self, ExecutionSpace::Hosted)
+    }
+
+    /// The FPU capability available to code in this execution space. A hosted
+    /// process is assumed to have hardware FP (host CPU); a bare-metal core's
+    /// capability is dictated by its Cortex-M variant.
+    pub const fn fpu(self) -> Fpu {
+        match self {
+            ExecutionSpace::BareMetal { core } => core.fpu(),
+            ExecutionSpace::Hosted => Fpu::Double,
+        }
+    }
+}
+
+/// Hardware floating-point capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Fpu {
+    /// No hardware FPU (integer-only core — soft-float only).
+    None,
+    /// Single-precision hardware FPU (FPv4/FPv5-SP).
+    Single,
+    /// Double-precision hardware FPU.
+    Double,
+}
+
+/// The physical/logical backing of a memory space — this is the axis the
+/// OS-mapping invariant checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryBacking {
+    /// On-chip Flash / ROM — read-only at runtime, exists only on real
+    /// silicon (or a bare-metal emulator). Physical.
+    Flash,
+    /// On-chip SRAM — read-write, physical.
+    Sram,
+    /// Tightly-Coupled Memory — fastest on-chip, physical.
+    Tcm,
+    /// External RAM (e.g. SDRAM over FMC) — physical, off-chip.
+    ExternalRam,
+    /// An OS/host mapping (e.g. `mmap`-backed region on Linux). Only exists
+    /// under a hosted execution space.
+    OsMapped,
+}
+
+impl MemoryBacking {
+    /// Whether this backing is a physical on-silicon region (as opposed to an
+    /// OS/host virtual mapping).
+    pub const fn is_physical(self) -> bool {
+        !matches!(self, MemoryBacking::OsMapped)
+    }
+}
+
+/// A memory space: where a class of data lives (Kokkos terminology).
+///
+/// Only the fields the two consistency invariants need are modeled — the full
+/// `{ base, size, latency, writeable }` descriptor from #77 is future work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemorySpace {
+    /// A short stable identifier for diagnostics (e.g. "flash", "sram1",
+    /// "extram", "host-heap").
+    pub name: &'static str,
+    /// The physical/logical backing — checked against the execution space.
+    pub backing: MemoryBacking,
+    /// Whether data placed in this space requires hardware floating-point to
+    /// operate on (FP working set). Checked against the core's FPU.
+    pub requires_fpu: bool,
+}
+
+impl MemorySpace {
+    /// A physical on-chip space with no FP requirement.
+    pub const fn physical(name: &'static str, backing: MemoryBacking) -> Self {
+        Self {
+            name,
+            backing,
+            requires_fpu: false,
+        }
+    }
+
+    /// An OS-mapped (hosted) space with no FP requirement.
+    pub const fn os_mapped(name: &'static str) -> Self {
+        Self {
+            name,
+            backing: MemoryBacking::OsMapped,
+            requires_fpu: false,
+        }
+    }
+
+    /// Mark this space as holding an FP working set (requires hardware FPU).
+    pub const fn with_fpu(mut self) -> Self {
+        self.requires_fpu = true;
+        self
+    }
+}
+
+/// A rejected platform configuration — the machine reason the pairing is
+/// inconsistent. Every variant names the offending space so the diagnostic is
+/// actionable (#77 red-first).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpaceError {
+    /// A bare-metal execution space was paired with an OS-mapped memory space.
+    /// Bare metal has no OS to provide the mapping.
+    BareMetalCannotUseOsSpace {
+        /// Name of the offending OS-mapped space.
+        space: &'static str,
+    },
+    /// A hosted execution space was paired with a physical on-silicon space
+    /// (Flash/TCM/ExternalRam) that only exists on real hardware.
+    HostedCannotUsePhysicalSpace {
+        /// Name of the offending physical space.
+        space: &'static str,
+        /// The physical backing that is unavailable in a hosted process.
+        backing: MemoryBacking,
+    },
+    /// A memory space requires hardware floating-point but the execution
+    /// space's core has no FPU.
+    FpuRequiredButAbsent {
+        /// Name of the space that requires FP.
+        space: &'static str,
+    },
+}
+
+impl core::fmt::Display for SpaceError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SpaceError::BareMetalCannotUseOsSpace { space } => write!(
+                f,
+                "#77 space-consistency: bare-metal execution space cannot use \
+                 OS-mapped memory space '{space}' (no operating system provides \
+                 the mapping on bare metal)"
+            ),
+            SpaceError::HostedCannotUsePhysicalSpace { space, backing } => write!(
+                f,
+                "#77 space-consistency: hosted execution space cannot use \
+                 physical on-silicon memory space '{space}' (backing {backing:?} \
+                 only exists on real hardware / a bare-metal emulator)"
+            ),
+            SpaceError::FpuRequiredButAbsent { space } => write!(
+                f,
+                "#77 space-consistency: memory space '{space}' requires hardware \
+                 floating-point, but the execution space's core has no FPU"
+            ),
+        }
+    }
+}
+
+/// A platform's selected execution space plus the memory spaces it will use.
+///
+/// [`validate`](PlatformSpaces::validate) is the checked invariant: it holds
+/// (`Ok`) iff every memory space is consistent with the execution space.
+#[derive(Debug, Clone)]
+pub struct PlatformSpaces {
+    /// Where code runs.
+    pub execution: ExecutionSpace,
+    /// Where data lives.
+    pub memories: Vec<MemorySpace>,
+}
+
+impl PlatformSpaces {
+    /// Construct a platform-spaces configuration.
+    pub fn new(execution: ExecutionSpace, memories: Vec<MemorySpace>) -> Self {
+        Self {
+            execution,
+            memories,
+        }
+    }
+
+    /// The checked consistency invariant (#77).
+    ///
+    /// Returns `Ok(())` iff every memory space is consistent with the selected
+    /// execution space under both invariants:
+    ///
+    /// 1. OS-mapping: bare metal ⇏ OS-mapped space; hosted ⇏ physical space.
+    /// 2. FPU: an `Fpu::None` core cannot host an FP-requiring space.
+    ///
+    /// The FIRST inconsistent space (in declaration order) is reported so the
+    /// diagnostic is deterministic.
+    pub fn validate(&self) -> Result<(), SpaceError> {
+        let os_hosted = self.execution.is_os_hosted();
+        let fpu = self.execution.fpu();
+        for m in &self.memories {
+            // Invariant 1: OS-mapping consistency.
+            if os_hosted {
+                if m.backing.is_physical() {
+                    return Err(SpaceError::HostedCannotUsePhysicalSpace {
+                        space: m.name,
+                        backing: m.backing,
+                    });
+                }
+            } else if m.backing == MemoryBacking::OsMapped {
+                return Err(SpaceError::BareMetalCannotUseOsSpace { space: m.name });
+            }
+            // Invariant 2: FPU-capability consistency.
+            if m.requires_fpu && fpu == Fpu::None {
+                return Err(SpaceError::FpuRequiredButAbsent { space: m.name });
+            }
+        }
+        Ok(())
+    }
+
+    /// Convenience: `true` iff [`validate`](Self::validate) holds.
+    pub fn is_consistent(&self) -> bool {
+        self.validate().is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cover target: STM32H743 (Cortex-M4F-class, on-chip Flash + SRAM + TCM).
+    /// A well-formed bare-metal config is consistent.
+    #[test]
+    fn baremetal_physical_spaces_are_consistent() {
+        let p = PlatformSpaces::new(
+            ExecutionSpace::BareMetal { core: CortexM::M4F },
+            vec![
+                MemorySpace::physical("flash", MemoryBacking::Flash),
+                MemorySpace::physical("sram1", MemoryBacking::Sram),
+                MemorySpace::physical("dtcm", MemoryBacking::Tcm),
+            ],
+        );
+        assert_eq!(p.validate(), Ok(()));
+        assert!(p.is_consistent());
+    }
+
+    /// RED-FIRST (#77 invariant 1): a bare-metal core asking for an OS-mapped
+    /// (Linux-only) space is REJECTED with the offending space named.
+    #[test]
+    fn baremetal_rejects_os_mapped_space() {
+        let p = PlatformSpaces::new(
+            ExecutionSpace::BareMetal { core: CortexM::M4F },
+            vec![
+                MemorySpace::physical("flash", MemoryBacking::Flash),
+                MemorySpace::os_mapped("host-heap"),
+            ],
+        );
+        assert_eq!(
+            p.validate(),
+            Err(SpaceError::BareMetalCannotUseOsSpace { space: "host-heap" })
+        );
+        assert!(!p.is_consistent());
+        // Diagnostic is actionable (names the space).
+        assert!(p.validate().unwrap_err().to_string().contains("host-heap"));
+    }
+
+    /// RED-FIRST (#77 invariant 1, other direction): a hosted process cannot
+    /// claim a physical on-silicon space.
+    #[test]
+    fn hosted_rejects_physical_space() {
+        let p = PlatformSpaces::new(
+            ExecutionSpace::Hosted,
+            vec![MemorySpace::physical("dtcm", MemoryBacking::Tcm)],
+        );
+        assert_eq!(
+            p.validate(),
+            Err(SpaceError::HostedCannotUsePhysicalSpace {
+                space: "dtcm",
+                backing: MemoryBacking::Tcm,
+            })
+        );
+    }
+
+    /// A hosted process with OS-mapped spaces is consistent.
+    #[test]
+    fn hosted_os_mapped_is_consistent() {
+        let p = PlatformSpaces::new(
+            ExecutionSpace::Hosted,
+            vec![MemorySpace::os_mapped("host-heap")],
+        );
+        assert_eq!(p.validate(), Ok(()));
+    }
+
+    /// RED-FIRST (#77 invariant 2): an FP-requiring space on an FPU-less core
+    /// (Cortex-M0) is REJECTED.
+    #[test]
+    fn fpu_required_but_core_has_none_is_rejected() {
+        let p = PlatformSpaces::new(
+            ExecutionSpace::BareMetal { core: CortexM::M0 },
+            vec![MemorySpace::physical("sram1", MemoryBacking::Sram).with_fpu()],
+        );
+        assert_eq!(
+            p.validate(),
+            Err(SpaceError::FpuRequiredButAbsent { space: "sram1" })
+        );
+    }
+
+    /// The same FP-requiring space on an M4F core (which has an FPU) IS
+    /// consistent — the invariant is not vacuous in either direction.
+    #[test]
+    fn fpu_required_on_fpu_core_is_consistent() {
+        let p = PlatformSpaces::new(
+            ExecutionSpace::BareMetal { core: CortexM::M4F },
+            vec![MemorySpace::physical("sram1", MemoryBacking::Sram).with_fpu()],
+        );
+        assert_eq!(p.validate(), Ok(()));
+        assert_eq!(CortexM::M4F.fpu(), Fpu::Single);
+        assert_eq!(CortexM::M0.fpu(), Fpu::None);
+    }
+
+    /// Determinism: the FIRST inconsistent space (declaration order) is the
+    /// one reported.
+    #[test]
+    fn first_violation_is_reported() {
+        let p = PlatformSpaces::new(
+            ExecutionSpace::BareMetal { core: CortexM::M0 },
+            vec![
+                MemorySpace::os_mapped("first-bad"),
+                MemorySpace::physical("sram1", MemoryBacking::Sram).with_fpu(),
+            ],
+        );
+        assert_eq!(
+            p.validate(),
+            Err(SpaceError::BareMetalCannotUseOsSpace { space: "first-bad" })
+        );
+    }
+}

--- a/tests/integration/async_error_context.wat
+++ b/tests/integration/async_error_context.wat
@@ -1,0 +1,15 @@
+;; #80: P3 async error-context intrinsic — the ONE lowered family.
+;; error-context.* are pure scalar handle ops that marshal like any AAPCS C
+;; call, so synth compiles the call site to a field-name BL through the
+;; existing relocatable host-link path (#197). Compiling this must SUCCEED.
+(module
+  ;; error-context.drop takes a scalar error-context handle, returns nothing.
+  (import "pulseengine:async" "error-context.drop" (func $ec_drop (param i32)))
+
+  ;; Exported function that drops an error-context handle then returns it.
+  (func (export "use_error_context") (param $ec i32) (result i32)
+    local.get $ec
+    call $ec_drop
+    local.get $ec
+  )
+)

--- a/tests/integration/async_error_context_new_declined.wat
+++ b/tests/integration/async_error_context_new_declined.wat
@@ -1,0 +1,10 @@
+;; #80 SOUNDNESS: error-context.new carries a linmem message pointer (canonical
+;; ABI), so despite being in the error-context family it is DECLINED — the same
+;; buffer class as stream. Only error-context.drop (scalar) is lowered.
+(module
+  (import "pulseengine:async" "error-context.new"
+    (func $ec_new (param i32 i32) (result i32)))
+  (func (export "make_ec") (param $ptr i32) (param $len i32) (result i32)
+    local.get $ptr
+    local.get $len
+    call $ec_new))

--- a/tests/integration/async_future_declined.wat
+++ b/tests/integration/async_future_declined.wat
@@ -1,0 +1,9 @@
+;; #80: future family — DECLINED (readable/writable-end buffer protocol
+;; unimplemented). Compiling must loud-decline.
+(module
+  (import "pulseengine:async" "future.read"
+    (func $future_read (param i32 i32) (result i32)))
+  (func (export "read_future") (param $f i32) (param $p i32) (result i32)
+    local.get $f
+    local.get $p
+    call $future_read))

--- a/tests/integration/async_stream_declined.wat
+++ b/tests/integration/async_stream_declined.wat
@@ -1,0 +1,16 @@
+;; #80: P3 async stream intrinsic — a DECLINED family. Synth does not yet
+;; generate the bounds-checked linear-memory buffer layout stream.read needs,
+;; so compiling this module must LOUD-DECLINE by name rather than emit a
+;; silently-miscompiling BL. (Honest degradation, #275-style.)
+(module
+  ;; stream.read(stream, ptr, len) -> i32 (RFC #46 shape, approximate).
+  (import "pulseengine:async" "stream.read"
+    (func $stream_read (param i32 i32 i32) (result i32)))
+
+  (func (export "read_stream") (param $s i32) (param $p i32) (param $n i32) (result i32)
+    local.get $s
+    local.get $p
+    local.get $n
+    call $stream_read
+  )
+)

--- a/tests/integration/async_task_declined.wat
+++ b/tests/integration/async_task_declined.wat
@@ -1,0 +1,7 @@
+;; #80: task family — DECLINED (same yield-point class as waitable-set).
+;; Must loud-decline.
+(module
+  (import "pulseengine:async" "task.return" (func $task_return (param i32)))
+  (func (export "finish_task") (param $r i32)
+    local.get $r
+    call $task_return))

--- a/tests/integration/async_waitable_declined.wat
+++ b/tests/integration/async_waitable_declined.wat
@@ -1,0 +1,9 @@
+;; #80: waitable-set family — DECLINED (register save/restore across the
+;; scheduler yield at waitable-set.wait unimplemented). Must loud-decline.
+(module
+  (import "pulseengine:async" "waitable-set.wait"
+    (func $wait (param i32 i32) (result i32)))
+  (func (export "do_wait") (param $ws i32) (param $p i32) (result i32)
+    local.get $ws
+    local.get $p
+    call $wait))


### PR DESCRIPTION
Bounded v0.49 hub Lane 7 (BREADTH — platform semantics). Two sub-parts, each red-first and oracle-gated. Refs #77, #80.

## Part A — #77: execution-space / memory-space consistency invariant

Gives the RAJA/Kokkos execution-space + memory-space choice a **checked property, not a convention**. New `synth_memory::space` model (`ExecutionSpace` × `MemorySpace`) with `PlatformSpaces::validate()` enforcing **two** consistency invariants:

1. **OS-mapping**: a bare-metal execution space cannot use an OS-mapped (Linux-only) memory space; a hosted space cannot claim a physical on-silicon space (Flash/TCM/ExternalRAM). *(the issue's own worked example.)*
2. **FPU capability**: an FP-requiring memory space cannot be hosted by an FPU-less core (Cortex-M0).

An inconsistent pairing is **REJECTED** with a machine reason naming the offending space (`SpaceError`).

**Red-first evidence**: 7 unit tests cover both directions of each invariant; neutering `validate()` to always-`Ok` fails 4 rejection tests.

**Bounded scope**: geometry (linmem/globals overlap, static-data addressing) is deliberately OUT — owned by `synth_core::static_data_addr` (VCR-VER-003, no file overlap with L2). This is a standalone model; wiring into live target selection is a named follow-up (disclosed in TP-009).

## Part B — #80: P3 async intrinsic compilation (honest degradation)

Meld lowers P3 async components with RFC #46 host intrinsics under the `pulseengine:async` module. Synth's raw call lowering to a field-name `BL` already exists (#197 relocatable path); the **missing piece is the semantic gate**. New `synth_core::async_intrinsics` classifier, wired at the single CLI import-collection choke point (before instruction selection → both selector paths covered):

- **LOWERED**: exactly `error-context.drop` — a pure scalar handle op (one i32 handle in, nothing out). It marshals as an ordinary AAPCS C call and compiles to a `BL error-context.drop` call site (UNDEF symbol the host linker resolves against kiln-builtins).
- **DECLINED by name with a machine reason**: `error-context.new` / `.debug-message` (they carry a linmem message pointer — the SAME bounds-checked buffer class as stream, NOT scalar), `stream`, `future`, `waitable-set`/`task` (register save/restore across the scheduler yield). Unknown async intrinsics also decline.

The lowering decision is **per op, not per family** — lowering `error-context.new` as if scalar would silently miscompile its pointer argument (the exact bug #80 exists to prevent).

**Gate evidence**: 7 unit tests + 2 CLI end-to-end tests. The lowered op compiles to a relocatable ELF carrying `error-context.drop` in the symtab (executes-vs-reference ABI contract, checked via **symtab** not disasm); each of 5 declined-op fixtures FAILS the compile with the `#80` reason.

**Contract caveat**: the `pulseengine:async` namespace and dotted `resource.method` field format are synth's **assumed contract pending meld#94** — the gate does not fire until Meld's lowering confirms these strings. Pinned in one place citing RFC #46.

## Frozen / gates

- Frozen `control_step` 13/13 PASS (byte-invisible — the async gate fires only on the `pulseengine:async` namespace; non-async modules are untouched). `flight_algo` anchor unaffected by the same argument (import-free module, binary proven unchanged by control_step).
- `cargo build -p synth-cli --features riscv` clean; touched-crate + synth-cli tests green; clippy -D; fmt.
- `claim_check.py` 25/25.
- rivet: TP-009 + TP-VER-001 (#77), KB-010 + KB-VER-001 (#80) — all `sys-verification` carry a `verifies` link; `rivet validate` adds **0 errors** vs baseline (52/52).
- No Rocq proofs added → `bazel test //coq:verify_proofs` not run (nothing to verify there).
- CI oracle steps appended to ci.yml for both parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L