### PR TITLE
feat(#851): aarch64 full control flow — if/else, loop, return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   frontier (documented, not silent): in-bounds only — OOB-trap, data-segment
   init, `memory.{size,grow}`, and emitting startup that establishes `x28` are
   follow-ons.
+- **aarch64 full control flow — `if`/`else`, `loop`, `return` (#851).** The
+  `-b aarch64` backend extends the void-block-only #538 control flow
+  (`block`/`br`/`br_if`) with the remaining structured constructs: `if`/`else`
+  (`cbz` cond → else/end, unconditional `b` over the else arm, join at end),
+  `loop` (a **backward** branch target — a `br`/`br_if` to a loop frame resolves
+  a negative offset eagerly at the loop header), and `return` (early epilogue:
+  funnel top → `x0`/`d0`, restore SP, `ret`). Branch resolution dispatches on
+  the **target frame's kind** (Block/If = forward, patched at `End`; Loop =
+  backward, resolved on emission), so loop back-edges and forward block exits
+  coexist; a single `patch_branch` helper centralizes the `b`/`cbnz`/`cbz`
+  re-encode. A reachability flag applies WASM's stack-polymorphism rule after
+  `br`/`return`/`unreachable`. Honest frontier (loud-decline, never silent):
+  **value-producing `if`/`loop`** (arity ≠ (0,0) — both arms would need the
+  result in one register / the value stack live across the back-edge) and
+  `br_table`. A dedicated execution differential
+  (`scripts/repro/aarch64_ctrlflow_851_differential.py`, 25 cases) proves
+  if/else (both arms), counting + countdown loops (multiple trip counts),
+  early-return, and return-inside-loop **bit-identical vs wasmtime** on a native
+  arm64 host (MAP_JIT fork) + unicorn, with both branch edges and a trap edge
+  exercised (non-vacuity-guarded). *Coordinator note:* wire the new differential
+  into `ci.yml` alongside `aarch64_cf_538` / `aarch64_mem_851` at assembly (this
+  lane does not edit repo config).
 
 ## [0.50.1] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **value-producing `if`/`loop`** (arity ≠ (0,0) — both arms would need the
   result in one register / the value stack live across the back-edge) and
   `br_table`. A dedicated execution differential
-  (`scripts/repro/aarch64_ctrlflow_851_differential.py`, 25 cases) proves
-  if/else (both arms), counting + countdown loops (multiple trip counts),
+  (`scripts/repro/aarch64_ctrlflow_851_differential.py`, 28 cases) proves
+  if/else (both arms), counting + countdown + **do-while** loops (multiple trip
+  counts; the do-while drives the backward *conditional* `cbnz`-to-header path),
   early-return, and return-inside-loop **bit-identical vs wasmtime** on a native
   arm64 host (MAP_JIT fork) + unicorn, with both branch edges and a trap edge
-  exercised (non-vacuity-guarded). *Coordinator note:* wire the new differential
+  exercised (non-vacuity-guarded). Branch displacements exceeding the A64 field
+  width (imm26 ±128 MB, imm19 ±1 MB) LOUD-DECLINE rather than wrap silently
+  (`check_imm26`/`check_imm19` at every eager and patched resolution site).
+  *Coordinator note:* wire the new differential
   into `ci.yml` alongside `aarch64_cf_538` / `aarch64_mem_851` at assembly (this
   lane does not edit repo config).
 

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -920,9 +920,7 @@ pub fn select_typed_cf(
                     )));
                 }
                 ctrl.push(Frame {
-                    kind: Kind::Loop {
-                        entry: words.len(),
-                    },
+                    kind: Kind::Loop { entry: words.len() },
                     pending: Vec::new(),
                     stack_entry: stack.len(),
                 });
@@ -964,17 +962,15 @@ pub fn select_typed_cf(
             // `cbz` to land HERE (the else-arm entry). The value stack is reset
             // to the if's entry height (a void then-arm must not leave a value).
             WasmOp::Else => {
-                let frame = ctrl.last_mut().ok_or_else(|| {
-                    SelectError("else without a matching if".into())
-                })?;
+                let frame = ctrl
+                    .last_mut()
+                    .ok_or_else(|| SelectError("else without a matching if".into()))?;
                 let else_fixup = match &mut frame.kind {
-                    Kind::If { else_fixup } => else_fixup.take().ok_or_else(|| {
-                        SelectError("duplicate else for one if".into())
-                    })?,
+                    Kind::If { else_fixup } => else_fixup
+                        .take()
+                        .ok_or_else(|| SelectError("duplicate else for one if".into()))?,
                     _ => {
-                        return Err(SelectError(
-                            "else does not close an if block".into(),
-                        ));
+                        return Err(SelectError("else does not close an if block".into()));
                     }
                 };
                 // A void then-arm leaves the stack at its entry height — but
@@ -1986,11 +1982,10 @@ mod tests {
     }
 
     #[test]
-    fn loop_and_br_table_and_if_are_loud_declined() {
-        // Backward-branch / join / jump-table control is out of this increment.
-        let loop_ops = vec![WasmOp::Loop, WasmOp::End, WasmOp::End];
-        assert!(select_typed_cf(&loop_ops, 0, &[], &[], &[(0, 0)]).is_err());
-
+    fn br_table_and_typed_loop_if_are_loud_declined() {
+        // #851: `loop`, `if`/`else` are now LOWERED for the void (0,0) shape.
+        // What still declines: `br_table` (jump table, catch-all) and any
+        // VALUE-carrying loop/if (arity != (0,0)).
         let brtable = vec![
             WasmOp::Block,
             WasmOp::LocalGet(0),
@@ -2003,8 +1998,97 @@ mod tests {
         ];
         assert!(select_typed_cf(&brtable, 1, &[], &[], &[(0, 0)]).is_err());
 
-        let if_ops = vec![WasmOp::LocalGet(0), WasmOp::If, WasmOp::End, WasmOp::End];
-        assert!(select_typed_cf(&if_ops, 1, &[], &[], &[(0, 0)]).is_err());
+        // A VALUE-producing if (result i32 → arity (0,1)) loud-declines.
+        let typed_if = vec![WasmOp::LocalGet(0), WasmOp::If, WasmOp::End, WasmOp::End];
+        assert!(select_typed_cf(&typed_if, 1, &[], &[], &[(0, 1)]).is_err());
+
+        // A VALUE-producing loop (arity (0,1)) loud-declines.
+        let typed_loop = vec![WasmOp::Loop, WasmOp::End, WasmOp::End];
+        assert!(select_typed_cf(&typed_loop, 0, &[], &[], &[(0, 1)]).is_err());
+    }
+
+    #[test]
+    fn void_if_without_else_emits_cbz_skip() {
+        // `if (then unreachable)` with cond in w0: cbz w0, <past-then> ; brk ;
+        // then fall-through. The cbz skips the then-arm when cond == 0.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::If,
+            WasmOp::Unreachable,
+            WasmOp::End, // if-end
+            WasmOp::End, // fn-end
+        ];
+        let w = select_typed_cf(&ops, 1, &[], &[], &[(0, 0)]).unwrap();
+        // cbz w0, .+8 (skip the brk) ; brk #0 ; ret
+        assert_eq!(w[0], enc::cbz(0, 2));
+        assert_eq!(w[1], enc::brk(0));
+        assert_eq!(w[2], enc::ret());
+    }
+
+    #[test]
+    fn void_if_else_patches_both_edges() {
+        // if(cond){} else{} — void arms. cbz skips to the else entry; the
+        // then-arm's trailing `b` skips the else-arm to the join.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::If,
+            WasmOp::Else,
+            WasmOp::Unreachable,
+            WasmOp::End,
+            WasmOp::End,
+        ];
+        let w = select_typed_cf(&ops, 1, &[], &[], &[(0, 0)]).unwrap();
+        // cbz w0, else ; b end ; brk ; ret
+        // then-arm is empty: cbz lands at the `b`? No — cbz skips the then-arm
+        // to the else entry. then-arm empty → cbz to the b's fall-through.
+        // Layout: [0] cbz w0, else_entry ; [1] b end ; [2] brk ; [3] ret
+        assert_eq!(w[0], enc::cbz(0, 2)); // to word 2 (else entry = brk)
+        assert_eq!(w[1], enc::b_uncond(2)); // skip else-arm to word 3 (ret)
+        assert_eq!(w[2], enc::brk(0));
+        assert_eq!(w[3], enc::ret());
+    }
+
+    #[test]
+    fn loop_back_edge_is_negative_offset() {
+        // block { loop { <body> br 0 } } — the `br 0` targets the loop header
+        // (BACKWARD), resolving to a negative offset. A `local.tee`/`local.get`
+        // on a NON-PARAM local emits real instructions ahead of the `br`, so
+        // the back-edge offset is strictly negative. Frame: 1 non-param local
+        // (idx 1) → a sub-sp + str-xzr prologue, then the loop body.
+        let ops = vec![
+            WasmOp::Block,
+            WasmOp::Loop,
+            WasmOp::LocalGet(1), // non-param local read → ldr (real instr)
+            WasmOp::LocalSet(1), // → str (real instr) — loop body has 2 instrs
+            WasmOp::Br(0),       // back-edge to loop header
+            WasmOp::End,         // loop end
+            WasmOp::End,         // block end
+            WasmOp::End,         // fn end
+        ];
+        // arity table: Block, Loop → two (0,0) entries.
+        let w = select_typed_cf(&ops, 1, &[], &[], &[(0, 0), (0, 0)]).unwrap();
+        // Find the back-edge `b` (0x14…): it must carry a NEGATIVE imm26.
+        let br = w
+            .iter()
+            .find(|&&x| x & 0xFC00_0000 == 0x1400_0000)
+            .expect("a back-edge b must be emitted");
+        let imm26 = (br & 0x03FF_FFFF) as i32;
+        let signed = (imm26 << 6) >> 6; // sign-extend 26 bits
+        assert!(
+            signed < 0,
+            "loop back-edge must be a negative offset, got {signed}"
+        );
+    }
+
+    #[test]
+    fn early_return_emits_epilogue_ret() {
+        // `local.get 0 ; return` — funnels w0 and rets early, then the trailing
+        // fn-end epilogue rets again (unreachable).
+        let ops = vec![WasmOp::LocalGet(0), WasmOp::Return, WasmOp::End];
+        let w = select_typed_cf(&ops, 1, &[], &[], &[]).unwrap();
+        // local.get 0 → mov x9,x0 ; return → mov x0,x9 ; ret
+        assert_eq!(*w.last().unwrap(), enc::ret());
+        assert!(w.contains(&enc::ret()));
     }
 
     #[test]

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -258,14 +258,36 @@ pub fn select_typed_cf(
         }
     }
 
-    // Control-flow state (#538 cf increment). Each open `block` pushes a frame;
-    // the matching `End` pops it and patches the recorded forward branches to
-    // land at the current instruction position (the block's fall-through point).
+    // Control-flow state (#538 cf increment, #851 full control flow). Each open
+    // `block`/`loop`/`if` pushes a frame. The matching `End` pops it. Where a
+    // `br`/`br_if` to that frame lands depends on the frame KIND:
+    //
+    //   * `Block` / `If`: a branch to the frame targets its END (fall-through) —
+    //     a FORWARD branch, recorded in `pending` and patched when `End` closes
+    //     the frame (the target position is only known then).
+    //   * `Loop`: a branch to the frame targets its ENTRY (the loop header) — a
+    //     BACKWARD branch, resolved to a NEGATIVE offset immediately at emission
+    //     (`entry` is already known), never patched.
+    //
+    // This "dispatch on the TARGET frame's kind, not on the branch op" is what
+    // makes loop back-edges correct alongside forward block exits.
+    enum Kind {
+        /// A plain `block`: branches to it go to its END (forward).
+        Block,
+        /// A `loop`: branches to it go to `entry` (the loop header, backward).
+        Loop { entry: usize },
+        /// An `if`: like Block for `br` (branches go to END), but also carries
+        /// the position of the `cbz`/`b.cond` that skips the THEN arm, patched
+        /// at `else` (to the else arm) or at `end` (past the then arm).
+        If { else_fixup: Option<usize> },
+    }
     struct Frame {
-        /// Word positions in `words` of branches targeting this block's END,
-        /// awaiting fix-up when the block closes.
+        kind: Kind,
+        /// Word positions in `words` of FORWARD branches targeting this frame's
+        /// END, awaiting fix-up when the frame closes (Block/If only; a Loop's
+        /// branches are backward and resolved eagerly).
         pending: Vec<usize>,
-        /// Value-stack height on entry — a void block must restore it at `End`.
+        /// Value-stack height on entry — a void frame must restore it at `End`.
         stack_entry: usize,
     }
     let mut ctrl: Vec<Frame> = Vec::new();
@@ -273,6 +295,14 @@ pub fn select_typed_cf(
     // `block_arity`. Incremented on EVERY control op encountered (even declined
     // ones, though a decline aborts the whole compile so alignment is moot).
     let mut ctrl_ord: usize = 0;
+    // Reachability of the current linear position (#851). Code after an
+    // UNCONDITIONAL transfer (`br`, `return`, `unreachable`) is unreachable and
+    // WASM's stack becomes polymorphic there — the straight-line height model no
+    // longer tracks the real stack. We keep truncating the value stack to the
+    // frame's entry height at `else`/`end` (that fixes the model), but SKIP the
+    // fall-through height assert when unreachable (it only holds on a reachable
+    // fall-through). `br_if` is conditional, so its fall-through stays reachable.
+    let mut reachable = true;
 
     // Pick a GP temp not holding a live GP value-stack entry.
     let alloc_temp = |stack: &[Val]| -> Result<Reg, SelectError> {
@@ -785,7 +815,11 @@ pub fn select_typed_cf(
             }
             // #665: wasm `unreachable` traps unconditionally (WASM §4.4.5) —
             // `brk #0`, the A64 analogue of Thumb-2 `udf #0` / RV32 `ebreak`.
-            WasmOp::Unreachable => words.push(enc::brk(0)),
+            WasmOp::Unreachable => {
+                words.push(enc::brk(0));
+                // `unreachable` traps unconditionally: fall-through is dead.
+                reachable = false;
+            }
 
             // --- control flow (#538 cf increment): VOID-result forward blocks ---
             //
@@ -807,6 +841,7 @@ pub fn select_typed_cf(
                     )));
                 }
                 ctrl.push(Frame {
+                    kind: Kind::Block,
                     pending: Vec::new(),
                     stack_entry: stack.len(),
                 });
@@ -828,8 +863,17 @@ pub fn select_typed_cf(
                 }
                 let target = ctrl.len() - 1 - d;
                 let pos = words.len();
-                words.push(enc::b_uncond(0)); // placeholder; patched at End
-                ctrl[target].pending.push(pos);
+                if let Kind::Loop { entry } = ctrl[target].kind {
+                    // BACKWARD branch to the loop header — resolve immediately.
+                    let off = (entry as i64 - pos as i64) as i32;
+                    words.push(enc::b_uncond(off));
+                } else {
+                    // FORWARD branch to a block/if END — patched at that `End`.
+                    words.push(enc::b_uncond(0)); // placeholder
+                    ctrl[target].pending.push(pos);
+                }
+                // Unconditional transfer: fall-through is unreachable.
+                reachable = false;
             }
             // `br_if N` — pop an i32 condition; branch to the block-N END iff it
             // is nonzero → `cbnz w_cond, <block-end>`. Not-taken falls through.
@@ -845,22 +889,123 @@ pub fn select_typed_cf(
                 let cond = pop_gp(&mut stack, "br_if")?;
                 let target = ctrl.len() - 1 - d;
                 let pos = words.len();
-                words.push(enc::cbnz(cond, 0)); // placeholder; patched at End
-                ctrl[target].pending.push(pos);
+                if let Kind::Loop { entry } = ctrl[target].kind {
+                    // BACKWARD conditional branch to the loop header.
+                    let off = (entry as i64 - pos as i64) as i32;
+                    words.push(enc::cbnz(cond, off));
+                } else {
+                    // FORWARD conditional branch to a block/if END.
+                    words.push(enc::cbnz(cond, 0)); // placeholder; patched at End
+                    ctrl[target].pending.push(pos);
+                }
             }
-            // `loop` (backward branch target), `if`/`else` (join reconciliation),
-            // and `br_table` (jump table) are OUT of this increment — decline by
-            // name rather than miscompile. (BrTable/If/Else hit the catch-all
-            // `other` arm below; loop is explicit so its arity ordinal is
-            // consumed with a clear message.)
+            // `loop` (#851): opens a control frame whose branch target is the
+            // loop HEADER (the current position), so a `br`/`br_if` to it is a
+            // BACKWARD branch. Only a VOID `(0,0)` loop is accepted: a
+            // value/param loop would need the value stack non-empty across the
+            // back-edge, and the deterministic temp-restart (`alloc_temp` picks
+            // the same register when the stack is empty) would no longer hold.
+            // The `(0,0)` gate enforces exactly the sound shape — loop-carried
+            // state must live in non-param LOCAL SLOTS (memory), reloaded each
+            // iteration. `br_table` still declines (catch-all).
             WasmOp::Loop => {
-                // (no ctrl_ord bump needed: a decline aborts the whole compile,
-                // so the arity-ordinal alignment is moot from here on.)
-                return Err(SelectError(
-                    "loop: backward-branch control flow not yet supported for \
-                     aarch64 — loud-declining (only forward void blocks)"
-                        .into(),
-                ));
+                let ord = ctrl_ord;
+                ctrl_ord += 1;
+                let arity = block_arity.get(ord).copied().unwrap_or((0, 0));
+                if arity != (0, 0) {
+                    return Err(SelectError(format!(
+                        "loop #{ord} has type {arity:?} — only void (0,0) loops \
+                         are supported (a value/param loop needs the value stack \
+                         live across the back-edge); loud-declining"
+                    )));
+                }
+                ctrl.push(Frame {
+                    kind: Kind::Loop {
+                        entry: words.len(),
+                    },
+                    pending: Vec::new(),
+                    stack_entry: stack.len(),
+                });
+            }
+            // `if` (#851): pop the i32 condition; emit `cbz cond, <else/end>` to
+            // SKIP the then-arm when the condition is false. The skip target is
+            // patched at the matching `else` (to the else-arm entry) or, if
+            // there is no `else`, at `end` (past the then-arm). Only VOID `(0,0)`
+            // `if` is accepted — a value-producing `if` would need both arms to
+            // leave the result in the same register, which this straight-line
+            // model does not guarantee, so it LOUD-DECLINES.
+            WasmOp::If => {
+                let ord = ctrl_ord;
+                ctrl_ord += 1;
+                let arity = block_arity.get(ord).copied().unwrap_or((0, 0));
+                if arity != (0, 0) {
+                    return Err(SelectError(format!(
+                        "if #{ord} has type {arity:?} — only void (0,0) if/else \
+                         is supported (a value-producing if needs both arms to \
+                         land the result in one register); loud-declining"
+                    )));
+                }
+                let cond = pop_gp(&mut stack, "if")?;
+                let else_pos = words.len();
+                // cbz: fall THROUGH into the then-arm when cond != 0; branch to
+                // the else/end when cond == 0. Offset patched at else/end.
+                words.push(enc::cbz(cond, 0)); // placeholder
+                ctrl.push(Frame {
+                    kind: Kind::If {
+                        else_fixup: Some(else_pos),
+                    },
+                    pending: Vec::new(),
+                    stack_entry: stack.len(),
+                });
+            }
+            // `else` (#851): closes the then-arm of the innermost `if`. Emit an
+            // unconditional `b <end>` to skip the else-arm at runtime (recorded
+            // in `pending`, patched at `end`), then patch the `if`'s pending
+            // `cbz` to land HERE (the else-arm entry). The value stack is reset
+            // to the if's entry height (a void then-arm must not leave a value).
+            WasmOp::Else => {
+                let frame = ctrl.last_mut().ok_or_else(|| {
+                    SelectError("else without a matching if".into())
+                })?;
+                let else_fixup = match &mut frame.kind {
+                    Kind::If { else_fixup } => else_fixup.take().ok_or_else(|| {
+                        SelectError("duplicate else for one if".into())
+                    })?,
+                    _ => {
+                        return Err(SelectError(
+                            "else does not close an if block".into(),
+                        ));
+                    }
+                };
+                // A void then-arm leaves the stack at its entry height — but
+                // only on a REACHABLE fall-through (a then-arm ending in
+                // `return`/`br` is polymorphic). Truncate unconditionally (fixes
+                // the model); assert only when reachable.
+                debug_assert!(
+                    !reachable || stack.len() == frame.stack_entry,
+                    "void then-arm must restore stack height"
+                );
+                stack.truncate(frame.stack_entry);
+                // The else-arm is a `cbz` target — always reachable.
+                reachable = true;
+                // Skip the else-arm when the then-arm falls through.
+                let skip_pos = words.len();
+                words.push(enc::b_uncond(0)); // placeholder; patched at end
+                frame.pending.push(skip_pos);
+                // The if's cbz now lands at the else-arm entry (current pos).
+                let here = words.len();
+                patch_branch(&mut words, else_fixup, here);
+            }
+            // `return` (#851): funnel the top-of-stack into x0/d0, tear down the
+            // frame, and `ret` — an EARLY function exit. Ops after `return` up
+            // to the enclosing `end` are unreachable (WASM stack-polymorphic);
+            // the selector still lowers them but this `ret` never falls into
+            // them. Mirrors the existing "code after `br` is unreachable but
+            // still emitted" model — no shared epilogue label needed.
+            WasmOp::Return => {
+                epilogue(&mut words, stack.last().copied(), frame_size);
+                // Unconditional transfer: fall-through is unreachable.
+                reachable = false;
             }
 
             // --- i32 arithmetic / bitwise ---
@@ -1004,30 +1149,41 @@ pub fn select_typed_cf(
             // into x0/d0 and return).
             WasmOp::End => {
                 if let Some(frame) = ctrl.pop() {
-                    // Block close: every recorded forward branch targets HERE
-                    // (the block's fall-through). Patch each placeholder with the
-                    // word-relative offset from the branch to the current position.
+                    // Frame close. Every recorded FORWARD branch (block/if exit,
+                    // else-arm skip) targets HERE (fall-through). A Loop's
+                    // branches were backward and already resolved. Patch each
+                    // placeholder via the kind-preserving `patch_branch`.
                     let here = words.len();
-                    for pos in frame.pending {
-                        let off = (here as i64 - pos as i64) as i32;
-                        let branch = words[pos];
-                        // Re-encode with the resolved offset, preserving the
-                        // opcode/register bits set at emission (b vs cbnz).
-                        words[pos] = if branch & 0xFF00_0000 == 0x1400_0000 {
-                            enc::b_uncond(off)
-                        } else {
-                            // cbnz: keep the Rt field, set the imm19.
-                            enc::cbnz((branch & 0x1F) as u8, off)
-                        };
+                    // An `if` with NO `else`: its `cbz` still needs to skip the
+                    // then-arm to here (the fall-through past the then-arm).
+                    if let Kind::If {
+                        else_fixup: Some(pos),
+                    } = frame.kind
+                    {
+                        patch_branch(&mut words, pos, here);
                     }
-                    // A void block leaves the value stack exactly as on entry.
+                    for pos in frame.pending {
+                        patch_branch(&mut words, pos, here);
+                    }
+                    // A void frame leaves the value stack exactly as on entry —
+                    // but only on a REACHABLE fall-through (a body ending in
+                    // `return`/`br` is stack-polymorphic). Truncate always;
+                    // assert only when the fall-through is reachable.
                     debug_assert!(
-                        stack.len() == frame.stack_entry,
-                        "void block must restore stack height: entry={} now={}",
+                        !reachable || stack.len() == frame.stack_entry,
+                        "void frame must restore stack height: entry={} now={}",
                         frame.stack_entry,
                         stack.len()
                     );
                     stack.truncate(frame.stack_entry);
+                    // After closing a frame the position is reachable again: a
+                    // forward branch could target this fall-through, and a loop's
+                    // continuation follows. (A dead nested block would want the
+                    // precise `fell_through || had_pending` rule; that only
+                    // affects a debug assert, never emitted bytes — noted as a
+                    // residual, the wasmtime differential is the correctness
+                    // oracle here.)
+                    reachable = true;
                 } else {
                     epilogue(&mut words, stack.last().copied(), frame_size);
                 }
@@ -1121,6 +1277,23 @@ pub fn select_typed_cf(
 /// is byte-identical to the pre-#851 epilogue). The result move is done BEFORE
 /// the `add sp` (the result lives in a caller-saved temp, unaffected by SP), so
 /// the sequence is: funnel result → restore SP → ret.
+/// Re-encode a placeholder FORWARD branch at `words[pos]` to land at `target`
+/// (a word index in `words`), preserving its kind. The three kinds we emit as
+/// forward placeholders are `b` (0x14…, imm26), `cbnz` (0x35…, imm19+Rt), and
+/// `cbz` (0x34…, imm19+Rt); the opcode's high bits discriminate them so the Rt
+/// field and op class survive the patch. Centralizing this prevents a `cbz`
+/// (added in #851) from being mis-patched as a `cbnz`.
+fn patch_branch(words: &mut [u32], pos: usize, target: usize) {
+    let off = (target as i64 - pos as i64) as i32;
+    let w = words[pos];
+    words[pos] = match w & 0xFF00_0000 {
+        0x1400_0000 => enc::b_uncond(off),
+        0x3500_0000 => enc::cbnz((w & 0x1F) as u8, off),
+        0x3400_0000 => enc::cbz((w & 0x1F) as u8, off),
+        _ => unreachable!("patch_branch: not a placeholder branch: {w:#010x}"),
+    };
+}
+
 fn epilogue(words: &mut Vec<u32>, top: Option<Val>, frame_size: u32) {
     match top {
         Some(Val {

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -865,7 +865,7 @@ pub fn select_typed_cf(
                 let pos = words.len();
                 if let Kind::Loop { entry } = ctrl[target].kind {
                     // BACKWARD branch to the loop header — resolve immediately.
-                    let off = (entry as i64 - pos as i64) as i32;
+                    let off = check_imm26((entry as i64 - pos as i64) as i32)?;
                     words.push(enc::b_uncond(off));
                 } else {
                     // FORWARD branch to a block/if END — patched at that `End`.
@@ -891,7 +891,7 @@ pub fn select_typed_cf(
                 let pos = words.len();
                 if let Kind::Loop { entry } = ctrl[target].kind {
                     // BACKWARD conditional branch to the loop header.
-                    let off = (entry as i64 - pos as i64) as i32;
+                    let off = check_imm19((entry as i64 - pos as i64) as i32)?;
                     words.push(enc::cbnz(cond, off));
                 } else {
                     // FORWARD conditional branch to a block/if END.
@@ -990,7 +990,7 @@ pub fn select_typed_cf(
                 frame.pending.push(skip_pos);
                 // The if's cbz now lands at the else-arm entry (current pos).
                 let here = words.len();
-                patch_branch(&mut words, else_fixup, here);
+                patch_branch(&mut words, else_fixup, here)?;
             }
             // `return` (#851): funnel the top-of-stack into x0/d0, tear down the
             // frame, and `ret` — an EARLY function exit. Ops after `return` up
@@ -1156,10 +1156,10 @@ pub fn select_typed_cf(
                         else_fixup: Some(pos),
                     } = frame.kind
                     {
-                        patch_branch(&mut words, pos, here);
+                        patch_branch(&mut words, pos, here)?;
                     }
                     for pos in frame.pending {
-                        patch_branch(&mut words, pos, here);
+                        patch_branch(&mut words, pos, here)?;
                     }
                     // A void frame leaves the value stack exactly as on entry —
                     // but only on a REACHABLE fall-through (a body ending in
@@ -1273,21 +1273,49 @@ pub fn select_typed_cf(
 /// is byte-identical to the pre-#851 epilogue). The result move is done BEFORE
 /// the `add sp` (the result lives in a caller-saved temp, unaffected by SP), so
 /// the sequence is: funnel result → restore SP → ret.
+/// Guard an `imm26` (unconditional `b`) displacement (words) against the A64
+/// field width (signed 26-bit → ±2^25 words = ±128 MB). Over-range would wrap
+/// silently in the encoder's mask, so we LOUD-DECLINE instead (unreachable for
+/// any realistic function; "No silent miscompile" is the hard rule).
+fn check_imm26(off: i32) -> Result<i32, SelectError> {
+    if !(-(1 << 25)..(1 << 25)).contains(&off) {
+        return Err(SelectError(format!(
+            "branch displacement {off} words exceeds A64 b imm26 range \
+             (±2^25) — loud-declining rather than wrap silently"
+        )));
+    }
+    Ok(off)
+}
+
+/// Guard an `imm19` (`cbz`/`cbnz`/`b.cond`) displacement (signed 19-bit →
+/// ±2^18 words = ±1 MB). Same silent-wrap hazard as [`check_imm26`].
+fn check_imm19(off: i32) -> Result<i32, SelectError> {
+    if !(-(1 << 18)..(1 << 18)).contains(&off) {
+        return Err(SelectError(format!(
+            "conditional-branch displacement {off} words exceeds A64 imm19 \
+             range (±2^18) — loud-declining rather than wrap silently"
+        )));
+    }
+    Ok(off)
+}
+
 /// Re-encode a placeholder FORWARD branch at `words[pos]` to land at `target`
 /// (a word index in `words`), preserving its kind. The three kinds we emit as
 /// forward placeholders are `b` (0x14…, imm26), `cbnz` (0x35…, imm19+Rt), and
 /// `cbz` (0x34…, imm19+Rt); the opcode's high bits discriminate them so the Rt
 /// field and op class survive the patch. Centralizing this prevents a `cbz`
-/// (added in #851) from being mis-patched as a `cbnz`.
-fn patch_branch(words: &mut [u32], pos: usize, target: usize) {
+/// (added in #851) from being mis-patched as a `cbnz`. Over-range displacements
+/// LOUD-DECLINE (no silent field wrap).
+fn patch_branch(words: &mut [u32], pos: usize, target: usize) -> Result<(), SelectError> {
     let off = (target as i64 - pos as i64) as i32;
     let w = words[pos];
     words[pos] = match w & 0xFF00_0000 {
-        0x1400_0000 => enc::b_uncond(off),
-        0x3500_0000 => enc::cbnz((w & 0x1F) as u8, off),
-        0x3400_0000 => enc::cbz((w & 0x1F) as u8, off),
+        0x1400_0000 => enc::b_uncond(check_imm26(off)?),
+        0x3500_0000 => enc::cbnz((w & 0x1F) as u8, check_imm19(off)?),
+        0x3400_0000 => enc::cbz((w & 0x1F) as u8, check_imm19(off)?),
         _ => unreachable!("patch_branch: not a placeholder branch: {w:#010x}"),
     };
+    Ok(())
 }
 
 fn epilogue(words: &mut Vec<u32>, top: Option<Val>, frame_size: u32) {

--- a/scripts/repro/aarch64_ctrlflow_851.wat
+++ b/scripts/repro/aarch64_ctrlflow_851.wat
@@ -73,23 +73,28 @@
     local.get 2)
 
   ;; countdown loop: while n != 0 { n-- ; iters++ } ; return iters.
+  ;; The param is copied into a non-param local (params are read-only
+  ;; by-reference on aarch64; `local.set` of a param loud-declines).
   (func (export "countdown") (param i32) (result i32)
-    (local i32) ;; iters
+    (local i32) ;; local 1: n (working copy)
+    (local i32) ;; local 2: iters
+    local.get 0
+    local.set 1
     (block
       (loop
-        local.get 0
+        local.get 1
         i32.eqz
         br_if 1
-        local.get 0
-        i32.const 1
-        i32.sub
-        local.set 0
         local.get 1
         i32.const 1
-        i32.add
+        i32.sub
         local.set 1
+        local.get 2
+        i32.const 1
+        i32.add
+        local.set 2
         br 0))
-    local.get 1)
+    local.get 2)
 
   ;; --- early return ---
   ;; if a < 0 return -1 early; else return a*2.

--- a/scripts/repro/aarch64_ctrlflow_851.wat
+++ b/scripts/repro/aarch64_ctrlflow_851.wat
@@ -96,6 +96,30 @@
         br 0))
     local.get 2)
 
+  ;; do-while loop: br_if BACK to the loop header (backward CONDITIONAL branch,
+  ;; the cbnz-to-loop-header path). Counts down n and returns the iteration
+  ;; count; the body always runs at least once (n>=1 for the taken back-edge).
+  (func (export "do_while_count") (param i32) (result i32)
+    (local i32) ;; local 1: n working copy
+    (local i32) ;; local 2: iters
+    local.get 0
+    local.set 1
+    (loop
+      ;; iters += 1
+      local.get 2
+      i32.const 1
+      i32.add
+      local.set 2
+      ;; n -= 1
+      local.get 1
+      i32.const 1
+      i32.sub
+      local.set 1
+      ;; continue while n != 0 -> br_if 0 to the LOOP HEADER (backward cbnz)
+      local.get 1
+      br_if 0)
+    local.get 2)
+
   ;; --- early return ---
   ;; if a < 0 return -1 early; else return a*2.
   (func (export "early_ret") (param i32) (result i32)

--- a/scripts/repro/aarch64_ctrlflow_851.wat
+++ b/scripts/repro/aarch64_ctrlflow_851.wat
@@ -1,0 +1,129 @@
+;; #851 aarch64 FULL control flow — if/else, loop (back-edge), return.
+;;
+;; Every function is a shape the void-block-only #538 increment DECLINED and the
+;; #851 increment must lower bit-identically to wasmtime. The observable
+;; taken/not-taken (or trap-vs-return) difference makes a wrong branch offset
+;; loud (see aarch64_ctrlflow_851_differential.py).
+
+(module
+  ;; --- if / else (void bodies, both arms reachable) ---
+  ;; if cond != 0 -> store a into local; else store b. Return the local.
+  ;; Exercises: cbz to else, unconditional b over else, join at end.
+  (func (export "if_else_pick") (param i32 i32 i32) (result i32)
+    (local i32)
+    local.get 0
+    (if
+      (then
+        local.get 1
+        local.set 3)
+      (else
+        local.get 2
+        local.set 3))
+    local.get 3)
+
+  ;; if WITHOUT else (void). cond -> guard a trap. cond 0 -> fall through.
+  (func (export "if_noelse_guard") (param i32) (result i32)
+    local.get 0
+    (if
+      (then
+        unreachable))
+    local.get 0)
+
+  ;; nested if/else -> classic max(a,b) via compare + branch.
+  (func (export "if_max") (param i32 i32) (result i32)
+    (local i32)
+    local.get 0
+    local.get 1
+    i32.gt_s
+    (if
+      (then
+        local.get 0
+        local.set 2)
+      (else
+        local.get 1
+        local.set 2))
+    local.get 2)
+
+  ;; --- loop with back-edge (br to loop label = BACKWARD) ---
+  ;; Sum 0..n-1 into an accumulator; classic counting loop.
+  ;; Counter + accumulator live in NON-PARAM LOCALS (memory slots), which is
+  ;; what makes the void loop sound: the value stack is empty at the back-edge.
+  (func (export "count_sum") (param i32) (result i32)
+    (local i32) ;; local 1: i (counter)
+    (local i32) ;; local 2: acc
+    (block
+      (loop
+        ;; if i >= n, exit the block
+        local.get 1
+        local.get 0
+        i32.ge_s
+        br_if 1
+        ;; acc += i
+        local.get 2
+        local.get 1
+        i32.add
+        local.set 2
+        ;; i += 1
+        local.get 1
+        i32.const 1
+        i32.add
+        local.set 1
+        ;; back-edge to loop
+        br 0))
+    local.get 2)
+
+  ;; countdown loop: while n != 0 { n-- ; iters++ } ; return iters.
+  (func (export "countdown") (param i32) (result i32)
+    (local i32) ;; iters
+    (block
+      (loop
+        local.get 0
+        i32.eqz
+        br_if 1
+        local.get 0
+        i32.const 1
+        i32.sub
+        local.set 0
+        local.get 1
+        i32.const 1
+        i32.add
+        local.set 1
+        br 0))
+    local.get 1)
+
+  ;; --- early return ---
+  ;; if a < 0 return -1 early; else return a*2.
+  (func (export "early_ret") (param i32) (result i32)
+    local.get 0
+    i32.const 0
+    i32.lt_s
+    (if
+      (then
+        i32.const -1
+        return))
+    local.get 0
+    i32.const 2
+    i32.mul
+    return)
+
+  ;; return inside a loop: return first i where i*i >= n.
+  (func (export "isqrt_ceil") (param i32) (result i32)
+    (local i32) ;; i
+    (loop
+      local.get 1
+      local.get 1
+      i32.mul
+      local.get 0
+      i32.ge_s
+      (if
+        (then
+          local.get 1
+          return))
+      local.get 1
+      i32.const 1
+      i32.add
+      local.set 1
+      br 0)
+    ;; unreachable fall-through (loop is infinite until return); keep validator happy
+    i32.const -1)
+)

--- a/scripts/repro/aarch64_ctrlflow_851_differential.py
+++ b/scripts/repro/aarch64_ctrlflow_851_differential.py
@@ -62,6 +62,7 @@ SIGS = {
     "if_max": ([32, 32], 32),
     "count_sum": ([32], 32),
     "countdown": ([32], 32),
+    "do_while_count": ([32], 32),
     "early_ret": ([32], 32),
     "isqrt_ceil": ([32], 32),
 }
@@ -91,6 +92,10 @@ CASES = [
     ("countdown", [0]),                   # -> 0
     ("countdown", [1]),                   # -> 1
     ("countdown", [37]),                  # -> 37
+    # do-while (backward cbnz to loop header): body runs >=1 time.
+    ("do_while_count", [1]),              # -> 1 (runs once, n->0, exit)
+    ("do_while_count", [5]),              # -> 5
+    ("do_while_count", [200]),            # -> 200
     # early return: negative -> -1 early; else a*2.
     ("early_ret", [0xFFFFFFFF]),          # -1 -> -1 (early)
     ("early_ret", [10]),                  # -> 20 (late)

--- a/scripts/repro/aarch64_ctrlflow_851_differential.py
+++ b/scripts/repro/aarch64_ctrlflow_851_differential.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""#851 aarch64 FULL control-flow — if/else, loop back-edge, return EXECUTION diff.
+
+The #851 increment extends the void-block-only #538 control flow with:
+  * `if` / `else` (void arms): `cbz`/`cmp+b.cond` to the else/end, `b` over the
+    else arm, join at end;
+  * `loop`: a BACKWARD branch target — `br` to a loop label resolves to a
+    negative offset at emission (not patched at End);
+  * `return`: early epilogue (funnel top -> x0, restore SP, `ret`).
+
+This harness proves the emitted A64 `.text` executes bit-identically to
+wasmtime. Both edges of every conditional branch are exercised, and loops run
+to a data-dependent trip count, so a wrong branch OFFSET (forward vs backward,
+too far, too short) changes the RESULT and is caught — the gate is non-vacuous.
+
+Traps (the `if_noelse_guard` `unreachable`) are execution-verified two ways:
+  (1) unicorn (UC_ARCH_ARM64): the `brk #0` raises a UC exception;
+  (2) natively on an arm64 host: each call runs in a forked child, so an
+      expected SIGTRAP is observed by the parent.
+
+The static expect column is validated against wasmtime FIRST, so the table
+cannot drift vacuous.
+
+Run (needs wasmtime + unicorn + pyelftools; native path needs an arm64 host):
+  SYNTH=<target>/debug/synth python scripts/repro/aarch64_ctrlflow_851_differential.py
+"""
+
+import ctypes
+import os
+import platform
+import signal
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM64, UC_MODE_ARM, Uc, UcError
+from unicorn.arm64_const import (
+    UC_ARM64_REG_LR,
+    UC_ARM64_REG_SP,
+    UC_ARM64_REG_W0,
+    UC_ARM64_REG_X0,
+    UC_ARM64_REG_X1,
+    UC_ARM64_REG_X2,
+)
+
+WAT = Path(__file__).with_name("aarch64_ctrlflow_851.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+CODE, STK, RET = 0x100000, 0x200000, 0x300000
+X_ARGS = [UC_ARM64_REG_X0, UC_ARM64_REG_X1, UC_ARM64_REG_X2]
+
+M32 = (1 << 32) - 1
+M64 = (1 << 64) - 1
+TRAP = "TRAP"
+
+# Signatures: fn -> ([arg widths in bits], ret width in bits).
+SIGS = {
+    "if_else_pick": ([32, 32, 32], 32),
+    "if_noelse_guard": ([32], 32),
+    "if_max": ([32, 32], 32),
+    "count_sum": ([32], 32),
+    "countdown": ([32], 32),
+    "early_ret": ([32], 32),
+    "isqrt_ceil": ([32], 32),
+}
+
+# (fn, [args...]). Cover BOTH arms of every if; run loops to several trip counts
+# (including 0 = never-enter and a large-ish count); exercise both return sites.
+CASES = [
+    # if/else pick: cond nonzero -> a (arg1); cond 0 -> b (arg2).
+    ("if_else_pick", [1, 10, 20]),        # -> 10
+    ("if_else_pick", [0, 10, 20]),        # -> 20
+    ("if_else_pick", [0xFFFFFFFF, 7, 9]), # any nonzero -> 7
+    # if without else guarding a trap: cond nonzero -> trap; cond 0 -> return arg.
+    ("if_noelse_guard", [0]),             # -> 0 (fall through)
+    ("if_noelse_guard", [5]),             # -> trap
+    ("if_noelse_guard", [0x80000000]),    # nonzero high bit -> trap
+    # max(a,b): both orderings + equal.
+    ("if_max", [3, 8]),                   # -> 8
+    ("if_max", [8, 3]),                   # -> 8
+    ("if_max", [5, 5]),                   # -> 5
+    ("if_max", [0xFFFFFFFF, 1]),          # -1 signed vs 1 -> 1
+    # counting loop: sum 0..n-1.
+    ("count_sum", [0]),                   # loop never entered -> 0
+    ("count_sum", [1]),                   # -> 0
+    ("count_sum", [5]),                   # -> 10
+    ("count_sum", [100]),                 # -> 4950
+    # countdown loop: return iteration count == n.
+    ("countdown", [0]),                   # -> 0
+    ("countdown", [1]),                   # -> 1
+    ("countdown", [37]),                  # -> 37
+    # early return: negative -> -1 early; else a*2.
+    ("early_ret", [0xFFFFFFFF]),          # -1 -> -1 (early)
+    ("early_ret", [10]),                  # -> 20 (late)
+    ("early_ret", [0]),                   # -> 0 (late)
+    # return-inside-loop: ceil sqrt.
+    ("isqrt_ceil", [0]),                  # 0*0>=0 -> 0
+    ("isqrt_ceil", [1]),                  # 1
+    ("isqrt_ceil", [16]),                 # 4
+    ("isqrt_ceil", [17]),                 # 5
+    ("isqrt_ceil", [10000]),              # 100
+]
+
+
+def wasmtime_run(fn, args, sig):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    f = wasmtime.Instance(store, module, []).exports(store)[fn]
+    widths, ret = sig
+    call = []
+    for w, a in zip(widths, args):
+        if w == 32:
+            call.append(struct.unpack("<i", struct.pack("<I", a & M32))[0])
+        else:
+            call.append(struct.unpack("<q", struct.pack("<Q", a & M64))[0])
+    try:
+        r = f(store, *call)
+    except wasmtime.Trap:
+        return TRAP
+    return r & (M32 if ret == 32 else M64)
+
+
+def compile_aarch64(out):
+    cmd = [SYNTH, "compile", str(WAT), "-o", out, "-b", "aarch64", "--all-exports"]
+    r = subprocess.run(cmd, capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin"})
+    if r.returncode != 0 or "skipping" in r.stderr:
+        sys.exit(f"aarch64 compile failed/skipped: {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for sy in sec.iter_symbols():
+                if sy.name:
+                    syms[sy.name] = sy["st_value"] & ~1
+    return code, base, syms
+
+
+def unicorn_run(code, base, faddr, sig, args):
+    off = faddr - base
+    widths, ret = sig
+    mu = Uc(UC_ARCH_ARM64, UC_MODE_ARM)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(STK - 0x10000, 0x20000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_ARM64_REG_SP, STK)
+    mu.reg_write(UC_ARM64_REG_LR, RET)
+    for r, (w, v) in zip(X_ARGS, zip(widths, args)):
+        mu.reg_write(r, v & (M32 if w == 32 else M64))
+    try:
+        mu.emu_start(CODE + off, RET, count=200000)
+    except UcError:
+        return TRAP  # the guarded `brk #0` — a trap, not a value
+    if ret == 32:
+        return mu.reg_read(UC_ARM64_REG_W0) & M32
+    return mu.reg_read(UC_ARM64_REG_X0) & M64
+
+
+# ---- native arm64 execution (forked child; SIGTRAP == trap) ---------------
+_MAP_PRIVATE = 0x0002
+_MAP_ANON = 0x1000 if sys.platform == "darwin" else 0x20
+_MAP_JIT = 0x0800
+_PROT_RWX = 0x1 | 0x2 | 0x4
+
+
+def native_setup(code):
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.mmap.restype = ctypes.c_void_p
+    libc.mmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int,
+                          ctypes.c_int, ctypes.c_int, ctypes.c_long]
+    size = max(len(code), 4096)
+    flags = _MAP_PRIVATE | _MAP_ANON
+    if sys.platform == "darwin":
+        flags |= _MAP_JIT
+    addr = libc.mmap(None, size, _PROT_RWX, flags, -1, 0)
+    if addr in (ctypes.c_void_p(-1).value, 0, None):
+        err = ctypes.get_errno()
+        raise OSError(err, f"mmap(MAP_JIT) failed: {os.strerror(err)}")
+    if sys.platform == "darwin":
+        wp = ctypes.CDLL(None).pthread_jit_write_protect_np
+        wp(0)
+    ctypes.memmove(addr, code, len(code))
+    if sys.platform == "darwin":
+        wp(1)
+        libc.sys_icache_invalidate.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+        libc.sys_icache_invalidate(ctypes.c_void_p(addr), len(code))
+    return addr
+
+
+def native_run(code, faddr, code_base, sig, args):
+    widths, ret = sig
+    rd, wr = os.pipe()
+    pid = os.fork()
+    if pid == 0:
+        try:
+            os.close(rd)
+            base_addr = native_setup(code)
+            fn_addr = base_addr + (faddr - code_base)
+            argtys = [ctypes.c_int32 if w == 32 else ctypes.c_int64 for w in widths]
+            retty = ctypes.c_int32 if ret == 32 else ctypes.c_int64
+            fn = ctypes.CFUNCTYPE(retty, *argtys)(fn_addr)
+            call = []
+            for w, a in zip(widths, args):
+                if w == 32:
+                    call.append(struct.unpack("<i", struct.pack("<I", a & M32))[0])
+                else:
+                    call.append(struct.unpack("<q", struct.pack("<Q", a & M64))[0])
+            r = fn(*call)  # a brk #0 here delivers SIGTRAP -> child dies
+            bits = r & (M32 if ret == 32 else M64)
+            os.write(wr, struct.pack("<Q", bits))
+            os.close(wr)
+        finally:
+            os._exit(0)
+    os.close(wr)
+    _, status = os.waitpid(pid, 0)
+    data = os.read(rd, 8)
+    os.close(rd)
+    if os.WIFSIGNALED(status):
+        if os.WTERMSIG(status) in (signal.SIGTRAP, signal.SIGILL):
+            return TRAP
+        return f"ERR:signal {os.WTERMSIG(status)}"
+    if len(data) != 8:
+        return "ERR:no result"
+    return struct.unpack("<Q", data)[0]
+
+
+def main():
+    out = "/tmp/aarch64_ctrlflow_851.o"
+    compile_aarch64(out)
+    code, base, syms = load(out)
+    host_native = platform.machine() in ("arm64", "aarch64")
+
+    fails = 0
+    total = 0
+    trap_cases = 0
+    ret_cases = 0
+    # Non-vacuity: every function must actually appear + run.
+    seen_fns = set()
+    for fn, args in CASES:
+        sig = SIGS[fn]
+        _, ret = sig
+        if fn not in syms:
+            print(f"FAIL {fn}: symbol missing")
+            fails += 1
+            continue
+        seen_fns.add(fn)
+        total += 1
+        exp = wasmtime_run(fn, args, sig)
+        if exp == TRAP:
+            trap_cases += 1
+        else:
+            ret_cases += 1
+        oracles = [("unicorn", unicorn_run(code, base, syms[fn], sig, args))]
+        if host_native:
+            oracles.append(("native", native_run(code, syms[fn], base, sig, args)))
+        for label, got in oracles:
+            ok = (exp == got) if (exp == TRAP or got == TRAP) else \
+                (isinstance(got, int) and got == (exp & (M32 if ret == 32 else M64)))
+            if not ok:
+                fails += 1
+                e = exp if exp == TRAP else hex(exp)
+                g = got if isinstance(got, str) else hex(got)
+                print(f"BUG {fn}{tuple(hex(a) for a in args)} [{label}] "
+                      f"A64={g} wasmtime={e}")
+
+    # Non-vacuity guards: both trap+return edges ran, and every function ran.
+    if trap_cases == 0 or ret_cases == 0:
+        print(f"VACUOUS: trap_cases={trap_cases} return_cases={ret_cases} — a "
+              f"branch edge was never exercised")
+        fails += 1
+    missing = set(SIGS) - seen_fns
+    if missing:
+        print(f"VACUOUS: functions never exercised: {sorted(missing)}")
+        fails += 1
+
+    print(f"\n{total} cases ({trap_cases} trap, {ret_cases} return), "
+          f"{'arm64 host + unicorn' if host_native else 'unicorn-only host'}")
+    print("RESULT:", "PASS — aarch64 if/else + loop back-edge + return match "
+          "wasmtime (both branch edges + loop trip counts execution-verified)"
+          if not fails else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Extends the `-b aarch64` backend's void-block-only #538 control flow
(`block`/`br`/`br_if`) with the remaining structured constructs, part of lane
L4 of the v0.51 hub. Closes the last major control-flow gap for the host-native
integer subset (#851).

Lowered (all execution-verified bit-identical vs wasmtime):
- **`if`/`else`** — `cbz` cond → else/end, unconditional `b` over the else arm,
  join at end (void `(0,0)` only).
- **`loop`** — backward branch target: a `br`/`br_if` to a loop frame resolves a
  **negative** offset eagerly at the loop header (void `(0,0)` only).
- **`return`** — early epilogue (funnel top → `x0`/`d0`, restore SP, `ret`).

### Design
- **Kind-tagged control frames.** `enum Kind { Block, Loop { entry }, If { else_fixup } }`.
  Branch resolution dispatches on the **target frame's kind** — Block/If are
  forward (recorded in `pending`, patched at `End`), Loop is backward (resolved
  on emission). This is what lets loop back-edges and forward block exits coexist.
- **`patch_branch` helper** centralizes the `b`/`cbnz`/`cbz` re-encode so the new
  `cbz` can't be mis-patched as a `cbnz`; it is fallible and range-checks every
  displacement.
- **Reachability flag** applies WASM's stack-polymorphism rule after
  `br`/`return`/`unreachable`: the value stack is truncated unconditionally
  (fixes the model) but the fall-through height `debug_assert` is gated on
  reachability.
- **`block_arity` ordinal** is now consumed by `Loop` and `If` (one entry each),
  keeping the arity-table lookup aligned.
- **Range guards** (`check_imm26`/`check_imm19`): displacements exceeding the A64
  field width LOUD-DECLINE rather than wrap silently.

### Honest frontier (loud-decline, never silent)
- Value-producing `if`/`loop` (arity ≠ `(0,0)` — both arms would need the result
  in one register / the value stack live across the back-edge).
- `br_table` (catch-all).
- Over-range branch displacements.

### Gate — RED-first execution differential
`scripts/repro/aarch64_ctrlflow_851_differential.py` (28 cases), native arm64
(MAP_JIT fork) + unicorn vs wasmtime:
- RED before: all 7 functions declined (`If` unsupported, `loop` declined by name).
- GREEN after: 28/28 bit-identical — if/else (both arms), counting + countdown +
  do-while loops (the do-while drives the backward **conditional** `cbnz`-to-header
  path), early-return, return-inside-loop. Both branch edges + a trap edge
  exercised; non-vacuity-guarded (every function + both edges must run).

### Verification
- Backend unit tests 70/70 (new: void-if cbz skip, if/else both-edge patch, loop
  back-edge negative offset, early-return epilogue).
- `scripts/repro/aarch64_matrix.sh` PASS (32 ops accepted, 86 native checks).
- Pre-existing `aarch64_cf_538` / `locals_851` / `mem_851` differentials still GREEN.
- `frozen_codegen_bytes` 10/10 untouched.
- `cargo fmt --check` + `cargo clippy --workspace --all-targets -D warnings` clean.

### Coordinator note
The new differential needs wiring into `.github/workflows/ci.yml` alongside
`aarch64_cf_538_differential.py` / `aarch64_mem_851_differential.py` at assembly
(this lane does not edit repo config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L