### PR TITLE
fix(#865): aarch64 linear-memory bounds — software OOB-trap checks, enforce-by-default, hard-error mask/mpu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,6 +453,8 @@ jobs:
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_locals_851_differential.py
       - name: Run #851 control-flow (if/else + loop back-edge + return) execution oracle
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_ctrlflow_851_differential.py
+      - name: Run #865 linear-memory BOUNDS oracle (OOB traps + modes differ + mask/mpu hard-error)
+        run: SYNTH=./target/debug/synth python scripts/repro/aarch64_bounds_865_differential.py
       - name: Run decline-matrix honesty oracle
         run: SYNTH=./target/debug/synth python scripts/repro/aarch64_m2_decline_538.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **aarch64: linear-memory accesses now BOUNDS-CHECK — `--safety-bounds` was a
+  silent no-op (#865).** The v0.51.0 `-b aarch64` lowering (#851) emitted NO
+  bounds check and every `--safety-bounds` mode (`none`/`software`/`mask`/`mpu`)
+  produced byte-identical unchecked output: a guest address is zero-extended
+  (`uxtw`), so `i32.load`/`i32.store` at `0xFFFFFFFF` reached `x28 + 4 GiB − 1`
+  — an OOB read (disclosure) / write (arbitrary-write) primitive where WASM
+  requires a trap (gale's executed table: 65536, 100000, −1 all returned host
+  memory; wasmtime traps). Now:
+  - **`software` emits a per-access check**: `mov w_k, #K; cmp w_addr, w_k;
+    b.ls +2; brk #0` with `K = limit − memarg.offset − access_size` folded at
+    compile time — one compare proves `uxtw(addr) + offset + size ≤ limit`
+    BEFORE the dereference (width + memarg-offset accounting included: a 4-byte
+    access at `limit−3`, or an `offset=65532` access at addr 4, traps). When
+    `offset + size` already exceed the limit the access unconditionally traps.
+    The static limit (declared min pages × 64 KiB) is sound because
+    `memory.grow` is not lowered on this backend.
+  - **The DEFAULT on `-b aarch64` is now `software`** — the flag-absent path
+    was the silent-unsafe path; unchecked output now requires the explicit
+    `--safety-bounds none` opt-out (which stays byte-identical to v0.51.0
+    output).
+  - **`mask`/`mpu` HARD-ERROR on `-b aarch64`** (CLI and backend, defense in
+    depth) instead of being silently accepted and ignored — the "flag exists
+    but doesn't enforce" class (cf. #651) is refused, never re-emitted.
+  - The single-function path (`-n`) now threads the module's real declared
+    memory limit (previously 0) into the config and the safety manifest.
+  - Gated red-first by `scripts/repro/aarch64_bounds_865_differential.py`
+    (CI `aarch64-oracle`): gale's exact table under unicorn with poisoned
+    OOB memory — in-bounds values match wasmtime, every OOB row must `brk`
+    exactly where wasmtime traps (strict classification: only `brk` counts,
+    an unmapped fault fails), `md5(none) ≠ md5(software)`, default ≡
+    software, and the mask/mpu rejections. RED on the pre-fix binary
+    (15 failures), GREEN after; all pre-existing aarch64 differentials and
+    gale's native matrix (35 ops / 91 checks) unchanged-green.
+
 ## [0.51.0] - 2026-07-23
 
 **"aarch64 runs real WASM modules."** The `-b aarch64` host-native backend crosses

--- a/crates/synth-backend-aarch64/src/backend.rs
+++ b/crates/synth-backend-aarch64/src/backend.rs
@@ -60,6 +60,28 @@ impl AArch64Backend {
         // value-carrying (typed) blocks.
         // #851: thread the call metadata so direct `call` lowers to `bl func_N`
         // + an R_AARCH64_CALL26 relocation (call-free bodies are unaffected).
+        // #865: resolve `--safety-bounds` into the selector's explicit
+        // `MemBounds` — `software` emits per-access OOB-trap checks against the
+        // module's declared memory limit, `none` is the explicit unchecked
+        // opt-out, and anything else (mask/mpu) HARD-ERRORS here too (defense
+        // in depth behind the CLI's early rejection): accepting a mode and
+        // emitting unchecked accesses is the #865 silent-no-op miscompile.
+        let bounds = match config.effective_safety_bounds() {
+            synth_core::backend::SafetyBounds::Software => selector::MemBounds::Software {
+                limit_bytes: config.linear_memory_bytes as u64,
+            },
+            synth_core::backend::SafetyBounds::None => selector::MemBounds::Unchecked,
+            other => {
+                return Err(BackendError::CompilationFailed(format!(
+                    "--safety-bounds {} is not implemented on the aarch64 backend — \
+                     refusing to silently emit UNCHECKED memory accesses (#865). \
+                     Use --safety-bounds software (the default: per-access bounds \
+                     checks that trap out-of-bounds) or --safety-bounds none \
+                     (explicit unchecked opt-out).",
+                    other.as_str()
+                )));
+            }
+        };
         let (words, call_sites) = selector::select_typed_cf_calls(
             ops,
             num_params,
@@ -70,6 +92,7 @@ impl AArch64Backend {
             &config.func_arg_counts,
             func_result_counts,
             func_ret_float,
+            bounds,
         )
         .map_err(|e| BackendError::CompilationFailed(e.to_string()))?;
         let code: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -104,7 +104,7 @@ const FTEMPS: [FReg; 8] = [16, 17, 18, 19, 20, 21, 22, 23];
 /// memory-using function is correct *given* the `x28 = base` precondition, which
 /// the #851 execution differential supplies explicitly; wiring the ABI/startup
 /// that establishes it in a real program is a documented follow-on (alongside
-/// OOB-trap, data-segment init, and memory.{size,grow}).
+/// data-segment init and memory.{size,grow}; OOB accesses trap since #865).
 const LINMEM_BASE: Reg = 28;
 
 /// #865 — linear-memory bounds-check mode for the load/store lowering.

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -30,9 +30,11 @@
 //!   float-result callees (returned in v0/d0, not x0), a caller reading its own
 //!   params across a call (param-homing is a later increment).
 //! - `br_table`, value-carrying `block`/`loop`/`if`, and register spilling.
-//! - OOB memory bounds-trap, data-segment init, and the startup that establishes
-//!   the `x28` linear-memory base (the load/store lowering is correct given the
-//!   base precondition; wiring it at runtime is a follow-on).
+//! - Data-segment init and the startup that establishes the `x28` linear-memory
+//!   base (the load/store lowering is correct given the base precondition;
+//!   wiring it at runtime is a follow-on). OOB accesses TRAP since #865 under
+//!   [`MemBounds::Software`] (the CLI default); `--safety-bounds none` is the
+//!   explicit unchecked opt-out.
 //!
 //! **#851 — non-param locals:** GP locals beyond the params (index >=
 //! `num_params`) get zero-initialized 8-byte stack slots (`[sp, #(idx -
@@ -104,6 +106,30 @@ const FTEMPS: [FReg; 8] = [16, 17, 18, 19, 20, 21, 22, 23];
 /// that establishes it in a real program is a documented follow-on (alongside
 /// OOB-trap, data-segment init, and memory.{size,grow}).
 const LINMEM_BASE: Reg = 28;
+
+/// #865 — linear-memory bounds-check mode for the load/store lowering.
+///
+/// v0.51.0 shipped the #851 lowering with NO bounds check and `--safety-bounds`
+/// silently ignored (all four modes byte-identical): a guest address is
+/// zero-extended (`uxtw`), so `0xFFFFFFFF` reaches `x28 + 4 GiB − 1` — an OOB
+/// read (disclosure) / write (arbitrary-write) primitive where WASM requires a
+/// trap. This enum makes the choice EXPLICIT at the selector boundary: a caller
+/// must either supply the memory limit (and get per-access trap checks) or
+/// explicitly opt out — there is no silent default.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MemBounds {
+    /// No per-access check — the explicit `--safety-bounds none` opt-out.
+    /// An out-of-bounds guest access dereferences host memory (documented,
+    /// deliberate; NOT the CLI default).
+    Unchecked,
+    /// Software bounds (#865): every access proves
+    /// `uxtw(addr) + memarg.offset + access_size <= limit_bytes`
+    /// or traps (`brk #0`) BEFORE the dereference — WASM §4.4.7 OOB-trap
+    /// semantics. `limit_bytes` is the module's declared minimum memory size
+    /// (pages × 64 KiB); `memory.grow` is not lowered on this backend, so the
+    /// declared minimum IS the runtime size and the static limit is sound.
+    Software { limit_bytes: u64 },
+}
 
 /// Which register file a value-stack entry lives in.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -209,6 +235,9 @@ pub fn select_typed_cf(
 ) -> Result<Vec<u32>, SelectError> {
     // No call metadata → any `call` in the body hits the honest catch-all decline
     // (byte-identical to the pre-#851 behavior for call-free functions).
+    // No memory context either → bounds-unchecked, matching the pre-#865
+    // behavior of these compatibility wrappers (the real driver — the Backend
+    // impl — threads the resolved `MemBounds` explicitly).
     let (words, _sites) = select_typed_cf_calls(
         ops,
         num_params,
@@ -219,6 +248,7 @@ pub fn select_typed_cf(
         &[],
         &[],
         &[],
+        MemBounds::Unchecked,
     )?;
     Ok(words)
 }
@@ -266,6 +296,7 @@ pub fn select_typed_cf_calls(
     func_arg_counts: &[u32],
     func_result_counts: &[u32],
     func_ret_float: &[bool],
+    bounds: MemBounds,
 ) -> Result<(Vec<u32>, Vec<CallSite>), SelectError> {
     if num_params > 8 {
         return Err(SelectError(format!(
@@ -913,18 +944,67 @@ pub fn select_typed_cf_calls(
     // that does not alias any live value-stack entry (the address operand has
     // already been popped, so its register is free to reuse).
     //
-    // SOUNDNESS / honest frontier: this computes the WASM effective address and
-    // dereferences it against the ambient base — it does NOT bounds-check. WASM
-    // requires an out-of-bounds access to TRAP; the host-native subset has no
-    // memory-size convention yet, so OOB is UNTRAPPED (reads/writes adjacent host
-    // memory). In-bounds load/store is execution-verified vs wasmtime; OOB-trap,
-    // data-segment init, and memory.{size,grow} are the documented follow-ons.
+    // SOUNDNESS (#865): under `MemBounds::Software` every access first PROVES
+    // `uxtw(addr) + offset + size <= limit` or traps (`brk #0`) — WASM §4.4.7.
+    // Since `offset`, `size`, and `limit` are all compile-time constants, the
+    // check reduces to a single unsigned compare of the 32-bit guest address
+    // against `K = limit - offset - size`:
+    //
+    //   in-bounds  ⇔  uxtw(addr) + offset + size ≤ limit  ⇔  uxtw(addr) ≤ K
+    //
+    //   mov  w_k, #K          ; K = limit - offset - size (compile-time)
+    //   cmp  w_addr, w_k      ; 32-bit compare — uxtw-correct by construction
+    //                         ; (w-form reads the low 32 bits, exactly the
+    //                         ;  zero-extended guest address the EA add uses)
+    //   b.ls +2               ; unsigned addr <= K → skip the trap
+    //   brk  #0               ; OOB → trap (same mechanism as div/0, #709)
+    //
+    // When `K < 0` (offset + size exceed the limit) NO i32 address is in
+    // bounds: emit an unconditional `brk` (the access always traps; the dead
+    // access code that follows keeps the value-stack bookkeeping uniform).
+    // K always fits u32 when non-negative: limit ≤ 2^32 and size ≥ 1.
+    // Under `MemBounds::Unchecked` (explicit opt-out) no check is emitted.
+    let bounds_check = |words: &mut Vec<u32>,
+                        stack: &mut Vec<Val>,
+                        addr: Reg,
+                        offset: u32,
+                        size_log2: u32|
+     -> Result<(), SelectError> {
+        let MemBounds::Software { limit_bytes } = bounds else {
+            return Ok(());
+        };
+        let size = 1u64 << size_log2;
+        let k = limit_bytes as i64 - offset as i64 - size as i64;
+        if k < 0 {
+            words.push(enc::brk(0));
+            return Ok(());
+        }
+        // Keep `addr` live while allocating the limit scratch so they are
+        // guaranteed distinct registers.
+        stack.push(Val::gp(addr));
+        let ktmp = alloc_temp(stack)?;
+        stack.pop();
+        for w in enc::mov_imm32(ktmp, k as u32) {
+            words.push(w);
+        }
+        words.push(enc::cmp(addr, ktmp));
+        words.push(enc::bcond(Cond::Ls, 2)); // in-bounds: hop over the brk
+        words.push(enc::brk(0)); // OOB trap
+        Ok(())
+    };
+
+    // In-bounds load/store is execution-verified vs wasmtime; the OOB-trap
+    // check above is #865 (see `MemBounds`). Data-segment init and
+    // memory.{size,grow} are the remaining documented follow-ons.
     let form_ea = |words: &mut Vec<u32>,
                    stack: &mut Vec<Val>,
                    addr: Reg,
                    offset: u32,
                    size_log2: u32|
      -> Result<(Reg, Option<u32>), SelectError> {
+        // #865: prove the access in-bounds (or trap) BEFORE clobbering any
+        // register — `addr` is still intact here.
+        bounds_check(words, stack, addr, offset, size_log2)?;
         // The address operand is popped; its register is now free. Allocate the
         // EA temp against the CURRENT live stack (addr already removed).
         let ea = alloc_temp(stack)?;

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -1831,6 +1831,7 @@ mod tests {
             arg_counts,
             result_counts,
             &[],
+            MemBounds::Unchecked,
         )
     }
 
@@ -1927,8 +1928,106 @@ mod tests {
             &[0],    // 0 args
             &[1],    // 1 result
             &[true], // ...which is a float
+            MemBounds::Unchecked,
         );
         assert!(r.is_err(), "float-returning callee must loud-decline");
+    }
+
+    // --- #865: software bounds check ---
+
+    fn sel_mem(ops: &[WasmOp], num_params: u32, bounds: MemBounds) -> Vec<u32> {
+        let (w, _) =
+            select_typed_cf_calls(ops, num_params, &[], &[], &[], 0, &[], &[], &[], bounds)
+                .unwrap();
+        w
+    }
+
+    #[test]
+    fn software_bounds_guards_i32_load_exact_sequence() {
+        // (memory 1) i32.load: K = 65536 - 0 - 4 = 65532; the check must
+        // precede the dereference. Pinned against `llvm-objdump` ground truth:
+        //   mov w9,#0xfffc; cmp w0,w9; b.ls +2; brk #0;
+        //   add x9,x28,w0,uxtw; ldr w9,[x9]; mov x0,x9; ret
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32Load {
+                offset: 0,
+                align: 2,
+            },
+            WasmOp::End,
+        ];
+        let w = sel_mem(&ops, 1, MemBounds::Software { limit_bytes: 65536 });
+        assert_eq!(
+            w,
+            vec![
+                0x529F_FF89, // mov w9, #65532
+                enc::cmp(0, 9),
+                enc::bcond(Cond::Ls, 2),
+                enc::brk(0),
+                enc::add_ext_uxtw(9, LINMEM_BASE, 0),
+                0xB940_0129, // ldr w9, [x9]
+                enc::mov_reg64(0, 9),
+                enc::ret(),
+            ]
+        );
+    }
+
+    #[test]
+    fn software_bounds_accounts_offset_and_width() {
+        // i32.load offset=65532 with limit 65536: K = 65536 - 65532 - 4 = 0 —
+        // only addr 0 is in bounds (bytes 65532..65535). The compare constant
+        // must be 0, not 65532 (offset+width accounting, the at-limit edge).
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32Load {
+                offset: 65532,
+                align: 2,
+            },
+            WasmOp::End,
+        ];
+        let w = sel_mem(&ops, 1, MemBounds::Software { limit_bytes: 65536 });
+        assert_eq!(w[0], enc::mov_imm32(9, 0)[0], "compare constant must be 0");
+        assert!(w.contains(&enc::brk(0)));
+    }
+
+    #[test]
+    fn software_bounds_offset_past_limit_always_traps() {
+        // offset + size > limit: NO i32 address is in bounds — an
+        // unconditional brk precedes the (dead) access.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32Load {
+                offset: 70000,
+                align: 2,
+            },
+            WasmOp::End,
+        ];
+        let w = sel_mem(&ops, 1, MemBounds::Software { limit_bytes: 65536 });
+        assert_eq!(w[0], enc::brk(0));
+    }
+
+    #[test]
+    fn unchecked_mode_emits_no_trap_check() {
+        // The explicit opt-out stays byte-identical to the pre-#865 lowering.
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32Load {
+                offset: 0,
+                align: 2,
+            },
+            WasmOp::End,
+        ];
+        let w = sel_mem(&ops, 1, MemBounds::Unchecked);
+        assert_eq!(
+            w,
+            vec![
+                enc::add_ext_uxtw(9, LINMEM_BASE, 0),
+                0xB940_0129, // ldr w9, [x9]
+                enc::mov_reg64(0, 9),
+                enc::ret(),
+            ]
+        );
+        assert!(!w.contains(&enc::brk(0)));
     }
 
     #[test]

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -654,7 +654,7 @@ fn main() -> Result<()> {
             // precedence; `--bounds-check` is the legacy alias and emits a
             // single-line deprecation notice when used.
             let resolved_safety_bounds =
-                resolve_safety_bounds(safety_bounds.as_deref(), bounds_check)?;
+                resolve_safety_bounds(safety_bounds.as_deref(), bounds_check, &backend)?;
 
             // Resolve the CycloneDX SBOM destination. `--sbom` with no value
             // means "next to the ELF" (`<output>.cdx.json`); `--sbom PATH`
@@ -1133,8 +1133,9 @@ fn maybe_run_loom(enabled: bool, wasm_bytes: Vec<u8>) -> Result<Vec<u8>> {
 fn resolve_safety_bounds(
     safety_bounds: Option<&str>,
     legacy_bounds_check: bool,
+    backend: &str,
 ) -> Result<SafetyBounds> {
-    if let Some(v) = safety_bounds {
+    let resolved = if let Some(v) = safety_bounds {
         let parsed = SafetyBounds::parse(v).map_err(|e| anyhow::anyhow!(e))?;
         if legacy_bounds_check {
             eprintln!(
@@ -1142,13 +1143,34 @@ fn resolve_safety_bounds(
                 parsed.as_str()
             );
         }
-        return Ok(parsed);
-    }
-    if legacy_bounds_check {
+        parsed
+    } else if legacy_bounds_check {
         eprintln!("warning: --bounds-check is deprecated; use --safety-bounds=software instead");
-        return Ok(SafetyBounds::Software);
+        SafetyBounds::Software
+    } else if backend == "aarch64" {
+        // #865: the aarch64 DEFAULT is `software` — enforce, don't hope. The
+        // v0.51.0 lowering emitted no bounds check at all, so the flag-absent
+        // path was the silent-unsafe path (OOB reads/writes up to 4 GiB past
+        // the guest memory where wasmtime traps). Unchecked output now requires
+        // the explicit `--safety-bounds none` opt-out.
+        SafetyBounds::Software
+    } else {
+        SafetyBounds::None
+    };
+    // #865: mask/mpu are NOT implemented on aarch64 — in v0.51.0 they were
+    // silently accepted and produced byte-identical UNCHECKED output (the
+    // "flag exists but doesn't enforce" class, cf. #651). Hard-error instead.
+    if backend == "aarch64" && matches!(resolved, SafetyBounds::Mask | SafetyBounds::Mpu) {
+        anyhow::bail!(
+            "--safety-bounds {} is not implemented on the aarch64 backend — \
+             refusing to silently emit UNCHECKED memory accesses (#865). Use \
+             --safety-bounds software (the default: per-access bounds checks \
+             that trap out-of-bounds) or --safety-bounds none (explicit \
+             unchecked opt-out).",
+            resolved.as_str()
+        );
     }
-    Ok(SafetyBounds::None)
+    Ok(resolved)
 }
 
 /// Emit the `safety-manifest.json` sidecar when any safety knob is active.
@@ -1541,6 +1563,11 @@ fn compile_command(
     // #758: set when the single-function compile path decodes a module carrying
     // active data segments — the single-func cortex-m builder can't ship them.
     let mut single_func_has_data_segments = false;
+    // #865: the module's declared minimum linear-memory size (memory 0, bytes).
+    // The single-function path previously never threaded memory context into
+    // the config; the aarch64 software bounds check needs the real limit (a 0
+    // limit would make every access an always-trap for a `(memory 1)` module).
+    let mut single_func_linear_memory_bytes: u32 = 0;
     let mut current_func_block_arity: Vec<(u8, u8)> = Vec::new(); // #509: value-carrying branches
     // VCR-PERF-002 Phase 1 (#494): loom `wsc.facts` premises — whole-module
     // table + this function's slice. Threaded to the CompileConfig; NOT yet
@@ -1602,6 +1629,13 @@ fn compile_command(
             // this path would silently read zeros. Record so the cortex-m call
             // below loud-declines rather than emit that silent miscompile.
             single_func_has_data_segments = !module.data_segments.is_empty();
+            // #865: capture memory 0's declared minimum size for the aarch64
+            // software bounds check (pages × 64 KiB).
+            single_func_linear_memory_bytes = module
+                .memories
+                .first()
+                .map(|m| m.initial_bytes())
+                .unwrap_or(0);
             let module_func_params_i64 = module.func_params_i64;
             let module_func_arg_counts = module.func_arg_counts;
             func_params_f32_all = module.func_params_f32.clone();
@@ -1824,6 +1858,17 @@ fn compile_command(
         // reserved stack size under --stack-layout=low; default = 0x2000_0100
         // (byte-identical).
         linmem_base: stack_layout.optimized_linmem_base(),
+        // #865: thread the module's declared memory limit so the aarch64
+        // software bounds check compares against the REAL size. Scoped to the
+        // aarch64 backend: the ARM/RV32 single-function paths never consumed
+        // this field (it defaulted to 0), and widening it here could move
+        // frozen ARM anchor bytes — those paths derive memory context in
+        // `compile_all_exports` instead.
+        linear_memory_bytes: if backend.name() == "aarch64" {
+            single_func_linear_memory_bytes
+        } else {
+            0
+        },
         ..CompileConfig::default()
     };
 
@@ -1881,11 +1926,16 @@ fn compile_command(
     file.write_all(&elf_data)
         .context("Failed to write ELF data")?;
 
-    // Phase 1: write the safety-manifest sidecar whenever any safety knob
-    // is active. Single-function path uses 0 for linear-memory-bytes because
-    // the WASM was supplied as a raw function-body slice — `compile_all_exports`
-    // has the module context and threads through the real value.
-    maybe_emit_safety_manifest(&output, target_spec, safety_bounds, 0)?;
+    // Phase 1: write the safety-manifest sidecar whenever any safety knob is
+    // active. #865: the single-function path now records the module's declared
+    // memory-0 minimum (it previously hardcoded 0; the demo path, which has no
+    // input module, still reports 0).
+    maybe_emit_safety_manifest(
+        &output,
+        target_spec,
+        safety_bounds,
+        single_func_linear_memory_bytes,
+    )?;
 
     // Emit a CycloneDX SBOM when requested. Only possible when synth compiled
     // an actual WASM module (not a built-in demo, which has no input file).

--- a/scripts/repro/aarch64_bounds_865_differential.py
+++ b/scripts/repro/aarch64_bounds_865_differential.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""#865 — aarch64 linear-memory BOUNDS differential (gale's OOB table).
+
+gale (#865): the v0.51.0 aarch64 lowering emitted NO bounds check and
+`--safety-bounds` was a silent no-op — `none|software|mask|mpu` produced
+byte-identical objects, and a `(memory 1)` guest could read/write up to
+4 GiB past its linear memory (the address is zero-extended, `uxtw`) where
+wasmtime traps. This gate reproduces gale's executed table and pins the fix:
+
+1. EXECUTION (unicorn, `(memory 1)` = 64 KiB, host memory beyond the limit
+   poisoned with a sentinel):
+     - addr 65532 (in-bounds)      → same value as wasmtime
+     - addr 65536 / 100000 / -1   → must TRAP (`brk` = UC_ERR_EXCEPTION)
+       exactly where wasmtime traps. Pre-fix these return host garbage
+       (the poison / an unmapped-fault, NOT a brk) → RED.
+   Width + memarg-offset accounting is pinned too: a 4-byte load at 65533
+   and an offset=65532 load at addr 4 both straddle the limit → trap;
+   a 1-byte load at 65535 is the last in-bounds byte → value.
+   The STORE form must trap OOB as well (the arbitrary-write primitive).
+2. MODES now DIFFER (the byte-identical-md5 symptom is gone):
+     - md5(--safety-bounds none) != md5(--safety-bounds software)
+     - flag ABSENT == software (the default ENFORCES — the silent path is
+       the checked path)
+     - `none` executed at 65536 does NOT brk (the opt-out is real and
+       distinct, reads the poison sentinel)
+     - mask / mpu → the compile HARD-ERRORS mentioning #865 (never again
+       a silently-accepted no-op mode).
+3. The SINGLE-FUNCTION path (`-n f`, gale's exact command) threads the real
+   memory limit: in-bounds returns the value (a 0 limit would always-trap),
+   OOB traps.
+
+Trap classification is STRICT to stay non-vacuous: only `brk`
+(UC_ERR_EXCEPTION) counts as a WASM trap. A returned value or an
+unmapped-memory fault (what the unchecked pre-fix code produces for -1)
+counts as the miscompile it is.
+
+Runs on any host (unicorn emulates A64). Needs wasmtime + unicorn +
+pyelftools:
+  SYNTH=<target>/debug/synth python scripts/repro/aarch64_bounds_865_differential.py
+"""
+
+import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM64, UC_ERR_EXCEPTION, UC_MODE_ARM, Uc, UcError
+from unicorn.arm64_const import (
+    UC_ARM64_REG_LR,
+    UC_ARM64_REG_SP,
+    UC_ARM64_REG_W0,
+    UC_ARM64_REG_X0,
+    UC_ARM64_REG_X1,
+    UC_ARM64_REG_X28,
+)
+
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+WAT = """(module
+  (memory 1)
+  (func (export "ld")  (param i32) (result i32) (i32.load    (local.get 0)))
+  (func (export "ld8") (param i32) (result i32) (i32.load8_u (local.get 0)))
+  (func (export "ldo") (param i32) (result i32)
+        (i32.load offset=65532 (local.get 0)))
+  (func (export "st")  (param i32 i32)
+        (i32.store (local.get 0) (local.get 1)))
+)
+"""
+
+# gale's exact single-function repro module (#865).
+WAT_SINGLE = """(module (memory 1)
+  (func (export "f") (param i32) (result i32) (i32.load (local.get 0))))
+"""
+
+# unicorn address map. LINMEM is 64 KiB of guest memory; MAPPED extends past
+# the limit and is POISONED so an unchecked OOB read visibly returns garbage
+# (gale's "reads host memory" row) instead of a lucky zero.
+CODE, STK, RET = 0x100000, 0x400000, 0x500000
+LINMEM = 0x1000000
+LIMIT = 0x10000  # (memory 1) = 64 KiB
+MAPPED = 0x30000  # 192 KiB mapped: covers addr 100000 (0x186A0) with poison
+POISON = 0xEE
+M32 = (1 << 32) - 1
+
+# gale's table + width/offset edges: (fn, args, kind) where kind is
+# "value" (must equal wasmtime's value) or "trap" (wasmtime traps; synth
+# must brk). The wasmtime side is EXECUTED, not assumed — a "trap" row
+# aborts if wasmtime unexpectedly succeeds.
+TABLE = [
+    ("ld", [65532], "value"),  # last in-bounds word
+    ("ld", [65536], "trap"),  # 1 byte past — gale row 2
+    ("ld", [100000], "trap"),  # gale row 3
+    ("ld", [0xFFFFFFFF], "trap"),  # gale row 4 (uxtw reaches +4GiB-1)
+    ("ld", [65533], "trap"),  # width: 4-byte access straddles the limit
+    ("ld", [0], "value"),
+    ("ld8", [65535], "value"),  # width: last single in-bounds byte
+    ("ld8", [65536], "trap"),
+    ("ldo", [0], "value"),  # memarg offset: 65532..65535 in-bounds
+    ("ldo", [4], "trap"),  # memarg offset: 65536.. straddles
+    ("ldo", [0xFFFFFFFF], "trap"),  # offset + uxtw(-1) far past the limit
+    ("st", [65532, 0x11223344], "value"),  # in-bounds write (checked below)
+    ("st", [65536, 0xDEAD], "trap"),  # the arbitrary-write primitive
+    ("st", [0xFFFFFFFF, 0xDEAD], "trap"),
+]
+
+
+def run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+def compile_synth(wat_path, out, extra):
+    return run([SYNTH, "compile", str(wat_path), "-o", out, "-b", "aarch64"] + extra)
+
+
+def load_elf(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = text.data(), text["sh_addr"]
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            for sy in sec.iter_symbols():
+                if sy.name:
+                    syms[sy.name] = sy["st_value"] & ~1
+    return code, base, syms
+
+
+def new_uc(code):
+    mu = Uc(UC_ARCH_ARM64, UC_MODE_ARM)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(STK - 0x10000, 0x20000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_map(LINMEM, MAPPED)
+    # Poison everything past the guest limit: an unchecked OOB read returns
+    # 0xEEEEEEEE, never a false-negative zero.
+    mu.mem_write(LINMEM + LIMIT, bytes([POISON]) * (MAPPED - LIMIT))
+    mu.mem_write(CODE, code)
+    return mu
+
+
+def call(mu, base, faddr, args):
+    """Returns ("value", v) | ("trap", None) | ("fault", errno).
+
+    Only UC_ERR_EXCEPTION (the `brk` the bounds check emits) counts as a
+    trap; an unmapped-access fault is the UNCHECKED dereference escaping
+    (pre-fix behavior for addr -1) and is reported distinctly.
+    """
+    mu.reg_write(UC_ARM64_REG_SP, STK)
+    mu.reg_write(UC_ARM64_REG_LR, RET)
+    mu.reg_write(UC_ARM64_REG_X28, LINMEM)
+    for reg, v in zip([UC_ARM64_REG_X0, UC_ARM64_REG_X1], args):
+        mu.reg_write(reg, v & M32)
+    try:
+        mu.emu_start(CODE + (faddr - base), RET, count=4000)
+    except UcError as e:
+        if e.errno == UC_ERR_EXCEPTION:
+            return ("trap", None)
+        return ("fault", e.errno)
+    return ("value", mu.reg_read(UC_ARM64_REG_W0) & M32)
+
+
+def wasmtime_run(wat_text, fn, args):
+    """Returns ("value", v) | ("trap", None) — fresh instance per call."""
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, wat_text)
+    store = wasmtime.Store(engine)
+    exports = wasmtime.Instance(store, module, []).exports(store)
+    sargs = [a - (1 << 32) if a & (1 << 31) else a for a in args]
+    try:
+        r = exports[fn](store, *sargs)
+    except Exception:
+        return ("trap", None)
+    return ("value", (r or 0) & M32)
+
+
+def main():
+    fails = 0
+
+    def check(ok, msg):
+        nonlocal fails
+        if not ok:
+            fails += 1
+            print(f"BUG {msg}")
+        else:
+            print(f"ok  {msg}")
+
+    tmp = Path(tempfile.mkdtemp(prefix="a64_bounds_865_"))
+    wat = tmp / "mem.wat"
+    wat.write_text(WAT)
+    wat_single = tmp / "single.wat"
+    wat_single.write_text(WAT_SINGLE)
+
+    # --- 2a. mode surface: mask/mpu must HARD-ERROR on -b aarch64 ---
+    for mode in ("mask", "mpu"):
+        r = compile_synth(
+            wat, str(tmp / f"m_{mode}.o"), ["--all-exports", "--safety-bounds", mode]
+        )
+        check(
+            r.returncode != 0 and "#865" in (r.stderr + r.stdout),
+            f"--safety-bounds {mode} hard-errors on aarch64 (was a silent no-op)",
+        )
+
+    # --- 2b. none / software / default must compile; none != software ---
+    objs = {}
+    for mode, extra in (
+        ("none", ["--safety-bounds", "none"]),
+        ("software", ["--safety-bounds", "software"]),
+        ("default", []),
+    ):
+        out = str(tmp / f"m_{mode}.o")
+        r = compile_synth(wat, out, ["--all-exports"] + extra)
+        if r.returncode != 0:
+            print(f"BUG compile ({mode}) failed: {r.stderr.strip()}")
+            sys.exit(1)
+        objs[mode] = hashlib.md5(Path(out).read_bytes()).hexdigest()
+    check(
+        objs["none"] != objs["software"],
+        f"modes DIFFER: md5(none)={objs['none'][:12]} != "
+        f"md5(software)={objs['software'][:12]} (gale's byte-identical symptom gone)",
+    )
+    check(
+        objs["default"] == objs["software"],
+        "flag-absent DEFAULT == software (the default enforces)",
+    )
+
+    # --- 1. gale's executed table on the DEFAULT-compiled module ---
+    code, base, syms = load_elf(str(tmp / "m_default.o"))
+    for fn, args, kind in TABLE:
+        if fn not in syms:
+            check(False, f"{fn}: symbol missing (declined?)")
+            continue
+        wt = (
+            ("trap", None)
+            if kind == "trap"
+            else wasmtime_run(WAT, fn, args)
+        )
+        if kind == "trap":
+            # never assume: confirm wasmtime REALLY traps this row
+            wt_actual = wasmtime_run(WAT, fn, args)
+            if wt_actual[0] != "trap":
+                check(False, f"{fn}{args}: expected wasmtime trap, got {wt_actual}")
+                continue
+        got = call(new_uc(code), base, syms[fn], args)
+        if fn == "st" and kind == "value":
+            # a void in-bounds store: it must complete (no trap/fault) and
+            # the round-trip below proves the write landed.
+            check(got[0] == "value", f"st{args}: in-bounds store completes, got {got}")
+            continue
+        if kind == "value":
+            check(
+                got == wt,
+                f"{fn}({args[0]:#x}): in-bounds value A64={got} wasmtime={wt}",
+            )
+        else:
+            check(
+                got[0] == "trap",
+                f"{fn}({args[0]:#x}): OOB must brk-trap (wasmtime traps), A64={got}",
+            )
+
+    # in-bounds store→load round-trip on ONE instance (write really landed)
+    mu = new_uc(code)
+    call(mu, base, syms["st"], [65532, 0x11223344])
+    got = call(mu, base, syms["ld"], [65532])
+    check(
+        got == ("value", 0x11223344),
+        f"st;ld round-trip at 65532 = 0x11223344, got {got}",
+    )
+
+    # --- 2c. the `none` opt-out is real: 65536 reads the poison, no brk ---
+    code_n, base_n, syms_n = load_elf(str(tmp / "m_none.o"))
+    got = call(new_uc(code_n), base_n, syms_n["ld"], [65536])
+    check(
+        got == ("value", 0xEEEEEEEE),
+        f"--safety-bounds none at 65536 reads unchecked host memory "
+        f"(documented opt-out), got {got}",
+    )
+
+    # --- 3. gale's exact single-function command threads the REAL limit ---
+    r = compile_synth(
+        wat_single, str(tmp / "single.o"), ["-n", "f", "--relocatable"]
+    )
+    if r.returncode != 0:
+        check(False, f"single-func compile failed: {r.stderr.strip()}")
+    else:
+        code_s, base_s, syms_s = load_elf(str(tmp / "single.o"))
+        got = call(new_uc(code_s), base_s, syms_s["f"], [65532])
+        check(
+            got == ("value", 0),
+            f"single-func ld(65532) in-bounds (limit=64Ki, not 0), got {got}",
+        )
+        for addr in (65536, 100000, 0xFFFFFFFF):
+            got = call(new_uc(code_s), base_s, syms_s["f"], [addr])
+            check(got[0] == "trap", f"single-func ld({addr:#x}) traps, got {got}")
+
+    print(
+        "\nRESULT:",
+        "PASS — aarch64 --safety-bounds enforces (#865: OOB traps, modes differ)"
+        if not fails
+        else f"FAIL ({fails})",
+    )
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/aarch64_mem_851_differential.py
+++ b/scripts/repro/aarch64_mem_851_differential.py
@@ -18,10 +18,12 @@ RED-first: before the #851 lowering every memory op loud-declines
 (`unsupported wasm op for aarch64 subset`), so `synth compile` fails and the
 symbols are absent → this gate is RED. After the lowering it is GREEN.
 
-SOUNDNESS / honest frontier: the lowering computes the WASM effective address
-and dereferences it — it does NOT bounds-check. All inputs here are IN-BOUNDS;
-out-of-bounds trap, data-segment init, and memory.{size,grow} are the documented
-follow-on frontier (the host-native subset has no memory-size convention yet).
+All inputs here are IN-BOUNDS — this gate pins the VALUE semantics of the
+lowering (and must stay green unchanged now that #865 bounds checks are on by
+default: an in-bounds access passes the check and behaves identically).
+Out-of-bounds TRAP semantics are gated separately by
+`aarch64_bounds_865_differential.py`; data-segment init and memory.{size,grow}
+remain the documented follow-on frontier.
 
 Runs on any host (unicorn emulates A64). Needs wasmtime + unicorn + pyelftools:
   SYNTH=<target>/debug/synth python scripts/repro/aarch64_mem_851_differential.py


### PR DESCRIPTION
Closes #865.

## What

The v0.51.0 aarch64 lowering (#851) emitted NO bounds check and `--safety-bounds` was a silent no-op (`none|software|mask|mpu` byte-identical): with `uxtw` zero-extension a guest address `0xFFFFFFFF` reached `x28 + 4 GiB − 1` — OOB read = disclosure, OOB store = arbitrary write, where wasmtime traps.

- **`software` emits a per-access check**: `mov w_k, #K; cmp w_addr, w_k; b.ls +2; brk #0` with `K = limit − memarg.offset − access_size` folded at compile time — one unsigned compare proves `uxtw(addr) + offset + size ≤ limit` BEFORE the dereference (width + memarg-offset accounting; `offset + size > limit` ⇒ unconditional trap). Static limit is sound: `memory.grow` is not lowered on this backend.
- **Default on `-b aarch64` is now `software`** — the flag-absent path was the silent-unsafe path. Unchecked output requires the explicit `--safety-bounds none` opt-out (byte-identical to v0.51.0 output).
- **`mask`/`mpu` HARD-ERROR** on `-b aarch64` (CLI + backend, defense in depth) instead of silently degrading to unchecked.
- Single-function path (`-n`) threads the module's real declared memory limit (was hardcoded 0) into the config + safety manifest.

## Verification (re-run from scratch, freshly built binaries)

**RED-first demonstrated** — the new gate `scripts/repro/aarch64_bounds_865_differential.py` against a binary built from `origin/main` (62d45bf, pre-fix): **FAIL (15), exit 1** — `ld(65536)`/`ld(100000)` return the poison sentinel `0xEEEEEEEE`, `ld(-1)` escapes as an unmapped fault, OOB stores land, all four modes md5-identical. Against this branch's binary: **PASS (25/25), exit 0** — gale's exact table (65532 in-bounds ≡ wasmtime; 65536 / 100000 / 0xFFFFFFFF `brk`-trap exactly where wasmtime traps; strict classification: only `brk` counts, a fault fails), `md5(none) ≠ md5(software)`, default ≡ software, mask/mpu rejected with #865 in the message, `none` opt-out real (reads poison, no brk), single-func path traps OOB / values in-bounds.

**Regressions** (all with the fresh binary):
- `aarch64_mem_851_differential.py` 38/38 (in-bounds values UNCHANGED), `aarch64_locals_851` 17/17, `aarch64_ctrlflow_851`, `aarch64_divrem_851` 179 cases, `aarch64_calls_851` — all PASS
- `aarch64_add_538` / `m2_538` / `m3_floats` / `m4_trunc_minmax` / `cf_538` / `m2_decline` — all PASS
- `./scripts/repro/aarch64_matrix.sh`: **35 ops, 91 native checks, PASS** (native arm64 + wasmtime)
- `cargo test -p synth-cli --test frozen_codegen_bytes`: **10/10** (ARM anchors unmoved — separate backend)
- `cargo test --workspace`: **2523 passed, 0 failed**
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean

**CI**: the bounds differential is wired into the `aarch64-oracle` job. CHANGELOG `[Unreleased]` entry included (its "RED (15 failures)" claim independently reproduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L