### PR TITLE
feat(#782): sound ARM32 i64 trunc_sat via branch-free FP decompose — falcon skip 4→0

### DIFF
--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -2692,15 +2692,21 @@ fn try_lower_f32(
             Ok(true)
         }
         op @ (I64TruncSatF32S | I64TruncSatF32U) => {
-            // #782a: the i64-target trunc_sat forms need an i64 register-pair
-            // conversion path that 32-bit ARM VFP does not provide (VCVT
-            // targets a single 32-bit register). LOUD-decline the function —
-            // decline > wrong (falcon needs only the i32-target forms, #782).
-            Err(synth_core::Error::synthesis(format!(
-                "{op:?} not supported on 32-bit ARM: no i64 register-pair \
-                 float→int conversion path — declining the function loudly \
-                 (#782a; the i32-target trunc_sat forms are lowered)"
-            )))
+            // #782 finale: SOUND i64-target trunc_sat from an f32 source —
+            // promote to f64 (EXACT, sign+NaN preserved) then run the shared
+            // branch-free FP word-decompose. Trap-free, self-contained.
+            let signed = matches!(op, I64TruncSatF32S);
+            let sm = pop_float(stack)?;
+            let dd = alloc_vfp_dtemp(vfp_used)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::F64PromoteF32 { dd, sm },
+                source_line: Some(idx),
+            });
+            free_vfp_temp(vfp_used, vfp_home, sm);
+            lower_i64_trunc_sat_from_f64(
+                dd, signed, idx, vfp_used, vfp_home, stack, next_temp, spill,
+                instructions, reserved,
+            )
         }
         F32ReinterpretI32 => {
             // #708: i32 bits → f32 (VMOV Sd, Rm). Pure bit-cast, no conversion.
@@ -2916,6 +2922,318 @@ fn materialize_f64_const(
         source_line: Some(idx),
     });
     Ok(dd)
+}
+
+/// #782 finale: lower `i64.trunc_sat_f64_{s,u}` (and, after an f64-promote,
+/// the f32-source twins) onto 32-bit ARM as a SOUND, TRAP-FREE, self-contained
+/// register-pair conversion — no `__aeabi` link dependency, no i64 VCVT (which
+/// ARMv7 VFP lacks).
+///
+/// WASM §4.3.2 `trunc_sat` is TOTAL: NaN → 0, out-of-range saturates to the
+/// integer bound (unsigned: negatives → 0), else truncate toward zero; it
+/// NEVER traps. The lowering realises this by an exact FP word-decompose:
+///
+/// ```text
+/// _u (decompose x directly; negatives saturate to 0 via VCVT.U32):
+///   hi = VCVT.U32.F64(x * 2^-32)            ; sat: x*2^-32 >= 2^32 -> 0xFFFFFFFF
+///                                           ;      NaN/negative      -> 0
+///   rem = x - (u32->f64)(hi) * 2^32         ; EXACT while x < 2^64
+///   lo = VCVT.U32.F64(rem)                  ; sat: overflow/inf -> 0xFFFFFFFF
+///   result = (hi:lo)                        ; x>=2^64 -> 0xFFFF_FFFF_FFFF_FFFF
+///
+/// _s (decompose |x|, then negate or clamp from the ORIGINAL sign bit):
+///   mag = |x| via VABS.F64  (sign cleared; NaN stays, |NaN| decomposes to 0)
+///   (hi:lo) = the same unsigned decompose applied to mag
+///   signmask = ASR(bit63(x), 31)            ; 0xFFFFFFFF if x<0 else 0
+///   satmask  = ASR(hi, 31)                  ; 0xFFFFFFFF if mag>=2^63 else 0
+///   sel = signmask ? -(hi:lo) : (hi:lo)     ; branch-free per-word blend
+///   out = satmask  ? sat_const : sel        ; sat_const = signmask?MIN:MAX
+/// ```
+///
+/// The selection is BRANCH-FREE (mask arithmetic), so the straight-line
+/// selector needs no control flow. NaN is safe automatically: `|NaN|`
+/// decomposes to mag=0, so the negate and identity branches coincide (0) and
+/// satmask is 0; −0.0 is likewise safe (mag=0). The `x = -2^63` edge is where
+/// clamp (INT64_MIN) and negate (-2^63) produce identical bits, so no fencepost
+/// is observable there. `sat_const`: when signmask=0, lo=~0=0xFFFFFFFF and
+/// hi=0x7FFFFFFF^0=0x7FFFFFFF = INT64_MAX; when signmask=~0, lo=~(~0)=0 and
+/// hi=0x7FFFFFFF^0xFFFFFFFF=0x80000000 = INT64_MIN. Execution-verified
+/// bit-exactly against wasmtime over the boundary table AND ≥10k random
+/// f32/f64 bit-patterns per form in
+/// `scripts/repro/trunc_sat_782_differential.py`.
+#[allow(clippy::too_many_arguments)]
+fn lower_i64_trunc_sat_from_f64(
+    x: VfpReg,
+    signed: bool,
+    idx: usize,
+    vfp_used: &mut [bool; 16],
+    vfp_home: &mut [bool; 16],
+    stack: &mut Vec<StackVal>,
+    next_temp: &mut u8,
+    spill: &mut SpillState,
+    instructions: &mut Vec<ArmInstruction>,
+    reserved: &[Reg],
+) -> Result<bool> {
+    // 2^-32 and 2^32 as f64 — exact powers of two (multiplying by them never
+    // rounds).
+    const SCALE_DOWN: u64 = 0x3DF0_0000_0000_0000; // 2^-32
+    const SCALE_UP: u64 = 0x41F0_0000_0000_0000; //   2^32
+
+    // For _s: capture the ORIGINAL sign bit (bit63) BEFORE VABS and decompose
+    // |x|. For _u: decompose x directly (VCVT.U32 saturates negatives to 0).
+    let mut signmask: Option<Reg> = None;
+    let value = if signed {
+        // Extract x's 64 bits; keep only the hi word's sign, broadened to a
+        // full-width mask by ASR #31.
+        let slo = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+        stack.push(StackVal::i32(slo));
+        let shi = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+        stack.pop();
+        instructions.push(ArmInstruction {
+            op: ArmOp::I64ReinterpretF64 {
+                rdlo: slo,
+                rdhi: shi,
+                dm: x,
+            },
+            source_line: Some(idx),
+        });
+        // signmask = ASR(shi, 31): 0xFFFFFFFF when x<0, else 0. (slo dead now.)
+        instructions.push(ArmInstruction {
+            op: ArmOp::Asr {
+                rd: shi,
+                rn: shi,
+                shift: 31,
+            },
+            source_line: Some(idx),
+        });
+        signmask = Some(shi);
+        let mag = alloc_vfp_dtemp(vfp_used)?;
+        instructions.push(ArmInstruction {
+            op: ArmOp::F64Abs { dd: mag, dm: x },
+            source_line: Some(idx),
+        });
+        free_vfp_dtemp(vfp_used, vfp_home, x);
+        mag
+    } else {
+        x
+    };
+
+    // Keep the captured signmask reg live across all further core-temp allocs.
+    let mut resv: Vec<Reg> = reserved.to_vec();
+    if let Some(s) = signmask {
+        resv.push(s);
+    }
+    let reserved = resv.as_slice();
+
+    // --- unsigned word-decompose of `value` ---------------------------------
+    let d_down = materialize_f64_const(
+        SCALE_DOWN, idx, vfp_used, stack, next_temp, spill, instructions, reserved,
+    )?;
+    let prod = alloc_vfp_dtemp(vfp_used)?;
+    instructions.push(ArmInstruction {
+        op: ArmOp::F64Mul {
+            dd: prod,
+            dn: value,
+            dm: d_down,
+        },
+        source_line: Some(idx),
+    });
+    free_vfp_dtemp(vfp_used, vfp_home, d_down);
+
+    // Allocate the i64 result pair; reserve both halves for the remainder.
+    let (lo_r, hi_r) =
+        alloc_consecutive_pair(next_temp, stack, instructions, spill, &[], reserved, idx)?;
+    let mut resv2: Vec<Reg> = reserved.to_vec();
+    resv2.push(lo_r);
+    resv2.push(hi_r);
+    let reserved = resv2.as_slice();
+
+    // hi = VCVT.U32.F64(value * 2^-32)  (saturating; NaN/negative -> 0)
+    instructions.push(ArmInstruction {
+        op: ArmOp::I32TruncF64U { rd: hi_r, dm: prod },
+        source_line: Some(idx),
+    });
+    free_vfp_dtemp(vfp_used, vfp_home, prod);
+
+    // rem = value - (u32->f64)(hi) * 2^32
+    let d_hi = alloc_vfp_dtemp(vfp_used)?;
+    instructions.push(ArmInstruction {
+        op: ArmOp::F64ConvertI32U { dd: d_hi, rm: hi_r },
+        source_line: Some(idx),
+    });
+    let d_up = materialize_f64_const(
+        SCALE_UP, idx, vfp_used, stack, next_temp, spill, instructions, reserved,
+    )?;
+    instructions.push(ArmInstruction {
+        op: ArmOp::F64Mul {
+            dd: d_hi,
+            dn: d_hi,
+            dm: d_up,
+        },
+        source_line: Some(idx),
+    });
+    free_vfp_dtemp(vfp_used, vfp_home, d_up);
+    let rem = alloc_vfp_dtemp(vfp_used)?;
+    instructions.push(ArmInstruction {
+        op: ArmOp::F64Sub {
+            dd: rem,
+            dn: value,
+            dm: d_hi,
+        },
+        source_line: Some(idx),
+    });
+    free_vfp_dtemp(vfp_used, vfp_home, d_hi);
+    // lo = VCVT.U32.F64(rem)  (saturating -> 0xFFFFFFFF on overflow/inf)
+    instructions.push(ArmInstruction {
+        op: ArmOp::I32TruncF64U { rd: lo_r, dm: rem },
+        source_line: Some(idx),
+    });
+    free_vfp_dtemp(vfp_used, vfp_home, rem);
+    free_vfp_dtemp(vfp_used, vfp_home, value); // `value` (= x or mag) is dead
+
+    // (lo_r:hi_r) now holds min(trunc(|x| or x), 2^64-1) as unsigned.
+    if !signed {
+        stack.push(StackVal::i64(lo_r));
+        return Ok(true);
+    }
+
+    // --- signed post-processing (branch-free, in place) ---------------------
+    let signmask = signmask.expect("signed path captured the signmask");
+    // satmask = ASR(hi, 31): mag >= 2^63  <=>  hi bit31 set. Computed BEFORE
+    // the negate mutates hi_r.
+    let satmask = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+    let mut resv3: Vec<Reg> = reserved.to_vec();
+    resv3.push(satmask);
+    let reserved = resv3.as_slice();
+    instructions.push(ArmInstruction {
+        op: ArmOp::Asr {
+            rd: satmask,
+            rn: hi_r,
+            shift: 31,
+        },
+        source_line: Some(idx),
+    });
+
+    // Conditional two's-complement negate WITHOUT any extra register pair, via
+    // the identity  -v == (v XOR -1) - (-1)  and  signmask ∈ {0, -1}:
+    //   (v XOR signmask) - (signmask:signmask)  ==  v   when signmask == 0
+    //                                              == -v   when signmask == -1
+    // The 64-bit subtrahend is (signmask:signmask) so both halves subtract -1/0.
+    instructions.push(ArmInstruction {
+        op: ArmOp::Eor {
+            rd: lo_r,
+            rn: lo_r,
+            op2: Operand2::Reg(signmask),
+        },
+        source_line: Some(idx),
+    });
+    instructions.push(ArmInstruction {
+        op: ArmOp::Eor {
+            rd: hi_r,
+            rn: hi_r,
+            op2: Operand2::Reg(signmask),
+        },
+        source_line: Some(idx),
+    });
+    instructions.push(ArmInstruction {
+        op: ArmOp::I64Sub {
+            rdlo: lo_r,
+            rdhi: hi_r,
+            rnlo: lo_r,
+            rnhi: hi_r,
+            rmlo: signmask,
+            rmhi: signmask,
+        },
+        source_line: Some(idx),
+    });
+
+    // Saturation blend, one word at a time (sat_lo/sat_hi never live together).
+    // sat_const: signmask=0 -> INT64_MAX (lo=0xFFFFFFFF, hi=0x7FFFFFFF);
+    //            signmask=-1 -> INT64_MIN (lo=0x00000000, hi=0x80000000).
+    // lo: sat_lo = ~signmask.
+    let sat_tmp = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+    let mut resv4: Vec<Reg> = reserved.to_vec();
+    resv4.push(sat_tmp);
+    let reserved = resv4.as_slice();
+    instructions.push(ArmInstruction {
+        op: ArmOp::Mvn {
+            rd: sat_tmp,
+            op2: Operand2::Reg(signmask),
+        },
+        source_line: Some(idx),
+    });
+    blend_word(instructions, lo_r, sat_tmp, satmask, next_temp, stack, spill, reserved, idx)?;
+    // hi: sat_hi = 0x7FFFFFFF ^ signmask.
+    instructions_push_movw(instructions, sat_tmp, 0xFFFF, idx);
+    instructions.push(ArmInstruction {
+        op: ArmOp::Movt {
+            rd: sat_tmp,
+            imm16: 0x7FFF,
+        },
+        source_line: Some(idx),
+    });
+    instructions.push(ArmInstruction {
+        op: ArmOp::Eor {
+            rd: sat_tmp,
+            rn: sat_tmp,
+            op2: Operand2::Reg(signmask),
+        },
+        source_line: Some(idx),
+    });
+    blend_word(instructions, hi_r, sat_tmp, satmask, next_temp, stack, spill, reserved, idx)?;
+
+    stack.push(StackVal::i64(lo_r));
+    Ok(true)
+}
+
+/// Emit `MOVW rd, #imm16` (helper for the trunc-sat routine).
+fn instructions_push_movw(instructions: &mut Vec<ArmInstruction>, rd: Reg, imm16: u16, idx: usize) {
+    instructions.push(ArmInstruction {
+        op: ArmOp::Movw { rd, imm16 },
+        source_line: Some(idx),
+    });
+}
+
+/// Branch-free per-word select: `dst = dst ^ ((dst ^ src) & mask)` — yields
+/// `src` where `mask` bits are 1, `dst` where 0. Uses one scratch temp.
+#[allow(clippy::too_many_arguments)]
+fn blend_word(
+    instructions: &mut Vec<ArmInstruction>,
+    dst: Reg,
+    src: Reg,
+    mask: Reg,
+    next_temp: &mut u8,
+    stack: &mut Vec<StackVal>,
+    spill: &mut SpillState,
+    reserved: &[Reg],
+    idx: usize,
+) -> Result<()> {
+    let t = alloc_temp_or_spill(next_temp, stack, instructions, spill, reserved, idx)?;
+    instructions.push(ArmInstruction {
+        op: ArmOp::Eor {
+            rd: t,
+            rn: dst,
+            op2: Operand2::Reg(src),
+        },
+        source_line: Some(idx),
+    });
+    instructions.push(ArmInstruction {
+        op: ArmOp::And {
+            rd: t,
+            rn: t,
+            op2: Operand2::Reg(mask),
+        },
+        source_line: Some(idx),
+    });
+    instructions.push(ArmInstruction {
+        op: ArmOp::Eor {
+            rd: dst,
+            rn: dst,
+            op2: Operand2::Reg(t),
+        },
+        source_line: Some(idx),
+    });
+    Ok(())
 }
 
 /// Lower an in-scope scalar f64 op onto the caller-saved D-register file.
@@ -3375,14 +3693,27 @@ fn try_lower_f64(
             Ok(true)
         }
         op @ (I64TruncSatF64S | I64TruncSatF64U) => {
-            // #782a: no i64 register-pair float→int conversion path on 32-bit
-            // ARM — LOUD-decline (decline > wrong; falcon needs only the
-            // i32-target forms, #782).
-            Err(synth_core::Error::synthesis(format!(
-                "{op:?} not supported on 32-bit ARM: no i64 register-pair \
-                 float→int conversion path — declining the function loudly \
-                 (#782a; the i32-target trunc_sat forms are lowered)"
-            )))
+            // #782 finale: SOUND i64-target trunc_sat via the branch-free
+            // FP word-decompose (see `lower_i64_trunc_sat_from_f64`). Trap-free,
+            // self-contained (no __aeabi link dep), §4.3.2-exact.
+            let signed = matches!(op, I64TruncSatF64S);
+            let dm = pop_double(stack)?;
+            // The routine consumes `dm` (frees it internally). If it is a pinned
+            // param/local HOME, hand it a fresh copy so the home survives.
+            let dm_is_home = vfp_d_index(dm).is_some_and(|d| vfp_home[2 * d]);
+            let work = if dm_is_home {
+                let copy = alloc_vfp_dtemp(vfp_used)?;
+                emit_d_copy(
+                    copy, dm, idx, stack, next_temp, spill, instructions, reserved,
+                )?;
+                copy
+            } else {
+                dm
+            };
+            lower_i64_trunc_sat_from_f64(
+                work, signed, idx, vfp_used, vfp_home, stack, next_temp, spill,
+                instructions, reserved,
+            )
         }
         _ => Ok(false),
     }

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -6502,12 +6502,18 @@ impl InstructionSelector {
                 vec![ArmOp::I32TruncF32U { rd, sm }]
             }
 
-            // #782a: i64-target trunc_sat from f32 — no i64 register-pair
-            // conversion path on 32-bit ARM. Loud decline (decline > wrong).
+            // #782: i64-target trunc_sat — SELECTOR ASYMMETRY. The shipping
+            // path `select_with_stack` LOWERS all four i64 forms (v0.49 finale,
+            // `lower_i64_trunc_sat_from_f64`, branch-free FP decompose). This
+            // register-blind `select_default` fallback has no i64 register-pair
+            // machinery, so it still LOUD-declines here (decline > wrong). Both
+            // CLI paths (self-contained `--all-exports` and `--relocatable`)
+            // route these ops through `select_with_stack`, so this arm is not
+            // reached for a normal compile; it remains an honest safety net.
             op @ (I64TruncSatF32S | I64TruncSatF32U) if self.fpu.is_some() => {
                 return Err(synth_core::Error::synthesis(format!(
-                    "{op:?} not supported on 32-bit ARM: no i64 register-pair \
-                     float→int conversion path (#782a)"
+                    "{op:?}: select_default has no i64 register-pair path — the \
+                     shipping select_with_stack selector lowers it (#782)"
                 )));
             }
 
@@ -6813,8 +6819,13 @@ impl InstructionSelector {
             }
 
             // F64 i64 conversions: VCVT.{F64,S32}.{S32,F64} with i64 register
-            // pairs is not implemented in the backend. Surface a typed error.
-            // (#782a: the i64-target trunc_sat forms decline identically.)
+            // pairs is not implemented in this register-blind `select_default`
+            // fallback. Surface a typed error. NOTE (#782): the two
+            // `I64TruncSatF64*` forms ARE lowered on the shipping
+            // `select_with_stack` path (v0.49 finale); they decline here only
+            // because select_default lacks the pair machinery, and a normal
+            // compile never routes them through this arm. The trapping
+            // `I64TruncF64*` and `F64ConvertI64*` remain genuinely unimplemented.
             op @ (F64ConvertI64S | F64ConvertI64U | I64TruncF64S | I64TruncF64U
             | I64TruncSatF64S | I64TruncSatF64U)
                 if self.has_double_fpu() =>

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -2704,8 +2704,16 @@ fn try_lower_f32(
             });
             free_vfp_temp(vfp_used, vfp_home, sm);
             lower_i64_trunc_sat_from_f64(
-                dd, signed, idx, vfp_used, vfp_home, stack, next_temp, spill,
-                instructions, reserved,
+                dd,
+                signed,
+                idx,
+                vfp_used,
+                vfp_home,
+                stack,
+                next_temp,
+                spill,
+                instructions,
+                reserved,
             )
         }
         F32ReinterpretI32 => {
@@ -3027,7 +3035,14 @@ fn lower_i64_trunc_sat_from_f64(
 
     // --- unsigned word-decompose of `value` ---------------------------------
     let d_down = materialize_f64_const(
-        SCALE_DOWN, idx, vfp_used, stack, next_temp, spill, instructions, reserved,
+        SCALE_DOWN,
+        idx,
+        vfp_used,
+        stack,
+        next_temp,
+        spill,
+        instructions,
+        reserved,
     )?;
     let prod = alloc_vfp_dtemp(vfp_used)?;
     instructions.push(ArmInstruction {
@@ -3062,7 +3077,14 @@ fn lower_i64_trunc_sat_from_f64(
         source_line: Some(idx),
     });
     let d_up = materialize_f64_const(
-        SCALE_UP, idx, vfp_used, stack, next_temp, spill, instructions, reserved,
+        SCALE_UP,
+        idx,
+        vfp_used,
+        stack,
+        next_temp,
+        spill,
+        instructions,
+        reserved,
     )?;
     instructions.push(ArmInstruction {
         op: ArmOp::F64Mul {
@@ -3162,7 +3184,17 @@ fn lower_i64_trunc_sat_from_f64(
         },
         source_line: Some(idx),
     });
-    blend_word(instructions, lo_r, sat_tmp, satmask, next_temp, stack, spill, reserved, idx)?;
+    blend_word(
+        instructions,
+        lo_r,
+        sat_tmp,
+        satmask,
+        next_temp,
+        stack,
+        spill,
+        reserved,
+        idx,
+    )?;
     // hi: sat_hi = 0x7FFFFFFF ^ signmask.
     instructions_push_movw(instructions, sat_tmp, 0xFFFF, idx);
     instructions.push(ArmInstruction {
@@ -3180,7 +3212,17 @@ fn lower_i64_trunc_sat_from_f64(
         },
         source_line: Some(idx),
     });
-    blend_word(instructions, hi_r, sat_tmp, satmask, next_temp, stack, spill, reserved, idx)?;
+    blend_word(
+        instructions,
+        hi_r,
+        sat_tmp,
+        satmask,
+        next_temp,
+        stack,
+        spill,
+        reserved,
+        idx,
+    )?;
 
     stack.push(StackVal::i64(lo_r));
     Ok(true)
@@ -3196,7 +3238,9 @@ fn instructions_push_movw(instructions: &mut Vec<ArmInstruction>, rd: Reg, imm16
 
 /// Branch-free per-word select: `dst = dst ^ ((dst ^ src) & mask)` — yields
 /// `src` where `mask` bits are 1, `dst` where 0. Uses one scratch temp.
-#[allow(clippy::too_many_arguments)]
+// `stack` is `&mut Vec` (not a slice) because it is threaded straight into
+// `alloc_temp_or_spill`, which spills by pushing/popping stack entries.
+#[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 fn blend_word(
     instructions: &mut Vec<ArmInstruction>,
     dst: Reg,
@@ -3704,15 +3748,30 @@ fn try_lower_f64(
             let work = if dm_is_home {
                 let copy = alloc_vfp_dtemp(vfp_used)?;
                 emit_d_copy(
-                    copy, dm, idx, stack, next_temp, spill, instructions, reserved,
+                    copy,
+                    dm,
+                    idx,
+                    stack,
+                    next_temp,
+                    spill,
+                    instructions,
+                    reserved,
                 )?;
                 copy
             } else {
                 dm
             };
             lower_i64_trunc_sat_from_f64(
-                work, signed, idx, vfp_used, vfp_home, stack, next_temp, spill,
-                instructions, reserved,
+                work,
+                signed,
+                idx,
+                vfp_used,
+                vfp_home,
+                stack,
+                next_temp,
+                spill,
+                instructions,
+                reserved,
             )
         }
         _ => Ok(false),

--- a/crates/synth-synthesis/tests/trunc_sat_782.rs
+++ b/crates/synth-synthesis/tests/trunc_sat_782.rs
@@ -12,9 +12,11 @@
 //!    trap — a miscompile);
 //!  * the trapping twins KEEP their `Udf` guard (the #709 soundness surface
 //!    must not be eroded by the new arms);
-//!  * the i64-target sat forms LOUD-decline on 32-bit ARM (no i64
-//!    register-pair conversion path) — decline > wrong;
-//!  * everything f32/f64 honest-rejects without the required FPU.
+//!  * the i64-target sat forms LOWER (v0.49 #782 finale) via the sound
+//!    branch-free FP word-decompose — trap-free, register-pair result, NO Udf;
+//!  * everything f32/f64 honest-rejects without the required FPU (the
+//!    f32-source i64 forms promote to f64, so they still decline on a
+//!    single-precision target — the double-FPU capability is genuinely absent).
 //!
 //! The execution truth (boundary table vs wasmtime under unicorn, ARM32 +
 //! aarch64 + native) lives in `scripts/repro/trunc_sat_782_differential.py`.
@@ -145,28 +147,67 @@ fn trapping_trunc_still_carries_the_709_udf_guard() {
 }
 
 // ---------------------------------------------------------------------------
-// i64-target sat forms: LOUD decline on 32-bit ARM
+// i64-target sat forms: LOWERED on cortex-m7dp (v0.49 #782 finale)
 // ---------------------------------------------------------------------------
+//
+// Honesty-gate FLIP (the v0.46 lesson — moved, not deleted): the i64 forms
+// LOUD-declined through v0.48; v0.49 lowers them via the branch-free FP
+// word-decompose. This test now pins that they COMPILE, are TRAP-FREE (no Udf —
+// §4.3.2 trunc_sat is total), and carry the decompose signature (the saturating
+// VCVT.U32.F64 that does the word split, and the I64Sub that realises the
+// conditional two's-complement negate / register-pair result).
 
 #[test]
-fn i64_trunc_sat_forms_loud_decline_on_arm32() {
-    for (op, is_f64) in [
-        (WasmOp::I64TruncSatF32S, false),
-        (WasmOp::I64TruncSatF32U, false),
-        (WasmOp::I64TruncSatF64S, true),
-        (WasmOp::I64TruncSatF64U, true),
+fn i64_trunc_sat_forms_lower_trap_free_on_cortex_m7dp() {
+    for (op, is_f64, signed) in [
+        (WasmOp::I64TruncSatF32S, false, true),
+        (WasmOp::I64TruncSatF32U, false, false),
+        (WasmOp::I64TruncSatF64S, true, true),
+        (WasmOp::I64TruncSatF64U, true, false),
     ] {
-        let err = lower(
+        let ops = lower(
             Some(FPUPrecision::Double),
             "cortex-m7dp",
             op.clone(),
             is_f64,
         )
-        .expect_err(&format!("{op:?} must DECLINE on 32-bit ARM, not compile"));
+        .unwrap_or_else(|e| {
+            panic!("{op:?} must LOWER on cortex-m7dp (#782 finale), not decline: {e}")
+        });
+        // §4.3.2 trunc_sat is TOTAL — a Udf guard would spuriously trap.
         assert!(
-            err.contains("register-pair"),
-            "{op:?} decline must NAME the missing capability (i64 \
-             register-pair conversion), got: {err}"
+            !has_udf(&ops),
+            "{op:?} is TOTAL (§4.3.2) — the i64 lowering must NEVER trap: {ops:?}"
+        );
+        // The word decompose uses the saturating VCVT.U32.F64 for both halves
+        // (all four forms — unsigned decompose is the shared core).
+        assert!(
+            ops.iter().any(|o| matches!(o, ArmOp::I32TruncF64U { .. })),
+            "{op:?} must decompose via the saturating VCVT.U32.F64: {ops:?}"
+        );
+        // The SIGNED forms carry the branch-free conditional two's-complement
+        // negate (I64Sub of the register pair against the sign mask); the
+        // unsigned forms return the raw magnitude and need no I64Sub.
+        assert_eq!(
+            ops.iter().any(|o| matches!(o, ArmOp::I64Sub { .. })),
+            signed,
+            "{op:?}: I64Sub presence must match the signed post-processing: {ops:?}"
+        );
+    }
+}
+
+/// The f32-source i64 forms promote to f64, so on a SINGLE-precision target
+/// (no double FPU) they still honest-decline — the capability is genuinely
+/// absent. (The decline surfaces at ISA validation, not here, but the selector
+/// itself declines the f64-source i64 forms on m4f via the double-FPU gate.)
+#[test]
+fn i64_trunc_sat_f64_source_declines_on_single_precision() {
+    for op in [WasmOp::I64TruncSatF64S, WasmOp::I64TruncSatF64U] {
+        let err = lower(Some(FPUPrecision::Single), "cortex-m4f", op.clone(), true)
+            .expect_err(&format!("{op:?} needs a double FPU — must decline on m4f"));
+        assert!(
+            err.contains("double-precision") || err.contains("f64") || err.contains("FPU"),
+            "{op:?} single-precision decline must name the capability: {err}"
         );
     }
 }

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -46,7 +46,7 @@ soundness feature, not an absence.
 | f32 scalar via VFP | Y (FPU targets) | Complete op set incl. all six comparisons, NaN-aware (v0.41); requires an FPU target (e.g. `cortex-m4f`) |
 | f64 scalar via VFP | Y (FPU targets) | Complete (v0.43, #369 closed); marshalling + AAPCS-VFP mixed params |
 | Trapping float→int truncations | Y | Domain-guarded (trap, not saturate) — the #709 soundness class |
-| Non-trapping `trunc_sat` (0xFC prefix) | D | Not decoded — functions using it loud-skip; tracked in #782 |
+| Non-trapping `trunc_sat` (0xFC prefix) | Y (FPU targets) | Decoded and lowered as bare saturating VCVT (§4.3.2: NaN→0, out-of-range saturates, never traps). i32-target forms on any FPU target; i64-target forms on a double-FPU target (`cortex-m7dp`) via a branch-free FP word-decompose (v0.49, #782); aarch64 lowers all eight. Residuals: i64-from-f32 declines on single-precision (needs the f64 promote); a pressure-dependent f32 class on `--relocatable cortex-m7dp` still tracked in #782 |
 | Control flow (block, loop, if/else, br, br_if, br_table) | Y | Renode execution tests |
 | Function calls (direct + `call_indirect`) | Y | `call_indirect` traps per WASM §4.4.8 (OOB index, type mismatch, null slot); self-contained dispatch is PC-relative via a flash funcref table (v0.47) |
 | Memory (load/store incl. sub-word, size/grow) | Y | `memory.grow` returns -1 on fixed-memory embedded targets; grow(0) ≡ size |

--- a/scripts/repro/trunc_sat_782_differential.py
+++ b/scripts/repro/trunc_sat_782_differential.py
@@ -49,6 +49,7 @@ from unicorn.arm_const import (
     UC_ARM_REG_LR,
     UC_ARM_REG_PC,
     UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
     UC_ARM_REG_R11,
     UC_ARM_REG_S0,
     UC_ARM_REG_SP,
@@ -187,8 +188,11 @@ def load(elf):
 
 
 # ---------------------------------------------------------------------------
-# ARM32 (Thumb-2) unicorn execution. Returns ('ok', r0) or ('trap', pc-info).
-def arm32_run(text, base, addr, aty, v):
+# ARM32 (Thumb-2) unicorn execution. Returns ('ok', result) or ('trap', info).
+# For an i32 return the AAPCS result is R0; for an i64 it is the pair
+# (R0 = lo bits[31:0], R1 = hi bits[63:32]) — reading only R0 would make every
+# hi-word bug (NaN→0 upper word, saturation MIN/MAX, sign) invisible.
+def arm32_run(text, base, addr, aty, v, rty="i32"):
     uc = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
     map_base = base & ~0xFFF
     size = ((len(text) + (base - map_base)) + 0xFFF) & ~0xFFF
@@ -218,7 +222,11 @@ def arm32_run(text, base, addr, aty, v):
             if hw & 0xFF00 == 0xDE00:  # Thumb UDF
                 kind = "trap-udf"
         return (kind, f"{e} at pc={pc:#x}")
-    return ("ok", uc.reg_read(UC_ARM_REG_R0) & M32)
+    lo = uc.reg_read(UC_ARM_REG_R0) & M32
+    if rty == "i64":
+        hi = uc.reg_read(UC_ARM_REG_R1) & M32
+        return ("ok", lo | (hi << 32))
+    return ("ok", lo)
 
 
 # ---------------------------------------------------------------------------
@@ -305,53 +313,135 @@ def native_run(code, faddr, code_base, aty, rty, v):
 
 
 # ---------------------------------------------------------------------------
+# Fuzz: >=10k random bit-patterns per source type vs wasmtime, checked against
+# the ARM32 m7dp lowering (all 8 forms) and the aarch64 lowering.
+FUZZ_PER_TYPE = int(os.environ.get("TRUNC_SAT_FUZZ", "12000"))
+
+
+def _rand_f32_bits(rng):
+    # Mix uniform 32-bit patterns with a bias toward the interesting exponents
+    # (near/over 2^31, 2^63, 2^64) so the saturation edges are well sampled.
+    import random
+    r = rng.random()
+    if r < 0.55:
+        return rng.getrandbits(32)
+    if r < 0.75:  # exponent near the i32/i64 boundaries, random sign+mantissa
+        exp = rng.randint(126, 191)  # ~2^-1 .. ~2^64
+        return (rng.getrandbits(1) << 31) | (exp << 23) | rng.getrandbits(23)
+    if r < 0.85:  # subnormals / tiny
+        return (rng.getrandbits(1) << 31) | rng.getrandbits(23)
+    # NaN/inf payloads
+    return (rng.getrandbits(1) << 31) | (0xFF << 23) | rng.getrandbits(23)
+
+
+def _rand_f64_bits(rng):
+    r = rng.random()
+    if r < 0.55:
+        return rng.getrandbits(64)
+    if r < 0.75:
+        exp = rng.randint(1022, 1087)  # ~2^-1 .. ~2^64
+        return (rng.getrandbits(1) << 63) | (exp << 52) | rng.getrandbits(52)
+    if r < 0.85:
+        return (rng.getrandbits(1) << 63) | rng.getrandbits(52)
+    return (rng.getrandbits(1) << 63) | (0x7FF << 52) | rng.getrandbits(52)
+
+
+def run_fuzz(text, base, syms, a64_code, a64_base, a64_syms, host_native):
+    import random
+    rng = random.Random(0x782F17E)  # fixed seed => reproducible CI gate
+
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    wexp = wasmtime.Instance(store, module, []).exports(store)
+
+    fails = 0
+    checks = 0
+    for src, gen, bits_of in (("f32", _rand_f32_bits, f32_bits),
+                              ("f64", _rand_f64_bits, f64_bits)):
+        fns = [(fn, rty) for fn, (aty, rty) in SIGS.items() if aty == src]
+        for _ in range(FUZZ_PER_TYPE):
+            b = gen(rng)
+            if src == "f32":
+                v = struct.unpack("<f", struct.pack("<I", b))[0]
+            else:
+                v = struct.unpack("<d", struct.pack("<Q", b))[0]
+            for fn, rty in fns:
+                mask = M32 if rty == "i32" else M64
+                try:
+                    want = int(wexp[fn](store, v)) & mask
+                except wasmtime.Trap:
+                    sys.exit(f"TABLE-BUG: wasmtime TRAPPED on {fn}(bits={b:#x})")
+                # ARM32 m7dp
+                if fn in syms:
+                    checks += 1
+                    kind, got = arm32_run(text, base, syms[fn], src, v, rty)
+                    if kind != "ok":
+                        fails += 1
+                        if fails <= 20:
+                            print(f"FUZZ-BUG [arm32] {fn}(bits={b:#x}) -> "
+                                  f"{kind}: {got} (wasmtime {want:#x})")
+                    elif got != want:
+                        fails += 1
+                        if fails <= 20:
+                            print(f"FUZZ-BUG [arm32] {fn}(bits={b:#x}) = "
+                                  f"{got:#x} != wasmtime {want:#x}")
+                # aarch64
+                if fn in a64_syms:
+                    checks += 1
+                    faddr = a64_syms[fn] & ~1
+                    kind, got = a64_run(a64_code, a64_base, faddr, src, rty, v)
+                    if kind != "ok":
+                        fails += 1
+                        if fails <= 20:
+                            print(f"FUZZ-BUG [a64] {fn}(bits={b:#x}) -> TRAP "
+                                  f"(wasmtime {want:#x})")
+                    elif got != want:
+                        fails += 1
+                        if fails <= 20:
+                            print(f"FUZZ-BUG [a64] {fn}(bits={b:#x}) = "
+                                  f"{got:#x} != wasmtime {want:#x}")
+    return fails, checks
+
+
+# ---------------------------------------------------------------------------
 def main():
     expected = wasmtime_expected()
     fails = 0
     total = 0
 
     # ==== falcon repro flags (#782): -t cortex-m7dp --relocatable ==========
-    # The four i32-target exports must NOT skip; the four i64-target exports
-    # MUST still skip with the named ARM32 decline (decline-honesty).
-    log = compile_or_die("/tmp/trunc_sat_782_reloc.elf",
-                         ["-b", "arm", "--target", "cortex-m7dp",
-                          "--relocatable"],
-                         "ARM32 --relocatable (falcon flags)")
-    for fn in I32_FNS:
-        if fn in log and "kipping" in log:
-            # cheap guard; the authoritative check is the symbol table below
-            pass
+    # #782 FINALE: ALL EIGHT trunc_sat exports (the four i32-target AND the
+    # four i64-target forms) must now compile — NONE may skip. The i64 forms
+    # were LOUD-declined through v0.48; v0.49 lowers them via the sound
+    # branch-free FP word-decompose. (Honesty-gate flip, the v0.46 lesson: this
+    # assertion moved from "i64 absent + decline named" to "i64 present"; it is
+    # not deleted — a regression that drops any i64 form fails here.)
+    compile_or_die("/tmp/trunc_sat_782_reloc.elf",
+                   ["-b", "arm", "--target", "cortex-m7dp", "--relocatable"],
+                   "ARM32 --relocatable (falcon flags)")
     _, _, reloc_syms = load("/tmp/trunc_sat_782_reloc.elf")
-    for fn in I32_FNS:
+    for fn in SIGS:
         total += 1
         if fn not in reloc_syms:
             fails += 1
             print(f"FAIL [falcon-flags] {fn}: SKIPPED under "
-                  f"-t cortex-m7dp --relocatable (the #782 class)")
-    for fn in I64_FNS:
-        total += 1
-        if fn in reloc_syms:
-            fails += 1
-            print(f"FAIL [falcon-flags] {fn}: compiled on 32-bit ARM — "
-                  f"expected a LOUD decline (no i64 pair conversion)")
-    if "register-pair" not in log:
-        fails += 1
-        print("FAIL [falcon-flags]: the i64 trunc_sat decline is not NAMED "
-              "in the compile log (decline-honesty)")
+                  f"-t cortex-m7dp --relocatable (the #782 skip class)")
 
-    # ==== ARM32 self-contained (cortex-m7dp): execute the i32 quartet ======
+    # ==== ARM32 self-contained (cortex-m7dp): execute ALL EIGHT forms ======
     compile_or_die("/tmp/trunc_sat_782_arm.elf",
                    ["-b", "arm", "--target", "cortex-m7dp", "--all-exports"],
                    "ARM32 cortex-m7dp")
     text, base, syms = load("/tmp/trunc_sat_782_arm.elf")
-    for fn, (aty, rty) in I32_FNS.items():
+    for fn, (aty, rty) in SIGS.items():
         if fn not in syms:
             fails += 1
-            print(f"FAIL [arm32] {fn}: symbol missing")
+            print(f"FAIL [arm32] {fn}: symbol missing (#782 finale expects "
+                  f"all eight forms lowered)")
             continue
         for v, want in expected[fn]:
             total += 1
-            kind, got = arm32_run(text, base, syms[fn], aty, v)
+            kind, got = arm32_run(text, base, syms[fn], aty, v, rty)
             if kind != "ok":
                 fails += 1
                 print(f"BUG [arm32] {fn}({v!r}) -> {kind}: {got} — trunc_sat "
@@ -359,12 +449,6 @@ def main():
             elif got != want:
                 fails += 1
                 print(f"BUG [arm32] {fn}({v!r}) = {got:#x} != wasmtime {want:#x}")
-    # i64-target forms must be absent (loud-declined) on ARM32 here too.
-    for fn in I64_FNS:
-        total += 1
-        if fn in syms:
-            fails += 1
-            print(f"FAIL [arm32] {fn}: compiled on 32-bit ARM — expected decline")
 
     # ==== ARM32 single-precision (cortex-m4f): f32 quartet only ============
     # trunc_sat_f32_* needs only single-precision VFP; the f64-source forms
@@ -424,11 +508,26 @@ def main():
                     print(f"BUG [a64/{label}] {fn}({v!r}) = {got:#x} != "
                           f"wasmtime {want:#x}")
 
+    # ==== HEAVY FUZZ (the real gate for the multi-instruction i64 decompose) =
+    # A boundary table of ~40 points cannot characterise a word-decompose: a
+    # rounding/borrow bug at some arbitrary mid-range mantissa sails straight
+    # through. So drive >=10k random BIT-PATTERNS per source type (f32 and f64,
+    # covering subnormals/huge/NaN payloads/every sign) through wasmtime and
+    # compare bit-exactly against BOTH the ARM32 m7dp lowering (all eight forms,
+    # R0:R1 for i64) and the aarch64 lowering. A single mismatch (or any trap on
+    # our side) fails the pass.
+    f_fails, fuzz_n = run_fuzz(text, base, syms,
+                               a64_code, a64_base, a64_syms, host_native)
+    fails += f_fails
+    total += fuzz_n
+
     print(f"\n{total} checks ({checked_native} also run natively, "
+          f"{fuzz_n} random-bit-pattern fuzz, "
           f"{'arm64 host' if host_native else 'unicorn-only host'})")
-    print("RESULT:", "PASS — trunc_sat boundary table matches wasmtime on "
-          "ARM32(m7dp+m4f)+aarch64; no traps anywhere; ARM32 i64 forms "
-          "loud-declined" if not fails else f"FAIL ({fails})")
+    print("RESULT:", "PASS — trunc_sat boundary+fuzz matches wasmtime on "
+          "ARM32(m7dp all 8 forms)+m4f+aarch64; no traps anywhere; ARM32 i64 "
+          "forms lowered (branch-free FP decompose)"
+          if not fails else f"FAIL ({fails})")
     sys.exit(1 if fails else 0)
 
 

--- a/scripts/repro/trunc_sat_782_differential.py
+++ b/scripts/repro/trunc_sat_782_differential.py
@@ -478,6 +478,20 @@ def main():
             elif got != want:
                 fails += 1
                 print(f"BUG [m4f] {fn}({v!r}) = {got:#x} != wasmtime {want:#x}")
+    # DECLINE-HONESTY (the v0.46 lesson — this residual must still assert):
+    # ALL FOUR i64-target forms need a DOUBLE FPU. The f32-source pair promotes
+    # to f64 (VCVT.F64.F32) and the f64-source pair needs f64 arithmetic — both
+    # are genuinely absent on a single-precision m4f, so all four must be
+    # loud-declined (absent from the symbol table) here. This is the ONLY gate
+    # on the f32-source i64 decline, which surfaces at ISA validation (below the
+    # selector-level Rust unit test).
+    for fn in I64_FNS:
+        total += 1
+        if fn in m4f_syms:
+            fails += 1
+            print(f"FAIL [m4f] {fn}: an i64 trunc_sat form compiled on a "
+                  f"single-precision target — expected a LOUD decline "
+                  f"(no double FPU for the f64 decompose)")
 
     # ==== aarch64: all eight, unicorn + native ==============================
     compile_or_die("/tmp/trunc_sat_782_a64.o",

--- a/scripts/templates/feature_matrix.md.tmpl
+++ b/scripts/templates/feature_matrix.md.tmpl
@@ -46,7 +46,7 @@ soundness feature, not an absence.
 | f32 scalar via VFP | Y (FPU targets) | Complete op set incl. all six comparisons, NaN-aware (v0.41); requires an FPU target (e.g. `cortex-m4f`) |
 | f64 scalar via VFP | Y (FPU targets) | Complete (v0.43, #369 closed); marshalling + AAPCS-VFP mixed params |
 | Trapping float→int truncations | Y | Domain-guarded (trap, not saturate) — the #709 soundness class |
-| Non-trapping `trunc_sat` (0xFC prefix) | D | Not decoded — functions using it loud-skip; tracked in #782 |
+| Non-trapping `trunc_sat` (0xFC prefix) | Y (FPU targets) | Decoded and lowered as bare saturating VCVT (§4.3.2: NaN→0, out-of-range saturates, never traps). i32-target forms on any FPU target; i64-target forms on a double-FPU target (`cortex-m7dp`) via a branch-free FP word-decompose (v0.49, #782); aarch64 lowers all eight. Residuals: i64-from-f32 declines on single-precision (needs the f64 promote); a pressure-dependent f32 class on `--relocatable cortex-m7dp` still tracked in #782 |
 | Control flow (block, loop, if/else, br, br_if, br_table) | Y | Renode execution tests |
 | Function calls (direct + `call_indirect`) | Y | `call_indirect` traps per WASM §4.4.8 (OOB index, type mismatch, null slot); self-contained dispatch is PC-relative via a flash funcref table (v0.47) |
 | Memory (load/store incl. sub-word, size/grow) | Y | `memory.grow` returns -1 on fixed-memory embedded targets; grow(0) ≡ size |


### PR DESCRIPTION
## #782 finale — drive falcon fused-core trunc_sat skips toward zero

Closes the ARM32 half of the `#782` trunc_sat skip class: the four
`i64.trunc_sat_f32/f64_{s,u}` forms — LOUD-declined through v0.48 — now lower
**soundly and trap-free** on 32-bit ARM (double-FPU / `cortex-m7dp`). Refs #782, #242.

### Skip delta (the headline)
Under the falcon repro flags (`-t cortex-m7dp --relocatable`) on the `#782`
skip-class proxy module (`scripts/repro/trunc_sat_782.wat`):

| | v0.48 (main) | v0.49 (this PR) |
|---|---|---|
| i32-target trunc_sat (4 forms) | lowered | lowered |
| **i64-target trunc_sat (4 forms)** | **4/4 LOUD-declined** | **0 declined — all 4 lowered** |
| falcon-flags skip count | 4 | **0** |

**The falcon fused-core's own 26→N delta is UNMEASURABLE LOCALLY** — the real
`falcon-flight-v1.123` module is a relay/jess-owned asset not in the repo (only
the 29-line `falcon_axis.wat`, which carries no trunc_sat), and `relay` was not
addressable via SendMessage this session. So this reports the **capability
delta on the `#782` skip class the fused core flagged** (4→0), not a fabricated
fused-core count. If the asset arrives, the measurement is a `compile → grep
"skipping" → categorize` away. **Blocker surfaced, not papered over.**

### How (sound, self-contained, trap-free)
`lower_i64_trunc_sat_from_f64` (shipping `select_with_stack` path). WASM §4.3.2
`trunc_sat` is TOTAL (NaN→0, out-of-range saturates, never traps). No `__aeabi`
link dependency, no i64 VCVT (ARMv7 VFP lacks it) — an exact FP word-decompose:

- **`_u`**: decompose `x` directly via two saturating `VCVT.U32.F64` over an
  exact `2^-32`/`2^32` word split (negatives→0, NaN→0, ≥2^64→u64 MAX).
- **`_s`**: `VABS` to `|x|`, same unsigned decompose, then a **branch-free**
  conditional two's-complement negate `(v XOR signmask) − signmask` (signmask ∈
  {0,−1} from bit 63 of the original `x`, so no zero/neg register pair) and a
  saturation blend to `INT64_MIN/MAX` under `ASR(hi,31)`. The `−2^63` edge is
  where clamp and negate coincide — no fencepost.

f32-source forms promote to f64 first (exact). On a single-precision target the
f64 promote is genuinely unavailable, so those i64 forms **still honest-decline**
(ISA-validated on `VCVT.F64.F32`).

### Verification (the real gate — not a self-test)
`scripts/repro/trunc_sat_782_differential.py` vs **wasmtime**, bit-exact:
- **Boundary table** (NaN, ±inf, exact 2^63/2^64 bounds, ±2^63, ±0.5, in-range).
- **Heavy fuzz — 192,000 random bit-pattern checks** (≥10k per source type,
  subnormals / huge / NaN-payloads / every sign, seeded) — the real gate for a
  multi-instruction decompose that a boundary table cannot characterise.
- Executed on **ARM32 m7dp (all 8 forms), aarch64 unicorn, AND native arm64**.
  Zero traps anywhere.
- **Fixed a latent vacuity**: `arm32_run` now reads the AAPCS i64 return as
  `R0 | (R1<<32)` (was `R0` only — every hi-word bug was invisible).

### Decline-honesty (the v0.46 lesson — moved, never deleted)
- Repro falcon/arm32 assertions **flipped** from "i64 SKIPPED + `register-pair`
  decline named" to "all 8 COMPILE + execute bit-exact" — a regression that
  drops any i64 form fails the gate.
- New repro **m4f assertion**: all 4 i64 forms must be ABSENT (loud-declined) on
  single-precision — the *only* gate on the f32-source ISA-validation decline.
- `select_default` (register-blind fallback) still declines i64 trunc_sat as an
  honest safety net (both CLI paths route through `select_with_stack`); commented.

### Gates
- boundary+fuzz differential **PASS** (192k checks bit-identical, 0 traps)
- `cargo build -p synth-cli --features riscv` clean
- `cargo test --workspace` **2432 passed / 0 failed**
- clippy `-D warnings` clean · fmt clean
- frozen **10/10** (control_step / flight_algo byte-identical — new lowerings
  only fire on trunc_sat ops)
- `claim_check.py` **25/25** (FEATURE_MATRIX trunc_sat row corrected via its
  template + regenerated; NOT marked "#782 closed" — the pressure-dependent f32
  class stays open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
