### PR TITLE
Make the gates real: CI-wire the gpio-thin + rv32-boot oracles (#879), claim-pin template prose (#880)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,7 +574,8 @@ jobs:
         with:
           python-version: "3.x"
       - name: Install emulation deps
-        run: pip install wasmtime unicorn pyelftools
+        # capstone: the #846 gpio-thin oracle's mask census disassembles .text
+        run: pip install wasmtime unicorn pyelftools capstone
       - name: Run unreachable trap oracle (#665, thumb2 + rv32)
         run: SYNTH=./target/debug/synth python scripts/repro/unreachable_665_differential.py
       - name: Run rem_s trap-table oracle (#666, rv32)
@@ -589,6 +590,20 @@ jobs:
       # elision never fires unsoundly (red-tested at land time).
       - name: Run i32 shift-mask oracle with mask elision ON (#686)
         run: SYNTH_SHIFT_MASK_ELIDE=1 SYNTH=./target/debug/synth python scripts/repro/i32_shift_mask_682_differential.py
+      # #846/#879: gale's REAL gpio-thin driver (pinned loom.wasm, never a
+      # synthetic) under the default-ON mask elision — BOTH halves of the
+      # v0.50.1 headline claim: (a) .text shrinks and the redundant mod-32
+      # masks strictly drop, (b) 75 mmio (addr,value) traces + returns are
+      # bit-identical vs wasmtime across a pin sweep INCLUDING pin >= 32 (the
+      # boundary an unsound elision would corrupt). #879: this gate existed
+      # for two releases but was never CI-wired. The grep asserts the
+      # NON-ZERO check count from the script's machine-readable summary —
+      # exit 0 alone is not trusted (the "0 ops accepted PASS" lesson).
+      - name: Run gpio-thin size + mmio execution oracle (#846/#879, cortex-m3)
+        run: |
+          set -o pipefail
+          SYNTH=./target/debug/synth python scripts/repro/gpio_thin_846_differential.py | tee gpio846.out
+          grep -q "^#846 CHECKS=75/75" gpio846.out
       # #752: the software bounds guard must trap the top-of-address-space
       # wraparound class — the retired shape ADD-computed the end address
       # mod 2^32, so `addr >= 2^32 - (offset+size-1)` wrapped small, passed
@@ -819,6 +834,18 @@ jobs:
       # needs pyelftools ONLY (no unicorn/wasmtime).
       - name: Run VCR-DEC-001 graph-alloc spike differential (#242, thumb2)
         run: python scripts/repro/vcr_dec_001_graph_alloc_differential.py ./target/debug/synth
+      # #798/#879: the RV32 active-data-segment FULL-BOOT oracle — found
+      # un-wired in the same #879 audit as the gpio gate. clang+lld build a
+      # bare-metal riscv32 firmware from synth's object + generated startup/
+      # linker script; unicorn boots it FROM _reset so the record-copy loop
+      # (declaration order => later-wins) is what initializes linear memory;
+      # result vs wasmtime. The script LOUD-fails on missing tools (never a
+      # skip) and this wiring is pinned in claims.yaml
+      # (SYNTH-MATRIX-RV32-DATA-SHIP).
+      - name: Install clang + lld (riscv32 bare-metal, #798 boot oracle)
+        run: sudo apt-get update && sudo apt-get install -y clang lld
+      - name: Run RV32 data-segment full-boot oracle (#798, rv32imac)
+        run: SYNTH=./target/debug/synth python scripts/repro/rv32_data_798_boot_differential.py
 
   fact-spec-oracle:
     name: fact-spec elision oracle (#494 phases 2 + 2b + 3+ + bounds)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The gpio-thin gate is now a gate (#879).** `gpio_thin_846_differential.py`
+  — the check behind the v0.50.1 (534→506 B) and v0.52.0 (506→502 B) headline
+  size claims, and the only harness that executes gale's real driver across a
+  pin sweep *including pin ≥ 32* (the mod-32 boundary an unsound shift-mask
+  elision would corrupt) — was never wired into CI. It now runs in the ARM
+  trap-semantics oracle job (capstone added to that job's deps for the mask
+  census), the CI step greps the script's machine-readable `#846 CHECKS=75/75`
+  summary so a vacuous exit-0 cannot pass, and the script itself hard-fails on
+  zero/short check sweeps, zero mmio trace events, or missing import call
+  sites. The same audit found and wired the second shelfware oracle:
+  `rv32_data_798_boot_differential.py` (the #798 full-boot gate). Both wirings
+  are pinned in `claims.yaml` so they cannot be silently un-wired again.
+- **Feature-matrix template prose is now claim-gated (#880).** The doc-honesty
+  gate verified the matrix against its *render*, never its *content* — wrong
+  template prose reproduced faithfully and stayed green (the v0.51 "div/rem
+  declined" / v0.52 "OOB-trap is a follow-on" cold-read defects). The
+  template's load-bearing capability phrases are now pinned verbatim in
+  `claims.yaml`, each bound to the oracle that executes the capability *and*
+  to that oracle's CI wiring (red-first verified: falsifying a pinned phrase
+  reddens `claim-check` even after regenerating the render). The same audit
+  fixed two live defects of exactly this class: the matrix still said "RV32
+  warns loudly on dropped initializer bytes" four releases after #798 shipped
+  the segments with a hard-error read-back, and still listed WCET "calls" as a
+  blanket loud-decline two releases after phase-3 inter-procedural
+  composition. Honest limit: verbatim pins catch drift of pinned phrases, not
+  brand-new false prose — that residual stays on review.
+
 ## [0.52.0] - 2026-07-29
 
 **"Enforce what we promise."** Every backend in this release stopped

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 &nbsp;
 
-Synth is an ahead-of-time compiler from WebAssembly to ARM Cortex-M machine code, with additional backends for ARM Cortex-R5 (A32, `--target cortex-r5`), RISC-V RV32IMAC (qemu_riscv32 / ESP32-C3), and AArch64 (host-native, `-b aarch64`). It produces bare-metal ELF binaries targeting embedded microcontrollers. The compiler handles i32, i64 (via register pairs), scalar f32/f64 via VFP on FPU targets (f32 complete v0.41, f64 complete v0.43 — #369 closed; open residuals tracked in #782), control flow, and memory operations; any construct without a lowering declines loudly rather than miscompiling (the #369/#554 gate class). Mechanized correctness proofs in [Rocq](https://rocq-prover.org/) cover the i32 and i64 instruction selection with result-correspondence (T1) proofs; float/SIMD selection has existence-only (T2) proofs.
+Synth is an ahead-of-time compiler from WebAssembly to ARM Cortex-M machine code, with additional backends for ARM Cortex-R5 (A32, `--target cortex-r5`), RISC-V RV32IMAC (qemu_riscv32 / ESP32-C3), and AArch64 (host-native, `-b aarch64`). It produces bare-metal ELF binaries targeting embedded microcontrollers. The compiler handles i32, i64 (via register pairs), scalar f32/f64 via VFP on FPU targets (f32 complete v0.41, f64 complete v0.43 — #369 closed; the remaining falcon `--relocatable cortex-m7dp` tail is tracked in #881), control flow, and memory operations; any construct without a lowering declines loudly rather than miscompiling (the #369/#554 gate class). Mechanized correctness proofs in [Rocq](https://rocq-prover.org/) cover the i32 and i64 instruction selection with result-correspondence (T1) proofs; float/SIMD selection has existence-only (T2) proofs.
 
 **This is pre-release software.** Generated code is validated by unit tests, Renode/QEMU emulation, execution differentials against wasmtime, and — for specific fixtures — cycle- and correctness-gated runs on real Cortex-M silicon (NUCLEO-G474RE, STM32F100, via the gale test loop). Broad hardware validation is still missing. Use at your own risk.
 
@@ -106,7 +106,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 |----------|--------|-------|
 | i32 arithmetic, bitwise, comparison, shift/rotate | **Tested** | Full Rocq T1 proofs, Renode execution tests |
 | i64 (register pairs): arithmetic, shifts, rotates, div/rem, compare | **Tested** | full pair lowering — right shifts fixed v0.28.0 (#599), rot/div/rem v0.30.1 (#610), A32 completeness v0.30.2 (#615); differential vs wasmtime |
-| Scalar f32/f64 via VFP on FPU targets | **Implemented** | Complete f32 (v0.41) + f64 (v0.43, #369 closed) incl. AAPCS-VFP marshalling; execution differentials vs wasmtime; non-FPU targets loud-reject; residuals: `trunc_sat` not decoded (loud skip) + a pressure-dependent f32 class (#782) |
+| Scalar f32/f64 via VFP on FPU targets | **Implemented** | Complete f32 (v0.41) + f64 (v0.43, #369 closed) incl. AAPCS-VFP marshalling; execution differentials vs wasmtime; non-FPU targets loud-reject; residuals: the falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail (#881; `trunc_sat` shipped v0.49, #782 closed) |
 | WASM SIMD via ARM Helium MVE | Experimental | Cortex-M55 only; encoding untested on hardware |
 | Control flow (block, loop, if/else, br, br_table) | **Tested** | Renode execution tests, complex test suite |
 | Function calls (direct, indirect) | Implemented | `call_indirect` traps per WASM §4.4.8 (OOB index, type mismatch, null slot); self-contained `--cortex-m` dispatch via a PC-relative flash funcref table since v0.47 (#275), execution-differential-gated vs wasmtime |
@@ -124,7 +124,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 - **Narrow hardware coverage** — silicon validation is fixture-scoped (gale's NUCLEO-G474RE / STM32F100 cycle and correctness gates); there is no broad board matrix
 - **No multi-memory** — fused components from meld need single-memory mode
 - **No WASI on embedded** — kiln-builtins crate doesn't exist yet
-- **No component model execution** — components compile but can't run without kiln-builtins; `cabi_realloc` binds natively (synthesized in-module arena allocator) on self-contained dissolves since v0.47, with #418 still open for the real dissolved fixture
+- **No component model execution** — components compile but can't run without kiln-builtins; `cabi_realloc` binds natively (synthesized in-module arena allocator) on self-contained dissolves since v0.47 (#418 closed)
 - **Spill-on-exhaustion is opt-in** — Belady spilling is default-on (v0.24.0, VCR-RA-001), but replacing the register-exhaustion decline with allocation-time spilling (`SYNTH_SPILL_ON_EXHAUST`, #580) is held for silicon numbers
 - **No tail call optimization** — return_call compiles but doesn't optimize the call frame
 - **SIMD/Helium is untested** — MVE instruction encoding implemented but never run on M55 silicon or emulator
@@ -282,7 +282,7 @@ The one-sentence version: moving synth's correctness from *"we patched every bug
 | | `VCR-WASM-001` | Anchor WASM source semantics on WasmCert-Coq | phases 1-3 landed: the i32 integer fragment (19 ops) AND the i64 integer family (22 ops — arithmetic/bitwise/shifts/rotates/eqz/comparisons) transcribed from the same pinned coq9.0-wasm-2.2.0 sources with line-level provenance (`coq/Synth/WASM/WasmCertReference.v`) and proven refined by `exec_wasm_instr` (`WasmCertBridge.v`; op-level for all, executor-level for the wired ops — the 6 i64 arithmetic/bitwise ops are op-level-only, a named residual; lemma count: `artifacts/status.json`); still a hand transcription, the real external dep is nix-feasible, bazel-deferred on three named blockers (unfree CompCert 3.16 in the pin) |
 | **Gate** | `VCR-VER-001` | Success = a previously load-bearing greedy-fix becomes *revertable*, with the full differential bit-identical and cycles equal-or-better | **demonstrated** (implemented; [evidence](scripts/repro/vcr_ver_001_gate.md)): the v0.11.20 reciprocal-mult cost-gate deleted outright (PR #322, bit-identical); the #496 exhaustion decline revertable behind `SYNTH_SPILL_ON_EXHAUST` — red case green, anchors byte-identical, declines 14→8; flip held on a measured i32-shape cycle regression |
 
-Honest open items: the RV32 local-promotion flip is held on a failed no-grow gate (#601); float residuals — `trunc_sat` (0xFC prefix) is not decoded (functions using it loud-skip) and a pressure-dependent f32 class is open (#782); SIMD/Helium is untested on hardware.
+Honest open items: the RV32 local-promotion flip is held on a failed no-grow gate (#601); float residuals — the falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail (#881; `trunc_sat` shipped v0.49); SIMD/Helium is untested on hardware.
 
 **What it buys us:** synth stops being a real-ish compiler held together by oracle-gated patches and becomes a genuinely best-in-class *verified* compiler — and the verified selector DSL is the part that is potentially novel/publishable, not just catching up to Cranelift.
 

--- a/claims.yaml
+++ b/claims.yaml
@@ -766,3 +766,126 @@ claims:
         pattern: 'let \(hi, lo\) = \(at\(ceiling\)\?, at\(0\)\?\);'
         glob: ['crates/synth-backend/src/wcet_loops.rs']
         expect: 1
+
+  # ---------------------------------------------------------------------------
+  # #880 — FEATURE_MATRIX template prose pins. The staleness gate only proves
+  # committed doc == render(template); it cannot see WRONG TEMPLATE PROSE
+  # (v0.51 called shipped aarch64 div/rem/popcnt/calls "not yet"/"declined";
+  # v0.52 called the shipped-and-DEFAULT #865 OOB-trap a "follow-on" — both
+  # caught only by a human cold read at tag time). These claims pin the
+  # template's load-bearing capability phrases VERBATIM and bind each to
+  # independent evidence: the oracle that EXECUTES the capability exists AND
+  # is CI-WIRED (the #879 lesson — an unwired oracle gates nothing), plus a
+  # code anchor where a stable one exists. LIMIT (stated honestly): a
+  # verbatim pin catches DRIFT of a pinned phrase — weakening/rewording a
+  # shipped capability reddens CI and forces a deliberate ledger bump next to
+  # the evidence — but it cannot catch a brand-NEW false claim typed into the
+  # template; that residual stays on review, and on extending this list
+  # whenever a new load-bearing phrase lands.
+  # ---------------------------------------------------------------------------
+  - id: SYNTH-MATRIX-AARCH64-BOUNDS-DEFAULT
+    doc: scripts/templates/feature_matrix.md.tmpl
+    text: "**BOUNDS-CHECKED by default** — an out-of-bounds access traps (`brk`) exactly where wasmtime traps"
+    evidence:
+      - kind: file-exists
+        path: scripts/repro/aarch64_bounds_865_differential.py
+      - kind: count-min                      # the oracle is CI-wired, not shelfware
+        pattern: 'aarch64_bounds_865_differential\.py'
+        glob: ['.github/workflows/ci.yml']
+        min: 1
+      - kind: count-min                      # the enforcing default's code anchor
+        pattern: 'MemBounds::Software'
+        glob: ['crates/synth-backend-aarch64/src/selector.rs']
+        min: 1
+
+  - id: SYNTH-MATRIX-AARCH64-DIVREM-POPCNT
+    doc: scripts/templates/feature_matrix.md.tmpl
+    text: "`div_s/div_u/rem_s/rem_u` (with the ÷0 + INT_MIN/−1 WASM trap guards) and `popcnt` (#851)"
+    evidence:
+      - kind: file-exists
+        path: scripts/repro/aarch64_divrem_851_differential.py
+      - kind: count-min
+        pattern: 'aarch64_divrem_851_differential\.py'
+        glob: ['.github/workflows/ci.yml']
+        min: 1
+
+  - id: SYNTH-MATRIX-CALL-INDIRECT-FLASH-TABLE
+    doc: scripts/templates/feature_matrix.md.tmpl
+    text: "self-contained dispatch is PC-relative via a flash funcref table (v0.47)"
+    evidence:
+      - kind: file-exists
+        path: scripts/repro/call_indirect_275_selfcontained_execution_differential.py
+      - kind: count-min
+        pattern: 'call_indirect_275_selfcontained_execution_differential\.py'
+        glob: ['.github/workflows/ci.yml']
+        min: 1
+
+  - id: SYNTH-MATRIX-TRUNC-SAT
+    doc: scripts/templates/feature_matrix.md.tmpl
+    text: "Decoded and lowered as bare saturating VCVT (§4.3.2: NaN→0, out-of-range saturates, never traps)"
+    evidence:
+      - kind: file-exists
+        path: scripts/repro/trunc_sat_782_differential.py
+      - kind: count-min
+        pattern: 'trunc_sat_782_differential\.py'
+        glob: ['.github/workflows/ci.yml']
+        min: 1
+
+  # The v0.51/v0.52-CLASS defect this lane FIXED in the same PR: the template
+  # still said "RV32 warns loudly on dropped initializer bytes" four releases
+  # after #798 (v0.48) shipped the segments and replaced the warning with a
+  # hard error. The corrected phrase is pinned to the hard-error call site in
+  # the RV32 backend and to the full-boot oracle.
+  - id: SYNTH-MATRIX-RV32-DATA-SHIP
+    doc: scripts/templates/feature_matrix.md.tmpl
+    text: "RV32 ships active data segments as `.wasm_data` records — the emitted blob is read back and any served/runtime disagreement hard-errors the compile (#798, v0.48)"
+    evidence:
+      - kind: count-eq                       # the read-back hard-error in the backend
+        pattern: 'validate_served_image'
+        glob: ['crates/synth-backend-riscv/src/backend.rs']
+        expect: 1
+      - kind: file-exists
+        path: scripts/repro/rv32_data_798_boot_differential.py
+      - kind: count-min                      # #879-class: the boot oracle must be CI-wired
+        pattern: 'rv32_data_798_boot_differential\.py'
+        glob: ['.github/workflows/ci.yml']
+        min: 1
+
+  # Same class, second find of this audit: the WCET decline row still listed
+  # "calls" as a blanket D two releases after phase-3 inter-procedural
+  # composition (v0.48) bounded direct local calls.
+  - id: SYNTH-MATRIX-WCET-COMPOSITION
+    doc: scripts/templates/feature_matrix.md.tmpl
+    text: "`total = own + Σ site-multiplier × callee-total` over direct `BL` calls to local bounded callees (v0.48, phase 3); a declined callee propagates its decline UP"
+    evidence:
+      - kind: file-exists
+        path: crates/synth-backend/src/wcet_compose.rs
+      - kind: file-exists
+        path: crates/synth-backend/src/wcet_recursion.rs
+      - kind: file-exists
+        path: crates/synth-backend/src/wcet_loops.rs
+      - kind: file-exists
+        path: crates/synth-cli/tests/wcet_bound_gate.rs
+      - kind: verbatim                       # the honest residual row stays adjacent
+        text: "Unhinted data-dependent loops, indirect/external calls, tree/mutual recursion, i64 software div/rem, non-M3/M4 cores | D"
+
+  # ---------------------------------------------------------------------------
+  # #879 — the gpio-thin oracle's CI wiring, pinned so it cannot be silently
+  # UN-wired again (it sat un-wired for two releases while its size claim
+  # headlined v0.50.1 and v0.52.0). Pins the script + the pinned real-driver
+  # fixture, capstone in the job's dep install (the mask census disassembles
+  # .text), and the CI-side NON-ZERO check-count assertion (exit 0 alone is
+  # not trusted — the "0 ops accepted PASS" lesson).
+  # ---------------------------------------------------------------------------
+  - id: SYNTH-GPIO-846-ORACLE-CI-WIRED
+    doc: .github/workflows/ci.yml
+    text: "scripts/repro/gpio_thin_846_differential.py"
+    evidence:
+      - kind: file-exists
+        path: scripts/repro/gpio_thin_846_differential.py
+      - kind: file-exists
+        path: scripts/repro/gpio_thin_846.loom.wasm
+      - kind: verbatim
+        text: "pip install wasmtime unicorn pyelftools capstone"
+      - kind: verbatim
+        text: 'grep -q "^#846 CHECKS=75/75" gpio846.out'

--- a/claims.yaml
+++ b/claims.yaml
@@ -334,7 +334,10 @@ claims:
         glob: ['crates/synth-synthesis/src/instruction_selector.rs']
         expect: 1
       - kind: verbatim                       # the honest residual stays adjacent
-        text: "#782"
+        # (was "#782" until the v0.53 #880 audit: #782 closed v0.49–v0.52 and
+        # the README kept citing it as open, saying trunc_sat "not decoded"
+        # two releases after it shipped — the successor residual is #881)
+        text: "#881"
 
   # call_indirect: self-contained dispatch shipped v0.47 (#275 closed) with a
   # red-first execution differential; the README must not regress to either the
@@ -848,6 +851,22 @@ claims:
         path: scripts/repro/rv32_data_798_boot_differential.py
       - kind: count-min                      # #879-class: the boot oracle must be CI-wired
         pattern: 'rv32_data_798_boot_differential\.py'
+        glob: ['.github/workflows/ci.yml']
+        min: 1
+
+  # Multi-memory: the matrix said "D — module-level loud decline" while the
+  # #406 per-memory lowering (N distinct native base regions, execution
+  # differential CI-wired) had been shipping — the v0.51 understatement class.
+  - id: SYNTH-MATRIX-MULTI-MEMORY
+    doc: scripts/templates/feature_matrix.md.tmpl
+    text: "N memories lower to N distinct native base regions on ARM `--relocatable`"
+    evidence:
+      - kind: file-exists
+        path: crates/synth-cli/tests/multi_memory_406.rs
+      - kind: file-exists
+        path: scripts/repro/multi_memory_406_differential.py
+      - kind: count-min
+        pattern: 'multi_memory_406_differential\.py'
         glob: ['.github/workflows/ci.yml']
         min: 1
 

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -79,7 +79,7 @@ see [coq/STATUS.md](../../coq/STATUS.md) for the per-file matrix.
 |-----------|--------|-----------------|
 | SMT translation validation | Y | ordeal (pure-Rust QF_BV) default since v0.27.0; Z3 demoted to a feature-gated differential oracle |
 | Trap-preservation VC (VCR-VER-002) | Y (live classes) | Dropped WASM traps: i32 + i64 div/rem, memory OOB (all widths), `call_indirect`, `unreachable`, float→int trunc |
-| Static-data addressing VC (VCR-VER-003) | Y | Byte-equality of served vs runtime-image static data (the #757 wrong-segment class); spanned accesses, self-contained ROM image; RV32 warns loudly on dropped initializer bytes |
+| Static-data addressing VC (VCR-VER-003) | Y | Byte-equality of served vs runtime-image static data (the #757 wrong-segment class); spanned accesses, self-contained ROM image; RV32 ships active data segments as `.wasm_data` records — the emitted blob is read back and any served/runtime disagreement hard-errors the compile (#798, v0.48) |
 | Proof-carrying specialization (`SYNTH_FACT_SPEC`) | Y (opt-in) | ordeal-certified elisions from loom `wsc.facts` invariants (#494) |
 
 ### WCET (Track D, #778)
@@ -89,7 +89,9 @@ see [coq/STATUS.md](../../coq/STATUS.md) for the per-file matrix.
 | `--emit-wcet` sound per-function cycle bounds | Y | `synth-wcet-v1` sidecar; documented Cortex-M3/M4 worst-case per-op cycles (max over {M3, M4}); sound-critical model constants pinned in `claims.yaml` |
 | Statically-proven const-bound loop bounds | Y | Conservative symbolic walk over the final encoded stream (v0.47); nested-multiplicative |
 | `--wcet-hints` (untrusted hint seam) | Y | Every hint verified against synth's own derived trip count or rejected with a machine reason — never trusted into a bound |
-| Data-dependent loops, calls, i64 software div/rem, non-M3/M4 cores | D | Loud decline with machine reason |
+| Inter-procedural composition (direct call graph) | Y | `total = own + Σ site-multiplier × callee-total` over direct `BL` calls to local bounded callees (v0.48, phase 3); a declined callee propagates its decline UP |
+| Bounded single-self-recursion + masked-ceiling data-dependent loops | Y (hint-gated) | Depth/trip are always synth-DERIVED (mask-bounded, entry-independent), never the raw hint; too-low or unverifiable hints rejected with machine reasons (phases 4–5) |
+| Unhinted data-dependent loops, indirect/external calls, tree/mutual recursion, i64 software div/rem, non-M3/M4 cores | D | Loud decline with machine reason |
 
 ---
 

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -46,14 +46,14 @@ soundness feature, not an absence.
 | f32 scalar via VFP | Y (FPU targets) | Complete op set incl. all six comparisons, NaN-aware (v0.41); requires an FPU target (e.g. `cortex-m4f`) |
 | f64 scalar via VFP | Y (FPU targets) | Complete (v0.43, #369 closed); marshalling + AAPCS-VFP mixed params |
 | Trapping float→int truncations | Y | Domain-guarded (trap, not saturate) — the #709 soundness class |
-| Non-trapping `trunc_sat` (0xFC prefix) | Y (FPU targets) | Decoded and lowered as bare saturating VCVT (§4.3.2: NaN→0, out-of-range saturates, never traps). i32-target forms on any FPU target; i64-target forms on a double-FPU target (`cortex-m7dp`) via a branch-free FP word-decompose (v0.49, #782); aarch64 lowers all eight. Residuals: i64-from-f32 declines on single-precision (needs the f64 promote); a pressure-dependent f32 class on `--relocatable cortex-m7dp` still tracked in #782 |
+| Non-trapping `trunc_sat` (0xFC prefix) | Y (FPU targets) | Decoded and lowered as bare saturating VCVT (§4.3.2: NaN→0, out-of-range saturates, never traps). i32-target forms on any FPU target; i64-target forms on a double-FPU target (`cortex-m7dp`) via a branch-free FP word-decompose (v0.49, #782); aarch64 lowers all eight. Residuals: i64-from-f32 declines on single-precision (needs the f64 promote); the falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail is tracked in #881 (#782 closed) |
 | Control flow (block, loop, if/else, br, br_if, br_table) | Y | Renode execution tests |
 | Function calls (direct + `call_indirect`) | Y | `call_indirect` traps per WASM §4.4.8 (OOB index, type mismatch, null slot); self-contained dispatch is PC-relative via a flash funcref table (v0.47) |
 | Memory (load/store incl. sub-word, size/grow) | Y | `memory.grow` returns -1 on fixed-memory embedded targets; grow(0) ≡ size |
-| Multi-memory | D | Module-level loud decline with machine reason (#406 phase 1); fused components need single-memory mode |
+| Multi-memory | P | N memories lower to N distinct native base regions on ARM `--relocatable` (memory 0 keeps the runtime R11 base; memory k>0 via its own `__synth_wasm_data_<k>` symbol, #406) with an execution differential; everything outside that lane declines loudly — self-contained, native-pointer-abi, shadow-stack, riscv/aarch64, cross-memory copy/fill, i64/f32 access on memory k>0 |
 | Globals, select, locals | Y | R9-based globals; cmp→select fusion default-on |
 | SIMD (ARM Helium MVE) | R | Cortex-M55 encoding exists; untested on silicon/emulator; SIMD functions loud-skip on all other targets (category-level gate, #680) |
-| Component Model | P | Parses + ABI lift/lower; execution needs kiln-builtins; `cabi-arena-realloc` binds natively on self-contained dissolves (#418 partially open) |
+| Component Model | P | Parses + ABI lift/lower; execution needs kiln-builtins; `cabi-arena-realloc` binds natively on self-contained dissolves since v0.47 (#418 closed) |
 
 ---
 
@@ -131,6 +131,7 @@ see [coq/STATUS.md](../../coq/STATUS.md) for the per-file matrix.
   their coverage is listed above, not implied.
 - Broad hardware validation is still missing: silicon evidence is
   fixture-scoped (gale), emulation is Renode/QEMU/unicorn.
-- Known open soundness/coverage residuals are tracked as issues (e.g. #782:
-  `trunc_sat` + a pressure-dependent f32 class on `--relocatable cortex-m7dp`;
-  #418: real dissolved-component fixture).
+- Known open soundness/coverage residuals are tracked as issues (e.g. #881:
+  the falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail; #882:
+  RV32 real-driver `br_table`/label declines; #872: range-realloc
+  cross-barrier liveness blind spot).

--- a/scripts/repro/gpio_thin_846_differential.py
+++ b/scripts/repro/gpio_thin_846_differential.py
@@ -263,9 +263,18 @@ def main():
     # (b) EXECUTION half — on the flag-ON bytes, across the pin sweep incl >=32.
     syms, code, base = elf_syms_text(elf_on)
     wpc, rpc = import_call_sites(elf_on, base)
+    # ANTI-VACUITY (#879): if the reloc walk finds NO mmio call sites, the
+    # unicorn side never models the peripheral and the whole execution half
+    # degenerates. That must be a LOUD failure, never a silent 75/75.
+    if not wpc or not rpc:
+        sys.exit(f"VACUOUS: no mmio import call sites found in {elf_on} "
+                 f"(write sites={len(wpc)}, read sites={len(rpc)}) — the "
+                 f"reloc walk is broken or the fixture lost its imports")
     print("=== #846 EXECUTION UNCHANGED (flag-ON bytes vs wasmtime) ===")
+    expected = len(EXPORTS) * len(PINS)
     exec_ok = True
     checks = 0
+    trace_events = 0
     for export, idx, mkargs in EXPORTS:
         for pin in PINS:
             args = mkargs(pin)
@@ -275,6 +284,7 @@ def main():
             ok = (gt_trace == un_trace) and (gt_ret == un_ret
                                              if gt_ret is not None else True)
             checks += 1
+            trace_events += len(gt_trace)
             if not ok:
                 exec_ok = False
                 print(f"  MISMATCH {export}(pin={pin}):")
@@ -283,9 +293,22 @@ def main():
     if exec_ok:
         print(f"  {checks}/{checks} match — mmio (addr,value) sequences + returns "
               f"bit-identical across pins {PINS} (incl. >=32 mod-32 boundary)")
+    # ANTI-VACUITY (#879): the sweep must have RUN something. A zero check
+    # count, a short sweep, or a sweep whose ground-truth traces were all
+    # empty is a gate that measured nothing — hard-fail, never green.
+    if checks == 0 or checks != expected:
+        sys.exit(f"VACUOUS: ran {checks} checks, expected {expected} "
+                 f"({len(EXPORTS)} exports x {len(PINS)} pins)")
+    if trace_events == 0:
+        sys.exit("VACUOUS: 0 mmio trace events across the whole sweep — "
+                 "wasmtime ground truth exercised no peripheral traffic, so "
+                 "the trace comparison compared nothing")
 
     print("=== RESULT ===")
     ok = size_ok and exec_ok
+    # Machine-readable summary line for the CI step's non-zero-count grep
+    # (asserted in .github/workflows/ci.yml — exit 0 alone is not trusted).
+    print(f"#846 CHECKS={checks}/{expected} trace_events={trace_events}")
     print("gpio-thin #846: PASS" if ok else "gpio-thin #846: FAIL")
     sys.exit(0 if ok else 1)
 

--- a/scripts/templates/feature_matrix.md.tmpl
+++ b/scripts/templates/feature_matrix.md.tmpl
@@ -79,7 +79,7 @@ see [coq/STATUS.md](../../coq/STATUS.md) for the per-file matrix.
 |-----------|--------|-----------------|
 | SMT translation validation | Y | ordeal (pure-Rust QF_BV) default since v0.27.0; Z3 demoted to a feature-gated differential oracle |
 | Trap-preservation VC (VCR-VER-002) | Y (live classes) | Dropped WASM traps: i32 + i64 div/rem, memory OOB (all widths), `call_indirect`, `unreachable`, float→int trunc |
-| Static-data addressing VC (VCR-VER-003) | Y | Byte-equality of served vs runtime-image static data (the #757 wrong-segment class); spanned accesses, self-contained ROM image; RV32 warns loudly on dropped initializer bytes |
+| Static-data addressing VC (VCR-VER-003) | Y | Byte-equality of served vs runtime-image static data (the #757 wrong-segment class); spanned accesses, self-contained ROM image; RV32 ships active data segments as `.wasm_data` records — the emitted blob is read back and any served/runtime disagreement hard-errors the compile (#798, v0.48) |
 | Proof-carrying specialization (`SYNTH_FACT_SPEC`) | Y (opt-in) | ordeal-certified elisions from loom `wsc.facts` invariants (#494) |
 
 ### WCET (Track D, #778)
@@ -89,7 +89,9 @@ see [coq/STATUS.md](../../coq/STATUS.md) for the per-file matrix.
 | `--emit-wcet` sound per-function cycle bounds | Y | `synth-wcet-v1` sidecar; documented Cortex-M3/M4 worst-case per-op cycles (max over {M3, M4}); sound-critical model constants pinned in `claims.yaml` |
 | Statically-proven const-bound loop bounds | Y | Conservative symbolic walk over the final encoded stream (v0.47); nested-multiplicative |
 | `--wcet-hints` (untrusted hint seam) | Y | Every hint verified against synth's own derived trip count or rejected with a machine reason — never trusted into a bound |
-| Data-dependent loops, calls, i64 software div/rem, non-M3/M4 cores | D | Loud decline with machine reason |
+| Inter-procedural composition (direct call graph) | Y | `total = own + Σ site-multiplier × callee-total` over direct `BL` calls to local bounded callees (v0.48, phase 3); a declined callee propagates its decline UP |
+| Bounded single-self-recursion + masked-ceiling data-dependent loops | Y (hint-gated) | Depth/trip are always synth-DERIVED (mask-bounded, entry-independent), never the raw hint; too-low or unverifiable hints rejected with machine reasons (phases 4–5) |
+| Unhinted data-dependent loops, indirect/external calls, tree/mutual recursion, i64 software div/rem, non-M3/M4 cores | D | Loud decline with machine reason |
 
 ---
 

--- a/scripts/templates/feature_matrix.md.tmpl
+++ b/scripts/templates/feature_matrix.md.tmpl
@@ -46,14 +46,14 @@ soundness feature, not an absence.
 | f32 scalar via VFP | Y (FPU targets) | Complete op set incl. all six comparisons, NaN-aware (v0.41); requires an FPU target (e.g. `cortex-m4f`) |
 | f64 scalar via VFP | Y (FPU targets) | Complete (v0.43, #369 closed); marshalling + AAPCS-VFP mixed params |
 | Trapping float→int truncations | Y | Domain-guarded (trap, not saturate) — the #709 soundness class |
-| Non-trapping `trunc_sat` (0xFC prefix) | Y (FPU targets) | Decoded and lowered as bare saturating VCVT (§4.3.2: NaN→0, out-of-range saturates, never traps). i32-target forms on any FPU target; i64-target forms on a double-FPU target (`cortex-m7dp`) via a branch-free FP word-decompose (v0.49, #782); aarch64 lowers all eight. Residuals: i64-from-f32 declines on single-precision (needs the f64 promote); a pressure-dependent f32 class on `--relocatable cortex-m7dp` still tracked in #782 |
+| Non-trapping `trunc_sat` (0xFC prefix) | Y (FPU targets) | Decoded and lowered as bare saturating VCVT (§4.3.2: NaN→0, out-of-range saturates, never traps). i32-target forms on any FPU target; i64-target forms on a double-FPU target (`cortex-m7dp`) via a branch-free FP word-decompose (v0.49, #782); aarch64 lowers all eight. Residuals: i64-from-f32 declines on single-precision (needs the f64 promote); the falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail is tracked in #881 (#782 closed) |
 | Control flow (block, loop, if/else, br, br_if, br_table) | Y | Renode execution tests |
 | Function calls (direct + `call_indirect`) | Y | `call_indirect` traps per WASM §4.4.8 (OOB index, type mismatch, null slot); self-contained dispatch is PC-relative via a flash funcref table (v0.47) |
 | Memory (load/store incl. sub-word, size/grow) | Y | `memory.grow` returns -1 on fixed-memory embedded targets; grow(0) ≡ size |
-| Multi-memory | D | Module-level loud decline with machine reason (#406 phase 1); fused components need single-memory mode |
+| Multi-memory | P | N memories lower to N distinct native base regions on ARM `--relocatable` (memory 0 keeps the runtime R11 base; memory k>0 via its own `__synth_wasm_data_<k>` symbol, #406) with an execution differential; everything outside that lane declines loudly — self-contained, native-pointer-abi, shadow-stack, riscv/aarch64, cross-memory copy/fill, i64/f32 access on memory k>0 |
 | Globals, select, locals | Y | R9-based globals; cmp→select fusion default-on |
 | SIMD (ARM Helium MVE) | R | Cortex-M55 encoding exists; untested on silicon/emulator; SIMD functions loud-skip on all other targets (category-level gate, #680) |
-| Component Model | P | Parses + ABI lift/lower; execution needs kiln-builtins; `cabi-arena-realloc` binds natively on self-contained dissolves (#418 partially open) |
+| Component Model | P | Parses + ABI lift/lower; execution needs kiln-builtins; `cabi-arena-realloc` binds natively on self-contained dissolves since v0.47 (#418 closed) |
 
 ---
 
@@ -131,6 +131,7 @@ see [coq/STATUS.md](../../coq/STATUS.md) for the per-file matrix.
   their coverage is listed above, not implied.
 - Broad hardware validation is still missing: silicon evidence is
   fixture-scoped (gale), emulation is Renode/QEMU/unicorn.
-- Known open soundness/coverage residuals are tracked as issues (e.g. #782:
-  `trunc_sat` + a pressure-dependent f32 class on `--relocatable cortex-m7dp`;
-  #418: real dissolved-component fixture).
+- Known open soundness/coverage residuals are tracked as issues (e.g. #881:
+  the falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail; #882:
+  RV32 real-driver `br_table`/label declines; #872: range-realloc
+  cross-barrier liveness blind spot).


### PR DESCRIPTION
Closes #879. Closes #880. Two defects, one class: gates that look like gates but don't bite.

## #879 — the gpio differential is now CI-enforced

`scripts/repro/gpio_thin_846_differential.py` — the gate behind the v0.50.1 (534→506 B) and v0.52.0 (506→502 B) headline size claims, and the only harness executing gale's REAL gpio-thin driver across a pin sweep **including pin ≥ 32** (the mod-32 boundary an unsound shift-mask elision would corrupt) — appeared nowhere in CI.

- Wired into the ARM **trap-semantics oracle** job, right after the #686 mask-elision oracle it complements. `capstone` added to that job's pip line (the mask census disassembles `.text`; the job previously installed only wasmtime/unicorn/pyelftools).
- **Non-zero check count asserted, not just exit 0**: the script now prints a machine-readable `#846 CHECKS=75/75 trace_events=N` summary and the CI step greps the pinned `75/75`. Script-side anti-vacuity added: hard-fail on empty/short sweeps, zero mmio trace events, or a reloc walk that finds no import call sites (a missing-import path can no longer skip).
- Same audit found a **second shelfware oracle**: `rv32_data_798_boot_differential.py` (the #798 full-boot gate — clang+lld build the bare-metal riscv32 firmware, unicorn boots it from `_reset`). Wired into the same job. Both wirings are pinned in `claims.yaml` (`SYNTH-GPIO-846-ORACLE-CI-WIRED`, `SYNTH-MATRIX-RV32-DATA-SHIP`) so they cannot be silently un-wired again.

Red-first evidence (local, hardened script + fresh debug binary):
- Green: `75/75 match`, 105 mmio trace events, 534→502 B / 10→3 masks; rv32 boot oracle PASS.
- RED 1: simulated broken reloc walk (no call sites) → `VACUOUS: no mmio import call sites found`, exit 1.
- RED 2: silently shrunk pin sweep → script self-consistent at `CHECKS=70/70` but the CI-side `grep "^#846 CHECKS=75/75"` exits 1 — the pinned count bites where exit-0 would not.

## #880 — template prose is now claim-gated (approach 3 + oracle binding, limits stated)

The staleness gate proves `doc == render(template)`; wrong template prose renders faithfully and stays green (the v0.51 "div/rem declined" / v0.52 "OOB-trap is a follow-on" cold-read defects). Chosen approach: **pin the template's load-bearing capability phrases verbatim in `claims.yaml`** (mechanism already existed), each bound to independent evidence — the oracle script that *executes* the capability exists **and is CI-wired** (`count-min` over `ci.yml`, the #879 lesson generalized), plus a stable code anchor where one exists (`MemBounds::Software`, `validate_served_image`). 8 new `SYNTH-MATRIX-*` / gpio-wiring claims; 34/34 hold.

Red-first evidence: replaced the template's `**BOUNDS-CHECKED by default** …` phrase with "bounds checking is a follow-on" (the literal v0.52 defect), **regenerated** so the old staleness gate stays green → `claim_check` exits 1 with `FAIL SYNTH-MATRIX-AARCH64-BOUNDS-DEFAULT`. Reverted. (Incidentally re-proven a second time when a careless `git checkout` of the template reverted the legit fixes — the new pins went red on that too.)

**Honest limit**: verbatim pins catch *drift* of pinned phrases (weakening a shipped-capability claim forces a deliberate ledger bump next to its evidence); they cannot catch a brand-new false claim typed into the template. That residual stays on review + on extending the pin list when new load-bearing phrases land. Deriving the prose from the selector's decline sites (option 1) remains the stronger end-state.

## Template/README audit — six live defects of exactly the #880 class, fixed here

1. Matrix said "RV32 **warns loudly** on dropped initializer bytes" — #798 (v0.48) ships the segments and **hard-errors** on served/runtime disagreement; four releases stale.
2. WCET decline row listed "**calls**" as blanket-D — phase-3 inter-procedural composition (v0.48) bounds direct local calls; phases 4–5 (hint-gated recursion depth / masked-ceiling loops) were absent entirely.
3. Matrix + README said `trunc_sat` "**not decoded**" and "a pressure-dependent f32 class **still tracked in #782**" — trunc_sat shipped v0.49; #782 is closed, successor residual is #881.
4. "**#418 partially open**" — closed with the v0.47 arena-bind.
5. Multi-memory row said "**D — module-level loud decline**" while the #406 per-memory lowering (N distinct base regions, CI-wired execution differential) had been shipping — the v0.51 understatement class.
6. Honest-summary "open residuals" examples cited two closed issues; now cite the actually-open #881/#882/#872.

Remaining unpinned load-bearing prose (reported, not pinned — candidates for follow-up): the A32 "221-variant no-wildcard tripwire" hand-carried number; the RV32 `#871` relocation/arity-marshalling sentence; per-row f32/f64 "Complete" wording (README analogue is pinned); issue-number *open-state* citations have no offline check (a closed issue cited as open only reddens when its phrase is pinned).

## Gates

- `claim_check` 34/34 (incl. staleness re-render), `model_coverage_audit --check` ok, `ci.yml` parses
- `frozen_codegen_bytes` 10/10 — lane is byte-invisible to codegen
- gpio oracle green (75/75, non-vacuous), rv32 #798 boot oracle green, both locally with the fresh worktree binary
- fmt clean; workspace tests + clippy running at PR time (no Rust code touched — Python/YAML/docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L