### PR TITLE
feat(#851): aarch64 direct `call` lowering (bl + R_AARCH64_CALL26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,6 +500,21 @@ jobs:
             echo "VACUOUS GATE: only ${acc:-0} ops accepted (expected >= 32) — \
           objcopy/objdump/synth extraction likely broke"; exit 1
           fi
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
+      - name: Install wasmtime python bindings
+        run: pip install wasmtime
+      - name: Run #851 direct-call execution differential
+        # The matrix above is single-function (loads one function's .text) so it
+        # cannot exercise CALLS. This harness compiles MULTI-function modules,
+        # resolves the R_AARCH64_CALL26 relocations itself, JITs the linked blob
+        # (MAP_JIT), and diffs bit-exact vs wasmtime. It asserts every expected
+        # symbol is present, so a silently-declined caller fails LOUDLY.
+        run: |
+          SYNTH=./target/debug/synth \
+            WASMTOOLS=wasm-tools WASMTIME=wasmtime \
+            python scripts/repro/aarch64_calls_851.py
 
   trap-semantics-oracle:
     name: trap-semantics oracle (#665 unreachable + #666 rem_s)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **aarch64 direct `call` (#851).** The `-b aarch64` backend now lowers WASM
+  direct `call` (previously a loud-decline). Args are marshalled into `x0..x7`
+  per AAPCS64, a `bl func_N` targets the callee (linkable via a new
+  `R_AARCH64_CALL26` `.rela.text` relocation — ELF64 `r_info` sym in the high
+  word, type 283), and the `x0` result is pushed. A function that emits a call
+  becomes NON-LEAF: it saves/restores FP+LR (`stp x29,x30,[sp,#-16]!` /
+  `ldp x29,x30,[sp],#16`) around the body — leaf functions stay byte-identical.
+  The multi-function object now places EVERY reachable local function with a
+  `func_N` symbol (plus its export alias) so a call to a non-exported helper
+  resolves. New encoders `bl`/`stp_fp_lr_pre16`/`ldp_fp_lr_post16`; new
+  `RelocKind::AArch64Call26` and `DecodedModule::func_result_counts` (the
+  0-vs-1 result distinction the call push decision needs). Honest frontier
+  (loud-declined, never wrong code): calling an IMPORT, `> 8` integer args,
+  multi-result or FLOAT-result callees (returned in v0/d0, not x0), a CALLER
+  that reads its OWN incoming params across a call (param-homing is a later
+  increment; a callee freely reads its params), any live value beneath the
+  args at the call site, and `call_indirect`. Verified: 8 new selector/elf unit
+  tests + a native-arm64 MAP_JIT execution differential
+  (`scripts/repro/aarch64_calls_851.py`) proving 5 call modules (const/computed
+  args, void, i64, result-consumed) bit-identical vs wasmtime; the standing
+  `aarch64_matrix.sh` op-set gate is unchanged (32 ops / 86 checks PASS).
 - **aarch64 non-param locals (#856).** The `-b aarch64` backend now supports
   `local` declarations beyond params: each non-param local gets a zero-init
   8-byte stack slot (`[sp, #(idx − num_params)*8]`, frame rounded to a 16-byte

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-result or FLOAT-result callees (returned in v0/d0, not x0), a CALLER
   that reads its OWN incoming params across a call (param-homing is a later
   increment; a callee freely reads its params), any live value beneath the
-  args at the call site, and `call_indirect`. Verified: 8 new selector/elf unit
-  tests + a native-arm64 MAP_JIT execution differential
+  args at the call site, and `call_indirect`. Verified: 10 new unit tests (8
+  selector + 1 elf `.rela.text` + 1 encoder) + a native-arm64 MAP_JIT
+  execution differential
   (`scripts/repro/aarch64_calls_851.py`) proving 5 call modules (const/computed
   args, void, i64, result-consumed) bit-identical vs wasmtime; the standing
   `aarch64_matrix.sh` op-set gate is unchanged (32 ops / 86 checks PASS).

--- a/crates/synth-backend-aarch64/src/backend.rs
+++ b/crates/synth-backend-aarch64/src/backend.rs
@@ -39,6 +39,7 @@ impl AArch64Backend {
         ops: &[WasmOp],
         config: &CompileConfig,
         func_result_counts: &[u32],
+        func_ret_float: &[bool],
     ) -> Result<CompiledFunction, BackendError> {
         // #457: cap the access-pattern inference with the declared count when
         // the driver supplied one — a read-before-write non-param local (wasm
@@ -68,6 +69,7 @@ impl AArch64Backend {
             config.num_imports,
             &config.func_arg_counts,
             func_result_counts,
+            func_ret_float,
         )
         .map_err(|e| BackendError::CompilationFailed(e.to_string()))?;
         let code: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
@@ -144,7 +146,18 @@ impl Backend for AArch64Backend {
         ops: &[WasmOp],
         config: &CompileConfig,
     ) -> Result<CompiledFunction, BackendError> {
-        self.compile_function_with_results(name, ops, config, &[])
+        // #851: the CLI's per-function compile path threads the module-wide
+        // result-count + float-return tables via the config so direct `call`
+        // lowers here too (a float-returning callee is loud-declined — v0/d0).
+        let result_counts = config.func_result_counts.clone();
+        let n = config.func_ret_f32.len().max(config.func_ret_f64.len());
+        let ret_float: Vec<bool> = (0..n)
+            .map(|i| {
+                config.func_ret_f32.get(i).copied().unwrap_or(false)
+                    || config.func_ret_f64.get(i).copied().unwrap_or(false)
+            })
+            .collect();
+        self.compile_function_with_results(name, ops, config, &result_counts, &ret_float)
     }
 
     fn compile_module(
@@ -175,6 +188,16 @@ impl Backend for AArch64Backend {
                 "no exported functions found".into(),
             ));
         }
+
+        // #851: per-function "returns a float" mask (v0/d0 result) — a
+        // float-returning callee is loud-declined by the call lowering.
+        let nrf = module.func_ret_f32.len().max(module.func_ret_f64.len());
+        let func_ret_float: Vec<bool> = (0..nrf)
+            .map(|i| {
+                module.func_ret_f32.get(i).copied().unwrap_or(false)
+                    || module.func_ret_f64.get(i).copied().unwrap_or(false)
+            })
+            .collect();
 
         let mut functions = Vec::new();
         let mut elf_funcs = Vec::new();
@@ -213,15 +236,16 @@ impl Backend for AArch64Backend {
                 &func.ops,
                 &func_config,
                 &module.func_result_counts,
+                &func_ret_float,
             )?;
             // Symbol aliases at this function's `.text` offset: always `func_N`;
             // plus the export name when it differs (so both `run` and `func_1`
             // resolve to the same body).
             let mut aliases = vec![func_sym.clone()];
-            if let Some(exp) = &func.export_name {
-                if *exp != func_sym {
-                    aliases.push(exp.clone());
-                }
+            if let Some(exp) = &func.export_name
+                && *exp != func_sym
+            {
+                aliases.push(exp.clone());
             }
             elf_funcs.push(ElfFunction {
                 symbols: aliases,

--- a/crates/synth-backend-aarch64/src/backend.rs
+++ b/crates/synth-backend-aarch64/src/backend.rs
@@ -8,7 +8,8 @@
 //! returns an error), never miscompiled.
 
 use synth_core::backend::{
-    Backend, BackendCapabilities, BackendError, CompilationResult, CompileConfig, CompiledFunction,
+    Backend, BackendCapabilities, BackendError, CodeRelocation, CompilationResult, CompileConfig,
+    CompiledFunction, RelocKind,
 };
 use synth_core::wasm_decoder::DecodedModule;
 use synth_core::{TargetSpec, WasmOp};
@@ -23,6 +24,76 @@ pub struct AArch64Backend;
 impl AArch64Backend {
     pub fn new() -> Self {
         Self
+    }
+
+    /// Lower one function body, threading the module-wide call metadata needed to
+    /// lower direct `call` (#851): `num_imports`, `func_arg_counts`, and
+    /// `func_result_counts` come from the decoded module (all indexed by full
+    /// function index). Each lowered `bl` becomes an `R_AARCH64_CALL26`
+    /// relocation against the callee's `func_N` symbol, which
+    /// [`Self::compile_module`] emits for every local function. Call-free
+    /// functions produce byte-identical code and no relocations.
+    fn compile_function_with_results(
+        &self,
+        name: &str,
+        ops: &[WasmOp],
+        config: &CompileConfig,
+        func_result_counts: &[u32],
+    ) -> Result<CompiledFunction, BackendError> {
+        // #457: cap the access-pattern inference with the declared count when
+        // the driver supplied one — a read-before-write non-param local (wasm
+        // zero-init) is otherwise indistinguishable from a param and would be
+        // read from an argument register (caller garbage). The reclassified
+        // local then hits the selector's "non-param locals not yet supported"
+        // guard: a LOUD skip instead of a silent miscompile (milestone-1
+        // contract; frame-slot zero-init lands with non-param local support).
+        let inferred = count_params(ops);
+        let num_params = match config.current_func_param_count {
+            Some(declared) => inferred.min(declared),
+            None => inferred,
+        };
+        // m3: thread the per-param float masks so float params resolve to their
+        // AAPCS64 V registers (an independent counter from the GP arg registers).
+        // #538 cf: also thread the decoder's blocktype-arity side-table so the
+        // void-block control-flow lowering can gate on `(0,0)` and loud-decline
+        // value-carrying (typed) blocks.
+        // #851: thread the call metadata so direct `call` lowers to `bl func_N`
+        // + an R_AARCH64_CALL26 relocation (call-free bodies are unaffected).
+        let (words, call_sites) = selector::select_typed_cf_calls(
+            ops,
+            num_params,
+            &config.current_func_params_f32,
+            &config.current_func_params_f64,
+            &config.current_func_block_arity,
+            config.num_imports,
+            &config.func_arg_counts,
+            func_result_counts,
+        )
+        .map_err(|e| BackendError::CompilationFailed(e.to_string()))?;
+        let code: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
+        // Each direct call site → an R_AARCH64_CALL26 against the callee's
+        // `func_N` symbol (emitted for every local function by compile_module).
+        let relocations: Vec<CodeRelocation> = call_sites
+            .iter()
+            .map(|cs| CodeRelocation {
+                offset: cs.offset,
+                symbol: format!("func_{}", cs.callee),
+                kind: RelocKind::AArch64Call26,
+            })
+            .collect();
+        Ok(CompiledFunction {
+            name: name.to_string(),
+            code,
+            wasm_ops: ops.to_vec(),
+            relocations,
+            // AArch64 DWARF `.debug_line` is a later milestone (pairs with #394).
+            line_map: Vec::new(),
+            // VCR-DEC-003 (#396): provenance is ARM(Thumb)-only in v1.
+            branch_map: Vec::new(),
+            // #778: WCET cycle model is ARM(Thumb-2)-only in v1.
+            wcet: None,
+            wcet_intermediate: None,
+        })
     }
 }
 
@@ -73,45 +144,7 @@ impl Backend for AArch64Backend {
         ops: &[WasmOp],
         config: &CompileConfig,
     ) -> Result<CompiledFunction, BackendError> {
-        // #457: cap the access-pattern inference with the declared count when
-        // the driver supplied one — a read-before-write non-param local (wasm
-        // zero-init) is otherwise indistinguishable from a param and would be
-        // read from an argument register (caller garbage). The reclassified
-        // local then hits the selector's "non-param locals not yet supported"
-        // guard: a LOUD skip instead of a silent miscompile (milestone-1
-        // contract; frame-slot zero-init lands with non-param local support).
-        let inferred = count_params(ops);
-        let num_params = match config.current_func_param_count {
-            Some(declared) => inferred.min(declared),
-            None => inferred,
-        };
-        // m3: thread the per-param float masks so float params resolve to their
-        // AAPCS64 V registers (an independent counter from the GP arg registers).
-        // #538 cf: also thread the decoder's blocktype-arity side-table so the
-        // void-block control-flow lowering can gate on `(0,0)` and loud-decline
-        // value-carrying (typed) blocks.
-        let words = selector::select_typed_cf(
-            ops,
-            num_params,
-            &config.current_func_params_f32,
-            &config.current_func_params_f64,
-            &config.current_func_block_arity,
-        )
-        .map_err(|e| BackendError::CompilationFailed(e.to_string()))?;
-        let code: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
-        Ok(CompiledFunction {
-            name: name.to_string(),
-            code,
-            wasm_ops: ops.to_vec(),
-            relocations: Vec::new(),
-            // AArch64 DWARF `.debug_line` is a later milestone (pairs with #394).
-            line_map: Vec::new(),
-            // VCR-DEC-003 (#396): provenance is ARM(Thumb)-only in v1.
-            branch_map: Vec::new(),
-            // #778: WCET cycle model is ARM(Thumb-2)-only in v1.
-            wcet: None,
-            wcet_intermediate: None,
-        })
+        self.compile_function_with_results(name, ops, config, &[])
     }
 
     fn compile_module(
@@ -119,12 +152,25 @@ impl Backend for AArch64Backend {
         module: &DecodedModule,
         config: &CompileConfig,
     ) -> Result<CompilationResult, BackendError> {
-        let exports: Vec<&_> = module
+        // #851: to lower direct `call`, EVERY locally-defined function must be
+        // placed in `.text` with a `func_N` symbol — a callee is often a
+        // non-exported helper, and an R_AARCH64_CALL26 needs a symbol to resolve
+        // against. (Pre-#851 only exported functions were emitted; a module with
+        // no local functions still errors.) Side effect, noted honestly: a
+        // non-exported helper containing an unsupported op now FAILS the compile
+        // instead of being silently ignored — the loud-skip contract, applied to
+        // the whole reachable local set.
+        let locals: Vec<&_> = module
             .functions
             .iter()
-            .filter(|f| f.export_name.is_some())
+            .filter(|f| f.index >= module.num_imported_funcs)
             .collect();
-        if exports.is_empty() {
+        if locals.is_empty() {
+            return Err(BackendError::CompilationFailed(
+                "no locally-defined functions found".into(),
+            ));
+        }
+        if !module.functions.iter().any(|f| f.export_name.is_some()) {
             return Err(BackendError::CompilationFailed(
                 "no exported functions found".into(),
             ));
@@ -132,8 +178,13 @@ impl Backend for AArch64Backend {
 
         let mut functions = Vec::new();
         let mut elf_funcs = Vec::new();
-        for func in &exports {
-            let name = func.export_name.clone().unwrap();
+        for func in &locals {
+            // The `.text` symbol is the export name when exported, else `func_N`
+            // (the full function index). The relocation-target symbol is ALWAYS
+            // `func_N` (added as an alias below) so a call by index resolves
+            // regardless of export status.
+            let func_sym = format!("func_{}", func.index);
+            let name = func.export_name.clone().unwrap_or_else(|| func_sym.clone());
             // #554: honor the decoder's loud-skip marker. An op dropped at decode
             // (`_ => None`, e.g. scalar `f32.*`) is absent from `func.ops`, so it
             // never reaches the selector's unsupported-op guard — lowering the
@@ -149,19 +200,33 @@ impl Backend for AArch64Backend {
             // #457: THIS function's declared param count (imports-first full
             // index) caps the param-count inference in `compile_function`.
             let declared_params = config.func_arg_counts.get(func.index as usize).copied();
-            let func_config = if declared_params.is_some() {
-                Some(CompileConfig {
-                    current_func_param_count: declared_params,
-                    ..config.clone()
-                })
-            } else {
-                None
+            // #851: thread num_imports + func_arg_counts (call metadata) so the
+            // call lowering can classify import vs local and marshal args.
+            let func_config = CompileConfig {
+                current_func_param_count: declared_params.or(config.current_func_param_count),
+                num_imports: module.num_imported_funcs,
+                func_arg_counts: module.func_arg_counts.clone(),
+                ..config.clone()
             };
-            let cfg = func_config.as_ref().unwrap_or(config);
-            let compiled = self.compile_function(&name, &func.ops, cfg)?;
+            let compiled = self.compile_function_with_results(
+                &name,
+                &func.ops,
+                &func_config,
+                &module.func_result_counts,
+            )?;
+            // Symbol aliases at this function's `.text` offset: always `func_N`;
+            // plus the export name when it differs (so both `run` and `func_1`
+            // resolve to the same body).
+            let mut aliases = vec![func_sym.clone()];
+            if let Some(exp) = &func.export_name {
+                if *exp != func_sym {
+                    aliases.push(exp.clone());
+                }
+            }
             elf_funcs.push(ElfFunction {
-                name: compiled.name.clone(),
+                symbols: aliases,
                 code: compiled.code.clone(),
+                relocations: compiled.relocations.clone(),
             });
             functions.push(compiled);
         }

--- a/crates/synth-backend-aarch64/src/elf.rs
+++ b/crates/synth-backend-aarch64/src/elf.rs
@@ -1,23 +1,37 @@
-//! Minimal `EM_AARCH64` ELF64 relocatable-object emitter — milestone-1b (#538).
+//! Minimal `EM_AARCH64` ELF64 relocatable-object emitter — milestone-1b (#538),
+//! extended for direct calls (#851).
 //!
 //! Produces an `ET_REL` object for AArch64 (`e_machine = 183`) with a single
-//! `.text` (all function bodies concatenated), a `.symtab` exposing one
-//! `STT_FUNC`/`GLOBAL` symbol per function at its `.text` offset, and the two
-//! string tables. Milestone-1b functions are leaf integer bodies with no external
-//! references, so no relocation section is needed yet (`bl`/imports arrive with
-//! calls in a later milestone). The object is host-linkable on arm64 ELF targets
-//! (arm64 Linux/CI) and its `.text` is directly runnable under a native or
-//! emulated A64 core.
+//! `.text` (all function bodies concatenated), a `.symtab` exposing one or more
+//! `STT_FUNC`/`GLOBAL` symbols per function at its `.text` offset (each function
+//! carries a `func_N` symbol plus its export name when exported), the two string
+//! tables, and — when any function has a call relocation — a `.rela.text`
+//! section of `R_AARCH64_CALL26` entries so `bl func_N` sites are linkable
+//! (#851). The object is host-linkable on arm64 ELF targets and its `.text` is
+//! directly runnable under a native or emulated A64 core once relocated.
+
+use synth_core::backend::{CodeRelocation, RelocKind};
+
+/// R_AARCH64_CALL26 — the ELF relocation type for a `bl`/`b` 26-bit call site.
+const R_AARCH64_CALL26: u32 = 283;
 
 /// A compiled function to place in `.text`.
 pub struct ElfFunction {
-    pub name: String,
+    /// Symbol name aliases for this function's `.text` offset. The first is the
+    /// canonical `func_N`; a distinct export name (if any) follows. All are
+    /// emitted as GLOBAL `STT_FUNC` symbols pointing at the same body.
+    pub symbols: Vec<String>,
+    /// Function body machine code.
     pub code: Vec<u8>,
+    /// Call relocations within this function's code (offsets are function-local;
+    /// the builder rebases them to the `.text` offset). Empty for leaf functions.
+    pub relocations: Vec<CodeRelocation>,
 }
 
 const EHDR_SIZE: usize = 64;
 const SHDR_SIZE: usize = 64;
 const SYM_SIZE: usize = 24;
+const RELA_SIZE: usize = 24;
 
 fn push_u16(v: &mut Vec<u8>, x: u16) {
     v.extend_from_slice(&x.to_le_bytes());
@@ -29,41 +43,67 @@ fn push_u64(v: &mut Vec<u8>, x: u64) {
     v.extend_from_slice(&x.to_le_bytes());
 }
 
-/// Build an `EM_AARCH64` `ET_REL` object exposing each function as a global
-/// `STT_FUNC` symbol in `.text`.
+/// Build an `EM_AARCH64` `ET_REL` object exposing each function's symbols as
+/// GLOBAL `STT_FUNC` in `.text`, plus a `.rela.text` for any call relocations.
 pub fn build_relocatable_object(functions: &[ElfFunction]) -> Vec<u8> {
-    // --- .text: concatenated bodies; record each function's (offset, size). ---
+    // --- .text: concatenated bodies; record each function's .text offset. ---
     let mut text: Vec<u8> = Vec::new();
-    let mut placement: Vec<(u64, u64)> = Vec::new();
+    let mut func_off: Vec<u64> = Vec::new();
     for f in functions {
         // A64 instructions are 4-byte aligned; bodies are whole words already.
-        placement.push((text.len() as u64, f.code.len() as u64));
+        func_off.push(text.len() as u64);
         text.extend_from_slice(&f.code);
     }
 
-    // --- .strtab: symbol names (index 0 is the empty string). ---
+    // --- .strtab + .symtab: one GLOBAL STT_FUNC per (function, symbol-alias). ---
+    // st_info = (bind << 4) | type; GLOBAL=1, FUNC=2 → 0x12. shndx = 1 (.text).
+    // Also build a name → symbol-index map so relocations resolve by symbol name.
     let mut strtab: Vec<u8> = vec![0];
-    let mut name_off: Vec<u32> = Vec::new();
-    for f in functions {
-        name_off.push(strtab.len() as u32);
-        strtab.extend_from_slice(f.name.as_bytes());
-        strtab.push(0);
+    let mut symtab: Vec<u8> = Vec::new();
+    symtab.extend_from_slice(&[0u8; SYM_SIZE]); // null symbol at index 0
+    let mut sym_index: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+    let mut next_sym_idx: u32 = 1;
+    for (i, f) in functions.iter().enumerate() {
+        let off = func_off[i];
+        let size = f.code.len() as u64;
+        for sym in &f.symbols {
+            let name_off = strtab.len() as u32;
+            strtab.extend_from_slice(sym.as_bytes());
+            strtab.push(0);
+            push_u32(&mut symtab, name_off); // st_name
+            symtab.push(0x12); // st_info: GLOBAL FUNC
+            symtab.push(0); // st_other
+            push_u16(&mut symtab, 1); // st_shndx = .text (section 1)
+            push_u64(&mut symtab, off); // st_value
+            push_u64(&mut symtab, size); // st_size
+            sym_index.entry(sym.clone()).or_insert(next_sym_idx);
+            next_sym_idx += 1;
+        }
     }
 
-    // --- .symtab: [0]=NULL, then one GLOBAL STT_FUNC per function. ---
-    // st_info = (bind << 4) | type; GLOBAL=1, FUNC=2 → 0x12. shndx = 1 (.text).
-    let mut symtab: Vec<u8> = Vec::new();
-    // null symbol
-    symtab.extend_from_slice(&[0u8; SYM_SIZE]);
-    for (i, _f) in functions.iter().enumerate() {
-        let (off, size) = placement[i];
-        push_u32(&mut symtab, name_off[i]); // st_name
-        symtab.push(0x12); // st_info: GLOBAL FUNC
-        symtab.push(0); // st_other
-        push_u16(&mut symtab, 1); // st_shndx = .text (section 1)
-        push_u64(&mut symtab, off); // st_value
-        push_u64(&mut symtab, size); // st_size
+    // --- .rela.text: one entry per call relocation (rebased to .text). ---
+    // ELF64 packs r_info = (sym_index << 32) | type (sym in the HIGH word).
+    let mut rela: Vec<u8> = Vec::new();
+    for (i, f) in functions.iter().enumerate() {
+        for r in &f.relocations {
+            debug_assert!(
+                matches!(r.kind, RelocKind::AArch64Call26),
+                "aarch64 ELF builder only emits R_AARCH64_CALL26 relocations (#851)"
+            );
+            let Some(&sidx) = sym_index.get(&r.symbol) else {
+                // A call to a symbol we did not place: leave it unrelocated. The
+                // selector only records calls to LOCAL functions (all placed), so
+                // this is defensive — a missing symbol would fail at link time.
+                continue;
+            };
+            let r_offset = func_off[i] + r.offset as u64;
+            let r_info = ((sidx as u64) << 32) | (R_AARCH64_CALL26 as u64);
+            push_u64(&mut rela, r_offset);
+            push_u64(&mut rela, r_info);
+            push_u64(&mut rela, 0); // r_addend = 0
+        }
     }
+    let have_rela = !rela.is_empty();
 
     // --- .shstrtab: section header names. ---
     let mut shstrtab: Vec<u8> = vec![0];
@@ -74,17 +114,46 @@ pub fn build_relocatable_object(functions: &[ElfFunction]) -> Vec<u8> {
         o
     };
     let n_text = add_shstr(&mut shstrtab, ".text");
+    // .rela.text must precede .symtab in the string table only for readability;
+    // order is arbitrary. Emit its name only when present.
+    let n_rela = if have_rela {
+        add_shstr(&mut shstrtab, ".rela.text")
+    } else {
+        0
+    };
     let n_symtab = add_shstr(&mut shstrtab, ".symtab");
     let n_strtab = add_shstr(&mut shstrtab, ".strtab");
     let n_shstrtab = add_shstr(&mut shstrtab, ".shstrtab");
 
-    // --- Layout: ehdr | .text | .symtab | .strtab | .shstrtab | shdrs. ---
+    // --- Section indices. ---
+    // [0]=NULL [1]=.text [2]=.symtab [3]=.strtab [4]=.shstrtab, and when present
+    // .rela.text is appended as the LAST content section (index 5). Keeping
+    // .text=1/.symtab=2/.strtab=3/.shstrtab=4 stable preserves the milestone-1b
+    // layout for call-free modules (byte-identical) — the symtab st_shndx=1 and
+    // e_shstrndx=4 are unchanged.
+    let idx_symtab = 2u32;
+    let idx_rela = 5u32; // only used when have_rela
+
+    // --- Layout: ehdr | .text | .symtab | .strtab | .shstrtab | [.rela] | shdrs. ---
     let text_off = EHDR_SIZE;
     let symtab_off = text_off + text.len();
     let strtab_off = symtab_off + symtab.len();
     let shstrtab_off = strtab_off + strtab.len();
-    let shdr_off = shstrtab_off + shstrtab.len();
-    let num_sections = 5u16; // NULL, .text, .symtab, .strtab, .shstrtab
+    // 8-align .rela.text (SHT_RELA entries are 8-aligned).
+    let rela_off = {
+        let base = shstrtab_off + shstrtab.len();
+        base.div_ceil(8) * 8
+    };
+    let rela_pad = rela_off - (shstrtab_off + shstrtab.len());
+    let after_content = if have_rela {
+        rela_off + rela.len()
+    } else {
+        shstrtab_off + shstrtab.len()
+    };
+    // 8-align the section-header table.
+    let shdr_off = after_content.div_ceil(8) * 8;
+    let shdr_pad = shdr_off - after_content;
+    let num_sections: u16 = if have_rela { 6 } else { 5 };
 
     let mut out: Vec<u8> = Vec::new();
 
@@ -115,9 +184,14 @@ pub fn build_relocatable_object(functions: &[ElfFunction]) -> Vec<u8> {
     out.extend_from_slice(&symtab);
     out.extend_from_slice(&strtab);
     out.extend_from_slice(&shstrtab);
+    if have_rela {
+        out.extend_from_slice(&vec![0u8; rela_pad]);
+        out.extend_from_slice(&rela);
+    }
+    out.extend_from_slice(&vec![0u8; shdr_pad]);
     debug_assert_eq!(out.len(), shdr_off);
 
-    // Section headers (Elf64_Shdr × 5).
+    // Section headers (Elf64_Shdr).
     let mut shdr =
         |name, sh_type, flags, offset: usize, size: usize, link, info, align, entsize| {
             push_u32(&mut out, name);
@@ -151,6 +225,22 @@ pub fn build_relocatable_object(functions: &[ElfFunction]) -> Vec<u8> {
     shdr(n_strtab, 3, 0, strtab_off, strtab.len(), 0, 0, 1, 0);
     // [4] .shstrtab — STRTAB(3)
     shdr(n_shstrtab, 3, 0, shstrtab_off, shstrtab.len(), 0, 0, 1, 0);
+    // [5] .rela.text — RELA(4), link=.symtab(2), info=.text(1), align 8. Only
+    // emitted when there is at least one relocation.
+    if have_rela {
+        shdr(
+            n_rela,
+            4,
+            0,
+            rela_off,
+            rela.len(),
+            idx_symtab,
+            1, // info = .text section index
+            8,
+            RELA_SIZE as u64,
+        );
+        let _ = idx_rela; // documented section index; not otherwise referenced
+    }
 
     out
 }
@@ -163,12 +253,14 @@ mod tests {
     fn well_formed_header_and_symbols() {
         let obj = build_relocatable_object(&[
             ElfFunction {
-                name: "add".into(),
+                symbols: vec!["func_0".into(), "add".into()],
                 code: vec![0, 0, 1, 0x0B, 0xE0, 0x03, 9, 0x2A, 0xC0, 0x03, 0x5F, 0xD6],
+                relocations: vec![],
             },
             ElfFunction {
-                name: "sub".into(),
+                symbols: vec!["func_1".into(), "sub".into()],
                 code: vec![0x62, 0, 4, 0x4B, 0xC0, 0x03, 0x5F, 0xD6],
+                relocations: vec![],
             },
         ]);
         // ELF magic + class64 + LSB.
@@ -178,10 +270,43 @@ mod tests {
         // e_type = ET_REL, e_machine = EM_AARCH64.
         assert_eq!(u16::from_le_bytes([obj[16], obj[17]]), 1);
         assert_eq!(u16::from_le_bytes([obj[18], obj[19]]), 183);
-        // e_shnum = 5.
+        // e_shnum = 5 (no relocations).
         assert_eq!(u16::from_le_bytes([obj[60], obj[61]]), 5);
-        // The object must be non-trivial and contain both symbol names.
+        // The object must contain all four symbol names.
         let s = String::from_utf8_lossy(&obj);
         assert!(s.contains("add") && s.contains("sub"));
+        assert!(s.contains("func_0") && s.contains("func_1"));
+    }
+
+    #[test]
+    fn call_reloc_produces_rela_text() {
+        // A caller (func_1) with a `bl func_0` at byte offset 0.
+        let obj = build_relocatable_object(&[
+            ElfFunction {
+                symbols: vec!["func_0".into()],
+                code: vec![0xC0, 0x03, 0x5F, 0xD6], // ret
+                relocations: vec![],
+            },
+            ElfFunction {
+                symbols: vec!["func_1".into(), "run".into()],
+                code: vec![0x00, 0x00, 0x00, 0x94, 0xC0, 0x03, 0x5F, 0xD6], // bl #0 ; ret
+                relocations: vec![CodeRelocation {
+                    offset: 0,
+                    symbol: "func_0".into(),
+                    kind: RelocKind::AArch64Call26,
+                }],
+            },
+        ]);
+        // e_shnum = 6 (adds .rela.text).
+        assert_eq!(u16::from_le_bytes([obj[60], obj[61]]), 6);
+        let s = String::from_utf8_lossy(&obj);
+        assert!(s.contains(".rela.text"));
+        // The reloc r_offset points at func_1's bl: func_0 is 4 bytes, so func_1
+        // starts at .text offset 4, reloc at 4+0 = 4. The r_info encodes the
+        // symbol index of func_0 (index 1: null=0, func_0=1) in the high word and
+        // type 283 in the low word. We can't easily locate the rela bytes by
+        // structure here, but readelf -r on the emitted .o verifies it (the
+        // differential harness links + runs, the ultimate check).
+        assert_eq!(R_AARCH64_CALL26, 283);
     }
 }

--- a/crates/synth-backend-aarch64/src/elf.rs
+++ b/crates/synth-backend-aarch64/src/elf.rs
@@ -131,8 +131,10 @@ pub fn build_relocatable_object(functions: &[ElfFunction]) -> Vec<u8> {
     // .text=1/.symtab=2/.strtab=3/.shstrtab=4 stable preserves the milestone-1b
     // layout for call-free modules (byte-identical) — the symtab st_shndx=1 and
     // e_shstrndx=4 are unchanged.
+    // .symtab is section 2 (the .rela.text `sh_link`). .rela.text, when present,
+    // is section 5 (the last content section) — but the ELF section-header table
+    // is position-indexed, so we never need to name that index explicitly.
     let idx_symtab = 2u32;
-    let idx_rela = 5u32; // only used when have_rela
 
     // --- Layout: ehdr | .text | .symtab | .strtab | .shstrtab | [.rela] | shdrs. ---
     let text_off = EHDR_SIZE;
@@ -239,7 +241,6 @@ pub fn build_relocatable_object(functions: &[ElfFunction]) -> Vec<u8> {
             8,
             RELA_SIZE as u64,
         );
-        let _ = idx_rela; // documented section index; not otherwise referenced
     }
 
     out

--- a/crates/synth-backend-aarch64/src/encoder.rs
+++ b/crates/synth-backend-aarch64/src/encoder.rs
@@ -341,6 +341,33 @@ pub fn b_uncond(imm26: i32) -> u32 {
     0x1400_0000 | ((imm26 as u32) & 0x03FF_FFFF)
 }
 
+/// `bl #(imm26*4)` — branch-with-link, PC-relative in words (signed 26-bit),
+/// sets `x30`/LR to the return address. WASM direct `call` lowers to `bl func_N`
+/// (#851). When the callee's `.text` offset is not known at selection time (the
+/// common case), emit `bl #0` (offset 0) and record an `R_AARCH64_CALL26`
+/// relocation against the callee symbol; the linker patches the imm26 field.
+/// Clang ground truth: `bl .+8` = 0x9400_0002 (imm26 = 2). The op is `b` with
+/// bit 31 set (0x9400_0000 vs `b`'s 0x1400_0000).
+pub fn bl(imm26: i32) -> u32 {
+    0x9400_0000 | ((imm26 as u32) & 0x03FF_FFFF)
+}
+
+/// `stp x29, x30, [sp, #-16]!` — pre-indexed store-pair, the non-leaf function
+/// prologue that saves FP/LR and lowers SP by 16 (staying 16-byte aligned). A
+/// function that emits a `bl` clobbers `x30` and can no longer `ret` without
+/// first preserving the incoming LR. Clang ground truth:
+/// `stp x29, x30, [sp, #-16]!` = 0xA9BF7BFD.
+pub fn stp_fp_lr_pre16() -> u32 {
+    0xA9BF_7BFD
+}
+
+/// `ldp x29, x30, [sp], #16` — post-indexed load-pair, the matching non-leaf
+/// epilogue: restore FP/LR and raise SP by 16. Emitted just before `ret`. Clang
+/// ground truth: `ldp x29, x30, [sp], #16` = 0xA8C17BFD.
+pub fn ldp_fp_lr_post16() -> u32 {
+    0xA8C1_7BFD
+}
+
 /// `cbnz wt, #(imm19*4)` — compare-and-branch-if-nonzero, 32-bit form, offset in
 /// words (signed 19-bit). WASM `br_if` branches when the popped i32 condition is
 /// nonzero, so `cbnz w_cond, <block-end>` is the exact lowering. Clang ground
@@ -981,5 +1008,17 @@ mod tests {
         assert_eq!(cbnz(9, 2), 0x3500_0049);
         assert_eq!(cbz(9, 2), 0x3400_0049);
         assert_eq!(cbnz(0, 3), 0x3500_0060); // cbnz w0, .+12
+    }
+
+    #[test]
+    fn call_and_frame_encodings_match_clang() {
+        // #851 direct-call lowering primitives. clang -target aarch64:
+        // `bl .+8` = 0x94000002; `bl .-8` = 0x97FFFFFE;
+        // `stp x29,x30,[sp,#-16]!` = 0xA9BF7BFD; `ldp x29,x30,[sp],#16` = 0xA8C17BFD.
+        assert_eq!(bl(2), 0x9400_0002);
+        assert_eq!(bl(-2), 0x97FF_FFFE);
+        assert_eq!(bl(0), 0x9400_0000); // reloc placeholder (imm26 patched by linker)
+        assert_eq!(stp_fp_lr_pre16(), 0xA9BF_7BFD);
+        assert_eq!(ldp_fp_lr_post16(), 0xA8C1_7BFD);
     }
 }

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -203,8 +203,17 @@ pub fn select_typed_cf(
 ) -> Result<Vec<u32>, SelectError> {
     // No call metadata → any `call` in the body hits the honest catch-all decline
     // (byte-identical to the pre-#851 behavior for call-free functions).
-    let (words, _sites) =
-        select_typed_cf_calls(ops, num_params, params_f32, params_f64, block_arity, 0, &[], &[])?;
+    let (words, _sites) = select_typed_cf_calls(
+        ops,
+        num_params,
+        params_f32,
+        params_f64,
+        block_arity,
+        0,
+        &[],
+        &[],
+        &[],
+    )?;
     Ok(words)
 }
 
@@ -229,6 +238,11 @@ pub struct CallSite {
 ///   values `call` pops off the value stack and marshals into `x0..x7`).
 /// - `func_result_counts[idx]`: the callee's result count (0 = void, 1 = one
 ///   value pushed back). Multi-result and out-of-range are declined.
+/// - `func_ret_float[idx]`: true when the callee returns an f32/f64. AAPCS64
+///   returns floats in `v0/d0`, NOT `x0`, so a float-returning callee is
+///   LOUD-DECLINED (pushing `x0` would read a stale GP register — the
+///   "more-total-than-WASM" silent-miscompile class). Float results are a
+///   documented later increment.
 ///
 /// A function whose body contains a lowered `call` becomes NON-LEAF: `bl`
 /// clobbers `x30`, so a non-leaf prologue saves FP/LR (`stp x29,x30,[sp,#-16]!`)
@@ -245,6 +259,7 @@ pub fn select_typed_cf_calls(
     num_imports: u32,
     func_arg_counts: &[u32],
     func_result_counts: &[u32],
+    func_ret_float: &[bool],
 ) -> Result<(Vec<u32>, Vec<CallSite>), SelectError> {
     if num_params > 8 {
         return Err(SelectError(format!(
@@ -1215,6 +1230,17 @@ pub fn select_typed_cf_calls(
                          are not supported for aarch64; loud-declining (#851)"
                     )));
                 }
+                // AAPCS64 returns f32/f64 in v0/d0, NOT x0. A float-returning
+                // callee must decline: pushing x0 as the result would read a
+                // stale GP register — a silent miscompile. (Float call results
+                // are a documented later increment.)
+                if rc == 1 && func_ret_float.get(idx as usize).copied().unwrap_or(false) {
+                    return Err(SelectError(format!(
+                        "call to function {idx}: float result (returned in v0/d0, \
+                         not x0) — float call results are not yet supported for \
+                         aarch64; loud-declining (#851)"
+                    )));
+                }
                 // The value stack must be EXACTLY the args (nothing survives the
                 // clobber underneath). This also guarantees no arg is FP-tagged
                 // improperly — an FP arg would need v-register marshalling we do
@@ -1340,6 +1366,7 @@ mod tests {
             num_imports,
             arg_counts,
             result_counts,
+            &[],
         )
     }
 
@@ -1419,6 +1446,25 @@ mod tests {
             WasmOp::End,
         ];
         assert!(sel_calls(&ops, 0, 0, &[1], &[1]).is_err());
+    }
+
+    #[test]
+    fn call_with_float_result_loud_declines() {
+        // A callee that returns f32/f64 (result in v0/d0, not x0) must decline —
+        // pushing x0 would be a silent miscompile.
+        let ops = vec![WasmOp::Call(0), WasmOp::End];
+        let r = select_typed_cf_calls(
+            &ops,
+            0,
+            &[],
+            &[],
+            &[],
+            0,
+            &[0],    // 0 args
+            &[1],    // 1 result
+            &[true], // ...which is a float
+        );
+        assert!(r.is_err(), "float-returning callee must loud-decline");
     }
 
     #[test]

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -201,10 +201,79 @@ pub fn select_typed_cf(
     params_f64: &[bool],
     block_arity: &[(u8, u8)],
 ) -> Result<Vec<u32>, SelectError> {
+    // No call metadata → any `call` in the body hits the honest catch-all decline
+    // (byte-identical to the pre-#851 behavior for call-free functions).
+    let (words, _sites) =
+        select_typed_cf_calls(ops, num_params, params_f32, params_f64, block_arity, 0, &[], &[])?;
+    Ok(words)
+}
+
+/// A direct-`call` site produced during selection (#851): the BYTE offset of the
+/// `bl` instruction within the function's code, and the callee's FULL wasm
+/// function index (imports first). The backend turns each into an
+/// `R_AARCH64_CALL26` relocation against the callee's `func_N` symbol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CallSite {
+    /// Byte offset of the `bl` instruction within the function's machine code.
+    pub offset: u32,
+    /// Callee's full wasm function index (imports first).
+    pub callee: u32,
+}
+
+/// Lower a body, ALSO lowering direct `call` (#851). Same as [`select_typed_cf`]
+/// plus the call-lowering inputs:
+///
+/// - `num_imports`: functions with full index `< num_imports` are IMPORTS —
+///   calling one is loud-declined in v1 (no import-dispatch ABI yet).
+/// - `func_arg_counts[idx]`: the callee's AAPCS integer-arg slot count (how many
+///   values `call` pops off the value stack and marshals into `x0..x7`).
+/// - `func_result_counts[idx]`: the callee's result count (0 = void, 1 = one
+///   value pushed back). Multi-result and out-of-range are declined.
+///
+/// A function whose body contains a lowered `call` becomes NON-LEAF: `bl`
+/// clobbers `x30`, so a non-leaf prologue saves FP/LR (`stp x29,x30,[sp,#-16]!`)
+/// and every epilogue restores them (`ldp`) before `ret`. Leaf functions stay
+/// byte-identical to the pre-#851 output (the frame is gated on "body has a
+/// lowered call").
+#[allow(clippy::too_many_arguments)]
+pub fn select_typed_cf_calls(
+    ops: &[WasmOp],
+    num_params: u32,
+    params_f32: &[bool],
+    params_f64: &[bool],
+    block_arity: &[(u8, u8)],
+    num_imports: u32,
+    func_arg_counts: &[u32],
+    func_result_counts: &[u32],
+) -> Result<(Vec<u32>, Vec<CallSite>), SelectError> {
     if num_params > 8 {
         return Err(SelectError(format!(
             "{num_params} params — supports at most 8 register params"
         )));
+    }
+
+    // #851 — is this function NON-LEAF (contains a `call` we will lower)? A `bl`
+    // clobbers x30, so a non-leaf must save/restore LR. Computed up front so the
+    // prologue can emit the frame; call-free functions stay byte-identical.
+    let is_non_leaf = ops.iter().any(|op| matches!(op, WasmOp::Call(_)));
+
+    // A non-leaf function that reads a PARAMETER is loud-declined: params arrive
+    // in x0..x7 (caller-saved), a `bl` clobbers them, and this backend does not
+    // yet HOME params to callee-saved storage — reading `local.get p` after a
+    // call would be garbage. Declining here ALSO makes arg marshalling
+    // hazard-free: with no param-Vals, every value-stack entry lives in a temp
+    // (x9..x15), disjoint from the arg destinations (x0..x7), so an argument
+    // move `mov x{arg}, x{temp}` never overwrites a not-yet-read source.
+    if is_non_leaf
+        && ops.iter().any(
+            |op| matches!(op, WasmOp::LocalGet(i) | WasmOp::LocalSet(i) | WasmOp::LocalTee(i) if *i < num_params),
+        )
+    {
+        return Err(SelectError(
+            "non-leaf function references a parameter — param homing across a \
+             call is not yet supported for aarch64; loud-declining (#851)"
+                .into(),
+        ));
     }
     let params = param_map(num_params, params_f32, params_f64);
     let mut words: Vec<u32> = Vec::new();
@@ -249,14 +318,25 @@ pub fn select_typed_cf(
     // Byte offset of non-param local `idx`'s slot from SP.
     let local_slot_off = |idx: u32| -> u32 { (idx - num_params) * 8 };
 
-    // Prologue: lower SP by the frame, then zero every non-param local slot with
-    // `str xzr, [sp, #off]` (64-bit store clears the whole slot).
+    // Prologue. Order (each step lowers SP; epilogue reverses):
+    //   1. #851 non-leaf: `stp x29,x30,[sp,#-16]!` saves FP/LR (a `bl` clobbers
+    //      x30). SP stays 16-byte aligned. Only when the body has a lowered call.
+    //   2. Non-param-local frame: `sub sp` then zero each 8-byte slot. Slot
+    //      offsets are relative to the POST-sub SP, unaffected by the LR save
+    //      that sits above them.
+    if is_non_leaf {
+        words.push(enc::stp_fp_lr_pre16());
+    }
     if frame_size > 0 {
         words.push(enc::sub_imm64(enc::SP, enc::SP, frame_size));
         for k in 0..num_non_param_locals {
             words.push(enc::str_x_imm(enc::XZR, enc::SP, k * 8));
         }
     }
+
+    // #851 — direct-call sites recorded during selection (byte offset of the
+    // `bl`, callee full index) for the backend's R_AARCH64_CALL26 relocations.
+    let mut call_sites: Vec<CallSite> = Vec::new();
 
     // Control-flow state (#538 cf increment). Each open `block` pushes a frame;
     // the matching `End` pops it and patches the recorded forward branches to
@@ -1029,7 +1109,7 @@ pub fn select_typed_cf(
                     );
                     stack.truncate(frame.stack_entry);
                 } else {
-                    epilogue(&mut words, stack.last().copied(), frame_size);
+                    epilogue(&mut words, stack.last().copied(), frame_size, is_non_leaf);
                 }
             }
             // --- #851 linear-memory load/store ---
@@ -1094,6 +1174,93 @@ pub fn select_typed_cf(
             WasmOp::I64Store32 { offset, .. } => {
                 store(&mut words, &mut stack, *offset, 2, enc::str_w)?
             }
+            // --- #851 direct `call` ---
+            //
+            // AAPCS64: pop `argc` integer args off the value stack, marshal them
+            // into x0..x{argc-1} in order (deepest = x0), `bl func_N` (recorded as
+            // an R_AARCH64_CALL26 relocation), then push the x0 result if the
+            // callee returns one value. LR is preserved by the non-leaf prologue.
+            //
+            // SOUNDNESS (v1 scope — everything else loud-declines, never wrong
+            // code): a call CLOBBERS all caller-saved registers (x0..x18), so
+            // value-stack temps (x9..x15) below the args do NOT survive it. We
+            // therefore require the value stack to hold EXACTLY the args at the
+            // call (`height == argc`) and decline otherwise. Combined with the
+            // non-leaf "no param reads" guard, this leaves every arg in a temp
+            // (x9..x15) disjoint from its destination (x0..x7), so the moves need
+            // no shuffle. Imports, >8 args, and non-{0,1}-result callees decline.
+            WasmOp::Call(func_idx) => {
+                let idx = *func_idx;
+                if idx < num_imports {
+                    return Err(SelectError(format!(
+                        "call to imported function {idx} — import dispatch is not \
+                         yet supported for aarch64; loud-declining (#851)"
+                    )));
+                }
+                let argc = *func_arg_counts.get(idx as usize).ok_or_else(|| {
+                    SelectError(format!("call to function {idx}: unknown arg count"))
+                })?;
+                if argc > 8 {
+                    return Err(SelectError(format!(
+                        "call to function {idx}: {argc} args — at most 8 register \
+                         args are supported; loud-declining (#851)"
+                    )));
+                }
+                let rc = *func_result_counts.get(idx as usize).ok_or_else(|| {
+                    SelectError(format!("call to function {idx}: unknown result count"))
+                })?;
+                if rc > 1 {
+                    return Err(SelectError(format!(
+                        "call to function {idx}: {rc} results — multi-result calls \
+                         are not supported for aarch64; loud-declining (#851)"
+                    )));
+                }
+                // The value stack must be EXACTLY the args (nothing survives the
+                // clobber underneath). This also guarantees no arg is FP-tagged
+                // improperly — an FP arg would need v-register marshalling we do
+                // not do, and it is caught here or by the disjointness below.
+                if stack.len() != argc as usize {
+                    return Err(SelectError(format!(
+                        "call to function {idx}: value stack holds {} entries but \
+                         needs exactly {argc} (call clobbers caller-saved temps \
+                         below the args); loud-declining (#851)",
+                        stack.len()
+                    )));
+                }
+                // Args are stack[0..argc] with stack[0] = x0 (deepest arg first).
+                // All are GP temps (x9..x15) by the guards above; decline any FP.
+                for (arg_reg, v) in stack.iter().enumerate() {
+                    if v.file != File::Gp {
+                        return Err(SelectError(format!(
+                            "call to function {idx}: argument {arg_reg} is a float \
+                             — FP call args are not supported for aarch64; \
+                             loud-declining (#851)"
+                        )));
+                    }
+                }
+                for (arg_reg, v) in stack.iter().enumerate() {
+                    if v.reg != arg_reg as u8 {
+                        words.push(enc::mov_reg64(arg_reg as u8, v.reg));
+                    }
+                }
+                stack.clear();
+                // Record the reloc site (byte offset of the `bl`) then emit `bl 0`.
+                call_sites.push(CallSite {
+                    offset: (words.len() * 4) as u32,
+                    callee: idx,
+                });
+                words.push(enc::bl(0));
+                // Push the result if the callee returns one value. Move x0 into a
+                // regular value-stack temp (x9..x15) immediately so the rest of the
+                // selector's invariant holds — value-stack entries live in the temp
+                // pool, never in x0 (which the epilogue and the next call reuse).
+                // i64 fits in x0; the value stack is width-agnostic (op-carried).
+                if rc == 1 {
+                    let dst = alloc_temp(&stack)?;
+                    words.push(enc::mov_reg64(dst, 0));
+                    stack.push(Val::gp(dst));
+                }
+            }
             other => {
                 return Err(SelectError(format!(
                     "unsupported wasm op for aarch64 subset: {other:?}"
@@ -1104,9 +1271,9 @@ pub fn select_typed_cf(
 
     // A body without a trailing `End` still needs an epilogue.
     if !matches!(ops.last(), Some(WasmOp::End)) {
-        epilogue(&mut words, stack.last().copied(), frame_size);
+        epilogue(&mut words, stack.last().copied(), frame_size, is_non_leaf);
     }
-    Ok(words)
+    Ok((words, call_sites))
 }
 
 /// Emit the function epilogue: move the top-of-stack result into the ABI return
@@ -1121,7 +1288,7 @@ pub fn select_typed_cf(
 /// is byte-identical to the pre-#851 epilogue). The result move is done BEFORE
 /// the `add sp` (the result lives in a caller-saved temp, unaffected by SP), so
 /// the sequence is: funnel result → restore SP → ret.
-fn epilogue(words: &mut Vec<u32>, top: Option<Val>, frame_size: u32) {
+fn epilogue(words: &mut Vec<u32>, top: Option<Val>, frame_size: u32, is_non_leaf: bool) {
     match top {
         Some(Val {
             reg,
@@ -1137,8 +1304,13 @@ fn epilogue(words: &mut Vec<u32>, top: Option<Val>, frame_size: u32) {
         }
         _ => {}
     }
+    // Unwind in reverse of the prologue: raise SP past the locals frame, then
+    // (#851 non-leaf) restore FP/LR before `ret` — `ret` returns to x30.
     if frame_size > 0 {
         words.push(enc::add_imm64(enc::SP, enc::SP, frame_size));
+    }
+    if is_non_leaf {
+        words.push(enc::ldp_fp_lr_post16());
     }
     words.push(enc::ret());
 }
@@ -1149,6 +1321,117 @@ mod tests {
 
     fn bytes(words: &[u32]) -> Vec<u8> {
         words.iter().flat_map(|w| w.to_le_bytes()).collect()
+    }
+
+    // Helper: no-import module, callee `func` has `argc` args and 1 result.
+    fn sel_calls(
+        ops: &[WasmOp],
+        num_params: u32,
+        num_imports: u32,
+        arg_counts: &[u32],
+        result_counts: &[u32],
+    ) -> Result<(Vec<u32>, Vec<CallSite>), SelectError> {
+        select_typed_cf_calls(
+            ops,
+            num_params,
+            &[],
+            &[],
+            &[],
+            num_imports,
+            arg_counts,
+            result_counts,
+        )
+    }
+
+    #[test]
+    fn direct_call_no_args_one_result() {
+        // (func (export "run") (result i32) call 0)  — func 0 returns i32, 0 args.
+        let ops = vec![WasmOp::Call(0), WasmOp::End];
+        let (w, sites) = sel_calls(&ops, 0, 0, &[0], &[1]).unwrap();
+        // Non-leaf prologue (stp) ; bl #0 ; mov temp,x0 ; mov x0,temp ; ldp ; ret.
+        assert_eq!(w[0], enc::stp_fp_lr_pre16());
+        // The bl is the reloc site.
+        assert_eq!(sites.len(), 1);
+        assert_eq!(sites[0].callee, 0);
+        assert_eq!(w[sites[0].offset as usize / 4], enc::bl(0));
+        // Last two words are the LR restore + ret.
+        assert_eq!(w[w.len() - 2], enc::ldp_fp_lr_post16());
+        assert_eq!(w[w.len() - 1], enc::ret());
+    }
+
+    #[test]
+    fn direct_call_two_const_args_marshalled_to_x0_x1() {
+        // i32.const 20 ; i32.const 22 ; call 0   — func 0: (param i32 i32)->i32.
+        let ops = vec![
+            WasmOp::I32Const(20),
+            WasmOp::I32Const(22),
+            WasmOp::Call(0),
+            WasmOp::End,
+        ];
+        let (w, sites) = sel_calls(&ops, 0, 0, &[2], &[1]).unwrap();
+        // The two consts land in x9/x10; the call marshals x9->x0, x10->x1.
+        assert!(w.contains(&enc::mov_reg64(0, 9)));
+        assert!(w.contains(&enc::mov_reg64(1, 10)));
+        assert_eq!(sites.len(), 1);
+        // bl is right after the two arg moves.
+        let bl_word = w[sites[0].offset as usize / 4];
+        assert_eq!(bl_word, enc::bl(0));
+    }
+
+    #[test]
+    fn leaf_function_is_byte_identical_without_call() {
+        // A call-free body must not gain the non-leaf LR frame.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32Add,
+            WasmOp::End,
+        ];
+        let (w, sites) = sel_calls(&ops, 2, 0, &[], &[]).unwrap();
+        assert!(sites.is_empty());
+        assert_eq!(w, vec![enc::add(9, 0, 1), enc::mov_reg64(0, 9), enc::ret()]);
+    }
+
+    #[test]
+    fn call_to_import_loud_declines() {
+        // func 0 is an import (num_imports = 1); calling it declines.
+        let ops = vec![WasmOp::Call(0), WasmOp::End];
+        assert!(sel_calls(&ops, 0, 1, &[0], &[0]).is_err());
+    }
+
+    #[test]
+    fn non_leaf_referencing_param_loud_declines() {
+        // A function that both reads a param AND makes a call declines (param
+        // homing across a call is unsupported — reading x0 after bl is garbage).
+        let ops = vec![WasmOp::LocalGet(0), WasmOp::Call(1), WasmOp::End];
+        // func 1 takes 1 arg (the local.get 0 value).
+        assert!(sel_calls(&ops, 1, 0, &[0, 1], &[0, 1]).is_err());
+    }
+
+    #[test]
+    fn call_with_extra_stack_below_args_loud_declines() {
+        // A live value beneath the args does not survive the call → decline.
+        // stack: [const_a, const_b] but callee takes only 1 arg → height 2 != 1.
+        let ops = vec![
+            WasmOp::I32Const(1),
+            WasmOp::I32Const(2),
+            WasmOp::Call(0),
+            WasmOp::End,
+        ];
+        assert!(sel_calls(&ops, 0, 0, &[1], &[1]).is_err());
+    }
+
+    #[test]
+    fn void_result_call_pushes_nothing() {
+        // call 0 where func 0 returns void: no value pushed, epilogue returns x0
+        // as-is (whatever the ABI leaves) — the important part is it lowers.
+        let ops = vec![WasmOp::Call(0), WasmOp::End];
+        let (w, sites) = sel_calls(&ops, 0, 0, &[0], &[0]).unwrap();
+        assert_eq!(sites.len(), 1);
+        // No `mov temp, x0` after the bl (nothing pushed): the word after bl is
+        // the ldp restore.
+        let bl_i = sites[0].offset as usize / 4;
+        assert_eq!(w[bl_i + 1], enc::ldp_fp_lr_post16());
     }
 
     #[test]

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2584,6 +2584,7 @@ fn compile_all_exports(
         all_imports,
         max_num_imported_funcs,
         func_arg_counts,
+        func_result_counts, // #851: per-function result count (0/1) — aarch64 direct-call lowering
         type_arg_counts,
         all_data_segments, // #237: active data segments, for --native-pointer-abi
         stack_pointer_global_opt, // #237: (index, init) of the SP global, if any
@@ -2620,6 +2621,7 @@ fn compile_all_exports(
         // #195: keep the arg-count tables aligned with the module whose
         // imports get merged (the one that defines `max_imports`).
         let mut merged_func_arg_counts: Vec<u32> = Vec::new();
+        let mut merged_func_result_counts: Vec<u32> = Vec::new(); // #851
         let mut merged_type_arg_counts: Vec<u32> = Vec::new();
 
         for (idx, wasm_bytes) in module_binaries.iter().enumerate() {
@@ -2668,6 +2670,7 @@ fn compile_all_exports(
                         max_imports = module.num_imported_funcs;
                         merged_imports = module.imports.clone();
                         merged_func_arg_counts = module.func_arg_counts.clone();
+                        merged_func_result_counts = module.func_result_counts.clone();
                         merged_type_arg_counts = module.type_arg_counts.clone();
                         // Keep the SBOM input aligned with the merged
                         // imports (the module the dependency graph reflects).
@@ -2676,6 +2679,7 @@ fn compile_all_exports(
                         // No imports anywhere yet: still carry the arg-count
                         // tables from a module so direct calls get marshalled.
                         merged_func_arg_counts = module.func_arg_counts.clone();
+                        merged_func_result_counts = module.func_result_counts.clone();
                         merged_type_arg_counts = module.type_arg_counts.clone();
                     }
                 }
@@ -2692,6 +2696,7 @@ fn compile_all_exports(
             merged_imports,
             max_imports,
             merged_func_arg_counts,
+            merged_func_result_counts, // #851: per-function result count (WAST-merged)
             merged_type_arg_counts,
             Vec::new(), // #237: data segments not threaded for WAST (single-module .wasm path covers it)
             None,       // #237: SP-global promotion is single-module .wasm only
@@ -2779,6 +2784,7 @@ fn compile_all_exports(
         // function addresses and ships the table in flash.
         let funcref_slots = module.funcref_region_slots();
         let func_arg_counts = module.func_arg_counts;
+        let func_result_counts = module.func_result_counts; // #851
         let type_arg_counts = module.type_arg_counts;
         let memories = module.memories;
         let imports = module.imports;
@@ -2876,6 +2882,7 @@ fn compile_all_exports(
             imports,
             num_imports,
             func_arg_counts,
+            func_result_counts, // #851
             type_arg_counts,
             data_segs,
             sp_global,
@@ -3034,6 +3041,7 @@ fn compile_all_exports(
         safety_bounds,
         num_imports: max_num_imported_funcs,
         func_arg_counts,
+        func_result_counts, // #851: per-function result count for aarch64 direct call
         type_arg_counts,
         target: target_spec.clone(),
         // #197: --relocatable forces the direct selector + direct func_N import
@@ -6513,8 +6521,9 @@ fn build_multi_func_riscv_elf(_funcs: &[ElfFunction], _wasm_data: &[u8]) -> Resu
 fn build_aarch64_elf(code: &[u8], func_name: &str) -> Result<Vec<u8>> {
     use synth_backend_aarch64::elf::{ElfFunction as A64ElfFunction, build_relocatable_object};
     Ok(build_relocatable_object(&[A64ElfFunction {
-        name: func_name.to_string(),
+        symbols: vec![func_name.to_string()],
         code: code.to_vec(),
+        relocations: Vec::new(),
     }]))
 }
 
@@ -6525,9 +6534,22 @@ fn build_multi_func_aarch64_elf(funcs: &[ElfFunction]) -> Result<Vec<u8>> {
     use synth_backend_aarch64::elf::{ElfFunction as A64ElfFunction, build_relocatable_object};
     let a64_funcs: Vec<A64ElfFunction> = funcs
         .iter()
-        .map(|f| A64ElfFunction {
-            name: f.name.clone(),
-            code: f.code.clone(),
+        .map(|f| {
+            // #851: EVERY function gets a `func_N` symbol (the target of a direct
+            // `bl` R_AARCH64_CALL26 reloc) plus its export name when it differs.
+            // The `name` field is the export name when exported, else `func_N`.
+            let func_sym = format!("func_{}", f.wasm_index);
+            let mut symbols = vec![func_sym.clone()];
+            if f.name != func_sym {
+                symbols.push(f.name.clone());
+            }
+            A64ElfFunction {
+                symbols,
+                code: f.code.clone(),
+                // #851: forward the call relocations so `bl func_N` sites resolve
+                // via `.rela.text` (these were dropped pre-#851).
+                relocations: f.relocations.clone(),
+            }
         })
         .collect();
     Ok(build_relocatable_object(&a64_funcs))

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -5047,6 +5047,15 @@ fn build_relocatable_elf(
                     );
                     ArmRelocationType::Abs32
                 }
+                // #851: R_AARCH64_CALL26 is emitted only by the EM_AARCH64 backend
+                // (its own `.rela.text` builder). It can never reach this ARM ELF
+                // relocation path; bail loudly if it somehow does.
+                synth_core::backend::RelocKind::AArch64Call26 => {
+                    anyhow::bail!(
+                        "internal error: AArch64 CALL26 relocation reached the ARM \
+                         ELF emitter — the aarch64 backend emits its own .rela.text (#851)"
+                    )
+                }
             };
             elf_builder.add_relocation(Relocation {
                 offset: func_base + reloc.offset,

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -527,6 +527,11 @@ pub enum RelocKind {
     /// semantics), which survives placement into a large multi-object image —
     /// whereas an inline-instruction MOVW_ABS immediate can be mangled.
     Abs32,
+    /// R_AARCH64_CALL26 (ELF type 283) — an AArch64 `BL` call site (#851). The
+    /// AArch64 analogue of [`RelocKind::ThmCall`]: the linker patches the 26-bit
+    /// word-offset immediate of the `bl` at `offset` to reach the target symbol.
+    /// Emitted only by the `EM_AARCH64` backend's `.rela.text`.
+    AArch64Call26,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -111,6 +111,13 @@ pub struct CompileConfig {
     /// of operand-stack values into R0–R3 (issue #195). Empty = pass no args
     /// (pre-#195 behaviour).
     pub func_arg_counts: Vec<u32>,
+    /// #851: result (return-value) count per function, indexed by full WASM
+    /// function index (imports first). `0` = void, `1` = one value. The AArch64
+    /// direct-`call` lowering needs the 0-vs-1 distinction to decide whether to
+    /// push the `x0` result — `func_ret_i64/f32/f64` carry the result TYPE but
+    /// conflate void and i32. Empty on backends/paths that do not lower calls
+    /// this way (byte-invisible there).
+    pub func_result_counts: Vec<u32>,
     /// AAPCS integer-argument count per function type, indexed by type index.
     /// Used by `call_indirect` (issue #195).
     pub type_arg_counts: Vec<u32>,
@@ -428,6 +435,7 @@ impl Default for CompileConfig {
             loom_compat: false,
             num_imports: 0,
             func_arg_counts: Vec::new(),
+            func_result_counts: Vec::new(),
             type_arg_counts: Vec::new(),
             relocatable: false,
             // #275: self-contained funcref-table dispatch is opt-in by the

--- a/crates/synth-core/src/wasm_decoder.rs
+++ b/crates/synth-core/src/wasm_decoder.rs
@@ -386,6 +386,13 @@ pub struct DecodedModule {
     /// #642: type index per function, indexed by the FULL function index
     /// (imports first, then locally-defined ones).
     pub func_type_indices: Vec<u32>,
+    /// #851: result (return-value) count per function, indexed by the FULL
+    /// function index (imports first). `0` = void, `1` = single result, etc.
+    /// (saturated at 255 for pathological signatures). The aarch64 direct-`call`
+    /// lowering needs the 0-vs-1 distinction — `func_ret_i64/f32/f64` carry the
+    /// result TYPE but conflate void and i32 (both all-false), so they cannot say
+    /// whether a value is pushed back after the call.
+    pub func_result_counts: Vec<u32>,
     /// #642: canonical structural signature per type index (params/results
     /// rendered as a string) — used for the closed-world `call_indirect` type
     /// check, which must compare SIGNATURES, not raw type indices (a module
@@ -1310,6 +1317,15 @@ pub fn decode_wasm_module(wasm_bytes: &[u8]) -> Result<DecodedModule> {
         table_size: table_sizes.first().copied().flatten(),
         table_sizes,
         elem_segments,
+        func_result_counts: func_type_indices
+            .iter()
+            .map(|&ti| {
+                type_block_arity
+                    .get(ti as usize)
+                    .map(|&(_p, r)| r as u32)
+                    .unwrap_or(0)
+            })
+            .collect(),
         func_type_indices,
         type_signatures,
         wsc_facts: wsc_facts.unwrap_or_default(),

--- a/scripts/repro/aarch64_calls_851.py
+++ b/scripts/repro/aarch64_calls_851.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""synth aarch64 direct-`call` execution differential (#851, lane L3).
+
+The standing gate `aarch64_matrix.sh` is single-function (it loads only the
+`.text` of one function), so it cannot exercise CALLS. This harness compiles a
+MULTI-function module with `synth -b aarch64 --relocatable`, resolves the
+R_AARCH64_CALL26 relocations itself (patching each `bl` imm26 for the concatenated
+layout), loads the combined blob into MAP_JIT executable memory, runs the
+exported entry, and diffs the result bit-exact against wasmtime.
+
+RED before the lane: the module DECLINES (aarch64 loud-skips `call`) → synth
+compile fails → this harness reports the compile error (no green run possible).
+GREEN after: bit-identical to wasmtime.
+
+Requires an arm64 host (Apple Silicon / Linux arm64), clang, wasm-tools,
+wasmtime. Env: SYNTH, WASMTIME, WASMTOOLS (defaults on PATH). Exits non-zero on
+any MISCOMPILE or on a call module that should compile but declines.
+"""
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+
+SYNTH = os.environ.get("SYNTH", "synth")
+WASMTIME = os.environ.get("WASMTIME", "wasmtime")
+WASMTOOLS = os.environ.get("WASMTOOLS", "wasm-tools")
+
+R_AARCH64_CALL26 = 283
+
+# --- native MAP_JIT runner: loads a full multi-function blob, calls it at
+#     entry offset 0 (the harness places the entry function first). ---
+RUNNER_C = r"""
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#ifdef __APPLE__
+#include <pthread.h>
+#endif
+int main(int c, char** v){
+  // argv: <hexblob> <a> <b> ...  up to 4 i64 args. Entry is at blob offset 0.
+  if(c < 2){ fprintf(stderr,"usage: %s <hex> [args...]\n", v[0]); return 2; }
+  size_t n = strlen(v[1])/2; uint8_t* code = malloc(n);
+  for(size_t i=0;i<n;i++){ unsigned b; sscanf(v[1]+2*i,"%2x",&b); code[i]=(uint8_t)b; }
+  int mf = MAP_PRIVATE|MAP_ANON;
+#ifdef MAP_JIT
+  mf |= MAP_JIT;
+#endif
+  size_t pg = (n + 4095) & ~((size_t)4095);
+  void* m = mmap(0, pg, PROT_READ|PROT_WRITE|PROT_EXEC, mf, -1, 0);
+  if(m==MAP_FAILED){ perror("mmap"); return 2; }
+#ifdef __APPLE__
+  pthread_jit_write_protect_np(0); memcpy(m, code, n); pthread_jit_write_protect_np(1);
+#else
+  memcpy(m, code, n);
+#endif
+  __builtin___clear_cache((char*)m, (char*)m+n);
+  long a0 = c>2 ? strtoll(v[2],0,10) : 0;
+  long a1 = c>3 ? strtoll(v[3],0,10) : 0;
+  long a2 = c>4 ? strtoll(v[4],0,10) : 0;
+  long a3 = c>5 ? strtoll(v[5],0,10) : 0;
+  long (*fn)(long,long,long,long) = (void*)m;
+  printf("%lld\n", (long long)fn(a0,a1,a2,a3));
+  return 0;
+}
+"""
+
+
+def sh(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+def parse_elf(path):
+    """Minimal ELF64 parser: returns (text_bytes, {symname:(value,size)},
+    [(r_offset, sym_value, sym_size)] for CALL26 relocs)."""
+    with open(path, "rb") as f:
+        data = f.read()
+    assert data[:4] == b"\x7fELF", "not ELF"
+    assert data[4] == 2, "not ELF64"
+    e_shoff = struct.unpack_from("<Q", data, 40)[0]
+    e_shentsize = struct.unpack_from("<H", data, 58)[0]
+    e_shnum = struct.unpack_from("<H", data, 60)[0]
+    e_shstrndx = struct.unpack_from("<H", data, 62)[0]
+
+    secs = []
+    for i in range(e_shnum):
+        base = e_shoff + i * e_shentsize
+        (sh_name, sh_type, sh_flags, sh_addr, sh_offset, sh_size, sh_link,
+         sh_info, sh_align, sh_entsize) = struct.unpack_from("<IIQQQQIIQQ", data, base)
+        secs.append(dict(name=sh_name, type=sh_type, offset=sh_offset,
+                         size=sh_size, link=sh_link, info=sh_info,
+                         entsize=sh_entsize))
+    shstr = secs[e_shstrndx]
+    shstrtab = data[shstr["offset"]:shstr["offset"] + shstr["size"]]
+
+    def secname(s):
+        end = shstrtab.index(b"\0", s["name"])
+        return shstrtab[s["name"]:end].decode()
+
+    named = {secname(s): s for s in secs}
+    text = data[named[".text"]["offset"]:named[".text"]["offset"] + named[".text"]["size"]]
+
+    # symtab + strtab
+    symtab = named[".symtab"]
+    strtab = secs[symtab["link"]]
+    strtab_bytes = data[strtab["offset"]:strtab["offset"] + strtab["size"]]
+    syms = []  # index -> (name, value, size)
+    nsym = symtab["size"] // 24
+    for i in range(nsym):
+        b = symtab["offset"] + i * 24
+        st_name, st_info, st_other, st_shndx, st_value, st_size = struct.unpack_from("<IBBHQQ", data, b)
+        end = strtab_bytes.index(b"\0", st_name)
+        nm = strtab_bytes[st_name:end].decode()
+        syms.append((nm, st_value, st_size))
+    symtab_by_name = {}
+    for nm, val, sz in syms:
+        if nm and nm not in symtab_by_name:
+            symtab_by_name[nm] = (val, sz)
+
+    relocs = []
+    if ".rela.text" in named:
+        rs = named[".rela.text"]
+        nrel = rs["size"] // 24
+        for i in range(nrel):
+            b = rs["offset"] + i * 24
+            r_offset, r_info, r_addend = struct.unpack_from("<QQq", data, b)
+            r_type = r_info & 0xFFFFFFFF
+            r_sym = r_info >> 32
+            assert r_type == R_AARCH64_CALL26, f"unexpected reloc type {r_type}"
+            sym_nm, sym_val, sym_sz = syms[r_sym]
+            relocs.append((r_offset, sym_val, r_addend))
+    return text, symtab_by_name, relocs
+
+
+def resolve_and_link(text, relocs):
+    """Patch each CALL26 in-place: bl imm26 = (target - site)/4, encoded into the
+    low 26 bits. .text already holds all functions concatenated at their final
+    offsets, so no relayout is needed — just fill in the branch displacements."""
+    blob = bytearray(text)
+    for (site, target, addend) in relocs:
+        disp = (target + addend - site) // 4
+        # 26-bit signed
+        imm26 = disp & 0x03FFFFFF
+        word = struct.unpack_from("<I", blob, site)[0]
+        word = (word & 0xFC000000) | imm26  # keep opcode bits (bl = 0x94)
+        struct.pack_into("<I", blob, site, word)
+    return bytes(blob)
+
+
+def main():
+    if os.uname().machine not in ("arm64", "aarch64"):
+        print("SKIP: needs a native arm64 host")
+        return 0
+    W = tempfile.mkdtemp()
+    runner_c = os.path.join(W, "run.c")
+    with open(runner_c, "w") as f:
+        f.write(RUNNER_C)
+    runner = os.path.join(W, "run")
+    r = sh(["clang", "-O0", "-o", runner, runner_c])
+    if r.returncode != 0:
+        print("SKIP: cannot build JIT runner\n" + r.stderr)
+        return 0
+
+    # Each case: (name, wat, expected_syms, [(arg-tuple)]). The entry export MUST
+    # be the FIRST local function so it sits at .text offset 0 (the runner enters
+    # there). `expected_syms` are function symbols that MUST appear in the emitted
+    # object — if any is missing (a caller silently skipped by a decline), the
+    # harness FAILS LOUDLY rather than running an unrelocated `bl #0`
+    # (branch-to-self infinite loop).
+    #
+    # SCOPE (honest): a CALLER that reads its OWN incoming params while calling
+    # loud-declines (param homing across a call is a later increment). So every
+    # exported ENTRY here marshals CONST or COMPUTED args; the CALLEE freely reads
+    # its params (a leaf). This exercises the real call path end-to-end.
+    cases = [
+        (
+            "call_const_args",
+            """(module
+  (func (export "run") (result i32)
+    (call $mul (i32.const 6) (i32.const 7)))
+  (func $mul (param i32 i32) (result i32)
+    (i32.mul (local.get 0) (local.get 1))))""",
+            ["run", "func_1"],
+            [()],
+        ),
+        (
+            "call_computed_args",
+            """(module
+  (func (export "run") (result i32)
+    (call $add (i32.add (i32.const 100) (i32.const 23)) (i32.const 22)))
+  (func $add (param i32 i32) (result i32)
+    (i32.add (local.get 0) (local.get 1))))""",
+            ["run", "func_1"],
+            [()],
+        ),
+        (
+            "void_call_then_value",
+            """(module
+  (func (export "run") (result i32)
+    (call $noop)
+    (i32.const 99))
+  (func $noop))""",
+            ["run", "func_1"],
+            [()],
+        ),
+        (
+            "i64_call_const_args",
+            """(module
+  (func (export "run") (result i64)
+    (call $add64 (i64.const 1000000000000) (i64.const 2000000000000)))
+  (func $add64 (param i64 i64) (result i64)
+    (i64.add (local.get 0) (local.get 1))))""",
+            ["run", "func_1"],
+            [()],
+        ),
+        (
+            "call_returns_helper_result",
+            """(module
+  (func (export "run") (result i32)
+    (i32.add (call $seven) (i32.const 1)))
+  (func $seven (result i32)
+    (i32.const 7)))""",
+            ["run", "func_1"],
+            [()],
+        ),
+    ]
+
+    fails = []
+    ran = 0
+    for name, wat, expected_syms, argsets in cases:
+        wat_p = os.path.join(W, f"{name}.wat")
+        wasm_p = os.path.join(W, f"{name}.wasm")
+        obj_p = os.path.join(W, f"{name}.o")
+        with open(wat_p, "w") as f:
+            f.write(wat)
+        if sh([WASMTOOLS, "validate", wat_p]).returncode != 0:
+            fails.append(f"{name}: wat invalid")
+            continue
+        sh([WASMTOOLS, "parse", wat_p, "-o", wasm_p])
+        c = sh([SYNTH, "compile", wat_p, "-b", "aarch64", "--relocatable", "-o", obj_p])
+        if c.returncode != 0:
+            fails.append(f"{name}: synth DECLINED/failed: {c.stderr.strip()[:200]}")
+            continue
+        try:
+            text, syms, relocs = parse_elf(obj_p)
+            blob = resolve_and_link(text, relocs)
+        except Exception as e:
+            fails.append(f"{name}: ELF/link error: {e}")
+            continue
+        # sanity: `run` symbol must be at offset 0 (entry-first requirement).
+        run_val = syms.get("run", (None, None))[0]
+        if run_val != 0:
+            fails.append(f"{name}: export 'run' not at .text offset 0 (got {run_val})")
+            continue
+        # LOUD skip-masking guard: every function we expect MUST be in the object.
+        # A silently-skipped caller (declined) would leave a dangling `bl #0`
+        # (branch-to-self infinite loop) — fail here instead of hanging.
+        missing = [s for s in expected_syms if s not in syms]
+        if missing:
+            fails.append(f"{name}: expected symbols missing from object (a caller "
+                         f"was silently declined/skipped): {missing}")
+            continue
+        hexblob = blob.hex()
+        for args in argsets:
+            native = sh([runner, hexblob, *[str(a) for a in args]])
+            wt = sh([WASMTIME, "run", "--invoke", "run", wasm_p, *[str(a) for a in args]])
+            g = native.stdout.strip()
+            o = wt.stdout.strip()
+            ran += 1
+            if g != o:
+                fails.append(f"{name}{args}: native={g!r} wasmtime={o!r} "
+                             f"(native_err={native.stderr.strip()[:80]} "
+                             f"wt_err={wt.stderr.strip()[:80]})")
+
+    if fails:
+        print(f"FAIL ({ran} runs, {len(fails)} problems):")
+        for f in fails:
+            print("  " + f)
+        return 1
+    print(f"PASS: {ran} call runs bit-identical to wasmtime "
+          f"across {len(cases)} modules")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Lane L3 of the v0.51 hub. Lowers WASM direct `call` on the `-b aarch64` backend (previously a loud-decline). Ref #851.

## What was lowered

**Direct `call`** — args marshalled into `x0..x7` per AAPCS64, `bl func_N` to the callee (linkable via a new `R_AARCH64_CALL26` `.rela.text` relocation), `x0` result pushed. A function that emits a call becomes NON-LEAF: it saves/restores FP+LR (`stp x29,x30,[sp,#-16]!` / `ldp x29,x30,[sp],#16`) around the body. **Leaf functions stay byte-identical** (the frame is gated on "body has a lowered call").

The multi-function object now places **every reachable local function** with a `func_N` symbol (+ export alias) so a call to a non-exported helper resolves.

## Honest frontier (loud-declined, never wrong code)

- calling an **import** (no import-dispatch ABI yet)
- **> 8** integer args; **multi-result**; **float-result** callees (returned in v0/d0, not x0 — this guard prevents a silent miscompile)
- a **caller that reads its own incoming params across a call** (param-homing is a later increment; a *callee* freely reads its params — leaf)
- any live value beneath the args at the call site
- **`call_indirect`** (the named residual)

## Changes

| area | change |
|------|--------|
| encoder | `bl` (imm26), `stp_fp_lr_pre16`, `ldp_fp_lr_post16` — clang-ground-truth-verified |
| selector | `select_typed_cf_calls` threads num_imports / arg / result / float-return; marshals + emits bl + records call sites; non-leaf LR frame |
| backend | `func_result_counts` + `func_ret_float` threaded; relocations produced; `compile_module` places all locals |
| elf | `.rela.text` (ELF64 `r_info` sym in high word, type 283); multi-symbol-per-function |
| core | `RelocKind::AArch64Call26`; `DecodedModule::func_result_counts`; `CompileConfig::func_result_counts` |
| cli | thread `func_result_counts` (single + WAST-merged paths); fix `build_multi_func_aarch64_elf` to emit `func_N` + forward relocations |

## Gate evidence (RED → GREEN)

**RED** (origin/main): `unsupported wasm op for aarch64 subset: Call(1)` — the exported caller is skipped, absent from the object.

**GREEN**: `scripts/repro/aarch64_calls_851.py` (native arm64 MAP_JIT, resolves the CALL26 relocations itself) — **5 call modules bit-identical vs wasmtime** (const args, computed args, void call, i64 call, result-consumed). Asserts every expected symbol is present, so a silently-declined caller fails loudly (never hangs on an unrelocated `bl #0`). Wired into the `aarch64-native-matrix` CI job.

- 10 new unit tests — 8 selector + 1 elf `.rela.text` + 1 encoder (76 backend tests pass)
- Frozen ARM anchors **10/10 untouched** (aarch64 is a separate backend)
- Standing `aarch64_matrix.sh` **unchanged** (32 ops / 86 checks PASS — calls aren't in its op-set)
- fmt clean; clippy `-D warnings` clean on aarch64/core/cli; `--features riscv` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L