### PR TITLE
range-realloc cross-barrier live-in soundness — the pass AND its validator (#872)

### DIFF
--- a/artifacts/size_attribution_390.md
+++ b/artifacts/size_attribution_390.md
@@ -15,11 +15,11 @@ thumbv7m baseline (gust_poll 208 B, gust_mix 12 B, 3.9x) is **CITED** from issue
 
 | function | synth .text (measured) | LLVM (cited #390) | ratio | #390 cited synth |
 |---|---|---|---|---|
-| gust_poll | 692 B | 208 B | 3.33x | 816 B (v0.11.50) |
+| gust_poll | 696 B | 208 B | 3.35x | 816 B (v0.11.50) |
 | gust_mix  | 32 B | 12 B | 2.67x | 44 B (v0.11.50) |
 
 synth has already shrunk since #390 was filed (levers landed v0.12–v0.39): the
-gap is now ~3.33x / ~2.67x, not 3.9x / 3.7x. In particular the
+gap is now ~3.35x / ~2.67x, not 3.9x / 3.7x. In particular the
 `and #0xffff -> uxth` peephole (issue Pass 5) has landed — gust_mix now emits
 `uxth r3, r0`, not the `movw+and` pair. Still open: spill churn, address
 re-materialization, the shadow-stack dance, and bool materialization.
@@ -28,7 +28,7 @@ re-materialization, the shadow-stack dance, and bool materialization.
 
 | function | .text B | spill_reload | addr_materialize | redundant_const | prologue_shadow | guard_bool | copy_move | productive | align_pad |
 |---|---|---|---|---|---|---|---|---|---|
-| gust_poll | 692 | 196 | 56 | 58 | 36 | 96 | 66 | 184 | 0 |
+| gust_poll | 696 | 200 | 56 | 58 | 36 | 96 | 66 | 182 | 2 |
 | gust_mix | 32 | 4 | 0 | 0 | 16 | 0 | 6 | 6 | 0 |
 | func_0 | 380 | 8 | 44 | 138 | 8 | 26 | 14 | 142 | 0 |
 | func_1 | 60 | 0 | 0 | 24 | 8 | 4 | 8 | 16 | 0 |

--- a/crates/synth-cli/tests/fact_spec_bounds_494.rs
+++ b/crates/synth-cli/tests/fact_spec_bounds_494.rs
@@ -238,15 +238,31 @@ fn proven_slot_bound_elides_all_eight_guards_494() {
     // guarded build (232->226) and 10 B off the specialized one (104->94). The
     // guard-elision win itself is unchanged (still 8 guards x 16 B = 128 B; see
     // the UDF census 16->0 above); the elision just shaves 4 B MORE off the
-    // specialized build, so the measured delta is 128 + 4 = 132.
+    // specialized build, so the measured delta was 128 + 4 = 132.
+    //
+    // #872 RE-PIN (v0.53): 132 -> 140. The guard-elision component did NOT
+    // change (UDF census still 16 -> 0, still 8 x 16 B) and the GUARDED build
+    // is byte-for-byte the same size (226). What moved is the guard-FREE
+    // lowering: the #872 exit-holding-range rule changed `poll`'s segment
+    // colouring so the body no longer needs r7/r8, which shrinks the prologue
+    // to a 16-bit `push {r4,r5,r6,lr}` and lets several intermediates use
+    // 16-bit encodings — 8 B off. The UNGUARDED FLOOR moved identically
+    // (94 -> 86, measured), and the differential's ratchet
+    // "specialized .text == unguarded floor .text" (bounds-guard tax = 0)
+    // still holds exactly, so the delta grows by the floor's improvement:
+    // 128 + 4 + 8 = 140. Execution evidence on the new bytes:
+    // fact_spec_bounds_494_differential.py (1024-case in-bounds sweep vs
+    // wasmtime + retained-trap + decline + RED force-admit legs).
     let (b_len, s_len) = (b.func("poll").len(), s.func("poll").len());
     assert_eq!(b_len, 226, "baseline poll size drifted");
-    assert_eq!(s_len, 94, "specialized poll size drifted");
+    assert_eq!(s_len, 86, "specialized poll size drifted");
     assert_eq!(
         b_len - s_len,
-        132,
+        140,
         "128 B guard elision (8 guards x 16 B, #752 SUB.W+CMP+BHS+UDF+CMP+BLS+UDF) \
-         + 4 B shift-mask elision on the specialized poll (#846, default-on)"
+         + 4 B shift-mask elision on the specialized poll (#846, default-on) \
+         + 8 B #872 colouring improvement on the guard-free lowering (the \
+         unguarded floor moved with it)"
     );
 
     // Certificate trail: one ADMIT per access, naming the obligation.

--- a/crates/synth-cli/tests/size_attribution_390.rs
+++ b/crates/synth-cli/tests/size_attribution_390.rs
@@ -128,8 +128,22 @@ fn per_function_sizes() -> BTreeMap<String, u64> {
 // gust_mix (no register shifts) is unchanged. Execution UNCHANGED — re-pinned
 // only after gust_spill_fwd_390_differential.py PASSED on the new default-on
 // bytes (gust_poll return + post-call state struct vs wasmtime).
+// RE-PINNED for the #872 range-realloc cross-barrier soundness fix (v0.53):
+// gust_poll 692→696 (+4). This is a SOUNDNESS COST, deliberately paid. The pass
+// no longer treats a segment live-in as dead at its last IN-SEGMENT use, so a
+// register holding a value post-segment code may still read is no longer a
+// recolouring target. gust_poll carries the exact #869 shape the issue reported:
+//     base:  movw r3, #0     mvns r5, r3     <- writes pass-through r3
+//     now:   movw r5, #0     mvns r5, r5     <- r3's exit value preserved
+// The +4 is the knock-on colouring change in the udiv/mls block downstream (one
+// const materialization the tighter colouring leaves un-DCE'd, `lsl.w`→`lsls`
+// recovering 2 B of it). func_0/func_1/gust_mix are byte-IDENTICAL.
+// Execution UNCHANGED — re-pinned only after gust_spill_fwd_390_differential.py
+// PASSED on the new bytes (gust_poll return + post-call state struct vs
+// wasmtime, in default and both lever opt-outs), alongside the full
+// trap-semantics oracle set and the #494 bounds differential.
 const LOCKED: &[(&str, u64)] = &[
-    ("gust_poll", 692),
+    ("gust_poll", 696),
     ("gust_mix", 32),
     ("func_0", 380),
     ("func_1", 60),

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -14162,6 +14162,71 @@ mod tests {
         );
     }
 
+    /// HONEST RESIDUAL BOUND (#872), pinned so it cannot be silently assumed
+    /// away: `validate_segment_rewrite` does NOT catch a recoloured
+    /// `Pop {…, PC}` that sits in the MIDDLE of a segment. It has no notion of
+    /// a mid-segment control transfer, so walking backward it discharges the
+    /// seeded `r7~r7` exit equation at the UNREACHABLE trailing pop, long
+    /// before the walk reaches the live one — and then accepts anything the
+    /// live pop does. This is the one place the #872 union exit seed does not
+    /// reach, and it is why that class is pinned at the PASS
+    /// (`realloc_never_recolours_a_pop_register_list_872`, `arch_pinned`) with
+    /// the whole-function `validate_final_allocation` as the independent
+    /// backstop — it returns `CalleeSavedNotRestored` on exactly this stream,
+    /// which is how the defect was found.
+    ///
+    /// Closing it in the segment validator needs intra-segment control-flow
+    /// modelling (a `Pop {…, PC}` is a return, not a straight-line op) — the
+    /// same "segment-local analysis cannot see the barrier" root cause as #872
+    /// itself. Change this assertion to a rejection when that lands.
+    #[test]
+    fn validator_misses_midsegment_pop_clobber_the_documented_872_bound() {
+        let epi = vec![Reg::R4, Reg::R5, Reg::R6, Reg::R7, Reg::R8, Reg::PC];
+        let mk = |first: Vec<Reg>| {
+            vec![
+                ins(ArmOp::Add {
+                    rd: Reg::SP,
+                    rn: Reg::SP,
+                    op2: Operand2::Imm(72),
+                }),
+                ins(ArmOp::Pop { regs: first }),
+                ins(ArmOp::Add {
+                    rd: Reg::SP,
+                    rn: Reg::SP,
+                    op2: Operand2::Imm(72),
+                }),
+                ins(ArmOp::Pop { regs: epi.clone() }),
+            ]
+        };
+        let orig = mk(epi.clone());
+        // The live epilogue restores r2-r7 from a stack image laid out for
+        // r4-r8: the caller's r8 is clobbered. A real miscompile.
+        let bad = mk(vec![Reg::R7, Reg::R6, Reg::R5, Reg::R4, Reg::R2, Reg::PC]);
+        assert_eq!(
+            validate_segment_rewrite(&orig, &bad),
+            Ok(()),
+            "documented bound moved — if the segment validator now REJECTS the \
+             mid-segment pop clobber, that is a win: update this pin to expect \
+             the rejection and say so"
+        );
+        // The whole-function validator is NOT blind to it — the backstop that
+        // actually caught this in the field must stay red on this stream.
+        assert!(
+            matches!(
+                validate_final_allocation(&[
+                    ins(ArmOp::Push {
+                        regs: vec![Reg::R4, Reg::R5, Reg::R6, Reg::R7, Reg::R8, Reg::LR],
+                    }),
+                    ins(ArmOp::Pop {
+                        regs: vec![Reg::R7, Reg::R6, Reg::R5, Reg::R4, Reg::R2, Reg::PC],
+                    }),
+                ]),
+                RaFinalVerdict::Violation(RaFinalViolation::CalleeSavedNotRestored { .. })
+            ),
+            "the whole-function backstop must stay red on the clobbering epilogue"
+        );
+    }
+
     #[test]
     fn validator_accepts_a_legitimate_internal_rename() {
         // Hand-built valid rewrite: the interior r5 range (born 0, dies 1) of

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -14064,6 +14064,104 @@ mod tests {
         );
     }
 
+    /// #872 follow-on, found by the whole-function VCR-RA-003 validator on
+    /// `sret_decide` (`CalleeSavedNotRestored { reg: R7 }`, which HARD-ERRORED
+    /// the compile and dropped the `shim` function).
+    ///
+    /// A `Pop` register list is NOT a renameable operand: it is a bitmask whose
+    /// stack layout is REGISTER-NUMBER order, paired with the prologue `Push`,
+    /// carrying the #490 callee-saved contract. And `Pop {…, PC}` is a RETURN —
+    /// so a LIVE one in the MIDDLE of a segment (the sret-shim shape: a real
+    /// epilogue followed by an unreachable second one) has defs that look
+    /// segment-locally DEAD, because the trailing pop re-defines them. The
+    /// colourer duly recoloured them — RED-FIRST, this test on the unfixed pass
+    /// emitted `pop {r7,r6,r5,r4,r2,pc}` for `pop {r4,r5,r6,r7,r8,pc}`,
+    /// restoring r2-r7 from the stack image the push laid out for r4-r8 and
+    /// leaving the caller's r8 clobbered. `validate_segment_rewrite` misses it
+    /// for the same reason the pass proposed it — walking backward, the seeded
+    /// `r7~r7` is discharged by the DEAD trailing pop before the walk reaches
+    /// the live one, the segment-local model having no notion of a mid-segment
+    /// control transfer. So this is pinned at the PASS.
+    #[test]
+    fn realloc_never_recolours_a_pop_register_list_872() {
+        let epilogue_regs = vec![Reg::R4, Reg::R5, Reg::R6, Reg::R7, Reg::R8, Reg::PC];
+        let seg = vec![
+            ins(ArmOp::Ldr {
+                rd: Reg::R2,
+                addr: MemAddr {
+                    base: Reg::SP,
+                    offset: 8,
+                    offset_reg: None,
+                },
+            }),
+            // Short-lived intermediates on r4/r6 — recolourable, and recolouring
+            // THEM is fine; that freedom is what makes the pop's dead-looking
+            // defs attractive rename targets.
+            ins(ArmOp::Mov {
+                rd: Reg::R4,
+                op2: Operand2::Reg(Reg::R2),
+            }),
+            ins(ArmOp::Add {
+                rd: Reg::R6,
+                rn: Reg::R4,
+                op2: Operand2::Imm(32),
+            }),
+            ins(ArmOp::Mov {
+                rd: Reg::R0,
+                op2: Operand2::Reg(Reg::R6),
+            }),
+            ins(ArmOp::Add {
+                rd: Reg::SP,
+                rn: Reg::SP,
+                op2: Operand2::Imm(72),
+            }),
+            // THE LIVE RETURN, mid-segment.
+            ins(ArmOp::Pop {
+                regs: epilogue_regs.clone(),
+            }),
+            // Unreachable second epilogue — the thing that makes the live pop's
+            // defs look dead to a segment-local last-use analysis.
+            ins(ArmOp::Add {
+                rd: Reg::SP,
+                rn: Reg::SP,
+                op2: Operand2::Imm(72),
+            }),
+            ins(ArmOp::Pop {
+                regs: epilogue_regs.clone(),
+            }),
+        ];
+        let pool = [
+            Reg::R0,
+            Reg::R1,
+            Reg::R2,
+            Reg::R3,
+            Reg::R4,
+            Reg::R5,
+            Reg::R6,
+            Reg::R7,
+            Reg::R8,
+        ];
+        let (out, stats) = reallocate_function(&seg, &pool);
+        assert_eq!(out.len(), seg.len(), "the pass never adds or drops ops");
+        for (i, (before, after)) in seg.iter().zip(out.iter()).enumerate() {
+            match (&before.op, &after.op) {
+                (ArmOp::Pop { regs: o }, ArmOp::Pop { regs: r }) => assert_eq!(
+                    o, r,
+                    "instruction {i}: a Pop register list was recoloured \
+                     (#872 / #490 CalleeSavedNotRestored): {out:?}"
+                ),
+                (ArmOp::Pop { .. }, other) => {
+                    panic!("instruction {i}: Pop rewritten into {other:?}")
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(
+            stats.validator_rejects, 0,
+            "the pass must not propose rewrites its own validator rejects"
+        );
+    }
+
     #[test]
     fn validator_accepts_a_legitimate_internal_rename() {
         // Hand-built valid rewrite: the interior r5 range (born 0, dies 1) of

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -3271,10 +3271,15 @@ fn op_shape(op: &ArmOp) -> Option<ArmOp> {
 /// downstream code to behave identically, the rewritten execution's value in
 /// `rewritten_reg` must equal the original execution's value in `orig_reg`."
 ///
-/// - **Exit seed:** for every register the original segment *writes* (the
-///   per-register last-written set), require `r ~ r` — the pass's live-out
-///   pinning contract (later segments read live-outs from their original
-///   registers). One refinement, because the seed models the segment's exit
+/// - **Exit seed:** for every register EITHER segment *writes* (the union of
+///   the two per-register last-written sets), require `r ~ r` — the pass's
+///   live-out pinning contract (later segments read live-outs from their
+///   original registers), PLUS the #872 half: a rewritten-side write to a
+///   register the original never defines must also prove exit identity,
+///   which a genuine clobber of a pass-through value (a live-in dead at its
+///   last *in-segment* use but read by post-segment code — unmodeled
+///   `reg_effect = None` ops read unknowable register sets) cannot.
+///   One refinement, because the seed models the segment's exit
 ///   INTERFACE: when the segment ends in a function return (`pop {..., pc}`),
 ///   the AAPCS caller-saved scratch registers `R2/R3/R12/LR` are dead-out by
 ///   calling convention (synth's own callers never read them after a call),
@@ -3312,13 +3317,20 @@ fn op_shape(op: &ArmOp) -> Option<ArmOp> {
 /// value of the same field — which in concrete syntax is necessarily the same
 /// register on each side.
 ///
-/// **Honest v1 bound** (matches the pass's own cross-segment contract, which
-/// pins only registers the original holds at exit): a rewritten-side write to
+/// **The former honest-v1 bound is CLOSED (#872):** a rewritten-side write to
 /// a register the original segment never defines (clobbering a pass-through
-/// value) is accepted when that write is segment-internally dead. Closing
-/// this requires cross-segment liveness (step 5) for both the pass and the
-/// validator. Everything else in the renames-only class — wrong renames, def
-/// redirects, live clobbers, swapped destinations, RMW splits — is rejected.
+/// value) used to be accepted when segment-internally dead — and that shared
+/// blind spot let the validator certify the #869 `f32.convert_i64_u`
+/// miscompile (`mvns r3, r3` recoloured onto a live-in the following
+/// unmodeled `I64Add` expansion still read). The exit seed now covers the
+/// union of both sides' written registers, so the validated contract is full
+/// exit register-file equivalence: every register written by either side
+/// proves identity at exit, and registers written by neither trivially hold
+/// their entry values on both sides. No cross-segment liveness is assumed —
+/// which is exactly why it is sound in front of `reg_effect = None` ops
+/// whose reads are unknowable. Everything in the renames-only class — wrong
+/// renames, def redirects, live clobbers, pass-through clobbers, swapped
+/// destinations, RMW splits — is rejected.
 pub fn validate_segment_rewrite(
     orig: &[ArmInstruction],
     rewritten: &[ArmInstruction],
@@ -3367,7 +3379,19 @@ pub fn validate_segment_rewrite_exempting(
         effects.push((eo, er));
     }
 
-    // Exit seed: identity equations for the original's written registers.
+    // Exit seed: identity equations for every register EITHER side writes.
+    // Seeding the original's written set enforces the pass's live-out pinning
+    // contract; seeding the REWRITTEN side's written set as well (#872)
+    // rejects a rewrite that clobbers a register the original never defines —
+    // a pass-through value (e.g. a live-in whose last modeled use is early)
+    // that post-segment code may still read. The segment cannot know its
+    // readers (a following `reg_effect = None` op reads an unknowable
+    // register set), so the only sound exit contract is register-file
+    // equivalence: registers written by either side must prove identity, and
+    // registers written by neither hold their entry values on both sides.
+    // Before #872 the rewritten side was NOT seeded, and the validator
+    // ACCEPTED the #869 `mvns r3, r3` live-in clobber its own pass produced —
+    // the mirror-pinning blind spot this seed closes.
     // At a function return (`pop {..., pc}` as the final instruction) the
     // AAPCS caller-saved scratch registers are dead-out by convention and
     // are exempted; everywhere else every written register is conservatively
@@ -3379,7 +3403,7 @@ pub fn validate_segment_rewrite_exempting(
     let aapcs_dead_at_return = [Reg::R2, Reg::R3, Reg::R12, Reg::LR];
     let mut eqs: BTreeSet<(Reg, Reg)> = effects
         .iter()
-        .flat_map(|(eo, _)| eo.defs.iter())
+        .flat_map(|(eo, er)| eo.defs.iter().chain(er.defs.iter()))
         .filter(|r| !(ends_in_return && aapcs_dead_at_return.contains(r)))
         .filter(|r| !exempt.contains(r))
         .map(|r| (*r, *r))
@@ -3461,10 +3485,13 @@ pub struct ReallocStats {
 ///     to its original register, so values produced by earlier segments are
 ///     read where they were left;
 ///   - per physical register, the LAST range opened (the one holding the
-///     register's value at segment exit) is pinned to its original register,
-///     so later segments find live-outs where they expect them — whether or
-///     not they actually read them (cross-segment liveness is step 5's
-///     refinement, not assumed here);
+///     register's value at segment exit) is pinned to its original register
+///     AND (#872) extended live-through to the segment end, so later readers
+///     — modeled ones in following segments and unmodeled `reg_effect = None`
+///     ops whose register reads are unknowable — find EVERY register's exit
+///     value where the original left it, whether or not the segment-local
+///     view saw a use (cross-segment liveness is step 5's refinement, not
+///     assumed here; a live-in's last in-segment use is NOT a death point);
 ///   - ranges on registers outside `pool` (reserved R9–R12, SP) are identity-
 ///     assigned and never enter the colouring (their registers cannot collide
 ///     with pool colours).
@@ -5178,7 +5205,7 @@ fn try_reallocate_segment(
             seg.last().map(|i| &i.op)
         );
     }
-    let Some(ranges) = straight_line_value_ranges(seg) else {
+    let Some(mut ranges) = straight_line_value_ranges(seg) else {
         if dbg {
             eprintln!("[postex-dbg] realloc decline: value_ranges=None");
         }
@@ -5186,6 +5213,39 @@ fn try_reallocate_segment(
     };
     if ranges.is_empty() {
         return SegmentOutcome::Declined;
+    }
+    // #872 exit-state equivalence: extend each register's EXIT-HOLDING range
+    // (the last range opened on it — including a pass-through live-in the
+    // segment never redefines) to the segment end, so no other value can be
+    // recoloured onto that register after its last in-segment use. The
+    // segment-local last-use is NOT a death point: segment-local analysis
+    // cannot see the readers that follow — an unmodeled `reg_effect = None`
+    // op (i64-pair pseudo-ops, FP reinterprets, calls) reads an unknowable
+    // register set, and a later segment reads live-ins where the greedy
+    // selector left them. The sound contract is therefore that the rewritten
+    // segment leaves EVERY physical register with the same exit value as the
+    // original: exit-holding ranges are pinned to their original register
+    // (below) AND — this extension — keep it to the end, closing the reuse
+    // window that miscompiled #869's `f32.convert_i64_u` (`mvns r3, r3`
+    // recoloured onto a live-in the following `I64Add` expansion still read).
+    // Registers with no range at all stay untouched on both sides (#677
+    // absent-colour blockers below; reserved registers identity-assign).
+    // Ranges wholly BEFORE a register's final def may still recolour onto it
+    // — the final def overwrites them on both sides, so exit state is
+    // unaffected. Under `relaxed_exit` (VCR-VER-001 terminal segment) only
+    // R0/R1 are observable past the `bx lr`, so only their exit-holding
+    // ranges are extended — matching the pin/exemption sets below.
+    {
+        let mut exit_holder: BTreeMap<Reg, usize> = BTreeMap::new();
+        for r in &ranges {
+            exit_holder.insert(r.reg, r.vreg); // creation order → last wins
+        }
+        for (reg, vreg) in exit_holder {
+            if relaxed_exit && !matches!(reg, Reg::R0 | Reg::R1) {
+                continue;
+            }
+            ranges[vreg].last_use = seg.len(); // vreg == index by construction
+        }
     }
     let pool_index: BTreeMap<Reg, usize> = pool.iter().enumerate().map(|(i, r)| (*r, i)).collect();
     let adj = range_interference(&ranges);
@@ -11747,14 +11807,20 @@ mod tests {
         // little freedom — the honest property is SOUNDNESS, not shrinkage.
         //
         // VCR-RA-003 UPDATE: the backward-dataflow validator found that the
-        // colourer's candidate rewrite for THIS segment relocates the first
+        // colourer's candidate rewrite for THIS segment relocated the first
         // r6 value onto r0 AFTER r0's pinned last range dies (dies-at-birth
         // non-interference), changing r0's EXIT value (3 → r3+r4). For a
         // mid-function segment a downstream read of r0 would then be a
-        // miscompile — the pinning protects where the last range LIVES, not
-        // the register's exit state. The validator therefore REJECTS the
-        // rewrite and the pass keeps the original bytes: soundness is now
-        // FULL identity here, enforced by the gate rather than assumed.
+        // miscompile — the pinning protected where the last range LIVES, not
+        // the register's exit state.
+        //
+        // #872 UPDATE: the pass now extends every register's exit-holding
+        // range live-through to the segment end, so the exit-state-changing
+        // candidate is never PROPOSED — `validator_rejects` must be 0 (a
+        // nonzero count is a pass bug by contract) and the bytes stay
+        // identical. The validator retains independent teeth for this class
+        // (`validator_rejects_pass_through_live_in_clobber_872` feeds it the
+        // bad rewrite directly).
         let seq = vec![
             ins(ArmOp::Movw {
                 rd: Reg::R0,
@@ -11805,12 +11871,11 @@ mod tests {
         let (out, stats) = reallocate_function(&seq, &pool);
         assert_eq!(stats.segments, 1);
         assert_eq!(
-            stats.validator_rejects, 1,
-            "the exit-state-changing candidate rewrite must be caught"
+            stats.validator_rejects, 0,
+            "the pass must no longer PROPOSE the exit-state-changing rewrite (#872)"
         );
-        assert_eq!(stats.reallocated, 0);
-        // The rejected segment passes through byte-identical — the safe
-        // fallback IS the original greedy code.
+        // Whether the segment recolours identically or declines, the bytes
+        // are the original greedy code — soundness is FULL identity here.
         assert_eq!(out, seq);
     }
 
@@ -13780,19 +13845,27 @@ mod tests {
     }
 
     #[test]
-    fn validator_accepts_dead_def_redirect_the_documented_v1_bound() {
-        // HONEST BOUND (documented on validate_segment_rewrite): a
-        // segment-internally DEAD def redirected to a register the original
-        // never writes is accepted — the validated contract covers exactly
-        // the original's last-written exit state (the pass's own pinning
-        // contract). Closing this needs cross-segment liveness (step 5).
+    fn validator_rejects_dead_def_redirect_onto_unwritten_register_872() {
+        // The FORMER honest-v1 bound, closed by #872: a segment-internally
+        // DEAD def redirected onto a register the original never writes used
+        // to be accepted — but segment-local deadness proves nothing about
+        // the post-segment readers (unmodeled ops read unknowable register
+        // sets, later segments read pass-through live-ins), so the rewrite
+        // changes r7's exit value and must be rejected.
         let seg = dead_def_segment();
         let mut rew = seg.clone();
         rew[0].op = ArmOp::Movw {
             rd: Reg::R7,
             imm16: 1,
-        }; // dead in both; r7 not in the original's written set
-        assert_eq!(validate_segment_rewrite(&seg, &rew), Ok(()));
+        }; // dead in-segment, but clobbers pass-through r7's exit value
+        assert_eq!(
+            validate_segment_rewrite(&seg, &rew),
+            Err(RewriteViolation::DefClobbersEquation {
+                index: 0,
+                orig: Reg::R7,
+                rewritten: Reg::R7
+            })
+        );
         // ... and a redirect that is dead in BOTH segments w.r.t. the
         // written-set contract (movw r0 overwritten by the add) is likewise
         // accepted — genuinely equivalent exit state, not a miss.
@@ -13819,23 +13892,145 @@ mod tests {
         );
     }
 
+    /// The #872 shape (the #869-era `f32.convert_i64_u` miscompile, minimized):
+    /// a pass-through live-in (`r3`, read once early, never redefined in the
+    /// segment) whose physical register the pass reused for a segment-internal
+    /// intermediate after its last *modeled* use — while an unmodeled op AFTER
+    /// the segment (`I64Add` pseudo-op / FP-reinterpret `vmov`) still reads
+    /// `r3`. `r2` is redefined at 3 so the intermediate born at 1 is NOT `r2`'s
+    /// exit range (unpinned, free to recolour — the reuse window).
+    fn pass_through_live_in_segment_872() -> Vec<ArmInstruction> {
+        vec![
+            // 0: orr r7, r5, r6 — intermediate A from live-ins r5/r6
+            ins(ArmOp::Orr {
+                rd: Reg::R7,
+                rn: Reg::R5,
+                op2: Operand2::Reg(Reg::R6),
+            }),
+            // 1: mvn r2, r3 — intermediate B; LAST in-segment use of live-in r3
+            ins(ArmOp::Mvn {
+                rd: Reg::R2,
+                op2: Operand2::Reg(Reg::R3),
+            }),
+            // 2: add r0, r2, r7 — consume A and B
+            ins(ArmOp::Add {
+                rd: Reg::R0,
+                rn: Reg::R2,
+                op2: Operand2::Reg(Reg::R7),
+            }),
+            // 3: movw r2, #0 — r2 redefined: B is not r2's exit-holding range
+            ins(ArmOp::Movw {
+                rd: Reg::R2,
+                imm16: 0,
+            }),
+            // 4: add r1, r2, r0
+            ins(ArmOp::Add {
+                rd: Reg::R1,
+                rn: Reg::R2,
+                op2: Operand2::Reg(Reg::R0),
+            }),
+        ]
+    }
+
+    /// The #872 bad rewrite: intermediate B recoloured onto the pass-through
+    /// live-in's register r3 (`mvn r3, r3`), clobbering r3's exit value —
+    /// exactly the `mvns r3, r3` reuse in the #869 disassembly. Original exit
+    /// r3 = entry r3; rewritten exit r3 = ~entry r3.
+    fn pass_through_live_in_bad_rewrite_872() -> Vec<ArmInstruction> {
+        let mut rew = pass_through_live_in_segment_872();
+        rew[1].op = ArmOp::Mvn {
+            rd: Reg::R3,
+            op2: Operand2::Reg(Reg::R3),
+        };
+        rew[2].op = ArmOp::Add {
+            rd: Reg::R0,
+            rn: Reg::R3,
+            op2: Operand2::Reg(Reg::R7),
+        };
+        rew
+    }
+
+    #[test]
+    fn validator_rejects_pass_through_live_in_clobber_872() {
+        // RED-FIRST evidence for #872: before the fix the validator ACCEPTED
+        // this rewrite (its exit seed covered only registers the ORIGINAL
+        // writes, so the pass-through r3 had no equation — the same
+        // segment-local last-use assumption the pass itself made: consistent
+        // wrongness, the VCR-ORACLE mirror-pinning class). Post-segment code
+        // (modeled reader in a later segment, or an unmodeled reg_effect=None
+        // op) observes r3's exit value, so the rewrite is a miscompile.
+        let seg = pass_through_live_in_segment_872();
+        let rew = pass_through_live_in_bad_rewrite_872();
+        assert_eq!(
+            validate_segment_rewrite(&seg, &rew),
+            Err(RewriteViolation::DefClobbersEquation {
+                index: 1,
+                orig: Reg::R3,
+                rewritten: Reg::R3
+            }),
+            "pass-through live-in clobber must be rejected (#872)"
+        );
+    }
+
+    #[test]
+    fn realloc_preserves_pass_through_live_in_exit_state_872() {
+        // RED-FIRST evidence for #872 at pass level: with a pool ordered so
+        // the colourer's preferred colour for intermediate B is exactly the
+        // pass-through live-in's register (everything else reserved-identity),
+        // the unfixed pass emits `mvn r3, r3` — and its validator accepted it.
+        // The fixed pass must leave EVERY register's exit value equal to the
+        // original's: r3 is never written by the original segment, so no
+        // rewrite may define it.
+        let seg = pass_through_live_in_segment_872();
+        let (out, stats) = reallocate_function(&seg, &[Reg::R3, Reg::R2]);
+        for i in &out {
+            if let Some(e) = reg_effect(&i.op) {
+                assert!(
+                    !e.defs.contains(&Reg::R3),
+                    "rewritten segment defines the pass-through live-in r3 \
+                     (exit-state divergence, #872): {out:?}"
+                );
+            }
+        }
+        // And the pass must never have shipped a rewrite its validator had to
+        // save it from: a nonzero count is a pass bug by contract.
+        assert_eq!(stats.validator_rejects, 0, "pass proposed an unsound rewrite");
+    }
+
     #[test]
     fn validator_accepts_a_legitimate_internal_rename() {
         // Hand-built valid rewrite: the interior r5 range (born 0, dies 1) of
-        // reshuffle_segment moved to r4; inputs (r0) and live-outs
-        // (r1/r2/r5-final) untouched.
+        // reshuffle_segment moved to r2 — a register the segment WRITES, whose
+        // exit-holding def (the `mov r2, ...` at 1) overwrites the recoloured
+        // value on both sides, so exit register-file equivalence holds.
+        // Inputs (r0) and live-outs (r1/r2/r5-final) untouched.
         let seg = reshuffle_segment();
         let mut rew = seg.clone();
         rew[0].op = ArmOp::Add {
-            rd: Reg::R4,
+            rd: Reg::R2,
             rn: Reg::R0,
             op2: Operand2::Imm(1),
         };
         rew[1].op = ArmOp::Mov {
             rd: Reg::R2,
-            op2: Operand2::Reg(Reg::R4),
+            op2: Operand2::Reg(Reg::R2),
         };
         assert_eq!(validate_segment_rewrite(&seg, &rew), Ok(()));
+        // The SAME interior rename targeted at r4 — a register neither side
+        // otherwise writes — is now rejected (#872): segment-locally r4's
+        // rewritten write is dead, but its exit value diverges from the
+        // original's pass-through r4.
+        let mut rew_r4 = seg.clone();
+        rew_r4[0].op = ArmOp::Add {
+            rd: Reg::R4,
+            rn: Reg::R0,
+            op2: Operand2::Imm(1),
+        };
+        rew_r4[1].op = ArmOp::Mov {
+            rd: Reg::R2,
+            op2: Operand2::Reg(Reg::R4),
+        };
+        assert!(validate_segment_rewrite(&seg, &rew_r4).is_err());
     }
 
     // --- VCR-RA-003 criterion 2: seeded mutation campaign ----------------

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -5232,16 +5232,36 @@ fn try_reallocate_segment(
     // absent-colour blockers below; reserved registers identity-assign).
     // Ranges wholly BEFORE a register's final def may still recolour onto it
     // — the final def overwrites them on both sides, so exit state is
-    // unaffected. Under `relaxed_exit` (VCR-VER-001 terminal segment) only
-    // R0/R1 are observable past the `bx lr`, so only their exit-holding
-    // ranges are extended — matching the pin/exemption sets below.
+    // unaffected.
+    //
+    // EXEMPTIONS — deliberately the SAME sets `validate_segment_rewrite`
+    // already exempts from its exit seed, so the pass proposes exactly what
+    // the validator can certify (`validator_rejects == 0` is the contract;
+    // a wider pass rule would only cost recolourings the oracle accepts):
+    //   - `ends_in_return` (`pop {..., pc}` last): R2/R3/R12/LR are AAPCS
+    //     caller-saved scratch, dead-out past a function return, so their
+    //     exit values are unobservable and their post-last-use windows stay
+    //     reusable. Without this the pass loses legal recolourings on every
+    //     return-terminated segment (measured: flight_seam's `mul r3, r2, r3`
+    //     tail) with zero soundness gain.
+    //   - `relaxed_exit` (VCR-VER-001 terminal segment): only R0/R1 are
+    //     observable past the `bx lr`, so only their exit-holding ranges are
+    //     extended — matching the pin/exemption sets below.
     {
+        let ends_in_return = matches!(
+            seg.last().map(|i| &i.op),
+            Some(ArmOp::Pop { regs }) if regs.contains(&Reg::PC)
+        );
+        let aapcs_dead_at_return = [Reg::R2, Reg::R3, Reg::R12, Reg::LR];
         let mut exit_holder: BTreeMap<Reg, usize> = BTreeMap::new();
         for r in &ranges {
             exit_holder.insert(r.reg, r.vreg); // creation order → last wins
         }
         for (reg, vreg) in exit_holder {
             if relaxed_exit && !matches!(reg, Reg::R0 | Reg::R1) {
+                continue;
+            }
+            if ends_in_return && aapcs_dead_at_return.contains(&reg) {
                 continue;
             }
             ranges[vreg].last_use = seg.len(); // vreg == index by construction
@@ -13994,7 +14014,10 @@ mod tests {
         }
         // And the pass must never have shipped a rewrite its validator had to
         // save it from: a nonzero count is a pass bug by contract.
-        assert_eq!(stats.validator_rejects, 0, "pass proposed an unsound rewrite");
+        assert_eq!(
+            stats.validator_rejects, 0,
+            "pass proposed an unsound rewrite"
+        );
     }
 
     #[test]

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -5270,6 +5270,50 @@ fn try_reallocate_segment(
     let pool_index: BTreeMap<Reg, usize> = pool.iter().enumerate().map(|(i, r)| (*r, i)).collect();
     let adj = range_interference(&ranges);
 
+    // ARCHITECTURAL REGISTER LISTS (#872 follow-on, caught by the whole-function
+    // VCR-RA-003 validator on `sret_decide`): a `Push`/`Pop` register list is
+    // NOT a renameable operand. It is a bitmask whose stack layout is the
+    // register NUMBER order, matched pairwise between the prologue push and
+    // every epilogue pop, and it carries the #490 callee-saved contract. A
+    // `Pop {…, PC}` in the MIDDLE of a segment is a return, so its defs look
+    // segment-locally dead (a later pop re-defines them) and the colourer
+    // happily recoloured them — `pop {r4,r5,r6,r7,r8,pc}` became
+    // `pop {r6,r5,r4,r3,r2,pc}`, restoring r2-r6 instead of r4-r8 and leaving
+    // the caller's r7/r8 clobbered (`CalleeSavedNotRestored { reg: R7 }`).
+    // Identity-pin every range a `Push` USES or a `Pop` DEFINES. Byte-neutral
+    // on the shipped corpus: at a segment's own prologue/epilogue these ranges
+    // are already pinned as inputs (`def == 0`) / exit-holders — this only
+    // catches the mid-segment return, whose ranges are dead-on-arrival and so
+    // interfere with nothing, costing no other recolouring.
+    let mut arch_pinned: BTreeSet<usize> = BTreeSet::new();
+    {
+        let mut current: BTreeMap<Reg, usize> = BTreeMap::new();
+        let mut next = 0usize; // same numbering as `straight_line_value_ranges`
+        for ins in seg {
+            let Some(e) = reg_effect(&ins.op) else {
+                return SegmentOutcome::Declined;
+            };
+            let arch = matches!(&ins.op, ArmOp::Push { .. } | ArmOp::Pop { .. });
+            for u in &e.uses {
+                let v = *current.entry(*u).or_insert_with(|| {
+                    let v = next;
+                    next += 1;
+                    v
+                });
+                if arch {
+                    arch_pinned.insert(v);
+                }
+            }
+            for d in &e.defs {
+                current.insert(*d, next);
+                if arch {
+                    arch_pinned.insert(next);
+                }
+                next += 1;
+            }
+        }
+    }
+
     // Pins: inputs (def == 0) and per-register last-opened ranges (live-outs)
     // keep their original register. Reserved-register ranges are identity-
     // assigned outside the colouring. With `relaxed_exit` (VCR-VER-001
@@ -5293,7 +5337,7 @@ fn try_reallocate_segment(
                 pool_nodes.insert(r.vreg);
                 let exit_pinned = last_opened.get(&r.reg) == Some(&r.vreg)
                     && (!relaxed_exit || matches!(r.reg, Reg::R0 | Reg::R1));
-                if r.def == 0 || exit_pinned {
+                if r.def == 0 || exit_pinned || arch_pinned.contains(&r.vreg) {
                     pins.insert(r.vreg, idx);
                 }
             }

--- a/scripts/repro/fact_spec_bounds_494_differential.py
+++ b/scripts/repro/fact_spec_bounds_494_differential.py
@@ -324,11 +324,16 @@ def main():
           f"+ 4 B from SYNTH_SHIFT_MASK_ELIDE, default-on since v0.50.1 (#846): "
           f"the elision trims BOTH builds but 4 B more off the specialized poll "
           f"[guarded 232->226, specialized 104->94]); unguarded floor {f_len} B")
-    # 132 = 128 (guard elision) + 4 (shift-mask elision fires more on the
-    # specialized build; SYNTH_SHIFT_MASK_ELIDE default-on since v0.50.1/#846).
-    # With SYNTH_SHIFT_MASK_ELIDE=0 this is exactly 128 (the pre-flip win).
-    if b_len - s_len != 132:
-        sys.exit(f"byte win drifted: expected exactly 132 B "
+    # 140 = 128 (guard elision) + 4 (shift-mask elision fires more on the
+    # specialized build; SYNTH_SHIFT_MASK_ELIDE default-on since v0.50.1/#846)
+    # + 8 (#872, v0.53: the exit-holding-range rule recoloured `poll`'s
+    # segments off r7/r8, shrinking the prologue to a 16-bit push and several
+    # intermediates to 16-bit encodings). The +8 is a GUARD-FREE-lowering win,
+    # NOT a guard-elision win: the guarded build is unchanged at 226 B and the
+    # unguarded floor moved with the specialized build (94 -> 86), so the
+    # byte-identity ratchet asserted just below still holds exactly.
+    if b_len - s_len != 140:
+        sys.exit(f"byte win drifted: expected exactly 140 B "
                  f"(got {b_len - s_len})")
     scode, sbase, ssyms = load(spec_elf)
     fcode, _, _ = load(floor_elf)


### PR DESCRIPTION
v0.53 lane L4. Fixes the defect v0.52 shipped **knowingly open**: default-on `SYNTH_RANGE_REALLOC` reused a segment live-in's register after its last in-segment use while an unmodeled (`reg_effect=None`) op past the segment still read it — **and `validate_segment_rewrite` shared the blind spot**, so it certified the miscompile. Shipped #782 survived on shape luck, not soundness.

Both halves fixed: a validator that still shares the bug's blind spot is not a fix.

Closes #872. Lane hit the session limit before final self-report; coordinator gating on CI.