### PR TITLE
VFP register-file spilling — the GI-FPU-002 exhaustion rung (#881, VCR-RA-004, epic #242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,6 +576,12 @@ jobs:
       - name: Install emulation deps
         # capstone: the #846 gpio-thin oracle's mask census disassembles .text
         run: pip install wasmtime unicorn pyelftools capstone
+      - name: Install arm-none-eabi-ld (#881 VFP spill oracle)
+        # binutils only (NOT the full gcc-arm-none-eabi): the #881 oracle links
+        # its ET_REL object with a REAL ld so the internal `bl` reloc is proven
+        # to resolve. Skipping the link would make that half of the gate
+        # vacuous, so install the linker rather than weaken the check.
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends binutils-arm-none-eabi
       - name: Run unreachable trap oracle (#665, thumb2 + rv32)
         run: SYNTH=./target/debug/synth python scripts/repro/unreachable_665_differential.py
       - name: Run rem_s trap-table oracle (#666, rv32)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,6 +624,21 @@ jobs:
       # exercised only lt/gt, which is how eq/ne/le/ge stayed ungated).
       - name: Run f32 arith/compare execution oracle (#619/#712, cortex-m4f)
         run: SYNTH=./target/debug/synth python scripts/repro/f32_vfp_619_differential.py
+      # #881: the VFP register-file spilling gate (GI-FPU-002 phase 1 S0..S15 +
+      # phase 2 D0..D7) — the oracle behind the "falcon reaches the M7" claim,
+      # so it must RUN, not merely exist. The lane wrote this differential and
+      # never wired it: the #879 shelfware class, recurring in the very release
+      # whose audit fixed two other instances of it. The greps assert BOTH
+      # halves of the claim from the script's own summary lines — every export
+      # actually emitted (nm -> T, so a silent decline cannot read as success)
+      # AND a non-zero count of execution rows bit-identical to wasmtime. Exit
+      # 0 alone is not trusted (the "0 ops accepted PASS" lesson).
+      - name: Run VFP spill execution oracle (#881, cortex-m7dp)
+        run: |
+          set -o pipefail
+          SYNTH=./target/debug/synth python scripts/repro/vfp_spill_881_differential.py | tee vfp881.out
+          grep -q "^PASS: all 7 exports emitted (nm -> T)" vfp881.out
+          grep -qE "^PASS: [1-9][0-9]+ execution rows bit-identical to wasmtime" vfp881.out
       # #708/#709: f32.load/reinterpret bit-casts + i32.trunc_f32 trap table.
       - name: Run f32 load/reinterpret + trunc-trap oracle (#708/#709, m4f)
         run: SYNTH=./target/debug/synth python scripts/repro/f32_mem_trunc_708_709_differential.py

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -421,7 +421,8 @@ fn compile_wasm_to_arm(
     let select_direct_attempt = |spill_on_exhaustion: bool,
                                  param_backing_on_exhaustion: bool,
                                  local_promote: bool,
-                                 i64_spill_slots: Option<usize>|
+                                 i64_spill_slots: Option<usize>,
+                                 vfp_spill_on_exhaustion: bool|
      -> Result<Vec<ArmInstruction>, synth_core::Error> {
         let db = RuleDatabase::with_standard_rules();
         let mut selector =
@@ -514,6 +515,10 @@ fn compile_wasm_to_arm(
         selector.set_global_widths(config.global_widths.clone());
         selector.set_spill_on_exhaustion(spill_on_exhaustion);
         selector.set_param_backing_on_exhaustion(param_backing_on_exhaustion);
+        // #881 (VCR-RA-004): VFP register-file spilling, set ONLY on the retry
+        // after an attempt failed with a GI-FPU-002 exhaustion Err — functions
+        // that compile without it keep byte-identical output by construction.
+        selector.set_vfp_spill_on_exhaustion(vfp_spill_on_exhaustion);
         // #587 pool-grow rung: a larger i64 spill-slot pool, set ONLY on the
         // retry after an attempt failed with the slot-pool-exhausted Err —
         // functions that compile with the default pool keep their frame
@@ -552,34 +557,38 @@ fn compile_wasm_to_arm(
         // returned a recoverable register-exhaustion Err, so a function that
         // compiles on the first attempt is untouched by the later rungs. Returns
         // the result AND which rung produced it (for the #242 measurement below).
-        let recovery_ladder =
-            |promote: bool,
-             i64_spill_slots: Option<usize>|
-             -> (Result<Vec<ArmInstruction>, synth_core::Error>, &'static str) {
-                let mut attempt = select_direct_attempt(false, false, promote, i64_spill_slots);
-                let mut rung = "base";
-                // VCR-RA-001 step 3b-lite (#242): the i32 register-exhaustion
-                // hard-fail is recoverable — retry with spill-on-exhaustion, which
-                // reserves the spill area and spills the deepest stack value when
-                // the pool is full.
-                if let Err(e) = &attempt
-                    && e.to_string().contains(SINGLE_EXHAUSTION)
-                {
-                    attempt = select_direct_attempt(true, false, promote, i64_spill_slots);
-                    rung = "spill";
-                }
-                // VCR-RA-001 acceptance increment (#242): the i64 consecutive-PAIR
-                // exhaustion is recoverable too — not by stack spilling (the pair
-                // allocator already spills stack values, #171) but by frame-backing
-                // the params (#204) so they stop pinning R0-R3, with spill kept on.
-                if let Err(e) = &attempt
-                    && e.to_string().contains(PAIR_EXHAUSTION)
-                {
-                    attempt = select_direct_attempt(true, true, promote, i64_spill_slots);
-                    rung = "param-backing";
-                }
-                (attempt, rung)
-            };
+        let recovery_ladder = |promote: bool,
+                               i64_spill_slots: Option<usize>,
+                               vfp_spill: bool|
+         -> (
+            Result<Vec<ArmInstruction>, synth_core::Error>,
+            &'static str,
+        ) {
+            let mut attempt =
+                select_direct_attempt(false, false, promote, i64_spill_slots, vfp_spill);
+            let mut rung = "base";
+            // VCR-RA-001 step 3b-lite (#242): the i32 register-exhaustion
+            // hard-fail is recoverable — retry with spill-on-exhaustion, which
+            // reserves the spill area and spills the deepest stack value when
+            // the pool is full.
+            if let Err(e) = &attempt
+                && e.to_string().contains(SINGLE_EXHAUSTION)
+            {
+                attempt = select_direct_attempt(true, false, promote, i64_spill_slots, vfp_spill);
+                rung = "spill";
+            }
+            // VCR-RA-001 acceptance increment (#242): the i64 consecutive-PAIR
+            // exhaustion is recoverable too — not by stack spilling (the pair
+            // allocator already spills stack values, #171) but by frame-backing
+            // the params (#204) so they stop pinning R0-R3, with spill kept on.
+            if let Err(e) = &attempt
+                && e.to_string().contains(PAIR_EXHAUSTION)
+            {
+                attempt = select_direct_attempt(true, true, promote, i64_spill_slots, vfp_spill);
+                rung = "param-backing";
+            }
+            (attempt, rung)
+        };
         // #474: local promotion (default-on since v0.14.0) is an OPTIMIZATION — it
         // must never be the reason a function fails to compile. Run the full ladder
         // with promotion first (so every function that compiles today is
@@ -594,12 +603,14 @@ fn compile_wasm_to_arm(
         // The full pre-#587 recovery sequence (promotion-on ladder, then the
         // #474 promotion-off fallback), parameterized on the pool size so the
         // pool-grow retry below reruns it verbatim.
-        let full_sequence = |slots: Option<usize>| -> (
+        let full_sequence = |slots: Option<usize>,
+                             vfp_spill: bool|
+         -> (
             Result<Vec<ArmInstruction>, synth_core::Error>,
             &'static str,
             bool,
         ) {
-            let (mut attempt, mut rung) = recovery_ladder(promote, slots);
+            let (mut attempt, mut rung) = recovery_ladder(promote, slots, vfp_spill);
             let mut promotion_dropped = false;
             if promote
                 && attempt
@@ -607,7 +618,7 @@ fn compile_wasm_to_arm(
                     .err()
                     .is_some_and(|e| e.to_string().contains("register exhaustion"))
             {
-                let (rescued, off_rung) = recovery_ladder(false, slots);
+                let (rescued, off_rung) = recovery_ladder(false, slots, vfp_spill);
                 if rescued.is_ok() {
                     attempt = rescued;
                     rung = off_rung;
@@ -616,7 +627,7 @@ fn compile_wasm_to_arm(
             }
             (attempt, rung, promotion_dropped)
         };
-        let (mut attempt, mut rung, mut promotion_dropped) = full_sequence(None);
+        let (mut attempt, mut rung, mut promotion_dropped) = full_sequence(None, false);
         // #587 pool-grow retry (the falcon func_60/func_73 remainder): the fixed
         // 8-slot i64 spill pool can exhaust while spilling is otherwise working —
         // an i64-dense function simply has more values simultaneously live than
@@ -637,11 +648,53 @@ fn compile_wasm_to_arm(
             .is_some_and(|e| e.to_string().contains(SLOT_EXHAUSTION))
         {
             let depth = synth_core::wasm_stack_check::max_depth_bound(wasm_ops) as usize;
-            let (grown, _, grown_dropped) = full_sequence(Some(depth.saturating_add(4)));
+            let (grown, _, grown_dropped) = full_sequence(Some(depth.saturating_add(4)), false);
             if grown.is_ok() {
                 attempt = grown;
                 rung = "pool-grow";
                 promotion_dropped = grown_dropped;
+            }
+        }
+        // #881 (VCR-RA-004): the GI-FPU-002 VFP register-file exhaustion is
+        // recoverable too — retry the ENTIRE sequence with VFP spilling
+        // enabled (the pre-op pressure guard spills the deepest segment-local
+        // f32/f64 stack value into the shared spill area and reloads spilled
+        // operands before their consumers). Deliberately LAST, after every
+        // integer rung, so any function that compiled yesterday is produced
+        // by exactly yesterday's path; the VFP rung only ever fires for
+        // functions whose every existing escape ended in a GI-FPU-002
+        // exhaustion Err (previously an unconditional loud skip). A VFP-
+        // spilling function can in turn exhaust the shared slot pool — the
+        // #587 pool-grow retry composes inside the rung.
+        const VFP_S_EXHAUSTION: &str = "VFP register file exhausted";
+        const VFP_D_EXHAUSTION: &str = "VFP D-register file exhausted";
+        if attempt.as_ref().err().is_some_and(|e| {
+            let msg = e.to_string();
+            msg.contains(VFP_S_EXHAUSTION) || msg.contains(VFP_D_EXHAUSTION)
+        }) {
+            let (vfp, vfp_rung, vfp_dropped) = full_sequence(None, true);
+            let (vfp, vfp_rung, vfp_dropped) = if vfp.as_ref().err().is_some_and(|e| {
+                let msg = e.to_string();
+                msg.contains(SLOT_EXHAUSTION) || msg.contains("spilling the VFP register file")
+            }) {
+                let depth = synth_core::wasm_stack_check::max_depth_bound(wasm_ops) as usize;
+                let (grown, grown_rung, grown_dropped) =
+                    full_sequence(Some(depth.saturating_add(4)), true);
+                if grown.is_ok() {
+                    (grown, grown_rung, grown_dropped)
+                } else {
+                    (vfp, vfp_rung, vfp_dropped)
+                }
+            } else {
+                (vfp, vfp_rung, vfp_dropped)
+            };
+            if vfp.is_ok() {
+                attempt = vfp;
+                rung = match vfp_rung {
+                    "base" => "vfp-spill",
+                    _ => "vfp-spill+int",
+                };
+                promotion_dropped = vfp_dropped;
             }
         }
         // VCR-RA measurement (#242): log which recovery rung produced the result,

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -1460,7 +1460,8 @@ fn compile_wasm_to_arm(
                 "VCR-RA-003: register-allocation validation FAILED — {v:?}. \
                  The emitted stream violates a register-allocation invariant \
                  (callee-saved preservation #490 / spill-slot non-aliasing #331 \
-                 / caller-saved-across-call / join-value-availability); this is a \
+                 / caller-saved-across-call / join-value-availability / the #881 \
+                 VFP twins); this is a \
                  compiler bug, not a program error. Refusing to emit a \
                  miscompiled object."
             ));

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -328,6 +328,19 @@ enum StackVal {
     /// call-spill machinery preserves a live double as its two aliased words —
     /// bit-exact by the VFP register-file aliasing rule.
     Double { dreg: VfpReg },
+    /// #881 (VCR-RA-004 spill/reload for the VFP file): an f32 value spilled
+    /// to the frame at `[sp, slot]` (the lo 4 bytes of an 8-byte [`SpillState`]
+    /// slot). Like the integer [`StackVal::Spilled`], a spilled VFP entry
+    /// reserves NO S-register, so spilling relieves VFP pressure; it is
+    /// reloaded into a fresh S-register by the pre-op VFP pressure guard
+    /// before the op that consumes it. Only constructed under the
+    /// `vfp_spill_on_exhaustion` retry rung — functions that compile without
+    /// it never see one.
+    FloatSpilled { slot: i32 },
+    /// #881: an f64 value spilled to the frame at `[sp, slot]` (the full
+    /// 8-byte slot; VSTR.64/VLDR.64 keep it bit-exact). Reserves no
+    /// D-register. Rung-only, like [`StackVal::FloatSpilled`].
+    DoubleSpilled { slot: i32 },
 }
 
 impl StackVal {
@@ -352,6 +365,9 @@ impl StackVal {
             // register pair — the integer pop/peek/spill paths that consult
             // this reject a `Double` outright before width matters.
             StackVal::Double { .. } => false,
+            // #881: spilled VFP entries are float-typed — the integer paths
+            // that consult this reject them outright before width matters.
+            StackVal::FloatSpilled { .. } | StackVal::DoubleSpilled { .. } => false,
         }
     }
     /// GI-FPU-002: the S-register of an f32 stack value, if this is one.
@@ -554,6 +570,15 @@ struct SpillState {
     /// exhaustion `Err` — so every function that compiles without it keeps
     /// byte-identical output by construction.
     spill_on_exhaustion: bool,
+    /// #881 (VCR-RA-004): when set, the VFP register file spills too — the
+    /// pre-op VFP pressure guard spills the deepest straight-line-segment
+    /// f32/f64 stack value (farthest next use under LIFO stack discipline)
+    /// into this same slot pool when S0..S15 / the aligned D0..D7 pairs run
+    /// out, and reloads spilled operands before the op that consumes them.
+    /// Default OFF; flipped on only by the backend's retry rung after a first
+    /// pass failed with a GI-FPU-002 exhaustion `Err` — every function that
+    /// compiles without it keeps byte-identical output by construction.
+    vfp_spill_on_exhaustion: bool,
     /// Whether `compute_local_layout` actually reserved the spill area this
     /// state hands slots out of (`has_i64 || force_spill_area`). When it did
     /// NOT (an i32-only first pass), `base` is just the end of the frame and
@@ -579,6 +604,7 @@ impl SpillState {
             base,
             used: vec![false; slots],
             spill_on_exhaustion: false,
+            vfp_spill_on_exhaustion: false,
             area_reserved: true,
         }
     }
@@ -1110,6 +1136,16 @@ fn pop_operand(
              integer path"
                 .to_string(),
         )),
+        // #881: same contract for a SPILLED VFP value — the pre-op pressure
+        // guard reloads the operands of every float-consuming op, so one
+        // reaching an integer pop is invalid wasm or an unlowered shape.
+        StackVal::FloatSpilled { .. } | StackVal::DoubleSpilled { .. } => {
+            Err(synth_core::Error::synthesis(
+                "#881: an integer operation popped a spilled VFP stack value — \
+                 invalid wasm or an unlowered float op reached the integer path"
+                    .to_string(),
+            ))
+        }
         StackVal::Spilled { lo_slot, is_i64 } => {
             // Reload against the *remaining* stack (this entry already popped).
             // i32: one temp + one LDR. i64: a consecutive pair + LDR lo/hi.
@@ -1186,6 +1222,14 @@ fn peek_operand(
              integer path"
                 .to_string(),
         )),
+        // #881: same contract for a spilled VFP value (see `pop_operand`).
+        Some(StackVal::FloatSpilled { .. } | StackVal::DoubleSpilled { .. }) => {
+            Err(synth_core::Error::synthesis(
+                "#881: an integer operation peeked a spilled VFP stack value — \
+                 invalid wasm or an unlowered float op reached the integer path"
+                    .to_string(),
+            ))
+        }
         Some(StackVal::Spilled { lo_slot, is_i64 }) => {
             let lo = if is_i64 {
                 let (lo, hi) = alloc_consecutive_pair(
@@ -2268,6 +2312,18 @@ fn free_vfp_temp(used: &mut [bool; 16], home: &[bool; 16], r: VfpReg) {
 fn pop_float(stack: &mut Vec<StackVal>) -> Result<VfpReg> {
     match stack.pop() {
         Some(StackVal::Float { sreg }) => Ok(sreg),
+        // #881: a spilled f32 reaching a consumer means the pre-op pressure
+        // guard missed a reload site — an internal gap, never a miscompile:
+        // decline the function loudly (the value is in the frame, not in the
+        // S-register a lowering would read).
+        Some(StackVal::FloatSpilled { .. } | StackVal::DoubleSpilled { .. }) => {
+            Err(synth_core::Error::synthesis(
+                "#881: an f32 operation popped a SPILLED VFP value — the VFP \
+                 pressure guard missed a reload site for this op shape; \
+                 declining loudly rather than reading a stale register"
+                    .to_string(),
+            ))
+        }
         Some(_) => Err(synth_core::Error::synthesis(
             "GI-FPU-002: an f32 operation expected an f32 (VFP) operand but the \
              stack top was an integer value — invalid wasm or an unlowered \
@@ -2896,6 +2952,16 @@ fn free_vfp_dtemp(used: &mut [bool; 16], home: &[bool; 16], r: VfpReg) {
 fn pop_double(stack: &mut Vec<StackVal>) -> Result<VfpReg> {
     match stack.pop() {
         Some(StackVal::Double { dreg }) => Ok(dreg),
+        // #881: see `pop_float` — a spilled VFP value reaching a consumer is
+        // a missed guard reload site; loud decline, never a stale read.
+        Some(StackVal::FloatSpilled { .. } | StackVal::DoubleSpilled { .. }) => {
+            Err(synth_core::Error::synthesis(
+                "#881: an f64 operation popped a SPILLED VFP value — the VFP \
+                 pressure guard missed a reload site for this op shape; \
+                 declining loudly rather than reading a stale register"
+                    .to_string(),
+            ))
+        }
         Some(_) => Err(synth_core::Error::synthesis(
             "GI-FPU-002 phase 2: an f64 operation expected an f64 (VFP D) \
              operand but the stack top was not one — invalid wasm or an \
@@ -2908,7 +2974,280 @@ fn pop_double(stack: &mut Vec<StackVal>) -> Result<VfpReg> {
     }
 }
 
-/// True if `op` is one of the in-scope scalar f64 ops this phase-2 increment
+// ============================================================================
+// #881 (VCR-RA-004, epic #242): VFP register-file spilling — the exact
+// analogue of the integer spill-on-exhaustion rung (VCR-RA-001 step 3b-lite)
+// for the S0..S15 / D0..D7 files. Active ONLY under
+// `SpillState::vfp_spill_on_exhaustion` (the backend's retry rung after a
+// first pass failed with a GI-FPU-002 exhaustion Err), so every function that
+// compiles today is produced by exactly yesterday's code path.
+//
+// Design:
+//  * Victim choice: the DEEPEST spillable f32/f64 operand-stack entry within
+//    the current straight-line segment — under LIFO stack discipline the
+//    deepest entry has the farthest next use (the Belady criterion the
+//    integer rung and VCR-RA-001 both use).
+//  * Straight-line safety (`cf_floor`): a spill store emitted inside a
+//    conditionally-executed region must dominate its reload. Entries pushed
+//    BEFORE the last control-flow boundary are never chosen as victims — a
+//    then-arm spill of a value pushed before the `if` would leave the else
+//    path reloading a never-written slot (a silent wrong value). The floor is
+//    reset to the operand-stack depth at every Block/Loop/If/Else/End/Br/
+//    BrIf/BrTable and clamped downward as the stack shrinks, so victims are
+//    always values whose spill store post-dominates their push in the same
+//    segment.
+//  * Slots come from the SAME [`SpillState`] pool as the integer spills (an
+//    f32 uses the lo word of its 8-byte slot; an f64 the full slot), so the
+//    slot-aliasing invariants (#331/#581) carry over unchanged.
+//  * S/D aliasing: `D(i)` = `S(2i):S(2i+1)` is modelled by the ONE shared
+//    16-slot `vfp_used` map (a D-alloc marks both S halves; a D-spill frees
+//    both), so spilling an f32 can open half of an aligned pair and the
+//    D-headroom loop below keeps spilling until a FULL aligned pair is free.
+//  * VSTR/VLDR encode `[sp,#imm]` as imm8*4 (0..=1020): an out-of-range slot
+//    declines loudly instead of silently masking the offset (#180/#185).
+// ============================================================================
+
+/// Emit the VSTR for one spilled VFP value, range-checked. `Ok` is the
+/// instruction pushed; `Err` is the loud VSTR-range decline.
+fn vfp_check_slot_range(slot: i32, is_double: bool) -> Result<()> {
+    let hi = slot + if is_double { 4 } else { 0 };
+    if !(0..=1020).contains(&hi) || !(0..=1020).contains(&slot) {
+        return Err(synth_core::Error::synthesis(format!(
+            "#881: VFP spill slot offset {slot} exceeds the VSTR/VLDR \
+             [sp,#imm] range (1020) — frame too large; declining loudly"
+        )));
+    }
+    Ok(())
+}
+
+/// Spill the DEEPEST spillable VFP operand-stack entry to a fresh frame slot,
+/// freeing its S-register (f32) or aligned S-pair (f64). Spillable = a
+/// [`StackVal::Float`]/[`StackVal::Double`] at position `>= cf_floor` (pushed
+/// in the current straight-line segment, see the module comment above) and
+/// below the top `protect_top` entries (the operands of the op being lowered),
+/// whose register is not a pinned param/local home (a home stays pinned for
+/// the function's extent — freeing it would relieve nothing).
+///
+/// Returns `Ok(true)` on success, `Ok(false)` if nothing spillable remains,
+/// `Err` if the slot pool is exhausted or the slot is out of VSTR range.
+fn spill_deepest_vfp(
+    stack: &mut [StackVal],
+    cf_floor: usize,
+    protect_top: usize,
+    vfp_used: &mut [bool; 16],
+    vfp_home: &[bool; 16],
+    spill: &mut SpillState,
+    instructions: &mut Vec<ArmInstruction>,
+    idx: usize,
+) -> Result<bool> {
+    let floor = cf_floor.min(stack.len());
+    let hi = stack.len().saturating_sub(protect_top);
+    let pos = (floor..hi).find(|&p| match stack[p] {
+        StackVal::Float { sreg } => vfp_s_index(sreg).is_some_and(|k| !vfp_home[k]),
+        StackVal::Double { dreg } => {
+            vfp_d_index(dreg).is_some_and(|i| !vfp_home[2 * i] && !vfp_home[2 * i + 1])
+        }
+        _ => false,
+    });
+    let Some(pos) = pos else {
+        return Ok(false);
+    };
+    let slot = spill.alloc().ok_or_else(|| {
+        synth_core::Error::synthesis(
+            "#881: spill-slot pool exhausted while spilling the VFP register \
+             file — function too complex for current register allocator"
+                .to_string(),
+        )
+    })?;
+    match stack[pos] {
+        StackVal::Float { sreg } => {
+            vfp_check_slot_range(slot, false)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::F32Store {
+                    sd: sreg,
+                    addr: MemAddr::imm(Reg::SP, slot),
+                },
+                source_line: Some(idx),
+            });
+            free_vfp_temp(vfp_used, vfp_home, sreg);
+            stack[pos] = StackVal::FloatSpilled { slot };
+        }
+        StackVal::Double { dreg } => {
+            vfp_check_slot_range(slot, true)?;
+            instructions.push(ArmInstruction {
+                op: ArmOp::F64Store {
+                    dd: dreg,
+                    addr: MemAddr::imm(Reg::SP, slot),
+                },
+                source_line: Some(idx),
+            });
+            free_vfp_dtemp(vfp_used, vfp_home, dreg);
+            stack[pos] = StackVal::DoubleSpilled { slot };
+        }
+        _ => unreachable!("victim position was matched as Float/Double above"),
+    }
+    Ok(true)
+}
+
+/// Reload the spilled VFP entry at `stack[pos]` (if it is one) into a fresh
+/// S-register / aligned D-pair, spilling deeper segment-local values to make
+/// room when the file is full. No-op for register-resident / integer entries.
+#[allow(clippy::too_many_arguments)] // mirrors the integer spill helpers' threading
+fn vfp_reload_spilled(
+    pos: usize,
+    stack: &mut [StackVal],
+    cf_floor: usize,
+    protect_top: usize,
+    vfp_used: &mut [bool; 16],
+    vfp_home: &[bool; 16],
+    spill: &mut SpillState,
+    instructions: &mut Vec<ArmInstruction>,
+    idx: usize,
+) -> Result<()> {
+    match stack[pos] {
+        StackVal::FloatSpilled { slot } => {
+            let sreg = loop {
+                match alloc_vfp_temp(vfp_used) {
+                    Ok(r) => break r,
+                    Err(e) => {
+                        if !spill_deepest_vfp(
+                            stack,
+                            cf_floor,
+                            protect_top,
+                            vfp_used,
+                            vfp_home,
+                            spill,
+                            instructions,
+                            idx,
+                        )? {
+                            return Err(e);
+                        }
+                    }
+                }
+            };
+            instructions.push(ArmInstruction {
+                op: ArmOp::F32Load {
+                    sd: sreg,
+                    addr: MemAddr::imm(Reg::SP, slot),
+                },
+                source_line: Some(idx),
+            });
+            spill.free(slot);
+            stack[pos] = StackVal::Float { sreg };
+        }
+        StackVal::DoubleSpilled { slot } => {
+            let dreg = loop {
+                match alloc_vfp_dtemp(vfp_used) {
+                    Ok(r) => break r,
+                    Err(e) => {
+                        if !spill_deepest_vfp(
+                            stack,
+                            cf_floor,
+                            protect_top,
+                            vfp_used,
+                            vfp_home,
+                            spill,
+                            instructions,
+                            idx,
+                        )? {
+                            return Err(e);
+                        }
+                    }
+                }
+            };
+            instructions.push(ArmInstruction {
+                op: ArmOp::F64Load {
+                    dd: dreg,
+                    addr: MemAddr::imm(Reg::SP, slot),
+                },
+                source_line: Some(idx),
+            });
+            spill.free(slot);
+            stack[pos] = StackVal::Double { dreg };
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Best-effort headroom: spill deepest segment-local VFP values until at
+/// least `need_s` free S-slots AND `need_pairs` free ALIGNED S-pairs (whole
+/// D-registers) exist, or nothing spillable remains. Never fails for lack of
+/// victims (the op's own allocation will then raise the honest exhaustion
+/// `Err` exactly as before this rung existed); only a slot-pool exhaustion /
+/// VSTR-range problem propagates.
+#[allow(clippy::too_many_arguments)] // mirrors the integer spill helpers' threading
+fn vfp_ensure_headroom(
+    need_s: usize,
+    need_pairs: usize,
+    stack: &mut [StackVal],
+    cf_floor: usize,
+    protect_top: usize,
+    vfp_used: &mut [bool; 16],
+    vfp_home: &[bool; 16],
+    spill: &mut SpillState,
+    instructions: &mut Vec<ArmInstruction>,
+    idx: usize,
+) -> Result<()> {
+    loop {
+        let free_s = vfp_used.iter().filter(|&&u| !u).count();
+        let free_pairs = (0..8)
+            .filter(|&i| !vfp_used[2 * i] && !vfp_used[2 * i + 1])
+            .count();
+        if free_s >= need_s.max(2 * need_pairs) && free_pairs >= need_pairs {
+            return Ok(());
+        }
+        if !spill_deepest_vfp(
+            stack,
+            cf_floor,
+            protect_top,
+            vfp_used,
+            vfp_home,
+            spill,
+            instructions,
+            idx,
+        )? {
+            return Ok(()); // best-effort: nothing left to spill
+        }
+    }
+}
+
+/// The VFP pressure demand of one wasm op under the #881 rung:
+/// `(reload_window, need_s, need_pairs)` — reload the (up to) `reload_window`
+/// top spilled VFP operands this op will consume, then ensure `need_s` free
+/// S-slots and `need_pairs` free aligned D-pairs before lowering starts. The
+/// numbers are conservative UPPER bounds on the op's transient allocations
+/// (an under-estimate only re-raises the pre-rung exhaustion decline — never
+/// a miscompile; an over-estimate merely spills deeper values early).
+fn vfp_op_demand(op: &WasmOp) -> (usize, usize, usize) {
+    use WasmOp::*;
+    match op {
+        // The #869 i64<->f32/f64 conversion family runs on multi-D-temp f64
+        // machinery (exact two-word build, round-to-odd fixup, #782 decompose).
+        I64TruncF32S | I64TruncF32U | I64TruncSatF32S | I64TruncSatF32U | F32ConvertI64S
+        | F32ConvertI64U | I64TruncF64S | I64TruncF64U | I64TruncSatF64S | I64TruncSatF64U
+        | F64ConvertI64S | F64ConvertI64U => (1, 1, 4),
+        // f32<->f64 width changes hold an S and a D at once.
+        F64PromoteF32 | F32DemoteF64 => (1, 1, 2),
+        // Remaining in-scope f64 ops: binops hold 2 operand D-regs + 1 result.
+        op if is_scope_f64_op(op) => (2, 0, 3),
+        // Pure f32 ops: 2 operands + 1 result S-registers.
+        op if is_scope_f32_op(op) => (2, 2, 0),
+        // f32 memory ops lowered in the main match.
+        F32Load { .. } | F32Store { .. } => (1, 1, 0),
+        // Float select (#782): [val1 val2 cond] — cond is integer; the two
+        // values below it may be VFP (f32 or f64) and the result needs one
+        // fresh register of the same kind.
+        Select => (3, 1, 1),
+        // A float local.set/tee may allocate a fresh pinned home (S or D).
+        LocalSet(_) | LocalTee(_) => (1, 1, 1),
+        // Explicit-return result homing pops the top value (must be resident).
+        // (`End` is a control op — the guard's control arm reloads its top-1
+        // before resetting the straight-line floor.)
+        Return => (1, 0, 0),
+        _ => (0, 0, 0),
+    }
+}
 /// lowers (mirrors the decoder's un-dropped f64 set EXACTLY — every decoded
 /// f64 op must be intercepted before the main match's `select_default`
 /// fallback, which is register-blind). `F64Load`/`F64Store` are lowered in the
@@ -4623,6 +4962,16 @@ pub struct InstructionSelector {
     /// `spill_on_exhaustion`, bit-identity is structural: only functions that
     /// failed BOTH earlier passes ever compile with this set.
     param_backing_on_exhaustion: bool,
+    /// #881 (VCR-RA-004): VFP spill-on-exhaustion retry mode. Default OFF —
+    /// the backend sets it only for a retry after `select_with_stack` failed
+    /// with a GI-FPU-002 register-file exhaustion `Err` (S0..S15 or the
+    /// caller-saved D0..D7 all live). When ON: (a) the shared spill area is
+    /// always reserved in the frame, and (b) the pre-op VFP pressure guard
+    /// spills the deepest straight-line-segment f32/f64 stack value (farthest
+    /// next use, Belady under LIFO discipline) and reloads spilled operands
+    /// before the ops that consume them. Bit-identity is structural, like the
+    /// two integer rungs above.
+    vfp_spill_on_exhaustion: bool,
     /// VCR-RA local promotion (#390, #242): keep eligible non-param i32 locals
     /// in callee-saved registers (r4..r8) instead of frame slots, eliminating
     /// their `ldr/str [sp,#off]` traffic — the structural step toward native
@@ -4753,6 +5102,7 @@ impl InstructionSelector {
             next_qreg: 0,
             spill_on_exhaustion: false,
             param_backing_on_exhaustion: false,
+            vfp_spill_on_exhaustion: false,
             local_promote: false,
             i64_spill_slots: I64_SPILL_SLOTS,
             sel_dsl: sel_dsl_from_env(),
@@ -4804,6 +5154,7 @@ impl InstructionSelector {
             next_qreg: 0,
             spill_on_exhaustion: false,
             param_backing_on_exhaustion: false,
+            vfp_spill_on_exhaustion: false,
             local_promote: false,
             i64_spill_slots: I64_SPILL_SLOTS,
             sel_dsl: sel_dsl_from_env(),
@@ -4838,6 +5189,15 @@ impl InstructionSelector {
     /// would change its bytes.
     pub fn set_param_backing_on_exhaustion(&mut self, enabled: bool) {
         self.param_backing_on_exhaustion = enabled;
+    }
+
+    /// #881 (VCR-RA-004): enable VFP spill-on-exhaustion. Intended ONLY as
+    /// the backend's retry after `select_with_stack` failed with a GI-FPU-002
+    /// register-file exhaustion `Err` — enabling it reserves the shared spill
+    /// area in the frame, so calling it for a function that compiles without
+    /// it would change its bytes.
+    pub fn set_vfp_spill_on_exhaustion(&mut self, enabled: bool) {
+        self.vfp_spill_on_exhaustion = enabled;
     }
 
     /// #587 pool-grow recovery rung: size the i64 spill-slot pool. Intended
@@ -10088,7 +10448,9 @@ impl InstructionSelector {
             &params_f64_vfp,
             &self.func_ret_i64,
             &self.type_ret_i64,
-            self.spill_on_exhaustion,
+            // #881: the VFP spill rung hands out slots from the same shared
+            // pool, so it must force the area exactly like the integer rung.
+            self.spill_on_exhaustion || self.vfp_spill_on_exhaustion,
             self.param_backing_on_exhaustion,
             calls_float_boundary,
             outgoing_arg_bytes,
@@ -10178,6 +10540,7 @@ impl InstructionSelector {
         // must match the area `compute_local_layout` reserved above.
         let mut spill = SpillState::with_slots(layout.i64_spill_base, self.i64_spill_slots);
         spill.spill_on_exhaustion = self.spill_on_exhaustion;
+        spill.vfp_spill_on_exhaustion = self.vfp_spill_on_exhaustion;
         spill.area_reserved = layout.spill_area_reserved;
         // Next available register for temporaries (start after params)
         let mut next_temp = num_params.min(4) as u8;
@@ -10507,6 +10870,12 @@ impl InstructionSelector {
             }
         }
 
+        // #881: straight-line floor for the VFP spill rung — the operand-stack
+        // depth at the last control-flow boundary. Entries below it were pushed
+        // before a branch/label and are never spill victims (a conditionally-
+        // executed spill store would not dominate its reload). Only consulted
+        // when `vfp_spill_on_exhaustion` is set.
+        let mut vfp_cf_floor: usize = 0;
         for (idx, op) in wasm_ops.iter().enumerate() {
             // Param registers still live at this op — reserved from temp/pair/
             // reload allocation so a constant/result/reload never clobbers a live
@@ -10536,6 +10905,73 @@ impl InstructionSelector {
             for bl in &block_labels {
                 if let Some(r) = bl.result_reg {
                     live_params.push(r);
+                }
+            }
+            // #881 (VCR-RA-004): the VFP pressure guard — rung-only (inert in
+            // every default compile). Control ops reset the straight-line
+            // floor (reloading a spilled top first, so End/Else result
+            // handling always sees a register-resident value); float-demand
+            // ops get their spilled operands reloaded and conservative
+            // register headroom freed by spilling the deepest segment-local
+            // VFP values (farthest next use under LIFO stack discipline).
+            if spill.vfp_spill_on_exhaustion && fpu.is_some() {
+                // Keep the floor meaningful as the stack shrinks.
+                vfp_cf_floor = vfp_cf_floor.min(stack.len());
+                match op {
+                    WasmOp::Block
+                    | WasmOp::Loop
+                    | WasmOp::If
+                    | WasmOp::Else
+                    | WasmOp::End
+                    | WasmOp::Br(_)
+                    | WasmOp::BrIf(_)
+                    | WasmOp::BrTable { .. } => {
+                        if !stack.is_empty() {
+                            vfp_reload_spilled(
+                                stack.len() - 1,
+                                &mut stack,
+                                vfp_cf_floor,
+                                1,
+                                &mut vfp_used,
+                                &vfp_home,
+                                &mut spill,
+                                &mut instructions,
+                                idx,
+                            )?;
+                        }
+                        vfp_cf_floor = stack.len();
+                    }
+                    _ => {
+                        let (window, need_s, need_pairs) = vfp_op_demand(op);
+                        if window + need_s + need_pairs > 0 {
+                            let lo = stack.len().saturating_sub(window);
+                            for pos in lo..stack.len() {
+                                vfp_reload_spilled(
+                                    pos,
+                                    &mut stack,
+                                    vfp_cf_floor,
+                                    window,
+                                    &mut vfp_used,
+                                    &vfp_home,
+                                    &mut spill,
+                                    &mut instructions,
+                                    idx,
+                                )?;
+                            }
+                            vfp_ensure_headroom(
+                                need_s,
+                                need_pairs,
+                                &mut stack,
+                                vfp_cf_floor,
+                                window,
+                                &mut vfp_used,
+                                &vfp_home,
+                                &mut spill,
+                                &mut instructions,
+                                idx,
+                            )?;
+                        }
+                    }
                 }
             }
             // GI-FPU-002 (#619/#369): intercept in-scope scalar f32 ops (and f32
@@ -14053,6 +14489,31 @@ impl InstructionSelector {
                     // R0..R3/NSAA walk consumes since AAPCS-VFP floats occupy
                     // neither). Integer-only callees keep the byte-identical
                     // legacy pop.
+                    // #881: under the VFP spill rung, a float argument may
+                    // have been spilled to the frame while deeper expression
+                    // pressure was relieved — reload every spilled VFP entry
+                    // in the argument window so pop_float/pop_double see
+                    // register-resident values. Non-argument entries stay
+                    // spilled (a frame slot trivially survives the call —
+                    // they need no caller-saved preservation).
+                    if spill.vfp_spill_on_exhaustion && fpu.is_some() && arg_count > 0 {
+                        let n = (arg_count as usize).min(stack.len());
+                        let lo = stack.len() - n;
+                        vfp_cf_floor = vfp_cf_floor.min(stack.len());
+                        for pos in lo..stack.len() {
+                            vfp_reload_spilled(
+                                pos,
+                                &mut stack,
+                                vfp_cf_floor,
+                                n,
+                                &mut vfp_used,
+                                &vfp_home,
+                                &mut spill,
+                                &mut instructions,
+                                idx,
+                            )?;
+                        }
+                    }
                     let (arg_srcs, float_args) = if float_arg_layout.is_empty() {
                         (
                             Self::pop_call_args(
@@ -14493,8 +14954,24 @@ impl InstructionSelector {
                 }
 
                 Drop => {
-                    // Just pop a value from the stack and discard it
-                    stack.pop();
+                    // Just pop a value from the stack and discard it.
+                    // #881 (rung-only, byte-invisible otherwise): a dropped
+                    // VFP value releases its register / spill slot so deep
+                    // drop-heavy shapes don't leak the finite S-file/pool.
+                    match stack.pop() {
+                        Some(StackVal::Float { sreg }) if spill.vfp_spill_on_exhaustion => {
+                            free_vfp_temp(&mut vfp_used, &vfp_home, sreg);
+                        }
+                        Some(StackVal::Double { dreg }) if spill.vfp_spill_on_exhaustion => {
+                            free_vfp_dtemp(&mut vfp_used, &vfp_home, dreg);
+                        }
+                        Some(
+                            StackVal::FloatSpilled { slot } | StackVal::DoubleSpilled { slot },
+                        ) => {
+                            spill.free(slot);
+                        }
+                        _ => {}
+                    }
                 }
 
                 Select => {

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -3884,6 +3884,32 @@ pub enum RaFinalViolation {
     /// lesson). Params/SP/LR are seeded available at entry, so a join reading a
     /// param is never flagged (documented boundary).
     JoinValueNotAvailable { reg: Reg, join_block: usize },
+    /// #881 (VFP extension): within one straight-line segment, a VFP frame
+    /// slot half `[sp,#slot]` is overwritten by a second live VFP value
+    /// (different source, or the same source after an intervening
+    /// redefinition) while the first value stored there is still needed — a
+    /// later VLDR of the slot reads the wrong value. The VFP twin of
+    /// [`RaFinalViolation::SpillSlotAliased`], at 4-byte-half granularity so
+    /// an `F32Store` clobbering half of a live `F64Store`'s slot is caught.
+    /// A re-store of the PROVABLY SAME value (same source S-word, no
+    /// redefinition in between — the legal preserve-then-arg-stage overlap)
+    /// is benign and not flagged.
+    VfpSpillSlotAliased {
+        slot: i32,
+        first_store: usize,
+        overwriting_store: usize,
+        stale_reload: usize,
+    },
+    /// #881 (VFP extension of the across-CALL invariant): the S-register word
+    /// `S{word}` (word in 2..16; each `D(i)` = words `2i`/`2i+1`) holds a value
+    /// defined before a `bl`/`blx`/`call` and read after it with no
+    /// intervening redefinition — yet ALL of S0..S15/D0..D7 are AAPCS-VFP
+    /// CALLER-saved, so the callee is free to clobber it. A correct
+    /// allocation spills such a value to the frame across the call
+    /// (`preserve_vfp_caller_saved` / a #881 spill slot). Words 0/1 (S0/S1 =
+    /// D0) are DELIBERATELY excluded: a call DEFINES them (the float return
+    /// value) — the documented false-negative twin of the R0/R1 exclusion.
+    VfpCallerSavedLiveAcrossCall { word: usize, call_index: usize },
 }
 
 /// The verdict of the UNCONDITIONAL final register-allocation validator
@@ -4206,6 +4232,20 @@ pub fn validate_final_allocation(instrs: &[ArmInstruction]) -> RaFinalVerdict {
         return RaFinalVerdict::Violation(v);
     }
 
+    // ---- Invariants 5+6 (#881): the VFP register file ----
+    // An unvalidated VFP allocation is exactly the #872 shape (a pass whose
+    // validator cannot see its errors): the VFP spill/reload machinery gets
+    // the same two whole-stream checks the integer file has — slot aliasing
+    // per straight-line segment, and caller-saved liveness across calls —
+    // over the shared S-word file (D(i) = S(2i):S(2i+1) aliasing modeled at
+    // word granularity).
+    if let Some(v) = check_vfp_slot_aliasing(instrs) {
+        return RaFinalVerdict::Violation(v);
+    }
+    if let Some(v) = check_vfp_caller_saved_across_calls(instrs) {
+        return RaFinalVerdict::Violation(v);
+    }
+
     // ---- Invariant 4: value availability across a join (phase 2) ----
     match check_join_availability(instrs) {
         JoinCheck::Consistent => {}
@@ -4252,6 +4292,327 @@ pub fn validate_final_allocation(instrs: &[ArmInstruction]) -> RaFinalVerdict {
 /// STRICTER route: require the post-call read to be reached with NO intervening
 /// def AND on the straight-line fall-through (we stop the forward scan at the
 /// first branch/label/call), so we never invent a cross-CF read.
+/// #881: the S-register WORD indices (0..=31; `S(k)` = word `k`, `D(i)` =
+/// words `2i`,`2i+1`) a [`crate::rules::VfpReg`] covers. `None` for the MVE
+/// Q-registers (not scalar VFP).
+fn vfp_reg_words(r: &crate::rules::VfpReg) -> Option<[Option<usize>; 2]> {
+    use crate::rules::VfpReg::*;
+    Some(match r {
+        S0 => [Some(0), None],
+        S1 => [Some(1), None],
+        S2 => [Some(2), None],
+        S3 => [Some(3), None],
+        S4 => [Some(4), None],
+        S5 => [Some(5), None],
+        S6 => [Some(6), None],
+        S7 => [Some(7), None],
+        S8 => [Some(8), None],
+        S9 => [Some(9), None],
+        S10 => [Some(10), None],
+        S11 => [Some(11), None],
+        S12 => [Some(12), None],
+        S13 => [Some(13), None],
+        S14 => [Some(14), None],
+        S15 => [Some(15), None],
+        D0 => [Some(0), Some(1)],
+        D1 => [Some(2), Some(3)],
+        D2 => [Some(4), Some(5)],
+        D3 => [Some(6), Some(7)],
+        D4 => [Some(8), Some(9)],
+        D5 => [Some(10), Some(11)],
+        D6 => [Some(12), Some(13)],
+        D7 => [Some(14), Some(15)],
+        D8 => [Some(16), Some(17)],
+        D9 => [Some(18), Some(19)],
+        D10 => [Some(20), Some(21)],
+        D11 => [Some(22), Some(23)],
+        D12 => [Some(24), Some(25)],
+        D13 => [Some(26), Some(27)],
+        D14 => [Some(28), Some(29)],
+        D15 => [Some(30), Some(31)],
+        _ => return None,
+    })
+}
+
+/// #881: word-level VFP register effect of one [`ArmOp`] —
+/// `Some((defs, uses))` over S-word indices for the ops whose VFP footprint
+/// is EXACTLY their listed operands, `None` for the compound VFP lowerings
+/// the encoder expands with internal sequences (trunc-with-guard, min/max
+/// NaN fix-ups, copysign, VRINT forms, the i64<->float family) — the checker
+/// stops/conservatively-widens at `None` rather than guessing (decline >
+/// guess, applied to the checker itself). Ops with NO VFP operands return
+/// `Some(empty)` — an integer op provably touches no S-word.
+#[allow(clippy::type_complexity)]
+fn vfp_word_effect(op: &ArmOp) -> Option<(Vec<usize>, Vec<usize>)> {
+    use ArmOp::*;
+    let w = |r: &crate::rules::VfpReg| -> Option<Vec<usize>> {
+        vfp_reg_words(r).map(|ws| ws.iter().flatten().copied().collect())
+    };
+    let some2 = |defs: Vec<usize>, uses: Vec<usize>| Some((defs, uses));
+    match op {
+        // Three-operand arithmetic: d <- n op m.
+        F32Add { sd, sn, sm }
+        | F32Sub { sd, sn, sm }
+        | F32Mul { sd, sn, sm }
+        | F32Div { sd, sn, sm } => some2(w(sd)?, [w(sn)?, w(sm)?].concat()),
+        F64Add { dd, dn, dm }
+        | F64Sub { dd, dn, dm }
+        | F64Mul { dd, dn, dm }
+        | F64Div { dd, dn, dm } => some2(w(dd)?, [w(dn)?, w(dm)?].concat()),
+        // Two-operand: d <- op m (single-instruction forms only).
+        F32Abs { sd, sm } | F32Neg { sd, sm } | F32Sqrt { sd, sm } => some2(w(sd)?, w(sm)?),
+        F64Abs { dd, dm } | F64Neg { dd, dm } | F64Sqrt { dd, dm } => some2(w(dd)?, w(dm)?),
+        // Compares read both VFP operands, write a core register.
+        F32Eq { sn, sm, .. }
+        | F32Ne { sn, sm, .. }
+        | F32Lt { sn, sm, .. }
+        | F32Le { sn, sm, .. }
+        | F32Gt { sn, sm, .. }
+        | F32Ge { sn, sm, .. } => some2(vec![], [w(sn)?, w(sm)?].concat()),
+        F64Eq { dn, dm, .. }
+        | F64Ne { dn, dm, .. }
+        | F64Lt { dn, dm, .. }
+        | F64Le { dn, dm, .. }
+        | F64Gt { dn, dm, .. }
+        | F64Ge { dn, dm, .. } => some2(vec![], [w(dn)?, w(dm)?].concat()),
+        // Materializations / loads define; stores use.
+        F32Const { sd, .. } | F32Load { sd, .. } => some2(w(sd)?, vec![]),
+        F64Const { dd, .. } | F64Load { dd, .. } => some2(w(dd)?, vec![]),
+        F32Store { sd, .. } => some2(vec![], w(sd)?),
+        F64Store { dd, .. } => some2(vec![], w(dd)?),
+        // Register-file crossings whose footprint is exactly the operands.
+        F32ConvertI32S { sd, .. } | F32ConvertI32U { sd, .. } => some2(w(sd)?, vec![]),
+        F64ConvertI32S { dd, .. } | F64ConvertI32U { dd, .. } => some2(w(dd)?, vec![]),
+        F32ReinterpretI32 { sd, .. } => some2(w(sd)?, vec![]),
+        I32ReinterpretF32 { sm, .. } => some2(vec![], w(sm)?),
+        F64ReinterpretI64 { dd, .. } => some2(w(dd)?, vec![]),
+        I64ReinterpretF64 { dm, .. } => some2(vec![], w(dm)?),
+        F64PromoteF32 { dd, sm } => some2(w(dd)?, w(sm)?),
+        F32DemoteF64 { sd, dm } => some2(w(sd)?, w(dm)?),
+        // Compound lowerings (encoder-expanded multi-instruction sequences
+        // whose internal VFP footprint is not visible here): UNMODELED.
+        F32Ceil { .. }
+        | F32Floor { .. }
+        | F32Trunc { .. }
+        | F32Nearest { .. }
+        | F32Min { .. }
+        | F32Max { .. }
+        | F32Copysign { .. }
+        | F64Ceil { .. }
+        | F64Floor { .. }
+        | F64Trunc { .. }
+        | F64Nearest { .. }
+        | F64Min { .. }
+        | F64Max { .. }
+        | F64Copysign { .. }
+        | F32ConvertI64S { .. }
+        | F32ConvertI64U { .. }
+        | F64ConvertI64S { .. }
+        | F64ConvertI64U { .. }
+        | I32TruncF32S { .. }
+        | I32TruncF32U { .. }
+        | I32TruncF64S { .. }
+        | I32TruncF64U { .. }
+        | I64TruncF64S { .. }
+        | I64TruncF64U { .. } => None,
+        // MVE (vector) ops: unmodeled — Q-registers alias the S-file.
+        MveAddF32 { .. }
+        | MveSubF32 { .. }
+        | MveMulF32 { .. }
+        | MveNegF32 { .. }
+        | MveAbsF32 { .. }
+        | MveCmpEqF32 { .. }
+        | MveCmpNeF32 { .. }
+        | MveCmpLtF32 { .. }
+        | MveCmpLeF32 { .. }
+        | MveCmpGtF32 { .. }
+        | MveCmpGeF32 { .. }
+        | MveDupF32 { .. }
+        | MveExtractLaneF32 { .. }
+        | MveReplaceLaneF32 { .. }
+        | MveDivF32 { .. }
+        | MveSqrtF32 { .. } => None,
+        // Every other op is integer-only: provably no S-word footprint.
+        _ => some2(vec![], vec![]),
+    }
+}
+
+/// #881 (VFP twin of invariant 2): per-straight-line-segment VFP spill-slot
+/// non-aliasing at 4-byte-half granularity. See
+/// [`RaFinalViolation::VfpSpillSlotAliased`].
+fn check_vfp_slot_aliasing(instrs: &[ArmInstruction]) -> Option<RaFinalViolation> {
+    use ArmOp::*;
+    #[derive(Clone)]
+    struct HalfState {
+        owner_store: usize,
+        // The source S-word this half was stored from, and the word's
+        // def-version at store time — a later store of the SAME word at the
+        // SAME version provably re-stores the identical value (benign, the
+        // preserve-then-arg-stage overlap).
+        src_word: usize,
+        src_version: u64,
+        owner_reloaded: bool,
+        shadowed: Option<(usize, usize)>,
+    }
+    let mut i = 0usize;
+    while i < instrs.len() {
+        if !is_straight_line(&instrs[i].op) {
+            i += 1;
+            continue;
+        }
+        let mut halves: BTreeMap<i32, HalfState> = BTreeMap::new();
+        // Def-version per S-word (0..32): bumped on every def; bumped for ALL
+        // words on an unmodeled VFP op (conservative: the benign-refresh
+        // proof needs "no redefinition", and an unmodeled op might define).
+        let mut version = [0u64; 32];
+        while i < instrs.len() && is_straight_line(&instrs[i].op) {
+            // (a) store/load slot tracking (before the def bump: a store
+            // reads its source's PRE-instruction value).
+            let mut store_halves: Vec<(i32, usize)> = Vec::new(); // (half, src_word)
+            let mut load_halves: Vec<i32> = Vec::new();
+            match &instrs[i].op {
+                F32Store { sd, addr } if sp_slot(addr).is_some() => {
+                    if let Some([Some(w0), None]) = vfp_reg_words(sd) {
+                        store_halves.push((sp_slot(addr).unwrap(), w0));
+                    }
+                }
+                F64Store { dd, addr } if sp_slot(addr).is_some() => {
+                    if let Some([Some(w0), Some(w1)]) = vfp_reg_words(dd) {
+                        let slot = sp_slot(addr).unwrap();
+                        store_halves.push((slot, w0));
+                        store_halves.push((slot + 4, w1));
+                    }
+                }
+                F32Load { addr, .. } if sp_slot(addr).is_some() => {
+                    load_halves.push(sp_slot(addr).unwrap());
+                }
+                F64Load { addr, .. } if sp_slot(addr).is_some() => {
+                    let slot = sp_slot(addr).unwrap();
+                    load_halves.push(slot);
+                    load_halves.push(slot + 4);
+                }
+                _ => {}
+            }
+            for half in load_halves {
+                if let Some(st) = halves.get_mut(&half) {
+                    if let Some((first_store, overwriting_store)) = st.shadowed {
+                        return Some(RaFinalViolation::VfpSpillSlotAliased {
+                            slot: half,
+                            first_store,
+                            overwriting_store,
+                            stale_reload: i,
+                        });
+                    }
+                    st.owner_reloaded = true;
+                }
+            }
+            for (half, src_word) in store_halves {
+                let v = version[src_word.min(31)];
+                let shadowed = match halves.get(&half) {
+                    Some(prev) if !prev.owner_reloaded => {
+                        if prev.src_word == src_word && prev.src_version == v {
+                            // Provably the same value re-stored: benign.
+                            prev.shadowed
+                        } else {
+                            Some((prev.owner_store, i))
+                        }
+                    }
+                    Some(prev) => prev.shadowed,
+                    None => None,
+                };
+                halves.insert(
+                    half,
+                    HalfState {
+                        owner_store: i,
+                        src_word,
+                        src_version: v,
+                        owner_reloaded: false,
+                        shadowed,
+                    },
+                );
+            }
+            // (b) def-version bump AFTER the slot tracking.
+            match vfp_word_effect(&instrs[i].op) {
+                Some((defs, _)) => {
+                    for d in defs {
+                        version[d.min(31)] += 1;
+                    }
+                }
+                None => {
+                    for v in version.iter_mut() {
+                        *v += 1;
+                    }
+                }
+            }
+            i += 1;
+        }
+    }
+    None
+}
+
+/// #881 (VFP twin of the across-CALL invariant): a VFP S-word live across a
+/// `bl`/`blx`/`call`. Same structure as [`check_caller_saved_across_calls`]
+/// — backward straight-line producer scan, forward straight-line consumer
+/// scan, both stopping conservatively at barriers and unmodeled ops — over
+/// S-words 2..16 (words 0/1 = the S0/D0 return, excluded; words >= 16 =
+/// D8..D15 are CALLEE-saved, out of scope for a caller-side check).
+fn check_vfp_caller_saved_across_calls(instrs: &[ArmInstruction]) -> Option<RaFinalViolation> {
+    use ArmOp::*;
+    let is_call = |op: &ArmOp| matches!(op, Bl { .. } | Blx { .. } | Call { .. });
+    for (ci, ins) in instrs.iter().enumerate() {
+        if !is_call(&ins.op) {
+            continue;
+        }
+        for word in 2..16usize {
+            // (a) pre-call producer.
+            let mut has_producer = false;
+            for prev in instrs[..ci].iter().rev() {
+                if !is_straight_line(&prev.op) {
+                    break;
+                }
+                match vfp_word_effect(&prev.op) {
+                    Some((defs, _)) => {
+                        if defs.contains(&word) {
+                            has_producer = true;
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+            if !has_producer {
+                continue;
+            }
+            // (b) post-call consumer on the straight-line fall-through.
+            let mut read_after = false;
+            for next in &instrs[ci + 1..] {
+                if !is_straight_line(&next.op) {
+                    break;
+                }
+                match vfp_word_effect(&next.op) {
+                    Some((defs, uses)) => {
+                        if uses.contains(&word) {
+                            read_after = true;
+                            break;
+                        }
+                        if defs.contains(&word) {
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+            if read_after {
+                return Some(RaFinalViolation::VfpCallerSavedLiveAcrossCall {
+                    word,
+                    call_index: ci,
+                });
+            }
+        }
+    }
+    None
+}
+
 fn check_caller_saved_across_calls(instrs: &[ArmInstruction]) -> Option<RaFinalViolation> {
     use ArmOp::*;
     const CALLER_SAVED: [Reg; 3] = [Reg::R2, Reg::R3, Reg::R12];

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -16180,4 +16180,210 @@ mod tests {
             "the identity rewrite must pass — the gate is non-vacuous"
         );
     }
+
+    // =====================================================================
+    // #881: the VFP twins of the RA-003 invariants (red-first pins).
+    // The live-fixture red evidence: injecting a dropped S2 preservation in
+    // preserve_vfp_caller_saved fired VfpCallerSavedLiveAcrossCall{word:2}
+    // on spill_call, and forcing every VFP spill onto slot 0 in
+    // spill_deepest_vfp fired VfpSpillSlotAliased on deep_s/deep_d — these
+    // unit pins keep both detections from regressing.
+    // =====================================================================
+
+    use crate::rules::VfpReg;
+
+    fn f32c(sd: VfpReg) -> ArmInstruction {
+        ins(ArmOp::F32Const { sd, value: 1.5 })
+    }
+    fn f32st(sd: VfpReg, off: i32) -> ArmInstruction {
+        ins(ArmOp::F32Store {
+            sd,
+            addr: MemAddr::imm(Reg::SP, off),
+        })
+    }
+    fn f32ld(sd: VfpReg, off: i32) -> ArmInstruction {
+        ins(ArmOp::F32Load {
+            sd,
+            addr: MemAddr::imm(Reg::SP, off),
+        })
+    }
+
+    /// RED: two DIFFERENT live VFP values sharing one frame slot — the later
+    /// reload consumes the overwriting value.
+    #[test]
+    fn ra003_vfp_slot_aliased_two_live_values_caught_881() {
+        let body = vec![
+            push_prologue(vec![Reg::LR]),
+            f32c(VfpReg::S2),
+            f32st(VfpReg::S2, 0), // value A -> [sp,0]
+            f32c(VfpReg::S3),
+            f32st(VfpReg::S3, 0), // value B overwrites A (A never reloaded)
+            f32ld(VfpReg::S4, 0), // reload expecting A, reads B
+            pop_epilogue(vec![Reg::PC]),
+        ];
+        assert!(
+            matches!(
+                validate_final_allocation(&body),
+                RaFinalVerdict::Violation(RaFinalViolation::VfpSpillSlotAliased { slot: 0, .. })
+            ),
+            "two live VFP values sharing a slot must be a violation"
+        );
+    }
+
+    /// RED: an F32Store clobbering HALF of a live F64Store's slot (the S/D
+    /// aliasing hazard the half-granularity model exists for).
+    #[test]
+    fn ra003_vfp_slot_aliased_f32_over_f64_half_caught_881() {
+        let body = vec![
+            push_prologue(vec![Reg::LR]),
+            ins(ArmOp::F64Const {
+                dd: VfpReg::D1,
+                value: 2.25,
+            }),
+            ins(ArmOp::F64Store {
+                dd: VfpReg::D1,
+                addr: MemAddr::imm(Reg::SP, 8),
+            }), // D1 -> [sp,8..16]
+            f32c(VfpReg::S1),
+            f32st(VfpReg::S1, 12), // clobbers the HI half of the live f64
+            ins(ArmOp::F64Load {
+                dd: VfpReg::D2,
+                addr: MemAddr::imm(Reg::SP, 8),
+            }), // reload expecting the f64: hi half is S1'''s bits
+            pop_epilogue(vec![Reg::PC]),
+        ];
+        assert!(
+            matches!(
+                validate_final_allocation(&body),
+                RaFinalVerdict::Violation(RaFinalViolation::VfpSpillSlotAliased { slot: 12, .. })
+            ),
+            "an F32Store into half of a live F64 slot must be a violation"
+        );
+    }
+
+    /// GREEN: a re-store of the PROVABLY SAME value (same source word, no
+    /// redefinition between) is the legal preserve-then-arg-stage overlap.
+    #[test]
+    fn ra003_vfp_slot_same_value_refresh_benign_881() {
+        let body = vec![
+            push_prologue(vec![Reg::LR]),
+            f32c(VfpReg::S2),
+            f32st(VfpReg::S2, 0), // preserve S2
+            f32st(VfpReg::S2, 0), // arg-stage S2 again — same bytes
+            f32ld(VfpReg::S3, 0),
+            pop_epilogue(vec![Reg::PC]),
+        ];
+        assert!(
+            !matches!(
+                validate_final_allocation(&body),
+                RaFinalVerdict::Violation(_)
+            ),
+            "a same-value re-store must be benign (no false positive)"
+        );
+    }
+
+    /// RED: the same-source refresh is NOT benign after the source register
+    /// was redefined — the second store writes a DIFFERENT value.
+    #[test]
+    fn ra003_vfp_slot_refresh_after_redef_caught_881() {
+        let body = vec![
+            push_prologue(vec![Reg::LR]),
+            f32c(VfpReg::S2),
+            f32st(VfpReg::S2, 0), // value A
+            f32c(VfpReg::S2),     // S2 redefined -> value B
+            f32st(VfpReg::S2, 0), // stores B over the still-live A
+            f32ld(VfpReg::S3, 0),
+            pop_epilogue(vec![Reg::PC]),
+        ];
+        assert!(
+            matches!(
+                validate_final_allocation(&body),
+                RaFinalVerdict::Violation(RaFinalViolation::VfpSpillSlotAliased { slot: 0, .. })
+            ),
+            "a re-store after the source was redefined must be a violation"
+        );
+    }
+
+    /// RED: an S-word live across a bl with no spill/reload — the AAPCS-VFP
+    /// caller-saved clobber (the dropped-preservation injection shape).
+    #[test]
+    fn ra003_vfp_caller_saved_live_across_call_caught_881() {
+        let body = vec![
+            push_prologue(vec![Reg::LR]),
+            f32c(VfpReg::S2),
+            ins(ArmOp::Bl {
+                label: "func_1".to_string(),
+            }),
+            ins(ArmOp::F32Add {
+                sd: VfpReg::S3,
+                sn: VfpReg::S2,
+                sm: VfpReg::S2,
+            }), // reads S2 straight after the call
+            pop_epilogue(vec![Reg::PC]),
+        ];
+        assert!(
+            matches!(
+                validate_final_allocation(&body),
+                RaFinalVerdict::Violation(RaFinalViolation::VfpCallerSavedLiveAcrossCall {
+                    word: 2,
+                    ..
+                })
+            ),
+            "an S-word live across a bl without preservation must be a violation"
+        );
+    }
+
+    /// GREEN: the shipped preserve/restore pattern — VSTR before the bl,
+    /// VLDR after (the reload REDEFINES the word before any use).
+    #[test]
+    fn ra003_vfp_caller_saved_preserved_across_call_ok_881() {
+        let body = vec![
+            push_prologue(vec![Reg::LR]),
+            f32c(VfpReg::S2),
+            f32st(VfpReg::S2, 0), // preserve
+            ins(ArmOp::Bl {
+                label: "func_1".to_string(),
+            }),
+            f32ld(VfpReg::S2, 0), // restore (redefines S2)
+            ins(ArmOp::F32Add {
+                sd: VfpReg::S3,
+                sn: VfpReg::S2,
+                sm: VfpReg::S2,
+            }),
+            pop_epilogue(vec![Reg::PC]),
+        ];
+        assert!(
+            !matches!(
+                validate_final_allocation(&body),
+                RaFinalVerdict::Violation(_)
+            ),
+            "the preserve/restore pattern must not be flagged"
+        );
+    }
+
+    /// GREEN: S0/S1 (the D0 float return) are excluded — the "use the call'''s
+    /// float result" pattern is not a clobber.
+    #[test]
+    fn ra003_vfp_return_words_excluded_881() {
+        let body = vec![
+            push_prologue(vec![Reg::LR]),
+            f32c(VfpReg::S0),
+            ins(ArmOp::Bl {
+                label: "func_1".to_string(),
+            }),
+            ins(ArmOp::F32Add {
+                sd: VfpReg::S2,
+                sn: VfpReg::S0,
+                sm: VfpReg::S0,
+            }), // consumes the callee'''s S0 result
+            pop_epilogue(vec![Reg::PC]),
+        ];
+        assert!(
+            !matches!(
+                validate_final_allocation(&body),
+                RaFinalVerdict::Violation(_)
+            ),
+            "S0/S1 across a call is the float-return pattern, not a clobber"
+        );
+    }
 }

--- a/scripts/repro/vfp_spill_881.wat
+++ b/scripts/repro/vfp_spill_881.wat
@@ -1,0 +1,86 @@
+;; #881 (GI-FPU-002 + RA tail): VFP register-file exhaustion — the two decline
+;; classes that block the falcon cascade entry points on cortex-m7dp:
+;;
+;;  * `deep_s`  — phase 1: an f32 expression tree with >16 simultaneously-live
+;;    single-precision values (S0..S15 all live) — `position@0.7.0#tick` /
+;;    `attitude@0.7.0#tick` / iekf `ekf@0.7.0#estimate`.
+;;  * `deep_d`  — phase 2: an f64 expression with >8 simultaneously-live
+;;    double-precision values (caller-saved D0..D7 all live) —
+;;    `rate@0.7.0#tick` / `ekf@0.7.0#estimate`.
+;;  * `deep_mix` — the v0.52 #869 shape: i64<->f32 conversions (whose lowerings
+;;    run on D-register machinery) fired while a deep f32 stack is live —
+;;    the exact "f32-only code with no f64 of its own" D-pressure gale reported.
+;;
+;; The real falcon-components-v1.128.tar.gz per-stage artifact is not
+;; reachable from this environment, so these fixtures reproduce the SAME
+;; exhaustion errors (message-for-message) as the falcon entry points, and the
+;; gate is: all three compile to `nm -> T` symbols on
+;; `-t cortex-m7dp --relocatable` AND execute bit-identical to wasmtime.
+(module
+  ;; Phase 1: 20 f32 values live at peak (params a..d kept live to the end,
+  ;; plus a 16-deep constant tree), folded so every intermediate stays live.
+  (func $deep_s (export "deep_s") (param $a f32) (param $b f32) (result f32)
+    local.get $a
+    local.get $b
+    f32.const 1.5
+    f32.const 2.5
+    f32.const 3.25
+    f32.const 4.125
+    f32.const 5.0625
+    f32.const 6.5
+    f32.const 7.25
+    f32.const 8.125
+    f32.const 9.5
+    f32.const 10.25
+    f32.const 11.125
+    f32.const 12.5
+    f32.const 13.25
+    f32.const 14.125
+    f32.const 15.5
+    f32.const 16.25
+    f32.const 17.125
+    f32.const 18.5
+    ;; fold 20 values -> 1 (19 adds); peak simultaneous liveness = 20 > 16
+    f32.add f32.add f32.add f32.add f32.add
+    f32.add f32.add f32.add f32.add f32.add
+    f32.add f32.add f32.add f32.add f32.add
+    f32.add f32.add f32.add f32.add)
+
+  ;; Phase 2: 10 f64 values live at peak > 8 caller-saved D registers.
+  (func $deep_d (export "deep_d") (result f32)
+    f64.const 1.5
+    f64.const 2.25
+    f64.const 3.125
+    f64.const 4.0625
+    f64.const 5.5
+    f64.const 6.25
+    f64.const 7.125
+    f64.const 8.0625
+    f64.const 9.5
+    f64.const 10.25
+    f64.add f64.add f64.add f64.add f64.add
+    f64.add f64.add f64.add f64.add
+    f32.demote_f64)
+
+  ;; The #869 shape: i64->f32 converts (D-register machinery: exact two-word
+  ;; f64 build + round-to-odd fixup + demote) under a live f32 stack.
+  (func $deep_mix (export "deep_mix") (param $x i64) (param $y i64) (result f32)
+    f32.const 1.5
+    f32.const 2.5
+    f32.const 3.5
+    f32.const 4.5
+    f32.const 5.5
+    f32.const 6.5
+    f32.const 7.5
+    f32.const 8.5
+    f32.const 9.5
+    f32.const 10.5
+    f32.const 11.5
+    f32.const 12.5
+    local.get $x
+    f32.convert_i64_u
+    local.get $y
+    f32.convert_i64_s
+    f32.add
+    f32.add f32.add f32.add f32.add f32.add f32.add
+    f32.add f32.add f32.add f32.add f32.add f32.add))

--- a/scripts/repro/vfp_spill_881.wat
+++ b/scripts/repro/vfp_spill_881.wat
@@ -62,6 +62,119 @@
     f64.add f64.add f64.add f64.add
     f32.demote_f64)
 
+  ;; f32 spilled ACROSS a call: ~12 live f32 while calling a helper — the
+  ;; spilled entries are frame-resident (no caller-saved preservation needed),
+  ;; the register-resident rest rides the #719 VFP call-spill area.
+  (func $helper (param $v f32) (result f32)
+    local.get $v
+    f32.const 2.0
+    f32.mul)
+  (func $spill_call (export "spill_call") (param $a f32) (result f32)
+    f32.const 1.5
+    f32.const 2.5
+    f32.const 3.25
+    f32.const 4.125
+    f32.const 5.5
+    f32.const 6.25
+    f32.const 7.125
+    f32.const 8.5
+    f32.const 9.25
+    f32.const 10.125
+    f32.const 11.5
+    f32.const 12.25
+    f32.const 13.125
+    f32.const 14.5
+    f32.const 15.25
+    local.get $a
+    call $helper
+    f32.add f32.add f32.add f32.add f32.add
+    f32.add f32.add f32.add f32.add f32.add
+    f32.add f32.add f32.add f32.add f32.add)
+
+  ;; Pinned f32 local homes + a deep tree: homes are never spill victims,
+  ;; the expression temps around them are.
+  (func $deep_local (export "deep_local") (param $a f32) (result f32)
+    (local $t f32) (local $u f32)
+    local.get $a
+    f32.const 3.0
+    f32.mul
+    local.set $t
+    local.get $a
+    f32.const 5.0
+    f32.add
+    local.set $u
+    local.get $t
+    local.get $u
+    f32.const 1.5
+    f32.const 2.5
+    f32.const 3.25
+    f32.const 4.125
+    f32.const 5.5
+    f32.const 6.25
+    f32.const 7.125
+    f32.const 8.5
+    f32.const 9.25
+    f32.const 10.125
+    f32.const 11.5
+    f32.const 12.25
+    f32.const 13.125
+    f32.const 14.5
+    f32.const 15.25
+    f32.const 16.125
+    f32.add f32.add f32.add f32.add f32.add f32.add
+    f32.add f32.add f32.add f32.add f32.add f32.add
+    f32.add f32.add f32.add f32.add f32.add)
+
+  ;; The falcon clamp idiom under pressure: select over two f32 with a deep
+  ;; live stack (exercises the select reload window: [val1 val2 cond]).
+  (func $deep_select (export "deep_select") (param $a f32) (param $c i32) (result f32)
+    f32.const 1.5
+    f32.const 2.5
+    f32.const 3.25
+    f32.const 4.125
+    f32.const 5.5
+    f32.const 6.25
+    f32.const 7.125
+    f32.const 8.5
+    f32.const 9.25
+    f32.const 10.125
+    f32.const 11.5
+    f32.const 12.25
+    f32.const 13.125
+    f32.const 14.5
+    f32.const 15.25
+    f32.const 16.125
+    local.get $a
+    f32.const 100.0
+    local.get $c
+    select
+    f32.add f32.add f32.add f32.add f32.add f32.add
+    f32.add f32.add f32.add f32.add f32.add f32.add
+    f32.add f32.add f32.add f32.add)
+
+  ;; Interleaved S/D pressure: live f32 values below live f64 values in the
+  ;; ONE aliased register file, with promotes churning transient S-regs
+  ;; between D allocations — D-alloc must keep finding ALIGNED pairs (or
+  ;; spill until one frees) in a fragmented shared file.
+  (func $deep_sd_mix (export "deep_sd_mix") (param $a f32) (result f32)
+    local.get $a
+    f32.const 1.5
+    f32.const 2.5
+    f32.const 3.25
+    f32.const 4.125
+    f32.const 5.5
+    f32.const 6.25
+    f32.const 7.125
+    f64.const 10.25
+    f64.const 11.5
+    f64.const 12.25
+    f64.const 13.125
+    f64.const 14.5
+    f64.const 15.25
+    f64.add f64.add f64.add f64.add f64.add
+    f32.demote_f64
+    f32.add f32.add f32.add f32.add f32.add f32.add f32.add f32.add)
+
   ;; The #869 shape: i64->f32 converts (D-register machinery: exact two-word
   ;; f64 build + round-to-odd fixup + demote) under a live f32 stack.
   (func $deep_mix (export "deep_mix") (param $x i64) (param $y i64) (result f32)

--- a/scripts/repro/vfp_spill_881_differential.py
+++ b/scripts/repro/vfp_spill_881_differential.py
@@ -193,12 +193,39 @@ def main():
     obj = compile_relocatable(tmp)
 
     # Gate 1: falcon flags — every export is an emitted T symbol.
-    nm = subprocess.run(["arm-none-eabi-nm", obj], capture_output=True,
-                        text=True)
-    if nm.returncode != 0:
-        fail("nm failed on the relocatable object")
-    tsyms = {ln.split()[-1] for ln in nm.stdout.splitlines()
-             if " T " in ln}
+    #
+    # Read the symbols from the ELF SYMBOL TABLE via pyelftools rather than
+    # shelling out to `arm-none-eabi-nm`. The ARM GNU toolchain is NOT installed
+    # on the CI runner, so the nm form raised FileNotFoundError there while
+    # passing locally — a host dependency that made this oracle unrunnable in CI
+    # (the #850 class: an oracle that only works on the author's machine is a
+    # local check, not a gate). pyelftools is already a dependency of this job.
+    #
+    # `nm`'s "T" is: STT_FUNC-ish global symbol defined in an executable
+    # section. Reproduced here as: binding GLOBAL, defined (st_shndx is a real
+    # section index, not UND/ABS), and that section is executable (SHF_EXECINSTR).
+    from elftools.elf.elffile import ELFFile  # noqa: PLC0415 (CI dep, local import)
+
+    # Look the symbol table up by TYPE (SHT_SYMTAB), not by name: synth's
+    # relocatable objects emit the symtab with an EMPTY sh_name, so
+    # get_section_by_name(".symtab") returns None on them. `nm` finds it anyway
+    # because it searches by type — which is exactly why the nm form worked and
+    # a by-name port silently reported "no .symtab" on a file that has one.
+    with open(obj, "rb") as fh:
+        ef = ELFFile(fh)
+        symtab = next((s for s in ef.iter_sections()
+                       if s["sh_type"] == "SHT_SYMTAB"), None)
+        if symtab is None:
+            fail("relocatable object has no SHT_SYMTAB section")
+        tsyms = set()
+        for sym in symtab.iter_symbols():
+            if not sym.name or sym["st_info"]["bind"] != "STB_GLOBAL":
+                continue
+            shndx = sym["st_shndx"]
+            if shndx in ("SHN_UNDEF", "SHN_ABS", "SHN_COMMON"):
+                continue
+            if ef.get_section(shndx)["sh_flags"] & 0x4:  # SHF_EXECINSTR
+                tsyms.add(sym.name)
     missing = [e for e in EXPORTS if e not in tsyms]
     if missing:
         fail(f"exports missing from nm -> T: {missing}")

--- a/scripts/repro/vfp_spill_881_differential.py
+++ b/scripts/repro/vfp_spill_881_differential.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""#881 (GI-FPU-002 + RA tail / VCR-RA-004) — EXECUTION-validate VFP
+register-file spilling on cortex-m7dp under falcon's exact flags
+(`-t cortex-m7dp --relocatable`).
+
+The two exhaustion classes that block the falcon v1.128 cascade entry points
+(`position/attitude#tick` = phase-1 S0..S15, `rate#tick`/`ekf#estimate` =
+phase-2 D0..D7, plus the v0.52 #869 D-pressure-in-f32-only-code shape) are
+reproduced by `vfp_spill_881.wat` and must now:
+
+  1. COMPILE — every export reaches an `nm -> T` symbol (no GI-FPU-002 skip);
+  2. EXECUTE bit-identically to wasmtime through the SPILLED paths:
+       * deep_s      — 20 simultaneously-live f32 (S-file spill/reload)
+       * deep_d      — 10 simultaneously-live f64 (D-file spill/reload)
+       * deep_mix    — i64->f32 converts under a live 14-deep f32 stack
+       * spill_call  — spilled f32 frame-resident ACROSS a bl + helper call
+       * deep_local  — pinned f32 local homes are never victims
+       * deep_select — the falcon clamp idiom (select) under pressure
+       * deep_sd_mix — S/D aliasing churn (aligned-pair search while
+                       fragmented by live f32s)
+
+A function that emits but computes wrong is worse than one that declines:
+results are compared BIT-EXACT (NaN==NaN per WASM Core §4.3.3).
+
+The internal `bl` (spill_call -> helper) is resolved by linking the ET_REL
+object with arm-none-eabi-ld; ANY unresolved/unexpected relocation hard-fails
+the harness (the #757/#743 inverse-vacuity lesson: never skip-on-assumption).
+
+Run (needs wasmtime + unicorn + pyelftools + arm-none-eabi-ld):
+  SYNTH=/path/to/synth python scripts/repro/vfp_spill_881_differential.py
+"""
+
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R3,
+    UC_ARM_REG_S0,
+    UC_ARM_REG_S1,
+    UC_ARM_REG_SP,
+)
+
+try:
+    from unicorn.arm_const import UC_ARM_REG_C1_C0_2, UC_ARM_REG_FPEXC
+except ImportError:  # older unicorn naming
+    UC_ARM_REG_C1_C0_2 = None
+    UC_ARM_REG_FPEXC = None
+
+WAT = Path(__file__).with_name("vfp_spill_881.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+EXPORTS = [
+    "deep_s", "deep_d", "deep_mix", "spill_call",
+    "deep_local", "deep_select", "deep_sd_mix",
+]
+
+
+def fail(msg):
+    print(f"FAIL: {msg}")
+    sys.exit(1)
+
+
+def compile_relocatable(tmp):
+    obj = str(Path(tmp) / "vfp881.o")
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-o", obj,
+         "-t", "cortex-m7dp", "--relocatable"],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        fail(f"compile failed:\n{r.stderr}\n{r.stdout}")
+    combined = r.stderr + r.stdout
+    if "skipping function" in combined:
+        fail(f"a function was skipped (GI-FPU-002 regression):\n{combined}")
+    return obj
+
+
+def link(tmp, obj):
+    """Resolve the internal bl via a real link. Hard-fail on ANY ld
+    diagnostic — an unresolved reloc silently skipped is a vacuous gate."""
+    ld = shutil.which("arm-none-eabi-ld")
+    if ld is None:
+        fail("arm-none-eabi-ld not found (required to resolve the internal bl)")
+    out = str(Path(tmp) / "vfp881.elf")
+    r = subprocess.run(
+        [ld, "-e", "deep_s", "-Ttext=0x0", obj, "-o", out],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0 or r.stderr.strip():
+        fail(f"link failed / diagnostics:\n{r.stderr}")
+    return out
+
+
+def load(elf):
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    data, base = text.data(), text["sh_addr"]
+    syms = {}
+    for s in f.iter_sections():
+        if s.header.sh_type == "SHT_SYMTAB":  # #489: symtab, not disasm text
+            for sym in s.iter_symbols():
+                if sym.name:
+                    syms[sym.name] = sym["st_value"]
+    return data, base, syms
+
+
+def f32_bits(x):
+    return struct.unpack("<I", struct.pack("<f", x))[0]
+
+
+def bits_f32(b):
+    return struct.unpack("<f", struct.pack("<I", b & 0xFFFFFFFF))[0]
+
+
+def is_nan32(bits):
+    b = bits & 0xFFFFFFFF
+    return (b & 0x7F800000) == 0x7F800000 and (b & 0x007FFFFF) != 0
+
+
+def f32_bits_eq(got, want):
+    if is_nan32(got) and is_nan32(want):
+        return True  # WASM Core §4.3.3: NaN sign/payload non-deterministic
+    return (got & 0xFFFFFFFF) == (want & 0xFFFFFFFF)
+
+
+def new_uc(text, text_base):
+    uc = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    try:
+        from unicorn.arm_const import UC_CPU_ARM_MAX
+        uc.ctl_set_cpu_model(UC_CPU_ARM_MAX)
+    except (ImportError, AttributeError):
+        pass
+    map_base = text_base & ~0xFFF
+    size = ((len(text) + (text_base - map_base)) + 0xFFF) & ~0xFFF
+    uc.mem_map(map_base, max(size, 0x1000))
+    uc.mem_write(text_base, text)
+    uc.mem_map(0x30000, 0x10000)  # stack
+    uc.reg_write(UC_ARM_REG_SP, 0x38000)
+    # Enable the FPU (off at reset): CPACR CP10/CP11 + FPEXC.EN.
+    if UC_ARM_REG_C1_C0_2 is not None:
+        uc.reg_write(UC_ARM_REG_C1_C0_2, 0x00F00000)
+    if UC_ARM_REG_FPEXC is not None:
+        uc.reg_write(UC_ARM_REG_FPEXC, 0x40000000)
+    return uc
+
+
+def run_f32(text, base, addr, s0=None, s1=None, r0=None, r1=None, r2=None,
+            r3=None):
+    """Execute a function returning f32 in S0 (AAPCS-VFP hard-float)."""
+    uc = new_uc(text, base)
+    for reg, val in ((UC_ARM_REG_S0, s0), (UC_ARM_REG_S1, s1)):
+        if val is not None:
+            uc.reg_write(reg, val & 0xFFFFFFFF)
+    for reg, val in ((UC_ARM_REG_R0, r0), (UC_ARM_REG_R1, r1),
+                     (UC_ARM_REG_R2, r2), (UC_ARM_REG_R3, r3)):
+        if val is not None:
+            uc.reg_write(reg, val & 0xFFFFFFFF)
+    uc.reg_write(UC_ARM_REG_LR, 0x38000 | 1)
+    # Deep spilled expressions execute a few hundred instructions; 5000 is a
+    # loud upper bound (emu_start raises on runaway, never silent-passes).
+    uc.emu_start(addr | 1, 0x38000, count=5000)
+    return uc.reg_read(UC_ARM_REG_S0) & 0xFFFFFFFF
+
+
+def wasm_instance():
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, WAT.read_bytes())
+    store = wasmtime.Store(eng)
+    inst = wasmtime.Instance(store, mod, [])
+    return store, inst
+
+
+F32_VALS = [0.0, -0.0, 1.0, -1.5, 3.14159265, 1e30, -1e-30, 65535.875,
+            float("inf"), float("-inf"), float("nan"), 1.1754944e-38]
+I64_VALS = [0, 1, -1, 0x7FFFFFFFFFFFFFFF, -0x8000000000000000,
+            0xDEADBEEFCAFEBABE - (1 << 64), 1 << 32, (1 << 53) + 1, 12345]
+
+
+def main():
+    tmp = tempfile.mkdtemp(prefix="vfp881_")
+    obj = compile_relocatable(tmp)
+
+    # Gate 1: falcon flags — every export is an emitted T symbol.
+    nm = subprocess.run(["arm-none-eabi-nm", obj], capture_output=True,
+                        text=True)
+    if nm.returncode != 0:
+        fail("nm failed on the relocatable object")
+    tsyms = {ln.split()[-1] for ln in nm.stdout.splitlines()
+             if " T " in ln}
+    missing = [e for e in EXPORTS if e not in tsyms]
+    if missing:
+        fail(f"exports missing from nm -> T: {missing}")
+    print(f"PASS: all {len(EXPORTS)} exports emitted (nm -> T) under "
+          "-t cortex-m7dp --relocatable")
+
+    # Gate 2: execution, bit-exact vs wasmtime, on the LINKED image (the bl
+    # inside spill_call is resolved by a real link, never skipped).
+    elf = link(tmp, obj)
+    text, base, syms = load(elf)
+    store, inst = wasm_instance()
+    exp = inst.exports(store)
+
+    checked = 0
+    # deep_s(a, b): S-file spilling.
+    for a in F32_VALS:
+        for b in (0.5, -2.25, 1e20):
+            want = f32_bits(exp["deep_s"](store, a, b))
+            got = run_f32(text, base, syms["deep_s"],
+                          s0=f32_bits(a), s1=f32_bits(b))
+            if not f32_bits_eq(got, want):
+                fail(f"deep_s({a}, {b}): got {got:#010x} "
+                     f"({bits_f32(got)}), want {want:#010x}")
+            checked += 1
+
+    # deep_d(): D-file spilling (constant fold — one row, but the whole
+    # spilled path executes).
+    want = f32_bits(exp["deep_d"](store))
+    got = run_f32(text, base, syms["deep_d"])
+    if not f32_bits_eq(got, want):
+        fail(f"deep_d(): got {got:#010x}, want {want:#010x}")
+    checked += 1
+
+    # deep_mix(x, y): #869 i64->f32 under f32 pressure. AAPCS: x in r0:r1,
+    # y in r2:r3 (lo:hi little-endian pairs).
+    for x in I64_VALS:
+        for y in (0, -1, 1 << 40):
+            want = f32_bits(exp["deep_mix"](store, x, y))
+            xu, yu = x & (2**64 - 1), y & (2**64 - 1)
+            got = run_f32(text, base, syms["deep_mix"],
+                          r0=xu & 0xFFFFFFFF, r1=xu >> 32,
+                          r2=yu & 0xFFFFFFFF, r3=yu >> 32)
+            if not f32_bits_eq(got, want):
+                fail(f"deep_mix({x}, {y}): got {got:#010x}, want {want:#010x}")
+            checked += 1
+
+    # spill_call(a): spilled f32 across a bl.
+    for a in F32_VALS:
+        want = f32_bits(exp["spill_call"](store, a))
+        got = run_f32(text, base, syms["spill_call"], s0=f32_bits(a))
+        if not f32_bits_eq(got, want):
+            fail(f"spill_call({a}): got {got:#010x}, want {want:#010x}")
+        checked += 1
+
+    # deep_local(a): pinned homes + spilling.
+    for a in F32_VALS:
+        want = f32_bits(exp["deep_local"](store, a))
+        got = run_f32(text, base, syms["deep_local"], s0=f32_bits(a))
+        if not f32_bits_eq(got, want):
+            fail(f"deep_local({a}): got {got:#010x}, want {want:#010x}")
+        checked += 1
+
+    # deep_select(a, c): clamp idiom under pressure — BOTH select arms.
+    for a in (1.5, -7.25, float("nan")):
+        for c in (0, 1, 0x80000000):
+            want = f32_bits(exp["deep_select"](store, a, c))
+            got = run_f32(text, base, syms["deep_select"],
+                          s0=f32_bits(a), r0=c)
+            if not f32_bits_eq(got, want):
+                fail(f"deep_select({a}, {c:#x}): got {got:#010x}, "
+                     f"want {want:#010x}")
+            checked += 1
+
+    # deep_sd_mix(a): S/D aliasing churn.
+    for a in F32_VALS:
+        want = f32_bits(exp["deep_sd_mix"](store, a))
+        got = run_f32(text, base, syms["deep_sd_mix"], s0=f32_bits(a))
+        if not f32_bits_eq(got, want):
+            fail(f"deep_sd_mix({a}): got {got:#010x}, want {want:#010x}")
+        checked += 1
+
+    print(f"PASS: {checked} execution rows bit-identical to wasmtime "
+          "(unicorn, cortex-m7dp, spilled VFP paths)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
v0.53 lane L1. Gives the VFP register file the spill path the integer file has had since VCR-RA-001, closing the GI-FPU-002 exhaustion rungs (phase 1 S0..S15, phase 2 D0..D7) that block five falcon entry points.

- red-first repro of both exhaustion classes + the #869 mixed shape
- VFP spilling proper (VCR-RA-004 cycle-safe parallel-move)
- execution differential: 7 spilled-VFP shapes bit-identical vs wasmtime
- **VCR-RA-003 extended to see the VFP file** — slot-aliasing + caller-saved-across-call twins. An unvalidated VFP allocation would be exactly the #872 shape, so the validator had to grow with the pass.

Closes #881. Lane hit the session limit before final self-report; coordinator gating on CI.