### PR TITLE
fix(ci): repair red main — Cargo.lock wasmparser dedup + ordeal 0.12 BvTerm::Urem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,18 +1599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.254.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
-dependencies = [
- "bitflags",
- "hashbrown",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "wast"
 version = "252.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/synth-verify/src/solver.rs
+++ b/crates/synth-verify/src/solver.rs
@@ -187,6 +187,7 @@ mod z3_backend {
             BvTerm::Sub(a, b) => bv_to_z3(a).bvsub(&bv_to_z3(b)),
             BvTerm::Mul(a, b) => bv_to_z3(a).bvmul(&bv_to_z3(b)),
             BvTerm::Udiv(a, b) => bv_to_z3(a).bvudiv(&bv_to_z3(b)),
+            BvTerm::Urem(a, b) => bv_to_z3(a).bvurem(&bv_to_z3(b)),
             BvTerm::And(a, b) => bv_to_z3(a).bvand(&bv_to_z3(b)),
             BvTerm::Or(a, b) => bv_to_z3(a).bvor(&bv_to_z3(b)),
             BvTerm::Xor(a, b) => bv_to_z3(a).bvxor(&bv_to_z3(b)),

--- a/crates/synth-verify/src/term.rs
+++ b/crates/synth-verify/src/term.rs
@@ -64,6 +64,7 @@ fn bv_rank(t: &BvTerm) -> u8 {
         BvTerm::Sub(..) => 3,
         BvTerm::Mul(..) => 4,
         BvTerm::Udiv(..) => 5,
+        BvTerm::Urem(..) => 5,
         BvTerm::And(..) => 6,
         BvTerm::Or(..) => 7,
         BvTerm::Xor(..) => 8,
@@ -234,6 +235,10 @@ fn canonicalize_bv(t: &BvTerm) -> BvTerm {
         BvTerm::Udiv(a, b) => {
             let (a, b) = bin(a, b);
             BvTerm::Udiv(a, b)
+        }
+        BvTerm::Urem(a, b) => {
+            let (a, b) = bin(a, b);
+            BvTerm::Urem(a, b)
         }
         BvTerm::Shl(a, b) => {
             let (a, b) = bin(a, b);
@@ -843,6 +848,7 @@ fn fmt_bv(t: &BvTerm, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         BvTerm::Sub(a, b) => fmt_bin(f, "bvsub", a, b),
         BvTerm::Mul(a, b) => fmt_bin(f, "bvmul", a, b),
         BvTerm::Udiv(a, b) => fmt_bin(f, "bvudiv", a, b),
+        BvTerm::Urem(a, b) => fmt_bin(f, "bvurem", a, b),
         BvTerm::And(a, b) => fmt_bin(f, "bvand", a, b),
         BvTerm::Or(a, b) => fmt_bin(f, "bvor", a, b),
         BvTerm::Xor(a, b) => fmt_bin(f, "bvxor", a, b),


### PR DESCRIPTION
**Main is RED and unbuildable** — two dependabot-merge artifacts:

1. **`Cargo.lock` duplicate `wasmparser 0.254.0`** (two `[[package]]` blocks, same version+checksum, differing only in the `serde` dep) — a 3-way merge artifact cargo never produces; the tree fails to build (`package wasmparser is specified twice in the lockfile`). Removed the stale block; **minimal 12-line dedup, zero version bumps** (rejected `cargo generate-lockfile`, which over-bumped ~40 unrelated transitive deps).

2. **ordeal 0.9→0.12 (#825) added `BvTerm::Urem`** — synth-verify's three `match t` sites in `term.rs` didn't handle it (E0004). Added the arms mirroring the `Udiv` sibling (cost 5, structural rebuild, `bvurem` SMT-LIB formatter — `bvudiv`↔`bvurem` is the standard pairing). Sound mapping, not a `todo!()`.

Whole workspace builds clean; synth-verify tests pass; fmt clean; frozen 10/10; claims 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)