### PR TITLE
feat(aarch64): div/rem + popcnt + f64↔i64 reinterpret — frontier to empty (#851)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,9 +410,10 @@ jobs:
     # (NaN-ordering compares, promote/demote, converts, reinterprets), m4 the
     # #709 boundary table (domain-guarded trapping trunc: every case where
     # WASM traps must TRAP under emulation, in-range must match bit-exactly)
-    # + min/max NaN/±0 matrix + copysign. The decline-matrix probe asserts
-    # div/rem/popcnt/rounding/i64<->float still LOUD-decline (A64 SDIV/UDIV
-    # don't trap; a naive lowering would be a silent miscompile).
+    # + min/max NaN/±0 matrix + copysign. #851 added div/rem (SDIV/UDIV+MSUB
+    # with WASM ÷0 + INT_MIN/-1 trap guards, execution-verified), popcnt (SIMD
+    # CNT/ADDV), and f64<->i64 reinterpret; the decline-matrix probe now
+    # asserts only rounding + i64<->float conversions still LOUD-decline.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -446,6 +447,8 @@ jobs:
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_cf_538_differential.py
       - name: Run #851 linear-memory load/store execution oracle
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_mem_851_differential.py
+      - name: Run #851 div/rem trap-and-value execution oracle (÷0 + INT_MIN/-1)
+        run: SYNTH=./target/debug/synth python scripts/repro/aarch64_divrem_851_differential.py
       - name: Run decline-matrix honesty oracle
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_m2_decline_538.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,7 +447,7 @@ jobs:
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_cf_538_differential.py
       - name: Run #851 linear-memory load/store execution oracle
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_mem_851_differential.py
-      - name: Run #851 div/rem trap-and-value execution oracle (÷0 + INT_MIN/-1)
+      - name: Run #851 div/rem trap + popcnt + reinterpret execution oracle (÷0 + INT_MIN/-1)
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_divrem_851_differential.py
       - name: Run decline-matrix honesty oracle
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_m2_decline_538.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **aarch64 div/rem + popcnt + f64↔i64 reinterpret (#851).** Three op groups
+  that previously loud-declined on `-b aarch64` now lower, shrinking gale's
+  acceptance frontier (`scripts/repro/aarch64_matrix.sh`) from
+  `popcnt div_s rem_s` to **empty** (32 → 35 accepted ops, 86 → 91 native
+  checks, all bit-identical vs wasmtime):
+  - **Integer div/rem (i32+i64):** `div_{s,u}` → A64 `SDIV`/`UDIV`; `rem_{s,u}`
+    → `SDIV`/`UDIV` + `MSUB` (`rem = a − (a/b)·b`). A64 divide is TOTAL where
+    WASM is PARTIAL, so — the #633/#666/#709 totality class — the lowering emits
+    explicit WASM trap guards: divisor `== 0` → `brk` (all four forms;
+    full-width `cbnz` for i64) and, for SIGNED DIV only, the `INT_MIN / −1`
+    overflow → `brk`. `rem_s(INT_MIN, −1) == 0` (no trap) falls out of `MSUB`
+    naturally. The ÷0 and INT_MIN/−1 traps are execution-verified vs wasmtime
+    (`scripts/repro/aarch64_divrem_851_differential.py`: 152 cases / 34 trap
+    cases, native SIGTRAP + unicorn `brk`).
+  - **popcnt (i32+i64):** A64 has no scalar popcount, so `fmov` gpr→SIMD,
+    `CNT vN.8b`, `ADDV bN, vN.8b`, `fmov` back (i32 uses `fmov s` to zero-fill
+    the upper lanes; i64 uses `fmov d`).
+  - **f64↔i64 reinterpret (GI-FPU-001):** `i64.reinterpret_f64` /
+    `f64.reinterpret_i64` → bit-preserving `fmov x,d` / `fmov d,x`. These
+    `WasmOp` variants existed but were never decoded (`convert_operator`), so
+    they globally declined; un-dropping them at decode also un-blocks the ARM
+    backend's existing VFP lowering. Verified every backend still emits or
+    LOUD-declines (never silent-drops): aarch64 + cortex-m7dp ARM emit;
+    no-FPU ARM / single-precision Cortex-M / RV32 loud-decline.
+  - New encoders (llvm-mc ground-truth byte tests): `sdiv`/`udiv`/`msub`
+    (+64-bit), `cnt_8b`, `addv_8b`, `cbnz64`.
 - **aarch64 non-param locals (#856).** The `-b aarch64` backend now supports
   `local` declarations beyond params: each non-param local gets a zero-init
   8-byte stack slot (`[sp, #(idx − num_params)*8]`, frame rounded to a 16-byte

--- a/crates/synth-backend-aarch64/src/encoder.rs
+++ b/crates/synth-backend-aarch64/src/encoder.rs
@@ -96,6 +96,45 @@ pub fn mul64(rd: Reg, rn: Reg, rm: Reg) -> u32 {
 }
 
 // ---------------------------------------------------------------------------
+// #851 — integer divide and multiply-subtract, the lowering targets for WASM
+// `i32/i64.{div,rem}_{s,u}`. A64 `SDIV`/`UDIV` round toward zero (matching
+// WASM `idiv`), and remainder is `a − (a/b)·b` via `MSUB rd, q, b, a`. NOTE:
+// A64 SDIV/UDIV are TOTAL — `x/0 = 0` and `INT_MIN/−1 = INT_MIN` in hardware,
+// NEITHER of which traps. WASM REQUIRES a trap in both cases, so the selector
+// emits an explicit divisor-zero guard (all four div/rem forms) and, for
+// signed DIV only, an INT_MIN/−1 overflow guard. The encoders below are the
+// bare arithmetic; the guards live in the selector (see the `divrem` closure).
+// clang/llvm-mc ground truth:
+//   sdiv w0,w1,w2 = 0x1AC20C20   udiv w0,w1,w2 = 0x1AC20820
+//   msub w0,w1,w2,w3 = 0x1B028C20   (x-forms set SF64)
+
+/// `sdiv wd, wn, wm` — signed divide, round toward zero.
+pub fn sdiv(rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    0x1AC0_0C00 | ((rm as u32) << 16) | ((rn as u32) << 5) | (rd as u32)
+}
+/// `sdiv xd, xn, xm`
+pub fn sdiv64(rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    sdiv(rd, rn, rm) | SF64
+}
+/// `udiv wd, wn, wm` — unsigned divide, round toward zero.
+pub fn udiv(rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    0x1AC0_0800 | ((rm as u32) << 16) | ((rn as u32) << 5) | (rd as u32)
+}
+/// `udiv xd, xn, xm`
+pub fn udiv64(rd: Reg, rn: Reg, rm: Reg) -> u32 {
+    udiv(rd, rn, rm) | SF64
+}
+/// `msub wd, wn, wm, wa` — `wd = wa − wn·wm`. Used for remainder:
+/// `rem = a − (a/b)·b` = `msub rd, quotient, divisor, dividend`.
+pub fn msub(rd: Reg, rn: Reg, rm: Reg, ra: Reg) -> u32 {
+    0x1B00_8000 | ((rm as u32) << 16) | ((ra as u32) << 10) | ((rn as u32) << 5) | (rd as u32)
+}
+/// `msub xd, xn, xm, xa`
+pub fn msub64(rd: Reg, rn: Reg, rm: Reg, ra: Reg) -> u32 {
+    msub(rd, rn, rm, ra) | SF64
+}
+
+// ---------------------------------------------------------------------------
 // Variable shifts / rotates (register shift amount). Base = `0x1AC0_2000`
 // with the op2 field selecting LSL/LSR/ASR/ROR at bits [11:10]:
 //   00 = LSLV, 01 = LSRV, 10 = ASRV, 11 = RORV.
@@ -347,6 +386,14 @@ pub fn b_uncond(imm26: i32) -> u32 {
 /// truth: `cbnz w9, .+8` = 0x3500_0049 (imm19 = 2, Rt = 9).
 pub fn cbnz(rt: Reg, imm19: i32) -> u32 {
     0x3500_0000 | (((imm19 as u32) & 0x7FFFF) << 5) | (rt as u32)
+}
+/// `cbnz xt, #(imm19*4)` — 64-bit form (tests the FULL 64-bit register). #851:
+/// the i64 div/rem divisor-zero guard MUST test all 64 bits — a 32-bit `cbnz w`
+/// on a divisor like `0x1_0000_0000` (nonzero, low word 0) would falsely take
+/// the "nonzero" path and let a divide-by-zero through. llvm-mc: `cbnz x2, #8`
+/// = 0xB5000042 (= the w-form with SF64 set).
+pub fn cbnz64(rt: Reg, imm19: i32) -> u32 {
+    cbnz(rt, imm19) | SF64
 }
 
 /// `cbz wt, #(imm19*4)` — compare-and-branch-if-zero, 32-bit form. Symmetric
@@ -695,6 +742,28 @@ pub fn fmov_d(rd: FReg, rn: FReg) -> u32 {
     fp2(0x1E60_4000, rd, rn)
 }
 
+// ---------------------------------------------------------------------------
+// #851 — the two SIMD (Advanced-SIMD) ops used to synthesize a scalar popcount
+// (A64 has no scalar POPCNT). The sequence is:
+//   fmov d_n, x/w_a        (move the integer into the low lane of a V register)
+//   cnt  v_n.8b, v_n.8b    (per-BYTE population count into 8 byte lanes)
+//   addv b_n, v_n.8b       (horizontal ADD of the 8 byte counts → one byte)
+//   fmov w_d, s_n          (move the scalar result back to a GP register)
+// For an i32 input, `fmov s_n, w_a` writes only the low 32 bits and zeroes the
+// rest of the V register, so `cnt.8b` sees 4 value bytes + 4 zero bytes — the
+// count is correct without masking. For i64, `fmov d_n, x_a` fills 8 bytes.
+// clang/llvm-mc ground truth:
+//   cnt v0.8b, v0.8b = 0x0E205800   addv b0, v0.8b = 0x0E31B800
+
+/// `cnt vd.8b, vn.8b` — per-byte population count (8 byte lanes).
+pub fn cnt_8b(rd: FReg, rn: FReg) -> u32 {
+    0x0E20_5800 | ((rn as u32) << 5) | (rd as u32)
+}
+/// `addv bd, vn.8b` — horizontal add of the 8 byte lanes into scalar byte `bd`.
+pub fn addv_8b(rd: FReg, rn: FReg) -> u32 {
+    0x0E31_B800 | ((rn as u32) << 5) | (rd as u32)
+}
+
 /// `fcvt dd, sn` — single→double (`f64.promote_f32`). Exact, never traps.
 pub fn fcvt_d_from_s(rd: FReg, rn: FReg) -> u32 {
     fp2(0x1E22_C000, rd, rn)
@@ -744,6 +813,26 @@ mod tests {
         assert_eq!(movk(9, 1, 1), 0x72A0_0029);
         assert_eq!(mov_reg(0, 9), 0x2A09_03E0);
         assert_eq!(ret(), 0xD65F_03C0);
+    }
+
+    // #851 — divide / multiply-subtract / SIMD popcount building blocks.
+    // Ground truth from `llvm-mc -triple=aarch64 -show-encoding`.
+    #[test]
+    fn divrem_and_popcnt_encodings_match_llvm_mc() {
+        // sdiv w0,w1,w2 = [0x20,0x0c,0xc2,0x1a]  (LE) → 0x1AC20C20
+        assert_eq!(sdiv(0, 1, 2), 0x1AC2_0C20);
+        // udiv w0,w1,w2 = 0x1AC20820
+        assert_eq!(udiv(0, 1, 2), 0x1AC2_0820);
+        // msub w0,w1,w2,w3 = 0x1B028C20
+        assert_eq!(msub(0, 1, 2, 3), 0x1B02_8C20);
+        // x-forms set SF64 (bit 31)
+        assert_eq!(sdiv64(0, 1, 2), 0x9AC2_0C20);
+        assert_eq!(udiv64(0, 1, 2), 0x9AC2_0820);
+        assert_eq!(msub64(0, 1, 2, 3), 0x9B02_8C20);
+        // cnt v0.8b, v0.8b = 0x0E205800
+        assert_eq!(cnt_8b(0, 0), 0x0E20_5800);
+        // addv b0, v0.8b = 0x0E31B800
+        assert_eq!(addv_8b(0, 0), 0x0E31_B800);
     }
 
     #[test]

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -545,6 +545,160 @@ pub fn select_typed_cf(
         Ok(())
     };
 
+    // #851 — integer divide / remainder with WASM-faithful traps.
+    //
+    // A64 SDIV/UDIV are TOTAL where WASM is PARTIAL, so the raw instruction is a
+    // "more-total-than-WASM" silent miscompile (the #633/#666/#709 class). WASM
+    // (Core §4.3.2) requires:
+    //   * div/rem by ZERO traps         (all four forms)
+    //   * div_s(INT_MIN, -1) traps      (overflow: +2^(N-1) is unrepresentable)
+    //   * rem_s(INT_MIN, -1) = 0        (NO trap — falls out of MSUB naturally)
+    // We therefore emit an explicit divisor-zero guard for every form and, for
+    // SIGNED DIV only, an INT_MIN/-1 overflow guard. `is_rem`/`signed`/`is64`
+    // parameterize the one closure.
+    //
+    // Aliasing (the #776 lesson): `msub rd, q, b, a` reads a, b AND q at once, and
+    // the guards read a/b after materializing const scratch. So every temp
+    // (quotient, const scratch, result) is allocated while a and b are STILL on
+    // the value stack (pushed back as reservations), guaranteeing no allocation
+    // hands back a register still holding a live operand.
+    let divrem = |words: &mut Vec<u32>,
+                  stack: &mut Vec<Val>,
+                  signed: bool,
+                  is64: bool,
+                  is_rem: bool|
+     -> Result<(), SelectError> {
+        let b = pop_gp(stack, "divrem")?; // divisor
+        let a = pop_gp(stack, "divrem")?; // dividend
+        // Reserve a and b so temp allocation never collides with them.
+        stack.push(Val::gp(a));
+        stack.push(Val::gp(b));
+        // Need up to three DISTINCT scratch regs beyond a/b: quotient, and (for
+        // the signed-div overflow guard) two const-materialization temps.
+        let mut free = TEMPS
+            .iter()
+            .copied()
+            .filter(|t| !stack.iter().any(|v| v.file == File::Gp && v.reg == *t));
+        let (Some(q), Some(s0), Some(s1)) = (free.next(), free.next(), free.next()) else {
+            stack.pop();
+            stack.pop();
+            return Err(SelectError(
+                "value-stack too deep (divrem needs 3 GP temps)".into(),
+            ));
+        };
+        stack.pop(); // b
+        stack.pop(); // a
+
+        // --- Guard 1: divisor == 0 → trap (all four forms). Test the FULL width
+        // so an i64 divisor with a zero low word but nonzero high word (e.g.
+        // 0x1_0000_0000) is correctly seen as nonzero. `cbnz b, +2` skips the
+        // brk when the divisor is nonzero.
+        if is64 {
+            words.push(enc::cbnz64(b, 2));
+        } else {
+            words.push(enc::cbnz(b, 2));
+        }
+        words.push(enc::brk(0)); // divide by zero
+
+        // --- Guard 2 (signed DIV only): dividend == INT_MIN && divisor == -1
+        // → overflow trap. rem_s does NOT trap here (result is 0). Materialize
+        // INT_MIN and -1, compare, and branch over the brk when EITHER differs.
+        if signed && !is_rem {
+            let (min_bits, neg1_bits): (u64, u64) = if is64 {
+                (0x8000_0000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF)
+            } else {
+                (0x8000_0000, 0xFFFF_FFFF)
+            };
+            if is64 {
+                for w in enc::mov_imm64(s0, min_bits) {
+                    words.push(w);
+                }
+                for w in enc::mov_imm64(s1, neg1_bits) {
+                    words.push(w);
+                }
+                words.push(enc::cmp64(a, s0));
+            } else {
+                for w in enc::mov_imm32(s0, min_bits as u32) {
+                    words.push(w);
+                }
+                for w in enc::mov_imm32(s1, neg1_bits as u32) {
+                    words.push(w);
+                }
+                words.push(enc::cmp(a, s0));
+            }
+            // b.ne → dividend != INT_MIN, no overflow: jump PAST the second cmp,
+            // its b.ne, and the brk (3 words ahead of THIS branch).
+            words.push(enc::bcond(Cond::Ne, 3));
+            words.push(if is64 {
+                enc::cmp64(b, s1)
+            } else {
+                enc::cmp(b, s1)
+            });
+            words.push(enc::bcond(Cond::Ne, 2)); // divisor != -1 → skip brk
+            words.push(enc::brk(0)); // INT_MIN / -1 overflow
+        }
+
+        // --- The arithmetic.
+        let dst = if is_rem {
+            // rem = a − (a/b)·b. SDIV/UDIV into q, then MSUB into the result reg
+            // (which may reuse q — msub reads q before writing its dst).
+            if signed {
+                words.push(if is64 {
+                    enc::sdiv64(q, a, b)
+                } else {
+                    enc::sdiv(q, a, b)
+                });
+            } else {
+                words.push(if is64 {
+                    enc::udiv64(q, a, b)
+                } else {
+                    enc::udiv(q, a, b)
+                });
+            }
+            words.push(if is64 {
+                enc::msub64(q, q, b, a)
+            } else {
+                enc::msub(q, q, b, a)
+            });
+            q
+        } else {
+            words.push(match (signed, is64) {
+                (true, false) => enc::sdiv(q, a, b),
+                (true, true) => enc::sdiv64(q, a, b),
+                (false, false) => enc::udiv(q, a, b),
+                (false, true) => enc::udiv64(q, a, b),
+            });
+            q
+        };
+        stack.push(Val::gp(dst));
+        Ok(())
+    };
+
+    // #851 — scalar popcount via the Advanced-SIMD unit (A64 has no scalar
+    // POPCNT): move the integer into a V register, per-byte CNT, horizontal
+    // ADDV, move back. For i32, `fmov s,w` zero-fills the upper lanes so CNT.8b
+    // counts exactly 4 value bytes; for i64, `fmov d,x` fills all 8.
+    let popcnt = |words: &mut Vec<u32>, stack: &mut Vec<Val>, is64: bool| -> Result<(), SelectError> {
+        let a = pop_gp(stack, "popcnt")?;
+        let dst = alloc_temp(stack)?;
+        // Grab an FP scratch that no live FP value-stack entry holds.
+        let vtmp = FTEMPS
+            .iter()
+            .copied()
+            .find(|t| !stack.iter().any(|v| v.file == File::Fp && v.reg == *t))
+            .ok_or_else(|| SelectError("value-stack too deep (popcnt needs an FP temp)".into()))?;
+        if is64 {
+            words.push(enc::fmov_d_from_x(vtmp, a));
+        } else {
+            words.push(enc::fmov_s_from_w(vtmp, a));
+        }
+        words.push(enc::cnt_8b(vtmp, vtmp));
+        words.push(enc::addv_8b(vtmp, vtmp));
+        words.push(enc::fmov_w_from_s(dst, vtmp));
+        stack.push(Val::gp(dst));
+        Ok(())
+    };
+
     // `ctz` = `rbit` then `clz` (A64 has no direct CTZ). `sf` selects width.
     let ctz = |words: &mut Vec<u32>, stack: &mut Vec<Val>, sf: bool| -> Result<(), SelectError> {
         let a = pop_gp(stack, "ctz")?;
@@ -877,6 +1031,13 @@ pub fn select_typed_cf(
             WasmOp::I32Rotl => rotl(&mut words, &mut stack, false)?,
             WasmOp::I32Clz => unop(&mut words, &mut stack, enc::clz)?,
             WasmOp::I32Ctz => ctz(&mut words, &mut stack, false)?,
+            WasmOp::I32Popcnt => popcnt(&mut words, &mut stack, false)?,
+            // #851 — i32 divide / remainder (SDIV/UDIV + MSUB) with the WASM
+            // trap guards (÷0 all forms; INT_MIN/-1 signed-div only).
+            WasmOp::I32DivS => divrem(&mut words, &mut stack, true, false, false)?,
+            WasmOp::I32DivU => divrem(&mut words, &mut stack, false, false, false)?,
+            WasmOp::I32RemS => divrem(&mut words, &mut stack, true, false, true)?,
+            WasmOp::I32RemU => divrem(&mut words, &mut stack, false, false, true)?,
 
             // --- i32 comparisons ---
             WasmOp::I32Eqz => eqz(&mut words, &mut stack, false)?,
@@ -905,6 +1066,13 @@ pub fn select_typed_cf(
             WasmOp::I64Rotl => rotl(&mut words, &mut stack, true)?,
             WasmOp::I64Clz => unop(&mut words, &mut stack, enc::clz64)?,
             WasmOp::I64Ctz => ctz(&mut words, &mut stack, true)?,
+            WasmOp::I64Popcnt => popcnt(&mut words, &mut stack, true)?,
+            // #851 — i64 divide / remainder (x-form SDIV/UDIV + MSUB) with the
+            // WASM trap guards (÷0 all forms; INT64_MIN/-1 signed-div only).
+            WasmOp::I64DivS => divrem(&mut words, &mut stack, true, true, false)?,
+            WasmOp::I64DivU => divrem(&mut words, &mut stack, false, true, false)?,
+            WasmOp::I64RemS => divrem(&mut words, &mut stack, true, true, true)?,
+            WasmOp::I64RemU => divrem(&mut words, &mut stack, false, true, true)?,
 
             // --- i64 comparisons (result is an i32 0/1) ---
             WasmOp::I64Eqz => eqz(&mut words, &mut stack, true)?,
@@ -997,6 +1165,14 @@ pub fn select_typed_cf(
             }
             WasmOp::I32ReinterpretF32 => {
                 reinterpret_fp_to_gp(&mut words, &mut stack, enc::fmov_w_from_s)?
+            }
+            // #851 (GI-FPU-001) — f64 <-> i64 bit-cast reinterprets, the 64-bit
+            // twins of the f32/i32 pair above (`fmov dd,xn` / `fmov xd,dn`).
+            WasmOp::F64ReinterpretI64 => {
+                reinterpret_gp_to_fp(&mut words, &mut stack, enc::fmov_d_from_x)?
+            }
+            WasmOp::I64ReinterpretF64 => {
+                reinterpret_fp_to_gp(&mut words, &mut stack, enc::fmov_x_from_d)?
             }
 
             // `End` is overloaded: it closes the innermost open `block`, or —
@@ -1295,9 +1471,9 @@ mod tests {
         );
     }
 
+    // #851 — div/rem now LOWER (SDIV/UDIV + MSUB) with WASM trap guards.
     #[test]
-    fn division_is_loud_declined() {
-        // A64 SDIV/UDIV do not trap → we refuse rather than silently miscompile.
+    fn division_and_remainder_lower_with_guards() {
         for op in [
             WasmOp::I32DivS,
             WasmOp::I32DivU,
@@ -1305,16 +1481,149 @@ mod tests {
             WasmOp::I32RemU,
             WasmOp::I64DivS,
             WasmOp::I64DivU,
+            WasmOp::I64RemS,
+            WasmOp::I64RemU,
         ] {
-            let ops = vec![WasmOp::LocalGet(0), WasmOp::LocalGet(1), op, WasmOp::End];
-            assert!(select(&ops, 2).is_err(), "division must loud-decline");
+            let ops = vec![WasmOp::LocalGet(0), WasmOp::LocalGet(1), op.clone(), WasmOp::End];
+            assert!(select(&ops, 2).is_ok(), "div/rem must lower: {op:?}");
         }
     }
 
     #[test]
-    fn popcnt_is_loud_declined() {
+    fn div_u_emits_divisor_zero_guard_only() {
+        // i32.div_u: cbnz w1,+2 ; brk ; udiv w9,w0,w1 ; mov x0,x9 ; ret.
+        // Exactly ONE brk (÷0), no overflow guard for the unsigned form.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32DivU,
+            WasmOp::End,
+        ];
+        let w = select(&ops, 2).unwrap();
+        assert_eq!(
+            w,
+            vec![
+                enc::cbnz(1, 2),
+                enc::brk(0),
+                enc::udiv(9, 0, 1),
+                enc::mov_reg64(0, 9),
+                enc::ret(),
+            ]
+        );
+    }
+
+    #[test]
+    fn div_s_emits_zero_and_overflow_guards() {
+        // i32.div_s: ÷0 guard + INT_MIN/-1 overflow guard, then sdiv.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32DivS,
+            WasmOp::End,
+        ];
+        let w = select(&ops, 2).unwrap();
+        // Temps: q=9 (quotient/result), s0=10 (INT_MIN), s1=11 (-1).
+        let mut expect = vec![enc::cbnz(1, 2), enc::brk(0)];
+        expect.extend(enc::mov_imm32(10, 0x8000_0000)); // INT_MIN scratch
+        expect.extend(enc::mov_imm32(11, 0xFFFF_FFFF)); // -1 scratch
+        expect.push(enc::cmp(0, 10)); // dividend == INT_MIN?
+        expect.push(enc::bcond(Cond::Ne, 3));
+        expect.push(enc::cmp(1, 11)); // divisor == -1?
+        expect.push(enc::bcond(Cond::Ne, 2));
+        expect.push(enc::brk(0));
+        expect.push(enc::sdiv(9, 0, 1));
+        expect.push(enc::mov_reg64(0, 9));
+        expect.push(enc::ret());
+        assert_eq!(w, expect);
+    }
+
+    #[test]
+    fn rem_s_has_zero_guard_but_no_overflow_guard() {
+        // rem_s traps ONLY on ÷0 (rem_s(INT_MIN,-1) == 0). So exactly one brk,
+        // and the arithmetic is sdiv + msub.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32RemS,
+            WasmOp::End,
+        ];
+        let w = select(&ops, 2).unwrap();
+        assert_eq!(
+            w,
+            vec![
+                enc::cbnz(1, 2),
+                enc::brk(0),
+                enc::sdiv(9, 0, 1),
+                enc::msub(9, 9, 1, 0),
+                enc::mov_reg64(0, 9),
+                enc::ret(),
+            ]
+        );
+        // Exactly one brk — no overflow guard.
+        assert_eq!(w.iter().filter(|&&x| x == enc::brk(0)).count(), 1);
+    }
+
+    #[test]
+    fn i64_div_zero_guard_tests_full_width() {
+        // The i64 ÷0 guard MUST use the x-form cbnz (all 64 bits).
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I64DivU,
+            WasmOp::End,
+        ];
+        let w = select(&ops, 2).unwrap();
+        assert_eq!(w[0], enc::cbnz64(1, 2), "i64 ÷0 guard must be 64-bit cbnz");
+        assert_eq!(w[1], enc::brk(0));
+    }
+
+    #[test]
+    fn popcnt_lowers_via_simd_cnt_addv() {
+        // i32.popcnt: fmov s16,w0 ; cnt v16.8b ; addv b16 ; fmov w9,s16.
         let ops = vec![WasmOp::LocalGet(0), WasmOp::I32Popcnt, WasmOp::End];
-        assert!(select(&ops, 1).is_err());
+        let w = select(&ops, 1).unwrap();
+        assert_eq!(
+            w,
+            vec![
+                enc::fmov_s_from_w(16, 0),
+                enc::cnt_8b(16, 16),
+                enc::addv_8b(16, 16),
+                enc::fmov_w_from_s(9, 16),
+                enc::mov_reg64(0, 9),
+                enc::ret(),
+            ]
+        );
+    }
+
+    #[test]
+    fn i64_popcnt_uses_d_move() {
+        // i64.popcnt fills all 8 bytes: fmov d16,x0.
+        let ops = vec![WasmOp::LocalGet(0), WasmOp::I64Popcnt, WasmOp::End];
+        let w = select(&ops, 1).unwrap();
+        assert_eq!(w[0], enc::fmov_d_from_x(16, 0));
+        assert_eq!(w[1], enc::cnt_8b(16, 16));
+        assert_eq!(w[2], enc::addv_8b(16, 16));
+    }
+
+    #[test]
+    fn f64_i64_reinterpret_round_trips_through_fmov() {
+        // i64 param → f64.reinterpret → i64.reinterpret: fmov d16,x0; fmov x9,d16.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::F64ReinterpretI64,
+            WasmOp::I64ReinterpretF64,
+            WasmOp::End,
+        ];
+        let w = select(&ops, 1).unwrap();
+        assert_eq!(
+            w,
+            vec![
+                enc::fmov_d_from_x(16, 0),
+                enc::fmov_x_from_d(9, 16),
+                enc::mov_reg64(0, 9),
+                enc::ret(),
+            ]
+        );
     }
 
     // ---- milestone 3: scalar float ----

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -680,7 +680,10 @@ pub fn select_typed_cf(
     // POPCNT): move the integer into a V register, per-byte CNT, horizontal
     // ADDV, move back. For i32, `fmov s,w` zero-fills the upper lanes so CNT.8b
     // counts exactly 4 value bytes; for i64, `fmov d,x` fills all 8.
-    let popcnt = |words: &mut Vec<u32>, stack: &mut Vec<Val>, is64: bool| -> Result<(), SelectError> {
+    let popcnt = |words: &mut Vec<u32>,
+                  stack: &mut Vec<Val>,
+                  is64: bool|
+     -> Result<(), SelectError> {
         let a = pop_gp(stack, "popcnt")?;
         let dst = alloc_temp(stack)?;
         // Grab an FP scratch that no live FP value-stack entry holds.
@@ -1486,7 +1489,12 @@ mod tests {
             WasmOp::I64RemS,
             WasmOp::I64RemU,
         ] {
-            let ops = vec![WasmOp::LocalGet(0), WasmOp::LocalGet(1), op.clone(), WasmOp::End];
+            let ops = vec![
+                WasmOp::LocalGet(0),
+                WasmOp::LocalGet(1),
+                op.clone(),
+                WasmOp::End,
+            ];
             assert!(select(&ops, 2).is_ok(), "div/rem must lower: {op:?}");
         }
     }

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -627,8 +627,10 @@ pub fn select_typed_cf(
                 words.push(enc::cmp(a, s0));
             }
             // b.ne → dividend != INT_MIN, no overflow: jump PAST the second cmp,
-            // its b.ne, and the brk (3 words ahead of THIS branch).
-            words.push(enc::bcond(Cond::Ne, 3));
+            // its b.ne, and the brk, landing on the arithmetic. Those are the
+            // next THREE instructions, so the branch target is +4 words from
+            // this branch (`b.<cond> #(imm*4)` is pc-relative to the branch).
+            words.push(enc::bcond(Cond::Ne, 4));
             words.push(if is64 {
                 enc::cmp64(b, s1)
             } else {
@@ -1527,7 +1529,7 @@ mod tests {
         expect.extend(enc::mov_imm32(10, 0x8000_0000)); // INT_MIN scratch
         expect.extend(enc::mov_imm32(11, 0xFFFF_FFFF)); // -1 scratch
         expect.push(enc::cmp(0, 10)); // dividend == INT_MIN?
-        expect.push(enc::bcond(Cond::Ne, 3));
+        expect.push(enc::bcond(Cond::Ne, 4));
         expect.push(enc::cmp(1, 11)); // divisor == -1?
         expect.push(enc::bcond(Cond::Ne, 2));
         expect.push(enc::brk(0));

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -2229,6 +2229,15 @@ fn convert_operator(op: &wasmparser::Operator) -> Option<WasmOp> {
         // register and a single-precision S-register — no numeric conversion.
         F32ReinterpretI32 => Some(WasmOp::F32ReinterpretI32),
         I32ReinterpretF32 => Some(WasmOp::I32ReinterpretF32),
+        // #851 (GI-FPU-001): the f64<->i64 bit-casts, the 64-bit twins of the
+        // pair above. The WasmOp variants already existed and every backend
+        // that lowers f64 has a lowering (ARM: `ArmOp::{F64ReinterpretI64,
+        // I64ReinterpretF64}` VFP moves; aarch64: `fmov d,x` / `fmov x,d`);
+        // they were merely never DECODED, so they globally declined. Backends
+        // without an f64 lowering (RV32) still loud-decline downstream — this
+        // only un-drops the op at decode.
+        F64ReinterpretI64 => Some(WasmOp::F64ReinterpretI64),
+        I64ReinterpretF64 => Some(WasmOp::I64ReinterpretF64),
         F32ConvertI32S => Some(WasmOp::F32ConvertI32S),
         F32ConvertI32U => Some(WasmOp::F32ConvertI32U),
         I32TruncF32S => Some(WasmOp::I32TruncF32S),

--- a/scripts/repro/aarch64_divrem_851.wat
+++ b/scripts/repro/aarch64_divrem_851.wat
@@ -1,0 +1,21 @@
+(module
+  ;; #851 — aarch64 integer div/rem lowering (SDIV/UDIV + MSUB) with the WASM
+  ;; trap guards. Exercised by aarch64_divrem_851_differential.py against
+  ;; wasmtime (value + trap), executed natively (SIGTRAP) and under unicorn.
+  (func (export "i32_div_s") (param i32 i32) (result i32)
+    (i32.div_s (local.get 0) (local.get 1)))
+  (func (export "i32_div_u") (param i32 i32) (result i32)
+    (i32.div_u (local.get 0) (local.get 1)))
+  (func (export "i32_rem_s") (param i32 i32) (result i32)
+    (i32.rem_s (local.get 0) (local.get 1)))
+  (func (export "i32_rem_u") (param i32 i32) (result i32)
+    (i32.rem_u (local.get 0) (local.get 1)))
+  (func (export "i64_div_s") (param i64 i64) (result i64)
+    (i64.div_s (local.get 0) (local.get 1)))
+  (func (export "i64_div_u") (param i64 i64) (result i64)
+    (i64.div_u (local.get 0) (local.get 1)))
+  (func (export "i64_rem_s") (param i64 i64) (result i64)
+    (i64.rem_s (local.get 0) (local.get 1)))
+  (func (export "i64_rem_u") (param i64 i64) (result i64)
+    (i64.rem_u (local.get 0) (local.get 1)))
+)

--- a/scripts/repro/aarch64_divrem_851.wat
+++ b/scripts/repro/aarch64_divrem_851.wat
@@ -18,4 +18,13 @@
     (i64.rem_s (local.get 0) (local.get 1)))
   (func (export "i64_rem_u") (param i64 i64) (result i64)
     (i64.rem_u (local.get 0) (local.get 1)))
+  ;; popcnt (SIMD CNT/ADDV) — i32 zero-fills upper lanes, i64 fills all 8.
+  (func (export "i32_popcnt") (param i32) (result i32)
+    (i32.popcnt (local.get 0)))
+  (func (export "i64_popcnt") (param i64) (result i64)
+    (i64.popcnt (local.get 0)))
+  ;; f64<->i64 reinterpret round-trips (bit-preserving fmov) — a full round
+  ;; trip is the identity, so f(x) must equal the input bits for every x.
+  (func (export "i64_reinterpret_rt") (param i64) (result i64)
+    (i64.reinterpret_f64 (f64.reinterpret_i64 (local.get 0))))
 )

--- a/scripts/repro/aarch64_divrem_851_differential.py
+++ b/scripts/repro/aarch64_divrem_851_differential.py
@@ -36,9 +36,9 @@ import wasmtime
 from elftools.elf.elffile import ELFFile
 from unicorn import UC_ARCH_ARM64, UC_MODE_ARM, Uc, UcError
 from unicorn.arm64_const import (
+    UC_ARM64_REG_CPACR_EL1,
     UC_ARM64_REG_LR,
     UC_ARM64_REG_SP,
-    UC_ARM64_REG_W0,
     UC_ARM64_REG_X0,
     UC_ARM64_REG_X1,
 )
@@ -64,6 +64,19 @@ SIGS = {
     "i64_div_u": (64, False),
     "i64_rem_s": (64, True),
     "i64_rem_u": (64, False),
+}
+
+# Unary (param T)(result T) coverage: popcnt (both widths) + the f64<->i64
+# reinterpret round-trip (a bit-identity). fn -> width_bits.
+UNARY_SIGS = {
+    "i32_popcnt": 32,
+    "i64_popcnt": 64,
+    "i64_reinterpret_rt": 64,
+}
+UNARY_VALS = {
+    32: [0, 1, -1, 0xAAAA, 0x5555, 0x8000_0000, 0x7FFF_FFFF, 42, 0xFFFF_0000],
+    64: [0, 1, -1, 0xAAAA_AAAA_AAAA_AAAA, 0x8000_0000_0000_0000,
+         0x7FFF_FFFF_FFFF_FFFF, 0x0001_0203_0405_0607, 123456789, (1 << 40)],
 }
 
 
@@ -116,6 +129,65 @@ def compile_aarch64(out):
                        env={"PATH": "/usr/bin:/bin"})
     if r.returncode != 0:
         sys.exit(f"aarch64 compile failed: {r.stderr}")
+
+
+def wasmtime_run1(fn, a, width):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    f = wasmtime.Instance(store, module, []).exports(store)[fn]
+    try:
+        r = f(store, to_signed(a, width))
+    except wasmtime.Trap:
+        return TRAP
+    return to_unsigned(r, width)
+
+
+def unicorn_run1(code, base, faddr, a, width):
+    off = faddr - base
+    mu = Uc(UC_ARCH_ARM64, UC_MODE_ARM)
+    mu.reg_write(UC_ARM64_REG_CPACR_EL1, 0x3 << 20)  # FPEN: enable V/D regs
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(STK - 0x10000, 0x20000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_ARM64_REG_SP, STK)
+    mu.reg_write(UC_ARM64_REG_LR, RET)
+    mu.reg_write(X_ARGS[0], to_unsigned(a, width))
+    try:
+        mu.emu_start(CODE + off, RET, count=2000)
+    except UcError:
+        return TRAP
+    return mu.reg_read(UC_ARM64_REG_X0) & (M32 if width == 32 else M64)
+
+
+def native_run1(code, faddr, code_base, a, width):
+    cty = ctypes.c_int32 if width == 32 else ctypes.c_int64
+    rd, wr = os.pipe()
+    pid = os.fork()
+    if pid == 0:
+        try:
+            os.close(rd)
+            base_addr = native_setup(code)
+            fn_addr = base_addr + (faddr - code_base)
+            fn = ctypes.CFUNCTYPE(cty, cty)(fn_addr)
+            r = fn(to_signed(a, width))
+            os.write(wr, struct.pack("<q", int(r)))
+            os.close(wr)
+        finally:
+            os._exit(0)
+    os.close(wr)
+    _, status = os.waitpid(pid, 0)
+    data = os.read(rd, 8)
+    os.close(rd)
+    if os.WIFSIGNALED(status):
+        sig_no = os.WTERMSIG(status)
+        if sig_no in (signal.SIGTRAP, signal.SIGILL, signal.SIGFPE):
+            return TRAP
+        return f"ERR:signal {sig_no}"
+    if len(data) != 8:
+        return "ERR:no result"
+    return to_unsigned(struct.unpack("<q", data)[0], width)
 
 
 def load(elf):
@@ -252,11 +324,32 @@ def main():
                     g = got if isinstance(got, str) else hex(got)
                     print(f"BUG {fn}(a={a},b={b}) [{label}] A64={g} wasmtime={e}")
 
+    # --- unary coverage: popcnt (both widths) + reinterpret round-trip.
+    for fn, width in UNARY_SIGS.items():
+        if fn not in syms:
+            print(f"FAIL {fn}: symbol missing (op declined?)")
+            fails += 1
+            continue
+        for a in UNARY_VALS[width]:
+            total += 1
+            exp = wasmtime_run1(fn, a, width)
+            oracles = [("unicorn", unicorn_run1(code, base, syms[fn], a, width))]
+            if host_native:
+                oracles.append(("native", native_run1(code, syms[fn], base, a, width)))
+                checked_native += 1
+            for label, got in oracles:
+                if exp != got:
+                    fails += 1
+                    e = exp if exp == TRAP else hex(exp)
+                    g = got if isinstance(got, str) else hex(got)
+                    print(f"BUG {fn}(a={a}) [{label}] A64={g} wasmtime={e}")
+
     print(f"\n{total} wasmtime cases ({trap_cases} trap cases), "
           f"{checked_native} also run natively "
           f"({'arm64 host' if host_native else 'unicorn-only host'})")
-    print("RESULT:", "PASS — aarch64 div/rem match wasmtime; the ÷0 and "
-          "INT_MIN/-1 traps are execution-verified (native SIGTRAP + unicorn brk)"
+    print("RESULT:", "PASS — aarch64 div/rem + popcnt + f64<->i64 reinterpret "
+          "match wasmtime; the ÷0 and INT_MIN/-1 traps are execution-verified "
+          "(native SIGTRAP + unicorn brk)"
           if not fails else f"FAIL ({fails})")
     sys.exit(1 if fails else 0)
 

--- a/scripts/repro/aarch64_divrem_851_differential.py
+++ b/scripts/repro/aarch64_divrem_851_differential.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""#851 — aarch64 integer div/rem trap-and-value EXECUTION differential.
+
+A64 SDIV/UDIV are TOTAL where WASM `idiv`/`irem` (Core §4.3.2) are PARTIAL, so
+a bare lowering is a silent "more-total-than-WASM" miscompile (the #633/#666/
+#709 class). synth's aarch64 backend defends the totality gap with explicit
+guards; this harness proves those guards TRAP exactly where wasmtime traps and
+compute the right value everywhere else, execution-verified TWO ways:
+  (1) unicorn (UC_ARCH_ARM64): a guard's `brk #0` raises UC_ERR_EXCEPTION;
+  (2) natively on an arm64 host: each call runs in a forked child, so an
+      expected SIGTRAP is observed by the parent (and a surprise trap can't
+      take the harness down).
+
+The trap table pinned (per WASM Core §4.3.2):
+  * div/rem by ZERO  -> TRAP (all four forms, both widths).
+  * div_s(INT_MIN, -1) -> TRAP (quotient +2^(N-1) is unrepresentable).
+  * rem_s(INT_MIN, -1) -> 0  (NO trap — a64 MSUB yields 0 naturally).
+The static expect-trap column is itself validated against wasmtime FIRST — if
+wasmtime disagrees, the FIXTURE is declared wrong (loud), so the table cannot
+drift vacuous (matches the m4 boundary-table gate).
+
+Run (needs wasmtime + unicorn + pyelftools; native path needs an arm64 host):
+  SYNTH=<target>/debug/synth python scripts/repro/aarch64_divrem_851_differential.py
+"""
+
+import ctypes
+import os
+import platform
+import signal
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM64, UC_MODE_ARM, Uc, UcError
+from unicorn.arm64_const import (
+    UC_ARM64_REG_LR,
+    UC_ARM64_REG_SP,
+    UC_ARM64_REG_W0,
+    UC_ARM64_REG_X0,
+    UC_ARM64_REG_X1,
+)
+
+WAT = Path(__file__).with_name("aarch64_divrem_851.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+CODE, STK, RET = 0x100000, 0x200000, 0x300000
+X_ARGS = [UC_ARM64_REG_X0, UC_ARM64_REG_X1]
+
+M32 = (1 << 32) - 1
+M64 = (1 << 64) - 1
+I32_MIN = -(1 << 31)
+I64_MIN = -(1 << 63)
+TRAP = "TRAP"
+
+# fn -> (width_bits, signed). All are (param T T)(result T).
+SIGS = {
+    "i32_div_s": (32, True),
+    "i32_div_u": (32, False),
+    "i32_rem_s": (32, True),
+    "i32_rem_u": (32, False),
+    "i64_div_s": (64, True),
+    "i64_div_u": (64, False),
+    "i64_rem_s": (64, True),
+    "i64_rem_u": (64, False),
+}
+
+
+def cases_for(fn, width):
+    """(a, b) operand pairs — a mix of ordinary values + every trap edge."""
+    mn = I32_MIN if width == 32 else I64_MIN
+    ordinary = [
+        (7, 2), (7, 3), (-7, 2), (7, -2), (-7, -3),
+        (100, 7), (-100, 7), (100, -7),
+        (mn, 1), (mn, 2), (mn, -2), (0, 5), (5, 5),
+        (mn + 1, -1),  # NOT INT_MIN: -1 divisor is fine here
+    ]
+    edges = [
+        (7, 0), (0, 0), (-7, 0), (mn, 0),  # divide-by-zero: always traps
+        (mn, -1),  # div_s: overflow trap; rem_s: 0; div_u/rem_u: no trap
+    ]
+    return ordinary + edges
+
+
+# --------------------------------------------------------------------------- #
+def to_signed(v, width):
+    m = M32 if width == 32 else M64
+    v &= m
+    bit = 1 << (width - 1)
+    return v - (1 << width) if v & bit else v
+
+
+def to_unsigned(v, width):
+    return v & (M32 if width == 32 else M64)
+
+
+# --------------------------------------------------------------------------- #
+# wasmtime ground truth (TRAP on wasmtime.Trap).
+def wasmtime_run(fn, a, b, width):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    f = wasmtime.Instance(store, module, []).exports(store)[fn]
+    try:
+        r = f(store, to_signed(a, width), to_signed(b, width))
+    except wasmtime.Trap:
+        return TRAP
+    return to_unsigned(r, width)
+
+
+# --------------------------------------------------------------------------- #
+def compile_aarch64(out):
+    cmd = [SYNTH, "compile", str(WAT), "-o", out, "-b", "aarch64", "--all-exports"]
+    r = subprocess.run(cmd, capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin"})
+    if r.returncode != 0:
+        sys.exit(f"aarch64 compile failed: {r.stderr}")
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for sy in sec.iter_symbols():
+                if sy.name:
+                    syms[sy.name] = sy["st_value"] & ~1
+    return code, base, syms
+
+
+# --------------------------------------------------------------------------- #
+# unicorn execution: value, or TRAP when a guard's brk raises an exception.
+def unicorn_run(code, base, faddr, a, b, width):
+    off = faddr - base
+    mu = Uc(UC_ARCH_ARM64, UC_MODE_ARM)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(STK - 0x10000, 0x20000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_ARM64_REG_SP, STK)
+    mu.reg_write(UC_ARM64_REG_LR, RET)
+    mu.reg_write(X_ARGS[0], to_unsigned(a, width))
+    mu.reg_write(X_ARGS[1], to_unsigned(b, width))
+    try:
+        mu.emu_start(CODE + off, RET, count=2000)
+    except UcError:
+        return TRAP
+    v = mu.reg_read(UC_ARM64_REG_X0)
+    return v & (M32 if width == 32 else M64)
+
+
+# --------------------------------------------------------------------------- #
+# native execution on an arm64 host — each call in a forked child so an
+# expected `brk #0` (SIGTRAP) is observable and a surprise one survivable.
+_MAP_PRIVATE = 0x0002
+_MAP_ANON = 0x1000 if sys.platform == "darwin" else 0x20
+_MAP_JIT = 0x0800  # darwin only
+_PROT_RWX = 0x1 | 0x2 | 0x4
+
+
+def native_setup(code):
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.mmap.restype = ctypes.c_void_p
+    libc.mmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int,
+                          ctypes.c_int, ctypes.c_int, ctypes.c_long]
+    size = max(len(code), 4096)
+    flags = _MAP_PRIVATE | _MAP_ANON
+    if sys.platform == "darwin":
+        flags |= _MAP_JIT
+    addr = libc.mmap(None, size, _PROT_RWX, flags, -1, 0)
+    if addr in (ctypes.c_void_p(-1).value, 0, None):
+        err = ctypes.get_errno()
+        raise OSError(err, f"mmap(MAP_JIT) failed: {os.strerror(err)}")
+    if sys.platform == "darwin":
+        wp = ctypes.CDLL(None).pthread_jit_write_protect_np
+        wp(0)
+    ctypes.memmove(addr, code, len(code))
+    if sys.platform == "darwin":
+        wp(1)
+        libc.sys_icache_invalidate.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+        libc.sys_icache_invalidate(ctypes.c_void_p(addr), len(code))
+    return addr
+
+
+def native_run(code, faddr, code_base, a, b, width):
+    """Fork; the child JITs + calls the function and pipes back the result. A
+    trap (SIGTRAP from `brk #0`) kills the CHILD; the parent reports TRAP. The
+    MAP_JIT region is created IN the child (an inherited parent mapping can
+    SIGBUS after fork on macOS)."""
+    cty = ctypes.c_int32 if width == 32 else ctypes.c_int64
+    rd, wr = os.pipe()
+    pid = os.fork()
+    if pid == 0:  # child
+        try:
+            os.close(rd)
+            base_addr = native_setup(code)
+            fn_addr = base_addr + (faddr - code_base)
+            proto = ctypes.CFUNCTYPE(cty, cty, cty)
+            fn = proto(fn_addr)
+            r = fn(to_signed(a, width), to_signed(b, width))
+            os.write(wr, struct.pack("<q", int(r)))
+            os.close(wr)
+        finally:
+            os._exit(0)
+    os.close(wr)
+    _, status = os.waitpid(pid, 0)
+    data = os.read(rd, 8)
+    os.close(rd)
+    if os.WIFSIGNALED(status):
+        sig_no = os.WTERMSIG(status)
+        if sig_no in (signal.SIGTRAP, signal.SIGILL, signal.SIGFPE):
+            return TRAP
+        return f"ERR:signal {sig_no}"
+    if len(data) != 8:
+        return "ERR:no result"
+    return to_unsigned(struct.unpack("<q", data)[0], width)
+
+
+# --------------------------------------------------------------------------- #
+def main():
+    out = "/tmp/aarch64_divrem_851.o"
+    compile_aarch64(out)
+    code, base, syms = load(out)
+    host_native = platform.machine() in ("arm64", "aarch64")
+
+    fails = 0
+    total = 0
+    trap_cases = 0
+    checked_native = 0
+    for fn, (width, _signed) in SIGS.items():
+        if fn not in syms:
+            print(f"FAIL {fn}: symbol missing (op declined?)")
+            fails += 1
+            continue
+        for a, b in cases_for(fn, width):
+            total += 1
+            exp = wasmtime_run(fn, a, b, width)
+            if exp == TRAP:
+                trap_cases += 1
+            oracles = [("unicorn", unicorn_run(code, base, syms[fn], a, b, width))]
+            if host_native:
+                oracles.append(("native", native_run(code, syms[fn], base, a, b, width)))
+                checked_native += 1
+            for label, got in oracles:
+                ok = (exp == got) if (exp == TRAP or got == TRAP) else (exp == got)
+                if not ok:
+                    fails += 1
+                    e = exp if exp == TRAP else hex(exp)
+                    g = got if isinstance(got, str) else hex(got)
+                    print(f"BUG {fn}(a={a},b={b}) [{label}] A64={g} wasmtime={e}")
+
+    print(f"\n{total} wasmtime cases ({trap_cases} trap cases), "
+          f"{checked_native} also run natively "
+          f"({'arm64 host' if host_native else 'unicorn-only host'})")
+    print("RESULT:", "PASS — aarch64 div/rem match wasmtime; the ÷0 and "
+          "INT_MIN/-1 traps are execution-verified (native SIGTRAP + unicorn brk)"
+          if not fails else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/aarch64_m2_decline_538.py
+++ b/scripts/repro/aarch64_m2_decline_538.py
@@ -25,26 +25,13 @@ SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
 
 # Each entry: (label, wat body). All must FAIL to compile with -b aarch64.
 DECLINED = [
-    ("i32.div_s", '(func (export "f") (param i32 i32) (result i32) '
-                  '(i32.div_s (local.get 0) (local.get 1)))'),
-    ("i32.div_u", '(func (export "f") (param i32 i32) (result i32) '
-                  '(i32.div_u (local.get 0) (local.get 1)))'),
-    ("i32.rem_s", '(func (export "f") (param i32 i32) (result i32) '
-                  '(i32.rem_s (local.get 0) (local.get 1)))'),
-    ("i32.rem_u", '(func (export "f") (param i32 i32) (result i32) '
-                  '(i32.rem_u (local.get 0) (local.get 1)))'),
-    ("i64.div_s", '(func (export "f") (param i64 i64) (result i64) '
-                  '(i64.div_s (local.get 0) (local.get 1)))'),
-    ("i64.rem_u", '(func (export "f") (param i64 i64) (result i64) '
-                  '(i64.rem_u (local.get 0) (local.get 1)))'),
-    ("i32.popcnt", '(func (export "f") (param i32) (result i32) '
-                   '(i32.popcnt (local.get 0)))'),
-    ("i64.popcnt", '(func (export "f") (param i64) (result i64) '
-                   '(i64.popcnt (local.get 0)))'),
-    # m3 (#787) landed non-trapping scalar floats; m4 landed the #709-class
-    # conversions (domain-guarded i32.trunc_f32/f64_s/u, FMIN/FMAX min/max,
-    # copysign) — those are now SUPPORTED, so the honesty gate moves to the
-    # floats that DELIBERATELY stay declined:
+    # #851 landed div/rem (SDIV/UDIV+MSUB with WASM ÷0 + INT_MIN/-1 trap
+    # guards), popcnt (SIMD CNT/ADDV), and f64<->i64 reinterpret — those are
+    # now SUPPORTED and execution-verified (aarch64_divrem_851_differential.py
+    # + the native matrix), so they moved off this honesty list. m3 (#787)
+    # landed non-trapping scalar floats; m4 landed the #709-class conversions
+    # (domain-guarded i32.trunc_f32/f64_s/u, FMIN/FMAX, copysign). The honesty
+    # gate now covers what DELIBERATELY stays declined:
     #   - rounding (ceil/floor/trunc/nearest): f64.floor is DECODED and must
     #     loud-decline at the aarch64 SELECTOR; f32.floor is dropped at decode
     #     (both paths must stay loud, never silent).


### PR DESCRIPTION
## Summary

L5 of the v0.51 hub. Flips the three op groups that previously loud-declined on `-b aarch64`. Gale's acceptance gate (`scripts/repro/aarch64_matrix.sh`) frontier goes **`popcnt div_s rem_s` → empty** (32 → 35 accepted ops, 86 → 91 native checks, all bit-identical vs wasmtime).

### 1. Integer div/rem (i32 + i64) — with WASM trap guards
`div_{s,u}` → A64 `SDIV`/`UDIV`; `rem_{s,u}` → `SDIV`/`UDIV` + `MSUB` (`rem = a − (a/b)·b`).

**Soundness (the #633/#666/#709 totality class):** A64 divide is TOTAL where WASM is PARTIAL — SDIV/UDIV return 0 on ÷0 and INT_MIN on INT_MIN/−1, neither traps. So the lowering emits explicit WASM trap guards:
- divisor `== 0` → `brk` — **all four forms**, full-width `cbnz` for i64 (a 32-bit test would miss a divisor like `0x1_0000_0000`).
- `INT_MIN / −1` overflow → `brk` — **signed DIV only**. `rem_s(INT_MIN,−1) == 0` (no trap) falls out of `MSUB` naturally.

Aliasing follows the #776 rule: `MSUB` reads a, b AND the quotient at once, so every temp is allocated while a/b are still reserved on the value stack.

### 2. popcnt (i32 + i64)
A64 has no scalar popcount: `fmov` gpr→SIMD, `CNT vN.8b`, `ADDV bN, vN.8b`, `fmov` back. i32 uses `fmov s` (zero-fills upper lanes → CNT sees 4 value + 4 zero bytes); i64 uses `fmov d`.

### 3. f64↔i64 reinterpret (GI-FPU-001)
`i64.reinterpret_f64` / `f64.reinterpret_i64` → bit-preserving `fmov x,d` / `fmov d,x`. These `WasmOp` variants existed but were never decoded (`convert_operator`), so they globally declined. Un-dropping them at decode also un-blocks ARM's existing VFP lowering — **verified every backend still emits OR loud-declines, never silent-drops**: aarch64 + cortex-m7dp ARM emit; no-FPU ARM / single-precision Cortex-M / RV32 loud-decline. Cross-backend op-parity gate green.

## Frontier: before → after
| | accepted ops | native checks | declined frontier |
|---|---|---|---|
| main (before) | 32 | 86 | `popcnt div_s rem_s` |
| this PR (after) | 35 | 91 | *(empty)* |

## Trap evidence
`scripts/repro/aarch64_divrem_851_differential.py` — **179 cases (34 trap cases)** vs wasmtime, executed two ways: unicorn (`brk`→UcError) and natively on arm64 (each call forked, SIGTRAP observed by parent). Covers ÷0 (all forms, both widths), div_s INT_MIN/−1 TRAP, rem_s(INT_MIN,−1)==0, plus popcnt (both widths) and the reinterpret round-trip. Wired into the `aarch64-oracle` CI job (unicorn-gated there; native path exercised on the macos-latest native-matrix runner + locally). During bring-up the native matrix caught a real red — the div_s overflow-guard branch offset was off by one (`+3`→`+4`), spuriously trapping `div_s(7,2)`.

## New encoders (llvm-mc ground-truth byte tests)
`sdiv`/`udiv`/`msub` (+64-bit), `cnt_8b`, `addv_8b`, `cbnz64`.

## Verification
- `cargo test -p synth-backend-aarch64 --lib`: 73/73
- `cargo test --workspace`: green
- cross-backend op-parity gate, frozen_codegen_bytes 10/10, all 7 aarch64 differentials, decline-honesty probe (3/3): green
- fmt + clippy (`synth-backend-aarch64`, `synth-core`): clean
- `claim_check.py`: 25/25 claims pass (the 2 generated-file staleness failures are `status.json` / `FEATURE_MATRIX.md`, regenerated by the coordinator at assembly per #805 — not hand-edited here)

## Notes for coordinator / other lanes
- Touches shared **`synth-core` `convert_operator`** (decode) — changes cross-backend op exposure for the two reinterpret ops. Behavior surface verified per-backend above; textual conflict risk with L3/L4 low.
- The aarch64 selector op count rose (four new arm groups), so the generated `aarch64_selector_ops` figure changed — regenerate `status.json` + `FEATURE_MATRIX.md` at assembly.

Closes the div/rem/popcnt/reinterpret portion of #851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L