### PR TITLE
fix(main): restore BvTerm::Urem arms for ordeal 0.16.1 + latent ord_bv panic + hold 0.x-minor dependabot bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,12 +18,51 @@ jobs:
       - name: Fetch Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@v3
-      - name: Enable auto-merge for patch + minor updates
-        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+      # A 0.x MINOR bump is BREAKING by semver convention (for 0.x the MINOR
+      # component is the de-facto major), but Dependabot reports it as
+      # `semver-minor` because the major component is still 0. That gap bit synth
+      # TWICE on the SAME dep: ordeal 0.9->0.12 (added `BvTerm::Urem`, broke every
+      # exhaustive match) and again 0.9->0.16 (#864 — landed with NO CI run and
+      # left `main` uncompilable). So: HOLD when the previous version is 0.x and
+      # the minor component changed.
+      - name: Classify 0.x-minor as breaking (hold)
+        id: zerox
+        env:
+          # Via env (never interpolated into the script body): this is a
+          # pull_request_target workflow with contents:write, so no
+          # ${{ }} expansion inside `run:`.
+          PREV_VERSION: ${{ steps.meta.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.meta.outputs.new-version }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+        run: |
+          hold=false
+          if [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
+            case "$PREV_VERSION" in
+              0.*)
+                pm=$(printf '%s' "$PREV_VERSION" | cut -d. -f2)
+                nm=$(printf '%s' "$NEW_VERSION" | cut -d. -f2)
+                [ "$pm" != "$nm" ] && hold=true
+                ;;
+            esac
+          fi
+          echo "hold=$hold" >> "$GITHUB_OUTPUT"
+          echo "0.x-minor hold=$hold ($PREV_VERSION -> $NEW_VERSION)"
+      - name: Enable auto-merge for patch + true-minor updates
+        if: (steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor') && steps.zerox.outputs.hold != 'true'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Comment + label held 0.x-minor bumps
+        if: steps.zerox.outputs.hold == 'true'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREV_VERSION: ${{ steps.meta.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.meta.outputs.new-version }}
+        run: |
+          gh pr edit "$PR_URL" --add-label "major-bump-hold" 2>/dev/null || true
+          gh pr comment "$PR_URL" --body "🔒 **0.x MINOR bump — held for manual review.** \`$PREV_VERSION\` → \`$NEW_VERSION\`: for a 0.x crate the MINOR component is the de-facto major, so this is BREAKING even though Dependabot labels it \`semver-minor\`. This gap broke synth twice on \`ordeal\` (0.9→0.12 added \`BvTerm::Urem\`, breaking every exhaustive match; 0.9→0.16 in #864 landed with no CI run and left main uncompilable). Build EVERY affected feature set (incl. \`--features z3-solver\`) and run the full \`synth-verify\` suite before merging."
       - name: Comment + label major updates for manual review
         if: steps.meta.outputs.update-type == 'version-update:semver-major'
         run: |

--- a/crates/synth-verify/src/solver.rs
+++ b/crates/synth-verify/src/solver.rs
@@ -187,6 +187,7 @@ mod z3_backend {
             BvTerm::Sub(a, b) => bv_to_z3(a).bvsub(&bv_to_z3(b)),
             BvTerm::Mul(a, b) => bv_to_z3(a).bvmul(&bv_to_z3(b)),
             BvTerm::Udiv(a, b) => bv_to_z3(a).bvudiv(&bv_to_z3(b)),
+            BvTerm::Urem(a, b) => bv_to_z3(a).bvurem(&bv_to_z3(b)),
             BvTerm::And(a, b) => bv_to_z3(a).bvand(&bv_to_z3(b)),
             BvTerm::Or(a, b) => bv_to_z3(a).bvor(&bv_to_z3(b)),
             BvTerm::Xor(a, b) => bv_to_z3(a).bvxor(&bv_to_z3(b)),

--- a/crates/synth-verify/src/term.rs
+++ b/crates/synth-verify/src/term.rs
@@ -64,18 +64,24 @@ fn bv_rank(t: &BvTerm) -> u8 {
         BvTerm::Sub(..) => 3,
         BvTerm::Mul(..) => 4,
         BvTerm::Udiv(..) => 5,
-        BvTerm::And(..) => 6,
-        BvTerm::Or(..) => 7,
-        BvTerm::Xor(..) => 8,
-        BvTerm::Shl(..) => 9,
-        BvTerm::Lshr(..) => 10,
-        BvTerm::Ashr(..) => 11,
-        BvTerm::Rotr(..) => 12,
-        BvTerm::Extract { .. } => 13,
-        BvTerm::Concat(..) => 14,
-        BvTerm::ZeroExt { .. } => 15,
-        BvTerm::SignExt { .. } => 16,
-        BvTerm::Ite { .. } => 17,
+        // Urem MUST have its own rank: `ord_bv` asserts (via `unreachable!`)
+        // that rank-equal variants are exhaustively matched below, and there is
+        // no (Udiv, Urem) cross pair — sharing rank 5 made comparing a `Udiv`
+        // against a `Urem` panic. Reachable: the rem model is
+        // `rem = a − (a/b)·b`, so div and rem terms meet under a commutative op.
+        BvTerm::Urem(..) => 6,
+        BvTerm::And(..) => 7,
+        BvTerm::Or(..) => 8,
+        BvTerm::Xor(..) => 9,
+        BvTerm::Shl(..) => 10,
+        BvTerm::Lshr(..) => 11,
+        BvTerm::Ashr(..) => 12,
+        BvTerm::Rotr(..) => 13,
+        BvTerm::Extract { .. } => 14,
+        BvTerm::Concat(..) => 15,
+        BvTerm::ZeroExt { .. } => 16,
+        BvTerm::SignExt { .. } => 17,
+        BvTerm::Ite { .. } => 18,
     }
 }
 
@@ -117,6 +123,7 @@ fn ord_bv(a: &BvTerm, b: &BvTerm) -> Ordering {
         | (BvTerm::Sub(a1, a2), BvTerm::Sub(b1, b2))
         | (BvTerm::Mul(a1, a2), BvTerm::Mul(b1, b2))
         | (BvTerm::Udiv(a1, a2), BvTerm::Udiv(b1, b2))
+        | (BvTerm::Urem(a1, a2), BvTerm::Urem(b1, b2))
         | (BvTerm::And(a1, a2), BvTerm::And(b1, b2))
         | (BvTerm::Or(a1, a2), BvTerm::Or(b1, b2))
         | (BvTerm::Xor(a1, a2), BvTerm::Xor(b1, b2))
@@ -234,6 +241,10 @@ fn canonicalize_bv(t: &BvTerm) -> BvTerm {
         BvTerm::Udiv(a, b) => {
             let (a, b) = bin(a, b);
             BvTerm::Udiv(a, b)
+        }
+        BvTerm::Urem(a, b) => {
+            let (a, b) = bin(a, b);
+            BvTerm::Urem(a, b)
         }
         BvTerm::Shl(a, b) => {
             let (a, b) = bin(a, b);
@@ -843,6 +854,7 @@ fn fmt_bv(t: &BvTerm, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         BvTerm::Sub(a, b) => fmt_bin(f, "bvsub", a, b),
         BvTerm::Mul(a, b) => fmt_bin(f, "bvmul", a, b),
         BvTerm::Udiv(a, b) => fmt_bin(f, "bvudiv", a, b),
+        BvTerm::Urem(a, b) => fmt_bin(f, "bvurem", a, b),
         BvTerm::And(a, b) => fmt_bin(f, "bvand", a, b),
         BvTerm::Or(a, b) => fmt_bin(f, "bvor", a, b),
         BvTerm::Xor(a, b) => fmt_bin(f, "bvxor", a, b),


### PR DESCRIPTION
## main does not compile

Dependabot auto-merged `ordeal 0.9.1 → 0.16.1` (#864) **with no CI run**, and the four `BvTerm::Urem` match arms — removed when we downgraded to 0.9.1 (`4ad175e`, which lacks the variant) — were never restored. Result: 3× `E0004` non-exhaustive-match, `main` unbuildable.

## What this does

1. **Restores the 4 `Urem` arms** — term.rs (`bv_rank`, `canonicalize_bv`, SMT-LIB `bvurem` formatter) + the z3-gated solver.rs.
2. **Fixes a latent panic** found while restoring them: `bv_rank` gave `Udiv` and `Urem` **both rank 5**, but `ord_bv` asserts via `unreachable!()` that rank-equal variants are exhaustively matched — and there's no `(Udiv, Urem)` cross pair. Comparing a Udiv against a Urem **panics**. Reachable: `rem = a − (a/b)·b` puts div and rem terms under a commutative op. `Urem` now has its own rank; the `(Urem, Urem)` pair is matched.
3. **KEEPS the 0.16.1 bump — it is correct.** Verified: full `synth-verify` suite **236 tests / 0 failed / ~33s** (vs ~41s on 0.9.1). ordeal 0.16.1 fixes the unsigned-`bvurem` blast regression (ordeal#101) that 0.16.0 still had → the `=0.9.1` pin is no longer needed, and **#848/#849 unblock**.
4. **Closes the dependabot gap** (second time this dep bit us): a **0.x MINOR** bump is BREAKING by convention but Dependabot labels it `semver-minor`, so the workflow auto-merged it. `dependabot-auto-merge.yml` now HOLDS 0.x-minor bumps with a label + explanatory comment. Version strings go through `env:`, never interpolated into `run:` (this is `pull_request_target` + `contents: write`).

## Verification
build clean · synth-verify 236/236 in ~33s · fmt + clippy clean · workflow YAML parses.

## ⚠️ Separate finding for the maintainer (not fixed here)
`main`'s branch protection appears to have **no required status checks**, so `gh pr merge --auto` merges as soon as a PR is mergeable — CI or not. That's how #864 landed unverified. Configuring required checks is a repo setting, left for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)