### PR TITLE
VCR-DEC-001: graph-colouring allocator across if/else joins — measured, flag-off (#242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -851,16 +851,42 @@ jobs:
       # APPLIES on ≥2 fixtures and the UNCONDITIONAL VCR-RA-003 validator returns
       # Consistent on every applied function (observed via SYNTH_RA003_VERBOSE —
       # the acceptance oracle validating the new allocator's REAL output), and
-      # (3) flag-ON ≡ flag-OFF corpus-wide (a DESIGNED property: on a
-      # straight-line function graph_alloc and the shipping reallocate_function
-      # share pins + chaitin_core + single-segment scope, so byte-identity is by
-      # construction; execution correctness follows transitively via the frozen
-      # wasmtime differentials above). The red-first teeth are the unit probe
-      # graph_alloc_bad_rename_rejected_by_segment_validator (validate_segment_
-      # rewrite rejects a value-flow-breaking merge-rename). Byte-only compare —
-      # needs pyelftools ONLY (no unicorn/wasmtime).
+      # (3) NO SILENT DRIFT / NO GROWTH. v0.53 widened the spike to colour
+      # ACROSS if/else joins (increment 2), so applied functions now genuinely
+      # DIVERGE from the shipping bytes and the old "flag-ON ≡ flag-OFF
+      # corpus-wide" claim — which made execution correctness TRANSITIVE — is
+      # retired. What replaces it: a fixture the allocator did NOT apply to must
+      # stay byte-identical (no drift through a decline path), an applied one
+      # must not GROW its .text, and ≥2 fixtures must actually diverge or
+      # increment 2's reach has regressed. Byte-only compare — needs pyelftools
+      # ONLY (no unicorn/wasmtime).
       - name: Run VCR-DEC-001 graph-alloc spike differential (#242, thumb2)
         run: python scripts/repro/vcr_dec_001_graph_alloc_differential.py ./target/debug/synth
+      # VCR-DEC-001 increment 2 (#242): EXECUTION-gate the DIVERGENT bytes the
+      # join-aware colouring now produces. This is NOT redundant with the byte
+      # differential above: increment 1's correctness followed transitively from
+      # byte identity, and increment 2 broke that. `validate_cfg_rewrite` — the
+      # pass's own CFG-lifted trace-equality oracle — SHARES the CFG shape with
+      # the pass it validates, and #872 is the standing lesson that a validator
+      # can share its pass's blind spot, so the new bytes get EXECUTED: unicorn
+      # runs the flag-ON image and compares return value + linear-memory window
+      # against wasmtime, over every join shape the allocator reaches (real
+      # if/else, if-without-else, desugared block+br_if, early return, counted
+      # and data-dependent loops, two-level br_if). PROVEN non-vacuous by
+      # MUTATION: emptying `cfg_exit_observable` (the exit contract the pass and
+      # its validator SHARE) while removing the churn bias that masks it emits
+      # code leaving the return value in the wrong register — validate_cfg_rewrite
+      # AND VCR-RA-003 both ACCEPT it and only this gate catches it (16 wrong
+      # results). The grep asserts the NON-ZERO check count AND a non-zero
+      # engaged-function count from the machine-readable summary: exit 0 alone is
+      # not trusted, and a run where the allocator stopped changing bytes would
+      # pass every comparison while gating nothing.
+      - name: Run VCR-DEC-001 join-allocator execution differential (#242, thumb2)
+        run: |
+          set -o pipefail
+          SYNTH=./target/debug/synth python scripts/repro/vcr_dec_001_join_alloc_execution_differential.py | tee ga_join.out
+          grep -q "^VCR-DEC-001-JOIN CHECKS=" ga_join.out
+          awk -F'[=/ ]' '/^VCR-DEC-001-JOIN/ { if ($3+0 > 0 && $3 == $4 && $6+0 > 0) ok = 1 } END { exit ok ? 0 : 1 }' ga_join.out
       # #798/#879: the RV32 active-data-segment FULL-BOOT oracle — found
       # un-wired in the same #879 audit as the gpio gate. clang+lld build a
       # bare-metal riscv32 firmware from synth's object + generated startup/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **VCR-DEC-001 increment 2 — the graph-colouring allocator colours ACROSS
+  if/else joins (epic #242, still flag-off `SYNTH_GRAPH_ALLOC`).** Increment 1
+  could only colour a function that was ONE straight-line segment. The shipping
+  `reallocate_function` handles branchy functions by cutting them into maximal
+  straight-line segments and pinning each segment's inputs and per-register exit
+  holders — and those pins are exactly where the greedy allocator's weakness
+  concentrates: an if/else arm's first `movw r4, #400` is a segment-index-0 def,
+  so segment-local analysis is FORCED to treat it as a segment input and cannot
+  move it, even though whole-function liveness shows the value is born there,
+  dies two instructions later, and never crosses the join. Increment 2 builds the
+  function's label-form CFG, splits each register's def-use chains into
+  cross-block **webs** (reaching-def fixpoint), takes interference from CFG
+  liveness, and colours the whole function at once — so two arms' values, never
+  simultaneously live, share one register and the callee-saved save/restore
+  disappears under `shrink_callee_saved_saves`.
+  **MEASURED** (`scripts/repro/vcr_dec_001_join_alloc_measure.py`, 617 corpus
+  functions, 275 applied, `.text` sizes from the ELF symtab and SOUND cycle
+  bounds from `--emit-wcet`): **−46 bytes (−0.11 %) and −25 worst-case cycles
+  (−0.18 %); 8 functions shrank, 1 grew, 0 cycle regressions.** That is the
+  v0.54 flip input, and it says *not yet* — the reach is the limit, not the
+  soundness. In the measured (label-form) scope 164 functions decline on an
+  unmodeled i64/FP op and 68 on a call; on the DEFAULT self-contained path a
+  further 43 decline on pre-resolved numeric branches, whose displacements are
+  already baked so a rename that changes a Thumb encoding width would overshoot
+  (#606). Every decline is now named in a machine-readable histogram instead of
+  one opaque bucket, which is what makes the next increment schedulable. Two defects the measurement itself found are fixed here: an
+  edge-recheck that rejected two *pinned* webs of one register (16 functions
+  declined wholesale), and `chaitin_core`'s lowest-free-colour select repacking
+  whole functions into R0/R1 — which on `loop_param_bound_663::sum_const` landed
+  the loop's compare result on the register a later `forward_stack_reloads` was
+  forwarding through, turning two `mov`s into two `ldr`s inside the loop for
+  **+22 cycles**. A whole-function allocator that ignores what the rest of the
+  pipeline is about to do is not automatically better than a greedy one, so the
+  select now prefers a web's own register when it is already caller-saved, then
+  the lowest free caller-saved colour (the actual objective: evacuate R4–R8).
+  `chaitin_core` itself is deliberately untouched — it is shared with the
+  shipping pass, so a different select order there would move the frozen bytes.
+  **The oracles are the point.** The acceptance gate is
+  `liveness::validate_cfg_rewrite`, the straight-line Rideau/Leroy trace-equality
+  validator lifted to a backward MUST-fixpoint over the CFG (union at joins,
+  back edges included); it computes its own exit contract, so the pass cannot
+  hand it a weakened seed — the v0.50 join attempt failed exactly there. Because
+  that validator SHARES the CFG shape with the pass it validates, and #872 is the
+  standing lesson that a validator can share its pass's blind spot, the divergent
+  bytes are now EXECUTED: `vcr_dec_001_join_alloc_execution_differential.py`
+  (unicorn vs wasmtime, 38 checks over 13 engaged functions, CI-wired) is proven
+  non-vacuous by MUTATION — emptying the shared exit contract emits code leaving
+  the return value in the wrong register, and `validate_cfg_rewrite` *and*
+  VCR-RA-003 both ACCEPT it while only the execution gate catches it. `Push`/`Pop`
+  register lists are identity-pinned (the #888 class) and a mid-stream
+  `pop {…, pc}` is modelled as a RETURN sink. **Flag-OFF is byte-identical** —
+  frozen anchors 10/10, no default flip.
 - **RV32 `br_table` lowering (#882)** — the RISC-V selector now lowers
   `br_table` as a compare-and-branch chain (entry 0 against `x0`, `li`+`beq`
   per further entry, `jal` to the default), closing the last op gap on gale's

--- a/crates/synth-synthesis/src/graph_alloc.rs
+++ b/crates/synth-synthesis/src/graph_alloc.rs
@@ -65,10 +65,29 @@ pub fn enabled() -> bool {
 /// run on the output unchanged (so a value homed in R4-R8 still gets its
 /// callee-saved push — the invariant VCR-RA-003 guards).
 pub fn reallocate(instrs: &[ArmInstruction], pool: &[Reg]) -> Option<Vec<ArmInstruction>> {
+    if std::env::var("SYNTH_GRAPH_ALLOC_DUMP").is_ok() {
+        eprintln!("[ga-dump] ---- function, {} instrs ----", instrs.len());
+        for (i, ins) in instrs.iter().enumerate() {
+            eprintln!("[ga-dump] {i:3}: {:?}", ins.op);
+        }
+    }
+    // INCREMENT 1 (v0.50) — whole straight-line functions. Tried FIRST and left
+    // bit-for-bit as it shipped, so the increment-1 corpus stays byte-identical.
+    if let Some(out) = reallocate_straight_line(instrs, pool) {
+        return Some(out);
+    }
+    // INCREMENT 2 (v0.53, this lane) — colour ACROSS if/else joins.
+    joins::reallocate_across_joins(instrs, pool)
+}
+
+/// Increment 1: the whole-straight-line-function colouring, unchanged.
+fn reallocate_straight_line(
+    instrs: &[ArmInstruction],
+    pool: &[Reg],
+) -> Option<Vec<ArmInstruction>> {
     // BOUNDED SCOPE: the whole function must be ONE straight-line segment. Any
-    // control-flow / call / unmodeled op → decline (shipping path segments such
-    // functions; this spike does not, by design — increment 2 is the whole-
-    // function webs across joins).
+    // control-flow / call / unmodeled op → decline (increment 2 below takes the
+    // branchy ones; anything neither handles falls back to the shipping path).
     if instrs.is_empty() {
         return None;
     }
@@ -211,6 +230,830 @@ fn occurrence_costs(instrs: &[ArmInstruction]) -> Option<BTreeMap<usize, usize>>
         }
     }
     Some(costs)
+}
+
+/// VCR-DEC-001 **increment 2** — colour a whole branchy function ACROSS its
+/// control-flow joins.
+///
+/// **Why joins.** Increment 1 could only colour a function that was one
+/// straight-line segment; the shipping `reallocate_function` handles branchy
+/// functions by cutting them into maximal straight-line segments and pinning
+/// each segment's inputs (`def == 0`) and per-register exit holders to their
+/// original registers. Those pins are exactly where the greedy allocator's
+/// weakness concentrates: an if/else arm's first `movw r4, #400` is a
+/// segment-index-0 def, so segment-local analysis is FORCED to treat it as a
+/// segment input and cannot move it — even though whole-function liveness shows
+/// the value is born there, dies two instructions later, and never crosses the
+/// join. Every arm therefore keeps whatever register the greedy selector
+/// happened to hand it, and the callee-saved ones drag a `push {r4-r8,lr}` /
+/// `pop {r4-r8,pc}` behind them.
+///
+/// **What this does instead.** Build the function's label-form CFG, split every
+/// physical register's def-use chains into cross-block **webs** (a def site and
+/// every use its definition reaches, unified through joins by a reaching-def
+/// fixpoint), build interference over WEBS from CFG liveness, and colour the
+/// whole function at once with Chaitin/Briggs. Two values in opposite arms of an
+/// if/else are never simultaneously live, so they share one register — which is
+/// how the else-arm's R4 becomes R2 and the callee-saved save/restore
+/// disappears under the downstream `shrink_callee_saved_saves`.
+///
+/// **Acceptance oracle first (the L4/#872 lesson).** The rewrite is accepted
+/// only if [`validate_cfg_rewrite`] — the CFG-lifted backward must-fixpoint
+/// version of the trace-equality validator — proves it preserves dataflow on
+/// EVERY path, with an exit contract the validator computes itself (the pass
+/// cannot hand it a weakened seed). The pass mirrors that contract exactly in
+/// its own pins, so a colouring it proposes is one the oracle can certify.
+/// Downstream, the unconditional VCR-RA-003 [`validate_final_allocation`]
+/// re-checks the final stream through an INDEPENDENTLY written CFG builder, and
+/// the execution differential is the runtime backstop. That layering is the
+/// honest answer to "a validator can share its pass's blind spot": this
+/// validator shares the CFG *shape* with the pass, so it is necessary, not
+/// sufficient — which is why RA-003 and unicorn execution both gate it.
+///
+/// **Bounded scope — declines, never hard-fails.** `None` (→ the shipping
+/// `reallocate_function`) on: numeric/pre-resolved branches (`BOffset`/
+/// `BCondOffset` — their displacements are already baked, so a rename that
+/// changes a Thumb encoding width would silently overshoot; the label form is
+/// resolved AFTER this pass), calls (`Bl`/`Blx`/`Call`/`CallIndirect` — the
+/// AAPCS argument/clobber contract is a named follow-up), `BrTable`, computed
+/// `Bx`, duplicate/unknown labels, unreachable blocks, any op without a precise
+/// [`reg_effect`], any spill, and any validator rejection.
+mod joins {
+    use super::*;
+    use crate::liveness::{
+        BasicBlock, RegEffect, cfg_exit_observable, color_ranges, is_straight_line, reg_effect,
+        rewrite_op_maps, validate_cfg_rewrite,
+    };
+    use crate::rules::ArmOp;
+
+    /// Every architectural register the analysis tracks (pool + reserved).
+    const ALL_REGS: [Reg; 16] = [
+        Reg::R0,
+        Reg::R1,
+        Reg::R2,
+        Reg::R3,
+        Reg::R4,
+        Reg::R5,
+        Reg::R6,
+        Reg::R7,
+        Reg::R8,
+        Reg::R9,
+        Reg::R10,
+        Reg::R11,
+        Reg::R12,
+        Reg::SP,
+        Reg::LR,
+        Reg::PC,
+    ];
+
+    /// Decline diagnostics: `SYNTH_GRAPH_ALLOC_STATS=1` names WHY a branchy
+    /// function fell back to the shipping pass, so a "did nothing" result is
+    /// never mistaken for "nothing to do".
+    fn decline<T>(reason: &str) -> Option<T> {
+        if std::env::var("SYNTH_GRAPH_ALLOC_STATS").is_ok() {
+            eprintln!("[graph-alloc] join colouring DECLINED: {reason}");
+        }
+        None
+    }
+
+    enum Term<'a> {
+        Uncond(&'a str),
+        Cond(&'a str),
+        Ret,
+        Fall,
+        No,
+    }
+
+    fn classify(op: &ArmOp) -> Term<'_> {
+        use ArmOp::*;
+        match op {
+            B { label } => Term::Uncond(label),
+            Bhs { label } | Blo { label } | Bcc { label, .. } => Term::Cond(label),
+            Bx { rm: Reg::LR } => Term::Ret,
+            // A `pop {…, pc}` IS a return — the #888 class. Modeling it as a
+            // plain register-list def (which `reg_effect` alone would) is what
+            // let the range-realloc pass recolour `pop {r4..r8,pc}` into
+            // `pop {r6,r5,r4,r3,r2,pc}`.
+            Pop { regs } if regs.contains(&Reg::PC) => Term::Ret,
+            BOffset { .. }
+            | BCondOffset { .. }
+            | Bx { .. }
+            | BrTable { .. }
+            | Bl { .. }
+            | Blx { .. }
+            | Call { .. }
+            | CallIndirect { .. } => Term::No,
+            _ => Term::Fall,
+        }
+    }
+
+    /// The label-form CFG of `instrs`, or `None` to decline. Sound by
+    /// construction: a `Some` is a COMPLETE CFG (every block reachable from the
+    /// entry, every terminator modeled), never a partial guess.
+    pub(super) fn build_cfg(instrs: &[ArmInstruction]) -> Option<Vec<BasicBlock>> {
+        let n = instrs.len();
+        if n == 0 {
+            return None;
+        }
+        // 1. Admission.
+        let mut labels: BTreeSet<&str> = BTreeSet::new();
+        for ins in instrs {
+            match classify(&ins.op) {
+                Term::No => return None,
+                Term::Uncond(_) | Term::Cond(_) => {}
+                Term::Ret | Term::Fall => {
+                    if !matches!(ins.op, ArmOp::Label { .. })
+                        && !matches!(ins.op, ArmOp::Bx { .. })
+                        && reg_effect(&ins.op).is_none()
+                    {
+                        return None;
+                    }
+                }
+            }
+            if let ArmOp::Label { name } = &ins.op
+                && !labels.insert(name.as_str())
+            {
+                return None; // duplicate label ⇒ ambiguous CFG
+            }
+        }
+        // 2. Leaders.
+        let mut leader = vec![false; n];
+        leader[0] = true;
+        for i in 0..n {
+            if matches!(instrs[i].op, ArmOp::Label { .. }) {
+                leader[i] = true;
+            }
+            if matches!(
+                classify(&instrs[i].op),
+                Term::Uncond(_) | Term::Cond(_) | Term::Ret
+            ) && i + 1 < n
+            {
+                leader[i + 1] = true;
+            }
+        }
+        let starts: Vec<usize> = (0..n).filter(|&i| leader[i]).collect();
+        let mut blocks: Vec<BasicBlock> = starts
+            .iter()
+            .enumerate()
+            .map(|(bi, &start)| BasicBlock {
+                start,
+                end: starts.get(bi + 1).copied().unwrap_or(n),
+                succ: vec![],
+            })
+            .collect();
+        let block_of_start: BTreeMap<usize, usize> = blocks
+            .iter()
+            .enumerate()
+            .map(|(bi, b)| (b.start, bi))
+            .collect();
+        let mut block_of_label: BTreeMap<&str, usize> = BTreeMap::new();
+        for (bi, b) in blocks.iter().enumerate() {
+            if let ArmOp::Label { name } = &instrs[b.start].op {
+                block_of_label.insert(name.as_str(), bi);
+            }
+        }
+        // 3. Successors.
+        let mut succs: Vec<Vec<usize>> = Vec::with_capacity(blocks.len());
+        for b in &blocks {
+            let fallthrough = block_of_start.get(&b.end).copied();
+            succs.push(match classify(&instrs[b.end - 1].op) {
+                Term::Uncond(l) => vec![*block_of_label.get(l)?],
+                Term::Cond(l) => {
+                    let t = *block_of_label.get(l)?;
+                    let mut s = vec![t];
+                    if let Some(f) = fallthrough
+                        && f != t
+                    {
+                        s.push(f);
+                    }
+                    s
+                }
+                Term::Ret => vec![],
+                // A non-return block that falls off the end of the function is
+                // a stream we do not understand: decline rather than invent a
+                // sink (an invented sink would silently drop its exit contract).
+                Term::Fall => vec![fallthrough?],
+                Term::No => return None,
+            });
+        }
+        for (b, s) in blocks.iter_mut().zip(succs) {
+            b.succ = s;
+        }
+        // 4. Every block must be reachable from the entry — an unreachable
+        //    block's demands never reach the entry check, so a CFG that hides
+        //    one would validate vacuously.
+        let mut seen = vec![false; blocks.len()];
+        let mut work = vec![0usize];
+        seen[0] = true;
+        while let Some(b) = work.pop() {
+            for &s in &blocks[b].succ {
+                if !seen[s] {
+                    seen[s] = true;
+                    work.push(s);
+                }
+            }
+        }
+        if seen.iter().any(|r| !r) {
+            return None;
+        }
+        Some(blocks)
+    }
+
+    /// Simple union-find over web ids.
+    struct Uf(Vec<usize>);
+    impl Uf {
+        fn new(n: usize) -> Self {
+            Uf((0..n).collect())
+        }
+        fn find(&mut self, mut x: usize) -> usize {
+            while self.0[x] != x {
+                self.0[x] = self.0[self.0[x]];
+                x = self.0[x];
+            }
+            x
+        }
+        fn union(&mut self, a: usize, b: usize) {
+            let (a, b) = (self.find(a), self.find(b));
+            if a != b {
+                self.0[b] = a;
+            }
+        }
+    }
+
+    /// Per-instruction effect (`None` for control flow / labels).
+    fn effects(instrs: &[ArmInstruction]) -> Vec<Option<RegEffect>> {
+        instrs
+            .iter()
+            .map(|i| {
+                if is_straight_line(&i.op) {
+                    reg_effect(&i.op)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// The exit contract, taken VERBATIM from the oracle
+    /// ([`crate::liveness::cfg_exit_observable`]) rather than restated here.
+    /// Used as `live_out` at every sink, so a register the caller can observe
+    /// stays live from its last definition all the way to the return and its
+    /// holder web interferes with everything in between — the pass therefore
+    /// never proposes a colouring the validator would reject for clobbering an
+    /// exit-observable register. A register NEITHER side defines is live from
+    /// the function entry, so its entry web interferes with every web and no
+    /// value can be renamed onto it (the seqblocks case: a void function's
+    /// unwritten R0 is not a free rename target, because this pass cannot see
+    /// the wasm signature that would prove it dead).
+    fn exit_live(instrs: &[ArmInstruction], sink_end: usize) -> BTreeSet<Reg> {
+        cfg_exit_observable(&instrs[sink_end - 1].op)
+    }
+
+    /// Backward per-block register liveness over the CFG.
+    fn liveness(
+        instrs: &[ArmInstruction],
+        eff: &[Option<RegEffect>],
+        blocks: &[BasicBlock],
+    ) -> (Vec<BTreeSet<Reg>>, Vec<BTreeSet<Reg>>) {
+        let nb = blocks.len();
+        let mut use_b = vec![BTreeSet::<Reg>::new(); nb];
+        let mut def_b = vec![BTreeSet::<Reg>::new(); nb];
+        for (bi, b) in blocks.iter().enumerate() {
+            let mut defined = BTreeSet::new();
+            for e in eff[b.start..b.end].iter().flatten() {
+                for u in &e.uses {
+                    if !defined.contains(u) {
+                        use_b[bi].insert(*u);
+                    }
+                }
+                for d in &e.defs {
+                    defined.insert(*d);
+                }
+            }
+            def_b[bi] = defined;
+        }
+        let mut live_in = vec![BTreeSet::<Reg>::new(); nb];
+        let mut live_out = vec![BTreeSet::<Reg>::new(); nb];
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for bi in (0..nb).rev() {
+                let out: BTreeSet<Reg> = if blocks[bi].succ.is_empty() {
+                    exit_live(instrs, blocks[bi].end)
+                } else {
+                    blocks[bi]
+                        .succ
+                        .iter()
+                        .flat_map(|&s| live_in[s].iter().copied())
+                        .collect()
+                };
+                let mut in_ = use_b[bi].clone();
+                in_.extend(out.difference(&def_b[bi]).copied());
+                if out != live_out[bi] {
+                    live_out[bi] = out;
+                    changed = true;
+                }
+                if in_ != live_in[bi] {
+                    live_in[bi] = in_;
+                    changed = true;
+                }
+            }
+        }
+        (live_in, live_out)
+    }
+
+    /// Everything the colourer needs, derived from the CFG in one pass.
+    struct Webs {
+        /// web id per (instruction, def register), and the entry pseudo-defs.
+        def_web: BTreeMap<(usize, Reg), usize>,
+        entry_web: BTreeMap<Reg, usize>,
+        /// The (unique) original register of each web.
+        reg_of: Vec<Reg>,
+        /// `reach_before[i][r]` — the webs that may hold `r` immediately before
+        /// `i`. A SET, not a single web: two definitions of one register that
+        /// reach a common point but die there (each arm's own `movw r4, #k`)
+        /// are genuinely SEPARATE values and must stay separately colourable.
+        /// Merging them — the obvious "one holder per register per point"
+        /// shortcut — silently pins every arm-local value back to the greedy
+        /// selector's register and makes this whole pass an identity transform.
+        /// Wherever a single holder is REQUIRED (a use, an apply-time rename)
+        /// the set is a singleton by construction: `r` live at a point means
+        /// some downstream use reads it, and that use unified every definition
+        /// reaching it.
+        reach_before: Vec<BTreeMap<Reg, BTreeSet<usize>>>,
+        /// `reach_after[i][r]` — the webs that may hold `r` immediately after `i`.
+        reach_after: Vec<BTreeMap<Reg, BTreeSet<usize>>>,
+        n_webs: usize,
+    }
+
+    /// Split every physical register's def-use chains into cross-block webs.
+    ///
+    /// Because a use of `r` can only be reached by definitions OF `r`, every web
+    /// carries exactly ONE original register — webs partition per-register def
+    /// sites, they never merge two registers. The cross-arm sharing this pass
+    /// exists for comes from ABSENCE of interference between two arms' webs, not
+    /// from merging them.
+    fn build_webs(
+        instrs: &[ArmInstruction],
+        eff: &[Option<RegEffect>],
+        blocks: &[BasicBlock],
+    ) -> Option<Webs> {
+        // Def sites: one pseudo-def per register at function entry, then one per
+        // (instruction, def register).
+        let mut reg_of: Vec<Reg> = Vec::new();
+        let mut entry_web: BTreeMap<Reg, usize> = BTreeMap::new();
+        for r in ALL_REGS {
+            entry_web.insert(r, reg_of.len());
+            reg_of.push(r);
+        }
+        let mut def_web: BTreeMap<(usize, Reg), usize> = BTreeMap::new();
+        for (i, e) in eff.iter().enumerate() {
+            if let Some(e) = e {
+                for d in &e.defs {
+                    def_web.insert((i, *d), reg_of.len());
+                    reg_of.push(*d);
+                }
+            }
+        }
+        let n_sites = reg_of.len();
+        let mut uf = Uf::new(n_sites);
+
+        // Forward reaching-def fixpoint over the CFG. `in_b[bi][r]` = the set of
+        // def sites of `r` that may reach block `bi`'s entry.
+        type ReachMap = BTreeMap<Reg, BTreeSet<usize>>;
+        let nb = blocks.len();
+        let entry_reach: ReachMap = ALL_REGS
+            .iter()
+            .map(|r| (*r, BTreeSet::from([entry_web[r]])))
+            .collect();
+        let mut in_b: Vec<ReachMap> = vec![BTreeMap::new(); nb];
+        let mut out_b: Vec<ReachMap> = vec![BTreeMap::new(); nb];
+        in_b[0] = entry_reach.clone();
+        let transfer = |bi: usize, mut m: ReachMap| -> ReachMap {
+            for i in blocks[bi].start..blocks[bi].end {
+                if let Some(e) = &eff[i] {
+                    for d in &e.defs {
+                        m.insert(*d, BTreeSet::from([def_web[&(i, *d)]]));
+                    }
+                }
+            }
+            m
+        };
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for bi in 0..nb {
+                let mut inm: ReachMap = if bi == 0 {
+                    entry_reach.clone()
+                } else {
+                    BTreeMap::new()
+                };
+                for (pb, blk) in blocks.iter().enumerate() {
+                    if blk.succ.contains(&bi) {
+                        for (r, s) in &out_b[pb] {
+                            inm.entry(*r).or_default().extend(s.iter().copied());
+                        }
+                    }
+                }
+                if bi == 0 {
+                    for (r, s) in &entry_reach {
+                        inm.entry(*r).or_default().extend(s.iter().copied());
+                    }
+                }
+                if inm != in_b[bi] {
+                    in_b[bi] = inm;
+                    changed = true;
+                }
+                let outm = transfer(bi, in_b[bi].clone());
+                if outm != out_b[bi] {
+                    out_b[bi] = outm;
+                    changed = true;
+                }
+            }
+        }
+
+        // Replay each block, unifying at uses; record per-instruction reach maps.
+        let n = instrs.len();
+        let mut reach_before_sets: Vec<ReachMap> = vec![BTreeMap::new(); n];
+        let mut reach_after_sets: Vec<ReachMap> = vec![BTreeMap::new(); n];
+        for (bi, b) in blocks.iter().enumerate() {
+            let mut cur = in_b[bi].clone();
+            for i in b.start..b.end {
+                reach_before_sets[i] = cur.clone();
+                if let Some(e) = &eff[i] {
+                    for u in &e.uses {
+                        let set = cur.get(u)?;
+                        let mut it = set.iter().copied();
+                        let first = it.next()?;
+                        for d in it {
+                            uf.union(first, d);
+                        }
+                        // A single-field RMW (`movt`, `SelectMove`) reads and
+                        // writes ONE register field: its old and new webs must
+                        // land on the same colour, so unify them. Doing this for
+                        // every same-register def/use pair is a conservative
+                        // over-approximation (it can only force an assignment
+                        // the ORIGINAL already had), and `rewrite_op_maps`
+                        // independently rejects any residual disagreement.
+                        if e.defs.contains(u) {
+                            uf.union(first, def_web[&(i, *u)]);
+                        }
+                    }
+                    for d in &e.defs {
+                        cur.insert(*d, BTreeSet::from([def_web[&(i, *d)]]));
+                    }
+                }
+                reach_after_sets[i] = cur.clone();
+            }
+        }
+
+        // Canonicalise each reaching set through union-find — WITHOUT merging
+        // distinct webs. Two definitions of one register reaching a common
+        // point where the register is DEAD stay separate values; that is
+        // exactly the cross-arm freedom this pass exists to exploit.
+        let canon = |m: &ReachMap, uf: &mut Uf| -> BTreeMap<Reg, BTreeSet<usize>> {
+            m.iter()
+                .map(|(r, s)| (*r, s.iter().map(|d| uf.find(*d)).collect()))
+                .collect()
+        };
+        let mut reach_before: Vec<BTreeMap<Reg, BTreeSet<usize>>> = Vec::with_capacity(n);
+        for m in &reach_before_sets {
+            reach_before.push(canon(m, &mut uf));
+        }
+        let mut reach_after: Vec<BTreeMap<Reg, BTreeSet<usize>>> = Vec::with_capacity(n);
+        for m in &reach_after_sets {
+            reach_after.push(canon(m, &mut uf));
+        }
+        let entry_web: BTreeMap<Reg, usize> = entry_web
+            .into_iter()
+            .map(|(r, w)| (r, uf.find(w)))
+            .collect();
+        let def_web: BTreeMap<(usize, Reg), usize> =
+            def_web.into_iter().map(|(k, w)| (k, uf.find(w))).collect();
+        // Every web carries one register (a use of `r` only unifies defs of `r`).
+        for (k, w) in &def_web {
+            if reg_of[*w] != k.1 {
+                return None;
+            }
+        }
+        Some(Webs {
+            def_web,
+            entry_web,
+            reg_of,
+            reach_before,
+            reach_after,
+            n_webs: n_sites,
+        })
+    }
+
+    /// The increment-2 entry point. See the module doc for scope and oracles.
+    pub(super) fn reallocate_across_joins(
+        instrs: &[ArmInstruction],
+        pool: &[Reg],
+    ) -> Option<Vec<ArmInstruction>> {
+        let Some(blocks) = build_cfg(instrs) else {
+            return decline("cfg-unmodeled-construct");
+        };
+        // A single-block function is increment 1's domain (tried first); this
+        // path exists for the branchy ones.
+        if blocks.len() < 2 {
+            return decline("single-block");
+        }
+        let eff = effects(instrs);
+        // Every instruction is either a modeled straight-line op or pure control
+        // flow the rename passes through verbatim.
+        for (i, ins) in instrs.iter().enumerate() {
+            if eff[i].is_none() && is_straight_line(&ins.op) {
+                return decline("unmodeled-op");
+            }
+        }
+        let Some(webs) = build_webs(instrs, &eff, &blocks) else {
+            return decline("web-construction");
+        };
+        let (live_in, live_out) = liveness(instrs, &eff, &blocks);
+
+        // ---- Interference over WEBS ------------------------------------
+        let mut adj: BTreeMap<usize, BTreeSet<usize>> = BTreeMap::new();
+        let node = |w: usize, adj: &mut BTreeMap<usize, BTreeSet<usize>>| {
+            adj.entry(w).or_default();
+        };
+        let edge = |a: usize, b: usize, adj: &mut BTreeMap<usize, BTreeSet<usize>>| {
+            if a != b {
+                adj.entry(a).or_default().insert(b);
+                adj.entry(b).or_default().insert(a);
+            }
+        };
+        for w in 0..webs.n_webs {
+            node(w, &mut adj);
+        }
+        // Live web sets at every program point; simultaneously-live webs form a
+        // clique, and EVERY def (dead-on-arrival ones included — they still WRITE
+        // the register) interferes with everything live immediately after it.
+        let live_webs =
+            |regs: &BTreeSet<Reg>, m: &BTreeMap<Reg, BTreeSet<usize>>| -> BTreeSet<usize> {
+                regs.iter()
+                    .filter_map(|r| m.get(r))
+                    .flat_map(|s| s.iter().copied())
+                    .collect()
+            };
+        for (bi, b) in blocks.iter().enumerate() {
+            // Block entry.
+            let entry_set = live_webs(&live_in[bi], &webs.reach_before[b.start]);
+            for a in &entry_set {
+                for c in &entry_set {
+                    edge(*a, *c, &mut adj);
+                }
+            }
+            // Per-instruction. `live` tracks registers live AFTER `i`, walked
+            // backward from the block's live-out.
+            let mut live_regs = live_out[bi].clone();
+            for i in (b.start..b.end).rev() {
+                let after = live_webs(&live_regs, &webs.reach_after[i]);
+                for a in &after {
+                    for c in &after {
+                        edge(*a, *c, &mut adj);
+                    }
+                }
+                if let Some(e) = &eff[i] {
+                    for d in &e.defs {
+                        let dw = webs.def_web[&(i, *d)];
+                        for c in &after {
+                            edge(dw, *c, &mut adj);
+                        }
+                        // Co-defined registers (Umull rdlo/rdhi, a Pop list)
+                        // are simultaneously written and must stay distinct.
+                        for d2 in &e.defs {
+                            edge(dw, webs.def_web[&(i, *d2)], &mut adj);
+                        }
+                    }
+                    for d in &e.defs {
+                        live_regs.remove(d);
+                    }
+                    for u in &e.uses {
+                        live_regs.insert(*u);
+                    }
+                }
+            }
+        }
+
+        // ---- Pins ------------------------------------------------------
+        let pool_index: BTreeMap<Reg, usize> =
+            pool.iter().enumerate().map(|(i, r)| (*r, i)).collect();
+        let mut pins: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut assignment: BTreeMap<usize, Reg> = BTreeMap::new();
+        let mut pool_nodes: BTreeSet<usize> = BTreeSet::new();
+        for w in 0..webs.n_webs {
+            let r = webs.reg_of[w];
+            match pool_index.get(&r) {
+                None => {
+                    // Reserved (R9-R12, SP, LR, PC): identity, never coloured.
+                    assignment.insert(w, r);
+                }
+                Some(_) => {
+                    pool_nodes.insert(w);
+                }
+            }
+        }
+        let pin = |w: usize, pins: &mut BTreeMap<usize, usize>| {
+            if let Some(&idx) = pool_index.get(&webs.reg_of[w]) {
+                pins.insert(w, idx);
+            }
+        };
+        // (a) Function inputs arrive in their incoming registers.
+        for w in webs.entry_web.values() {
+            pin(*w, &mut pins);
+        }
+        // (b) The exit contract: whatever holds an exit-observable register at a
+        //     sink keeps that register. Mirrors `validate_cfg_rewrite`'s seed.
+        for b in blocks.iter() {
+            if !b.succ.is_empty() {
+                continue;
+            }
+            for r in exit_live(instrs, b.end) {
+                for w in webs.reach_after[b.end - 1].get(&r).into_iter().flatten() {
+                    pin(*w, &mut pins);
+                }
+            }
+        }
+        // (c) ARCHITECTURAL REGISTER LISTS (#888): a `Push`/`Pop` register list
+        //     is a bitmask whose stack layout is register-NUMBER order, matched
+        //     pairwise between prologue and epilogue, and it carries the #490
+        //     callee-saved contract. Identity-pin every web a `Push` USES or a
+        //     `Pop` DEFINES — recolouring one restores registers from a stack
+        //     image laid out for different ones.
+        for (i, ins) in instrs.iter().enumerate() {
+            if !matches!(&ins.op, ArmOp::Push { .. } | ArmOp::Pop { .. }) {
+                continue;
+            }
+            let Some(e) = &eff[i] else { return None };
+            for u in &e.uses {
+                for w in webs.reach_before[i].get(u).into_iter().flatten() {
+                    pin(*w, &mut pins);
+                }
+            }
+            for d in &e.defs {
+                pin(webs.def_web[&(i, *d)], &mut pins);
+            }
+        }
+
+        // ---- #677 absent-colour blockers -------------------------------
+        // A pool register with NO web in this function is not thereby a free
+        // rename target. Whole-function scope makes an absent CALLER-saved
+        // register genuinely free, but introducing an absent CALLEE-saved one
+        // would grow the prologue this pass exists to shrink — and on the direct
+        // path the prologue push list is fixed before we run. Block every absent
+        // pool colour, exactly the shipping pass's discipline: an identity-shaped
+        // colouring within the PRESENT registers always exists, so this never
+        // costs a recolouring the original bytes did not already have.
+        let present: BTreeSet<Reg> = (0..webs.n_webs)
+            .filter(|w| adj.get(w).is_some_and(|a| !a.is_empty()) || pins.contains_key(w))
+            .map(|w| webs.reg_of[w])
+            .chain(instrs.iter().enumerate().flat_map(|(i, _)| {
+                eff[i]
+                    .iter()
+                    .flat_map(|e| e.defs.iter().chain(e.uses.iter()).copied())
+                    .collect::<Vec<_>>()
+            }))
+            .collect();
+        let mut next_blocker = webs.n_webs;
+        for (idx, reg) in pool.iter().enumerate() {
+            if present.contains(reg) {
+                continue;
+            }
+            let blocker = next_blocker;
+            next_blocker += 1;
+            pins.insert(blocker, idx);
+            for w in &pool_nodes {
+                adj.entry(*w).or_default().insert(blocker);
+            }
+            adj.insert(blocker, pool_nodes.iter().copied().collect());
+        }
+
+        // ---- Colour ----------------------------------------------------
+        let pool_adj: BTreeMap<usize, BTreeSet<usize>> = adj
+            .iter()
+            .filter(|(w, _)| pool_nodes.contains(w) || pins.contains_key(w))
+            .filter(|(w, _)| **w >= webs.n_webs || pool_nodes.contains(w))
+            .map(|(w, nbrs)| {
+                (
+                    *w,
+                    nbrs.iter()
+                        .copied()
+                        .filter(|m| *m >= webs.n_webs || pool_nodes.contains(m))
+                        .collect(),
+                )
+            })
+            .collect();
+        let mut costs: BTreeMap<usize, usize> = BTreeMap::new();
+        for (i, e) in eff.iter().enumerate() {
+            if let Some(e) = e {
+                for u in &e.uses {
+                    for w in webs.reach_before[i].get(u).into_iter().flatten() {
+                        *costs.entry(*w).or_insert(0) += 1;
+                    }
+                }
+                for d in &e.defs {
+                    *costs.entry(webs.def_web[&(i, *d)]).or_insert(0) += 1;
+                }
+            }
+        }
+        let (coloring, spilled) = color_ranges(&pool_adj, pool.len(), &pins, &costs);
+        if !spilled.is_empty() {
+            // Spill-code insertion across joins is a named follow-up; the
+            // shipping path HAS spill support, so decline to it.
+            return decline("needs-spill");
+        }
+        for (w, c) in &coloring {
+            if *w < webs.n_webs {
+                assignment.insert(*w, pool[*c]);
+            }
+        }
+
+        // Defense in depth, independent of the colourer: re-check every
+        // interference edge against the final assignment.
+        for (a, nbrs) in &adj {
+            if *a >= webs.n_webs {
+                continue;
+            }
+            for b in nbrs {
+                if *b >= webs.n_webs {
+                    continue;
+                }
+                match (assignment.get(a), assignment.get(b)) {
+                    (Some(x), Some(y)) if x != y => {}
+                    _ => return decline("edge-recheck"),
+                }
+            }
+        }
+
+        if std::env::var("SYNTH_GRAPH_ALLOC_DUMP").is_ok() {
+            for w in 0..webs.n_webs {
+                if !pool_nodes.contains(&w) {
+                    continue;
+                }
+                eprintln!(
+                    "[ga-dump] web {w} reg={:?} pin={:?} -> {:?} nbrs={:?}",
+                    webs.reg_of[w],
+                    pins.get(&w),
+                    assignment.get(&w),
+                    adj.get(&w)
+                );
+            }
+        }
+
+        // ---- Apply -----------------------------------------------------
+        let mut out: Vec<ArmInstruction> = Vec::with_capacity(instrs.len());
+        for (i, ins) in instrs.iter().enumerate() {
+            let Some(e) = &eff[i] else {
+                out.push(ins.clone()); // control flow: verbatim
+                continue;
+            };
+            let mut use_map: BTreeMap<Reg, Reg> = BTreeMap::new();
+            for u in &e.uses {
+                // A USE has exactly one reaching web: it unified every
+                // definition that reaches it. A non-singleton here would mean
+                // the replay disagrees with the fixpoint — decline, never guess.
+                let set = webs.reach_before[i].get(u)?;
+                if set.len() != 1 {
+                    return decline("ambiguous-reaching-web");
+                }
+                let w = *set.iter().next()?;
+                use_map.insert(*u, *assignment.get(&w)?);
+            }
+            let mut def_map: BTreeMap<Reg, Reg> = BTreeMap::new();
+            for d in &e.defs {
+                let w = webs.def_web[&(i, *d)];
+                def_map.insert(*d, *assignment.get(&w)?);
+            }
+            out.push(ArmInstruction {
+                op: rewrite_op_maps(&ins.op, &use_map, &def_map)?,
+                source_line: ins.source_line,
+            });
+        }
+
+        // ---- The acceptance oracle -------------------------------------
+        // A rewrite the CFG-lifted trace-equality validator cannot justify is
+        // DROPPED (the function falls back to the shipping pass) — never
+        // emitted. `validate_cfg_rewrite` computes its own exit contract, so
+        // this cannot be weakened from here.
+        match validate_cfg_rewrite(instrs, &out, &blocks) {
+            Ok(()) => {
+                if out == instrs {
+                    // Identity rewrite: let the shipping pass have the function
+                    // (it may still find a segment-local win we did not).
+                    decline("identity-colouring")
+                } else {
+                    Some(out)
+                }
+            }
+            Err(v) => {
+                if std::env::var("SYNTH_GRAPH_ALLOC_STATS").is_ok() {
+                    eprintln!("[graph-alloc] join colouring REJECTED by validator: {v:?}");
+                }
+                None
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/synth-synthesis/src/graph_alloc.rs
+++ b/crates/synth-synthesis/src/graph_alloc.rs
@@ -16,28 +16,40 @@
 //! cannot handle a function within its bounded scope, it returns `None` and the
 //! caller falls back to the shipping `reallocate_function` — never a hard-fail.
 //!
-//! **Bounded scope (increment 1).** WHOLE straight-line functions only: a
-//! function whose entire body is one straight-line segment (no branches, no
-//! calls, no i64-pair / FP ops — anything [`crate::liveness::straight_line_value_ranges`]
-//! or [`crate::liveness::reg_effect`] declines). Such a function is coloured as a
-//! SINGLE whole-function interference graph over the R0-R8 pool, with segment
-//! inputs and live-outs pinned to their incoming/outgoing registers and reserved
-//! registers (R9-R12) identity-assigned. On ANY control flow, spill, or unmodeled
-//! op, it declines to the shipping path.
+//! **Increment 1 (v0.50) — whole straight-line functions.** A function whose
+//! entire body is one straight-line segment (no branches, no calls, no i64-pair /
+//! FP ops — anything [`crate::liveness::straight_line_value_ranges`] or
+//! [`crate::liveness::reg_effect`] declines) is coloured as a SINGLE
+//! whole-function interference graph over the R0-R8 pool, with segment inputs and
+//! live-outs pinned to their incoming/outgoing registers and reserved registers
+//! (R9-R12) identity-assigned. Tried FIRST and left bit-for-bit as it shipped.
 //!
-//! Increment 2 (NAMED, NOT in this spike): whole-function *webs* built from
-//! [`crate::liveness::cfg_liveness`] — colouring value ranges ACROSS control-flow
-//! joins, where "the allocator and validator share the dataflow" fully lands.
-//! That needs SSA-style web construction across joins that does not exist yet;
-//! it is honestly beyond a bounded first slice.
+//! **Increment 2 (v0.53) — colouring ACROSS if/else joins.** The `joins`
+//! submodule builds the function's label-form CFG, splits each register's def-use
+//! chains into cross-block *webs* (a reaching-def fixpoint), takes interference
+//! from CFG liveness and colours the whole branchy function at once — so two
+//! arms' values, never simultaneously live, share one register. See that module's
+//! own docs for the scope (label-form branches; no calls; no pre-resolved numeric
+//! branches) and for why each exclusion is a DECLINE rather than a guess.
 //!
-//! **The oracle IS the point (red-first).** Every rewrite this module produces is
-//! proven semantics-preserving by [`crate::liveness::validate_segment_rewrite`]
-//! (the Rideau/Leroy pairwise trace-equality validator — the SAME acceptance gate
-//! `reallocate_function` uses); a rewrite the validator rejects is dropped and the
-//! function declines. Downstream, the unconditional VCR-RA-003
-//! [`crate::liveness::validate_final_allocation`] re-checks the final stream, and
-//! the wasmtime execution differential is the runtime backstop.
+//! **The oracle IS the point (red-first).** A straight-line rewrite is proven
+//! semantics-preserving by [`crate::liveness::validate_segment_rewrite`] (the
+//! Rideau/Leroy pairwise trace-equality validator — the SAME acceptance gate
+//! `reallocate_function` uses); a branchy one by
+//! [`crate::liveness::validate_cfg_rewrite`], the same argument lifted to a
+//! backward must-fixpoint over the CFG. A rewrite either validator rejects is
+//! dropped and the function declines. Downstream, the unconditional VCR-RA-003
+//! [`crate::liveness::validate_final_allocation`] re-checks the final stream
+//! through an INDEPENDENTLY written CFG builder.
+//!
+//! **And the validators are not sufficient.** `validate_cfg_rewrite` shares the
+//! CFG shape with the pass it validates, so — #872's standing lesson — it cannot
+//! catch an error in what they share. Increment 2's divergent bytes are therefore
+//! EXECUTED against wasmtime by
+//! `scripts/repro/vcr_dec_001_join_alloc_execution_differential.py`, which is
+//! proven non-vacuous by mutation: emptying the shared exit contract emits code
+//! that leaves the return value in the wrong register, and BOTH validators accept
+//! it.
 
 use crate::instruction_selector::ArmInstruction;
 use crate::liveness::{
@@ -1586,6 +1598,26 @@ mod tests {
         assert!(
             early.succ.is_empty(),
             "a mid-stream `pop {{…, pc}}` must be a RETURN sink, not a fall-through"
+        );
+    }
+
+    /// A validator that accepts an EMPTY CFG for a non-empty stream would
+    /// certify every rewrite vacuously — the exact failure mode the v0.50 join
+    /// attempt's `entry_seed` hacks had. The structural tiling check must
+    /// reject it.
+    #[test]
+    fn cfg_validator_rejects_an_empty_cfg_for_a_nonempty_stream() {
+        let body = diamond();
+        assert!(
+            validate_cfg_rewrite(&body, &body, &[]).is_err(),
+            "an empty CFG must NOT validate a non-empty stream"
+        );
+        // ...and a CFG that does not tile the stream is equally rejected.
+        let mut partial = joins::build_cfg(&body).expect("CFG");
+        partial.pop();
+        assert!(
+            validate_cfg_rewrite(&body, &body, &partial).is_err(),
+            "a CFG that leaves instructions unwalked must NOT validate"
         );
     }
 

--- a/crates/synth-synthesis/src/graph_alloc.rs
+++ b/crates/synth-synthesis/src/graph_alloc.rs
@@ -1349,4 +1349,275 @@ mod tests {
     fn declines_on_empty() {
         assert!(reallocate(&[], &POOL).is_none());
     }
+
+    // ================================================================
+    // VCR-DEC-001 increment 2 — colouring ACROSS if/else joins.
+    // ================================================================
+
+    use crate::liveness::{RewriteViolation, validate_cfg_rewrite};
+    use crate::rules::{Condition, MemAddr};
+
+    fn lbl(n: &str) -> ArmInstruction {
+        ins(ArmOp::Label { name: n.into() })
+    }
+    fn mem(base: Reg, offset: i32) -> MemAddr {
+        MemAddr {
+            base,
+            offset,
+            offset_reg: None,
+        }
+    }
+
+    /// The canonical diamond: `push` / `cmp` / `bcc else` / then-arm writes R2 /
+    /// `b end` / else-arm writes R4 / `end:` / `pop`. The two arms' values are
+    /// never simultaneously live, so a whole-function colouring may give BOTH
+    /// the same register — the recolouring the segment-based shipping pass
+    /// structurally cannot make (the else-arm's `movw` is its segment's
+    /// instruction 0, hence pinned as a segment input).
+    fn diamond() -> Vec<ArmInstruction> {
+        vec![
+            ins(ArmOp::Push {
+                regs: vec![Reg::R4, Reg::R5, Reg::R6, Reg::R7, Reg::R8, Reg::LR],
+            }),
+            ins(ArmOp::Cmp {
+                rn: Reg::R0,
+                op2: Operand2::Imm(0),
+            }),
+            ins(ArmOp::Bcc {
+                cond: Condition::EQ,
+                label: ".else".into(),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R2,
+                imm16: 300,
+            }),
+            ins(ArmOp::Str {
+                rd: Reg::R2,
+                addr: mem(Reg::R11, 16),
+            }),
+            ins(ArmOp::B {
+                label: ".end".into(),
+            }),
+            lbl(".else"),
+            ins(ArmOp::Movw {
+                rd: Reg::R4,
+                imm16: 400,
+            }),
+            ins(ArmOp::Str {
+                rd: Reg::R4,
+                addr: mem(Reg::R11, 16),
+            }),
+            lbl(".end"),
+            ins(ArmOp::Pop {
+                regs: vec![Reg::R4, Reg::R5, Reg::R6, Reg::R7, Reg::R8, Reg::PC],
+            }),
+        ]
+    }
+
+    /// THE POINT OF INCREMENT 2. On the diamond the allocator must actually
+    /// recolour the else-arm off its callee-saved register — that is what lets
+    /// the downstream `shrink_callee_saved_saves` drop the prologue entry. A
+    /// `None` here means the join path regressed to increment 1's reach.
+    #[test]
+    fn colours_across_an_if_else_join() {
+        let body = diamond();
+        let out = reallocate(&body, &POOL).expect("the diamond must colour across its join");
+        assert_eq!(out.len(), body.len());
+        assert_ne!(out, body, "an identity rewrite gates nothing");
+        // The else-arm's R4 value moved OFF the callee-saved register.
+        assert!(
+            !matches!(out[7].op, ArmOp::Movw { rd: Reg::R4, .. }),
+            "the else-arm value should have left R4: {:?}",
+            out[7].op
+        );
+        // Control flow is untouched — a register allocator renames operands.
+        for i in [2usize, 5, 6, 9] {
+            assert_eq!(out[i].op, body[i].op, "control flow rewritten at {i}");
+        }
+        // The architectural register lists are identity-pinned (#888).
+        assert_eq!(out[0].op, body[0].op, "prologue push list recoloured");
+        assert_eq!(out[10].op, body[10].op, "epilogue pop list recoloured");
+    }
+
+    /// RED-FIRST for the CFG validator: a rewrite that renames a value in ONE
+    /// arm of a join while its consumer past the join still reads the ORIGINAL
+    /// register is a value-flow break on exactly one path. The straight-line
+    /// validator cannot see it (each arm validates fine in isolation); the
+    /// CFG-lifted must-fixpoint has to reject it.
+    #[test]
+    fn cfg_validator_rejects_a_one_armed_rename_across_a_join() {
+        // then: r2 = 1 ; else: r2 = 2 ; end: r0 = r2 + r2
+        let body = vec![
+            ins(ArmOp::Cmp {
+                rn: Reg::R0,
+                op2: Operand2::Imm(0),
+            }),
+            ins(ArmOp::Bcc {
+                cond: Condition::EQ,
+                label: ".else".into(),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R2,
+                imm16: 1,
+            }),
+            ins(ArmOp::B {
+                label: ".end".into(),
+            }),
+            lbl(".else"),
+            ins(ArmOp::Movw {
+                rd: Reg::R2,
+                imm16: 2,
+            }),
+            lbl(".end"),
+            ins(ArmOp::Add {
+                rd: Reg::R0,
+                rn: Reg::R2,
+                op2: Operand2::Reg(Reg::R2),
+            }),
+            ins(ArmOp::Bx { rm: Reg::LR }),
+        ];
+        let blocks = joins::build_cfg(&body).expect("label-form CFG");
+        assert_eq!(
+            validate_cfg_rewrite(&body, &body, &blocks),
+            Ok(()),
+            "the identity rewrite must be accepted (else the RED below is vacuous)"
+        );
+        // Rename ONLY the then-arm's definition. The join's consumer still reads
+        // R2, so the then path now adds an undefined R3.
+        let mut bad = body.clone();
+        bad[2] = ins(ArmOp::Movw {
+            rd: Reg::R3,
+            imm16: 1,
+        });
+        assert!(
+            matches!(
+                validate_cfg_rewrite(&body, &bad, &blocks),
+                Err(RewriteViolation::DefClobbersEquation { .. })
+                    | Err(RewriteViolation::EntryNotIdentity { .. })
+            ),
+            "a one-armed rename across a join must be REJECTED, got {:?}",
+            validate_cfg_rewrite(&body, &bad, &blocks)
+        );
+    }
+
+    /// A register allocator renames operands; it never rewrites control flow.
+    /// The validator enforces that structurally, so a mutated branch target or
+    /// condition can never be smuggled through as "a rename".
+    #[test]
+    fn cfg_validator_rejects_a_rewritten_branch() {
+        let body = diamond();
+        let blocks = joins::build_cfg(&body).expect("label-form CFG");
+        let mut bad = body.clone();
+        bad[2] = ins(ArmOp::Bcc {
+            cond: Condition::NE, // inverted condition
+            label: ".else".into(),
+        });
+        assert_eq!(
+            validate_cfg_rewrite(&body, &bad, &blocks),
+            Err(RewriteViolation::ShapeMismatch { index: 2 })
+        );
+    }
+
+    /// The exit contract has teeth: clobbering a register the caller can observe
+    /// past the return must be rejected even though nothing in the function
+    /// reads it again.
+    #[test]
+    fn cfg_validator_rejects_an_exit_observable_clobber() {
+        // r0 = 7 ; bx lr   — R0 is the result register.
+        let body = vec![
+            ins(ArmOp::Movw {
+                rd: Reg::R0,
+                imm16: 7,
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R1,
+                imm16: 9,
+            }),
+            ins(ArmOp::Bx { rm: Reg::LR }),
+        ];
+        let blocks = joins::build_cfg(&body).expect("CFG");
+        assert_eq!(validate_cfg_rewrite(&body, &body, &blocks), Ok(()));
+        let mut bad = body.clone();
+        bad[0] = ins(ArmOp::Movw {
+            rd: Reg::R3,
+            imm16: 7,
+        });
+        assert!(
+            validate_cfg_rewrite(&body, &bad, &blocks).is_err(),
+            "moving the result off R0 must be rejected"
+        );
+    }
+
+    /// #888: a `pop {…, pc}` is a RETURN, not a register-list def that a
+    /// segment-local view may recolour. The CFG builder must make it a sink, so
+    /// a mid-stream one ends its block and the code after it is unreachable —
+    /// which this pass declines rather than colour on a guessed CFG.
+    #[test]
+    fn mid_stream_pop_pc_is_a_return_sink() {
+        let body = vec![
+            ins(ArmOp::Push {
+                regs: vec![Reg::R4, Reg::LR],
+            }),
+            ins(ArmOp::Cmp {
+                rn: Reg::R0,
+                op2: Operand2::Imm(0),
+            }),
+            ins(ArmOp::Bcc {
+                cond: Condition::EQ,
+                label: ".tail".into(),
+            }),
+            ins(ArmOp::Pop {
+                regs: vec![Reg::R4, Reg::PC],
+            }),
+            lbl(".tail"),
+            ins(ArmOp::Movw {
+                rd: Reg::R0,
+                imm16: 5,
+            }),
+            ins(ArmOp::Pop {
+                regs: vec![Reg::R4, Reg::PC],
+            }),
+        ];
+        let blocks = joins::build_cfg(&body).expect("CFG");
+        let early = blocks
+            .iter()
+            .find(|b| b.end == 4)
+            .expect("the mid-stream pop must END a block");
+        assert!(
+            early.succ.is_empty(),
+            "a mid-stream `pop {{…, pc}}` must be a RETURN sink, not a fall-through"
+        );
+    }
+
+    /// Pre-resolved NUMERIC branches carry a baked displacement, so a rename
+    /// that changes a Thumb encoding width would silently overshoot (#606).
+    /// Out of scope by DECLINE, with the reason named.
+    #[test]
+    fn declines_numeric_branches_and_calls() {
+        let numeric = vec![
+            ins(ArmOp::Cmp {
+                rn: Reg::R0,
+                op2: Operand2::Imm(0),
+            }),
+            ins(ArmOp::BCondOffset {
+                cond: Condition::EQ,
+                offset: 2,
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R2,
+                imm16: 1,
+            }),
+            ins(ArmOp::Bx { rm: Reg::LR }),
+        ];
+        assert_eq!(joins::build_cfg(&numeric), Err("numeric-branch"));
+        let called = vec![
+            ins(ArmOp::Bl {
+                label: "func_1".into(),
+            }),
+            ins(ArmOp::Bx { rm: Reg::LR }),
+        ];
+        assert_eq!(joins::build_cfg(&called), Err("call"));
+        assert!(reallocate(&numeric, &POOL).is_none());
+        assert!(reallocate(&called, &POOL).is_none());
+    }
 }

--- a/crates/synth-synthesis/src/graph_alloc.rs
+++ b/crates/synth-synthesis/src/graph_alloc.rs
@@ -281,8 +281,8 @@ fn occurrence_costs(instrs: &[ArmInstruction]) -> Option<BTreeMap<usize, usize>>
 mod joins {
     use super::*;
     use crate::liveness::{
-        BasicBlock, RegEffect, cfg_exit_observable, color_ranges, is_straight_line, reg_effect,
-        rewrite_op_maps, validate_cfg_rewrite,
+        BasicBlock, RegEffect, cfg_exit_observable, is_straight_line, reg_effect, rewrite_op_maps,
+        validate_cfg_rewrite,
     };
     use crate::rules::ArmOp;
 
@@ -321,7 +321,10 @@ mod joins {
         Cond(&'a str),
         Ret,
         Fall,
-        No,
+        /// Outside the increment-2 scope, with the reason NAMED so the corpus
+        /// decline histogram is actionable evidence for the next increment
+        /// rather than one opaque `cfg-unmodeled-construct` bucket.
+        No(&'static str),
     }
 
     fn classify(op: &ArmOp) -> Term<'_> {
@@ -335,14 +338,19 @@ mod joins {
             // let the range-realloc pass recolour `pop {r4..r8,pc}` into
             // `pop {r6,r5,r4,r3,r2,pc}`.
             Pop { regs } if regs.contains(&Reg::PC) => Term::Ret,
-            BOffset { .. }
-            | BCondOffset { .. }
-            | Bx { .. }
-            | BrTable { .. }
-            | Bl { .. }
-            | Blx { .. }
-            | Call { .. }
-            | CallIndirect { .. } => Term::No,
+            // Pre-resolved numeric branches: the displacement is already baked
+            // into the stream, so a rename that changes a Thumb encoding width
+            // would silently overshoot the target (#606). Re-resolving them is
+            // the named next increment.
+            BOffset { .. } | BCondOffset { .. } => Term::No("numeric-branch"),
+            // A call needs the AAPCS argument + caller-saved clobber contract
+            // modeled in BOTH the pass and the validator (a validator that
+            // treats `bl` as effect-free would accept a non-identity equation
+            // across it). Named follow-up.
+            Bl { .. } | Blx { .. } | Call { .. } => Term::No("call"),
+            CallIndirect { .. } => Term::No("call-indirect"),
+            BrTable { .. } => Term::No("br-table"),
+            Bx { .. } => Term::No("computed-bx"),
             _ => Term::Fall,
         }
     }
@@ -350,30 +358,30 @@ mod joins {
     /// The label-form CFG of `instrs`, or `None` to decline. Sound by
     /// construction: a `Some` is a COMPLETE CFG (every block reachable from the
     /// entry, every terminator modeled), never a partial guess.
-    pub(super) fn build_cfg(instrs: &[ArmInstruction]) -> Option<Vec<BasicBlock>> {
+    pub(super) fn build_cfg(instrs: &[ArmInstruction]) -> Result<Vec<BasicBlock>, &'static str> {
         let n = instrs.len();
         if n == 0 {
-            return None;
+            return Err("empty");
         }
         // 1. Admission.
         let mut labels: BTreeSet<&str> = BTreeSet::new();
         for ins in instrs {
             match classify(&ins.op) {
-                Term::No => return None,
+                Term::No(why) => return Err(why),
                 Term::Uncond(_) | Term::Cond(_) => {}
                 Term::Ret | Term::Fall => {
                     if !matches!(ins.op, ArmOp::Label { .. })
                         && !matches!(ins.op, ArmOp::Bx { .. })
                         && reg_effect(&ins.op).is_none()
                     {
-                        return None;
+                        return Err("unmodeled-op");
                     }
                 }
             }
             if let ArmOp::Label { name } = &ins.op
                 && !labels.insert(name.as_str())
             {
-                return None; // duplicate label ⇒ ambiguous CFG
+                return Err("duplicate-label"); // ambiguous CFG
             }
         }
         // 2. Leaders.
@@ -417,9 +425,9 @@ mod joins {
         for b in &blocks {
             let fallthrough = block_of_start.get(&b.end).copied();
             succs.push(match classify(&instrs[b.end - 1].op) {
-                Term::Uncond(l) => vec![*block_of_label.get(l)?],
+                Term::Uncond(l) => vec![*block_of_label.get(l).ok_or("unknown-label")?],
                 Term::Cond(l) => {
-                    let t = *block_of_label.get(l)?;
+                    let t = *block_of_label.get(l).ok_or("unknown-label")?;
                     let mut s = vec![t];
                     if let Some(f) = fallthrough
                         && f != t
@@ -432,8 +440,8 @@ mod joins {
                 // A non-return block that falls off the end of the function is
                 // a stream we do not understand: decline rather than invent a
                 // sink (an invented sink would silently drop its exit contract).
-                Term::Fall => vec![fallthrough?],
-                Term::No => return None,
+                Term::Fall => vec![fallthrough.ok_or("falls-off-end")?],
+                Term::No(why) => return Err(why),
             });
         }
         for (b, s) in blocks.iter_mut().zip(succs) {
@@ -454,9 +462,9 @@ mod joins {
             }
         }
         if seen.iter().any(|r| !r) {
-            return None;
+            return Err("unreachable-block");
         }
-        Some(blocks)
+        Ok(blocks)
     }
 
     /// Simple union-find over web ids.
@@ -746,13 +754,107 @@ mod joins {
         })
     }
 
+    /// Chaitin/Briggs colouring with a **churn-minimising colour preference**.
+    ///
+    /// `chaitin_core` (which `color_ranges` wraps) selects the LOWEST free
+    /// colour. Across a whole branchy function that repacks nearly every value
+    /// into R0/R1 — measured on `loop_param_bound_663::sum_const`, where the
+    /// repack put the loop's compare result on top of the register a later
+    /// `forward_stack_reloads` was forwarding through, replacing two `mov`s with
+    /// two `ldr`s INSIDE the loop: +2 bytes and **+22 cycles** on the WCET bound.
+    /// A whole-function allocator that ignores what the rest of the pipeline is
+    /// about to do is not automatically better than a greedy one.
+    ///
+    /// So the select phase prefers, in order:
+    ///   1. the web's ORIGINAL register, when that register is CALLER-saved
+    ///      (R0-R3) — a value already in scratch has nothing to gain by moving,
+    ///      and moving it only disturbs downstream passes;
+    ///   2. the lowest free CALLER-saved colour — this is the actual objective:
+    ///      evacuate R4-R8 so `shrink_callee_saved_saves` can drop the
+    ///      prologue's push/pop entries;
+    ///   3. the web's original register (now necessarily callee-saved), keeping
+    ///      churn at zero when no scratch register is available;
+    ///   4. the lowest free colour, as a last resort.
+    ///
+    /// NOT implemented by changing `chaitin_core`: that core is shared with the
+    /// SHIPPING `reallocate_function`, so a different select order there would
+    /// move the frozen bytes. The simplify/optimistic-spill half is the same
+    /// algorithm, deliberately mirrored rather than reused for that reason.
+    fn color_webs_biased(
+        adj: &BTreeMap<usize, BTreeSet<usize>>,
+        k: usize,
+        precolored: &BTreeMap<usize, usize>,
+        costs: &BTreeMap<usize, usize>,
+        orig_colour: &BTreeMap<usize, usize>,
+        caller_saved: usize,
+    ) -> (BTreeMap<usize, usize>, BTreeSet<usize>) {
+        let cost_of = |n: &usize| costs.get(n).copied().unwrap_or(1);
+        let mut work: BTreeMap<usize, BTreeSet<usize>> = adj
+            .iter()
+            .filter(|(n, _)| !precolored.contains_key(n))
+            .map(|(n, nbrs)| (*n, nbrs.clone()))
+            .collect();
+        let mut stack: Vec<usize> = Vec::with_capacity(work.len());
+        while !work.is_empty() {
+            let pick = work
+                .iter()
+                .find(|(_, nbrs)| nbrs.len() < k)
+                .map(|(n, _)| *n)
+                .unwrap_or_else(|| {
+                    work.iter()
+                        .min_by(|a, b| {
+                            (cost_of(a.0) * b.1.len())
+                                .cmp(&(cost_of(b.0) * a.1.len()))
+                                .then(a.0.cmp(b.0))
+                        })
+                        .map(|(n, _)| *n)
+                        .unwrap()
+                });
+            let nbrs = work.remove(&pick).unwrap_or_default();
+            for n in &nbrs {
+                if let Some(s) = work.get_mut(n) {
+                    s.remove(&pick);
+                }
+            }
+            stack.push(pick);
+        }
+        let mut colour: BTreeMap<usize, usize> = precolored.clone();
+        let mut spilled: BTreeSet<usize> = BTreeSet::new();
+        while let Some(n) = stack.pop() {
+            let mut used = vec![false; k];
+            for nb in adj.get(&n).into_iter().flatten() {
+                if let Some(&c) = colour.get(nb)
+                    && c < k
+                {
+                    used[c] = true;
+                }
+            }
+            let own = orig_colour.get(&n).copied();
+            let pick = own
+                .filter(|&c| c < caller_saved && c < k && !used[c])
+                .or_else(|| (0..caller_saved.min(k)).find(|&c| !used[c]))
+                .or_else(|| own.filter(|&c| c < k && !used[c]))
+                .or_else(|| (0..k).find(|&c| !used[c]));
+            match pick {
+                Some(c) => {
+                    colour.insert(n, c);
+                }
+                None => {
+                    spilled.insert(n);
+                }
+            }
+        }
+        (colour, spilled)
+    }
+
     /// The increment-2 entry point. See the module doc for scope and oracles.
     pub(super) fn reallocate_across_joins(
         instrs: &[ArmInstruction],
         pool: &[Reg],
     ) -> Option<Vec<ArmInstruction>> {
-        let Some(blocks) = build_cfg(instrs) else {
-            return decline("cfg-unmodeled-construct");
+        let blocks = match build_cfg(instrs) {
+            Ok(b) => b,
+            Err(why) => return decline(why),
         };
         // A single-block function is increment 1's domain (tried first); this
         // path exists for the branchy ones.
@@ -957,7 +1059,24 @@ mod joins {
                 }
             }
         }
-        let (coloring, spilled) = color_ranges(&pool_adj, pool.len(), &pins, &costs);
+        // Each web's ORIGINAL colour — the churn-minimising bias's input.
+        let orig_colour: BTreeMap<usize, usize> = (0..webs.n_webs)
+            .filter_map(|w| pool_index.get(&webs.reg_of[w]).map(|&c| (w, c)))
+            .collect();
+        // The caller-saved prefix of the pool (R0-R3): the registers a value can
+        // move INTO for free, because they need no prologue save.
+        let caller_saved = pool
+            .iter()
+            .take_while(|r| matches!(r, Reg::R0 | Reg::R1 | Reg::R2 | Reg::R3))
+            .count();
+        let (coloring, spilled) = color_webs_biased(
+            &pool_adj,
+            pool.len(),
+            &pins,
+            &costs,
+            &orig_colour,
+            caller_saved,
+        );
         if !spilled.is_empty() {
             // Spill-code insertion across joins is a named follow-up; the
             // shipping path HAS spill support, so decline to it.
@@ -979,9 +1098,37 @@ mod joins {
                 if *b >= webs.n_webs {
                     continue;
                 }
+                // Skip edges whose BOTH endpoints are PINNED (identity-fixed by
+                // the ABI/architecture, or reserved and never coloured at all).
+                // A pinned web's register is not a choice the colourer made — it
+                // is the original's — so two pinned webs "sharing" a register is
+                // exactly the original code's behaviour, not a conflict. The
+                // edge exists only because the conservative exit contract makes
+                // a register live at the return with NO unifying use, so its
+                // entry web and its arm-local def web both land in the sink's
+                // live set (measured: 16 corpus functions declined wholesale on
+                // `1(R1)~16(R1) -> R1/R1`). The shipping pass exempts the same
+                // pair class for the same reason. Pool↔pool and pinned↔free
+                // edges are still enforced, and `validate_cfg_rewrite` proves
+                // the dataflow either way.
+                let fixed = |w: &usize| pins.contains_key(w) || !pool_nodes.contains(w);
+                if fixed(a) && fixed(b) {
+                    continue;
+                }
                 match (assignment.get(a), assignment.get(b)) {
                     (Some(x), Some(y)) if x != y => {}
-                    _ => return decline("edge-recheck"),
+                    _ => {
+                        if std::env::var("SYNTH_GRAPH_ALLOC_DUMP").is_ok() {
+                            eprintln!(
+                                "[ga-dump] edge-recheck {a}({:?})~{b}({:?}) -> {:?}/{:?}",
+                                webs.reg_of[*a],
+                                webs.reg_of[*b],
+                                assignment.get(a),
+                                assignment.get(b)
+                            );
+                        }
+                        return decline("edge-recheck");
+                    }
                 }
             }
         }

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -3552,9 +3552,12 @@ pub fn validate_cfg_rewrite(
             rewritten: rewritten.len(),
         });
     }
-    if orig.is_empty() || blocks.is_empty() {
+    if orig.is_empty() {
         return Ok(());
     }
+    // NOT `|| blocks.is_empty()`: an empty CFG for a NON-empty stream would
+    // then validate every rewrite vacuously. It falls through to the tiling
+    // check below, which rejects it.
 
     // ---- Structural re-check of the supplied CFG (never trusted) ----------
     // Blocks must tile the whole stream in order, so every instruction is

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -3453,6 +3453,256 @@ pub fn validate_segment_rewrite_exempting(
     Ok(())
 }
 
+/// [`rewrite_op`] made public for the VCR-DEC-001 whole-function allocator
+/// ([`crate::graph_alloc`]): rewrite `op`'s register operands through a `use`
+/// map and a `def` map. `None` on an op this module does not model, or when an
+/// RMW field's def and use disagree (a single register field cannot be renamed
+/// two ways). The straight-line pass reaches this via
+/// [`apply_range_coloring`]; the CFG-wide allocator needs the per-instruction
+/// form because its rename maps come from cross-block *webs*, not from a
+/// straight-line range replay.
+pub fn rewrite_op_maps(
+    op: &ArmOp,
+    use_map: &BTreeMap<Reg, Reg>,
+    def_map: &BTreeMap<Reg, Reg>,
+) -> Option<ArmOp> {
+    rewrite_op(op, use_map, def_map)
+}
+
+/// The registers whose value at a function return is OBSERVABLE — the exit
+/// contract [`validate_cfg_rewrite`] seeds and [`crate::graph_alloc`] mirrors in
+/// its own liveness, so the pass proposes exactly what the oracle certifies
+/// (#888 measured what a pass/validator mismatch costs: four "failures" that
+/// were one bug).
+///
+/// The WHOLE register file, minus — at a `pop {…, pc}` return only — the AAPCS
+/// caller-saved scratch `{R2, R3, R12, LR}` that [`validate_segment_rewrite`]
+/// already treats as dead-out there. A `bx lr` return gets NO exemption: at this
+/// pipeline position `LR` still carries the return address and the callee-saved
+/// save/restore has not been synthesized, so nothing new is claimed about it.
+/// Deliberately NOT derived from "registers either side writes": that heuristic
+/// makes the seed depend on the rewrite, which is how a pass can shrink its own
+/// acceptance test.
+pub fn cfg_exit_observable(terminator: &ArmOp) -> BTreeSet<Reg> {
+    use Reg::*;
+    const ALL: [Reg; 16] = [
+        R0, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, SP, LR, PC,
+    ];
+    let pop_return = matches!(terminator, ArmOp::Pop { regs } if regs.contains(&Reg::PC));
+    const AAPCS_DEAD_AT_POP_RETURN: [Reg; 4] = [R2, R3, R12, LR];
+    ALL.into_iter()
+        .filter(|r| !(pop_return && AAPCS_DEAD_AT_POP_RETURN.contains(r)))
+        .collect()
+}
+
+/// VCR-DEC-001 increment 2 — the CFG-lifted translation validator: prove a
+/// renames-only rewrite of a WHOLE branchy function preserves its dataflow
+/// **across control-flow joins**.
+///
+/// [`validate_segment_rewrite`] is the straight-line Rideau/Leroy pairwise
+/// trace-equality check: seed identity equations at the segment exit, walk
+/// backward discharging them at defs and generating them at uses, and require
+/// every survivor to be identity at entry. This is the same argument lifted to
+/// a CFG by a **backward must-fixpoint**:
+///
+/// ```text
+///   eqs_out[b] = ⋃ { eqs_in[s] : s ∈ succ(b) }      (ALL successors' demands)
+///   eqs_in[b]  = transfer_b(eqs_out[b])              (the straight-line walk)
+///   eqs_out[sink] = { (r,r) : r ∈ exit_observable(sink) }
+///   REQUIRE eqs_in[entry] ⊆ identity
+/// ```
+///
+/// The transfer is monotone and the lattice (subsets of `Reg × Reg`) is finite,
+/// so iterating from `∅` converges to the least fixpoint — the exact set of
+/// equations the exit contract forces backward through every path, back edges
+/// included. An equation a def cannot discharge is an immediate reject
+/// (rejection is monotone in the equation set, so failing early is sound).
+///
+/// **The exit contract is computed HERE, not supplied by the caller** — the
+/// deliberate anti-pattern guard: the v0.50 join-enforcement attempt failed by
+/// letting the pass hand the checker its own seed, and two `entry_seed` hacks
+/// then masked the red signal. The seed is register-file equivalence in the
+/// #872 sense: identity for every register EITHER side writes anywhere in the
+/// function (so a rewrite that clobbers a pass-through the original never
+/// touches is rejected), minus — at a `pop {…, pc}` return sink only — the
+/// AAPCS caller-saved scratch `{R2, R3, R12, LR}` that
+/// [`validate_segment_rewrite`] already exempts. A `bx lr` sink gets the STRICT
+/// seed (no exemption): at this pipeline position `LR` still carries the return
+/// address and the callee-saved save/restore has not been synthesized yet.
+///
+/// Control-flow instructions (`Label`, `B`, `Bcc`, `Bx`, …) have no
+/// [`reg_effect`] and are required to be **byte-for-byte identical** on both
+/// sides — a register allocator renames operands, it never rewrites control
+/// flow. So branch conditions and labels cannot drift, and flag equality at a
+/// `Bcc` follows from the equations its `Cmp`'s uses generate.
+///
+/// `blocks` must be a complete CFG of `orig` (each block's `[start, end)` and
+/// successors). Structural preconditions are re-checked here rather than
+/// trusted: blocks must tile `0..len` in order, a return terminator may appear
+/// only as a block's LAST instruction (the #872/#888 mid-segment `pop {…, pc}`
+/// class), and every successorless block must end in a recognized return.
+pub fn validate_cfg_rewrite(
+    orig: &[ArmInstruction],
+    rewritten: &[ArmInstruction],
+    blocks: &[BasicBlock],
+) -> Result<(), RewriteViolation> {
+    if orig.len() != rewritten.len() {
+        return Err(RewriteViolation::LengthMismatch {
+            orig: orig.len(),
+            rewritten: rewritten.len(),
+        });
+    }
+    if orig.is_empty() || blocks.is_empty() {
+        return Ok(());
+    }
+
+    // ---- Structural re-check of the supplied CFG (never trusted) ----------
+    // Blocks must tile the whole stream in order, so every instruction is
+    // walked exactly once by the transfer below.
+    let mut expect = 0usize;
+    for b in blocks {
+        if b.start != expect || b.end <= b.start || b.end > orig.len() {
+            return Err(RewriteViolation::Unmodeled { index: b.start });
+        }
+        for &s in &b.succ {
+            if s >= blocks.len() {
+                return Err(RewriteViolation::Unmodeled { index: b.start });
+            }
+        }
+        expect = b.end;
+    }
+    if expect != orig.len() {
+        return Err(RewriteViolation::Unmodeled { index: expect });
+    }
+
+    // ---- Pass 1: per-instruction correspondence --------------------------
+    // Straight-line ops must be shape-equal with matching def/use arity;
+    // everything else (control flow) must be literally identical.
+    let mut effects: Vec<Option<(RegEffect, RegEffect)>> = Vec::with_capacity(orig.len());
+    for (i, (o, r)) in orig.iter().zip(rewritten).enumerate() {
+        if !is_straight_line(&o.op) || !is_straight_line(&r.op) {
+            if o.op != r.op {
+                return Err(RewriteViolation::ShapeMismatch { index: i });
+            }
+            effects.push(None);
+            continue;
+        }
+        let (Some(eo), Some(er)) = (reg_effect(&o.op), reg_effect(&r.op)) else {
+            return Err(RewriteViolation::Unmodeled { index: i });
+        };
+        let (Some(so), Some(sr)) = (op_shape(&o.op), op_shape(&r.op)) else {
+            return Err(RewriteViolation::Unmodeled { index: i });
+        };
+        if so != sr || eo.defs.len() != er.defs.len() || eo.uses.len() != er.uses.len() {
+            return Err(RewriteViolation::ShapeMismatch { index: i });
+        }
+        effects.push(Some((eo, er)));
+    }
+
+    // A return terminator may only be a block's LAST instruction — the exact
+    // shape #888 found miscompiling (`pop {…, pc}` mid-segment looks like a
+    // plain register-list def to a straight-line walk).
+    for b in blocks {
+        for i in b.start..b.end - 1 {
+            if is_return_terminator(&orig[i].op) || is_return_terminator(&rewritten[i].op) {
+                return Err(RewriteViolation::Unmodeled { index: i });
+            }
+        }
+    }
+
+    // ---- Exit contract (computed here; see the doc comment) --------------
+    let mut sink_seed: Vec<Option<BTreeSet<(Reg, Reg)>>> = vec![None; blocks.len()];
+    for (bi, b) in blocks.iter().enumerate() {
+        if !b.succ.is_empty() {
+            continue;
+        }
+        if !is_return_terminator(&orig[b.end - 1].op) {
+            // A successorless block that is not a recognized return: the CFG is
+            // incomplete (falls off the end / unmodeled terminator). Decline.
+            return Err(RewriteViolation::Unmodeled { index: b.end - 1 });
+        }
+        sink_seed[bi] = Some(
+            cfg_exit_observable(&orig[b.end - 1].op)
+                .into_iter()
+                .map(|r| (r, r))
+                .collect(),
+        );
+    }
+
+    // ---- Backward must-fixpoint ------------------------------------------
+    let nb = blocks.len();
+    let mut eqs_in: Vec<BTreeSet<(Reg, Reg)>> = vec![BTreeSet::new(); nb];
+    // Monotone transfer over a finite lattice: |Reg|² equations × nb blocks
+    // bounds the number of productive rounds. The cap is defensive only.
+    let cap = nb.saturating_mul(16 * 16).saturating_add(64);
+    let mut rounds = 0usize;
+    let mut changed = true;
+    while changed {
+        changed = false;
+        rounds += 1;
+        if rounds > cap {
+            return Err(RewriteViolation::Unmodeled { index: 0 });
+        }
+        for bi in (0..nb).rev() {
+            let b = &blocks[bi];
+            let mut eqs: BTreeSet<(Reg, Reg)> = match &sink_seed[bi] {
+                Some(seed) => seed.clone(),
+                None => {
+                    let mut out = BTreeSet::new();
+                    for &s in &b.succ {
+                        out.extend(eqs_in[s].iter().copied());
+                    }
+                    out
+                }
+            };
+            for i in (b.start..b.end).rev() {
+                let Some((eo, er)) = &effects[i] else {
+                    continue; // control flow: identical on both sides, no effect
+                };
+                let pairs: BTreeSet<(Reg, Reg)> = eo
+                    .defs
+                    .iter()
+                    .copied()
+                    .zip(er.defs.iter().copied())
+                    .collect();
+                let defs_o: BTreeSet<Reg> = eo.defs.iter().copied().collect();
+                let defs_r: BTreeSet<Reg> = er.defs.iter().copied().collect();
+                let mut above: BTreeSet<(Reg, Reg)> = BTreeSet::new();
+                for eq in &eqs {
+                    if !defs_o.contains(&eq.0) && !defs_r.contains(&eq.1) {
+                        above.insert(*eq);
+                    } else if !pairs.contains(eq) {
+                        return Err(RewriteViolation::DefClobbersEquation {
+                            index: i,
+                            orig: eq.0,
+                            rewritten: eq.1,
+                        });
+                    }
+                }
+                for (uo, ur) in eo.uses.iter().zip(er.uses.iter()) {
+                    above.insert((*uo, *ur));
+                }
+                eqs = above;
+            }
+            if eqs != eqs_in[bi] {
+                eqs_in[bi] = eqs;
+                changed = true;
+            }
+        }
+    }
+
+    // ---- Entry: inputs arrive in their original registers -----------------
+    for (o, r) in &eqs_in[0] {
+        if o != r {
+            return Err(RewriteViolation::EntryNotIdentity {
+                orig: *o,
+                rewritten: *r,
+            });
+        }
+    }
+    Ok(())
+}
+
 /// What [`reallocate_function`] did, for the flag-gated measurement pass.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ReallocStats {

--- a/scripts/repro/vcr_dec_001_graph_alloc_differential.py
+++ b/scripts/repro/vcr_dec_001_graph_alloc_differential.py
@@ -18,22 +18,33 @@ sound, on the ARM fixture corpus (arm / cortex-m4, --all-exports --relocatable):
       validating the new allocator's REAL output (observed via
       SYNTH_RA003_VERBOSE, not inferred from returncode).
 
-  (3) FLAG-ON ≡ FLAG-OFF on the whole corpus. This is a DESIGNED PROPERTY, not a
-      null result: on a straight-line function graph_alloc and the shipping
-      `reallocate_function` use the same pins (inputs + last-opened live-outs),
-      the same chaitin_core, and the same single-segment scope, so their outputs
-      are byte-identical BY CONSTRUCTION; everywhere else graph_alloc declines.
-      graph_alloc's output ⊆ {shipping bytes, decline}, so divergence is
-      impossible in increment 1. Execution correctness therefore follows
-      TRANSITIVELY: flag-on bytes = shipping bytes on applied functions, and the
-      shipping bytes are already wasmtime-gated by the frozen execution
-      differentials. (A passive flag-on-vs-wasmtime corpus would merely re-test
-      the shipping compiler, so it is deliberately NOT built here.)
+  (3) NO SILENT DRIFT, NO GROWTH. Increment 1 could assert flag-on ≡ flag-off
+      corpus-wide: on a straight-line function the spike and the shipping
+      `reallocate_function` shared pins, chaitin_core and scope, so byte
+      identity held BY CONSTRUCTION and execution correctness followed
+      TRANSITIVELY. Increment 2 (v0.53) colours ACROSS if/else joins with a
+      different pin set and a churn-minimising colour bias, so applied
+      functions genuinely DIVERGE — that identity claim is retired. What
+      replaces it is two checks that still bite:
+        (3a) a fixture on which the allocator did NOT apply must be
+             byte-identical — no drift may leak in through a decline path;
+        (3b) a fixture on which it DID apply must not GROW its `.text`;
+        (3c) at least two fixtures must actually diverge, or increment 2's
+             reach has regressed and this file is gating increment 1 only.
+      Execution correctness for the DIVERGENT bytes is no longer transitive and
+      is gated separately, by
+      `vcr_dec_001_join_alloc_execution_differential.py` (unicorn vs wasmtime
+      on the flag-ON image).
 
-The red-first teeth — "a colouring bug → the acceptance oracle catches it" — are
-the unit probe `graph_alloc_bad_rename_rejected_by_segment_validator` in
-liveness.rs: validate_segment_rewrite (the trace-equality gate graph_alloc
-invokes) rejects a value-flow-breaking merge-rename and accepts the identity.
+The red-first teeth are two-layer. Unit: `graph_alloc_bad_rename_rejected_by_\
+segment_validator` in liveness.rs (validate_segment_rewrite rejects a
+value-flow-breaking merge-rename). Whole-pass, by MUTATION: emptying
+`cfg_exit_observable` — the exit contract the pass and its CFG validator SHARE —
+while removing the colour bias that masks it produces code that leaves the
+return value in the wrong register; `validate_cfg_rewrite` AND VCR-RA-003 both
+ACCEPT it, and only the execution differential catches it (16 wrong results).
+That is the #872 lesson made concrete: this validator is necessary, not
+sufficient.
 
 Usage: python3 vcr_dec_001_graph_alloc_differential.py <synth-binary>
 Exit 0 = all three properties hold; nonzero = a violation.
@@ -151,9 +162,10 @@ def main():
         print(f"  {wasm:<24} {sha(t)[:12]} len={len(t):<5} {'OK' if ok else 'MISMATCH <--'}")
         fails += 0 if ok else 1
 
-    # ---- Property 2+3: flag-on APPLIES + RA-003 Consistent + ≡ flag-off ------
-    print("== (2)(3) flag-on: applies, RA-003 Consistent, ≡ flag-off ==")
+    # ---- Property 2+3: flag-on APPLIES + RA-003 Consistent + no drift/growth -
+    print("== (2)(3) flag-on: applies, RA-003 Consistent, no drift, no growth ==")
     applied_fixtures = 0
+    diverged_fixtures = 0
     for wasm in CORPUS:
         r_off, off_elf = compile_arm(synth, wasm, {})
         r_on, on_elf = compile_arm(
@@ -172,15 +184,24 @@ def main():
         # if applied > 0, at least one Consistent appears and NO Violation.
         consistent = on_stderr.count("VCR-RA-003: Consistent")
         violation = "register-allocation validation FAILED" in on_stderr
-        # Byte-identity flag-on ≡ flag-off (the designed property).
-        ident = text_of(off_elf) == text_of(on_elf)
+        t_off, t_on = text_of(off_elf), text_of(on_elf)
+        ident = t_off == t_on
         if applied > 0:
             applied_fixtures += 1
-        ok = ident and not violation and (applied == 0 or consistent > 0)
-        tag = []
-        tag.append(f"applied={applied}")
-        tag.append(f"RA003-consistent={consistent}")
-        tag.append("bytes≡" if ident else "BYTES-DIFFER<--")
+        if not ident:
+            diverged_fixtures += 1
+        # (3a) no drift on a fixture the allocator never touched.
+        drift = applied == 0 and not ident
+        # (3b) an applied fixture may change bytes, but must not GROW.
+        grew = applied > 0 and len(t_on) > len(t_off)
+        ok = not drift and not grew and not violation and (applied == 0 or consistent > 0)
+        tag = [f"applied={applied}", f"RA003-consistent={consistent}",
+               f"bytes {len(t_off)}->{len(t_on)}",
+               "≡" if ident else "diverged"]
+        if drift:
+            tag.append("DRIFT-WITHOUT-APPLY<--")
+        if grew:
+            tag.append("GREW<--")
         if violation:
             tag.append("RA003-VIOLATION<--")
         print(f"  {wasm:<24} {'  '.join(tag)} {'OK' if ok else 'FAIL <--'}")
@@ -191,6 +212,14 @@ def main():
     print(f"== applying fixtures: {applied_fixtures} (must be ≥ 2 for non-vacuity) ==")
     if applied_fixtures < 2:
         print("  VACUOUS: graph_alloc never applied — increment-1 scope regressed.")
+        fails += 1
+    # (3c) increment 2 must actually reach past increment 1's byte-identical
+    # domain, or (3a)/(3b) degenerate into "the flag does nothing".
+    print(f"== diverging fixtures: {diverged_fixtures} (must be ≥ 2 for "
+          f"increment-2 non-vacuity) ==")
+    if diverged_fixtures < 2:
+        print("  VACUOUS: no fixture's bytes changed — the join colouring "
+              "(increment 2) no longer reaches this corpus.")
         fails += 1
 
     # DEEPER non-vacuity: prove graph_alloc's byte-match is NOT a trivial identity
@@ -224,7 +253,8 @@ def main():
     if fails:
         print(f"VIOLATION: {fails} check(s) failed.")
         return 1
-    print("OK: flag-off frozen, flag-on applies + RA-003 Consistent + ≡ flag-off.")
+    print("OK: flag-off frozen; flag-on applies, RA-003 Consistent, "
+          "no drift on non-applied, no growth on applied.")
     return 0
 
 

--- a/scripts/repro/vcr_dec_001_join_alloc_execution_differential.py
+++ b/scripts/repro/vcr_dec_001_join_alloc_execution_differential.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""VCR-DEC-001 increment 2 — EXECUTION differential for the join-aware
+graph-colouring allocator (`SYNTH_GRAPH_ALLOC=1`, epic #242).
+
+**Why this exists.** Increment 1 (v0.50) could claim execution correctness
+TRANSITIVELY: on a whole straight-line function the spike and the shipping
+`reallocate_function` share pins, `chaitin_core` and scope, so their bytes were
+identical BY CONSTRUCTION and the frozen wasmtime differentials already gated
+them. Increment 2 breaks that: colouring across joins uses a different colour
+bias and a different pin set, so the flag-on bytes genuinely DIVERGE. A
+byte-only gate would therefore certify nothing about the new bytes, and
+`validate_cfg_rewrite` — the pass's own acceptance oracle — shares the CFG shape
+with the pass it validates (#872 is the standing lesson that a validator can
+share its pass's blind spot). So the new bytes get executed.
+
+What is gated, per fixture function:
+  (E) ENGAGEMENT — the allocator must APPLY, and the flag-on `.text` must
+      actually DIFFER from flag-off. Without both, the harness would be
+      re-testing the shipping compiler and would pass vacuously; it FAILS
+      instead.
+  (1) EXECUTION — unicorn runs the flag-ON image and its return value AND the
+      compared linear-memory window must equal wasmtime's on every input.
+  (2) VCR-RA-003 — `validate_final_allocation` must return Consistent for every
+      applied function (observed via SYNTH_RA003_VERBOSE, not inferred from the
+      exit code), and no violation may be reported.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python3 \\
+      scripts/repro/vcr_dec_001_join_alloc_execution_differential.py
+Exits nonzero on any mismatch, any missing engagement, or any RA-003 verdict
+other than Consistent.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_PC,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R9,
+    UC_ARM_REG_R10,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+REPRO = Path(__file__).resolve().parent
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+LIN = 0x2000_0000
+LIN_SIZE = 0x1_0000
+CODE = 0x0
+SP_INIT = LIN + 0x2_0000
+MEM_WINDOW = 0x100
+ARG_REGS = [UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2]
+
+# (fixture, function, [arg tuples]). Chosen to cover every join shape the
+# allocator now colours: real if/else, if-without-else, the desugared
+# block+br_if form, an early (non-tail) return, counted and data-dependent
+# loops, and the two-level `br_if` exit — with inputs that take BOTH sides of
+# every branch (a one-sided input set would never execute the arm whose
+# register the colourer moved).
+CASES = [
+    ("cf_shapes_500.wat", "real_ifelse", [(0,), (1,), (7,)]),
+    ("cf_shapes_500.wat", "real_if", [(0,), (1,)]),
+    ("cf_shapes_500.wat", "br_func", [(0,), (1,)]),
+    ("cf_shapes_500.wat", "early_ret", [(0,), (1,)]),
+    ("provenance_branches_396.wat", "decide", [(0, 0), (5, 3), (3, 5), (100, 1)]),
+    ("aarch64_ctrlflow_851.wat", "count_sum", [(0,), (1,), (5,), (17,)]),
+    ("aarch64_ctrlflow_851.wat", "countdown", [(0,), (1,), (9,)]),
+    # do_while_count(0) is deliberately absent: `n` starts at 0, so the
+    # bottom-test loop runs 2**32 times before wrapping back to the exit. It
+    # terminates in wasmtime (JIT) but not within any emulator instruction
+    # budget, so it measures the budget, not the compiler.
+    ("aarch64_ctrlflow_851.wat", "do_while_count", [(1,), (6,), (23,)]),
+    ("loop_param_bound_663.wat", "sum_const", [(0, 0), (3, 4)]),
+    ("loop_param_bound_663.wat", "sum_below", [(0, 0), (1, 5), (4, 4), (2, 9)]),
+    ("if_else_result_343.wat", "pick", [(0,), (1,), (0xFFFFFFFF,)]),
+    ("if_else_result_343.wat", "pick2", [(0,), (1,)]),
+    ("brif_outer_740.wat", "poll", [(7, 0), (200, 0), (200, 1), (5, 3)]),
+]
+
+CLEAR = [
+    "SYNTH_NO_CMP_SELECT_FUSE", "SYNTH_NO_LOCAL_PROMOTE", "SYNTH_NO_IMM_SHIFT_FOLD",
+    "SYNTH_NO_STACK_FWD", "SYNTH_SPILL_REALLOC", "SYNTH_CONST_CSE", "SYNTH_BASE_CSE",
+    "SYNTH_DEAD_FRAME_ELIM", "SYNTH_UXTH_FOLD", "SYNTH_GRAPH_ALLOC",
+    "SYNTH_SHIFT_MASK_ELIDE", "SYNTH_RANGE_REALLOC",
+]
+
+
+def compile_image(wat, out, graph_alloc):
+    env = {k: v for k, v in os.environ.items()}
+    for k in CLEAR:
+        env.pop(k, None)
+    if graph_alloc:
+        env["SYNTH_GRAPH_ALLOC"] = "1"
+        env["SYNTH_GRAPH_ALLOC_STATS"] = "1"
+        env["SYNTH_RA003_VERBOSE"] = "1"
+    r = subprocess.run(
+        [SYNTH, "compile", str(REPRO / wat), "-o", out, "-b", "arm",
+         "--target", "cortex-m4", "--all-exports"],
+        capture_output=True, text=True, env=env,
+    )
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({wat}, graph_alloc={graph_alloc}): {r.stderr}")
+    return r.stderr
+
+
+def load(elf):
+    with open(elf, "rb") as fh:
+        f = ELFFile(fh)
+        text = f.get_section_by_name(".text").data()
+        lin = f.get_section_by_name(".linear_memory")
+        syms, sizes = {}, {}
+        for sec in f.iter_sections():
+            if sec.header.sh_type == "SHT_SYMTAB":
+                for s in sec.iter_symbols():
+                    if s.name:
+                        syms[s.name] = s["st_value"]
+                        sizes[s.name] = s["st_size"]
+        return text, lin.data() if lin else b"", syms, sizes
+
+
+def wasmtime_call(wat, func, args):
+    """(result_or_None, memory_window). A VOID export returns None — and that
+    None is propagated, NOT coerced to 0: for a void function R0 is AAPCS
+    scratch, so comparing it against a synthesized 0 would fail for a correct
+    compiler (measured: every void `cf_shapes_500` export). Void functions are
+    gated on their MEMORY effect instead."""
+    eng = wasmtime.Engine()
+    mod = wasmtime.Module(eng, (REPRO / wat).read_bytes())
+    st = wasmtime.Store(eng)
+    inst = wasmtime.Instance(st, mod, [])
+    exports = inst.exports(st)
+    r = exports[func](st, *[a - (1 << 32) if a >= (1 << 31) else a for a in args])
+    mem = exports.get("memory")
+    window = bytes(mem.read(st, 0, MEM_WINDOW)) if mem else b""
+    return (None if r is None else r & 0xFFFFFFFF), window
+
+
+def unicorn_call(text, lin_init, faddr, args):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x10000)
+    mu.mem_map(LIN, 0x2_0000)
+    mu.mem_write(CODE, text)
+    if lin_init:
+        mu.mem_write(LIN, lin_init[:LIN_SIZE])
+    mu.reg_write(UC_ARM_REG_R9, LIN + LIN_SIZE)
+    mu.reg_write(UC_ARM_REG_R10, LIN_SIZE)
+    mu.reg_write(UC_ARM_REG_R11, LIN)
+    mu.reg_write(UC_ARM_REG_SP, SP_INIT)
+    ret = CODE + 0xFF00
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    for reg, val in zip(ARG_REGS, args):
+        mu.reg_write(reg, val & 0xFFFFFFFF)
+    try:
+        mu.emu_start((faddr & ~1) | 1, ret, timeout=5_000_000, count=500_000)
+    except UcError as e:
+        return f"ERR:{e}", None
+    # A count/timeout-limited stop leaves PC INSIDE the function and the
+    # registers mid-flight. Comparing those against wasmtime's real result is
+    # how a truncated run gets read as a pass (or, worse, as a miscompile —
+    # measured on the 2**32-iteration `do_while_count(0)`, where the flag-off
+    # build happened to leave the right value in R0 and the flag-on build did
+    # not). Report it as its own failure instead.
+    pc = mu.reg_read(UC_ARM_REG_PC)
+    if (pc & ~1) != (ret & ~1):
+        return f"DID-NOT-RETURN@0x{pc:X}", None
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF, bytes(mu.mem_read(LIN, MEM_WINDOW))
+
+
+def main():
+    fails = 0
+    checks = 0
+    engaged_functions = 0
+    by_fixture = {}
+    for wat, func, argsets in CASES:
+        by_fixture.setdefault(wat, []).append((func, argsets))
+
+    for wat, entries in by_fixture.items():
+        off_elf = f"/tmp/ga_join_{Path(wat).stem}_off.elf"
+        on_elf = f"/tmp/ga_join_{Path(wat).stem}_on.elf"
+        compile_image(wat, off_elf, False)
+        stderr_on = compile_image(wat, on_elf, True)
+
+        # ---- (2) VCR-RA-003 on the REAL flag-on output --------------------
+        applied = stderr_on.count("whole-function colouring APPLIED")
+        consistent = stderr_on.count("VCR-RA-003: Consistent")
+        if "register-allocation validation FAILED" in stderr_on:
+            print(f"FAIL {wat}: VCR-RA-003 reported a violation")
+            fails += 1
+        if applied and consistent == 0:
+            print(f"FAIL {wat}: {applied} function(s) applied but no "
+                  f"'VCR-RA-003: Consistent' verdict observed")
+            fails += 1
+        print(f"== {wat}: applied={applied} RA003-consistent={consistent} ==")
+
+        text_off, _, syms_off, sizes_off = load(off_elf)
+        text_on, lin_init, syms_on, sizes_on = load(on_elf)
+
+        for func, argsets in entries:
+            if func not in syms_on:
+                print(f"FAIL {wat}:{func} — symbol missing")
+                fails += 1
+                continue
+            # ---- (E) ENGAGEMENT ------------------------------------------
+            a_off, n_off = syms_off[func] & ~1, sizes_off.get(func, 0)
+            a_on, n_on = syms_on[func] & ~1, sizes_on.get(func, 0)
+            body_off = text_off[a_off:a_off + n_off]
+            body_on = text_on[a_on:a_on + n_on]
+            if body_off == body_on:
+                print(f"FAIL {wat}:{func} — flag-on bytes IDENTICAL to flag-off: "
+                      f"this case gates nothing (the allocator no longer reaches "
+                      f"it). Re-pick the fixture or fix the regression.")
+                fails += 1
+                continue
+            engaged_functions += 1
+
+            # ---- (1) EXECUTION -------------------------------------------
+            for args in argsets:
+                gt_ret, gt_mem = wasmtime_call(wat, func, args)
+                got_ret, got_mem = unicorn_call(text_on, lin_init, a_on, args)
+                mem_ok = got_mem == gt_mem if gt_mem else True
+                # A void export has no result register to compare (R0 is AAPCS
+                # scratch past the return); its memory effect is the observable.
+                ret_ok = gt_ret is None or got_ret == gt_ret
+                ok = isinstance(got_ret, int) and ret_ok and mem_ok
+                if gt_ret is None and got_mem is None:
+                    ok = False  # DID-NOT-RETURN / emulation error
+                checks += 1
+                fails += 0 if ok else 1
+                tag = f"0x{got_ret:08X}" if isinstance(got_ret, int) else got_ret
+                gt_tag = "void" if gt_ret is None else f"0x{gt_ret:08X}"
+                argtxt = ",".join(str(a) for a in args)
+                print(f"{'OK  ' if ok else 'FAIL'} {func}({argtxt}) = {tag} "
+                      f"(wasmtime {gt_tag}) "
+                      f"{'mem==' if mem_ok else 'mem!=<--'}")
+
+    # Non-vacuity: the whole harness is worthless if the allocator stopped
+    # changing bytes anywhere. Require a real population.
+    print(f"\nengaged functions (flag-on bytes differ): {engaged_functions}")
+    if engaged_functions < 10:
+        print("VACUOUS: fewer than 10 functions have divergent flag-on bytes — "
+              "the join allocator's reach regressed; this gate no longer gates.")
+        fails += 1
+
+    # Machine-readable summary the CI wiring greps for a NON-ZERO count:
+    # exit 0 alone is not trusted (the "0 ops accepted PASS" lesson).
+    print(f"VCR-DEC-001-JOIN CHECKS={checks - fails}/{checks} "
+          f"ENGAGED={engaged_functions}")
+    print("RESULT:", "PASS" if not fails else f"FAIL ({fails} problem(s))")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repro/vcr_dec_001_join_alloc_measure.py
+++ b/scripts/repro/vcr_dec_001_join_alloc_measure.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""VCR-DEC-001 increment 2 — MEASURE the join-aware graph-colouring allocator
+against the shipping greedy/segment allocator (epic #242, the North Star).
+
+This is the lane's DELIVERABLE, not a gate: a widened allocator with no
+comparative numbers says nothing about whether to flip it. For every function
+in the ARM repro corpus it reports, per function and in total:
+
+  * `.text` bytes with `SYNTH_GRAPH_ALLOC` OFF (the shipping greedy allocator +
+    the verified segment re-allocation) vs ON (whole-function colouring across
+    joins), read from the ELF SYMTAB — never from `synth disasm` text, which is
+    host-toolchain dependent;
+  * the SOUND static worst-case cycle bound from `--emit-wcet`
+    (`synth-wcet-v1`), which is synth's own documented Cortex-M3/M4 per-op
+    model — so "cycles" here is a bound comparison on identical modelling
+    assumptions, not a hardware measurement. Functions whose bound DECLINES on
+    either side are excluded from the cycle total and counted separately.
+
+Both `--relocatable` (label-form branches — increment 2's scope) and the
+default self-contained path (pre-resolved NUMERIC branches — out of scope, so
+the allocator declines and the numbers must be flat) are measured, because the
+flat half is itself evidence: it bounds how much of the corpus the increment
+can reach today.
+
+Usage:  python3 vcr_dec_001_join_alloc_measure.py <synth-binary> [--json OUT]
+Exit 0 always unless a compile fails — this MEASURES, it does not judge.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPRO = Path(__file__).resolve().parent
+
+# Flags cleared so an ambient env var cannot skew a measurement.
+CLEAR = [
+    "SYNTH_NO_CMP_SELECT_FUSE", "SYNTH_NO_LOCAL_PROMOTE", "SYNTH_NO_IMM_SHIFT_FOLD",
+    "SYNTH_NO_STACK_FWD", "SYNTH_SPILL_REALLOC", "SYNTH_CONST_CSE", "SYNTH_BASE_CSE",
+    "SYNTH_DEAD_FRAME_ELIM", "SYNTH_UXTH_FOLD", "SYNTH_GRAPH_ALLOC",
+    "SYNTH_SHIFT_MASK_ELIDE", "SYNTH_RANGE_REALLOC", "SYNTH_FACT_SPEC",
+]
+
+
+def corpus():
+    """Every ARM-compilable repro fixture, sorted for a deterministic report."""
+    return sorted(
+        [p for p in REPRO.glob("*.wat")] + [p for p in REPRO.glob("*.wasm")],
+        key=lambda p: p.name,
+    )
+
+
+def compile_one(synth, src, outdir, relocatable, graph_alloc):
+    env = {k: v for k, v in os.environ.items()}
+    for k in CLEAR:
+        env.pop(k, None)
+    if graph_alloc:
+        env["SYNTH_GRAPH_ALLOC"] = "1"
+        env["SYNTH_GRAPH_ALLOC_STATS"] = "1"
+    elf = Path(outdir) / (src.stem + ".elf")
+    cmd = [synth, "compile", str(src), "-o", str(elf),
+           "-b", "arm", "--target", "cortex-m4", "--all-exports", "--emit-wcet"]
+    if relocatable:
+        cmd.append("--relocatable")
+    r = subprocess.run(cmd, capture_output=True, env=env)
+    return r, elf
+
+
+def func_sizes(elf):
+    """{name: size} for every STT_FUNC in the SYMTAB (never `synth disasm`
+    text, which is host-toolchain dependent — the #850 lesson). synth's
+    relocatable object leaves the symtab section NAME empty, so the section is
+    found by TYPE. Each function carries both a `func_N` symbol and its export
+    alias at the same address; the aliases are collapsed onto the export name so
+    a function is not counted twice."""
+    from elftools.elf.elffile import ELFFile
+    from elftools.elf.sections import SymbolTableSection
+    by_addr = {}
+    with open(elf, "rb") as fh:
+        ef = ELFFile(fh)
+        for sec in ef.iter_sections():
+            if not isinstance(sec, SymbolTableSection):
+                continue
+            for sym in sec.iter_symbols():
+                if sym["st_info"]["type"] != "STT_FUNC" or not sym["st_size"]:
+                    continue
+                key = (sym["st_value"], sym["st_size"])
+                prev = by_addr.get(key)
+                # Prefer the human-readable export alias over `func_N`.
+                if prev is None or (prev.startswith("func_") and
+                                    not sym.name.startswith("func_")):
+                    by_addr[key] = sym.name
+    return {name: key[1] for key, name in by_addr.items()}
+
+
+def wcet_bounds(elf):
+    """{name: cycles} from the synth-wcet-v1 sidecar; declines are omitted (a
+    DECLINE is a refusal to bound, not a zero)."""
+    side = Path(str(elf) + ".wcet.json")
+    if not side.exists():
+        return {}, set()
+    try:
+        doc = json.loads(side.read_text())
+    except json.JSONDecodeError:
+        return {}, set()
+    bounds, declined = {}, set()
+    for fn in doc.get("functions", []):
+        name = fn.get("name") or fn.get("function") or ""
+        cyc = fn.get("cycles")
+        if fn.get("status") != "bounded" or cyc is None:
+            declined.add(name)
+        else:
+            bounds[name] = cyc
+    return bounds, declined
+
+
+def measure(synth, relocatable):
+    rows, errors = [], []
+    applied_total = 0
+    declines = {}
+    with tempfile.TemporaryDirectory() as td_off, tempfile.TemporaryDirectory() as td_on:
+        for src in corpus():
+            r_off, elf_off = compile_one(synth, src, td_off, relocatable, False)
+            r_on, elf_on = compile_one(synth, src, td_on, relocatable, True)
+            if r_off.returncode != 0 or r_on.returncode != 0:
+                # Not every fixture targets ARM/cortex-m4; a fixture that does
+                # not compile on BOTH sides is simply out of the population.
+                if r_off.returncode != r_on.returncode:
+                    errors.append(f"{src.name}: asymmetric compile "
+                                  f"(off={r_off.returncode} on={r_on.returncode})")
+                continue
+            stderr_on = r_on.stderr.decode(errors="replace")
+            applied_total += stderr_on.count("whole-function colouring APPLIED")
+            for line in stderr_on.splitlines():
+                if "join colouring DECLINED:" in line:
+                    reason = line.rsplit(":", 1)[1].strip()
+                    declines[reason] = declines.get(reason, 0) + 1
+            s_off, s_on = func_sizes(elf_off), func_sizes(elf_on)
+            w_off, d_off = wcet_bounds(elf_off)
+            w_on, d_on = wcet_bounds(elf_on)
+            for name in sorted(set(s_off) & set(s_on)):
+                cyc_off = w_off.get(name)
+                cyc_on = w_on.get(name)
+                rows.append({
+                    "fixture": src.name,
+                    "func": name,
+                    "bytes_off": s_off[name],
+                    "bytes_on": s_on[name],
+                    "cycles_off": cyc_off,
+                    "cycles_on": cyc_on,
+                })
+    return rows, applied_total, declines, errors
+
+
+def report(tag, rows, applied, declines, errors):
+    changed = [r for r in rows if r["bytes_off"] != r["bytes_on"]]
+    b_off = sum(r["bytes_off"] for r in rows)
+    b_on = sum(r["bytes_on"] for r in rows)
+    cyc = [r for r in rows if r["cycles_off"] is not None and r["cycles_on"] is not None]
+    c_off = sum(r["cycles_off"] for r in cyc)
+    c_on = sum(r["cycles_on"] for r in cyc)
+    grew = [r for r in rows if r["bytes_on"] > r["bytes_off"]]
+    shrank = [r for r in rows if r["bytes_on"] < r["bytes_off"]]
+    cyc_grew = [r for r in cyc if r["cycles_on"] > r["cycles_off"]]
+    cyc_shrank = [r for r in cyc if r["cycles_on"] < r["cycles_off"]]
+
+    print(f"\n===== {tag} =====")
+    print(f"functions measured        : {len(rows)}")
+    print(f"graph-alloc APPLIED (fn)  : {applied}")
+    print(f"bytes  off={b_off}  on={b_on}  delta={b_on - b_off:+d} "
+          f"({100.0 * (b_on - b_off) / b_off:+.2f}%)" if b_off else "bytes: n/a")
+    if cyc:
+        print(f"wcet   off={c_off}  on={c_on}  delta={c_on - c_off:+d} "
+              f"({100.0 * (c_on - c_off) / c_off:+.2f}%)  "
+              f"[{len(cyc)}/{len(rows)} functions have a bound on both sides]")
+    else:
+        print("wcet   : no function has a sound bound on both sides")
+    print(f"bytes  : {len(shrank)} shrank, {len(grew)} grew, "
+          f"{len(rows) - len(changed)} unchanged")
+    print(f"cycles : {len(cyc_shrank)} shrank, {len(cyc_grew)} grew")
+    if declines:
+        print("decline reasons (flag-on):")
+        for k, v in sorted(declines.items(), key=lambda kv: -kv[1]):
+            print(f"    {k:<26} {v}")
+    if changed:
+        print("per-function changes:")
+        for r in sorted(changed, key=lambda r: r["bytes_on"] - r["bytes_off"]):
+            dc = ""
+            if r["cycles_off"] is not None and r["cycles_on"] is not None:
+                dc = f"  cyc {r['cycles_off']}->{r['cycles_on']} " \
+                     f"({r['cycles_on'] - r['cycles_off']:+d})"
+            print(f"    {r['fixture']:<34} {r['func']:<24} "
+                  f"{r['bytes_off']:>4} -> {r['bytes_on']:>4} "
+                  f"({r['bytes_on'] - r['bytes_off']:+d}){dc}")
+    for e in errors:
+        print(f"  ERROR {e}")
+    return {"functions": len(rows), "applied": applied,
+            "bytes_off": b_off, "bytes_on": b_on,
+            "cycles_off": c_off, "cycles_on": c_on,
+            "cycle_functions": len(cyc),
+            "shrank": len(shrank), "grew": len(grew),
+            "cyc_shrank": len(cyc_shrank), "cyc_grew": len(cyc_grew),
+            "declines": declines, "rows": rows}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    synth = sys.argv[1]
+    out_json = None
+    if "--json" in sys.argv:
+        out_json = sys.argv[sys.argv.index("--json") + 1]
+
+    summary = {}
+    for tag, reloc in (("relocatable / label-form branches (increment-2 scope)", True),
+                       ("self-contained / pre-resolved numeric branches (out of scope)", False)):
+        rows, applied, declines, errors = measure(synth, reloc)
+        summary["relocatable" if reloc else "self_contained"] = report(
+            tag, rows, applied, declines, errors)
+    if out_json:
+        Path(out_json).write_text(json.dumps(summary, indent=2))
+        print(f"\nwrote {out_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
v0.53 lane L5, the North Star allocator lane. Flag-off (`SYNTH_GRAPH_ALLOC`); frozen anchors 10/10; nothing runs unless the flag is set.

## The deliverable: measured delta vs greedy

617 corpus functions, 275 applied. Bytes from the ELF symtab; cycles are synth's own sound `--emit-wcet` bounds (identical modelling assumptions, not hardware):

| | flag-off | flag-on | delta |
|---|---|---|---|
| `.text` bytes | 40822 | 40776 | **−46 (−0.11 %)** |
| WCET bound (399 fns bounded both sides) | 13866 | 13841 | **−25 (−0.18 %)** |
| per-function | | | 8 shrank, 1 grew; 7 cycles shrank, **0 cycle regressions** |

**Verdict for a v0.54 flip: not yet — and the limiting factor is REACH, not soundness.** Declines are now a named histogram rather than one bucket: 164 unmodeled i64/FP op, 68 call/call-indirect, 73 single-block, 10 unreachable-block, 9 numeric-branch. Calls and numeric branches are the two schedulable next increments.

## Two defects found while building it

1. Interference edge-recheck rejected two *pinned* webs of one register, declining 16 functions wholesale.
2. `chaitin_core`'s lowest-free-colour select repacked into R0/R1 and landed a loop compare result on a register `forward_stack_reloads` was forwarding through — two `mov`s became two `ldr`s inside the loop, **+22 cycles**. Before the fix the corpus measured −22 B / **+4 cycles**. `color_webs_biased` now prefers a web's own register when already caller-saved. `chaitin_core` is untouched (shared with the shipping pass).

## The oracle finding worth reading

`validate_cfg_rewrite` lifts the trace-equality validator to a backward must-fixpoint over the CFG and **computes its own exit contract**, so the pass cannot hand it a weakened seed (the v0.50 failure mode).

Proven non-vacuous by mutation — and the result matters beyond this lane: emptying the shared exit contract emits code that leaves the return value in the wrong register, and **`validate_cfg_rewrite` AND VCR-RA-003 both ACCEPT it**. Only execution catches it (16 wrong results). Two independent validators, one shared blind spot — the #872 lesson generalising. Hence the CI-wired execution differential (unicorn vs wasmtime, 38/38 checks, 13 engaged functions).

Also: `Push`/`Pop` lists identity-pinned, mid-stream `pop {…,pc}` treated as a return sink, and a vacuity hole (empty CFG → `Ok`) closed with a test.

## RA-003
Corpus sweep both paths: **0 violations**, 431/447 `Consistent` — the sweep distinguishes "no violation" from "not checked".

Refs #242.