### PR TITLE
test(#850): harden 9 differential oracles to read ELF .symtab, not disasm text

### DIFF
--- a/scripts/repro/add_imm_large_differential.py
+++ b/scripts/repro/add_imm_large_differential.py
@@ -21,7 +21,6 @@ Run:
 
 Exits nonzero on any mismatch.
 """
-import re
 import subprocess
 import sys
 
@@ -55,11 +54,21 @@ def main():
         inst = wasmtime.Instance(store, module, [])
         return inst.exports(store)["store_load_large"](store, arg) & 0xFFFFFFFF
 
-    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
-    syms = {m.group(2): int(m.group(1), 16)
-            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
+    # Read function offsets from the ELF SYMBOL TABLE (host-independent), NOT by
+    # parsing `synth disasm` TEXT — disasm formatting is host-dependent and the
+    # regex matched nothing on the Linux CI runner (#850). synth emits the symtab
+    # as an UNNAMED SHT_SYMTAB section (get_section_by_name(".symtab") is None), so
+    # iterate by TYPE. An ARM Thumb function symbol carries the Thumb bit (bit 0),
+    # so mask `& ~1` — the masked value equals the clean disasm address exactly, so
+    # every downstream `(CODE + fa - base) | 1` formula is byte-identical.
+    ef = ELFFile(open(ELF, "rb"))
+    text_idx = ef.get_section_index(".text")
+    syms = {s.name: s["st_value"] & ~1 for sec in ef.iter_sections()
+            if sec.header.sh_type == "SHT_SYMTAB"
+            for s in sec.iter_symbols()
+            if s.name and s["st_shndx"] == text_idx}
     fa = syms.get("func_0") or syms.get("store_load_large")
-    text = ELFFile(open(ELF, "rb")).get_section_by_name(".text")
+    text = ef.get_section_by_name(".text")
     code, base = text.data(), text["sh_addr"]
 
     def arm(arg):

--- a/scripts/repro/bulk_memory_374_differential.py
+++ b/scripts/repro/bulk_memory_374_differential.py
@@ -31,7 +31,6 @@ Run:
   /tmp/n374venv/bin/python scripts/repro/bulk_memory_374_differential.py /tmp/bmd.elf
 Exits nonzero on any mismatch.
 """
-import re
 import subprocess
 import os
 import sys
@@ -108,11 +107,22 @@ def main():
         img = bytes(mem.read(store, 0, MEM_BYTES))
         return trapped, img
 
-    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
-    syms = {m.group(2): int(m.group(1), 16)
-            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
+    # Read symbol offsets from the ELF SYMBOL TABLE (host-independent), NOT by
+    # parsing `synth disasm` TEXT — disasm formatting is host-dependent and the
+    # regex matched nothing on the Linux CI runner (#850). synth emits the symtab
+    # as an UNNAMED SHT_SYMTAB section (get_section_by_name(".symtab") is None), so
+    # iterate by TYPE. ARM Thumb symbols carry the Thumb bit (bit 0); mask `& ~1`
+    # so the map equals the clean disasm addresses. This is load-bearing for
+    # trap_addr too: the hook compares the EVEN executing PC, so an unmasked
+    # (odd) trap_addr would never match and silently defeat trap detection.
+    ef = ELFFile(open(ELF, "rb"))
+    text_idx = ef.get_section_index(".text")
+    syms = {s.name: s["st_value"] & ~1 for sec in ef.iter_sections()
+            if sec.header.sh_type == "SHT_SYMTAB"
+            for s in sec.iter_symbols()
+            if s.name and s["st_shndx"] == text_idx}
     trap_sym = syms["Trap_Handler"]
-    text = ELFFile(open(ELF, "rb")).get_section_by_name(".text")
+    text = ef.get_section_by_name(".text")
     code, base = text.data(), text["sh_addr"]
     trap_addr = CODE + trap_sym - base
 

--- a/scripts/repro/control_step_riscv_differential.py
+++ b/scripts/repro/control_step_riscv_differential.py
@@ -28,7 +28,6 @@ Run:
         --all-exports --relocatable -o /tmp/cs_rv.o
   /tmp/armv/bin/python scripts/repro/control_step_riscv_differential.py /tmp/cs_rv.o
 """
-import re
 import struct
 import subprocess
 import sys
@@ -93,11 +92,21 @@ def main():
         inst = wasmtime.Instance(store, module, [])
         return inst.exports(store)["control_step_decide"](store, *args) & 0xFFFFFFFF
 
-    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
-    syms = {m.group(2): int(m.group(1), 16)
-            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
-    fa = syms["func_0"] if "func_0" in syms else syms["control_step_decide"]
+    # Read the function offset from the ELF SYMBOL TABLE (host-independent), NOT
+    # by parsing `synth disasm` TEXT — disasm formatting is host-dependent and the
+    # regex matched nothing on the Linux CI runner (#850). In a --relocatable RV32
+    # object a function symbol's st_value IS its offset within .text (base 0, no
+    # Thumb bit), exactly the `fa` unicorn expects at CODE + fa.
     elffile = ELFFile(open(ELF, "rb"))
+    text_idx = elffile.get_section_index(".text")
+    syms = {s.name: s["st_value"] for sec in elffile.iter_sections()
+            if sec.header.sh_type == "SHT_SYMTAB"
+            for s in sec.iter_symbols()
+            if s.name and s["st_shndx"] == text_idx}
+    fa = syms["func_0"] if "func_0" in syms else syms.get("control_step_decide")
+    if fa is None:
+        print(f"FAIL: control_step_decide symbol not found ({sorted(syms)})")
+        sys.exit(1)
     code = elffile.get_section_by_name(".text").data()
 
     # #798 gate: the module carries a nonzero active data segment (the decision

--- a/scripts/repro/controller_step_riscv_differential.py
+++ b/scripts/repro/controller_step_riscv_differential.py
@@ -15,7 +15,6 @@ Run:
         --all-exports --relocatable -o /tmp/ctrl_rv.o
   /tmp/armv/bin/python scripts/repro/controller_step_riscv_differential.py /tmp/ctrl_rv.o
 """
-import re
 import subprocess
 import sys
 
@@ -72,14 +71,22 @@ def main():
         inst = wasmtime.Instance(store, module, [])
         return inst.exports(store)["controller_step_decide"](store, *args) & 0xFFFFFFFF
 
-    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
-    syms = {m.group(2): int(m.group(1), 16)
-            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
+    # Read the function offset from the ELF SYMBOL TABLE (host-independent), NOT
+    # by parsing `synth disasm` TEXT — disasm formatting is host-dependent and the
+    # regex matched nothing on the Linux CI runner (#850). In a --relocatable RV32
+    # object a function symbol's st_value IS its offset within .text (base 0, no
+    # Thumb bit), exactly the `fa` unicorn expects at CODE + fa.
+    elffile = ELFFile(open(ELF, "rb"))
+    text_idx = elffile.get_section_index(".text")
+    syms = {s.name: s["st_value"] for sec in elffile.iter_sections()
+            if sec.header.sh_type == "SHT_SYMTAB"
+            for s in sec.iter_symbols()
+            if s.name and s["st_shndx"] == text_idx}
     fa = syms.get("func_0") or syms.get("controller_step_decide")
     if fa is None:
-        print("FAIL: controller_step_decide symbol not found (function skipped?)")
+        print(f"FAIL: controller_step_decide symbol not found ({sorted(syms)})")
         sys.exit(1)
-    code = ELFFile(open(ELF, "rb")).get_section_by_name(".text").data()
+    code = elffile.get_section_by_name(".text").data()
 
     def run(args):
         mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)

--- a/scripts/repro/div_const_differential.py
+++ b/scripts/repro/div_const_differential.py
@@ -14,7 +14,6 @@ Run:
 
 Exits nonzero on any mismatch so it can gate a release.
 """
-import re
 import subprocess
 import sys
 
@@ -63,13 +62,25 @@ def main():
     inst = wasmtime.Instance(store, module, [])
     wt = {w: inst.exports(store)[w] for w in PAIRS}
 
-    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
-    syms = sorted(int(m.group(1), 16)
-                  for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M))
+    # Read function offsets from the ELF SYMBOL TABLE (host-independent), NOT by
+    # parsing `synth disasm` TEXT — disasm formatting is host-dependent and the
+    # regex matched nothing on the Linux CI runner (#850). synth emits the symtab
+    # as an UNNAMED SHT_SYMTAB section (get_section_by_name(".symtab") is None), so
+    # iterate by TYPE. ARM Thumb symbols carry the Thumb bit (bit 0); mask `& ~1`.
+    # The symtab has TWO names per address (func_N and its export alias), so DEDUPE
+    # the addresses with set() before sorting — the masked sorted set equals the
+    # old sorted disasm addresses exactly, preserving the positional i-th mapping.
+    ef = ELFFile(open(ELF, "rb"))
+    text_idx = ef.get_section_index(".text")
+    syms = sorted({s["st_value"] & ~1 for sec in ef.iter_sections()
+                   if sec.header.sh_type == "SHT_SYMTAB"
+                   for s in sec.iter_symbols()
+                   if s.name and s["st_shndx"] == text_idx
+                   and s["st_info"]["type"] == "STT_FUNC"})
     # positional map: i-th wasm function -> i-th .text symbol by address
     assert len(syms) == len(PAIRS), f"{len(syms)} ELF syms vs {len(PAIRS)} wasm funcs"
     addr = dict(zip(PAIRS, syms))
-    text = ELFFile(open(ELF, "rb")).get_section_by_name(".text")
+    text = ef.get_section_by_name(".text")
     code, base = text.data(), text["sh_addr"]
 
     def run(a, x):

--- a/scripts/repro/i64_large_offset_382_differential.py
+++ b/scripts/repro/i64_large_offset_382_differential.py
@@ -20,7 +20,6 @@ Run (rebuild synth first):
     /tmp/synthvenv/bin/python scripts/repro/i64_large_offset_382_differential.py
 """
 import os
-import re
 import subprocess
 import sys
 
@@ -97,10 +96,20 @@ def run_unicorn():
          "--all-exports", "-o", ELF],
         check=True, capture_output=True,
     )
-    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
-    syms = {m.group(2): int(m.group(1), 16)
-            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
-    text = ELFFile(open(ELF, "rb")).get_section_by_name(".text")
+    # Read function offsets from the ELF SYMBOL TABLE (host-independent), NOT by
+    # parsing `synth disasm` TEXT — disasm formatting is host-dependent and the
+    # regex matched nothing on the Linux CI runner (#850). synth emits the symtab
+    # as an UNNAMED SHT_SYMTAB section (get_section_by_name(".symtab") is None), so
+    # iterate by TYPE. ARM Thumb symbols carry the Thumb bit (bit 0); mask `& ~1`
+    # so the map equals the clean disasm addresses and every downstream
+    # `(CODE + syms[fn] - base) | 1` formula is byte-identical.
+    ef = ELFFile(open(ELF, "rb"))
+    text_idx = ef.get_section_index(".text")
+    syms = {s.name: s["st_value"] & ~1 for sec in ef.iter_sections()
+            if sec.header.sh_type == "SHT_SYMTAB"
+            for s in sec.iter_symbols()
+            if s.name and s["st_shndx"] == text_idx}
+    text = ef.get_section_by_name(".text")
     code, base = text.data(), text["sh_addr"]
 
     CODE, STK = 0x10000, 0x30000000

--- a/scripts/repro/load_store_big_offset_382_differential.py
+++ b/scripts/repro/load_store_big_offset_382_differential.py
@@ -21,7 +21,6 @@ Run (rebuild synth first):
 
 Exits nonzero on mismatch so it can gate a release.
 """
-import re
 import subprocess
 import sys
 
@@ -76,10 +75,20 @@ def run_unicorn():
         [SYNTH, "compile", WASM, "-t", "cortex-m4", "--all-exports", "-o", ELF],
         check=True, capture_output=True,
     )
-    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
-    syms = {m.group(2): int(m.group(1), 16)
-            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
-    text = ELFFile(open(ELF, "rb")).get_section_by_name(".text")
+    # Read function offsets from the ELF SYMBOL TABLE (host-independent), NOT by
+    # parsing `synth disasm` TEXT — disasm formatting is host-dependent and the
+    # regex matched nothing on the Linux CI runner (#850). synth emits the symtab
+    # as an UNNAMED SHT_SYMTAB section (get_section_by_name(".symtab") is None), so
+    # iterate by TYPE. ARM Thumb symbols carry the Thumb bit (bit 0); mask `& ~1`
+    # so the map equals the clean disasm addresses and every downstream
+    # `(CODE + syms[fn] - base) | 1` formula is byte-identical.
+    ef = ELFFile(open(ELF, "rb"))
+    text_idx = ef.get_section_index(".text")
+    syms = {s.name: s["st_value"] & ~1 for sec in ef.iter_sections()
+            if sec.header.sh_type == "SHT_SYMTAB"
+            for s in sec.iter_symbols()
+            if s.name and s["st_shndx"] == text_idx}
+    text = ef.get_section_by_name(".text")
     code, base = text.data(), text["sh_addr"]
 
     CODE, LIN, STK = 0x10000, LIN_BASE & ~0xFFFF, 0x30000000

--- a/scripts/repro/signed_div_const_riscv_differential.py
+++ b/scripts/repro/signed_div_const_riscv_differential.py
@@ -12,7 +12,6 @@ Run:
         --all-exports --relocatable -o /tmp/sdiv.o
   /tmp/armv/bin/python scripts/repro/signed_div_const_riscv_differential.py /tmp/sdiv.o
 """
-import re
 import subprocess
 import sys
 
@@ -44,14 +43,22 @@ def main():
         inst = wasmtime.Instance(store, module, [])
         return inst.exports(store)["filter_axis_decide"](store, *args) & 0xFFFFFFFF
 
-    dis = subprocess.run([SYNTH, "disasm", ELF], capture_output=True, text=True).stdout
-    syms = {m.group(2): int(m.group(1), 16)
-            for m in re.finditer(r'^([0-9a-f]{8}) <(\w+)>:', dis, re.M)}
+    # Read the function offset from the ELF SYMBOL TABLE (host-independent), NOT
+    # by parsing `synth disasm` TEXT — disasm formatting is host-dependent and the
+    # regex matched nothing on the Linux CI runner (#850). In a --relocatable RV32
+    # object a function symbol's st_value IS its offset within .text (base 0, no
+    # Thumb bit), exactly the `fa` unicorn expects at CODE + fa.
+    elffile = ELFFile(open(ELF, "rb"))
+    text_idx = elffile.get_section_index(".text")
+    syms = {s.name: s["st_value"] for sec in elffile.iter_sections()
+            if sec.header.sh_type == "SHT_SYMTAB"
+            for s in sec.iter_symbols()
+            if s.name and s["st_shndx"] == text_idx}
     fa = syms.get("func_0") or syms.get("filter_axis_decide")
     if fa is None:
-        print("FAIL: filter_axis_decide symbol not found (function skipped?)")
+        print(f"FAIL: filter_axis_decide symbol not found ({sorted(syms)})")
         sys.exit(1)
-    code = ELFFile(open(ELF, "rb")).get_section_by_name(".text").data()
+    code = elffile.get_section_by_name(".text").data()
 
     def run(args):
         mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)

--- a/scripts/repro/uxth_fold_differential.py
+++ b/scripts/repro/uxth_fold_differential.py
@@ -68,11 +68,20 @@ def compile_variant(fold_on):
 
 
 def fn_addr_and_code(elf):
-    dis = subprocess.run([SYNTH, "disasm", elf], capture_output=True, text=True).stdout
-    syms = {m.group(2): int(m.group(1), 16)
-            for m in re.finditer(r"^([0-9a-f]{8}) <(\w+)>:", dis, re.M)}
+    # Read the function offset from the ELF SYMBOL TABLE (host-independent), NOT by
+    # parsing `synth disasm` TEXT — disasm formatting is host-dependent and the
+    # regex matched nothing on the Linux CI runner (#850). synth emits the symtab
+    # as an UNNAMED SHT_SYMTAB section (get_section_by_name(".symtab") is None), so
+    # iterate by TYPE. ARM Thumb symbols carry the Thumb bit (bit 0); mask `& ~1`
+    # so the value equals the clean disasm address ((CODE + fa - base) | 1 unchanged).
+    ef = ELFFile(open(elf, "rb"))
+    text_idx = ef.get_section_index(".text")
+    syms = {s.name: s["st_value"] & ~1 for sec in ef.iter_sections()
+            if sec.header.sh_type == "SHT_SYMTAB"
+            for s in sec.iter_symbols()
+            if s.name and s["st_shndx"] == text_idx}
     fa = syms.get("func_0") or syms.get("pack")
-    text = ELFFile(open(elf, "rb")).get_section_by_name(".text")
+    text = ef.get_section_by_name(".text")
     return fa, text.data(), text["sh_addr"]
 
 


### PR DESCRIPTION
## What

Nine sibling differential/oracle scripts under `scripts/repro/` located function offsets by regex-parsing `synth disasm` **TEXT**. That is host-dependent — the exact latent pattern that made the v0.50 `rv32 memory.size/grow` oracle fail 100% on the Linux CI runner (empty syms → "no symbol for export sz") while passing on macOS (**#850**). This converts each to read the ELF **symbol table** via pyelftools instead (host-independent), copying the `rv32_mem_size_grow_242_differential.py` reference fix.

## Scripts converted (9)

| script | regime | address handling |
|---|---|---|
| `add_imm_large_differential.py` | ARM reloc | mask `& ~1` (Thumb bit) |
| `bulk_memory_374_differential.py` | ARM linked | mask `& ~1` — **also fixes trap_addr** |
| `div_const_differential.py` | ARM reloc, **positional** | mask + `set()` dedupe + STT_FUNC |
| `i64_large_offset_382_differential.py` | ARM reloc | mask `& ~1` |
| `load_store_big_offset_382_differential.py` | ARM linked | mask `& ~1` |
| `uxth_fold_differential.py` | ARM reloc | mask `& ~1` |
| `control_step_riscv_differential.py` | RV32 reloc | `st_value` direct (no mask) |
| `controller_step_riscv_differential.py` | RV32 reloc | `st_value` direct |
| `signed_div_const_riscv_differential.py` | RV32 reloc | `st_value` direct |

## Key findings / correctness

- synth emits the symtab as an **UNNAMED** `SHT_SYMTAB` section for the ARM builds (`get_section_by_name(".symtab")` returns `None`), so every script iterates by `sh_type == "SHT_SYMTAB"` and filters `st_shndx == text_idx`.
- **ARM Thumb function symbols carry the Thumb bit (bit 0)**; `st_value` = clean disasm addr + 1. Masking `& ~1` **at map construction** makes the map byte-identical to the old disasm map, so every downstream `(CODE + fa - base) | 1` formula is unchanged. In `bulk_memory_374` the mask is load-bearing for `trap_addr` too (the hook compares the **even** executing PC — an unmasked odd trap_addr would silently never fire, a vacuous green).
- **`div_const` is positional** (sort addrs, zip with `PAIRS`): the symtab carries **two** names per address (`func_N` + export alias), so dedupe with `set()` and filter `STT_FUNC` before the `len == PAIRS` assert.
- **RV32** objects name the section `.symtab`, `st_value` is the `.text` offset with **no** Thumb bit → used directly.
- **No disasm fallback added**: every target build carries a symtab; none are the stripped self-contained images that motivated 677/679's fallback.

## Verification

Captured each script's baseline output **before** editing, then re-ran **after** with a freshly-built binary — all 9 PASS with **identical** match counts (before == after):

`control_step 5/5 · controller_step 5/5 · signed_div 5/5 · add_imm 8/8 · div_const 338/338 · uxth 7/7 · i64_lo 5/5 · ls382 5/5 · bulk_memory 16/16`

Cross-checked masked symtab addresses == disasm addresses across all ARM ELFs and RV32 (st_value=0, base=0) regimes before deleting the disasm path.

`bulk_mask_679` and `bulk_local_clobber_677` already read the symtab by type and mask `& ~1` at use — verified their symtab branch fires (fixtures carry a `SHT_SYMTAB`), so **left as-is** (already hardened).

Test-harness only — **byte-invisible to codegen**.

Advances #850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L