### PR TITLE
[BLOCKED] ordeal un-pin 0.9.1→0.16: bvsrem fixed but bvurem still hangs i32 rem_u — keep pinned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **ordeal un-pinned `=0.9.1` → `0.16.0` (#849) + per-query wall-clock deadline
+  wired (#848).** The ordeal 0.12 `bvsrem`/`bvsdiv` solver-performance regression
+  that HUNG the div/rem trap-preservation VCs (4–6 h CI timeouts) is fixed upstream
+  (ordeal PR#99 / ordeal#97 — `bvsrem` is multiplicative again). 0.16.0 adds
+  `Solver::check_with_deadline(ms)`, now wired into the `synth-verify` solver seam
+  (`OrdealSolver`, default 10 s, override `SYNTH_ORDEAL_DEADLINE_MS`) so a future
+  perf cliff degrades a slow query to a conservative `Unknown` — the soundness basis
+  being that `Unknown` is never mapped to `Verified` — instead of hanging the suite.
+  The four #836 `BvTerm::Urem` enum-completeness arms (term.rs ×3, z3-gated
+  solver.rs ×1) re-appear (the variant exists only in ordeal 0.12+).
+
+### Added
+
+- **Native i64 `rem_u`/`rem_s` value model re-landed (#844/#848).** The `I64RemU`/
+  `I64RemS` HAVOC in `synth-verify`'s `arm_semantics` is again a real native 64-bit
+  remainder (`dividend.bvurem`/`bvsrem(&divisor)` composed from the register halves,
+  with the ÷0 trap), so the value+trap VC (`verify_i64_rem_value_preservation`) is
+  load-bearing: a lowering that writes the remainder to the wrong register pair is
+  now `Invalid` (non-vacuity gate restored). Re-landed on ordeal 0.16.0 behind the
+  new per-query deadline (this is the #848 acceptance shape). Byte-invisible —
+  verify-only, no codegen change, frozen anchors untouched.
+
 ## [0.50.1] - 2026-07-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **ordeal un-pinned `=0.9.1` → `0.16.0` (#849) + per-query wall-clock deadline
-  wired (#848).** The ordeal 0.12 `bvsrem`/`bvsdiv` solver-performance regression
-  that HUNG the div/rem trap-preservation VCs (4–6 h CI timeouts) is fixed upstream
-  (ordeal PR#99 / ordeal#97 — `bvsrem` is multiplicative again). 0.16.0 adds
-  `Solver::check_with_deadline(ms)`, now wired into the `synth-verify` solver seam
-  (`OrdealSolver`, default 10 s, override `SYNTH_ORDEAL_DEADLINE_MS`) so a future
-  perf cliff degrades a slow query to a conservative `Unknown` — the soundness basis
-  being that `Unknown` is never mapped to `Verified` — instead of hanging the suite.
-  The four #836 `BvTerm::Urem` enum-completeness arms (term.rs ×3, z3-gated
-  solver.rs ×1) re-appear (the variant exists only in ordeal 0.12+).
-
-### Added
-
-- **Native i64 `rem_u`/`rem_s` value model re-landed (#844/#848).** The `I64RemU`/
-  `I64RemS` HAVOC in `synth-verify`'s `arm_semantics` is again a real native 64-bit
-  remainder (`dividend.bvurem`/`bvsrem(&divisor)` composed from the register halves,
-  with the ÷0 trap), so the value+trap VC (`verify_i64_rem_value_preservation`) is
-  load-bearing: a lowering that writes the remainder to the wrong register pair is
-  now `Invalid` (non-vacuity gate restored). Re-landed on ordeal 0.16.0 behind the
-  new per-query deadline (this is the #848 acceptance shape). Byte-invisible —
-  verify-only, no codegen change, frozen anchors untouched.
+<!--
+  BLOCKED (#848/#849, ordeal#97): the ordeal `=0.9.1` → 0.16.0 un-pin + native
+  i64 rem re-land is DRAFTED (PR #854) but MUST NOT MERGE. ordeal 0.16 fixed
+  `bvsrem`/`bvsdiv` (signed — the PR#99 claim; `verify_i32_rem_s`/`div_s`/`div_u`
+  all pass fast) but NOT `bvurem` (unsigned): the pre-existing i32
+  `verify_i32_rem_u` value VC (a cross-circuit `bvurem` equivalence, ~fast on the
+  ~41 s 0.9.1 baseline) does NOT decide on 0.16 — >8 min unbounded, killed. The
+  per-query wall-clock deadline (ordeal `check_with_deadline` + Z3 `Params`
+  timeout) works as insurance but cannot turn an undecidable-in-time `Verified`
+  assertion green. `ordeal = "=0.9.1"` STAYS PINNED until upstream fixes bvurem;
+  no [Unreleased] entry is claimed for this work yet. See PR #854 for the
+  measured finding.
+-->
 
 ## [0.50.1] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `verify_i32_rem_u` value VC (a cross-circuit `bvurem` equivalence, ~fast on the
   ~41 s 0.9.1 baseline) does NOT decide on 0.16 — >8 min unbounded, killed. The
   per-query wall-clock deadline (ordeal `check_with_deadline` + Z3 `Params`
-  timeout) works as insurance but cannot turn an undecidable-in-time `Verified`
-  assertion green. `ordeal = "=0.9.1"` STAYS PINNED until upstream fixes bvurem;
-  no [Unreleased] entry is claimed for this work yet. See PR #854 for the
-  measured finding.
+  timeout) does NOT even bound it: a 15 s deadline never fires on rem_u (the
+  cost is in bit-BLASTING the bvurem circuit, which `check_with_deadline` does
+  not bound — it bounds only the SAT search). `ordeal = "=0.9.1"` STAYS PINNED
+  until upstream (ordeal#101) fixes bvurem; no [Unreleased] entry is claimed for
+  this work yet. See PR #854 for the measured finding.
 -->
 
 ## [0.50.1] - 2026-07-23

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,18 +659,18 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "ordeal"
-version = "0.9.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c55b06587e2790390f278f8e0fdcb627aedf1ee45b9484a712c6cf1f80dccab"
+checksum = "51a5aeafeeae41f777063f5ec59ea62a1eabfbb10bb63ec9efa4b23695845640"
 dependencies = [
  "ordeal-lrat",
 ]
 
 [[package]]
 name = "ordeal-lrat"
-version = "0.9.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3affdf66f317047ddc588c7df4fbe5a463ee8f40a1e23f30115a8f8c7dffe82a"
+checksum = "3ac74759543c60b36b59ec627e897620ff0e66747e4f83e2dac07fb02de570d3"
 
 [[package]]
 name = "page_size"
@@ -1111,14 +1111,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1177,11 +1177,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.50.0"
+version = "0.50.1"
 
 [[package]]
 name = "synth-cli"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1237,14 +1237,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1252,11 +1252,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.50.0"
+version = "0.50.1"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.50.0"
+version = "0.50.1"
 
 [[package]]
 name = "tempfile"

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -32,11 +32,14 @@ synth-synthesis = { path = "../synth-synthesis", version = "0.50.1", optional = 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);
 # 0.9.1 adds the float→int trunc trap classifier (`trap_trunc`, ordeal#59/TR-020).
-# PINNED at 0.9.1: the 0.12.0 bump (#825) has a bvsrem/bvsdiv solver-performance
-# regression that HANGS div/rem trap-preservation VCs (4-6h CI timeouts, #849).
-# Re-adopt only once the perf regression is fixed upstream AND native i64 rem
-# (#844/#848) re-lands behind a per-query timeout. Do NOT let dependabot bump this.
-ordeal = "=0.9.1"
+# UN-PINNED at 0.16.0 (#848/#849): the 0.12.0 bvsrem/bvsdiv solver-performance
+# regression that HUNG div/rem trap-preservation VCs (4-6h CI timeouts) is fixed
+# upstream (ordeal PR#99 / ordeal#97 — bvsrem is multiplicative again). 0.16.0
+# also adds `Solver::check_with_deadline(ms)`, a per-query wall-clock timeout the
+# `solver.rs` seam now wires so a future perf cliff degrades to a conservative
+# `Unknown` instead of hanging the suite. Native i64 rem_u/rem_s (#844) re-lands
+# on this version behind that deadline. `BvTerm::Urem` re-appears in 0.12+.
+ordeal = "0.16.0"
 
 # Z3: optional differential oracle (feature `z3-solver`) — no longer default.
 # Default features only (NO `static-link-z3`/`bundled`): z3-sys links the

--- a/crates/synth-verify/src/arm_semantics.rs
+++ b/crates/synth-verify/src/arm_semantics.rs
@@ -689,20 +689,73 @@ impl ArmSemantics {
                 state.set_reg(rdhi, BV::new_const("i64_divu_hi", 32));
             }
 
-            ArmOp::I64RemS { rdlo, rdhi, .. } => {
-                // Signed 64-bit remainder (modulo)
-                // Real implementation would require __aeabi_ldivmod or equivalent
-                // For verification, return symbolic values
-                state.set_reg(rdlo, BV::new_const("i64_rems_lo", 32));
-                state.set_reg(rdhi, BV::new_const("i64_rems_hi", 32));
+            ArmOp::I64RemS {
+                rdlo,
+                rdhi,
+                rnlo,
+                rnhi,
+                rmlo,
+                rmhi,
+                ..
+            } => {
+                // Signed 64-bit remainder (modulo). Same shape as I64RemU but
+                // the SIGNED remainder (`bvsrem`, SMT-LIB sign-of-dividend). The
+                // shipped lowering is an `__aeabi_ldivmod` library call; the
+                // value it must produce is exactly the native 64-bit signed
+                // remainder. The value VC (`verify_i64_rem_value_preservation`)
+                // asserts the R0:R1 pair equals it on the non-trapping path.
+                // rem_s traps ONLY on ÷0 (`rem_s(INT64_MIN,-1) == 0`, no
+                // overflow trap).
+                let n_lo = state.get_reg(rnlo).clone();
+                let n_hi = state.get_reg(rnhi).clone();
+                let m_lo = state.get_reg(rmlo).clone();
+                let m_hi = state.get_reg(rmhi).clone();
+
+                let dividend = n_hi.concat(&n_lo); // 64-bit: n_hi:n_lo
+                let divisor = m_hi.concat(&m_lo); // 64-bit: m_hi:m_lo
+                let rem = dividend.bvsrem(&divisor); // native signed rem, 64-bit
+
+                state.set_reg(rdlo, rem.extract(31, 0));
+                state.set_reg(rdhi, rem.extract(63, 32));
             }
 
-            ArmOp::I64RemU { rdlo, rdhi, .. } => {
-                // Unsigned 64-bit remainder (modulo)
-                // Real implementation would require __aeabi_uldivmod or equivalent
-                // For verification, return symbolic values
-                state.set_reg(rdlo, BV::new_const("i64_remu_lo", 32));
-                state.set_reg(rdhi, BV::new_const("i64_remu_hi", 32));
+            ArmOp::I64RemU {
+                rdlo,
+                rdhi,
+                rnlo,
+                rnhi,
+                rmlo,
+                rmhi,
+                ..
+            } => {
+                // Unsigned 64-bit remainder (modulo). ARM32 has no 64-bit
+                // divide instruction — the shipped lowering expands this
+                // pseudo-op to an `__aeabi_uldivmod` library call — but for
+                // translation-validation the *value* the call must produce is
+                // exactly the native 64-bit unsigned remainder. Model it with
+                // the native `BvTerm::Urem` (ordeal 0.12, plumbed via
+                // `BV::bvurem`) instead of a HAVOC constant, so the value VC
+                // (`verify_i64_rem_value_preservation`) proves the register
+                // pair actually equals `dividend % divisor`.
+                //
+                // Compose the 64-bit operands from their register halves
+                // (`concat` puts self in the HIGH bits), take the 64-bit
+                // unsigned remainder, and split back to lo/hi. On a zero
+                // divisor SMT-LIB `bvurem` is total (returns the dividend),
+                // but WASM traps — the value clause is asserted only on the
+                // non-trapping path by the trap-guarded value VC, so this
+                // total model is sound.
+                let n_lo = state.get_reg(rnlo).clone();
+                let n_hi = state.get_reg(rnhi).clone();
+                let m_lo = state.get_reg(rmlo).clone();
+                let m_hi = state.get_reg(rmhi).clone();
+
+                let dividend = n_hi.concat(&n_lo); // 64-bit: n_hi:n_lo
+                let divisor = m_hi.concat(&m_lo); // 64-bit: m_hi:m_lo
+                let rem = dividend.bvurem(&divisor); // native bvurem, 64-bit
+
+                state.set_reg(rdlo, rem.extract(31, 0)); // low 32 bits
+                state.set_reg(rdhi, rem.extract(63, 32)); // high 32 bits
             }
 
             ArmOp::I64And {
@@ -2685,6 +2738,18 @@ impl ArmSemantics {
                 Ok(())
             }
             ArmOp::Strb { .. } | ArmOp::Strh { .. } => Ok(()),
+            // i64 rem_u/rem_s pseudo-ops (VCR-VER, #825/#836): register-only
+            // (they set the `rd*` pair), so they belong in this subset — the
+            // executor delegates to the general value model, which now builds a
+            // real `BvTerm::Urem`/`bvsrem` term. The ÷0 TRAP is NOT derived
+            // here (the bare pseudo-op carries no `UDF`); the VC reconstructs
+            // it from the pseudo-op's `elide_zero_guard` field, exactly like
+            // the i64 trap-only VC. div_u/div_s stay OUT (their 64-bit quotient
+            // value model is havoc — no value VC consumes it).
+            ArmOp::I64RemU { .. } | ArmOp::I64RemS { .. } => {
+                self.encode_op(op, state);
+                Ok(())
+            }
             other => Err(format!(
                 "op {other:?} outside the trap-derivation subset — loud decline"
             )),

--- a/crates/synth-verify/src/solver.rs
+++ b/crates/synth-verify/src/solver.rs
@@ -49,13 +49,18 @@ const DEFAULT_MAX_CONFLICTS: u64 = 1_000_000;
 /// still cut far below the 4-6 h CI timeout. `0` = unbounded (falls back to
 /// the conflict-budget path). Override: `SYNTH_ORDEAL_DEADLINE_MS`.
 ///
-/// KNOWN BLOCKER (#848/#849, ordeal#97 — why this branch is NOT merged): even
-/// at 120 s, the pre-existing i32 `verify_i32_rem_u` VC (full `rem_u(a,b) =
-/// a - (a/b)*b` equivalence, a cross-circuit `bvurem` bit-blast) does NOT
-/// decide on ordeal 0.16 — it ran >8 min unbounded and was killed. 0.16 fixed
-/// `bvsrem`/`bvsdiv` (signed; `verify_i32_rem_s` / `div_s` / `div_u` all pass
-/// fast) but `bvurem` (unsigned rem) is still exponential. The un-pin stays
-/// blocked on an upstream bvurem fix; keep `ordeal = "=0.9.1"` until then.
+/// KNOWN BLOCKER (#848/#849, ordeal#101 — why this branch is NOT merged): the
+/// pre-existing i32 `verify_i32_rem_u` VC (full `rem_u(a,b) = a - (a/b)*b`
+/// equivalence, a cross-circuit `bvurem` bit-blast) does NOT decide on ordeal
+/// 0.16 — it ran >8 min unbounded and was killed. 0.16 fixed `bvsrem`/`bvsdiv`
+/// (signed; `verify_i32_rem_s` / `div_s` / `div_u` all pass fast) but `bvurem`
+/// (unsigned rem) is still exponential. AND this deadline does NOT save it: a
+/// 15 s deadline never fired on rem_u (it ran to a 50 s wall-kill with no
+/// `Unknown`) — `check_with_deadline` bounds the SAT *search*, but bvurem's
+/// cost is in *blasting* the circuit, which the deadline does not bound. The
+/// deadline is sound insurance against a SAT-search cliff; it is ineffective
+/// against this blasting cliff. Un-pin stays blocked on an upstream bvurem
+/// fix; keep `ordeal = "=0.9.1"` until then.
 const DEFAULT_DEADLINE_MS: u64 = 120_000;
 
 /// Outcome of a one-shot `check` of the asserted conjunction.

--- a/crates/synth-verify/src/solver.rs
+++ b/crates/synth-verify/src/solver.rs
@@ -38,11 +38,25 @@ const DEFAULT_MAX_CONFLICTS: u64 = 1_000_000;
 /// insurance: a query that has not decided within the budget degrades to a
 /// conservative [`CheckOutcome::Unknown`] (never a verdict — soundness is in
 /// the never-`Unknown`-to-`Verified` mapping upstream) instead of hanging the
-/// whole suite. 10 s is generous — every real synth VC on ordeal 0.16 decides
-/// in well under a second, so a genuine-fast query never approaches it even on
-/// a loaded CI box; only a future regression would trip it. `0` = unbounded
-/// (falls back to the conflict-budget path). Override: `SYNTH_ORDEAL_DEADLINE_MS`.
-const DEFAULT_DEADLINE_MS: u64 = 10_000;
+/// whole suite.
+///
+/// The budget is set ABOVE the slowest *legitimate* query in the suite: the
+/// 32-bit popcount HAKMEM-fold equivalence (`popcnt_hakmem_formula_is_popcnt`,
+/// a wide-multiply `* 0x01010101 >> 24` proof over all 2^32 inputs — a
+/// known-hard SMT class, distinct from division) decides `Unsat` in ~41 s on
+/// ordeal 0.16. 120 s gives ~3x headroom so it never flakes on a loaded CI
+/// box, while a genuine perf cliff (the #849 class ran *minutes to hours*) is
+/// still cut far below the 4-6 h CI timeout. `0` = unbounded (falls back to
+/// the conflict-budget path). Override: `SYNTH_ORDEAL_DEADLINE_MS`.
+///
+/// KNOWN BLOCKER (#848/#849, ordeal#97 — why this branch is NOT merged): even
+/// at 120 s, the pre-existing i32 `verify_i32_rem_u` VC (full `rem_u(a,b) =
+/// a - (a/b)*b` equivalence, a cross-circuit `bvurem` bit-blast) does NOT
+/// decide on ordeal 0.16 — it ran >8 min unbounded and was killed. 0.16 fixed
+/// `bvsrem`/`bvsdiv` (signed; `verify_i32_rem_s` / `div_s` / `div_u` all pass
+/// fast) but `bvurem` (unsigned rem) is still exponential. The un-pin stays
+/// blocked on an upstream bvurem fix; keep `ordeal = "=0.9.1"` until then.
+const DEFAULT_DEADLINE_MS: u64 = 120_000;
 
 /// Outcome of a one-shot `check` of the asserted conjunction.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -274,9 +288,11 @@ mod z3_backend {
     /// "z3 could not decide, keep ordeal's verdict" branch — losing the oracle
     /// on the hardest query class degrades to certificate-checked ordeal (its
     /// `Unsat` carries an `ordeal-lrat`-validated LRAT proof), which is
-    /// acceptable, not a soundness hole. 10 s matches the ordeal deadline;
-    /// override with `SYNTH_Z3_TIMEOUT_MS`.
-    const DEFAULT_Z3_TIMEOUT_MS: u32 = 10_000;
+    /// acceptable, not a soundness hole. 120 s matches the ordeal deadline
+    /// ([`DEFAULT_DEADLINE_MS`]) so the differential stays meaningful on the
+    /// slow-but-legitimate popcount HAKMEM query rather than the oracle timing
+    /// out on it; override with `SYNTH_Z3_TIMEOUT_MS`.
+    const DEFAULT_Z3_TIMEOUT_MS: u32 = 120_000;
 
     /// The former engine, now the differential oracle.
     pub struct Z3Solver {

--- a/crates/synth-verify/src/solver.rs
+++ b/crates/synth-verify/src/solver.rs
@@ -29,6 +29,21 @@ use ordeal::{BoolTerm, CheckResult};
 /// commuted multiplies) to a conservative `Unknown`.
 const DEFAULT_MAX_CONFLICTS: u64 = 1_000_000;
 
+/// Default per-query **wall-clock deadline** (ms) for the ordeal core, wired
+/// via ordeal 0.16 `Solver::check_with_deadline` (#848/#849, ordeal#71/TR-029).
+///
+/// A conflict budget bounds SAT *logic* but not wall time — the ordeal 0.12
+/// `bvsrem`/`bvsdiv` perf cliff (#849) hung individual queries for minutes
+/// while WELL under the conflict limit. This deadline is the wall-clock
+/// insurance: a query that has not decided within the budget degrades to a
+/// conservative [`CheckOutcome::Unknown`] (never a verdict — soundness is in
+/// the never-`Unknown`-to-`Verified` mapping upstream) instead of hanging the
+/// whole suite. 10 s is generous — every real synth VC on ordeal 0.16 decides
+/// in well under a second, so a genuine-fast query never approaches it even on
+/// a loaded CI box; only a future regression would trip it. `0` = unbounded
+/// (falls back to the conflict-budget path). Override: `SYNTH_ORDEAL_DEADLINE_MS`.
+const DEFAULT_DEADLINE_MS: u64 = 10_000;
+
 /// Outcome of a one-shot `check` of the asserted conjunction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CheckOutcome {
@@ -80,24 +95,37 @@ pub fn new_solver() -> Box<dyn BvSolver> {
 // ordeal backend (default)
 // ---------------------------------------------------------------------------
 
-/// The default engine: pure-Rust `ordeal` with a conflict budget.
+/// The default engine: pure-Rust `ordeal` with a per-query wall-clock deadline
+/// (primary) and a conflict budget (fallback when the deadline is disabled).
 pub struct OrdealSolver {
     assertions: Vec<BoolTerm>,
     max_conflicts: u64,
+    /// Wall-clock deadline (ms) for `check_with_deadline`; 0 = disabled (use
+    /// the conflict-budget path instead). See [`DEFAULT_DEADLINE_MS`].
+    deadline_ms: u64,
     model: Option<ordeal::Model>,
 }
 
 impl OrdealSolver {
-    /// New solver with the budget from `SYNTH_ORDEAL_MAX_CONFLICTS`
-    /// (default [`DEFAULT_MAX_CONFLICTS`]; 0 = unbounded).
+    /// New solver with the wall-clock deadline from `SYNTH_ORDEAL_DEADLINE_MS`
+    /// (default [`DEFAULT_DEADLINE_MS`]; 0 = disabled) and the conflict budget
+    /// from `SYNTH_ORDEAL_MAX_CONFLICTS` (default [`DEFAULT_MAX_CONFLICTS`];
+    /// 0 = unbounded). When the deadline is enabled it is the operative bound
+    /// (it caps wall time, which a conflict count does not); the conflict
+    /// budget is used only when the deadline is disabled.
     pub fn new() -> Self {
         let max_conflicts = std::env::var("SYNTH_ORDEAL_MAX_CONFLICTS")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(DEFAULT_MAX_CONFLICTS);
+        let deadline_ms = std::env::var("SYNTH_ORDEAL_DEADLINE_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_DEADLINE_MS);
         Self {
             assertions: Vec::new(),
             max_conflicts,
+            deadline_ms,
             model: None,
         }
     }
@@ -123,10 +151,22 @@ impl BvSolver for OrdealSolver {
         for a in &self.assertions {
             solver.assert(a.clone());
         }
-        let result = if self.max_conflicts == 0 {
-            solver.check()
+        // Prefer the wall-clock deadline (bounds the SAT search in real time,
+        // which the ordeal 0.12 bvsrem/bvsdiv cliff #849 blew through while
+        // under the conflict budget). Fall back to the conflict budget only
+        // when the deadline is disabled (`SYNTH_ORDEAL_DEADLINE_MS=0`).
+        let (result, bound_desc) = if self.deadline_ms != 0 {
+            (
+                solver.check_with_deadline(self.deadline_ms),
+                format!("wall-clock deadline {} ms", self.deadline_ms),
+            )
+        } else if self.max_conflicts == 0 {
+            (solver.check(), "unbounded".to_string())
         } else {
-            solver.check_with_limit(self.max_conflicts)
+            (
+                solver.check_with_limit(self.max_conflicts),
+                format!("conflict budget {}", self.max_conflicts),
+            )
         };
         match result {
             CheckResult::Unsat(_certificate) => CheckOutcome::Unsat,
@@ -134,10 +174,12 @@ impl BvSolver for OrdealSolver {
                 self.model = Some(model);
                 CheckOutcome::Sat
             }
-            CheckResult::Unknown => CheckOutcome::Unknown(format!(
-                "ordeal returned unknown (conflict budget {})",
-                self.max_conflicts
-            )),
+            // Conservative non-answer: a deadline/budget exhaustion is NEVER a
+            // verdict. Callers must not map `Unknown` to Verified (this is the
+            // soundness basis of the deadline scheme, #848).
+            CheckResult::Unknown => {
+                CheckOutcome::Unknown(format!("ordeal returned unknown ({bound_desc})"))
+            }
         }
     }
 
@@ -187,6 +229,7 @@ mod z3_backend {
             BvTerm::Sub(a, b) => bv_to_z3(a).bvsub(&bv_to_z3(b)),
             BvTerm::Mul(a, b) => bv_to_z3(a).bvmul(&bv_to_z3(b)),
             BvTerm::Udiv(a, b) => bv_to_z3(a).bvudiv(&bv_to_z3(b)),
+            BvTerm::Urem(a, b) => bv_to_z3(a).bvurem(&bv_to_z3(b)),
             BvTerm::And(a, b) => bv_to_z3(a).bvand(&bv_to_z3(b)),
             BvTerm::Or(a, b) => bv_to_z3(a).bvor(&bv_to_z3(b)),
             BvTerm::Xor(a, b) => bv_to_z3(a).bvxor(&bv_to_z3(b)),
@@ -222,16 +265,35 @@ mod z3_backend {
         }
     }
 
+    /// Per-query wall-clock timeout (ms) for the Z3 differential oracle, the
+    /// twin of the ordeal [`DEFAULT_DEADLINE_MS`] deadline (#848/#849). Z3
+    /// itself is slow on the 64-bit `bvsrem`/`bvurem` i64-rem VC (#848 records
+    /// it hanging the "Z3 Verification" job, not just ordeal), so the oracle
+    /// gets its own bound. On timeout Z3 returns `SatResult::Unknown` →
+    /// [`CheckOutcome::Unknown`], which in [`DifferentialSolver`] lands on the
+    /// "z3 could not decide, keep ordeal's verdict" branch — losing the oracle
+    /// on the hardest query class degrades to certificate-checked ordeal (its
+    /// `Unsat` carries an `ordeal-lrat`-validated LRAT proof), which is
+    /// acceptable, not a soundness hole. 10 s matches the ordeal deadline;
+    /// override with `SYNTH_Z3_TIMEOUT_MS`.
+    const DEFAULT_Z3_TIMEOUT_MS: u32 = 10_000;
+
     /// The former engine, now the differential oracle.
     pub struct Z3Solver {
         assertions: Vec<BoolTerm>,
+        timeout_ms: u32,
         model: Option<z3::Model>,
     }
 
     impl Z3Solver {
         pub fn new() -> Self {
+            let timeout_ms = std::env::var("SYNTH_Z3_TIMEOUT_MS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(DEFAULT_Z3_TIMEOUT_MS);
             Self {
                 assertions: Vec::new(),
+                timeout_ms,
                 model: None,
             }
         }
@@ -248,6 +310,14 @@ mod z3_backend {
 
         fn check(&mut self) -> CheckOutcome {
             let solver = z3::Solver::new();
+            // Per-query wall-clock timeout so a hard bvsrem/bvurem degrades to
+            // `SatResult::Unknown` instead of hanging the Z3 Verification job
+            // (#848/#849). 0 = unbounded.
+            if self.timeout_ms != 0 {
+                let mut params = z3::Params::new();
+                params.set_u32("timeout", self.timeout_ms);
+                solver.set_params(&params);
+            }
             for a in &self.assertions {
                 solver.assert(bool_to_z3(a));
             }

--- a/crates/synth-verify/src/term.rs
+++ b/crates/synth-verify/src/term.rs
@@ -64,6 +64,7 @@ fn bv_rank(t: &BvTerm) -> u8 {
         BvTerm::Sub(..) => 3,
         BvTerm::Mul(..) => 4,
         BvTerm::Udiv(..) => 5,
+        BvTerm::Urem(..) => 5,
         BvTerm::And(..) => 6,
         BvTerm::Or(..) => 7,
         BvTerm::Xor(..) => 8,
@@ -234,6 +235,10 @@ fn canonicalize_bv(t: &BvTerm) -> BvTerm {
         BvTerm::Udiv(a, b) => {
             let (a, b) = bin(a, b);
             BvTerm::Udiv(a, b)
+        }
+        BvTerm::Urem(a, b) => {
+            let (a, b) = bin(a, b);
+            BvTerm::Urem(a, b)
         }
         BvTerm::Shl(a, b) => {
             let (a, b) = bin(a, b);
@@ -843,6 +848,7 @@ fn fmt_bv(t: &BvTerm, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         BvTerm::Sub(a, b) => fmt_bin(f, "bvsub", a, b),
         BvTerm::Mul(a, b) => fmt_bin(f, "bvmul", a, b),
         BvTerm::Udiv(a, b) => fmt_bin(f, "bvudiv", a, b),
+        BvTerm::Urem(a, b) => fmt_bin(f, "bvurem", a, b),
         BvTerm::And(a, b) => fmt_bin(f, "bvand", a, b),
         BvTerm::Or(a, b) => fmt_bin(f, "bvor", a, b),
         BvTerm::Xor(a, b) => fmt_bin(f, "bvxor", a, b),

--- a/crates/synth-verify/src/translation_validator.rs
+++ b/crates/synth-verify/src/translation_validator.rs
@@ -382,7 +382,17 @@ impl TranslationValidator {
             WasmOp::I32DivS | WasmOp::I32DivU | WasmOp::I32RemS | WasmOp::I32RemU => {
                 self.verify_div_rem_trap_preservation(wasm_op, arm_ops)
             }
-            WasmOp::I64DivS | WasmOp::I64DivU | WasmOp::I64RemS | WasmOp::I64RemU => {
+            // i64 rem_u/rem_s carry a REAL value model now (native
+            // `BvTerm::Urem`/`bvsrem` — VCR-VER, #825/#836): the VC asserts
+            // both the ÷0 trap AND the 64-bit remainder value, so a lowering
+            // that computes the wrong remainder — or writes it to the wrong
+            // register pair — is rejected. i64 div still leaves its 64-bit
+            // quotient symbolic (the full quotient value VC is not well-posed
+            // in QF_BV at that width), so it stays trap-condition-only.
+            WasmOp::I64RemU | WasmOp::I64RemS => {
+                self.verify_i64_rem_value_preservation(wasm_op, arm_ops)
+            }
+            WasmOp::I64DivS | WasmOp::I64DivU => {
                 self.verify_i64_div_rem_trap_preservation(wasm_op, arm_ops)
             }
             WasmOp::Unreachable => {
@@ -629,6 +639,119 @@ impl TranslationValidator {
             Self::i64_arm_trap_from_fields(div_op, &dividend, &divisor, elide_zero, elide_overflow);
 
         Ok(Self::condition_verdict(&wasm_trap, &arm_trap))
+    }
+
+    /// i64 `rem_u`/`rem_s` **value + trap** preservation (VCR-VER, #825/#836).
+    ///
+    /// Unlike [`Self::verify_i64_div_rem_trap_preservation`] (trap-only, used
+    /// for div where the 64-bit quotient value VC is not well-posed), this
+    /// gate asserts the FULL obligation for remainder: on the non-trapping
+    /// path the ARM register pair `R0:R1` must equal the native 64-bit
+    /// unsigned/signed remainder of the operands, AND the ÷0 trap must be
+    /// preserved. It is what makes the [`ArmSemantics`] `I64RemU` model —
+    /// which now builds a real `BvTerm::Urem` term (ordeal 0.12) instead of
+    /// HAVOC — actually load-bearing: a wrong remainder computation, or one
+    /// that writes the answer to the wrong register pair, is now `Invalid`.
+    ///
+    /// # Operand / result convention (the shipped ABI, NOT the op's fields)
+    ///
+    /// The value is READ from the FIXED ABI return registers `R0` (low) /
+    /// `R1` (high) and the operands are SEEDED at the FIXED ABI argument
+    /// registers — dividend `R0:R1`, divisor `R2:R3`. Reading the op's own
+    /// `rd*` fields (or seeding its own `rn*`/`rm*`) would make the VC
+    /// vacuous (read tracks write); anchoring on the ABI is exactly what lets
+    /// a pseudo-op whose destination deviates from `R0:R1` be REJECTED.
+    ///
+    /// # Trap-guarded value (why not a raw `==`)
+    ///
+    /// A bare `arm_value == wasm_value` would also assert the value on the ÷0
+    /// path, where WASM has no value and SMT-LIB `bvurem`-by-0 = the dividend
+    /// (total) — a spurious obligation. Routing through
+    /// [`crate::trap::DefineOrTrap`] + [`crate::trap::prove_trap_equivalence`]
+    /// guards the value clause under non-trap. The single branch-free
+    /// pseudo-op keeps the value ite-free, so no straight-line rewrite is
+    /// needed (unlike the i32 guarded-div machinery).
+    pub fn verify_i64_rem_value_preservation(
+        &self,
+        wasm_op: &WasmOp,
+        arm_ops: &[ArmOp],
+    ) -> Result<ValidationResult, VerificationError> {
+        let Some(div_op) = crate::trap::div_op(wasm_op) else {
+            return Err(VerificationError::UnsupportedOperation(format!(
+                "i64 rem value gate applies to rem only, got {wasm_op:?}"
+            )));
+        };
+        if !matches!(wasm_op, WasmOp::I64RemU | WasmOp::I64RemS) {
+            return Err(VerificationError::UnsupportedOperation(format!(
+                "i64 rem value gate supports i64 rem_u/rem_s only, got {wasm_op:?}"
+            )));
+        }
+
+        // Require the pseudo-op to be present and read its ÷0 guard-elision
+        // field (the selector emits exactly one). The ARM trap term is
+        // reconstructed from this field — NOT from `encode_sequence_br`'s
+        // `may_trap`, which is `false` for a bare pseudo-op (it carries no
+        // expanded `UDF`) — exactly as the i64 trap-only VC does. A lowering
+        // that elides the ÷0 guard without discharging `divisor != 0` yields a
+        // strictly weaker ARM trap and is rejected.
+        let Some((elide_zero, _elide_overflow)) = Self::i64_div_rem_guard_fields(arm_ops) else {
+            return Err(VerificationError::UnsupportedOperation(format!(
+                "i64 rem value gate needs an I64Rem pseudo-op in the sequence, \
+                 got {arm_ops:?}"
+            )));
+        };
+
+        // Four independent 32-bit half-symbols. Seed them at the FIXED ABI
+        // argument registers: dividend lo:hi = R0:R1, divisor lo:hi = R2:R3.
+        let dividend_lo = BV::new_const("input_dividend_lo", 32);
+        let dividend_hi = BV::new_const("input_dividend_hi", 32);
+        let divisor_lo = BV::new_const("input_divisor_lo", 32);
+        let divisor_hi = BV::new_const("input_divisor_hi", 32);
+
+        let mut state = ArmState::new_symbolic();
+        state.set_reg(&Reg::R0, dividend_lo.clone());
+        state.set_reg(&Reg::R1, dividend_hi.clone());
+        state.set_reg(&Reg::R2, divisor_lo.clone());
+        state.set_reg(&Reg::R3, divisor_hi.clone());
+        self.arm_encoder
+            .encode_sequence_br(arm_ops, &mut state)
+            .map_err(VerificationError::UnsupportedOperation)?;
+
+        // ARM result read from the FIXED ABI return pair R0:R1 (concat puts
+        // self in the HIGH bits).
+        let arm_lo = self.arm_encoder.extract_result(&state, &Reg::R0);
+        let arm_hi = self.arm_encoder.extract_result(&state, &Reg::R1);
+        let arm_value = arm_hi.concat(&arm_lo); // 64-bit R1:R0
+
+        // WASM spec side: the 64-bit remainder of the SAME operand symbols.
+        // Both sides feed identical concats, so the valid case is structural.
+        let dividend = dividend_hi.concat(&dividend_lo); // 64-bit
+        let divisor = divisor_hi.concat(&divisor_lo); // 64-bit
+        let wasm_value = match wasm_op {
+            WasmOp::I64RemU => dividend.bvurem(&divisor),
+            WasmOp::I64RemS => dividend.bvsrem(&divisor),
+            _ => unreachable!("guarded above"),
+        };
+        let wasm_trap = crate::trap::trap_div(div_op, &dividend, &divisor);
+
+        // ARM trap: rem's only trap is ÷0; present iff the guard was NOT
+        // elided. rem carries no overflow clause, so `elide_overflow=false`.
+        let arm_may_trap = Self::i64_arm_trap_from_fields(
+            div_op, &dividend, &divisor, elide_zero, /* elide_overflow */ false,
+        );
+
+        let orig = crate::trap::DefineOrTrap {
+            value: wasm_value,
+            may_trap: wasm_trap,
+        };
+        let opt = crate::trap::DefineOrTrap {
+            value: arm_value,
+            may_trap: arm_may_trap,
+        };
+
+        Ok(Self::trap_verdict_to_result(
+            crate::trap::prove_trap_equivalence(&orig, &opt),
+        ))
     }
 
     /// Locate the i64 div/rem pseudo-op in a sequence and read its guard-elision
@@ -2011,6 +2134,146 @@ mod tests {
                 );
             }
             println!("=== all rows discriminate: gate is non-vacuous ===\n");
+        });
+    }
+
+    // --- i64 rem VALUE model (VCR-VER, #825/#836): native BvTerm::Urem ---
+    //
+    // The i64 rem_u/rem_s VC now asserts the VALUE, not just the trap. Under
+    // the old HAVOC model the register result was an unconstrained fresh
+    // symbol, so ANY lowering (correct, wrong-remainder, wrong-destination)
+    // trivially satisfied a value-only obligation — the model proved nothing.
+    // These tests pin the value model as load-bearing.
+
+    /// Build an i64 rem pseudo-op with a chosen DESTINATION register pair. The
+    /// shipped ABI is `rd = R0:R1`; a lowering that writes elsewhere leaves
+    /// R0:R1 unrelated to the remainder and must be REJECTED by the value VC.
+    fn i64_rem_with_dest(op: &WasmOp, rdlo: Reg, rdhi: Reg) -> Vec<ArmOp> {
+        let arm = match op {
+            WasmOp::I64RemU => ArmOp::I64RemU {
+                rdlo,
+                rdhi,
+                rnlo: Reg::R0,
+                rnhi: Reg::R1,
+                rmlo: Reg::R2,
+                rmhi: Reg::R3,
+                elide_zero_guard: false,
+            },
+            WasmOp::I64RemS => ArmOp::I64RemS {
+                rdlo,
+                rdhi,
+                rnlo: Reg::R0,
+                rnhi: Reg::R1,
+                rmlo: Reg::R2,
+                rmhi: Reg::R3,
+                elide_zero_guard: false,
+            },
+            _ => unreachable!("i64_rem_with_dest: not an i64 rem op"),
+        };
+        vec![arm]
+    }
+
+    /// GREEN: the shipped rem_u/rem_s lowering (`rd = R0:R1`) computes the
+    /// correct 64-bit remainder into the ABI return pair — the value+trap VC
+    /// must be Verified.
+    #[test]
+    fn i64_rem_shipped_value_is_verified() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            for op in [WasmOp::I64RemU, WasmOp::I64RemS] {
+                let arm_ops = shipped_i64_div_rem(&op, false, false);
+                let result = validator.verify_trap_preservation(&op, &arm_ops).unwrap();
+                assert_eq!(
+                    result,
+                    ValidationResult::Verified,
+                    "GREEN: {op:?} shipped lowering (correct value + ÷0 guard) must be Verified"
+                );
+            }
+        });
+    }
+
+    /// RED / NON-VACUITY (the key gate): a lowering that writes the remainder
+    /// to the WRONG destination pair (`rd = R2:R3` instead of the ABI `R0:R1`)
+    /// leaves R0:R1 holding the (unrelated) input operands, so the ABI return
+    /// pair is NOT the remainder. Under the old HAVOC model this was ACCEPTED
+    /// (the result symbol was unconstrained); the native `BvTerm::Urem` value
+    /// model now REJECTS it. This is the accepted-under-havoc → rejected-now
+    /// discriminator.
+    #[test]
+    fn i64_rem_wrong_destination_register_is_rejected() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            for op in [WasmOp::I64RemU, WasmOp::I64RemS] {
+                let arm_ops = i64_rem_with_dest(&op, Reg::R2, Reg::R3);
+                let result = validator.verify_trap_preservation(&op, &arm_ops).unwrap();
+                assert!(
+                    matches!(result, ValidationResult::Invalid { .. }),
+                    "RED: {op:?} writing the remainder to R2:R3 (not the ABI R0:R1) \
+                     leaves R0:R1 non-remainder — must be Invalid, got {result:?}"
+                );
+            }
+        });
+    }
+
+    /// NON-VACUITY control: the correct-destination and wrong-destination
+    /// lowerings must give OPPOSITE verdicts. A gate that returned the same
+    /// verdict for both (as the HAVOC model did — both trivially valued) would
+    /// be vacuous.
+    #[test]
+    fn i64_rem_destination_field_is_load_bearing() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            for op in [WasmOp::I64RemU, WasmOp::I64RemS] {
+                let correct = validator
+                    .verify_trap_preservation(&op, &i64_rem_with_dest(&op, Reg::R0, Reg::R1))
+                    .unwrap();
+                let wrong = validator
+                    .verify_trap_preservation(&op, &i64_rem_with_dest(&op, Reg::R2, Reg::R3))
+                    .unwrap();
+                assert_eq!(correct, ValidationResult::Verified, "{op:?} correct dest");
+                assert!(
+                    matches!(wrong, ValidationResult::Invalid { .. }),
+                    "{op:?} wrong dest"
+                );
+                assert_ne!(
+                    correct, wrong,
+                    "non-vacuity: {op:?} destination register must change the verdict"
+                );
+            }
+        });
+    }
+
+    /// EVIDENCE that the value model closed a real gap: the OLD trap-only VC
+    /// (`verify_i64_div_rem_trap_preservation`, still present for div) ACCEPTS
+    /// the wrong-destination rem lowering — it never reads the value — whereas
+    /// the NEW value VC (`verify_i64_rem_value_preservation`, dispatched by
+    /// `verify_trap_preservation`) REJECTS it. Opposite verdicts from the two
+    /// gates on the same input is the accepted-under-havoc → rejected-now
+    /// proof, made concrete rather than merely narrated.
+    #[test]
+    fn i64_rem_value_model_closes_a_trap_only_gap() {
+        with_verification_context(|| {
+            let validator = TranslationValidator::new();
+            for op in [WasmOp::I64RemU, WasmOp::I64RemS] {
+                let wrong = i64_rem_with_dest(&op, Reg::R2, Reg::R3);
+                // Old trap-only path: value/destination invisible → accepted.
+                let trap_only = validator
+                    .verify_i64_div_rem_trap_preservation(&op, &wrong)
+                    .unwrap();
+                assert_eq!(
+                    trap_only,
+                    ValidationResult::Verified,
+                    "the trap-ONLY VC is blind to the wrong destination (this is the \
+                     havoc-era gap): {op:?} expected Verified, got {trap_only:?}"
+                );
+                // New value+trap path: destination is load-bearing → rejected.
+                let value = validator.verify_trap_preservation(&op, &wrong).unwrap();
+                assert!(
+                    matches!(value, ValidationResult::Invalid { .. }),
+                    "the value VC catches it: {op:?} expected Invalid, got {value:?}"
+                );
+                assert_ne!(trap_only, value, "the two gates must disagree ({op:?})");
+            }
         });
     }
 


### PR DESCRIPTION
## STATUS: BLOCKED — do not merge. ordeal 0.16 fixed `bvsrem` but NOT `bvurem`, and the deadline does not bound it.

This PR un-pins ordeal `=0.9.1` → `0.16.0`, wires a per-query wall-clock deadline, and re-lands the native i64 `rem_u`/`rem_s` value model (#844). **The un-pin is not clean** and this PR must not merge as-is.

### The blocker (measured, decisive)

The pre-existing i32 `verify_i32_rem_u` VC (`tests/comprehensive_verification.rs`, present + fast at the last-green baseline `61acec99`) proves the full `rem_u(a,b) = a − (a/b)·b` equivalence — a cross-circuit `bvurem`-vs-`(bvsub, bvudiv, bvmul)` bit-blast. On ordeal 0.16 it **does not decide in bounded time**:

- **0.9.1 baseline** (commit `4ad175e`): whole `-p synth-verify` suite = 236 tests, **~41 s**, green.
- **0.16, isolated, deadline disabled** (`SYNTH_ORDEAL_DEADLINE_MS=0` → `check_with_limit(1M)`, the exact path 0.9.1 used): `verify_i32_rem_u` ran **>7 m 48 s** and was killed without terminating.

### The deadline does NOT save it (blast-bound, not SAT-bound)

Probed `verify_i32_rem_u` with `SYNTH_ORDEAL_DEADLINE_MS=15000` and a hard 50 s wall timeout: the test binary reached execution and ran to the 50 s kill **with no `Unknown (wall-clock deadline 15000 ms)` line and no result** — i.e. the 15 s deadline **never fired**. ordeal 0.16's `check_with_deadline` doc says it bounds the SAT *search*, not blasting/canonicalization; `bvurem`'s cost is in bit-blasting the circuit, which the deadline does not bound. So the deadline is correct insurance against a *SAT-search* cliff (like the div/rem trap VCs) but is **ineffective against this bvurem blasting cliff** — it would still hang the CI Test job.

### Discriminator: signed fixed, unsigned still exponential

From the 0.16 run, the sibling VCs all pass fast — only `rem_u` is slow. Confirmed `verify_i32_rem_s` is the exact SIGNED twin (`SDIV+MLS`, same full `rem_s = a−(a/b)·b` equivalence, asserts `Verified`), so this is a clean symmetric discriminator:

```
verify_i32_div_u ... ok        # bvudiv
verify_i32_div_s ... ok        # bvsdiv
verify_i32_rem_s ... ok        # bvsrem — the PR#99/ordeal#97 fix works
verify_i32_rem_u ... >8 min, killed   # bvurem — still exponential, deadline ineffective
```

ordeal 0.16 fixed `bvsrem`/`bvsdiv` (signed — exactly the PR#99 / ordeal#97 claim) but **`bvurem` (unsigned remainder) remains an exponential bit-blast**. Reported upstream (ordeal#101).

### What IS sound (for when upstream fixes bvurem)

- The **native i64 rem re-land (#844)** is correct; its tests pass fast (the i64 rem value VC is structurally identical on both sides, not a hard cross-circuit equivalence).
- The **per-query deadline** correctly bounds SAT-search cliffs and degrades to a conservative `Unknown` (never `Verified`). It just cannot bound a *blasting* cliff.
- The un-pin is **coupled**: re-landing #844 requires 0.16 (`BvTerm::Urem` + `check_with_deadline`), so the good half can't be split from the blocked half.

### Not exercised

The Z3 differential path (`SYNTH_SOLVER_DIFF=1`) was **not** run — the default ordeal-only Test job is already the blocker, so STOP was reached before the Z3 gate. (The same `bvurem` VC would be expected slow in Z3 too; not measured.)

### Recommendation

**Keep `ordeal = "=0.9.1"` pinned** until upstream fixes the `bvurem` blasting regression (ordeal#101). Then re-adopt 0.16+ with this PR's deadline + #844 re-land. #848 and #849 stay open with this finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
