### PR TITLE
ci: auto-merge patch/minor Dependabot bumps, hold majors for review

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+# Auto-merge safe Dependabot updates so patch/minor dep bumps never require
+# hand-gating (they were consuming the maintenance loop one-at-a-time — each
+# merge moved main, staling the next). MAJOR bumps of any dep are HELD for
+# manual review (the ordeal 0.9->0.12 major bump silently broke synth-verify at
+# merge; wasm-tooling majors corrupted Cargo.lock). Auto-merge only enables the
+# merge — GitHub still requires every branch-protection gate to pass first, so
+# a broken bump cannot land.
+name: Dependabot Auto-Merge
+on: pull_request_target
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+      - name: Enable auto-merge for patch + minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Comment + label major updates for manual review
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr edit "$PR_URL" --add-label "major-bump-hold" 2>/dev/null || true
+          gh pr comment "$PR_URL" --body "🔒 **Major version bump — held for manual review.** Not auto-merged: a major bump of a load-bearing dep (solver/wasm-tooling/proof) can break the build at merge (ordeal 0.9→0.12 added an enum variant; wasm-tooling majors corrupted Cargo.lock). Review the changelog + build the affected feature sets before merging."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Stops the maintenance-loop churn.** Patch/minor dep bumps were being hand-gated one at a time — each merge moved main, staled the next, forced a rebase + re-check. This auto-merges patch/minor Dependabot PRs; auto-merge only *enables* the merge, so GitHub still requires every branch-protection gate to pass first — a broken bump cannot land.

**MAJOR bumps are HELD** (labeled `major-bump-hold` + commented) for manual review — the exact class that broke us: ordeal 0.9→0.12's new `BvTerm::Urem` silently failed synth-verify at merge, and the wasm-tooling majors corrupted `Cargo.lock`. Pulls the planned v0.51 L6 dependabot-resilience governance forward.

Note: requires repo "Allow auto-merge" enabled (Settings → General).

🤖 Generated with [Claude Code](https://claude.com/claude-code)