### PR TITLE
chore(release): v0.53.0 — "The last mile" (7 lanes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,67 @@ regions read zeros. It now refuses loudly.
   unsigned-edge indices (`scripts/repro/rv32_br_table_882_differential.py`,
   CI job `rv32-br-table-oracle`, vacuity-guarded against skipped exports).
 
+- **VFP register-file spilling — the GI-FPU-002 exhaustion rung is gone
+  (#881, VCR-RA-004, epic #242).** `VCR-RA-001` gave the INTEGER file Belady
+  spilling in v0.24; the VFP file never got it, so five falcon v1.128 entry
+  points died on `S0..S15 all live` (phase 1) or `caller-saved VFP D-register
+  file exhausted` (phase 2) — the wall v0.52's #869 fix moved rather than
+  removed. Both files now spill and reload, with a cycle-safe parallel-move
+  resolver for the swap/cycle cases, and **`VCR-RA-003` was extended to SEE the
+  VFP file** (slot-aliasing + caller-saved-across-call twins) — an unvalidated
+  VFP allocation would have been precisely the #872 shape. Gated by a new
+  execution differential: 7 spilled-VFP shapes on `-t cortex-m7dp
+  --relocatable`, **109 rows bit-identical to wasmtime**, NaN-aware per WASM
+  §4.3.3, with the internal `bl` resolved by a real link so an unresolved
+  relocation cannot be silently skipped.
+
+- **aarch64 is now MEASURABLE: VCR-SEL-005 covers a third backend (#883), and
+  the 13 gaps it measured are closed (#851).** The parity oracle was
+  universe-complete for ARM↔RV32 — every one of the ~279 `WasmOp` variants
+  classified with **no wildcard arm**, so a new op cannot be added without
+  classifying it — but aarch64 was absent from it entirely. Its only breadth
+  check was 25 hand-written probes, so "what does aarch64 not lower?" had no
+  mechanical answer and gap-picking was guesswork. aarch64 now sits in the same
+  no-wildcard enumeration; the 31 `Err(reason)` entries name the missing
+  selector arm **and the A64 instruction that would implement it** (`FRINTP`/
+  `FRINTM`/`FRINTZ`/`FRINTN` for rounding, `SCVTF`/`UCVTF` x-forms for
+  i64→float, LDR/STR SIMD&FP forms for FP memory), making the decline list a
+  work plan rather than an absence. The 13 ops closed off that list —
+  `select` (branchless `CSEL`/`FCSEL`, all four value types), `drop`/`nop`,
+  `i32.wrap_i64`, `i64.extend_i32_{s,u}`, the five `extend8/16/32_s` sign
+  extensions, and fixed-memory `memory.size`/`memory.grow` — take the selector
+  from **148 to 161** ops, each execution-verified (gale's matrix 35 → 45).
+
 ### Fixed
+
+- **range-realloc cross-barrier live-in soundness — the pass AND its validator
+  (#872).** Default-on `SYNTH_RANGE_REALLOC` reused a segment live-in's register
+  after its last IN-SEGMENT use while an unmodeled (`reg_effect=None`) op past
+  the segment still read it — **and `validate_segment_rewrite` shared the blind
+  spot**, so the validator CERTIFIED the wrong rewrite. Shipped #782 survived on
+  shape luck, not soundness. Both halves are fixed: a validator that still
+  shares its pass's blind spot is not a fix. Independence proven by MUTATION —
+  reverting only the validator's exit seed reddens two tests, reverting only the
+  pass extension reddens a third.
+
+  Fixing it surfaced a **second, older defect on the same default-on path**: the
+  pass was recolouring a `Pop` REGISTER LIST — `pop {r4,r5,r6,r7,r8,pc}` became
+  `pop {r6,r5,r4,r3,r2,pc}`, restoring r2–r6 from a stack image laid out for
+  r4–r8 and leaving the caller's r7/r8 clobbered. A `Pop {…,PC}` *is* a return,
+  so when one sits mid-segment its defs look segment-locally dead because a
+  trailing unreachable pop re-defines them. Latent since the pass shipped; base
+  and the #872 commit both avoided it by colouring luck. Fixed byte-neutrally by
+  identity-pinning every range a `Push` uses or a `Pop` defines.
+
+  **This changes shipped bytes on the default path** — `gust_poll` 692 → 696 B
+  (the `movw r3,#0; mvns r5,r3` pass-through shape being fixed, visible in the
+  output) and the fact-spec derived delta 132 → 140. A soundness cost, paid
+  deliberately. Frozen anchors unchanged, 10/10. Honest residual, stated because
+  it is otherwise only a code comment: `validate_segment_rewrite` still does NOT
+  catch a recoloured mid-segment `Pop {…, PC}`; that class is pinned at the pass
+  via `arch_pinned`, with whole-function `validate_final_allocation` as the
+  independent backstop.
+
 
 - **`--target`/backend ISA mismatch is now a hard error (#882).** `synth
   compile --target riscv32` without `-b riscv` silently printed
@@ -148,9 +208,16 @@ regions read zeros. It now refuses loudly.
   template prose reproduced faithfully and stayed green (the v0.51 "div/rem
   declined" / v0.52 "OOB-trap is a follow-on" cold-read defects). The
   template's load-bearing capability phrases are now pinned verbatim in
-  `claims.yaml`, each bound to the oracle that executes the capability *and*
-  to that oracle's CI wiring (red-first verified: falsifying a pinned phrase
-  reddens `claim-check` even after regenerating the render). The same audit
+  `claims.yaml`, and all but one are bound to the oracle that executes the
+  capability *and* to that oracle's CI wiring (red-first verified: falsifying a
+  pinned phrase reddens `claim-check` even after regenerating the render). The
+  exception is named rather than glossed: `SYNTH-MATRIX-WCET-COMPOSITION` has
+  only `file-exists` evidence — no oracle binding, no `ci.yml` `count-min` —
+  so the sound-WCET-bound row, one of the more safety-load-bearing claims in
+  the matrix, is pinned more weakly than the rest. (`wcet_bound_gate.rs` does
+  run under `cargo test --workspace`, so the capability itself is gated; it is
+  the *claim's evidence chain* that does not reach it.) Tracked with the other
+  unwired-oracle work in #890. The same audit
   fixed two live defects of exactly this class: the matrix still said "RV32
   warns loudly on dropped initializer bytes" four releases after #798 shipped
   the segments with a hard-error read-back, and still listed WCET "calls" as a
@@ -175,7 +242,6 @@ regions read zeros. It now refuses loudly.
   param is now spilled once at entry to a frame slot and accessed through it;
   call-free bodies are byte-identical.
 
-### Added
 - **RISC-V emit-time label invariant (#882 hard gate):** every referenced label
   must resolve to exactly one definition inside the current function — a
   duplicate definition (which last-wins insertion would silently rebind to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.53.0] - 2026-07-30
+
+**"The last mile" — seven lanes.** falcon's VFP wall comes down, RISC-V compiles
+gale's real drivers, aarch64 becomes *measurable*, and the allocator's blind
+spots get named.
+
+The recurring story of this release is that **the defects were found by
+instruments, not by looking for them.** Every lane was dispatched at a known
+issue; five of them surfaced something nobody had gone looking for:
+
+- The **#872 fix** (range-realloc pass *and* its validator, which had been
+  certifying its own pass's miscompile) turned up a second, older defect: the
+  pass was **recolouring a `Pop` register list** — `pop {r4..r8,pc}` becoming
+  `pop {r6,r5,r4,r3,r2,pc}`, restoring registers from a stack image laid out for
+  different ones. A `Pop {…,PC}` *is* a return, so when one sits mid-segment its
+  defs look segment-locally dead. Latent since the pass shipped; base and the
+  #872 commit both dodged it by colouring luck.
+- Root-causing **`undefined label Lend0`** (#882) rather than declining it
+  exposed a neighbour: RISC-V `local.get <param>` after a `call` read a clobbered
+  register.
+- The **#880 prose gate**, one release old, caught a stale capability claim on
+  its first cross-lane interaction — and its own audit found four more.
+- Wiring the **#881 VFP oracle** (which existed, was committed, and was
+  referenced *nowhere* — a green PR board with its central gate inert) exposed a
+  host dependency in a single CI cycle that no local run could have surfaced.
+- The **VCR-DEC-001 join colourer** proved its new CFG validator non-vacuous by
+  mutation and discovered that a wrong-return-register miscompile is accepted by
+  `validate_cfg_rewrite` **and** VCR-RA-003 *both*. Only execution catches it.
+  Two independent validators, one shared blind spot — #872 recurring a level up.
+
+That last one is the sharpest argument for the North Star yet: **independence is
+not something you get by writing a second checker, only by checking a different
+way.** Gates that share assumptions fail together and look like corroboration.
+
+Also closed: **aarch64 was absent from the cross-backend op-parity gate** (#883),
+so nothing could say what armv8 did not lower — 25 hand-written probes against a
+~279-variant universe. VCR-SEL-005 now covers a third backend, universe-complete
+with no wildcard arm, and the 13 gaps it *measured* were closed (148 → 161 ops).
+And a fourth instance of the #757/#758/#798 silent-zero class: aarch64 accepted
+modules with active data segments while emitting no data section, so initialized
+regions read zeros. It now refuses loudly.
+
 ### Added
 
 - **VCR-DEC-001 increment 2 — the graph-colouring allocator colours ACROSS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,14 +1111,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1178,11 +1178,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.52.0"
+version = "0.53.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1238,14 +1238,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1253,11 +1253,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.52.0"
+version = "0.53.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.52.0"
+version = "0.53.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.52.0"
+version = "0.53.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.52.0",
+    version = "0.53.0",
 )
 
 # Bazel dependencies

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 &nbsp;
 
-Synth is an ahead-of-time compiler from WebAssembly to ARM Cortex-M machine code, with additional backends for ARM Cortex-R5 (A32, `--target cortex-r5`), RISC-V RV32IMAC (qemu_riscv32 / ESP32-C3), and AArch64 (host-native, `-b aarch64`). It produces bare-metal ELF binaries targeting embedded microcontrollers. The compiler handles i32, i64 (via register pairs), scalar f32/f64 via VFP on FPU targets (f32 complete v0.41, f64 complete v0.43 — #369 closed; the remaining falcon `--relocatable cortex-m7dp` tail is tracked in #881), control flow, and memory operations; any construct without a lowering declines loudly rather than miscompiling (the #369/#554 gate class). Mechanized correctness proofs in [Rocq](https://rocq-prover.org/) cover the i32 and i64 instruction selection with result-correspondence (T1) proofs; float/SIMD selection has existence-only (T2) proofs.
+Synth is an ahead-of-time compiler from WebAssembly to ARM Cortex-M machine code, with additional backends for ARM Cortex-R5 (A32, `--target cortex-r5`), RISC-V RV32IMAC (qemu_riscv32 / ESP32-C3), and AArch64 (host-native, `-b aarch64`). It produces bare-metal ELF binaries targeting embedded microcontrollers. The compiler handles i32, i64 (via register pairs), scalar f32/f64 via VFP on FPU targets (f32 complete v0.41, f64 complete v0.43 — #369 closed; the falcon `--relocatable cortex-m7dp` VFP-exhaustion tail closed in v0.53 via register-file spilling, #881; the remaining float residual is `i64.trunc_sat_f32_*` declining on single-precision FPUs, which needs the f64 promote), control flow, and memory operations; any construct without a lowering declines loudly rather than miscompiling (the #369/#554 gate class). Mechanized correctness proofs in [Rocq](https://rocq-prover.org/) cover the i32 and i64 instruction selection with result-correspondence (T1) proofs; float/SIMD selection has existence-only (T2) proofs.
 
 **This is pre-release software.** Generated code is validated by unit tests, Renode/QEMU emulation, execution differentials against wasmtime, and — for specific fixtures — cycle- and correctness-gated runs on real Cortex-M silicon (NUCLEO-G474RE, STM32F100, via the gale test loop). Broad hardware validation is still missing. Use at your own risk.
 
@@ -106,7 +106,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 |----------|--------|-------|
 | i32 arithmetic, bitwise, comparison, shift/rotate | **Tested** | Full Rocq T1 proofs, Renode execution tests |
 | i64 (register pairs): arithmetic, shifts, rotates, div/rem, compare | **Tested** | full pair lowering — right shifts fixed v0.28.0 (#599), rot/div/rem v0.30.1 (#610), A32 completeness v0.30.2 (#615); differential vs wasmtime |
-| Scalar f32/f64 via VFP on FPU targets | **Implemented** | Complete f32 (v0.41) + f64 (v0.43, #369 closed) incl. AAPCS-VFP marshalling; execution differentials vs wasmtime; non-FPU targets loud-reject; residuals: the falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail (#881; `trunc_sat` shipped v0.49, #782 closed) |
+| Scalar f32/f64 via VFP on FPU targets | **Implemented** | Complete f32 (v0.41) + f64 (v0.43, #369 closed) incl. AAPCS-VFP marshalling; execution differentials vs wasmtime; non-FPU targets loud-reject; residual: `i64.trunc_sat_f32_*` declines on single-precision FPUs (needs the f64 promote). The falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail closed in v0.53 (#881); `trunc_sat` shipped v0.49 (#782) |
 | WASM SIMD via ARM Helium MVE | Experimental | Cortex-M55 only; encoding untested on hardware |
 | Control flow (block, loop, if/else, br, br_table) | **Tested** | Renode execution tests, complex test suite |
 | Function calls (direct, indirect) | Implemented | `call_indirect` traps per WASM §4.4.8 (OOB index, type mismatch, null slot); self-contained `--cortex-m` dispatch via a PC-relative flash funcref table since v0.47 (#275), execution-differential-gated vs wasmtime |
@@ -122,7 +122,7 @@ synth verify examples/wat/simple_add.wat firmware.elf
 ### What doesn't work yet
 
 - **Narrow hardware coverage** — silicon validation is fixture-scoped (gale's NUCLEO-G474RE / STM32F100 cycle and correctness gates); there is no broad board matrix
-- **No multi-memory** — fused components from meld need single-memory mode
+- **Multi-memory is phase 1** — N memories lower to N distinct native base regions on ARM `--relocatable` (v0.43, #749); fused-component paths beyond that still need single-memory mode
 - **No WASI on embedded** — kiln-builtins crate doesn't exist yet
 - **No component model execution** — components compile but can't run without kiln-builtins; `cabi_realloc` binds natively (synthesized in-module arena allocator) on self-contained dissolves since v0.47 (#418 closed)
 - **Spill-on-exhaustion is opt-in** — Belady spilling is default-on (v0.24.0, VCR-RA-001), but replacing the register-exhaustion decline with allocation-time spilling (`SYNTH_SPILL_ON_EXHAUST`, #580) is held for silicon numbers
@@ -282,7 +282,7 @@ The one-sentence version: moving synth's correctness from *"we patched every bug
 | | `VCR-WASM-001` | Anchor WASM source semantics on WasmCert-Coq | phases 1-3 landed: the i32 integer fragment (19 ops) AND the i64 integer family (22 ops — arithmetic/bitwise/shifts/rotates/eqz/comparisons) transcribed from the same pinned coq9.0-wasm-2.2.0 sources with line-level provenance (`coq/Synth/WASM/WasmCertReference.v`) and proven refined by `exec_wasm_instr` (`WasmCertBridge.v`; op-level for all, executor-level for the wired ops — the 6 i64 arithmetic/bitwise ops are op-level-only, a named residual; lemma count: `artifacts/status.json`); still a hand transcription, the real external dep is nix-feasible, bazel-deferred on three named blockers (unfree CompCert 3.16 in the pin) |
 | **Gate** | `VCR-VER-001` | Success = a previously load-bearing greedy-fix becomes *revertable*, with the full differential bit-identical and cycles equal-or-better | **demonstrated** (implemented; [evidence](scripts/repro/vcr_ver_001_gate.md)): the v0.11.20 reciprocal-mult cost-gate deleted outright (PR #322, bit-identical); the #496 exhaustion decline revertable behind `SYNTH_SPILL_ON_EXHAUST` — red case green, anchors byte-identical, declines 14→8; flip held on a measured i32-shape cycle regression |
 
-Honest open items: the RV32 local-promotion flip is held on a failed no-grow gate (#601); float residuals — the falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail (#881; `trunc_sat` shipped v0.49); SIMD/Helium is untested on hardware.
+Honest open items: the RV32 local-promotion flip is held on a failed no-grow gate (#601); float residual — `i64.trunc_sat_f32_*` declines on single-precision FPUs (the falcon cortex-m7dp VFP tail closed v0.53, #881); SIMD/Helium is untested on hardware.
 
 **What it buys us:** synth stops being a real-ish compiler held together by oracle-gated patches and becomes a genuinely best-in-class *verified* compiler — and the verified selector DSL is the part that is potentially novel/publishable, not just catching up to Cranelift.
 

--- a/artifacts/status.json
+++ b/artifacts/status.json
@@ -21,7 +21,7 @@
   "sel_dsl_rule_qed": 50,
   "sel_dsl_rules": 50,
   "sel_rules_simplified_basis": 50,
-  "version": "0.52.0",
+  "version": "0.53.0",
   "verus_spec_fns": 8,
   "wasmcert_bridge_qed": 104
 }

--- a/claims.yaml
+++ b/claims.yaml
@@ -334,10 +334,19 @@ claims:
         glob: ['crates/synth-synthesis/src/instruction_selector.rs']
         expect: 1
       - kind: verbatim                       # the honest residual stays adjacent
-        # (was "#782" until the v0.53 #880 audit: #782 closed v0.49–v0.52 and
-        # the README kept citing it as open, saying trunc_sat "not decoded"
-        # two releases after it shipped — the successor residual is #881)
-        text: "#881"
+        # THIRD occupant of this pin, and the churn is the lesson. It was "#782"
+        # until the v0.53 #880 audit (that issue closed across v0.49–v0.52 while
+        # the README still called it open), then "#881" — which v0.53's OWN L1
+        # lane closed 14 h AFTER the doc-honesty lane had already landed, so the
+        # release very nearly shipped citing three issues it had just fixed.
+        #
+        # Root cause: a pin naming an ISSUE NUMBER goes stale the instant that
+        # issue is fixed, and since claim_check only asserts the phrase is
+        # PRESENT, it then GREEN-CONFIRMS a false residual — the ledger defends
+        # the defect instead of catching it. Pin the CAPABILITY GAP instead of
+        # its tracker: this phrase becomes false exactly when the gap closes,
+        # which is the property a residual pin was always supposed to have.
+        text: "single-precision FPUs"
 
   # call_indirect: self-contained dispatch shipped v0.47 (#275 closed) with a
   # red-first execution differential; the README must not regress to either the

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.52.0" }
+synth-core = { path = "../synth-core", version = "0.53.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.52.0" }
+synth-core = { path = "../synth-core", version = "0.53.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.52.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.52.0" }
+synth-core = { path = "../synth-core", version = "0.53.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.53.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
@@ -21,4 +21,4 @@ tracing.workspace = true
 proptest.workspace = true
 # VCR-SEL-005 (#851): the cross-backend op-parity oracle probes the AArch64
 # selector as the THIRD backend (tests/cross_backend_op_parity.rs only).
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.52.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.53.0" }

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.52.0" }
+synth-core = { path = "../synth-core", version = "0.53.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.52.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.52.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.53.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.53.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.52.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.53.0", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -58,23 +58,23 @@ exports_only_275_probe = []
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.52.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.52.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.52.0" }
-synth-backend = { path = "../synth-backend", version = "0.52.0" }
+synth-core = { path = "../synth-core", version = "0.53.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.53.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.53.0" }
+synth-backend = { path = "../synth-backend", version = "0.53.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.52.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.53.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.52.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.52.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.52.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.53.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.53.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.53.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.52.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.53.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.52.0" }
+synth-core = { path = "../synth-core", version = "0.53.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.52.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.53.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.52.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.52.0" }
-synth-opt = { path = "../synth-opt", version = "0.52.0" }
+synth-core = { path = "../synth-core", version = "0.53.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.53.0" }
+synth-opt = { path = "../synth-opt", version = "0.53.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.52.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.52.0" }
-synth-opt = { path = "../synth-opt", version = "0.52.0" }
+synth-core = { path = "../synth-core", version = "0.53.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.53.0" }
+synth-opt = { path = "../synth-opt", version = "0.53.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.52.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.53.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -7,7 +7,7 @@
 > stale. All numbers come from [`artifacts/status.json`](../../artifacts/status.json),
 > which is re-derived from source on every run — never hand-edited.
 
-**Workspace version:** 0.52.0
+**Workspace version:** 0.53.0
 
 ---
 

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -46,7 +46,7 @@ soundness feature, not an absence.
 | f32 scalar via VFP | Y (FPU targets) | Complete op set incl. all six comparisons, NaN-aware (v0.41); requires an FPU target (e.g. `cortex-m4f`) |
 | f64 scalar via VFP | Y (FPU targets) | Complete (v0.43, #369 closed); marshalling + AAPCS-VFP mixed params |
 | Trapping float→int truncations | Y | Domain-guarded (trap, not saturate) — the #709 soundness class |
-| Non-trapping `trunc_sat` (0xFC prefix) | Y (FPU targets) | Decoded and lowered as bare saturating VCVT (§4.3.2: NaN→0, out-of-range saturates, never traps). i32-target forms on any FPU target; i64-target forms on a double-FPU target (`cortex-m7dp`) via a branch-free FP word-decompose (v0.49, #782); aarch64 lowers all eight. Residuals: i64-from-f32 declines on single-precision (needs the f64 promote); the falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail is tracked in #881 (#782 closed) |
+| Non-trapping `trunc_sat` (0xFC prefix) | Y (FPU targets) | Decoded and lowered as bare saturating VCVT (§4.3.2: NaN→0, out-of-range saturates, never traps). i32-target forms on any FPU target; i64-target forms on a double-FPU target (`cortex-m7dp`) via a branch-free FP word-decompose (v0.49, #782); aarch64 lowers all eight. Residual: i64-from-f32 declines on single-precision FPUs (needs the f64 promote). The falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail closed in v0.53 via VFP register-file spilling (#881); #782 closed v0.49 |
 | Control flow (block, loop, if/else, br, br_if, br_table) | Y | Renode execution tests |
 | Function calls (direct + `call_indirect`) | Y | `call_indirect` traps per WASM §4.4.8 (OOB index, type mismatch, null slot); self-contained dispatch is PC-relative via a flash funcref table (v0.47) |
 | Memory (load/store incl. sub-word, size/grow) | Y | `memory.grow` returns -1 on fixed-memory embedded targets; grow(0) ≡ size |
@@ -131,7 +131,17 @@ see [coq/STATUS.md](../../coq/STATUS.md) for the per-file matrix.
   their coverage is listed above, not implied.
 - Broad hardware validation is still missing: silicon evidence is
   fixture-scoped (gale), emulation is Renode/QEMU/unicorn.
-- Known open soundness/coverage residuals are tracked as issues (e.g. #881:
-  the falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail; #882:
-  RV32 real-driver `br_table`/label declines; #872: range-realloc
-  cross-barrier liveness blind spot).
+- Known open soundness/coverage residuals are tracked as issues (e.g. #890:
+  57 of 130 differential oracles are not CI-wired and nothing distinguishes
+  "manual by design" from "forgotten" — an absent gate is invisible to a green
+  board; #851: the aarch64 op-surface gaps the VCR-SEL-005 third-backend oracle
+  now enumerates mechanically; #846: two `gpio-thin` CRL/CRH sites still need
+  relational ranges).
+- Two residuals live in code comments rather than issues, and are restated here
+  so they are not implied away: `validate_segment_rewrite` does NOT catch a
+  recoloured `Pop {…, PC}` in the MIDDLE of a segment (pinned at the pass via
+  `arch_pinned`, with whole-function `validate_final_allocation` as the
+  independent backstop — #872); and a wrong-return-register rewrite is accepted
+  by `validate_cfg_rewrite` AND VCR-RA-003 *both*, caught only by execution
+  (VCR-DEC-001, flag-off). Two validators sharing a blind spot agree without
+  adding evidence.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"

--- a/scripts/templates/feature_matrix.md.tmpl
+++ b/scripts/templates/feature_matrix.md.tmpl
@@ -46,7 +46,7 @@ soundness feature, not an absence.
 | f32 scalar via VFP | Y (FPU targets) | Complete op set incl. all six comparisons, NaN-aware (v0.41); requires an FPU target (e.g. `cortex-m4f`) |
 | f64 scalar via VFP | Y (FPU targets) | Complete (v0.43, #369 closed); marshalling + AAPCS-VFP mixed params |
 | Trapping float→int truncations | Y | Domain-guarded (trap, not saturate) — the #709 soundness class |
-| Non-trapping `trunc_sat` (0xFC prefix) | Y (FPU targets) | Decoded and lowered as bare saturating VCVT (§4.3.2: NaN→0, out-of-range saturates, never traps). i32-target forms on any FPU target; i64-target forms on a double-FPU target (`cortex-m7dp`) via a branch-free FP word-decompose (v0.49, #782); aarch64 lowers all eight. Residuals: i64-from-f32 declines on single-precision (needs the f64 promote); the falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail is tracked in #881 (#782 closed) |
+| Non-trapping `trunc_sat` (0xFC prefix) | Y (FPU targets) | Decoded and lowered as bare saturating VCVT (§4.3.2: NaN→0, out-of-range saturates, never traps). i32-target forms on any FPU target; i64-target forms on a double-FPU target (`cortex-m7dp`) via a branch-free FP word-decompose (v0.49, #782); aarch64 lowers all eight. Residual: i64-from-f32 declines on single-precision FPUs (needs the f64 promote). The falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail closed in v0.53 via VFP register-file spilling (#881); #782 closed v0.49 |
 | Control flow (block, loop, if/else, br, br_if, br_table) | Y | Renode execution tests |
 | Function calls (direct + `call_indirect`) | Y | `call_indirect` traps per WASM §4.4.8 (OOB index, type mismatch, null slot); self-contained dispatch is PC-relative via a flash funcref table (v0.47) |
 | Memory (load/store incl. sub-word, size/grow) | Y | `memory.grow` returns -1 on fixed-memory embedded targets; grow(0) ≡ size |
@@ -131,7 +131,17 @@ see [coq/STATUS.md](../../coq/STATUS.md) for the per-file matrix.
   their coverage is listed above, not implied.
 - Broad hardware validation is still missing: silicon evidence is
   fixture-scoped (gale), emulation is Renode/QEMU/unicorn.
-- Known open soundness/coverage residuals are tracked as issues (e.g. #881:
-  the falcon `--relocatable cortex-m7dp` D-register-pressure + RA tail; #882:
-  RV32 real-driver `br_table`/label declines; #872: range-realloc
-  cross-barrier liveness blind spot).
+- Known open soundness/coverage residuals are tracked as issues (e.g. #890:
+  57 of 130 differential oracles are not CI-wired and nothing distinguishes
+  "manual by design" from "forgotten" — an absent gate is invisible to a green
+  board; #851: the aarch64 op-surface gaps the VCR-SEL-005 third-backend oracle
+  now enumerates mechanically; #846: two `gpio-thin` CRL/CRH sites still need
+  relational ranges).
+- Two residuals live in code comments rather than issues, and are restated here
+  so they are not implied away: `validate_segment_rewrite` does NOT catch a
+  recoloured `Pop {…, PC}` in the MIDDLE of a segment (pinned at the pass via
+  `arch_pinned`, with whole-function `validate_final_allocation` as the
+  independent backstop — #872); and a wrong-return-register rewrite is accepted
+  by `validate_cfg_rewrite` AND VCR-RA-003 *both*, caught only by execution
+  (VCR-DEC-001, flag-off). Two validators sharing a blind spot agree without
+  adding evidence.


### PR DESCRIPTION
Release assembly for **v0.53.0**. All seven lanes are already merged to main; this PR carries the version sweep, lockfile refresh, regenerated docs and the CHANGELOG headline.

## Lanes (all merged, each CI-gated)
| | |
|---|---|
| L1 #885 | VFP register-file spilling — the GI-FPU-002 exhaustion rung (#881, VCR-RA-004) |
| L2 #886 | RISC-V `Lend0` root-cause **+ a second param-clobber-across-call bug** (#882) |
| L3 #887 | RV32 `br_table` + hard-error on unknown `--target` (was silently selecting the arm backend) |
| L4 #888 | range-realloc cross-barrier soundness — pass **and** validator (#872) |
| L6 #884 | make the gates real: CI-wire gpio-thin + rv32-boot, claim-pin template prose (#879/#880) |
| L7 #889 | aarch64 VCR-SEL-005 third-backend parity gate + 13 measured op gaps (#851, #883) |
| L5 #891 | VCR-DEC-001 graph colouring across if/else joins — measured, flag-off (#242) |

## Assembly checklist
- Version sweep: workspace + **all 13** intra-workspace path-dep pins + `MODULE.bazel` + `status.json`
- **`Cargo.lock` refreshed to 0.53.0** — v0.52 cold review caught a stale lock; no CI job builds `--locked`, so this is a release-process gate, not a CI one
- Docs regenerated **once** at assembly (#805); lanes never hand-edit generated artifacts
- `claim_check` **34/34** · `check_version_pins` OK · frozen anchors **10/10** · build 0 · fmt 0

Per the v0.52 lesson, this PR **merges before the tag is cut**, so `v0.53.0` is an ancestor of `main`.