### PR TITLE
fix(#837): lower frame-backing i64/f64 VALUE param across a call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1402,6 +1402,14 @@ jobs:
         env:
           SYNTH: ./target/debug/synth
         run: python scripts/repro/i64_spill_pool_587_differential.py
+      - name: Run i64-param correctness + decline oracle (#518, d_call now emits #837)
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/repro/i64_param_518_differential.py
+      - name: Run frame-backing i64-param-with-call oracle (#837 gale gust:os/timer)
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/repro/framebacking_i64param_837_differential.py
 
   i64-rot-div-610-oracle:
     name: i64 rotl/rotr/div/rem expansion oracle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **#837 — frame-backing i64/f64 VALUE param across a call is now LOWERED** (the
+  last uncovered #518 i64-param sub-case). A function whose signature carries a
+  64-bit value param AND whose body makes a call (gale's `gust:os/timer`
+  `sleep(handle: u32, ticks: u64)` shape) previously loud-declined ("an i64/f64
+  param in a frame-backing function … is not yet lowered") rather than lowering.
+  Root cause: the frame-backing `param_slots` path sized an i64 param's slot from
+  `i64_set` (inferred i64 *locals*, which never contains params), giving a wide
+  param a 4-byte slot and dropping the high half. Fix: size the slot from the
+  declared AAPCS width (`params_i64`), so the even-aligned pair (R0:R1 or R2:R3)
+  is homed into an 8-byte frame slot in the prologue (`I64Str`) and reloaded
+  after the call (`I64Ldr`) — the store/reload machinery was already
+  width-aware. The u64 value param survives the call, verified bit-identically
+  under unicorn (`framebacking_i64param_837_differential.py`, gale's mmio-import
+  + in-module-call shape). Frozen fixtures byte-identical (all-i32 signatures are
+  untouched at the slot-sizing site). The one residual that still LOUD-DECLINES
+  by name is the register-pair-exhaustion retry (`param_backing_on_exhaustion`),
+  which has no execution oracle yet. Refs #518, #242.
+
 ## [0.49.0] - 2026-07-17
 
 **"Phase-2 frontier + falcon to zero" — the verified allocation validator went

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is homed into an 8-byte frame slot in the prologue (`I64Str`) and reloaded
   after the call (`I64Ldr`) — the store/reload machinery was already
   width-aware. The u64 value param survives the call, verified bit-identically
-  under unicorn (`framebacking_i64param_837_differential.py`, gale's mmio-import
-  + in-module-call shape). Frozen fixtures byte-identical (all-i32 signatures are
-  untouched at the slot-sizing site). The one residual that still LOUD-DECLINES
+  vs **wasmtime** under unicorn (`framebacking_i64param_837_differential.py`,
+  gale's mmio-import + in-module-call shape; `sleep` + `sleep_hi` exercising both
+  halves). Execution-verified for one i64 pair (R2:R3), two i64 pairs (R0:R1 +
+  R2:R3, correct carry), and a soft-float f64 value param (R0:R1) — all survive
+  the call. gale's report was the `--relocatable` direct path; the default
+  optimized path (separate codegen) already compiled the shape and still does.
+  Frozen fixtures byte-identical (all-i32 signatures are untouched at the
+  slot-sizing site). The one residual that still LOUD-DECLINES
   by name is the register-pair-exhaustion retry (`param_backing_on_exhaustion`),
   which has no execution oracle yet. Refs #518, #242.
 

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -1639,7 +1639,21 @@ fn compute_local_layout(
             }
         }
         for &p in &used_params {
-            let is_i64 = i64_set.contains(&p);
+            // #837: a frame-backed param's slot width is its DECLARED AAPCS
+            // width, not `i64_set` (which infers i64 *locals* from the op
+            // stream and never contains params — an i64 VALUE param whose body
+            // only reads it produces no i64-named op for a param index). Sizing
+            // from `i64_set` alone gave a wide param a 4-byte slot + `is_i64 =
+            // false`, dropping its high half — the exact reason the frame-
+            // backing i64/f64-param case was loud-declined at `select_with_stack`
+            // (#518). Consult `params_i64` (which lumps i64/f64) so R0:R1 or
+            // R2:R3 is homed as an 8-byte pair via `I64Str` and reloaded via
+            // `I64Ldr` (both already `is_i64`-aware). For an all-i32 signature
+            // `params_i64` is all-false ⇒ byte-identical to the old `i64_set`
+            // result (i64 *locals* are non-params, so `i64_set.contains(&p)`
+            // for a param index `p < num_params` was already always false).
+            let is_i64 =
+                params_i64.get(p as usize).copied().unwrap_or(false) || i64_set.contains(&p);
             if is_i64 && (offset % 8) != 0 {
                 offset += 4;
             }
@@ -9310,14 +9324,31 @@ impl InstructionSelector {
                 && param_layout.regs.contains_key(&i)
         });
         if has_reg_i64_param {
-            let has_call = wasm_ops
-                .iter()
-                .any(|op| matches!(op, Call(_) | CallIndirect { .. }));
-            if has_call || self.param_backing_on_exhaustion {
+            // #837: the frame-backing-with-CALL case is now LOWERED. A
+            // register-resident i64/f64 param in a function that contains a call
+            // homes its AAPCS even-aligned pair (R0:R1 or R2:R3) into an 8-byte
+            // frame slot in the prologue (`param_slots` now sizes it from the
+            // DECLARED width, above), survives the call's caller-saved clobber
+            // in the frame, and is reloaded as a pair via `I64Ldr` after — the
+            // store/reload machinery (prologue homing, LocalGet/Set/Tee) was
+            // already `is_i64`-aware; only the slot width was wrong. The
+            // past-R3 STACK-passed wide param never reached this guard
+            // (`param_layout.regs` excludes it) — it flows through
+            // `incoming_params` and has compiled since #503-i64.
+            //
+            // The one residual that still LOUD-DECLINES by name (decline >
+            // guess): the register-pair-exhaustion RETRY
+            // (`param_backing_on_exhaustion`) forces param backing on a
+            // call-FREE function whose i64-param homing across the retry's
+            // spill choreography is UNVERIFIED by a red→green fixture — kept
+            // declining until it has its own execution oracle rather than
+            // silently enabled.
+            if self.param_backing_on_exhaustion {
                 return Err(synth_core::Error::synthesis(
-                    "#518: an i64/f64 param in a frame-backing function (contains a \
-                     call, or the register-pair-exhaustion retry) is not yet \
-                     lowered — the param_slots path drops the high half"
+                    "#518/#837: an i64/f64 param in the register-pair-exhaustion \
+                     retry (force_param_backing on a call-free function) is not \
+                     yet lowered — the frame-backing-with-call case is handled, \
+                     but the exhaustion retry lacks an execution oracle"
                         .to_string(),
                 ));
             }
@@ -19225,12 +19256,16 @@ mod tests {
         );
     }
 
-    /// #503-i64: a wide STACK param in a has-call function lowers (it lives in
-    /// the caller's frame, surviving the BL without a backing slot), while a
-    /// wide REGISTER param in a has-call function keeps the #518 loud decline
-    /// (its `param_slots` backing would drop the high half).
+    /// #503-i64 + #837: a wide STACK param in a has-call function lowers (it
+    /// lives in the caller's frame, surviving the BL without a backing slot),
+    /// and a wide REGISTER param in a has-call function NOW ALSO lowers (#837):
+    /// its AAPCS pair is homed into an 8-byte frame slot (`I64Str`) in the
+    /// prologue and reloaded (`I64Ldr`) after the call — the pair survives the
+    /// caller-saved clobber in the frame. The one residual that still
+    /// LOUD-DECLINES is the register-pair-exhaustion RETRY
+    /// (`param_backing_on_exhaustion`), asserted below.
     #[test]
-    fn test_503_wide_stack_param_with_call_lowers_reg_still_declines() {
+    fn test_837_wide_reg_param_with_call_lowers_frame_backed() {
         let db = RuleDatabase::new();
         // (i32 i32 i32 i32 i64) + call: the i64 is stack-passed -> lowers.
         let mut selector = InstructionSelector::new(db.rules().to_vec());
@@ -19241,15 +19276,40 @@ mod tests {
             selector.select_with_stack(&ops, 5).is_ok(),
             "a wide STACK param + call must lower (caller-frame slot)"
         );
-        // (i64) + call: the i64 is REGISTER-resident -> #518 decline stands.
+        // (i64) + call: the i64 is REGISTER-resident -> #837 frame-backs it and
+        // homes it as an 8-byte pair. The lowering must emit an I64Str (prologue
+        // homing) and an I64Ldr (reload after the call), never dropping the hi.
         let mut selector = InstructionSelector::new(db.rules().to_vec());
         selector.set_params_i64(vec![true]);
         selector.set_func_arg_counts(vec![0, 0], Vec::new());
         let ops = vec![WasmOp::Call(1), WasmOp::LocalGet(0), WasmOp::Drop];
+        let arm = selector
+            .select_with_stack(&ops, 1)
+            .expect("#837: a wide REGISTER param + call must now lower (frame-backed pair)");
+        assert!(
+            arm.iter()
+                .any(|i| matches!(&i.op, ArmOp::I64Str { addr, .. }
+                if addr.base == Reg::SP)),
+            "the i64 param pair must be homed into the frame via I64Str [sp,#off]: {arm:#?}"
+        );
+        assert!(
+            arm.iter()
+                .any(|i| matches!(&i.op, ArmOp::I64Ldr { addr, .. }
+                if addr.base == Reg::SP)),
+            "the i64 param pair must be reloaded via I64Ldr [sp,#off] after the call: {arm:#?}"
+        );
+
+        // The residual honesty decline: the register-pair-exhaustion RETRY
+        // (force_param_backing on a call-FREE function) still LOUD-DECLINES by
+        // name until it has its own execution oracle.
+        let mut selector = InstructionSelector::new(db.rules().to_vec());
+        selector.set_params_i64(vec![true]);
+        selector.set_param_backing_on_exhaustion(true);
+        let ops = vec![WasmOp::LocalGet(0), WasmOp::Drop];
         let r = selector.select_with_stack(&ops, 1);
         assert!(
-            r.as_ref().is_err_and(|e| e.to_string().contains("#518")),
-            "a wide REGISTER param + call must keep the #518 loud decline: {r:?}"
+            r.as_ref().is_err_and(|e| e.to_string().contains("#837")),
+            "the exhaustion-retry i64 param must keep the loud decline: {r:?}"
         );
     }
 

--- a/scripts/repro/framebacking_i64param_837.wat
+++ b/scripts/repro/framebacking_i64param_837.wat
@@ -1,0 +1,59 @@
+;; #837 — a FRAME-BACKING function (body contains a call) with a 64-bit VALUE
+;; param. gale's `gust:os/timer` provider shape. The u64 param arrives in an
+;; AAPCS even-aligned register pair (here R2:R3, after the leading i32 in R0)
+;; and MUST survive the call's caller-saved clobber, so the pair is homed into
+;; the frame in the prologue and reloaded after the call. Previously this class
+;; loud-declined (#518): the frame-backing param_slots path sized an i64 param's
+;; slot from a width set (`i64_set`) that excludes params, dropping the high
+;; half. #837 sizes it from the declared AAPCS width instead. Executes bit-
+;; identically to the reference model via framebacking_i64param_837_differential.py.
+(module
+  ;; deterministic mmio read stub (the harness installs read32(x) = x ^ 0xA5A5A5A5)
+  (import "env" "read32" (func $read32 (param i32) (result i32)))
+
+  ;; in-module fn the body also calls (result dropped) — proves two BLs, both of
+  ;; which clobber R0..R3, so the u64 pair must be frame-resident across BOTH.
+  (func $combine (param i32) (result i32)
+    local.get 0
+    i32.const 7
+    i32.add)
+
+  ;; sleep(handle: u32, ticks: u64) -> u32
+  ;; = low32(ticks) + read32(handle). Uses only the LOW half after the calls, but
+  ;; the WHOLE pair is homed/reloaded — a dropped hi is caught by sleep_hi below.
+  (func (export "sleep") (param $handle i32) (param $ticks i64) (result i32)
+    (local $mmio i32)
+    local.get $handle
+    call $read32
+    local.set $mmio
+    local.get $mmio
+    call $combine
+    drop
+    local.get $ticks
+    i32.wrap_i64
+    local.get $mmio
+    i32.add)
+
+  ;; sleep_hi(handle: u32, ticks: u64) -> u32
+  ;; = (low32(ticks) XOR high32(ticks)) + read32(handle). Result depends on BOTH
+  ;; halves of the u64 param, so the full R2:R3 pair must survive the call.
+  (func (export "sleep_hi") (param $handle i32) (param $ticks i64) (result i32)
+    (local $mmio i32)
+    local.get $handle
+    call $read32
+    local.set $mmio
+    local.get $mmio
+    call $combine
+    drop
+    (i32.wrap_i64 (local.get $ticks))
+    (i32.wrap_i64 (i64.shr_u (local.get $ticks) (i64.const 32)))
+    i32.xor
+    local.get $mmio
+    i32.add)
+
+  ;; sibling with NO 64-bit param — the control that always compiled.
+  (func (export "slept") (param $handle i32) (result i32)
+    local.get $handle
+    call $read32)
+
+  (export "combine" (func $combine)))

--- a/scripts/repro/framebacking_i64param_837_differential.py
+++ b/scripts/repro/framebacking_i64param_837_differential.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""#837 — frame-backing i64/f64-param lowering (the last #518 i64-param sub-case).
+
+gale's `gust:os/timer` provider hit a LOUD DECLINE (not a miscompile — the object
+was never wrong, the function was just skipped) on a natural shape: a function
+whose signature carries a 64-bit VALUE param AND whose body makes a call:
+
+    sleep(handle: u32, ticks: u64) -> u32   # body calls read32(handle) then an
+                                            # in-module fn, then USES ticks.
+
+The u64 param arrives in an AAPCS even-aligned register pair (here R2:R3, since a
+leading i32 takes R0 and the pair even-aligns past R1). A call reclaims R0..R3 for
+its args and clobbers them (caller-saved), so the pair must be HOMED into the
+frame in the prologue, survive the call there, and be RELOADED after — exactly the
+frame-backing #204/#193 path, which previously sized an i64 param's slot from a
+width set (`i64_set`) that excludes params, giving it a 4-byte slot and dropping
+the high half. Rather than miscompile, the backend declined by name (#518).
+
+The #837 fix sizes the frame-backing param slot from the DECLARED AAPCS width
+(`params_i64`), so R2:R3 is homed as an 8-byte pair (`I64Str`) and reloaded as a
+pair (`I64Ldr`) after the call — machinery that was already `is_i64`-aware.
+
+This differential is the red->green EXECUTION oracle: it compiles the in-tree
+`framebacking_i64param_837.wat` `--relocatable --target cortex-m3`, resolves the
+`R_ARM_THM_CALL` relocations to `read32` (import) and `combine` (in-module),
+installs a deterministic `read32` stub, runs `sleep(handle, ticks)` under unicorn
+(Thumb-2), and checks the returned u32 equals the reference model over a matrix of
+`ticks` values whose HIGH 32 bits are non-zero — so a dropped high half or a
+clobbered pair would diverge. A companion `sleep_hi` export mixes BOTH halves of
+the u64 into its result, so the FULL pair (not just the low word) must survive.
+
+Reference model (mirrors the wat exactly):
+    read32(x)      = x ^ 0xA5A5A5A5            # deterministic mmio stub
+    combine(x)     = x + 7                     # in-module fn (result dropped)
+    sleep(h, t)    = (low32(t) + read32(h)) & 0xFFFFFFFF
+    sleep_hi(h, t) = ((low32(t) ^ high32(t)) + read32(h)) & 0xFFFFFFFF
+
+Run (needs unicorn + pyelftools; wasmtime not required — read32 is a host stub):
+  SYNTH=./target/debug/synth python scripts/repro/framebacking_i64param_837_differential.py
+"""
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R3,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("framebacking_i64param_837.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+TEXT = 0x100000
+STK = 0x900000
+RET = 0x300000
+READ32_STUB = 0x140000  # deterministic mmio read: read32(x) = x ^ MMIO_XOR
+MMIO_XOR = 0xA5A5A5A5
+
+ABS32, THM_CALL = 2, 10
+
+# ticks matrix — HIGH 32 bits non-zero so a dropped hi half still diverges on sleep_hi.
+CASES = [
+    0x00000000_00000000,
+    0x00000000_00000007,
+    0xDEADBEEF_00000001,
+    0xFFFFFFFF_FFFFFFFF,
+    0x12345678_9ABCDEF0,
+]
+
+
+def model_read32(x):
+    return (x ^ MMIO_XOR) & 0xFFFFFFFF
+
+
+def model_sleep(h, t):
+    return ((t & 0xFFFFFFFF) + model_read32(h)) & 0xFFFFFFFF
+
+
+def model_sleep_hi(h, t):
+    return (((t & 0xFFFFFFFF) ^ ((t >> 32) & 0xFFFFFFFF)) + model_read32(h)) & 0xFFFFFFFF
+
+
+def compile_synth(out):
+    env = {"PATH": "/usr/bin:/bin"}
+    cmd = [SYNTH, "compile", str(WAT), "-o", out, "-b", "arm",
+           "--target", "cortex-m3", "--all-exports", "--relocatable"]
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text_sec = f.get_section_by_name(".text")
+    text = bytearray(text_sec.data())
+    base = text_sec["sh_addr"]
+    st = None
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            st = sec
+    syms = {}
+    for s in st.iter_symbols():
+        if s.name and s["st_info"]["type"] == "STT_FUNC":
+            syms[s.name] = s["st_value"]
+    return f, st, text, base, syms
+
+
+def resolve_relocs(f, st, text, base, syms):
+    relsec = f.get_section_by_name(".rel.text")
+    for r in relsec.iter_relocations():
+        t = r["r_info_type"]
+        sym = st.get_symbol(r["r_info_sym"])
+        off = r["r_offset"]
+        if t == THM_CALL:
+            S = (READ32_STUB if sym.name == "read32" else TEXT + syms[sym.name]) & ~1
+            P = TEXT + off + 4
+            disp = S - P
+            imm = (disp >> 1) & 0x3FFFFF
+            s = (imm >> 21) & 1
+            i1 = (imm >> 20) & 1
+            i2 = (imm >> 19) & 1
+            j1 = (~i1 & 1) ^ s
+            j2 = (~i2 & 1) ^ s
+            imm10 = (imm >> 11) & 0x3FF
+            imm11 = imm & 0x7FF
+            hi = 0xF000 | (s << 10) | imm10
+            lo = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+            struct.pack_into("<HH", text, off, hi, lo)
+        elif t == ABS32:
+            (add,) = struct.unpack_from("<I", text, off)
+            struct.pack_into("<I", text, off, (TEXT + syms.get(sym.name, 0) + add) & 0xFFFFFFFF)
+        else:
+            raise SystemExit(f"unhandled reloc type {t} at {off:#x}")
+
+
+def _movw_movt(rd, imm16, is_movt):
+    base_op = 0xF2C0 if is_movt else 0xF240
+    i = (imm16 >> 11) & 1
+    imm4 = (imm16 >> 12) & 0xF
+    imm3 = (imm16 >> 8) & 0x7
+    imm8 = imm16 & 0xFF
+    w0 = base_op | (i << 10) | imm4
+    w1 = (imm3 << 12) | (rd << 8) | imm8
+    return struct.pack("<HH", w0, w1)
+
+
+def build_mu(text):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(TEXT, 0x80000)  # 0x100000..0x180000 — also covers READ32_STUB (0x140000)
+    mu.mem_map(STK - 0x10000, 0x20000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_write(TEXT, bytes(text))
+    # read32 stub: movw/movt r1,#MMIO_XOR ; eors r0,r1 ; bx lr  (Thumb-2).
+    lo = MMIO_XOR & 0xFFFF
+    hi = (MMIO_XOR >> 16) & 0xFFFF
+    stub = bytearray()
+    stub += _movw_movt(1, lo, False)
+    stub += _movw_movt(1, hi, True)
+    stub += struct.pack("<H", 0x4048)  # eors r0, r1
+    stub += struct.pack("<H", 0x4770)  # bx lr
+    mu.mem_write(READ32_STUB, bytes(stub))
+    mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+    return mu
+
+
+def run(mu, faddr, base, h, t):
+    foff = (faddr & ~1) - base
+    mu.reg_write(UC_ARM_REG_SP, STK)
+    mu.reg_write(UC_ARM_REG_R11, 0)
+    # AAPCS: (i32, i64) -> h in R0, ticks even-aligned in R2:R3 (R1 skipped).
+    mu.reg_write(UC_ARM_REG_R0, h & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_R1, 0xDEAD0000)  # poison the skipped R1
+    mu.reg_write(UC_ARM_REG_R2, t & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_R3, (t >> 32) & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    mu.emu_start((TEXT + foff) | 1, RET, count=100000)
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def main():
+    out = "/tmp/i837.o"
+    r = compile_synth(out)
+    if r.returncode != 0:
+        print(f"RESULT: FAIL — compile errored: {r.stderr}")
+        sys.exit(1)
+    if "skipping function 'sleep'" in r.stderr:
+        print("RESULT: FAIL — 'sleep' (frame-backing i64 param + call) was LOUD-SKIPPED; "
+              "the #837 lowering did not fire.")
+        sys.exit(1)
+
+    f, st, text, base, syms = load(out)
+    for need in ("sleep", "sleep_hi", "slept", "combine"):
+        if need not in syms:
+            print(f"RESULT: FAIL — '{need}' absent from symtab (unexpected skip).")
+            sys.exit(1)
+    resolve_relocs(f, st, text, base, syms)
+    mu = build_mu(text)
+
+    fails = 0
+    H = 0x0000_0011
+    print("=== sleep(handle, ticks) — low32(ticks)+read32(handle), u64 param survives call ===")
+    for t in CASES:
+        exp = model_sleep(H, t)
+        try:
+            got = run(mu, syms["sleep"], base, H, t)
+        except UcError as e:
+            got = f"ERR:{e}"
+        ok = isinstance(got, int) and got == exp
+        fails += 0 if ok else 1
+        print(f"  [{'ok ' if ok else 'BUG'}] sleep(h={H:#x}, ticks={t:#018x}) -> "
+              f"{got if isinstance(got, str) else hex(got)}  (model {hex(exp)})")
+
+    print("=== sleep_hi — result mixes BOTH halves of the u64 param (full pair must survive) ===")
+    for t in CASES:
+        exp = model_sleep_hi(H, t)
+        try:
+            got = run(mu, syms["sleep_hi"], base, H, t)
+        except UcError as e:
+            got = f"ERR:{e}"
+        ok = isinstance(got, int) and got == exp
+        fails += 0 if ok else 1
+        print(f"  [{'ok ' if ok else 'BUG'}] sleep_hi(h={H:#x}, ticks={t:#018x}) -> "
+              f"{got if isinstance(got, str) else hex(got)}  (model {hex(exp)})")
+
+    print("\n--- verdict ---")
+    if fails == 0:
+        print("RESULT: PASS — the frame-backing i64/f64-param-with-call shape (gale's "
+              "gust:os/timer sleep) is LOWERED and the u64 value param survives the "
+              "call bit-identically to the reference model (#837 fixed, #518 class "
+              "complete for the register-resident case).")
+        sys.exit(0)
+    print(f"RESULT: FAIL — {fails} divergence(s); the u64 param did not survive the call.")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/framebacking_i64param_837_differential.py
+++ b/scripts/repro/framebacking_i64param_837_differential.py
@@ -29,13 +29,16 @@ installs a deterministic `read32` stub, runs `sleep(handle, ticks)` under unicor
 clobbered pair would diverge. A companion `sleep_hi` export mixes BOTH halves of
 the u64 into its result, so the FULL pair (not just the low word) must survive.
 
-Reference model (mirrors the wat exactly):
-    read32(x)      = x ^ 0xA5A5A5A5            # deterministic mmio stub
+Ground truth is WASMTIME (the same .wat, with `read32` supplied as a host import
+`lambda h: h ^ 0xA5A5A5A5`), so the expected side is a real WASM execution, not a
+hand model. A pure-Python model with the identical semantics is also checked as a
+cross-check (they must agree), but wasmtime is the oracle:
+    read32(x)      = x ^ 0xA5A5A5A5            # host import, both sides
     combine(x)     = x + 7                     # in-module fn (result dropped)
     sleep(h, t)    = (low32(t) + read32(h)) & 0xFFFFFFFF
     sleep_hi(h, t) = ((low32(t) ^ high32(t)) + read32(h)) & 0xFFFFFFFF
 
-Run (needs unicorn + pyelftools; wasmtime not required — read32 is a host stub):
+Run (needs wasmtime + unicorn + pyelftools):
   SYNTH=./target/debug/synth python scripts/repro/framebacking_i64param_837_differential.py
 """
 import os
@@ -44,6 +47,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import wasmtime
 from elftools.elf.elffile import ELFFile
 from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
 from unicorn.arm_const import (
@@ -87,6 +91,28 @@ def model_sleep(h, t):
 
 def model_sleep_hi(h, t):
     return (((t & 0xFFFFFFFF) ^ ((t >> 32) & 0xFFFFFFFF)) + model_read32(h)) & 0xFFFFFFFF
+
+
+def wasmtime_ground_truth():
+    """Instantiate the SAME .wat with read32 as a host import; return a callable
+    (fn, h, t) -> u32 that runs the real WASM. This is the oracle; the Python
+    models above are a cross-check that must agree with it."""
+    engine = wasmtime.Engine()
+    mod = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    read32 = wasmtime.Func(
+        store,
+        wasmtime.FuncType([wasmtime.ValType.i32()], [wasmtime.ValType.i32()]),
+        lambda h: (h ^ MMIO_XOR) & 0xFFFFFFFF,
+    )
+    inst = wasmtime.Instance(store, mod, [read32])
+    exports = inst.exports(store)
+
+    def call(fn, h, t):
+        # wasmtime-py takes i64 as a Python int; results are signed — mask to u32.
+        return exports[fn](store, h, t) & 0xFFFFFFFF
+
+    return call
 
 
 def compile_synth(out):
@@ -202,39 +228,36 @@ def main():
             sys.exit(1)
     resolve_relocs(f, st, text, base, syms)
     mu = build_mu(text)
+    wt = wasmtime_ground_truth()
 
     fails = 0
     H = 0x0000_0011
-    print("=== sleep(handle, ticks) — low32(ticks)+read32(handle), u64 param survives call ===")
-    for t in CASES:
-        exp = model_sleep(H, t)
-        try:
-            got = run(mu, syms["sleep"], base, H, t)
-        except UcError as e:
-            got = f"ERR:{e}"
-        ok = isinstance(got, int) and got == exp
-        fails += 0 if ok else 1
-        print(f"  [{'ok ' if ok else 'BUG'}] sleep(h={H:#x}, ticks={t:#018x}) -> "
-              f"{got if isinstance(got, str) else hex(got)}  (model {hex(exp)})")
-
-    print("=== sleep_hi — result mixes BOTH halves of the u64 param (full pair must survive) ===")
-    for t in CASES:
-        exp = model_sleep_hi(H, t)
-        try:
-            got = run(mu, syms["sleep_hi"], base, H, t)
-        except UcError as e:
-            got = f"ERR:{e}"
-        ok = isinstance(got, int) and got == exp
-        fails += 0 if ok else 1
-        print(f"  [{'ok ' if ok else 'BUG'}] sleep_hi(h={H:#x}, ticks={t:#018x}) -> "
-              f"{got if isinstance(got, str) else hex(got)}  (model {hex(exp)})")
+    for fn, model in (("sleep", model_sleep), ("sleep_hi", model_sleep_hi)):
+        desc = ("low32(ticks)+read32(handle)" if fn == "sleep"
+                else "(low32^high32)(ticks)+read32(handle) — full pair must survive")
+        print(f"=== {fn}(handle, ticks) — {desc} ===")
+        for t in CASES:
+            exp = wt(fn, H, t)             # wasmtime ground truth
+            m = model(H, t)               # cross-check
+            if m != exp:                  # the harness's own model disagrees with WASM
+                print(f"  [BUG] harness model disagrees with wasmtime on {fn}: "
+                      f"model {hex(m)} != wasmtime {hex(exp)}")
+                fails += 1
+            try:
+                got = run(mu, syms[fn], base, H, t)
+            except UcError as e:
+                got = f"ERR:{e}"
+            ok = isinstance(got, int) and got == exp
+            fails += 0 if ok else 1
+            print(f"  [{'ok ' if ok else 'BUG'}] {fn}(h={H:#x}, ticks={t:#018x}) -> "
+                  f"{got if isinstance(got, str) else hex(got)}  (wasmtime {hex(exp)})")
 
     print("\n--- verdict ---")
     if fails == 0:
         print("RESULT: PASS — the frame-backing i64/f64-param-with-call shape (gale's "
               "gust:os/timer sleep) is LOWERED and the u64 value param survives the "
-              "call bit-identically to the reference model (#837 fixed, #518 class "
-              "complete for the register-resident case).")
+              "call BIT-IDENTICALLY TO WASMTIME (#837 fixed, #518 class complete for "
+              "the register-resident case).")
         sys.exit(0)
     print(f"RESULT: FAIL — {fails} divergence(s); the u64 param did not survive the call.")
     sys.exit(1)

--- a/scripts/repro/i64_param_518_decline.wat
+++ b/scripts/repro/i64_param_518_decline.wat
@@ -1,19 +1,20 @@
-;; #518 — the DECLINE half of the fix, minus what #503-i64 closed. The leaf,
-;; register-resident i64-param cases are lowered correctly (see
-;; i64_param_518.wat); the REMAINING sub-case is declined LOUDLY (a
-;; `warning: skipping function …` + absence from the symbol table) rather than
-;; silently miscompiled, because its correct lowering is a tracked follow-up:
+;; #518 — historically the DECLINE half of the fix. Every register-resident
+;; i64-param case is now LOWERED and executes correctly; this fixture is kept as
+;; the non-vacuity + AAPCS-matrix guard (all three functions emit + run):
 ;;   - d_call: a REGISTER-resident i64 param in a function that CONTAINS A
 ;;     CALL — params are frame-backed to survive the call's caller-saved
-;;     clobber, and that param_slots path sizes an i64 param's slot from a
-;;     width set that excludes params, dropping the high half. Declined until
-;;     the frame-backed i64 path lands.
+;;     clobber. #518 declined it because that param_slots path sized an i64
+;;     param's slot from a width set (`i64_set`) that EXCLUDES params, dropping
+;;     the high half. #837 sizes it from the DECLARED AAPCS width, so the pair
+;;     is homed into the frame (`I64Str`) and reloaded after the call (`I64Ldr`):
+;;     now emitted + executes correctly (d_call(p) = p + 7). The fuller gale
+;;     gust:os/timer shape (mmio import + in-module call) is exercised by
+;;     framebacking_i64param_837_differential.py.
 ;;   - d_past_r3 (an i64 param AAPCS-passed PAST R3, on the caller's stack)
-;;     was the #503-i64 stack-param case and is now LOWERED (width-aware
+;;     was the #503-i64 stack-param case and is LOWERED (width-aware
 ;;     `aapcs_param_layout` incoming homing): emitted + executes correctly,
 ;;     gated below and by i64_stack_param_503_differential.py.
-;; d_leaf is the control: a leaf register-resident i64 param IS emitted (proves
-;; the decline is specific to d_call, not a blanket i64-param refusal).
+;; d_leaf is the control: a leaf register-resident i64 param IS emitted.
 (module
   (func $helper (param i32) (result i32) (local.get 0))
 

--- a/scripts/repro/i64_param_518_differential.py
+++ b/scripts/repro/i64_param_518_differential.py
@@ -54,14 +54,21 @@ from unicorn.arm_const import (
 )
 
 WAT = Path(__file__).with_name("i64_param_518.wat")
-# The DECLINE half: the i64-param sub-case that is still loud-skipped (not
-# lowered) — a REGISTER-resident i64 param in a frame-backing (has-call)
-# function. d_past_r3 (i64 param past R3 = on the caller's stack) was the
-# #503-i64 case and is now LOWERED: it moved to the emitted+executes set.
-# d_leaf is the control: a leaf i64 param IS emitted.
+# The DECLINE half — now fully LOWERED for every register-resident i64 param:
+#   * d_past_r3 (i64 param past R3 = on the caller's stack) was the #503-i64 case.
+#   * d_call (a REGISTER-resident i64 param in a frame-backing (has-call)
+#     function) was the last #518 sub-case, lowered by #837: the frame-backing
+#     param slot is now sized from the DECLARED AAPCS width, so the pair is homed
+#     into the frame and reloaded after the call. It moved from DECLINE_SKIPPED
+#     to the emitted+executes set. See framebacking_i64param_837_differential.py
+#     for the fuller gale-shape (mmio import + in-module call) execution oracle.
+# d_leaf is the control: a leaf i64 param IS emitted. DECLINE_SKIPPED is now
+# EMPTY — there is no register-resident i64-param shape that loud-skips (the only
+# remaining honest decline is the register-pair-exhaustion RETRY, which no static
+# fixture triggers; it is asserted by name in the selector, not here).
 DECLINE_WAT = Path(__file__).with_name("i64_param_518_decline.wat")
-DECLINE_SKIPPED = ["d_call"]                # must warn + be absent from symtab
-DECLINE_EMITTED = ["d_leaf", "d_past_r3"]   # must be emitted (non-vacuity)
+DECLINE_SKIPPED = []                              # nothing loud-skips anymore
+DECLINE_EMITTED = ["d_leaf", "d_past_r3", "d_call"]  # emitted + execute correctly
 SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
 CODE, STK, RET, R11 = 0x100000, 0x900000, 0x300000, 0x20000000
 
@@ -202,9 +209,11 @@ def run_path(label, relocatable):
 
 
 def check_decline_contract():
-    """The unsupported i64-param sub-cases must LOUD-SKIP (warn + absent symbol),
-    never silently emit wrong code; a leaf i64 param must still be emitted AND
-    execute correctly (non-vacuity). Returns the number of failures."""
+    """Every register-resident i64-param shape must now be EMITTED and execute
+    correctly (d_leaf leaf, d_past_r3 stack-passed #503-i64, d_call frame-backed
+    across a call #837). DECLINE_SKIPPED is empty — the only remaining honest
+    decline (the register-pair-exhaustion retry) is asserted by name in the
+    selector, not by a static fixture. Returns the number of failures."""
     out = "/tmp/i518_decline.o"
     cmd = [SYNTH, "compile", str(DECLINE_WAT), "-o", out, "-b", "arm",
            "--target", "cortex-m4", "--all-exports", "--relocatable"]
@@ -238,6 +247,16 @@ def check_decline_contract():
         if fn == "d_leaf":
             # d_leaf: (param i64)(result i64) i64.add(p,3); run with p=7 -> 10
             ok = got_i64_leaf(code, base, syms[fn], 7) == leaf_expect(7)
+        elif fn == "d_call":
+            # d_call (#837): (param i64)(result i64)
+            # i64.add(p, i64.extend_i32_u(helper(7))); helper returns its arg, so
+            # = p + 7. Register-resident i64 param FRAME-BACKED across the call:
+            # the pair is homed into the frame and reloaded after the bl — the
+            # exact case #518 declined and #837 lowered. Needs the bl $helper
+            # (func_0) resolved so the call executes.
+            p = 0x1_0000_0009
+            ok = got_i64_dcall(out, base, syms[fn], p) == (
+                (p + 7) & 0xFFFFFFFFFFFFFFFF)
         else:
             # d_past_r3 (#503-i64): (param i32 i32 i32 i64)(result i64)
             # i64.add(p3,1); p3 arrives on the caller's stack at entry SP.
@@ -298,6 +317,56 @@ def got_i64_leaf(code, base, faddr, arg):
         (mu.reg_read(UC_ARM_REG_R1) & 0xFFFFFFFF) << 32)
 
 
+def got_i64_dcall(elf, base, faddr, arg):
+    """d_call (#837): resolve the in-module `bl func_N` (helper) reloc so the call
+    executes, then run the frame-backed i64-param function at CODE. `base` is the
+    .text sh_addr; the image is loaded at CODE, so relocs resolve against CODE."""
+    import struct
+    f = ELFFile(open(elf, "rb"))
+    text = bytearray(f.get_section_by_name(".text").data())
+    st = next(s for s in f.iter_sections() if s.header.sh_type == "SHT_SYMTAB")
+    fsyms = {s.name: s["st_value"] for s in st.iter_symbols()
+             if s.name and s["st_info"]["type"] == "STT_FUNC"}
+    relsec = f.get_section_by_name(".rel.text")
+    if relsec is not None:
+        for r in relsec.iter_relocations():
+            if r["r_info_type"] != 10:  # THM_CALL only (all internal here)
+                continue
+            sym = st.get_symbol(r["r_info_sym"])
+            off = r["r_offset"]
+            S = (CODE + fsyms[sym.name]) & ~1
+            P = CODE + off + 4
+            disp = S - P
+            imm = (disp >> 1) & 0x3FFFFF
+            s = (imm >> 21) & 1
+            i1 = (imm >> 20) & 1
+            i2 = (imm >> 19) & 1
+            j1 = (~i1 & 1) ^ s
+            j2 = (~i2 & 1) ^ s
+            imm10 = (imm >> 11) & 0x3FF
+            imm11 = imm & 0x7FF
+            hi = 0xF000 | (s << 10) | imm10
+            lo = 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+            struct.pack_into("<HH", text, off, hi, lo)
+    foff = (faddr & ~1) - base
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(STK - 0x10000, 0x20000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_write(CODE, bytes(text))
+    mu.reg_write(UC_ARM_REG_SP, STK)
+    mu.reg_write(UC_ARM_REG_R11, R11)
+    mu.reg_write(UC_ARM_REG_R0, arg & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_R1, (arg >> 32) & 0xFFFFFFFF)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    try:
+        mu.emu_start((CODE + foff) | 1, RET, count=100000)
+    except UcError as e:
+        return f"ERR:{e}"
+    return (mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF) | (
+        (mu.reg_read(UC_ARM_REG_R1) & 0xFFFFFFFF) << 32)
+
+
 def main():
     opt_div, opt_ctrl = run_path("OPTIMIZED (--target cortex-m4)", relocatable=False)
     rel_div, rel_ctrl = run_path("DIRECT (--relocatable)", relocatable=True)
@@ -326,9 +395,10 @@ def main():
         if total == 0:
             print("RESULT: PASS — both paths match wasmtime on every leaf i64-param "
                   "function across the full AAPCS matrix, the #503-i64 stack-param "
-                  "case (d_past_r3) is emitted and correct, AND the remaining "
-                  "unsupported sub-case (frame-backed REGISTER i64 param, d_call) "
-                  "loud-skips rather than miscompiles. #518 fixed.")
+                  "case (d_past_r3) is emitted and correct, AND the frame-backed "
+                  "REGISTER i64 param across a call (d_call) is now emitted and "
+                  "executes correctly (#837). #518 i64-param class complete for "
+                  "every register-resident shape.")
             sys.exit(0)
         print(f"RESULT: FAIL — {opt_div + rel_div} value divergence(s) + "
               f"{decline_fails} decline-contract failure(s); #518 not fully fixed.")


### PR DESCRIPTION
## What

Completes the **last uncovered #518 i64-param sub-case**: a function whose signature carries a **64-bit VALUE param** AND whose body **makes a call** was **loud-declined** (`an i64/f64 param in a frame-backing function (contains a call…) is not yet lowered`) instead of being lowered. This is gale's `gust:os/timer` provider shape:

```wat
sleep(handle: u32, ticks: u64) -> u32   ;; body calls read32(handle) then an in-module fn, then USES ticks
```

The decline was **safe** (never a miscompile — the object was correct, the function was just skipped), but the shape is natural and gale had to work around it by narrowing the seam to `u32`.

## Root cause

The u64 param arrives in an AAPCS even-aligned register pair (here **R2:R3**, since the leading `i32` takes R0 and the pair even-aligns past R1). A call reclaims R0..R3 (caller-saved), so the pair must be **homed into the frame** in the prologue, survive the call there, and be **reloaded after** — the frame-backing `param_slots` path (#204/#193).

That path sized an i64 param's slot from `i64_set` (inferred i64 **locals**, which **never contains params**), giving a wide param a **4-byte slot + `is_i64 = false`** → the **high half was dropped**. Rather than miscompile, the backend declined by name (#518).

## Fix

Size the frame-backing param slot from the **declared AAPCS width** (`params_i64`), so the pair is homed as an **8-byte slot** via `I64Str` in the prologue and reloaded via `I64Ldr` after the call. The store/reload machinery (prologue homing, `LocalGet`/`Set`/`Tee`) was **already `is_i64`-aware** — only the slot width was wrong. `i64_pair_hi(R0)=R1` and `i64_pair_hi(R2)=R3` hold (R0–R3 are consecutive in `ALLOCATABLE_REGS`), so the AAPCS home pair homes correctly.

Confined to `select_with_stack` + `compute_local_layout` (the `--relocatable`/direct path gale used). The optimized/default path uses separate codegen and already compiled the shape.

### Emitted `sleep` (cortex-m3, relocatable)
```
str.w r2, [sp, #0x60]   ; home u64 lo  ┐ ticks (R2:R3) frame-backed
str.w r3, [sp, #0x64]   ; home u64 hi  ┘
bl read32 ; bl combine  ; both clobber R0-R3
ldr.w r4, [sp, #0x60]   ; reload u64 lo ┐ ticks survived
ldr.w r5, [sp, #0x64]   ; reload u64 hi ┘
```

## Verification (red → green)

- **`framebacking_i64param_837_differential.py`** (new): gale's shape (`sleep` + `sleep_hi`, mmio import + in-module call) executed under unicorn vs **wasmtime** ground truth (the same `.wat` with `read32` as a host import). The u64 value param survives **both** calls bit-identically, including non-zero high halves. `sleep_hi` mixes **both** halves into its result so a dropped hi diverges.
- **`i64_param_518_differential.py`**: `d_call` moved `DECLINE_SKIPPED` → **emitted + executes** (`d_call(p) = p + 7`), resolving the in-module `bl helper`.
- **Execution matrix** (all survive the call): one i64 pair (R2:R3), two i64 pairs (R0:R1 + R2:R3, correct carry), soft-float **f64** value param (R0:R1).
- **Frozen 10/10 byte-identical** — all-i32 signatures are untouched at the slot-sizing site.
- `cargo build -p synth-cli` / `--features riscv` / `--workspace` clean; synth-synthesis 642/642; synth-cli suite green; clippy `-D warnings`; fmt; `claim_check` 25/25.
- CI: two steps appended to the i64 stack-param oracle job (wasmtime already installed there).

## Decline residual (honesty, decline > guess)

The only remaining register-resident i64-param decline is the **register-pair-exhaustion retry** (`param_backing_on_exhaustion`, `force_param_backing` on a call-free function) — it forces param backing across a spill choreography that has **no execution oracle yet**, so it keeps a loud decline **by name** (`#518/#837`) rather than being silently enabled. Asserted in `test_837_wide_reg_param_with_call_lowers_frame_backed`.

Closes #837. Refs #518, #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L