### PR TITLE
feat(rv32): close memory.size/memory.grow parity gaps (VCR-SEL-005, #223/#232/#242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -862,6 +862,40 @@ jobs:
           SYNTH: ./target/debug/synth
         run: python scripts/repro/const_addr_fold_riscv_differential.py
 
+  rv32-mem-size-grow-oracle:
+    name: rv32 memory.size / memory.grow execution oracle
+    # VCR-SEL-005 (#223/#242): EXECUTE the newly-lowered RV32 memory.size and
+    # memory.grow under unicorn (UC_ARCH_RISCV) and diff vs wasmtime. Closes two
+    # entries off the cross-backend op-parity allowlist — proves memory.size
+    # reports the declared page count, the shared rewrite_memory_grow_zero fold
+    # makes grow(0) return current size, and fixed-memory grow(>0) returns -1.
+    # Isolated job: emulation deps pip-installed here ONLY.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Run RV32 memory.size / memory.grow execution oracle
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/repro/rv32_mem_size_grow_242_differential.py
+
   callee-saved-490-oracle:
     name: optimized-path callee-saved preservation oracle
     # VCR-ORACLE-001 (#242, #490): EXECUTE optimized-path functions that use

--- a/crates/synth-backend-riscv/src/backend.rs
+++ b/crates/synth-backend-riscv/src/backend.rs
@@ -189,6 +189,12 @@ fn build_options(config: &CompileConfig, mem_size: u32) -> Result<SelectorOption
     Ok(SelectorOptions {
         bounds,
         signed_div_overflow_trap: true,
+        // #223/#242 (VCR-SEL-005): `memory.size` materializes the current page
+        // count from the module's FIXED linear-memory size. `mem_size` is the
+        // module's first-memory `initial_bytes()` (or the 64 KiB default on the
+        // no-module `compile_function` path), matching the linker-reserved
+        // region — so `memory.size` == the declared pages, byte-stable.
+        linear_memory_bytes: mem_size,
     })
 }
 
@@ -201,6 +207,12 @@ fn compile_function_with_opts(
     ensure_supported_target(&config.target)?;
 
     let num_params = effective_num_params(ops, config);
+    // #539/#242 (VCR-SEL-005): fold `i32.const 0; memory.grow` → `memory.size`
+    // BEFORE selection (shared with ARM), so the legal `memory.grow(0)` "return
+    // current size" idiom isn't miscompiled to the fixed-memory `-1` sentinel.
+    // `num_params` is unaffected (the fold only touches the memory-op body).
+    let ops = synth_core::rewrite_memory_grow_zero(ops);
+    let ops = ops.as_slice();
     // #312: pass the decoder's "returns i64" tables down so call-fed i64
     // locals get 8-byte frame slots and i64 call results the a0:a1 pair.
     let selection = select_with_result_types(
@@ -382,6 +394,11 @@ fn compile_to_riscv_ops(
     _compiled: &CompiledFunction,
 ) -> Result<Vec<crate::riscv_op::RiscVOp>, BackendError> {
     let num_params = effective_num_params(ops, config);
+    // Same `memory.grow(0)` fold as `compile_function_with_opts` — this path
+    // re-runs selection to produce the ELF bytes and MUST match it op-for-op
+    // (#539/#242), or the two selections would disagree.
+    let ops = synth_core::rewrite_memory_grow_zero(ops);
+    let ops = ops.as_slice();
     let selection = select_with_result_types(
         ops,
         num_params,

--- a/crates/synth-backend-riscv/src/backend.rs
+++ b/crates/synth-backend-riscv/src/backend.rs
@@ -155,10 +155,18 @@ impl Backend for RiscVBackend {
         config: &CompileConfig,
     ) -> Result<CompiledFunction, BackendError> {
         ensure_supported_target(&config.target)?;
-        // No module context — default the memory size to 1 wasm page so that
-        // Software/Mask modes can still synthesise the guard. Callers that
-        // need a different size go through `compile_module`.
-        let opts = build_options(config, 64 * 1024)?;
+        // Prefer the config's declared linear-memory size (the CLI populates it
+        // from the module's first memory — `--all-exports` compiles per function
+        // through here, NOT `compile_module`, so `memory.size` must read it from
+        // the config to report the right page count). Fall back to 1 wasm page
+        // when unset (a hand-built driver with no module context) so
+        // Software/Mask bounds modes can still synthesise their guard.
+        let mem_size = if config.linear_memory_bytes > 0 {
+            config.linear_memory_bytes
+        } else {
+            64 * 1024
+        };
+        let opts = build_options(config, mem_size)?;
         compile_function_with_opts(name, ops, config, opts)
     }
 

--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -2672,9 +2672,9 @@ impl Selector {
     /// declines with `-1`), so the page count is a COMPILE-TIME CONSTANT —
     /// materialized with `li rd, bytes / 65536`. This is the RV32 analogue of
     /// the ARM multi-memory constant path (`instruction_selector.rs`
-    /// `Movw/Movt` for a fixed-size memory), NOT ARM's memory-0 runtime `R10
-    /// >> 16` register — RV32 has no such runtime size register, and does not
-    /// need one because the size cannot change.
+    /// `Movw/Movt` for a fixed-size memory), NOT ARM's memory-0 runtime
+    /// `LSR R10, #16` register read — RV32 has no such runtime size register,
+    /// and does not need one because the size cannot change.
     ///
     /// Only memory 0 is lowered (this backend is single-memory; multi-memory
     /// is a separate #406 lane). A non-zero index declines loudly.
@@ -5647,6 +5647,7 @@ mod tests {
         let opts = SelectorOptions {
             bounds: RvBoundsMode::Software { mem_size: 0x10000 },
             signed_div_overflow_trap: true,
+            linear_memory_bytes: 0,
         };
         let out = s_with_opts(
             &[
@@ -5703,6 +5704,7 @@ mod tests {
         let opts = SelectorOptions {
             bounds: RvBoundsMode::Software { mem_size: 2 },
             signed_div_overflow_trap: true,
+            linear_memory_bytes: 0,
         };
         let out = s_with_opts(
             &[
@@ -6073,6 +6075,7 @@ mod tests {
         let opts = SelectorOptions {
             bounds: RvBoundsMode::Pmp,
             signed_div_overflow_trap: true,
+            linear_memory_bytes: 0,
         };
         let out = s_with_opts(
             &[
@@ -6104,6 +6107,7 @@ mod tests {
         let opts = SelectorOptions {
             bounds: RvBoundsMode::Mask { mask: 0xFFFF },
             signed_div_overflow_trap: true,
+            linear_memory_bytes: 0,
         };
         let out = s_with_opts(
             &[
@@ -6136,6 +6140,7 @@ mod tests {
         let opts = SelectorOptions {
             bounds: RvBoundsMode::Mask { mask: 0xFFFF },
             signed_div_overflow_trap: true,
+            linear_memory_bytes: 0,
         };
         let out = s_with_opts(
             &[
@@ -6186,6 +6191,7 @@ mod tests {
         let opts = SelectorOptions {
             bounds: RvBoundsMode::Mask { mask: 0xFFFF },
             signed_div_overflow_trap: true,
+            linear_memory_bytes: 0,
         };
         let word = s_with_opts(
             &[
@@ -6235,6 +6241,7 @@ mod tests {
         let sw = SelectorOptions {
             bounds: RvBoundsMode::Software { mem_size: 0x10000 },
             signed_div_overflow_trap: true,
+            linear_memory_bytes: 0,
         };
         let load = s_with_opts(
             &[
@@ -6263,6 +6270,7 @@ mod tests {
         let mask = SelectorOptions {
             bounds: RvBoundsMode::Mask { mask: 0xFFFF },
             signed_div_overflow_trap: true,
+            linear_memory_bytes: 0,
         };
         let store = s_with_opts(
             &[
@@ -6326,6 +6334,7 @@ mod tests {
         let opts = SelectorOptions {
             bounds: RvBoundsMode::None,
             signed_div_overflow_trap: false,
+            linear_memory_bytes: 0,
         };
         let out = s_with_opts(
             &[

--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -72,6 +72,16 @@ pub struct SelectorOptions {
     /// Always on for spec-compliant WASM output; exposed as a knob so the
     /// fuzz harness can disable it when comparing IR-level behaviour only.
     pub signed_div_overflow_trap: bool,
+    /// Linear-memory size in BYTES for memory-0, used by the `memory.size`
+    /// lowering to materialize the current page count as a constant
+    /// (`li rd, bytes / 65536`). This backend emits FIXED-SIZE linear memory
+    /// (the linker script reserves exactly this many bytes; `memory.grow`
+    /// always declines with `-1`), so the page count is a compile-time
+    /// constant — no runtime size register (the RV analogue of ARM's R10) is
+    /// needed. `0` (the default, e.g. the bare selector probe / a memory-less
+    /// module) materializes `0` pages, which is exactly what a module with no
+    /// declared memory reports.
+    pub linear_memory_bytes: u32,
 }
 
 impl SelectorOptions {
@@ -81,6 +91,7 @@ impl SelectorOptions {
         Self {
             bounds: RvBoundsMode::None,
             signed_div_overflow_trap: true,
+            linear_memory_bytes: 0,
         }
     }
 }
@@ -1748,6 +1759,15 @@ impl Selector {
             //   * More than 8 args (spill to stack per RV psABI)
             Call(func_idx) => self.lower_call(*func_idx, op)?,
 
+            // ─── Memory management (#223/#242, VCR-SEL-005) ──────────────
+            // FIXED-memory model, mirroring the ARM backend: this backend
+            // reserves exactly `linear_memory_bytes` for memory 0 in the
+            // generated linker script and `memory.grow` can never actually
+            // grow, so `memory.size` is a COMPILE-TIME CONSTANT (no runtime
+            // size register, the RV analogue of ARM's R10, is needed).
+            MemorySize(mem_idx) => self.lower_memory_size(*mem_idx, op)?,
+            MemoryGrow(mem_idx) => self.lower_memory_grow(*mem_idx, op)?,
+
             other => return Err(SelectorError::Unsupported(other.clone())),
         }
         Ok(())
@@ -2640,6 +2660,58 @@ impl Selector {
             },
         };
         self.out.push(op_built);
+        Ok(())
+    }
+
+    // ────────── Memory management (#223/#242, VCR-SEL-005) ──────────
+
+    /// `memory.size` — push the current linear-memory size in 64 KiB pages.
+    ///
+    /// This backend emits FIXED-size linear memory (the generated linker
+    /// script reserves exactly `linear_memory_bytes`; `memory.grow` always
+    /// declines with `-1`), so the page count is a COMPILE-TIME CONSTANT —
+    /// materialized with `li rd, bytes / 65536`. This is the RV32 analogue of
+    /// the ARM multi-memory constant path (`instruction_selector.rs`
+    /// `Movw/Movt` for a fixed-size memory), NOT ARM's memory-0 runtime `R10
+    /// >> 16` register — RV32 has no such runtime size register, and does not
+    /// need one because the size cannot change.
+    ///
+    /// Only memory 0 is lowered (this backend is single-memory; multi-memory
+    /// is a separate #406 lane). A non-zero index declines loudly.
+    fn lower_memory_size(&mut self, mem_idx: u32, op: &WasmOp) -> Result<(), SelectorError> {
+        if mem_idx != 0 {
+            return Err(SelectorError::Unsupported(op.clone()));
+        }
+        // 64 KiB = one wasm page. Integer division floors; a partial page
+        // cannot occur here because the linker reserves whole pages.
+        let pages = (self.options.linear_memory_bytes / 65536) as i32;
+        let dst = self.alloc_temp();
+        emit_load_imm(&mut self.out, dst, pages);
+        self.push_i32(dst);
+        Ok(())
+    }
+
+    /// `memory.grow` — on FIXED linear memory, growth can never succeed, so
+    /// return `-1` (WASM's "grow failed" sentinel).
+    ///
+    /// Byte-agnostic and identical to the ARM backend's `MemoryGrow` (which
+    /// emits `MVN rd, #0` = -1). The legal `memory.grow(0)` idiom ("grow by
+    /// zero pages can never fail; return current size", WASM Core §4.4.7) is
+    /// handled UP-FRONT by `rewrite_memory_grow_zero` in the backend entry
+    /// (shared with ARM), which folds `i32.const 0; memory.grow` → `memory.size`
+    /// BEFORE selection — so this arm only ever sees a genuine grow request
+    /// (or a runtime-variable page count), for which `-1` is the sound answer.
+    ///
+    /// Only memory 0 is lowered; a non-zero index declines loudly.
+    fn lower_memory_grow(&mut self, mem_idx: u32, op: &WasmOp) -> Result<(), SelectorError> {
+        if mem_idx != 0 {
+            return Err(SelectorError::Unsupported(op.clone()));
+        }
+        // Pop (and discard) the requested page count: fixed memory ignores it.
+        let _pages = self.pop_i32(op)?;
+        let dst = self.alloc_temp();
+        emit_load_imm(&mut self.out, dst, -1);
+        self.push_i32(dst);
         Ok(())
     }
 

--- a/crates/synth-backend-riscv/tests/cross_backend_op_parity.rs
+++ b/crates/synth-backend-riscv/tests/cross_backend_op_parity.rs
@@ -734,16 +734,30 @@ fn known_divergences() -> &'static [(&'static str, &'static str)] {
             "i32.popcnt",
             "Zbb cpop absent on RV32IMAC/rv32imc; RV32 seq-lowering deferred — VCR-SEL-005",
         ),
-        // ---- globals (measured 2026-07-17, universe-completeness) ----
+        // ---- globals (measured 2026-07-17; root-caused v0.50) ----
+        // NOT a missing selector arm — a missing SUBSTRATE. ARM addresses
+        // globals via a `__synth_globals` symbol + data reloc (R9-relative or
+        // emit_sym_addr); the RV32 encoder has NO data-symbol reloc path (Call
+        // is local-label-only, no %hi/%lo/%pcrel), and RV32 emits ET_REL only,
+        // so an absolute-constant address is unsound (the linker places the
+        // region). The reloc-free path — a linker-reserved region past linear
+        // memory, addressed `s11 + linear_memory_bytes + slot_off` — is sound
+        // and reuses the memory.size plumbing, BUT a HONEST landing needs the
+        // full #798-sized stack: CLI global-init emission + a startup init loop
+        // + a linker `.wasm_globals` region + a FULL-BOOT differential (a
+        // hand-initialized-region harness would be VACUOUS — the pre-#798
+        // control_step lesson). Deferred as that piece, VCR-SEL-005.
         (
             "global.get",
-            "RV32 selector has no GlobalGet arm (loud Unsupported); WASM globals \
-             not yet lowered on RV32 — deferred, VCR-SEL-005",
+            "RV32 globals need a base-relative region + startup init + linker \
+             wiring (#798-class), not a selector arm: the RV32 encoder has no \
+             data-symbol reloc and emits ET_REL only — deferred, VCR-SEL-005",
         ),
         (
             "global.set",
-            "RV32 selector has no GlobalSet arm (loud Unsupported); WASM globals \
-             not yet lowered on RV32 — deferred, VCR-SEL-005",
+            "RV32 globals need a base-relative region + startup init + linker \
+             wiring (#798-class), not a selector arm: the RV32 encoder has no \
+             data-symbol reloc and emits ET_REL only — deferred, VCR-SEL-005",
         ),
         // ---- bulk memory (measured 2026-07-17) ----
         // (memory.size / memory.grow CLOSED v0.50, #242 — RV32 now lowers both:

--- a/crates/synth-backend-riscv/tests/cross_backend_op_parity.rs
+++ b/crates/synth-backend-riscv/tests/cross_backend_op_parity.rs
@@ -704,8 +704,13 @@ fn all_wasm_op_representatives() -> Vec<WasmOp> {
 /// br_table, and the nine sub-word i64 loads/stores (load8/16/32_s/u,
 /// store8/16/32 — the full-word i64.load/i64.store DO lower on both; only the
 /// sub-word extend/truncate variants are the gap). Each is a TRACKED
-/// RV32-selector DEFERRAL under VCR-SEL-005, not a permanent ISA limit. Ledger
-/// total: 5 Zbb + 16 new = 21 entries.
+/// RV32-selector DEFERRAL under VCR-SEL-005, not a permanent ISA limit.
+///
+/// CLOSED v0.50 (#242): `memory.size` + `memory.grow` now lower on RV32
+/// (fixed-memory page-count constant + fixed-memory `-1` grow, shared
+/// `rewrite_memory_grow_zero` fold; execution differential
+/// `rv32_mem_size_grow_242_differential.py`). Ledger total: 5 Zbb + 16 −
+/// 2 closed = 19 entries.
 fn known_divergences() -> &'static [(&'static str, &'static str)] {
     &[
         // ---- Zbb bit-manipulation class (measured 2026-06-20) ----
@@ -740,17 +745,11 @@ fn known_divergences() -> &'static [(&'static str, &'static str)] {
             "RV32 selector has no GlobalSet arm (loud Unsupported); WASM globals \
              not yet lowered on RV32 — deferred, VCR-SEL-005",
         ),
-        // ---- memory management / bulk memory (measured 2026-07-17) ----
-        (
-            "memory.size",
-            "RV32 selector has no MemorySize arm (loud Unsupported); RV32 memory \
-             intrinsics not yet lowered — deferred, VCR-SEL-005",
-        ),
-        (
-            "memory.grow",
-            "RV32 selector has no MemoryGrow arm (loud Unsupported); RV32 memory \
-             intrinsics not yet lowered — deferred, VCR-SEL-005",
-        ),
+        // ---- bulk memory (measured 2026-07-17) ----
+        // (memory.size / memory.grow CLOSED v0.50, #242 — RV32 now lowers both:
+        //  fixed-memory page-count constant + fixed-memory `-1` grow, with the
+        //  shared `rewrite_memory_grow_zero` fold so grow(0)≡size. Execution
+        //  differential: scripts/repro/rv32_mem_size_grow_242_differential.py.)
         (
             "memory.copy",
             "RV32 selector has no MemoryCopy arm (loud Unsupported); RV32 bulk-memory \

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -237,31 +237,10 @@ fn count_params(wasm_ops: &[WasmOp]) -> u32 {
 }
 
 /// #539: fold the `i32.const 0; memory.grow m` idiom to `memory.size m`.
-/// `memory.grow(0)` always succeeds and returns the current page count (WASM
-/// Core §4.4.7), which is exactly `memory.size`; the fixed-memory backend
-/// otherwise emits a constant `-1` for every `memory.grow`, so the legal
-/// `memory.grow(0)` "read/validate current size" idiom wrongly reported failure.
-/// Only the ADJACENT const-0 delta is folded (a non-zero delta keeps the sound
-/// `-1` — fixed memory genuinely cannot grow; a runtime-computed 0 is a
-/// documented follow-up). Backend- and path-agnostic: `memory.size` reads the
-/// runtime memory-size register on every selector, so this fixes the optimized
-/// and direct paths at once.
-fn rewrite_memory_grow_zero(wasm_ops: &[WasmOp]) -> Vec<WasmOp> {
-    let mut out = Vec::with_capacity(wasm_ops.len());
-    let mut i = 0;
-    while i < wasm_ops.len() {
-        if matches!(wasm_ops[i], WasmOp::I32Const(0))
-            && let Some(WasmOp::MemoryGrow(m)) = wasm_ops.get(i + 1)
-        {
-            out.push(WasmOp::MemorySize(*m));
-            i += 2;
-        } else {
-            out.push(wasm_ops[i].clone());
-            i += 1;
-        }
-    }
-    out
-}
+/// Moved to `synth_core::rewrite_memory_grow_zero` (#242, VCR-SEL-005) so the
+/// ARM and RISC-V backends share ONE implementation and cannot drift; re-export
+/// here keeps the existing `rewrite_memory_grow_zero(...)` call sites working.
+use synth_core::rewrite_memory_grow_zero;
 
 /// #509: does the op stream contain a `br`/`br_if`/`br_table` that CARRIES a
 /// value — i.e. one targeting a result-typed block/if (forward edge with

--- a/crates/synth-core/src/lib.rs
+++ b/crates/synth-core/src/lib.rs
@@ -33,5 +33,5 @@ pub use wasm_decoder::{
     CallIndirectGuards, DecodedModule, ElemSegmentInfo, FunctionOps, ImportEntry, ImportKind,
     TableGuards, WasmMemory, decode_wasm_functions, decode_wasm_module,
 };
-pub use wasm_op::WasmOp;
+pub use wasm_op::{WasmOp, rewrite_memory_grow_zero};
 pub use wsc_facts::{FactKind, WSC_FACTS_SECTION_NAME, WscFact, WscFactsParse, parse_wsc_facts};

--- a/crates/synth-core/src/wasm_op.rs
+++ b/crates/synth-core/src/wasm_op.rs
@@ -489,3 +489,72 @@ pub enum WasmOp {
     F32x4ExtractLane(u8), // f32x4.extract_lane
     F32x4ReplaceLane(u8), // f32x4.replace_lane
 }
+
+/// Fold `i32.const 0; memory.grow` → `memory.size` up front, on every backend.
+///
+/// WASM Core §4.4.7: growing a memory by ZERO pages can never fail — it returns
+/// the current size. But every backend's `memory.grow` lowering on FIXED
+/// (non-growable) linear memory returns the "grow failed" sentinel `-1`, which
+/// would wrongly report failure for the legal `memory.grow(0)` "read current
+/// size" idiom. Rewriting the const-0 case to the semantically identical
+/// `memory.size` BEFORE selection fixes it uniformly. (A runtime-variable page
+/// count that happens to be 0 still lowers to `-1` — that is a documented
+/// follow-up, not this fold's concern; only the SYNTACTIC `i32.const 0` form is
+/// the well-known idiom.)
+///
+/// Shared by the ARM (`synth-backend`) and RISC-V (`synth-backend-riscv`)
+/// backend entry points so the two cannot drift (#242, VCR-SEL-005) — it lives
+/// here in `synth-core` next to `WasmOp` because both crates depend on it.
+pub fn rewrite_memory_grow_zero(wasm_ops: &[WasmOp]) -> Vec<WasmOp> {
+    let mut out = Vec::with_capacity(wasm_ops.len());
+    let mut i = 0;
+    while i < wasm_ops.len() {
+        if matches!(wasm_ops[i], WasmOp::I32Const(0))
+            && let Some(WasmOp::MemoryGrow(m)) = wasm_ops.get(i + 1)
+        {
+            out.push(WasmOp::MemorySize(*m));
+            i += 2;
+        } else {
+            out.push(wasm_ops[i].clone());
+            i += 1;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod grow_zero_tests {
+    use super::*;
+
+    #[test]
+    fn folds_const_zero_grow_to_size() {
+        assert_eq!(
+            rewrite_memory_grow_zero(&[WasmOp::I32Const(0), WasmOp::MemoryGrow(0)]),
+            vec![WasmOp::MemorySize(0)]
+        );
+    }
+
+    #[test]
+    fn leaves_nonzero_grow_alone() {
+        assert_eq!(
+            rewrite_memory_grow_zero(&[WasmOp::I32Const(2), WasmOp::MemoryGrow(0)]),
+            vec![WasmOp::I32Const(2), WasmOp::MemoryGrow(0)]
+        );
+    }
+
+    #[test]
+    fn leaves_variable_grow_alone() {
+        assert_eq!(
+            rewrite_memory_grow_zero(&[WasmOp::LocalGet(0), WasmOp::MemoryGrow(0)]),
+            vec![WasmOp::LocalGet(0), WasmOp::MemoryGrow(0)]
+        );
+    }
+
+    #[test]
+    fn preserves_memory_index() {
+        assert_eq!(
+            rewrite_memory_grow_zero(&[WasmOp::I32Const(0), WasmOp::MemoryGrow(3)]),
+            vec![WasmOp::MemorySize(3)]
+        );
+    }
+}

--- a/scripts/repro/rv32_mem_size_grow_242_differential.py
+++ b/scripts/repro/rv32_mem_size_grow_242_differential.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""#223 / #242 (VCR-SEL-005) — RV32 memory.size / memory.grow execution oracle.
+
+The v0.49 cross-backend op-parity gate ledgered `memory.size` and `memory.grow`
+as ARM-lowers / RV32-declines gaps. This lane lowers both on RV32:
+
+  * `memory.size`  — FIXED-memory page count, materialized as a compile-time
+    constant (`li rd, linear_memory_bytes / 65536`). No runtime size register
+    (the RV analogue of ARM's R10) is needed because the size cannot change.
+  * `memory.grow`  — fixed memory cannot grow, so return `-1` (WASM's "grow
+    failed" sentinel). The legal `memory.grow(0)` "return current size" idiom
+    (WASM Core §4.4.7) is folded to `memory.size` up front by the SHARED
+    `synth_core::rewrite_memory_grow_zero` (ARM+RV32), so `grow(0)` never
+    reports failure — that is the whole soundness point of this differential.
+
+This is the EXECUTION half of moving those two ops off the parity allowlist.
+It compiles a real module with a `(memory 3)` section on RV32, runs each export
+under unicorn with `s11 = __linear_memory_base`, and checks:
+
+  - `sz`     == 3   (current pages; == wasmtime)
+  - `grow0`  == 3   (grow-by-0 returns current size — the shared fold; == wasmtime)
+  - `grow2`  == -1  (grow-by->0 on FIXED memory returns -1; this is the sound,
+                     documented behavior and legitimately DIFFERS from wasmtime,
+                     whose memory can actually grow — so grow>0 is asserted
+                     DIRECTLY, not against wasmtime, mirroring mem_grow_539)
+
+`sz`/`grow0` are cross-checked against wasmtime with a FRESH instance per call
+(memory.grow mutates the store; a shared instance would pollute the oracle).
+
+A LOUD failure (never a skip) on a missing tool — a gate that skips on an
+assumption is vacuous.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/rv32_mem_size_grow_242_differential.py
+"""
+import os
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_RISCV, UC_MODE_RISCV32, Uc, UcError
+from unicorn.riscv_const import UC_RISCV_REG_A0, UC_RISCV_REG_RA, UC_RISCV_REG_S11, UC_RISCV_REG_SP
+
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+CODE, LIN, STK, RET = 0x100000, 0x40000, 0x90000, 0x200000
+PAGES = 3
+
+# A module with a fixed 3-page memory. `sz` reads the page count; `grow0` is the
+# legal grow-by-0 idiom (must return current size); `grow2` grows by 2 (fixed
+# memory: -1).
+WAT = """(module
+  (memory 3)
+  (func (export "sz") (result i32) memory.size)
+  (func (export "grow0") (result i32) i32.const 0 memory.grow)
+  (func (export "grow2") (result i32) i32.const 2 memory.grow))"""
+
+
+def wasmtime_run(module, engine, fn):
+    # FRESH instance per call: memory.grow mutates the store.
+    store = wasmtime.Store(engine)
+    return wasmtime.Instance(store, module, []).exports(store)[fn](store)
+
+
+def compile_rv32(wat_path, out):
+    cmd = [SYNTH, "compile", wat_path, "-o", out, "-b", "riscv",
+           "-t", "rv32imac", "--all-exports", "--relocatable"]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0 or "skipping" in (r.stdout + r.stderr):
+        print(f"RV32 mem-size/grow ORACLE: FAIL — compile failed/skipped:\n{r.stdout}{r.stderr}")
+        sys.exit(1)
+
+
+def load(elf):
+    dis = subprocess.run([SYNTH, "disasm", elf], capture_output=True, text=True).stdout
+    syms = {m.group(2): int(m.group(1), 16)
+            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
+    code = ELFFile(open(elf, "rb")).get_section_by_name(".text").data()
+    return code, syms
+
+
+def unicorn_run(code, faddr):
+    mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(LIN, PAGES * 0x10000)
+    mu.mem_map(STK - 0x8000, 0x10000)
+    mu.mem_map(RET, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_RISCV_REG_SP, STK)
+    mu.reg_write(UC_RISCV_REG_S11, LIN)  # s11 = __linear_memory_base
+    mu.reg_write(UC_RISCV_REG_RA, RET)
+    try:
+        mu.emu_start(CODE + faddr, RET, count=2000)
+    except UcError as e:
+        return f"ERR:{e}"
+    raw = mu.reg_read(UC_RISCV_REG_A0) & 0xFFFFFFFF
+    return struct.unpack("<i", struct.pack("<I", raw))[0]
+
+
+def main():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.encode())
+
+    # (export, expected). grow2 is asserted to -1 DIRECTLY (fixed memory cannot
+    # grow — sound behavior that differs from wasmtime, which can grow).
+    cases = [
+        ("sz", wasmtime_run(module, engine, "sz")),        # 3
+        ("grow0", wasmtime_run(module, engine, "grow0")),  # 3 — shared fold
+        ("grow2", -1),                                     # fixed-mem: -1
+    ]
+
+    d = tempfile.mkdtemp(prefix="rv32_memsg_")
+    wat = os.path.join(d, "m.wat")
+    open(wat, "w").write(WAT)
+    out = os.path.join(d, "m.o")
+    compile_rv32(wat, out)
+    code, syms = load(out)
+
+    fails = 0
+    for fn, expect in cases:
+        faddr = syms.get(f"func_{['sz', 'grow0', 'grow2'].index(fn)}") or syms.get(fn)
+        if faddr is None:
+            print(f"RV32 mem-size/grow ORACLE: FAIL — no symbol for export {fn} ({sorted(syms)})")
+            sys.exit(1)
+        got = unicorn_run(code, faddr)
+        ok = got == expect
+        fails += 0 if ok else 1
+        note = "" if fn != "grow2" else "  (fixed-mem: -1 is sound; wasmtime grows)"
+        print(f"{'OK ' if ok else 'BUG'} {fn:6} synth={got} expect={expect}{note}")
+
+    print("\nRV32 mem-size/grow ORACLE: PASS — memory.size + memory.grow (+ grow(0) fold) "
+          "execute correctly on RV32" if not fails else f"RV32 mem-size/grow ORACLE: FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Closes two entries off the v0.49 cross-backend op-parity allowlist (VCR-SEL-005,
epic #242): **`memory.size`** and **`memory.grow`** now lower on the RV32 backend,
moving them from ARM-lowers/RV32-declines to lowered-on-both.

Allowlist: **21 → 19** ledgered divergences.

## How

- **`memory.size`** — RV32 emits FIXED-size linear memory (the generated linker
  script reserves exactly `linear_memory_bytes`; `memory.grow` can never grow),
  so the page count is a **compile-time constant** — materialized `li rd, bytes /
  65536`. No runtime size register (the RV analogue of ARM's `R10`) is needed
  because the size cannot change. This mirrors ARM's multi-memory constant path,
  not ARM's memory-0 runtime `LSR R10, #16`.
- **`memory.grow`** — fixed memory cannot grow → return `-1` (WASM's grow-failed
  sentinel), byte-agnostic and identical to ARM's `MVN rd, #0`.
- **Shared `rewrite_memory_grow_zero`** — the `i32.const 0; memory.grow` →
  `memory.size` fold (WASM Core §4.4.7: grow-by-zero never fails, returns current
  size) was ARM-only in `arm_backend.rs`. **Moved to `synth_core`** so ARM+RV32
  share ONE implementation and cannot drift — this is the soundness point: without
  it, `memory.grow(0)` would miscompile to `-1` on RV32.
- Threaded `linear_memory_bytes` into RV32 `SelectorOptions`, and fixed
  `compile_function` to read `config.linear_memory_bytes` — the `--all-exports`
  path compiles per-function through there (NOT `compile_module`), so
  `memory.size` must read the declared size from the config to report the right
  page count.

### Latent fix worth noting
`compile_function` previously hard-coded `64 * 1024` for `build_options`'s
`mem_size`. On a multi-page module with **software bounds**, that bounds-checked
against the wrong 64 KiB and would wrongly trap valid page-1+ accesses. Now it
reads the real `linear_memory_bytes`. Frozen-confirmed no byte drift.

## Differential evidence (the real deliverable)

New `scripts/repro/rv32_mem_size_grow_242_differential.py` compiles a real
`(memory 3)` module on RV32, runs each export under unicorn with
`s11 = __linear_memory_base`, and diffs vs wasmtime:

```
OK  sz     synth=3 expect=3
OK  grow0  synth=3 expect=3   (grow-by-0 returns current size — the shared fold)
OK  grow2  synth=-1 expect=-1 (fixed-mem: -1 is sound; wasmtime grows)
RV32 mem-size/grow ORACLE: PASS
```

`grow2` is asserted DIRECTLY to `-1` (fixed memory legitimately diverges from
wasmtime, which can grow), mirroring `mem_grow_539`. CI-wired as
`rv32-mem-size-grow-oracle`.

## Declined (decline > guess)

- **`global.get` / `global.set`** — root-caused, NOT a missing selector arm but a
  missing SUBSTRATE. ARM addresses globals via a `__synth_globals` symbol + data
  reloc; the RV32 encoder has **no data-symbol reloc path** and emits ET_REL only,
  so an absolute-constant address is unsound (the linker places the region). The
  sound reloc-free path (a linker-reserved region past linear memory, addressed
  `s11 + linear_memory_bytes + slot_off`) needs the full #798-sized stack: CLI
  global-init emission + startup init loop + linker region + a **full-boot**
  differential (a hand-initialized-region harness would be vacuous — the pre-#798
  control_step lesson). Ledgered with that concrete reason.
- **`memory.copy` / `memory.fill`** — stay #374 bulk-memory declines.

## Gates

- parity gate green (21 → 19); red-first + stale-entry checks intact
- RV32 mem-size/grow differential: **PASS** (executes bit-identically to wasmtime)
- ARM `mem_grow_539` differential: **PASS** on both paths (shared-fold no regression)
- frozen 10/10 (no ARM/RV32 byte drift — new lowerings only touch functions using
  the ops; the `compile_function` fix is frozen-neutral)
- `cargo build -p synth-cli --features riscv` clean; workspace build clean
- synth-core / synth-backend-riscv / synth-backend / synth-cli tests green
- clippy `-D warnings` clean; `cargo fmt --check` clean
- `python3 scripts/claim_check.py claims.yaml`: 25/25
- no rivet artifact / claims.yaml touched (no serial-merge trigger, no new sys-verification)

Refs #223 #232 #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L