### PR TITLE
feat(#778): WCET phase 4 — bounded self-recursion via a verified depth-hint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,15 +51,19 @@ jobs:
         # disk-exhaustion workaround) is gone. The z3-solver feature path is
         # covered by the dedicated `Z3 Verification` differential job below.
         run: cargo test --workspace
-      - name: WCET bound gate (#778 — sound static WCET incl. phase-3 composition)
+      - name: WCET bound gate (#778 — sound static WCET incl. phase-3/4 recursion)
         # The soundness gate for --emit-wcet: bound >= actual on loop-free +
         # const-loop fixtures, EXACT-literal composed bounds over the direct call
         # graph (leaf->mid->root; a callee in a proven loop counted trip×), and the
         # decline-honesty matrix — recursion (`recursion`), indirect
         # (`indirect-call`), external/import (`call`), and declined-callee
-        # (`callee-unbounded`) still LOUD-DECLINE. Covered by `cargo test --workspace`
-        # above; run explicitly so a WCET-soundness regression is unmissable in the
-        # log (the #778 phase-3 inter-procedural-composition contract).
+        # (`callee-unbounded`) still LOUD-DECLINE. Phase 4 (#49): a masked
+        # single-self-call chain with a VERIFIED depth hint is BOUNDED (derived
+        # depth 15, frame_count 16, 752 cyc); a too-low hint / tree (fib) / uncapped
+        # countdown / mutual recursion STAY declined with the specific machine
+        # reason (hint-below-derived-depth / hint-unverifiable-recursion). Covered
+        # by `cargo test --workspace` above; run explicitly so a WCET-soundness
+        # regression is unmissable in the log.
         run: cargo test -p synth-cli --test wcet_bound_gate
 
   clippy:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,14 +199,31 @@ frozen and oracle-gated every step:
   counted `trip×` (never once). Decline-honesty residuals (moved, never deleted):
   recursion / any call-graph cycle → `recursion`, indirect `Blx`/`call_indirect`
   → `indirect-call`, external/import direct call → `call`, a declined callee →
-  `callee-unbounded` (a decline propagates UP). Data-dependent loops,
-  non-canonical shapes, i64-software-div and non-M3/M4 cores (incl. the
-  ambiguous `-eabihf` M4F/M7 triple) still LOUD-DECLINE with a machine reason.
-  Frozen-safe (`.text` unchanged, hints/sidecar byte-invisible); gated by
-  `wcet_bound_gate.rs` (bound ≥ actual + trip-aware floor + red-first hint
-  rejection + decline matrix + composed exact-literal chain + recursion/indirect
-  decline honesty). Richer hint certificates (data-dependent bounds, scry) are a
-  named follow-up.
+  `callee-unbounded` (a decline propagates UP). Phase 4 (#49): BOUNDED
+  SELF-RECURSION via a VERIFIED depth-hint (`wcet_recursion.rs`) — the `recursion`
+  decline is CONVERTED for exactly one provably-sound shape: a SINGLE-self-call
+  chain (mult 1) whose controlling value is ENTRY-INDEPENDENTLY bounded by a mask
+  (`m = param & K ∈ [0,K]`), decreasing by a const step toward a base guard on the
+  SAME masked quantity, with the self-call proven control-dependent on that guard.
+  synth DERIVES its own max depth (`exit_index` seeded at `init = mask`, wrap/
+  divisibility-safe) and the composer folds the self-edge as `(max_depth+1) ×
+  frame_cost` (the `+1` base frame is sound-critical, pinned in `claims.yaml`); a
+  `--wcet-hints` `recursion_depth` entry only GATES consumption (opt-in, mirroring
+  the equality-exit loop gate) — the emitted depth is always synth's DERIVED
+  ceiling, never the raw hint. Decline-honesty MOVED not deleted: a too-low hint →
+  `hint-below-derived-depth`; a TREE recursion (two self-calls, e.g. fib — `depth ×
+  per-frame` would under-count exponentially), an UNCAPPED runtime-param countdown
+  (unbounded at one end of i32), mutual / indirect recursion → still LOUD-decline
+  `recursion` + `hint-unverifiable-recursion`. Data-dependent loops, non-canonical
+  shapes, i64-software-div and non-M3/M4 cores (incl. the ambiguous `-eabihf`
+  M4F/M7 triple) still LOUD-DECLINE with a machine reason. Frozen-safe (`.text`
+  unchanged, hints/sidecar byte-invisible); gated by `wcet_bound_gate.rs` (bound ≥
+  actual + trip-aware floor + red-first hint rejection + decline matrix + composed
+  exact-literal chain + recursion/indirect decline honesty + masked-recursion
+  accept/reject) and the `wcet_phase4_49_recursion_soundness.py` unicorn cross-
+  check (`md(0xFFFFFFFF)` executes 267 insns across all 16 frames ≤ 752 cyc,
+  entry-independent). Richer recursion certificates (clamp-bounded controlling
+  values, data-dependent depths, scry) are a named follow-up.
 - **Gate `VCR-VER-001`:** DEMONSTRATED (implemented, evidence in
   `scripts/repro/vcr_ver_001_gate.md`) — the v0.11.20 reciprocal-mult
   cost-gate was deleted outright (PR #322, differential bit-identical); the

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -3388,9 +3388,15 @@ artifacts:
       (const step); and the self-call is proven CONTROL-DEPENDENT on the guard (the
       guard's taken target is a base block that does NOT contain the self-call, so
       the self-call is unreachable when the guard fires — this is what stops the
-      dangerous (base−step)&K re-mask from diverging). synth then DERIVES its own
-      maximum depth via the loop trip machinery (wcet_loops::exit_index, seeded at
-      init = mask — the worst case over all inputs; wrap/divisibility-safe), and the
+      dangerous (base−step)&K re-mask from diverging). The guard→self-call arg
+      region must ALSO be STRAIGHT-LINE + SINGLE-ENTRY (no branch inside it, no
+      branch targeting into it) so the decrement is provably UNCONDITIONAL — a
+      conditional decrement (gated on a second guard) would let a runtime path skip
+      it and recurse unbounded while the linear walk still saw m−step. synth then
+      DERIVES its own maximum depth via the loop trip machinery
+      (wcet_loops::exit_index, evaluated at BOTH init endpoints 0 and mask — the max
+      is the entry-independent worst case regardless of step direction;
+      wrap/divisibility-safe; Eq/Ne base guards restricted to step ±1), and the
       composer folds the certified self-edge as (max_depth+1) × frame_cost instead
       of declining. The +1 counts the BASE frame (runs own_cycles, no self-call);
       omitting it undercounts by one frame → the fold is pinned sound-critical in
@@ -3440,6 +3446,10 @@ artifacts:
         tree_recursion_two_self_calls_rejected_even_with_hint (fib → declined +
         hint-unverifiable-recursion — the fib-trap guard),
         uncapped_countdown_recursion_hint_rejected_unverifiable,
+        conditional_decrement_recursion_rejected_unverifiable (the decrement is
+        gated on a SECOND guard over the raw param → a path skips it → unbounded;
+        the straight-line/single-entry region check REJECTS it — the adversarial
+        guard against modeling a conditional decrement as unconditional),
         mutual_recursion_stays_declined_even_with_hint. 3 pure-composer unit tests
         in wcet_compose.rs (certified self folds depth frames / folds non-self
         callee per-frame / a distinct mutual cycle STILL declines). Execution-side

--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -3368,3 +3368,83 @@ artifacts:
         recursion/propagation/external). claims.yaml pins
         BL_BLX_CALL_OVERHEAD_CYCLES = 4 (SYNTH-WCET-CYCLE-MODEL); claim_check green.
         Frozen anchors 10/10 untouched (WCET is a byte-invisible sidecar).
+
+  - id: VCR-WCET-002
+    type: sys-verification
+    title: "WCET bounded self-recursion via a verified depth-hint (#778 phase 4 / #49)"
+    description: >
+      Phase 4 (#49) CONVERTS the phase-3 `recursion` decline for exactly ONE
+      provably-sound shape, keeping every other recursion a LOUD decline (the
+      decline is MOVED, never deleted — the v0.46 doctrine). SOUNDNESS = decline >
+      guess: a depth × per-frame bound is emitted only when synth can PROVE the
+      recursion cannot exceed the derived depth for ANY i32 input.
+
+      THE PROVABLE SHAPE (crates/synth-backend/src/wcet_recursion.rs): a
+      SINGLE-self-call chain (exactly one BL to the function's own func_<idx>,
+      executed at most once per frame — loop multiplier 1) whose controlling value
+      is ENTRY-INDEPENDENTLY bounded by a mask: m = (param & K) ∈ [0,K] for any
+      runtime param. The base guard and the recursive argument read the SAME masked
+      quantity (identical base register + mask constant); the argument is m − step
+      (const step); and the self-call is proven CONTROL-DEPENDENT on the guard (the
+      guard's taken target is a base block that does NOT contain the self-call, so
+      the self-call is unreachable when the guard fires — this is what stops the
+      dangerous (base−step)&K re-mask from diverging). synth then DERIVES its own
+      maximum depth via the loop trip machinery (wcet_loops::exit_index, seeded at
+      init = mask — the worst case over all inputs; wrap/divisibility-safe), and the
+      composer folds the certified self-edge as (max_depth+1) × frame_cost instead
+      of declining. The +1 counts the BASE frame (runs own_cycles, no self-call);
+      omitting it undercounts by one frame → the fold is pinned sound-critical in
+      claims.yaml (SYNTH-WCET-CYCLE-MODEL).
+
+      THE HINT SEAM (untrusted oracle + sound checker, no scry dependency): a
+      --wcet-hints `recursion_depth` entry only GATES consumption (a bound this
+      consequential is opt-in, mirroring the equality-exit loop-hint gate). The
+      emitted depth is ALWAYS synth's DERIVED ceiling, never the raw hint. Rejected
+      with machine reasons otherwise: a hint below the derived depth →
+      `hint-below-derived-depth`; a shape synth cannot prove →
+      `hint-unverifiable-recursion`.
+
+      NAMED RESIDUAL DECLINES (decline-honesty, nothing deleted):
+        - TREE recursion (≥2 self-calls per frame, e.g. fib): depth × per-frame
+          would under-count the exponential frame tree → reject
+          `hint-unverifiable-recursion` (the single-self-call gate is the direct
+          guard against this fatal class).
+        - UNCAPPED countdown (recursive arg is a raw runtime param, no mask):
+          runtime-unbounded at one end of i32 (negative entries diverge) → reject
+          `hint-unverifiable-recursion`.
+        - MUTUAL / INDIRECT recursion: the certificate exempts only a function's OWN
+          self-edge; a distinct cross-function cycle still declines `recursion`.
+
+      Frozen-safe: .text byte-identical (frozen 10/10; the only codegen-adjacent
+      change is a new current_func_index config field, byte-invisible). Richer
+      recursion certificates (clamp-bounded controlling values, data-dependent
+      depths, scry-supplied bounds) and inter-procedural recursion composition are
+      named follow-ups.
+
+    links:
+      - type: verifies
+        target: VCR-001
+      - type: refines
+        target: VCR-WCET-001
+    fields:
+      req-type: functional
+      priority: should
+      verification-criteria: >
+        crates/synth-cli/tests/wcet_bound_gate.rs (CI-gated, cargo test + explicit
+        ci.yml step) — 5 phase-4 fixtures: masked_recursion_correct_hint_converts_to_bound
+        (BOUNDED, derived max_depth 15 / frame_count 16 / 752 cyc EXACT literal +
+        frame floor; emitted depth is DERIVED not the raw hint),
+        masked_recursion_unhinted_still_declines (the decline the seam converts —
+        non-vacuity), masked_recursion_too_low_hint_rejected_red_first
+        (hint 3<15 → declined + hint-below-derived-depth, RED-FIRST),
+        tree_recursion_two_self_calls_rejected_even_with_hint (fib → declined +
+        hint-unverifiable-recursion — the fib-trap guard),
+        uncapped_countdown_recursion_hint_rejected_unverifiable,
+        mutual_recursion_stays_declined_even_with_hint. 3 pure-composer unit tests
+        in wcet_compose.rs (certified self folds depth frames / folds non-self
+        callee per-frame / a distinct mutual cycle STILL declines). Execution-side
+        cross-check: scripts/repro/wcet_phase4_49_recursion_soundness.py under
+        unicorn — md(0xFFFFFFFF) and md(0x7FFFFFFF) each execute 267 machine insns
+        across all 16 frames ≤ 752 cyc (entry-independent, the mask soundness
+        empirically confirmed). claims.yaml pins the (max_depth+1) frame fold;
+        claim_check green. Frozen anchors 10/10 untouched.

--- a/claims.yaml
+++ b/claims.yaml
@@ -629,3 +629,13 @@ claims:
         pattern: 'const BL_BLX_CALL_OVERHEAD_CYCLES: u64 = 4;'
         glob: ['crates/synth-backend/src/wcet.rs']
         expect: 1
+      # #778 phase 4 (#49) — the SOUND-critical self-recursion FRAME COUNT. A
+      # certified single-self-call chain of derived depth `d` runs `d+1` frames
+      # (the `+1` is the BASE frame, which executes own_cycles but no self-call);
+      # the composer folds `(max_depth+1) × frame_cost`. Omitting the +1 would
+      # undercount the base frame by one → unsound. Pinning the fold guards
+      # against a silent off-by-one regression.
+      - kind: count-eq
+        pattern: 'let frames = \(cert\.max_depth as u128\)\.saturating_add\(1\);'
+        glob: ['crates/synth-backend/src/wcet_compose.rs']
+        expect: 1

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -171,7 +171,14 @@ impl Backend for ArmBackend {
                 .wcet_hints
                 .as_ref()
                 .and_then(|h| h.functions.get(name));
-            crate::wcet::function_wcet_intermediate(name, instrs, &config.target.triple, hints)
+            let self_label = config.current_func_index.map(|i| format!("func_{i}"));
+            crate::wcet::function_wcet_intermediate(
+                name,
+                instrs,
+                &config.target.triple,
+                hints,
+                self_label.as_deref(),
+            )
         });
         // The SINGLE-FUNCTION standalone view (unresolved direct calls decline
         // `call`). Kept as a per-function fallback for any consumer that reads a

--- a/crates/synth-backend/src/lib.rs
+++ b/crates/synth-backend/src/lib.rs
@@ -40,6 +40,7 @@ pub mod vector_table;
 pub mod wcet;
 pub mod wcet_compose;
 mod wcet_loops;
+mod wcet_recursion;
 
 #[cfg(feature = "arm-cortex-m")]
 pub use arm_backend::ArmBackend;

--- a/crates/synth-backend/src/wcet.rs
+++ b/crates/synth-backend/src/wcet.rs
@@ -652,17 +652,21 @@ pub fn function_wcet_intermediate(
     // merged into this function's hint rejections.
     let mult_at_fn = |i: usize| mult_at(i);
     let recursion_hint = hints.and_then(|h| h.recursion_depth);
-    let (recursion_cert, mut rec_rejections) =
-        match crate::wcet_recursion::analyze_recursion(instrs, self_label, &mult_at_fn, recursion_hint) {
-            crate::wcet_recursion::RecursionAnalysis::NotRecursive => (None, Vec::new()),
-            crate::wcet_recursion::RecursionAnalysis::Unprovable { hint_rejections } => {
-                (None, hint_rejections)
-            }
-            crate::wcet_recursion::RecursionAnalysis::Certified {
-                cert,
-                hint_rejections,
-            } => (Some(cert), hint_rejections),
-        };
+    let (recursion_cert, mut rec_rejections) = match crate::wcet_recursion::analyze_recursion(
+        instrs,
+        self_label,
+        &mult_at_fn,
+        recursion_hint,
+    ) {
+        crate::wcet_recursion::RecursionAnalysis::NotRecursive => (None, Vec::new()),
+        crate::wcet_recursion::RecursionAnalysis::Unprovable { hint_rejections } => {
+            (None, hint_rejections)
+        }
+        crate::wcet_recursion::RecursionAnalysis::Certified {
+            cert,
+            hint_rejections,
+        } => (Some(cert), hint_rejections),
+    };
     let mut hint_rejections = hint_rejections;
     hint_rejections.append(&mut rec_rejections);
 

--- a/crates/synth-backend/src/wcet.rs
+++ b/crates/synth-backend/src/wcet.rs
@@ -535,7 +535,7 @@ pub fn function_wcet_with_hints(
     triple: &str,
     hints: Option<&WcetFunctionHints>,
 ) -> WcetFunction {
-    match function_wcet_intermediate(name, instrs, triple, hints) {
+    match function_wcet_intermediate(name, instrs, triple, hints, None) {
         WcetIntermediate::Declined {
             name,
             reason,
@@ -547,17 +547,21 @@ pub fn function_wcet_with_hints(
             instr_count,
             call_sites,
             loops,
+            recursion_cert: _,
             hint_rejections,
         } => {
             // No module context here: an unresolved direct call cannot be composed,
             // so a composable function WITH call sites declines `call`; one with no
-            // calls is a genuine intra-procedural bound.
+            // calls is a genuine intra-procedural bound. A self-recursion certificate
+            // is only foldable by the module composer (it needs the self-edge), so in
+            // this single-function view a recursive function still declines `call`.
             if call_sites.is_empty() {
                 WcetFunction::Bounded {
                     name,
                     cycles: own_cycles,
                     instr_count,
                     loops,
+                    recursion: None,
                     hint_rejections,
                 }
             } else {
@@ -582,6 +586,7 @@ pub fn function_wcet_intermediate(
     instrs: &[ArmInstruction],
     triple: &str,
     hints: Option<&WcetFunctionHints>,
+    self_label: Option<&str>,
 ) -> WcetIntermediate {
     let declined = |reason, hint_rejections| WcetIntermediate::Declined {
         name: name.to_string(),
@@ -639,12 +644,35 @@ pub fn function_wcet_intermediate(
         })
         .collect();
 
+    // #778 phase 4 (#49): if this function self-recurses (a `BL` to its own
+    // `func_<idx>` label), attempt a BOUNDED-recursion certificate. Only a
+    // single-self-call chain with an entry-independent masked-slot counter and a
+    // VERIFIED depth hint is certified; everything else keeps the phase-3
+    // `recursion` decline (moved here, never deleted). Rejected depth hints are
+    // merged into this function's hint rejections.
+    let mult_at_fn = |i: usize| mult_at(i);
+    let recursion_hint = hints.and_then(|h| h.recursion_depth);
+    let (recursion_cert, mut rec_rejections) =
+        match crate::wcet_recursion::analyze_recursion(instrs, self_label, &mult_at_fn, recursion_hint) {
+            crate::wcet_recursion::RecursionAnalysis::NotRecursive => (None, Vec::new()),
+            crate::wcet_recursion::RecursionAnalysis::Unprovable { hint_rejections } => {
+                (None, hint_rejections)
+            }
+            crate::wcet_recursion::RecursionAnalysis::Certified {
+                cert,
+                hint_rejections,
+            } => (Some(cert), hint_rejections),
+        };
+    let mut hint_rejections = hint_rejections;
+    hint_rejections.append(&mut rec_rejections);
+
     WcetIntermediate::Composable {
         name: name.to_string(),
         own_cycles,
         instr_count: instrs.len(),
         call_sites,
         loops,
+        recursion_cert,
         hint_rejections,
     }
 }

--- a/crates/synth-backend/src/wcet_compose.rs
+++ b/crates/synth-backend/src/wcet_compose.rs
@@ -124,8 +124,9 @@ pub fn compose(
             // back-edge to a certified self is NOT a Recursion decline. Any OTHER
             // cycle (mutual recursion, an uncertified self) still declines.
             let self_label: Option<&str> = recursion_cert.as_ref().map(|c| c.self_label.as_str());
-            let is_self_site =
-                |site: &synth_core::wcet::WcetCallSite| Some(site.callee_label.as_str()) == self_label;
+            let is_self_site = |site: &synth_core::wcet::WcetCallSite| {
+                Some(site.callee_label.as_str()) == self_label
+            };
 
             if !second {
                 // First visit: mark on-stack, schedule the second visit AFTER all
@@ -258,13 +259,13 @@ pub fn compose(
                         loops.clone(),
                         // #778 phase 4 (#49): surface the derived depth + frame count
                         // when this bound was composed via a self-recursion cert.
-                        recursion_cert.as_ref().map(|c| {
-                            synth_core::wcet::WcetRecursionBound {
+                        recursion_cert
+                            .as_ref()
+                            .map(|c| synth_core::wcet::WcetRecursionBound {
                                 max_depth: c.max_depth,
                                 frame_count: c.max_depth.saturating_add(1),
                                 hint: c.hint,
-                            }
-                        }),
+                            }),
                         hint_rejections.clone(),
                     ),
                     // A Bounded state always comes from a Composable node.

--- a/crates/synth-backend/src/wcet_compose.rs
+++ b/crates/synth-backend/src/wcet_compose.rs
@@ -106,6 +106,7 @@ pub fn compose(
             let WcetIntermediate::Composable {
                 own_cycles,
                 call_sites,
+                recursion_cert,
                 ..
             } = inter
             else {
@@ -116,12 +117,26 @@ pub fn compose(
                 continue;
             };
 
+            // #778 phase 4 (#49): a verified self-recursion certificate authorizes
+            // the function's OWN self-edge. The self-call site (`func_<idx>` == this
+            // node's own label) is DROPPED from the dependency graph — the recursive
+            // frames are folded analytically as `(max_depth+1) × frame_cost` — so a
+            // back-edge to a certified self is NOT a Recursion decline. Any OTHER
+            // cycle (mutual recursion, an uncertified self) still declines.
+            let self_label: Option<&str> = recursion_cert.as_ref().map(|c| c.self_label.as_str());
+            let is_self_site =
+                |site: &synth_core::wcet::WcetCallSite| Some(site.callee_label.as_str()) == self_label;
+
             if !second {
                 // First visit: mark on-stack, schedule the second visit AFTER all
                 // dependency resolutions (pushed on top, popped first).
                 state[i] = State::OnStack;
                 work.push((i, true));
                 for site in call_sites {
+                    // Skip the certified self-edge — it is not a graph dependency.
+                    if is_self_site(site) {
+                        continue;
+                    }
                     match index_by_func_label.get(&site.callee_label) {
                         None => {} // external — handled in the combine phase
                         Some(&callee) => match &state[callee] {
@@ -141,13 +156,21 @@ pub fn compose(
 
             // Second visit: every dependency is settled (or was a back-edge).
             // If this node itself was hit as a back-edge target, it is on a cycle.
-            if recursion_hits[i] {
+            // A CERTIFIED self is exempt: the only back-edge to it is its own
+            // (dropped) self-edge; a mutual cycle would still mark it via a
+            // DIFFERENT caller's non-self edge.
+            if recursion_hits[i] && recursion_cert.is_none() {
                 state[i] = State::Declined(WcetDecline::Recursion);
                 continue;
             }
-            let mut total: u128 = *own_cycles as u128;
+            // frame_cost = own body + every NON-self callee (counted at its site
+            // multiplier). own_cycles already prices the self-BL overhead once.
+            let mut frame_cost: u128 = *own_cycles as u128;
             let mut verdict: Option<WcetDecline> = None;
             for site in call_sites {
+                if is_self_site(site) {
+                    continue; // folded analytically below
+                }
                 let callee = match index_by_func_label.get(&site.callee_label) {
                     None => {
                         // Direct BL to a symbol with no body in this module.
@@ -158,7 +181,8 @@ pub fn compose(
                 };
                 match &state[callee] {
                     State::Bounded(c) => {
-                        total = total.saturating_add(site.multiplier.saturating_mul(*c as u128));
+                        frame_cost =
+                            frame_cost.saturating_add(site.multiplier.saturating_mul(*c as u128));
                     }
                     State::Declined(WcetDecline::Recursion) => {
                         verdict = Some(WcetDecline::Recursion);
@@ -177,6 +201,18 @@ pub fn compose(
                     }
                 }
             }
+            // Fold the certified self-recursion: `frame_count = max_depth + 1`
+            // frames (the base frame runs own_cycles but no self-call), each
+            // costing `frame_cost`. The self-call is a simple chain (single call
+            // per frame, multiplier 1, proven at certification), so summing
+            // frame_count × frame_cost is a sound upper bound.
+            let total: u128 = match (&verdict, recursion_cert.as_ref()) {
+                (None, Some(cert)) => {
+                    let frames = (cert.max_depth as u128).saturating_add(1);
+                    frame_cost.saturating_mul(frames)
+                }
+                _ => frame_cost,
+            };
             state[i] = match verdict {
                 Some(reason) => State::Declined(reason),
                 None => match u64::try_from(total) {
@@ -208,22 +244,32 @@ pub fn compose(
         .enumerate()
         .map(|(i, inter)| match &state[i] {
             State::Bounded(cycles) => {
-                let (name, instr_count, loops, hint_rejections) = match inter {
+                let (name, instr_count, loops, recursion, hint_rejections) = match inter {
                     WcetIntermediate::Composable {
                         name,
                         instr_count,
                         loops,
+                        recursion_cert,
                         hint_rejections,
                         ..
                     } => (
                         name.clone(),
                         *instr_count,
                         loops.clone(),
+                        // #778 phase 4 (#49): surface the derived depth + frame count
+                        // when this bound was composed via a self-recursion cert.
+                        recursion_cert.as_ref().map(|c| {
+                            synth_core::wcet::WcetRecursionBound {
+                                max_depth: c.max_depth,
+                                frame_count: c.max_depth.saturating_add(1),
+                                hint: c.hint,
+                            }
+                        }),
                         hint_rejections.clone(),
                     ),
                     // A Bounded state always comes from a Composable node.
                     WcetIntermediate::Declined { name, .. } => {
-                        (name.clone(), 0, Vec::new(), Vec::new())
+                        (name.clone(), 0, Vec::new(), None, Vec::new())
                     }
                 };
                 WcetFunction::Bounded {
@@ -231,6 +277,7 @@ pub fn compose(
                     cycles: *cycles,
                     instr_count,
                     loops,
+                    recursion,
                     hint_rejections,
                 }
             }
@@ -275,7 +322,44 @@ mod tests {
                 })
                 .collect(),
             loops: Vec::new(),
+            recursion_cert: None,
             hint_rejections: Vec::new(),
+        }
+    }
+
+    /// A composable node with a self-recursion certificate for `self_label` at
+    /// `max_depth` (the self-edge is folded `(max_depth+1)×frame_cost`).
+    fn recursive(
+        name: &str,
+        own: u64,
+        sites: &[(&str, u128)],
+        self_label: &str,
+        max_depth: u64,
+    ) -> WcetIntermediate {
+        let WcetIntermediate::Composable {
+            name,
+            own_cycles,
+            instr_count,
+            call_sites,
+            loops,
+            hint_rejections,
+            ..
+        } = composable(name, own, sites)
+        else {
+            unreachable!()
+        };
+        WcetIntermediate::Composable {
+            name,
+            own_cycles,
+            instr_count,
+            call_sites,
+            loops,
+            recursion_cert: Some(synth_core::wcet::WcetRecursionCert {
+                self_label: self_label.to_string(),
+                max_depth,
+                hint: max_depth,
+            }),
+            hint_rejections,
         }
     }
 
@@ -356,6 +440,41 @@ mod tests {
         let inters = vec![composable("func_0", 10, &[("func_0", 1)])];
         let out = compose(&inters, &labels(&["func_0"]));
         assert_eq!(reason_of(&out[0]), &WcetDecline::Recursion);
+    }
+
+    #[test]
+    fn certified_self_recursion_folds_depth_frames() {
+        // func_0 self-recurses (own 10) with a cert max_depth 3 → 4 frames × 10 = 40.
+        let inters = vec![recursive("func_0", 10, &[("func_0", 1)], "func_0", 3)];
+        let out = compose(&inters, &labels(&["func_0"]));
+        assert_eq!(cycles_of(&out[0]), 4 * 10); // (3+1) frames × own_cycles
+    }
+
+    #[test]
+    fn certified_self_recursion_folds_nonself_callee_per_frame() {
+        // func_1 self-recurses (own 5, cert depth 2 → 3 frames) and each frame also
+        // calls the leaf func_0 (own 10) once. Composed: 3 × (5 + 10) = 45.
+        let inters = vec![
+            composable("func_0", 10, &[]),
+            recursive("func_1", 5, &[("func_1", 1), ("func_0", 1)], "func_1", 2),
+        ];
+        let out = compose(&inters, &labels(&["func_0", "func_1"]));
+        assert_eq!(cycles_of(&out[0]), 10);
+        assert_eq!(cycles_of(&out[1]), 3 * (5 + 10)); // 45
+    }
+
+    #[test]
+    fn certified_self_still_declines_a_mutual_cycle() {
+        // func_0 has a self-cert BUT also participates in a mutual cycle with func_1
+        // (func_0→func_1→func_0). The mutual (non-self) cycle must STILL decline —
+        // the cert only exempts the self-edge, not a distinct cycle.
+        let inters = vec![
+            recursive("func_0", 10, &[("func_0", 1), ("func_1", 1)], "func_0", 3),
+            composable("func_1", 10, &[("func_0", 1)]),
+        ];
+        let out = compose(&inters, &labels(&["func_0", "func_1"]));
+        assert_eq!(reason_of(&out[0]), &WcetDecline::Recursion);
+        assert_eq!(reason_of(&out[1]), &WcetDecline::Recursion);
     }
 
     #[test]

--- a/crates/synth-backend/src/wcet_loops.rs
+++ b/crates/synth-backend/src/wcet_loops.rs
@@ -91,7 +91,7 @@ pub(crate) enum LoopAnalysis {
 
 /// Comparison relation of a predicate over the counter, by signedness.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Rel {
+pub(crate) enum Rel {
     Eq,
     Ne,
     LtS,
@@ -105,7 +105,7 @@ enum Rel {
 }
 
 impl Rel {
-    fn of(cond: Condition) -> Rel {
+    pub(crate) fn of(cond: Condition) -> Rel {
         match cond {
             Condition::EQ => Rel::Eq,
             Condition::NE => Rel::Ne,
@@ -121,7 +121,7 @@ impl Rel {
     }
 
     /// Logical negation over the same operands.
-    fn negate(self) -> Rel {
+    pub(crate) fn negate(self) -> Rel {
         match self {
             Rel::Eq => Rel::Ne,
             Rel::Ne => Rel::Eq,
@@ -140,17 +140,17 @@ impl Rel {
 /// A boolean predicate over the counter slot's REGION-ENTRY value `v`:
 /// `(v + add) REL rhs`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct Pred {
+pub(crate) struct Pred {
     /// SP-relative byte offset of the counter slot this predicate reads.
-    off: i64,
+    pub(crate) off: i64,
     /// Constant added to the entry value before the comparison.
-    add: i64,
-    rel: Rel,
-    rhs: i32,
+    pub(crate) add: i64,
+    pub(crate) rel: Rel,
+    pub(crate) rhs: i32,
 }
 
 impl Pred {
-    fn negate(self) -> Pred {
+    pub(crate) fn negate(self) -> Pred {
         Pred {
             rel: self.rel.negate(),
             ..self
@@ -1148,7 +1148,7 @@ fn shift_slots(st: &mut WalkState, delta: i64) {
 /// predicate's signedness domain. Returns `(n, requires_hint)`; equality exits
 /// set `requires_hint` (consumed only under a verified `--wcet-hints` entry).
 /// `None` = exit not statically guaranteed (or a possible wrap) → unproven.
-fn exit_index(init: i32, step: i64, p: &Pred) -> Option<(u64, bool)> {
+pub(crate) fn exit_index(init: i32, step: i64, p: &Pred) -> Option<(u64, bool)> {
     let s = step;
     debug_assert!(s != 0);
     let signed = matches!(

--- a/crates/synth-backend/src/wcet_recursion.rs
+++ b/crates/synth-backend/src/wcet_recursion.rs
@@ -1,0 +1,507 @@
+//! #778 phase 4 (#49) — sound static bound for a SINGLE-SELF-CALL recursion whose
+//! controlling value is ENTRY-INDEPENDENTLY bounded, plus the `--wcet-hints`
+//! `recursion_depth` sound-checker seam. Converts the `recursion` decline for
+//! exactly the shape synth can prove; every other recursion still LOUD-DECLINES.
+//!
+//! Phase 3 declined EVERY call-graph cycle. This module upgrades the ONE shape it
+//! can PROVE bounded and keeps declining the rest:
+//!
+//! - **Single-self-call chain**: the function contains EXACTLY ONE direct call to
+//!   its own `func_<idx>` label, executed at most once per frame (loop multiplier
+//!   1). More than one self-call, or a self-call inside a proven loop
+//!   (multiplier > 1), makes the call TREE branch — `depth × per-frame` would
+//!   under-count by an exponential factor (the fib trap) — so it declines.
+//! - **Entry-independent controlling value**: the base guard and the recursive
+//!   argument are formed from the SAME masked quantity `m = (param & mask)`, which
+//!   lies in `[0, mask]` for ANY runtime input. The recursive argument is
+//!   `m - step` (const step); the base guard fires at `m == base` on the path that
+//!   does NOT reach the self-call. Because `m ∈ [0, mask]` and decreases by `step`
+//!   each frame, the maximum recursion DEPTH is `exit_index(init = mask, step,
+//!   base_pred)` — an entry-independent ceiling DERIVED by synth (never the raw
+//!   hint), reusing the loop analyzer's wrap/divisibility-safe trip math.
+//!
+//! ## Why `depth × per-frame` is a sound upper bound here (and only here)
+//!
+//! 1. **Chain (not tree)**: exactly one self-call per frame, multiplier 1 ⇒ the
+//!    call graph unrolled from an entry is a simple PATH of length ≤ depth; the
+//!    total machine work is `Σ_{k=0..depth} frame_cost_k ≤ (depth+1) × max_frame_cost`.
+//!    The `+1` counts the BASE frame (which runs `own_cycles` but no self-call);
+//!    omitting it would undercount by one frame → unsound.
+//! 2. **Entry-independent depth**: `m = param & mask ∈ [0, mask]` regardless of the
+//!    runtime `param`; a strict decrease by `step` toward the base guard bounds the
+//!    number of recursive frames by `exit_index(mask, step, ·)`. Seeding the trip
+//!    math with `init = mask` is the WORST case over all inputs (real `m ≤ mask`,
+//!    and `(m - step) & mask ≤ m - step`, so real depth ≤ derived) — the mask buys
+//!    an entry-independent upper bound on an otherwise-runtime counter.
+//! 3. **Control-dependence**: the self-call is proven UNREACHABLE when the base
+//!    guard holds (the guard's taken target is a base block with no self-call; the
+//!    self-call sits on the guarded fall-through), so `m == base` never passes the
+//!    dangerous `base - step` into a re-mask (`(-1) & mask = mask` would diverge).
+//!    This is the linear-body analog of the loop analyzer's branch discipline.
+//! 4. **Hint discipline (the scry seam)**: the depth is DERIVED; a `--wcet-hints`
+//!    `recursion_depth` entry only GATES consumption (a bound this consequential is
+//!    opt-in, mirroring the equality-exit loop-hint gate). `hint < derived` →
+//!    `hint-below-derived-depth`; a structure synth cannot prove → any offered hint
+//!    is `hint-unverifiable-recursion`. The emitted depth is always synth's derived
+//!    ceiling.
+//!
+//! Anything the matcher does not precisely model → NO certificate → the function
+//! keeps the phase-3 `recursion` decline (the decline is MOVED, never deleted).
+
+use synth_core::wcet::{WcetHintReject, WcetHintRejection, WcetRecursionCert};
+use synth_synthesis::{ArmInstruction, ArmOp, Condition, Operand2, Reg};
+
+use crate::wcet_loops::{Pred, Rel, exit_index};
+
+/// Outcome of the self-recursion analysis over one function's final stream.
+pub(crate) enum RecursionAnalysis {
+    /// The function is not self-recursive (no `BL self_label`) — the caller
+    /// proceeds with the normal (non-recursion) intermediate.
+    NotRecursive,
+    /// The function self-recurses but synth could not prove a bounded chain, OR no
+    /// depth hint was offered — it keeps the `recursion` decline. Any offered hint
+    /// is recorded as rejected.
+    Unprovable {
+        hint_rejections: Vec<WcetHintRejection>,
+    },
+    /// A proven, hint-gated bounded self-recursion: the certificate + any rejected
+    /// hints. The caller attaches the certificate to the composable intermediate.
+    Certified {
+        cert: WcetRecursionCert,
+        hint_rejections: Vec<WcetHintRejection>,
+    },
+}
+
+/// Symbolic value the linear-body walk tracks. Deliberately tiny: only the shapes
+/// the canonical masked-recursion chain is built from; everything else is `Top`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Sym {
+    Top,
+    /// A compile-time constant.
+    Const(i32),
+    /// The raw incoming param value (whichever AAPCS register / spill slot it lives
+    /// in). All four in-arg registers alias the same logical "param" only if the
+    /// function has ONE controlling param — we track a single param identity keyed
+    /// by its origin register, so `Param(r)` means "the entry value of register r".
+    Param(Reg),
+    /// `(param_of(base) & mask)` — the masked controlling quantity, `∈ [0, mask]`.
+    Masked { base: Reg, mask: i32 },
+    /// `(param_of(base) & mask) + add` — the masked quantity shifted by a const
+    /// (the recursive-argument shape `m - step`).
+    MaskedStep { base: Reg, mask: i32, add: i64 },
+}
+
+/// Per-instruction walk state: symbolic registers + word SP slots + last compare.
+struct Walk {
+    regs: [Sym; 16],
+    /// SP-relative word slot → symbolic content (param spills; nothing else needed).
+    slots: std::collections::BTreeMap<i64, Sym>,
+    /// Operands of the last precisely-known compare (for the base guard predicate).
+    flags: Option<(Sym, Sym)>,
+}
+
+impl Walk {
+    /// Seed r0..r3 as their own entry-`Param` identities (the AAPCS integer args);
+    /// everything else is unknown.
+    fn entry() -> Self {
+        let mut regs = [Sym::Top; 16];
+        regs[Reg::R0 as usize] = Sym::Param(Reg::R0);
+        regs[Reg::R1 as usize] = Sym::Param(Reg::R1);
+        regs[Reg::R2 as usize] = Sym::Param(Reg::R2);
+        regs[Reg::R3 as usize] = Sym::Param(Reg::R3);
+        Walk {
+            regs,
+            slots: std::collections::BTreeMap::new(),
+            flags: None,
+        }
+    }
+
+    fn reg(&self, r: Reg) -> Sym {
+        self.regs[r as usize]
+    }
+    fn set(&mut self, r: Reg, v: Sym) {
+        self.regs[r as usize] = v;
+    }
+    fn op2(&self, o: &Operand2) -> Sym {
+        match o {
+            Operand2::Imm(c) => Sym::Const(*c),
+            Operand2::Reg(r) => self.reg(*r),
+            Operand2::RegShift { .. } => Sym::Top,
+        }
+    }
+}
+
+/// The base-guard predicate over the masked controlling value, resolved to the
+/// (base, mask) identity it reads.
+#[derive(Debug, Clone, Copy)]
+struct GuardPred {
+    base: Reg,
+    mask: i32,
+    /// `(m + add) REL rhs` where `m = param & mask`.
+    add: i64,
+    rel: Rel,
+    rhs: i32,
+}
+
+/// Analyze `instrs` for a bounded self-recursion. `self_label` is this function's
+/// own `func_<idx>` label; `mult_at(i)` gives instruction `i`'s proven loop
+/// execution-count multiplier (1 outside any proven loop). `hint` is the untrusted
+/// `recursion_depth` claim, if any.
+pub(crate) fn analyze_recursion(
+    instrs: &[ArmInstruction],
+    self_label: Option<&str>,
+    mult_at: &dyn Fn(usize) -> u128,
+    hint: Option<u64>,
+) -> RecursionAnalysis {
+    let Some(self_label) = self_label else {
+        return RecursionAnalysis::NotRecursive;
+    };
+
+    // ---- locate the self-call site(s) ----
+    let self_calls: Vec<usize> = instrs
+        .iter()
+        .enumerate()
+        .filter_map(|(i, ins)| match &ins.op {
+            ArmOp::Bl { label } if label == self_label => Some(i),
+            _ => None,
+        })
+        .collect();
+    if self_calls.is_empty() {
+        return RecursionAnalysis::NotRecursive;
+    }
+
+    // From here the function IS self-recursive: without a proof it declines
+    // `recursion`; any offered hint is rejected.
+    let reject = |reason: WcetHintReject| -> RecursionAnalysis {
+        let hint_rejections = hint
+            .map(|h| {
+                let note = reason.note().to_string();
+                vec![WcetHintRejection {
+                    loop_index: 0,
+                    head_offset: None,
+                    hint: h,
+                    reason,
+                    note,
+                }]
+            })
+            .unwrap_or_default();
+        RecursionAnalysis::Unprovable { hint_rejections }
+    };
+
+    // Gate 1: EXACTLY ONE self-call, executed once per frame (multiplier 1).
+    // Two self-calls (tree recursion, e.g. fib) or a self-call inside a proven
+    // loop would make `depth × per-frame` an exponential under-count.
+    if self_calls.len() != 1 {
+        return reject(WcetHintReject::HintUnverifiableRecursion);
+    }
+    let self_idx = self_calls[0];
+    if mult_at(self_idx) != 1 {
+        return reject(WcetHintReject::HintUnverifiableRecursion);
+    }
+
+    // Gate 2: the whole function must be free of OTHER backward branches (loops
+    // around the recursion) — analyze_loops already handles proven loops, but the
+    // control-dependence proof below assumes a linear body with only forward
+    // guards. A proven counted loop wrapping the self-call is out of scope
+    // (multiplier would be >1 and already rejected above); an UNPROVEN loop would
+    // have declined `loop` before we run. So here we only need to reject any
+    // backward branch defensively.
+    let byte = match byte_positions(instrs) {
+        Some(b) => b,
+        None => return reject(WcetHintReject::HintUnverifiableRecursion),
+    };
+
+    // Gate 3: prove the masked-chain structure + control dependence, derive depth.
+    let Some((base_pred, step)) = prove_masked_chain(instrs, self_idx, &byte) else {
+        return reject(WcetHintReject::HintUnverifiableRecursion);
+    };
+
+    // Derive max depth via the loop trip machinery, seeded with the worst-case
+    // entry-independent init = mask. The recursion continues while the base guard
+    // is FALSE; it exits (base) when the guard is TRUE. `exit_index` returns the
+    // number of steps until a predicate first HOLDS, so we pass the base predicate
+    // directly (predicate TRUE ⇒ base ⇒ stop) — its result is the count of
+    // recursive frames (steps taken before the base fires).
+    let p = Pred {
+        off: 0, // synthetic — exit_index reads only add/rel/rhs
+        add: base_pred.add,
+        rel: base_pred.rel,
+        rhs: base_pred.rhs,
+    };
+    let Some((derived_depth, _requires_hint)) = exit_index(base_pred.mask, step, &p) else {
+        // Step does not divide the distance, or the walk would wrap — not a
+        // guaranteed-terminating chain.
+        return reject(WcetHintReject::HintUnverifiableRecursion);
+    };
+
+    // Gate 4 (the scry seam): a bound this consequential is HINT-GATED. No hint ⇒
+    // keep the `recursion` decline (nothing rejected — none was offered).
+    let Some(h) = hint else {
+        return RecursionAnalysis::Unprovable {
+            hint_rejections: Vec::new(),
+        };
+    };
+    // Cross-check: a hint BELOW the derived ceiling is a wrong oracle claim.
+    if h < derived_depth {
+        return RecursionAnalysis::Unprovable {
+            hint_rejections: vec![WcetHintRejection {
+                loop_index: 0,
+                head_offset: None,
+                hint: h,
+                reason: WcetHintReject::HintBelowDerivedDepth,
+                note: WcetHintReject::HintBelowDerivedDepth.note().to_string(),
+            }],
+        };
+    }
+    // Accept: emit synth's DERIVED depth (never the raw hint).
+    RecursionAnalysis::Certified {
+        cert: WcetRecursionCert {
+            self_label: self_label.to_string(),
+            max_depth: derived_depth,
+            hint: h,
+        },
+        hint_rejections: Vec::new(),
+    }
+}
+
+/// Byte offset of each instruction from the REAL encoder (same source of truth the
+/// branch displacements were resolved against — the estimator is not exact).
+fn byte_positions(instrs: &[ArmInstruction]) -> Option<Vec<i64>> {
+    let encoder = crate::arm_encoder::ArmEncoder::new_thumb2();
+    let mut pos = Vec::with_capacity(instrs.len());
+    let mut p: i64 = 0;
+    for ins in instrs {
+        pos.push(p);
+        let bytes = encoder.encode(&ins.op).ok()?;
+        p += bytes.len() as i64;
+    }
+    Some(pos)
+}
+
+/// Prove the canonical masked-recursion chain around the single self-call at
+/// `self_idx`, returning `(base_guard_predicate, step)` on success.
+///
+/// Requirements (all load-bearing — see the module soundness argument):
+/// - a base guard `Cmp (param & mask), #rhs` + conditional branch whose TAKEN
+///   target is a block that does NOT contain the self-call, and whose FALL-THROUGH
+///   reaches the self-call (control dependence: self-call unreachable when guard
+///   holds);
+/// - the self-call argument in `R0` is `(param & mask) - step` reading the SAME
+///   (base, mask) the guard reads (identical masked quantity);
+/// - no other backward branch anywhere (a linear guarded body).
+fn prove_masked_chain(
+    instrs: &[ArmInstruction],
+    self_idx: usize,
+    byte: &[i64],
+) -> Option<(GuardPred, i64)> {
+    // Target byte of a Thumb-2 forward/backward branch at index `i`.
+    let target_byte = |i: usize, offset: i32| byte[i] + 4 + (offset as i64) * 2;
+    let idx_at = |b: i64| -> Option<usize> { byte.iter().position(|&p| p == b) };
+
+    // No backward branch may exist (a loop) — those are the loop analyzer's job and
+    // would already have been proven or declined; a residual one here breaks the
+    // linear-body control-dependence reasoning.
+    for (i, ins) in instrs.iter().enumerate() {
+        let off = match &ins.op {
+            ArmOp::BOffset { offset } => *offset,
+            ArmOp::BCondOffset { offset, .. } => *offset,
+            _ => continue,
+        };
+        if target_byte(i, off) <= byte[i] {
+            return None;
+        }
+    }
+
+    // Walk the linear body ONCE, tracking the masked quantity, the (single) base
+    // guard with its index + taken target, and R0 as it feeds the self-call.
+    let mut st = Walk::entry();
+    // (predicate, guard_instr_index, taken_target_index)
+    let mut guard: Option<(GuardPred, usize, usize)> = None;
+    // R0's symbolic value captured at the instant just before the self-call.
+    let mut arg_at_call: Option<Sym> = None;
+    for (i, ins) in instrs.iter().enumerate() {
+        if i == self_idx {
+            arg_at_call = Some(st.reg(Reg::R0));
+        }
+        match &ins.op {
+            ArmOp::BCondOffset { cond, offset } => {
+                if let Some(p) = eval_guard(*cond, &st.flags) {
+                    let tgt = target_byte(i, *offset);
+                    let ti = idx_at(tgt)?;
+                    // Only ONE base guard is modeled; a second distinct guard is a
+                    // non-canonical shape → decline.
+                    if guard.is_some() {
+                        return None;
+                    }
+                    guard = Some((p, i, ti));
+                }
+                // A conditional branch that is NOT a recognized masked base guard
+                // is fine as long as control-dependence still holds (checked below
+                // via the recorded guard); it does not update regs/flags.
+            }
+            op => step_sym(op, &mut st),
+        }
+    }
+    let (gpred, guard_idx, taken_idx) = guard?;
+    let arg = arg_at_call?;
+
+    // Control-dependence: the self-call must sit strictly AFTER the guard and
+    // strictly BEFORE the guard's taken target (the base block), so it is provably
+    // unreachable when the guard fires (base case). This is what stops the
+    // dangerous `base - step` from ever re-entering the mask.
+    if !(guard_idx < self_idx && self_idx < taken_idx) {
+        return None;
+    }
+
+    // The self-call argument in R0 must be the SAME masked quantity minus a const
+    // step (range containment: identical (base, mask) as the guard).
+    let (abase, amask, aadd) = match arg {
+        Sym::MaskedStep { base, mask, add } => (base, mask, add),
+        _ => return None, // no const shift on the masked value → not a chain
+    };
+    if abase != gpred.base || amask != gpred.mask {
+        return None; // different masked quantity — range containment broken
+    }
+    let step = aadd; // counter moves by `aadd` each frame (negative = countdown)
+    if step == 0 {
+        return None;
+    }
+    Some((gpred, step))
+}
+
+/// One symbolic step for a non-branch op. Models exactly the masked-chain ops;
+/// everything else conservatively kills its destination (→ Top).
+fn step_sym(op: &ArmOp, st: &mut Walk) {
+    use ArmOp::*;
+    match op {
+        Mov { rd, op2 } => {
+            let v = st.op2(op2);
+            st.set(*rd, v);
+            st.flags = None;
+        }
+        And { rd, rn, op2 } => {
+            // The masking op: (param & const) → Masked. Only a param source with a
+            // const mask is modeled.
+            let v = match (st.reg(*rn), st.op2(op2)) {
+                (Sym::Param(base), Sym::Const(mask)) => Sym::Masked { base, mask },
+                _ => Sym::Top,
+            };
+            st.set(*rd, v);
+            st.flags = None;
+        }
+        Add { rd, rn, op2 } | Adds { rd, rn, op2 } => {
+            let v = masked_shift(st.reg(*rn), st.op2(op2), 1);
+            st.set(*rd, v);
+            st.flags = None;
+        }
+        Sub { rd, rn, op2 } | Subs { rd, rn, op2 } => {
+            let v = masked_shift(st.reg(*rn), st.op2(op2), -1);
+            st.set(*rd, v);
+            st.flags = None;
+        }
+        Str { rd, addr } => {
+            if addr.base == Reg::SP && addr.offset_reg.is_none() {
+                st.slots.insert(addr.offset as i64, st.reg(*rd));
+            }
+        }
+        Ldr { rd, addr } => {
+            let v = if addr.base == Reg::SP && addr.offset_reg.is_none() {
+                st.slots
+                    .get(&(addr.offset as i64))
+                    .copied()
+                    .unwrap_or(Sym::Top)
+            } else {
+                Sym::Top
+            };
+            st.set(*rd, v);
+        }
+        Cmp { rn, op2 } => {
+            st.flags = Some((st.reg(*rn), st.op2(op2)));
+        }
+        SetCond { rd, .. } => {
+            // A cmp→setcond→cmp #0 chain: the guard predicate is recovered from the
+            // ORIGINAL compare when the SetCond's boolean is later compared to 0.
+            // We keep the flags (the first compare) so eval_guard can read them —
+            // but SetCond writes a boolean into rd, so track that specially.
+            st.set(*rd, Sym::Top);
+            // NB: flags preserved (SetCond does not clobber the recorded compare in
+            // our model) so the subsequent `Cmp rd,#0` can be tied back. However our
+            // eval_guard reads the LAST compare; see eval_guard for the shape it
+            // accepts.
+        }
+        Label { .. } | Nop => {}
+        // Any other op: kill its destination register(s) conservatively.
+        _ => {
+            if let Some(rd) = dest_reg(op) {
+                st.set(rd, Sym::Top);
+            }
+            st.flags = None;
+        }
+    }
+}
+
+/// `a + sign*b` restricted to the MaskedStep affine domain.
+fn masked_shift(a: Sym, b: Sym, sign: i64) -> Sym {
+    match (a, b) {
+        (Sym::Const(x), Sym::Const(y)) => {
+            i32::try_from(x as i64 + sign * y as i64).map_or(Sym::Top, Sym::Const)
+        }
+        (Sym::Masked { base, mask }, Sym::Const(y)) => {
+            let add = sign * y as i64;
+            if add.abs() <= 1 << 20 {
+                Sym::MaskedStep { base, mask, add }
+            } else {
+                Sym::Top
+            }
+        }
+        (Sym::MaskedStep { base, mask, add }, Sym::Const(y)) => {
+            match add.checked_add(sign * y as i64) {
+                Some(na) if na.abs() <= 1 << 20 => Sym::MaskedStep { base, mask, add: na },
+                _ => Sym::Top,
+            }
+        }
+        _ => Sym::Top,
+    }
+}
+
+/// Recover the base-guard predicate over a masked quantity from the last compare.
+///
+/// The lowering shape (from the real stream) is
+/// `Cmp (param&mask), #0 ; SetCond <cc> Rb ; Cmp Rb, #0 ; BCond EQ`.
+/// But synth also emits the DIRECT `Cmp (param&mask), #rhs ; BCond <cc>` shape.
+/// We accept the DIRECT masked compare (Masked vs Const) — the SetCond-boolean
+/// indirection collapses to it because the WASM `eqz`/`if` lowering ultimately
+/// branches on the masked value's relation to a constant.
+fn eval_guard(cond: Condition, flags: &Option<(Sym, Sym)>) -> Option<GuardPred> {
+    let (a, b) = flags.as_ref()?;
+    match (a, b) {
+        (Sym::Masked { base, mask }, Sym::Const(c)) => Some(GuardPred {
+            base: *base,
+            mask: *mask,
+            add: 0,
+            rel: Rel::of(cond),
+            rhs: *c,
+        }),
+        (Sym::MaskedStep { base, mask, add }, Sym::Const(c)) => Some(GuardPred {
+            base: *base,
+            mask: *mask,
+            add: *add,
+            rel: Rel::of(cond),
+            rhs: *c,
+        }),
+        _ => None,
+    }
+}
+
+/// Best-effort destination register of an op (for conservative kills).
+fn dest_reg(op: &ArmOp) -> Option<Reg> {
+    use ArmOp::*;
+    match op {
+        Add { rd, .. } | Sub { rd, .. } | Adds { rd, .. } | Subs { rd, .. } | And { rd, .. }
+        | Orr { rd, .. } | Eor { rd, .. } | Mov { rd, .. } | Movw { rd, .. } | Movt { rd, .. }
+        | Lsl { rd, .. } | Lsr { rd, .. } | Asr { rd, .. } | Ror { rd, .. } | Mul { rd, .. }
+        | Rsb { rd, .. } | Mvn { rd, .. } | Clz { rd, .. } | Uxtb { rd, .. } | Uxth { rd, .. }
+        | Sxtb { rd, .. } | Sxth { rd, .. } | SetCond { rd, .. } => Some(*rd),
+        _ => None,
+    }
+}

--- a/crates/synth-backend/src/wcet_recursion.rs
+++ b/crates/synth-backend/src/wcet_recursion.rs
@@ -223,23 +223,42 @@ pub(crate) fn analyze_recursion(
         return reject(WcetHintReject::HintUnverifiableRecursion);
     };
 
-    // Derive max depth via the loop trip machinery, seeded with the worst-case
-    // entry-independent init = mask. The recursion continues while the base guard
-    // is FALSE; it exits (base) when the guard is TRUE. `exit_index` returns the
-    // number of steps until a predicate first HOLDS, so we pass the base predicate
-    // directly (predicate TRUE ⇒ base ⇒ stop) — its result is the count of
-    // recursive frames (steps taken before the base fires).
+    // Derive max depth via the loop trip machinery. The controlling value at the
+    // first frame is `m ∈ [0, mask]` (any runtime input, by the mask); the recursion
+    // continues while the base guard is FALSE and stops when it holds. `exit_index`
+    // returns the number of steps until the base predicate first HOLDS for a GIVEN
+    // init, so the true worst-case depth is the MAX over the valid init domain
+    // `[0, mask]`. For a monotone counter that max is at an ENDPOINT (0 or mask)
+    // depending on step direction — but rather than reason about which, we evaluate
+    // BOTH endpoints and require BOTH terminate, taking the max. (Seeding only `mask`
+    // would UNDER-estimate a count-up whose worst case is init 0.) If either
+    // endpoint fails to terminate (step walks away, or a wrap), the chain is not
+    // guaranteed-terminating for all inputs → decline.
     let p = Pred {
         off: 0, // synthetic — exit_index reads only add/rel/rhs
         add: base_pred.add,
         rel: base_pred.rel,
         rhs: base_pred.rhs,
     };
-    let Some((derived_depth, _requires_hint)) = exit_index(base_pred.mask, step, &p) else {
-        // Step does not divide the distance, or the walk would wrap — not a
-        // guaranteed-terminating chain.
+    // Endpoint reasoning is sound only when `exit_index` is MONOTONE in init over
+    // `[0, mask]`. For a threshold predicate (<, <=, >, >=) it is. For an
+    // equality/inequality base guard, an INTERIOR init can diverge (miss the target
+    // residue class) even when both endpoints land — so restrict Eq/Ne base guards
+    // to step magnitude 1, where EVERY init in `[0, mask]` reaches the target and
+    // monotonicity holds. (A larger step with an Eq guard is exactly the
+    // divisibility-divergence trap; refusing it keeps the endpoint bound sound.)
+    if matches!(base_pred.rel, Rel::Eq | Rel::Ne) && step.abs() != 1 {
+        return reject(WcetHintReject::HintUnverifiableRecursion);
+    }
+    let (Some((d_hi, _)), Some((d_lo, _))) = (
+        exit_index(base_pred.mask, step, &p),
+        exit_index(0, step, &p),
+    ) else {
+        // An endpoint does not terminate (step does not divide the distance, walks
+        // away, or wraps) → not a bounded chain for all inputs.
         return reject(WcetHintReject::HintUnverifiableRecursion);
     };
+    let derived_depth = d_hi.max(d_lo);
 
     // Gate 4 (the scry seam): a bound this consequential is HINT-GATED. No hint ⇒
     // keep the `recursion` decline (nothing rejected — none was offered).
@@ -358,6 +377,37 @@ fn prove_masked_chain(
     // dangerous `base - step` from ever re-entering the mask.
     if !(guard_idx < self_idx && self_idx < taken_idx) {
         return None;
+    }
+
+    // STRAIGHT-LINE + SINGLE-ENTRY region `(guard_idx, self_idx]`. The linear walk
+    // applied the arg computation (the decrement) UNCONDITIONALLY; that is only a
+    // valid model if the region between the guard and the self-call has NO control
+    // flow — otherwise a runtime path could SKIP the decrement (passing `m`
+    // unchanged) and recurse unbounded while the walk still saw `m - step`. Two
+    // hard checks, the linear-body analog of the loop analyzer's branch discipline:
+    //   (a) no branch instruction sits inside the region (unconditional body), and
+    //   (b) no branch ANYWHERE targets a byte strictly inside the region (single
+    //       entry — control cannot jump PAST the decrement into the self-call).
+    if instrs[(guard_idx + 1)..=self_idx]
+        .iter()
+        .any(|ins| matches!(&ins.op, ArmOp::BOffset { .. } | ArmOp::BCondOffset { .. }))
+    {
+        return None; // (a) conditional/unconditional flow inside the region
+    }
+    let region_lo = byte[guard_idx + 1];
+    let region_hi = byte[self_idx]; // byte of the self-call BL
+    for (i, ins) in instrs.iter().enumerate() {
+        let off = match &ins.op {
+            ArmOp::BOffset { offset } => *offset,
+            ArmOp::BCondOffset { offset, .. } => *offset,
+            _ => continue,
+        };
+        let tgt = target_byte(i, off);
+        // A target strictly INSIDE the region (after its first instruction, at or
+        // before the self-call) is a second entry that could bypass the decrement.
+        if tgt > region_lo && tgt <= region_hi {
+            return None; // (b) mid-region entry — not single-entry
+        }
     }
 
     // The self-call argument in R0 must be the SAME masked quantity minus a const

--- a/crates/synth-backend/src/wcet_recursion.rs
+++ b/crates/synth-backend/src/wcet_recursion.rs
@@ -85,10 +85,17 @@ enum Sym {
     /// by its origin register, so `Param(r)` means "the entry value of register r".
     Param(Reg),
     /// `(param_of(base) & mask)` — the masked controlling quantity, `∈ [0, mask]`.
-    Masked { base: Reg, mask: i32 },
+    Masked {
+        base: Reg,
+        mask: i32,
+    },
     /// `(param_of(base) & mask) + add` — the masked quantity shifted by a const
     /// (the recursive-argument shape `m - step`).
-    MaskedStep { base: Reg, mask: i32, add: i64 },
+    MaskedStep {
+        base: Reg,
+        mask: i32,
+        add: i64,
+    },
 }
 
 /// Per-instruction walk state: symbolic registers + word SP slots + last compare.
@@ -456,7 +463,11 @@ fn masked_shift(a: Sym, b: Sym, sign: i64) -> Sym {
         }
         (Sym::MaskedStep { base, mask, add }, Sym::Const(y)) => {
             match add.checked_add(sign * y as i64) {
-                Some(na) if na.abs() <= 1 << 20 => Sym::MaskedStep { base, mask, add: na },
+                Some(na) if na.abs() <= 1 << 20 => Sym::MaskedStep {
+                    base,
+                    mask,
+                    add: na,
+                },
                 _ => Sym::Top,
             }
         }
@@ -497,11 +508,29 @@ fn eval_guard(cond: Condition, flags: &Option<(Sym, Sym)>) -> Option<GuardPred> 
 fn dest_reg(op: &ArmOp) -> Option<Reg> {
     use ArmOp::*;
     match op {
-        Add { rd, .. } | Sub { rd, .. } | Adds { rd, .. } | Subs { rd, .. } | And { rd, .. }
-        | Orr { rd, .. } | Eor { rd, .. } | Mov { rd, .. } | Movw { rd, .. } | Movt { rd, .. }
-        | Lsl { rd, .. } | Lsr { rd, .. } | Asr { rd, .. } | Ror { rd, .. } | Mul { rd, .. }
-        | Rsb { rd, .. } | Mvn { rd, .. } | Clz { rd, .. } | Uxtb { rd, .. } | Uxth { rd, .. }
-        | Sxtb { rd, .. } | Sxth { rd, .. } | SetCond { rd, .. } => Some(*rd),
+        Add { rd, .. }
+        | Sub { rd, .. }
+        | Adds { rd, .. }
+        | Subs { rd, .. }
+        | And { rd, .. }
+        | Orr { rd, .. }
+        | Eor { rd, .. }
+        | Mov { rd, .. }
+        | Movw { rd, .. }
+        | Movt { rd, .. }
+        | Lsl { rd, .. }
+        | Lsr { rd, .. }
+        | Asr { rd, .. }
+        | Ror { rd, .. }
+        | Mul { rd, .. }
+        | Rsb { rd, .. }
+        | Mvn { rd, .. }
+        | Clz { rd, .. }
+        | Uxtb { rd, .. }
+        | Uxth { rd, .. }
+        | Sxtb { rd, .. }
+        | Sxth { rd, .. }
+        | SetCond { rd, .. } => Some(*rd),
         _ => None,
     }
 }

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -3173,6 +3173,10 @@ fn compile_all_exports(
             // cap the access-pattern param inference that mistook a
             // read-before-write non-param local for a param.
             fc.current_func_param_count = config.func_arg_counts.get(func.index as usize).copied();
+            // #778 phase 4 / #49: THIS function's WASM index, so the WCET pass can
+            // identify its own `func_<idx>` self-call and prove/decline the
+            // self-recursion depth.
+            fc.current_func_index = Some(func.index);
             // VCR-PERF-002 Phase 1 (#494): THIS function's wsc.facts slice
             // (`compile_function` carries no function index — the same reason
             // `current_func_params_i64` exists). Not yet consumed.

--- a/crates/synth-cli/tests/wcet_bound_gate.rs
+++ b/crates/synth-cli/tests/wcet_bound_gate.rs
@@ -1095,6 +1095,37 @@ fn mutual_recursion_stays_declined_even_with_hint() {
     assert_declined(&report, "pong", "recursion");
 }
 
+/// DECLINE-HONESTY (conditional decrement): the controlling value is masked
+/// (`m = param & 15`) and the base guard is on it, BUT the decrement is applied
+/// only under a SECOND guard on the RAW param (`param > 100`). A runtime path with
+/// `param ≤ 100` recurses with `m` UNCHANGED → unbounded. The straight-line +
+/// single-entry region check (the guard→self-call arg computation must be
+/// unconditional) catches this: REJECTED `hint-unverifiable-recursion`, declined.
+/// This is the adversarial guard against modeling a conditional decrement as
+/// unconditional — without the region check this fixture would emit a bound < a
+/// real (infinite) execution.
+#[test]
+fn conditional_decrement_recursion_rejected_unverifiable() {
+    let wat = r#"
+        (module
+          (func $f (export "f") (param i32) (result i32)
+            (local i32)
+            local.get 0 i32.const 15 i32.and
+            (if (result i32)
+              (then
+                (local.set 1 (i32.and (local.get 0) (i32.const 15)))
+                (if (i32.gt_s (local.get 0) (i32.const 100))
+                  (then (local.set 1 (i32.sub (local.get 1) (i32.const 1)))))
+                (call $f (local.get 1))
+                i32.const 1 i32.add)
+              (else i32.const 0))))
+    "#;
+    let hints = r#"{"schema":"synth-wcet-hints-v1","functions":{"f":{"recursion_depth":15}}}"#;
+    let report = compile_wcet_hinted(wat, "cortex-m4", Some(hints));
+    assert_declined(&report, "f", "recursion");
+    assert_hint_rejection(&report, "f", "hint-unverifiable-recursion", 15);
+}
+
 /// Assert `name` carries a hint rejection with EXACTLY `reason` and `hint`.
 fn assert_hint_rejection(report: &Value, name: &str, reason: &str, hint: u64) {
     let f = func(report, name);

--- a/crates/synth-cli/tests/wcet_bound_gate.rs
+++ b/crates/synth-cli/tests/wcet_bound_gate.rs
@@ -949,6 +949,170 @@ fn hints_cli_misuse_fails_loudly() {
 }
 
 // ---------------------------------------------------------------------------
+// #778 phase 4 (#49) — bounded self-recursion via a VERIFIED depth-hint.
+//
+// The `recursion` decline is CONVERTED for exactly ONE provably-sound shape: a
+// single-self-call chain whose controlling value is entry-independently bounded by
+// a mask (`m = param & K ∈ [0,K]`), decreasing by a const step toward a base guard
+// on the SAME masked quantity. synth DERIVES its own max depth (never the raw
+// hint); the hint only gates consumption. RED-FIRST: the wrong/unverifiable
+// rejections are asserted alongside the conversion, and the tree/uncapped/mutual
+// shapes STILL decline (decline-honesty MOVED, not deleted).
+// ---------------------------------------------------------------------------
+
+/// The masked-recursion ACCEPT fixture: `m = param & 15 ∈ [0,15]`; recurse while
+/// `m != 0` passing `m-1`; base returns 0. Depth ≤ 15 for ANY i32 input (the mask
+/// buys an entry-independent ceiling). Own body 47 cyc × 16 frames = 752.
+const MASKED_REC_WAT: &str = r#"
+    (module
+      (func $md (export "md") (param i32) (result i32)
+        local.get 0 i32.const 15 i32.and
+        (if (result i32)
+          (then
+            local.get 0 i32.const 15 i32.and i32.const 1 i32.sub call $md i32.const 1 i32.add)
+          (else i32.const 0))))
+"#;
+
+/// GREEN: a correct depth hint (15 ≥ synth's DERIVED ceiling 15) converts the
+/// `recursion` decline into a bound. The emitted `max_depth` is synth's DERIVED
+/// value 15, `frame_count` 16 (the +1 base frame), never the raw hint. The exact
+/// bound literal (752 = 16 × 47) is pinned — a lowering change fails loud.
+/// unicorn ground truth (phase-4 harness): md(0xFFFFFFFF)=r0 15, 267 executed
+/// machine insns across all frames ≤ 752 (entry-independent).
+#[test]
+fn masked_recursion_correct_hint_converts_to_bound() {
+    let hints = r#"{"schema":"synth-wcet-hints-v1","functions":{"md":{"recursion_depth":15}}}"#;
+    let report = compile_wcet_hinted(MASKED_REC_WAT, "cortex-m4", Some(hints));
+    assert_bounded(&report, "md", 752);
+    let f = func(&report, "md");
+    let rec = f
+        .get("recursion")
+        .unwrap_or_else(|| panic!("bounded recursion must carry a `recursion` record: {f}"));
+    assert_eq!(
+        rec.get("max_depth").and_then(Value::as_u64),
+        Some(15),
+        "emitted depth must be synth's DERIVED ceiling (15), not the raw hint: {rec}"
+    );
+    assert_eq!(
+        rec.get("frame_count").and_then(Value::as_u64),
+        Some(16),
+        "frame_count must be max_depth+1 (the base frame counts): {rec}"
+    );
+    // Trip-aware floor: 16 frames each running the whole body must not exceed the
+    // bound (every instruction costs ≥ 1 cycle).
+    let instrs = f.get("instr_count").and_then(Value::as_u64).unwrap();
+    assert!(
+        752 >= 16 * instrs,
+        "bound 752 < 16 frames × {instrs} instrs — unsound"
+    );
+}
+
+/// Unhinted, the masked shape STAYS declined `recursion` — the decline the hint
+/// seam converts (asserted so the conversion above is non-vacuous). A bound this
+/// consequential is opt-in (mirroring the equality-exit loop-hint gate).
+#[test]
+fn masked_recursion_unhinted_still_declines() {
+    let report = compile_wcet(MASKED_REC_WAT, "cortex-m4");
+    assert_declined(&report, "md", "recursion");
+}
+
+/// RED: a too-LOW depth hint (3 < synth's derived ceiling 15) is REJECTED
+/// `hint-below-derived-depth` and the function STAYS declined — a wrong oracle
+/// claim never becomes a bound.
+#[test]
+fn masked_recursion_too_low_hint_rejected_red_first() {
+    let hints = r#"{"schema":"synth-wcet-hints-v1","functions":{"md":{"recursion_depth":3}}}"#;
+    let report = compile_wcet_hinted(MASKED_REC_WAT, "cortex-m4", Some(hints));
+    assert_declined(&report, "md", "recursion");
+    assert_hint_rejection(&report, "md", "hint-below-derived-depth", 3);
+}
+
+/// DECLINE-HONESTY (tree recursion): a TWO-self-call fixture (fib-shaped) — even
+/// masked and hinted — is REJECTED `hint-unverifiable-recursion` and stays
+/// declined. `depth × per-frame` would under-count the exponential frame tree; the
+/// single-self-call gate is the direct guard against that fatal class.
+#[test]
+fn tree_recursion_two_self_calls_rejected_even_with_hint() {
+    let wat = r#"
+        (module
+          (func $fib (export "fib") (param i32) (result i32)
+            local.get 0 i32.const 15 i32.and i32.const 2 i32.lt_s
+            (if (result i32)
+              (then i32.const 1)
+              (else
+                local.get 0 i32.const 15 i32.and i32.const 1 i32.sub call $fib
+                local.get 0 i32.const 15 i32.and i32.const 2 i32.sub call $fib
+                i32.add))))
+    "#;
+    let hints = r#"{"schema":"synth-wcet-hints-v1","functions":{"fib":{"recursion_depth":15}}}"#;
+    let report = compile_wcet_hinted(wat, "cortex-m4", Some(hints));
+    assert_declined(&report, "fib", "recursion");
+    assert_hint_rejection(&report, "fib", "hint-unverifiable-recursion", 15);
+}
+
+/// DECLINE-HONESTY (uncapped countdown): base at `param == 0`, recursive arg
+/// `param - 1` with NO mask on the arg path → the controlling value is a raw
+/// runtime param, unbounded at one end of i32 (negative entries diverge). A depth
+/// hint is REJECTED `hint-unverifiable-recursion`; the function stays declined.
+#[test]
+fn uncapped_countdown_recursion_hint_rejected_unverifiable() {
+    let wat = r#"
+        (module
+          (func $count (export "count") (param i32) (result i32)
+            local.get 0 i32.eqz
+            (if (result i32)
+              (then i32.const 0)
+              (else local.get 0 i32.const 1 i32.sub call $count i32.const 1 i32.add))))
+    "#;
+    let hints = r#"{"schema":"synth-wcet-hints-v1","functions":{"count":{"recursion_depth":100}}}"#;
+    let report = compile_wcet_hinted(wat, "cortex-m4", Some(hints));
+    assert_declined(&report, "count", "recursion");
+    assert_hint_rejection(&report, "count", "hint-unverifiable-recursion", 100);
+}
+
+/// DECLINE-HONESTY (mutual recursion): a two-function cycle — even if one carries a
+/// (self-shaped) depth hint — declines `recursion` on BOTH. The certificate only
+/// exempts a function's OWN self-edge; a distinct cross-function cycle is not a
+/// self-recursion and is never converted.
+#[test]
+fn mutual_recursion_stays_declined_even_with_hint() {
+    let wat = r#"
+        (module
+          (func $ping (export "ping") (param i32) (result i32)
+            local.get 0 i32.eqz
+            (if (result i32)
+              (then i32.const 0)
+              (else local.get 0 i32.const 1 i32.sub call $pong)))
+          (func $pong (export "pong") (param i32) (result i32)
+            local.get 0 i32.eqz
+            (if (result i32)
+              (then i32.const 1)
+              (else local.get 0 i32.const 1 i32.sub call $ping))))
+    "#;
+    let hints = r#"{"schema":"synth-wcet-hints-v1","functions":{"ping":{"recursion_depth":50}}}"#;
+    let report = compile_wcet_hinted(wat, "cortex-m4", Some(hints));
+    assert_declined(&report, "ping", "recursion");
+    assert_declined(&report, "pong", "recursion");
+}
+
+/// Assert `name` carries a hint rejection with EXACTLY `reason` and `hint`.
+fn assert_hint_rejection(report: &Value, name: &str, reason: &str, hint: u64) {
+    let f = func(report, name);
+    let rej = f
+        .get("hint_rejections")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .find(|r| r.get("reason").and_then(Value::as_str) == Some(reason))
+        .unwrap_or_else(|| panic!("{name}: expected a hint rejection `{reason}` (entry: {f})"));
+    assert_eq!(
+        rej.get("hint").and_then(Value::as_u64),
+        Some(hint),
+        "{name}: rejection carries the offered hint value (record: {rej})"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Phase-2 assertion helpers.
 // ---------------------------------------------------------------------------
 

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -267,6 +267,13 @@ pub struct CompileConfig {
     /// `None` → declared signature unknown (hand-built op streams, direct
     /// `compile_function` callers) → pure inference, the legacy behaviour.
     pub current_func_param_count: Option<u32>,
+    /// (#778 phase 4 / #49) The WASM index of the function CURRENTLY being compiled,
+    /// so the WCET pass can identify this function's OWN `func_<idx>` self-call label
+    /// (a self-recursive `BL func_N` where N == this index) and prove/decline the
+    /// self-recursion depth. Set per function by the driver loop (like
+    /// [`current_func_params_i64`]). `None` → unknown (hand-built op streams, direct
+    /// `compile_function` callers) → no self-recursion certificate is attempted.
+    pub current_func_index: Option<u32>,
     /// #509: blocktype-arity side-table of the function CURRENTLY being compiled
     /// — `(param_count, result_count)` of the k-th `Block`/`Loop`/`If` in its op
     /// stream (ordinal-keyed; see [`FunctionOps::block_arity`]). Set per function
@@ -458,6 +465,7 @@ impl Default for CompileConfig {
             // #457: None ⇒ declared signature unknown ⇒ param-count inference
             // only (unit tests / hand-built op streams); driver loops fill it.
             current_func_param_count: None,
+            current_func_index: None,
             // #509: empty ⇒ legacy void-block lowering (unit tests / hand-built
             // op streams); the driver loops fill it per function.
             current_func_block_arity: Vec::new(),

--- a/crates/synth-core/src/wcet.rs
+++ b/crates/synth-core/src/wcet.rs
@@ -216,6 +216,18 @@ pub enum WcetHintReject {
     /// The hint indexes a loop that does not exist in this function's final
     /// instruction stream.
     HintUnknownLoop,
+    /// A recursion-depth hint (`recursion_depth`) was offered but synth could NOT
+    /// verify the self-recursion is a single-self-call chain whose controlling
+    /// value is entry-independently bounded (a masked-slot counter decreasing by a
+    /// const step toward a base guard on the SAME masked quantity). Without an
+    /// entry-independent ceiling the true depth is runtime-unbounded, so the hint
+    /// is never trusted into a bound. (#778 phase 4 / #49.)
+    HintUnverifiableRecursion,
+    /// A recursion-depth hint is SMALLER than synth's own DERIVED maximum depth
+    /// (the entry-independent ceiling proven from the masked-slot induction). A
+    /// hint below the derived depth is a wrong oracle claim — trusting it would
+    /// emit a bound < a real execution (the fatal class). (#778 phase 4 / #49.)
+    HintBelowDerivedDepth,
 }
 
 impl WcetHintReject {
@@ -234,6 +246,18 @@ impl WcetHintReject {
             WcetHintReject::HintUnknownLoop => {
                 "hint indexes a loop that does not exist in the final \
                  instruction stream"
+            }
+            WcetHintReject::HintUnverifiableRecursion => {
+                "recursion-depth hint not verifiable — the self-recursion is not a \
+                 single-self-call chain whose controlling value is entry-independently \
+                 bounded (masked-slot counter decreasing by a const step toward a base \
+                 guard on the same masked quantity); depth is runtime-unbounded, so \
+                 the hint is never trusted into a bound"
+            }
+            WcetHintReject::HintBelowDerivedDepth => {
+                "recursion-depth hint is below synth's derived maximum depth (the \
+                 entry-independent ceiling proven from the masked-slot induction) — \
+                 a wrong hint; trusting it would emit an unsound bound"
             }
         }
     }
@@ -257,6 +281,22 @@ pub struct WcetHintRejection {
     pub note: String,
 }
 
+/// (#778 phase 4 / #49) The self-recursion record carried on a bounded function
+/// whose bound was composed via a verified recursion-depth certificate, so the
+/// sidecar states exactly how the frame count was established (and that a hint gated
+/// it — the derived depth is still synth's own).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WcetRecursionBound {
+    /// The DERIVED maximum recursion depth (entry-independent ceiling).
+    pub max_depth: u64,
+    /// The number of frames folded into the bound (`max_depth + 1`, counting the
+    /// base frame). Diagnostic — lets a consumer cross-check `cycles ≥ frames`.
+    pub frame_count: u64,
+    /// The `--wcet-hints` `recursion_depth` value that gated the certificate (the
+    /// emitted `max_depth` is synth's DERIVED value, never this raw hint).
+    pub hint: u64,
+}
+
 /// The per-function result: either a sound cycle bound or a loud decline.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "kebab-case")]
@@ -277,6 +317,10 @@ pub enum WcetFunction {
         /// Proven loops (empty for a loop-free function), ascending head offset.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         loops: Vec<WcetLoopBound>,
+        /// (#778 phase 4 / #49) Present iff this bound was composed via a verified
+        /// self-recursion certificate; states the derived depth + frame count.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        recursion: Option<WcetRecursionBound>,
         /// Hints that were rejected (the static proof stands independently).
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         hint_rejections: Vec<WcetHintRejection>,
@@ -324,6 +368,32 @@ impl WcetFunction {
             hint_rejections,
         }
     }
+}
+
+/// (#778 phase 4 / #49) A proven SELF-recursion certificate: the function is a
+/// single-self-call chain whose controlling value is entry-independently bounded
+/// (a masked-slot counter decreasing by a const step toward a base guard on the
+/// SAME masked quantity), so its maximum recursion DEPTH is DERIVED (not
+/// hint-supplied) as an entry-independent ceiling. The composer folds the self-edge
+/// as `frame_count × frame_cost` (`frame_count = max_depth + 1`, counting the base
+/// frame) instead of declining `Recursion`.
+///
+/// A certificate is attached ONLY after the depth was cross-checked against a
+/// `--wcet-hints` `recursion_depth` entry (the untrusted oracle asserts intent;
+/// synth's derived ceiling is what is emitted). Without a hint the recursion still
+/// declines (a bound this consequential is opt-in, mirroring the equality-exit
+/// loop-hint gate). `self_label` is the function's own `func_<idx>` self-call label
+/// so the composer can identify and special-case exactly that edge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WcetRecursionCert {
+    /// The self-call `BL` label (`func_<idx>`) this certificate authorizes.
+    pub self_label: String,
+    /// The DERIVED maximum recursion depth (entry-independent ceiling). The base
+    /// frame is NOT included here — the composer uses `max_depth + 1` frames.
+    pub max_depth: u64,
+    /// The hint value that gated this certificate (recorded for the sidecar; the
+    /// emitted depth is always the derived `max_depth`, never the raw hint).
+    pub hint: u64,
 }
 
 /// One direct call site inside a composable function (#778 phase 3). Records the
@@ -380,6 +450,12 @@ pub enum WcetIntermediate {
         call_sites: Vec<WcetCallSite>,
         /// Proven loops inside this function (carried to the bound unchanged).
         loops: Vec<WcetLoopBound>,
+        /// (#778 phase 4 / #49) A proven self-recursion certificate, when this
+        /// function is a bounded single-self-call chain with a verified depth hint.
+        /// The composer folds the self-edge as `(max_depth+1) × frame_cost` instead
+        /// of declining `Recursion`. `None` for a non-recursive function or an
+        /// unverifiable/unhinted recursion (which still declines).
+        recursion_cert: Option<WcetRecursionCert>,
         /// Hints rejected while analyzing this function (carried to the bound).
         hint_rejections: Vec<WcetHintRejection>,
     },
@@ -420,6 +496,16 @@ pub struct WcetFunctionHints {
     /// order; `null` leaves that loop unhinted.
     #[serde(default)]
     pub loop_bounds: Vec<Option<u64>>,
+    /// (#778 phase 4 / #49) An UNTRUSTED claimed maximum SELF-recursion depth for
+    /// this function. Consulted only when synth has proven the function is a
+    /// single-self-call chain whose controlling value is entry-independently bounded
+    /// (a masked-slot counter): synth then DERIVES its own maximum depth from the
+    /// mask+step+base induction and cross-checks this hint (`hint < derived` →
+    /// `hint-below-derived-depth`). A hint on a function whose recursion synth cannot
+    /// so verify is REJECTED (`hint-unverifiable-recursion`) and never trusted. The
+    /// emitted bound always uses synth's DERIVED depth, never the raw hint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recursion_depth: Option<u64>,
 }
 
 /// The full `synth-wcet-v1` sidecar: schema header, precondition, and per-function
@@ -483,6 +569,7 @@ mod tests {
             cycles: 42,
             instr_count: 7,
             loops: Vec::new(),
+            recursion: None,
             hint_rejections: Vec::new(),
         });
         r.functions

--- a/scripts/repro/wcet_phase4_49_recursion_soundness.py
+++ b/scripts/repro/wcet_phase4_49_recursion_soundness.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""#778 phase 4 (#49) recursion-bound soundness cross-check: execute a compiled
+BOUNDED self-recursion under unicorn (Thumb-2) and confirm the composed
+recursion bound is a sound upper bound on the ACTUAL total executed cost across
+EVERY recursive frame — for the WORST-CASE entry over the whole i32 input domain.
+
+The masked-recursion accept shape (`md`) bounds its controlling value to
+`m = param & 15 ∈ [0,15]` for ANY runtime input, so the derived maximum depth is
+15 (entry-independent) and the composed bound folds 16 frames. We drive the
+worst-case entry (param & 15 == 15, e.g. param = 15 or 0xFFFFFFFF) and check:
+
+  1. functional result (r0) matches the WASM ground truth (a lost frame or wrong
+     fold would change it);
+  2. composed bound_cycles >= total executed machine instructions across ALL
+     frames (every machine instruction costs >= 1 cycle) — the recursion bound is
+     a sound ceiling on the whole call tree, not one frame.
+
+And the decline-honesty half: the uncapped countdown (`count`) and the two-self-
+call tree (`fib`) STAY declined `recursion` even WITH a depth hint (moved, never
+deleted) — with the specific rejection reason.
+
+This is execution-side evidence the cargo gate (wcet_bound_gate.rs) cannot
+produce in-CI (no unicorn dep there); the gate pins the same fixtures
+analytically (derived depth 15, frame_count 16, bound == 16 x own, wrong-hint /
+tree-recursion / uncapped-countdown decline matrix).
+
+Usage:
+    SYNTH=/path/to/synth python3 scripts/repro/wcet_phase4_49_recursion_soundness.py
+Requires: pip install unicorn pyelftools
+"""
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from wcet_phase2_778_unicorn_soundness import (  # noqa: E402
+    load_elf, run_func, sidecar_entry,
+)
+
+SYNTH = os.environ.get("SYNTH", "synth")
+TMP = "/tmp/wcet_phase4"
+
+# A masked-recursion accept fixture: m = param & 15 in [0,15]; recurse while m != 0
+# passing (m-1); base returns 0. Depth <= 15 entry-independent, for ANY input.
+MASKED_WAT = r"""
+(module
+  (func $md (export "md") (param i32) (result i32)
+    local.get 0 i32.const 15 i32.and
+    (if (result i32)
+      (then
+        local.get 0 i32.const 15 i32.and i32.const 1 i32.sub call $md i32.const 1 i32.add)
+      (else i32.const 0))))
+"""
+
+# Uncapped countdown: base at param==0, arg param-1 (NO mask on the arg path). Runtime
+# unbounded (negative entry diverges); must REJECT any depth hint.
+COUNT_WAT = r"""
+(module
+  (func $count (export "count") (param i32) (result i32)
+    local.get 0 i32.eqz
+    (if (result i32)
+      (then i32.const 0)
+      (else local.get 0 i32.const 1 i32.sub call $count i32.const 1 i32.add))))
+"""
+
+# Tree recursion (two self-calls per frame) even with a mask: depth x per-frame
+# under-counts exponentially — must REJECT (single-self-call gate).
+FIB_WAT = r"""
+(module
+  (func $fib (export "fib") (param i32) (result i32)
+    local.get 0 i32.const 15 i32.and i32.const 2 i32.lt_s
+    (if (result i32)
+      (then i32.const 1)
+      (else
+        local.get 0 i32.const 15 i32.and i32.const 1 i32.sub call $fib
+        local.get 0 i32.const 15 i32.and i32.const 2 i32.sub call $fib
+        i32.add))))
+"""
+
+
+def wat_file(name, wat):
+    p = os.path.join(TMP, name + ".wat")
+    open(p, "w").write(wat)
+    return p, os.path.join(TMP, name + ".elf")
+
+
+def write_hints(name, fn, depth):
+    p = os.path.join(TMP, name + ".hints.json")
+    json.dump({"schema": "synth-wcet-hints-v1",
+               "functions": {fn: {"recursion_depth": depth}}}, open(p, "w"))
+    return p
+
+
+def compile_wat(wat_path, elf_path, hints=None, relocatable=False):
+    cmd = [SYNTH, "compile", wat_path, "-o", elf_path, "-t", "cortex-m4", "--emit-wcet"]
+    if relocatable:
+        cmd.append("--relocatable")
+    if hints:
+        cmd += ["--wcet-hints", hints]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    assert r.returncode == 0, r.stderr
+    return json.load(open(elf_path + ".wcet.json"))
+
+
+def md_ref(n):
+    """Ground-truth: md(n) counts down m=n&15 to 0, returning m (each frame +1)."""
+    m = n & 15
+    return m
+
+
+def main():
+    os.makedirs(TMP, exist_ok=True)
+
+    print("== masked recursion: composed bound >= WHOLE call tree (bound >= actual) ==")
+    p, e = wat_file("masked", MASKED_WAT)
+    hints = write_hints("masked", "md", 15)
+    # Self-contained image so the self-call BL is patched to the in-image target.
+    rep = compile_wat(p, e, hints=hints, relocatable=False)
+    f = sidecar_entry(rep, "md")
+    assert f["status"] == "bounded", f"md: expected bounded, got {f}"
+    assert f["recursion"]["max_depth"] == 15, f"derived depth != 15: {f['recursion']}"
+    assert f["recursion"]["frame_count"] == 16, f["recursion"]
+    bound = f["cycles"]
+
+    text, text_addr, syms = load_elf(e)
+    # WORST-CASE entry: param & 15 == 15 → maximal 15-deep recursion. Also check a
+    # large/negative entry (0xFFFFFFFF) which & 15 == 15 — the entry-independence.
+    for arg in (15, 0xFFFFFFFF, 0x7FFFFFFF):
+        r0, n_exec = run_func(text, text_addr, syms["md"], (arg,))
+        assert r0 == md_ref(arg) & 0xFFFFFFFF, \
+            f"md({arg:#x}): r0={r0} expected {md_ref(arg)}"
+        assert bound >= n_exec, (
+            f"md({arg:#x}): UNSOUND — recursion bound {bound} cycles < {n_exec} "
+            f"executed machine insns across all frames"
+        )
+        print(f"  OK md({arg:#x})=r0 {r0}: executed {n_exec} insns (all frames)"
+              f" <= composed bound {bound} cycles")
+
+    print("== decline-honesty: uncapped countdown + tree recursion STAY declined ==")
+    p, e = wat_file("count", COUNT_WAT)
+    hints = write_hints("count", "count", 100)
+    rep = compile_wat(p, e, hints=hints, relocatable=True)
+    f = sidecar_entry(rep, "count")
+    assert f["status"] == "declined" and f["reason"] == "recursion", f
+    reasons = [r["reason"] for r in f.get("hint_rejections", [])]
+    assert "hint-unverifiable-recursion" in reasons, f
+    print("  OK count: declined `recursion` + hint-unverifiable-recursion "
+          "(uncapped runtime param — no entry-independent ceiling)")
+
+    p, e = wat_file("fib", FIB_WAT)
+    hints = write_hints("fib", "fib", 15)
+    rep = compile_wat(p, e, hints=hints, relocatable=True)
+    f = sidecar_entry(rep, "fib")
+    assert f["status"] == "declined" and f["reason"] == "recursion", f
+    reasons = [r["reason"] for r in f.get("hint_rejections", [])]
+    assert "hint-unverifiable-recursion" in reasons, f
+    print("  OK fib: declined `recursion` + hint-unverifiable-recursion "
+          "(two self-calls/frame — depth x per-frame would under-count)")
+
+    # Wrong (too-low) hint on the provable masked shape → rejected below-derived.
+    p, e = wat_file("masked", MASKED_WAT)
+    hints = write_hints("masked_low", "md", 3)
+    rep = compile_wat(p, e, hints=hints, relocatable=True)
+    f = sidecar_entry(rep, "md")
+    assert f["status"] == "declined" and f["reason"] == "recursion", f
+    reasons = [r["reason"] for r in f.get("hint_rejections", [])]
+    assert "hint-below-derived-depth" in reasons, f
+    print("  OK md + too-low hint(3<15): declined `recursion` + hint-below-derived-depth")
+
+    print("\nALL PHASE-4 (#49) RECURSION SOUNDNESS CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/wcet_phase4_49_recursion_soundness.py
+++ b/scripts/repro/wcet_phase4_49_recursion_soundness.py
@@ -79,6 +79,25 @@ FIB_WAT = r"""
 """
 
 
+# ADVERSARIAL: masked base guard, but the decrement is applied only under a SECOND
+# guard on the RAW param (param > 100). A path with param <= 100 recurses with the
+# masked value UNCHANGED → unbounded. Must REJECT (region not straight-line).
+COND_DECR_WAT = r"""
+(module
+  (func $f (export "f") (param i32) (result i32)
+    (local i32)
+    local.get 0 i32.const 15 i32.and
+    (if (result i32)
+      (then
+        (local.set 1 (i32.and (local.get 0) (i32.const 15)))
+        (if (i32.gt_s (local.get 0) (i32.const 100))
+          (then (local.set 1 (i32.sub (local.get 1) (i32.const 1)))))
+        (call $f (local.get 1))
+        i32.const 1 i32.add)
+      (else i32.const 0))))
+"""
+
+
 def wat_file(name, wat):
     p = os.path.join(TMP, name + ".wat")
     open(p, "w").write(wat)
@@ -167,6 +186,20 @@ def main():
     reasons = [r["reason"] for r in f.get("hint_rejections", [])]
     assert "hint-below-derived-depth" in reasons, f
     print("  OK md + too-low hint(3<15): declined `recursion` + hint-below-derived-depth")
+
+    # ADVERSARIAL: conditional decrement (masked value + a decrement gated on a
+    # SECOND guard over the RAW param). A path that skips the decrement recurses
+    # unbounded — the straight-line/single-entry region check must REJECT it.
+    p, e = wat_file("cond", COND_DECR_WAT)
+    hints = write_hints("cond", "f", 15)
+    rep = compile_wat(p, e, hints=hints, relocatable=True)
+    f = sidecar_entry(rep, "f")
+    assert f["status"] == "declined" and f["reason"] == "recursion", \
+        f"UNSOUND — conditional-decrement recursion was BOUNDED: {f}"
+    reasons = [r["reason"] for r in f.get("hint_rejections", [])]
+    assert "hint-unverifiable-recursion" in reasons, f
+    print("  OK cond: declined `recursion` + hint-unverifiable-recursion "
+          "(conditional decrement — arg region not straight-line/single-entry)")
 
     print("\nALL PHASE-4 (#49) RECURSION SOUNDNESS CHECKS PASSED")
 


### PR DESCRIPTION
v0.49 Lane 3. Converts the `recursion` WCET decline for the BOUNDABLE case: an untrusted recursion-depth hint (extends the `--wcet-hints` scry seam) is SOUNDLY CHECKED — the bound `depth × per-frame` is admissible only if synth verifies the recursion cannot exceed the hinted depth (straight-line single-entry const-decrement); otherwise the hint is REJECTED with a machine reason and the function still declines.

**Soundness gates (red-first, verified from scratch):**
- `wcet_bound_gate` 34/34 incl. `wrong_hint_below_real_trip_is_rejected_red_first`.
- `scripts/repro/wcet_phase4_49_recursion_soundness.py`: bounded self-recursion under a correct hint → bounded (bound ≥ actual); a too-low hint (3<15) → declined `hint-below-derived-depth`; a conditional-decrement / count-up recursion → declined `hint-unverifiable-recursion` (a soundness fix — the arg region isn't straight-line single-entry).
- Decline-honesty preserved: unverifiable/mutual/indirect recursion still LOUD-DECLINE.

`.text` byte-invisible (WCET sidecar): frozen 10/10 (control_step 0x00210A55). claims 25/25 (new depth-frame constant pinned). rivet clean (new sys-verification carries a `verifies` link). L7's async gate re-verified green on the merged tree.

Note: the authoring agent hit an API stall after committing; this PR was salvaged by re-verifying every gate from scratch on the rebased tree (commit-per-step preserved all 3 commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)