### PR TITLE
fix(#916): i64 zero-fill mis-encoded for a high destination — MOVS transmuted to CMP at FIVE sites, not two

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2519,6 +2519,12 @@ jobs:
         run: python scripts/repro/i64_popcnt_632_differential.py
       - name: i64 shr_u/shr_s single-function path differential (#599)
         run: python scripts/repro/i64_shr_599_differential.py
+      - name: i64 high-register zero-fill differential (#916)
+        run: |
+          set -euo pipefail
+          ./target/debug/synth compile scripts/repro/i64_high_reg_zero_fill_916.wat \
+            -o /tmp/zf916.elf --target cortex-m4 --relocatable --all-exports
+          python scripts/repro/i64_high_reg_zero_fill_916_differential.py /tmp/zf916.elf
       - name: dead-frame elision differential (#390, both flag states)
         run: python scripts/repro/leaf_dead_frame_differential.py
       - name: i32 local-promotion differential (#390, clean + dirty)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,72 @@ addressed by fixing its output.
 
 ### Fixed
 
+- **#916 — i64 zero-fill mis-encoded for a high destination (R8-R12): `MOVS`
+  transmuted into `CMP`, and the half that had to be zeroed was never
+  written.** The 16-bit `MOVS Rd, #imm8` (T1) has a **three-bit** Rd field.
+  `reg_to_bits(R8)` is 8, so `8 << 8 = 0x0800` overflowed into bit 11 and
+  `0x2000 | 0x0800 = 0x2800` — the emitted halfword was `CMP r0, #0`, not a
+  move at all. The destination kept whatever it held on entry and the flags
+  were clobbered. Same class as #180 / H-CODE-9, and the same defect #311
+  already fixed for `I64SetCond`; the fix here follows that shape (32-bit
+  `MOV.W`, T2 `F04F 0000 | Rd<<8 | imm8`, for `rd >= R8`) behind one shared
+  helper so a sixth site cannot reintroduce it silently.
+
+  **The issue named two sites; a sweep of every 16-bit imm8 T1 emission in the
+  Thumb-2 encoder found five**, and the three extra ones are worse than the
+  two filed:
+
+  | expansion | register left unwritten | precondition |
+  |---|---|---|
+  | `I64Shl` | `rd_lo` (large-shift arm) | shift `>= 32` |
+  | `I64ShrU` | `rd_hi` (large-shift arm) | shift `>= 32` |
+  | `I64Clz` | `rnhi` (high-word clear) | **none** |
+  | `I64Ctz` | `rnhi` (high-word clear) | **none** |
+  | `I64ExtendI32U` | `rdhi` (high-word clear) | **none** |
+
+  The bottom three have no `>= 32` guard, so *every* `i64.clz` / `i64.ctz` /
+  `i64.extend_i32_u` whose high half landed in R8 returned garbage in its
+  upper 32 bits. `I64ExtendI32U { rdhi: R8 }` emitted the literal two-halfword
+  stream `[4608, 2800]` — half of a two-instruction expansion was the wrong
+  instruction.
+
+  **Not a one-liner, because the fix changes instruction size.** `MOV.W` is 4
+  bytes where `MOVS` was 2, and whether that moves a branch target was settled
+  per site by decoding the emitted `imm` fields rather than by reading the
+  comments. In `I64Shl`/`I64ShrU` the internal `B .done` targets the **end** of
+  the expansion — past the zero-fill — so its displacement is now *derived*
+  from the zero-fill's real width (`0xE002` low / `0xE003` high) instead of
+  hard-coded; leaving it would have traded a data miscompile for a
+  control-flow one, which is strictly worse. In `I64Clz`/`I64Ctz` the `B .done`
+  targets the zero-fill's **own address**, which cannot move, so those need no
+  displacement change. Reordering the large-shift arm to dodge the size change
+  was rejected, not overlooked: zeroing `rd_lo` before the `LSL.W` destroys
+  `rn_lo` in the in-place case `rd_lo == rn_lo`.
+
+  `estimate_arm_byte_size` — the hand-maintained estimator that feeds
+  optimized-path branch resolution — is mirrored to match (38/40, 24/26,
+  32/34), following the existing register-shape-sensitive pattern for
+  `Cmn`/`Sxtb`/`Uxth`/`Mov`. The direct selector needs no change: it resolves
+  branches from real `code.len()`.
+
+  **Scope of the byte change is confined to `rd >= R8`** — low-register
+  expansions are byte-identical, so no frozen fixture moved. A32 (cortex-r5)
+  never shared the defect (`MOV Rd,#0` is `0xE3A00000 | Rd<<12`, a four-bit
+  field) and `I64ShrS` never did either (its large arm sign-fills with the
+  32-bit `ASR.W`); both are now pinned as such so the sweep is recorded rather
+  than asserted in prose.
+
+  **Three validators were blind to this.** `estimator_encoder_agreement` (#498)
+  only ever tested these ops at low registers; the i64 expansion certifier fed
+  them only at R0/R1 and listed high-register variants for just
+  `I64SetCond`/`SetCondZ`/`Mul`/`Popcnt`; and nothing executed a `>= 32` shift
+  that *kept* the affected half. All three are closed in the same change, each
+  proven non-vacuous against the pre-fix bytes — the new
+  `i64_high_reg_zero_fill_916_differential.py` (48 executions vs wasmtime,
+  R8 poisoned with `0xDEADBEEF` so a stale-but-zero register cannot produce a
+  false green) fails on exactly the shift amounts `>= 32` before the fix and
+  passes after.
+
 - **#890 — `sret_decide_differential.py` was a gate that could not fail.** It
   printed `MISMATCH <-- BUG` and still exited 0. The verdict is now the exit
   status (proved by mutation: flipping the `-35` expectation gives `rc=1`).

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -4660,8 +4660,16 @@ impl ArmEncoder {
                 bytes.extend_from_slice(&hw1.to_le_bytes());
                 bytes.extend_from_slice(&hw2.to_le_bytes());
 
-                // B .done (skip large shift: +2 halfwords)
-                let b_done: u16 = 0xE002;
+                // B .done — `.done` is the END of the expansion, i.e. PAST the
+                // large-shift arm's trailing zero-fill. #916: that zero-fill is
+                // 1 halfword for a low rd_lo but 2 for R8-R12 (MOV.W), so the
+                // displacement is DERIVED from its real width instead of the
+                // hard-coded 0xE002 — widening the MOV without this would
+                // overshoot `.done` and turn a data miscompile into a
+                // control-flow one. Thumb `B` reads PC as its own address + 4
+                // (= +2 halfwords), so imm11 = (large-arm halfwords) - 1.
+                let large_arm_hw = 2 + thumb_zero_fill_halfwords(rd_lo_bits);
+                let b_done: u16 = 0xE000 | (large_arm_hw - 1);
                 bytes.extend_from_slice(&b_done.to_le_bytes());
 
                 // --- Large shift (n >= 32) ---
@@ -4671,11 +4679,13 @@ impl ArmEncoder {
                 bytes.extend_from_slice(&hw1.to_le_bytes());
                 bytes.extend_from_slice(&hw2.to_le_bytes());
 
-                // MOV rd_lo, #0
-                let mov_zero: u16 = 0x2000 | ((rd_lo_bits as u16) << 8);
-                bytes.extend_from_slice(&mov_zero.to_le_bytes());
+                // MOV rd_lo, #0 (#916: MOV.W for rd_lo >= R8). NOTE the order
+                // is load-bearing — zeroing rd_lo BEFORE the LSL.W would
+                // destroy rn_lo in the in-place case rd_lo == rn_lo, so this
+                // cannot be reordered to dodge the displacement change.
+                emit_thumb_zero_fill(&mut bytes, rd_lo_bits);
 
-                Ok(bytes) // Total: 38 bytes
+                Ok(bytes) // 38 bytes (40 when rd_lo >= R8 takes MOV.W)
             }
 
             // I64ShrU: 64-bit logical shift right with branch for n<32 vs n>=32
@@ -4742,8 +4752,11 @@ impl ArmEncoder {
                 bytes.extend_from_slice(&hw1.to_le_bytes());
                 bytes.extend_from_slice(&hw2.to_le_bytes());
 
-                // B .done (+2 halfwords)
-                let b_done: u16 = 0xE002;
+                // B .done — see I64Shl: `.done` is the END of the expansion,
+                // past the trailing zero-fill, so the displacement is derived
+                // from that zero-fill's real width (#916).
+                let large_arm_hw = 2 + thumb_zero_fill_halfwords(rd_hi_bits);
+                let b_done: u16 = 0xE000 | (large_arm_hw - 1);
                 bytes.extend_from_slice(&b_done.to_le_bytes());
 
                 // --- Large shift (n >= 32) ---
@@ -4753,11 +4766,12 @@ impl ArmEncoder {
                 bytes.extend_from_slice(&hw1.to_le_bytes());
                 bytes.extend_from_slice(&hw2.to_le_bytes());
 
-                // MOV rd_hi, #0
-                let mov_zero: u16 = 0x2000 | ((rd_hi_bits as u16) << 8);
-                bytes.extend_from_slice(&mov_zero.to_le_bytes());
+                // MOV rd_hi, #0 (#916: MOV.W for rd_hi >= R8). Order is
+                // load-bearing: the LSR.W above reads rn_hi, which may BE
+                // rd_hi in the in-place case.
+                emit_thumb_zero_fill(&mut bytes, rd_hi_bits);
 
-                Ok(bytes) // Total: 38 bytes
+                Ok(bytes) // 38 bytes (40 when rd_hi >= R8 takes MOV.W)
             }
 
             // I64ShrS: 64-bit arithmetic shift right with branch for n<32 vs n>=32
@@ -5006,12 +5020,16 @@ impl ArmEncoder {
                 bytes.extend_from_slice(&hw2.to_le_bytes());
 
                 // .done: (offset 22)
-                // i64.clz returns i64, so clear high word: MOV rnhi, #0 (2 bytes)
-                // MOVS Rn, #0: 0010 0 Rn 00000000
-                let mov0: u16 = (0x2000 | (rn_hi_bits << 8)) as u16;
-                bytes.extend_from_slice(&mov0.to_le_bytes());
+                // i64.clz returns i64, so clear high word (#916: MOV.W for
+                // rnhi >= R8 — this site is UNCONDITIONALLY reached, so every
+                // i64.clz with a high `rnhi` returned garbage in its upper 32
+                // bits, not just the shift ops the issue named). No branch
+                // displacement changes: `B .done` above targets offset 22,
+                // which IS this instruction's own address, and `BEQ` targets
+                // offset 14, before it.
+                emit_thumb_zero_fill(&mut bytes, rn_hi_bits);
 
-                Ok(bytes)
+                Ok(bytes) // 24 bytes (26 when rnhi >= R8 takes MOV.W)
             }
 
             // I64Ctz: Count trailing zeros in 64-bit value
@@ -5090,11 +5108,13 @@ impl ArmEncoder {
                 bytes.extend_from_slice(&hw2.to_le_bytes());
 
                 // .done: (offset 30)
-                // i64.ctz returns i64, so clear high word: MOV rnhi, #0 (2 bytes)
-                let mov0: u16 = (0x2000 | (rn_hi_bits << 8)) as u16;
-                bytes.extend_from_slice(&mov0.to_le_bytes());
+                // i64.ctz returns i64, so clear high word (#916: MOV.W for
+                // rnhi >= R8). As with I64Clz this site is unconditional, and
+                // no displacement moves: `B .done` targets offset 30 = this
+                // instruction's own address, `BEQ` targets offset 18.
+                emit_thumb_zero_fill(&mut bytes, rn_hi_bits);
 
-                Ok(bytes)
+                Ok(bytes) // 32 bytes (34 when rnhi >= R8 takes MOV.W)
             }
 
             // I64Popcnt: Population count of 64-bit value
@@ -6631,10 +6651,12 @@ impl ArmEncoder {
                         op2: Operand2::Reg(*rn),
                     })?);
                 }
-                // MOV rdhi, #0 (16-bit: MOVS Rd, #0)
-                let rdhi_bits = reg_to_bits(rdhi) as u16;
-                let instr: u16 = 0x2000 | (rdhi_bits << 8);
-                bytes.extend_from_slice(&instr.to_le_bytes());
+                // MOV rdhi, #0 (#916: MOV.W for rdhi >= R8). Unconditional
+                // site with no branches in the expansion — before the fix this
+                // emitted the literal two-instruction stream [4608, 2800], half
+                // of which was `CMP r0,#0` rather than the high-word clear, so
+                // every i64.extend_i32_u into a high pair leaked stale bits.
+                emit_thumb_zero_fill(&mut bytes, reg_to_bits(rdhi));
                 Ok(bytes)
             }
 
@@ -8234,6 +8256,43 @@ fn check_ldst_imm12(offset: u32) -> Result<()> {
     } else {
         Ok(())
     }
+}
+
+/// #916 — emit `Rd = 0` in Thumb-2, correctly for EVERY destination register.
+///
+/// The 16-bit `MOVS Rd, #imm8` (T1) is `0010 0 Rd(3) imm8` — the Rd field is
+/// **three bits**. For R8-R12 `reg_to_bits` yields 8..12, so `rd_bits << 8`
+/// overflows into bit 11 and `0x2000 | 0x0800` is `0x2800` = `CMP r0, #0`:
+/// not a move at all. The destination is never written (it keeps stale data)
+/// and the flags are clobbered. Same class as #180 / H-CODE-9, and the same
+/// defect #311 fixed for `I64SetCond`.
+///
+/// High registers therefore take the 32-bit `MOV.W Rd, #imm8` (T2,
+/// `F04F 0000 | Rd<<8 | imm8`), whose Rd field is four bits. `MOV.W` with S=0
+/// does not set flags, which is what these zero-fill sites want anyway.
+///
+/// **Callers with branches must consult [`thumb_zero_fill_halfwords`].** This
+/// emits 1 halfword for R0-R7 and 2 for R8-R12; any branch whose target lies
+/// PAST this instruction moves when it widens and its displacement has to be
+/// derived rather than hard-coded. (A branch targeting this instruction's own
+/// address is unaffected — an instruction cannot move itself.)
+fn emit_thumb_zero_fill(bytes: &mut Vec<u8>, rd_bits: u32) {
+    if rd_bits < 8 {
+        let movs: u16 = 0x2000 | ((rd_bits as u16) << 8);
+        bytes.extend_from_slice(&movs.to_le_bytes());
+    } else {
+        bytes.extend_from_slice(&0xF04Fu16.to_le_bytes());
+        bytes.extend_from_slice(&(((rd_bits as u16) << 8) as u16).to_le_bytes());
+    }
+}
+
+/// Halfword length of the encoding [`emit_thumb_zero_fill`] picks for
+/// `rd_bits`. Branch displacements spanning the zero-fill derive from this so
+/// the encoder cannot drift from itself (#916; the byte-size estimator mirrors
+/// it in `synth_synthesis::estimate_arm_byte_size`, pinned by the #498
+/// `estimator_encoder_agreement` oracle).
+fn thumb_zero_fill_halfwords(rd_bits: u32) -> u16 {
+    if rd_bits < 8 { 1 } else { 2 }
 }
 
 fn reg_to_bits(reg: &Reg) -> u32 {

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -8282,7 +8282,7 @@ fn emit_thumb_zero_fill(bytes: &mut Vec<u8>, rd_bits: u32) {
         bytes.extend_from_slice(&movs.to_le_bytes());
     } else {
         bytes.extend_from_slice(&0xF04Fu16.to_le_bytes());
-        bytes.extend_from_slice(&(((rd_bits as u16) << 8) as u16).to_le_bytes());
+        bytes.extend_from_slice(&((rd_bits as u16) << 8).to_le_bytes());
     }
 }
 

--- a/crates/synth-backend/tests/estimator_encoder_agreement.rs
+++ b/crates/synth-backend/tests/estimator_encoder_agreement.rs
@@ -582,6 +582,65 @@ fn cases() -> Vec<Case> {
                 rm_hi: Reg::R5,
             },
         ),
+        // #916 — HIGH-DESTINATION shift/bit-count shapes. The zeroed half is
+        // `MOVS Rd,#0` (2 bytes) only for R0-R7; a 3-bit Rd field means R8-R12
+        // must take the 32-bit `MOV.W`, so these expansions are 2 bytes LONGER
+        // (38->40, 24->26, 32->34) and the estimator has to know it. Without
+        // these cases the oracle only ever saw the low-reg shapes and would
+        // have stayed green while the estimator under-counted every high-reg
+        // i64 shift by 2 — drifting each branch that spans one (the #483 class).
+        // The allocator pool is R0-R8, so R8 is producible today.
+        agree(
+            "I64Shl_hi_rd_lo",
+            I64Shl {
+                rd_lo: Reg::R8,
+                rd_hi: Reg::R1,
+                rn_lo: Reg::R2,
+                rn_hi: Reg::R3,
+                rm_lo: Reg::R4,
+                rm_hi: Reg::R5,
+            },
+        ),
+        agree(
+            "I64ShrU_hi_rd_hi",
+            I64ShrU {
+                rd_lo: r0,
+                rd_hi: Reg::R8,
+                rn_lo: Reg::R2,
+                rn_hi: Reg::R3,
+                rm_lo: Reg::R4,
+                rm_hi: Reg::R5,
+            },
+        ),
+        // I64ShrS sign-fills with the 32-bit ASR.W (4-bit Rd) — no 16-bit form
+        // to widen, so it must stay 40 bytes at a high destination too.
+        agree(
+            "I64ShrS_hi_rd_hi",
+            I64ShrS {
+                rd_lo: r0,
+                rd_hi: Reg::R8,
+                rn_lo: Reg::R2,
+                rn_hi: Reg::R3,
+                rm_lo: Reg::R4,
+                rm_hi: Reg::R5,
+            },
+        ),
+        agree(
+            "I64Clz_hi_rnhi",
+            I64Clz {
+                rd: r0,
+                rnlo: Reg::R1,
+                rnhi: Reg::R8,
+            },
+        ),
+        agree(
+            "I64Ctz_hi_rnhi",
+            I64Ctz {
+                rd: r0,
+                rnlo: Reg::R1,
+                rnhi: Reg::R8,
+            },
+        ),
         agree(
             "I64Rotl",
             I64Rotl {

--- a/crates/synth-backend/tests/i64_expansion_certification.rs
+++ b/crates/synth-backend/tests/i64_expansion_certification.rs
@@ -107,6 +107,64 @@ fn shipped_expansions_certify_high_register_variants() {
                     rnhi: Reg::R1,
                 },
             ),
+            // #916 — the certifier's OWN blind spot, closed. Until this lane
+            // `covered_i64_pseudo_selections` only ever fed these five ops at
+            // R0/R1 and the high-register variant list only covered
+            // I64SetCond/I64SetCondZ/I64Mul/I64Popcnt, so the symbolic executor
+            // never saw the shape where the 16-bit `MOVS Rd,#0` zero-fill
+            // transmutes into `CMP r0,#0` and the half is left unwritten. Every
+            // one of these FAILS validation against the pre-#916 encoder and
+            // certifies against the fixed one — which is what makes the
+            // validator non-vacuous here rather than merely green.
+            (
+                synth_core::WasmOp::I64Shl,
+                ArmOp::I64Shl {
+                    rd_lo: Reg::R8,
+                    rd_hi: Reg::R7,
+                    rn_lo: Reg::R0,
+                    rn_hi: Reg::R1,
+                    rm_lo: Reg::R2,
+                    rm_hi: Reg::R3,
+                },
+            ),
+            (
+                synth_core::WasmOp::I64ShrU,
+                ArmOp::I64ShrU {
+                    rd_lo: Reg::R7,
+                    rd_hi: Reg::R8,
+                    rn_lo: Reg::R0,
+                    rn_hi: Reg::R1,
+                    rm_lo: Reg::R2,
+                    rm_hi: Reg::R3,
+                },
+            ),
+            (
+                synth_core::WasmOp::I64ShrS,
+                ArmOp::I64ShrS {
+                    rd_lo: Reg::R7,
+                    rd_hi: Reg::R8,
+                    rn_lo: Reg::R0,
+                    rn_hi: Reg::R1,
+                    rm_lo: Reg::R2,
+                    rm_hi: Reg::R3,
+                },
+            ),
+            (
+                synth_core::WasmOp::I64Clz,
+                ArmOp::I64Clz {
+                    rd: Reg::R0,
+                    rnlo: Reg::R1,
+                    rnhi: Reg::R8,
+                },
+            ),
+            (
+                synth_core::WasmOp::I64Ctz,
+                ArmOp::I64Ctz {
+                    rd: Reg::R0,
+                    rnlo: Reg::R1,
+                    rnhi: Reg::R8,
+                },
+            ),
         ];
         for (wasm, pseudo) in variants {
             let code = thumb_bytes(&pseudo);

--- a/crates/synth-backend/tests/i64_expansion_certification.rs
+++ b/crates/synth-backend/tests/i64_expansion_certification.rs
@@ -312,3 +312,66 @@ fn div_family_is_held_out_loudly() {
         }
     });
 }
+
+/// RED — the literal #916 bug shape, reconstructed byte-for-byte from the
+/// pre-fix encoder. This is what makes the high-register variants above
+/// non-vacuous: without it, "they certify" would be indistinguishable from
+/// "the validator cannot see this class at all".
+///
+/// The pre-fix `I64ShrU { rd_hi: R8, .. }` large-shift arm ended:
+///
+/// ```text
+/// B     .done          ; 0xE002 -> halfword 19, the end of a 38-byte expansion
+/// LSR.W rd_lo, rn_hi, rm_hi
+/// 0x2800                ; MOVS R8,#0 INTENDED — assembles as CMP r0,#0
+/// ```
+///
+/// so for any shift amount >= 32 the high half was never zeroed and kept
+/// whatever R8 held on entry. Splicing that tail back on MUST produce a
+/// counterexample.
+#[test]
+fn red_916_transmuted_zero_fill_fails() {
+    with_verification_context(|| {
+        let pseudo = ArmOp::I64ShrU {
+            rd_lo: Reg::R7,
+            rd_hi: Reg::R8,
+            rn_lo: Reg::R0,
+            rn_hi: Reg::R1,
+            rm_lo: Reg::R2,
+            rm_hi: Reg::R3,
+        };
+        let code = thumb_bytes(&pseudo);
+
+        // The FIXED tail (10 bytes): B .done (0xE003, widened); LSR.W R7,R1,R3;
+        // MOV.W R8,#0. Pinned so this test screams if the encoder changes.
+        let fixed: Vec<u8> = [0xE003u16, 0xFA21, 0xF703, 0xF04F, 0x0800]
+            .iter()
+            .flat_map(|hw| hw.to_le_bytes())
+            .collect();
+        assert_eq!(
+            &code[code.len() - 10..],
+            &fixed[..],
+            "shipped I64ShrU tail changed — update the #916 red-shape splice"
+        );
+
+        // The #916 shape: the narrow B (0xE002) and the transmuted 0x2800.
+        let mut buggy = code[..code.len() - 10].to_vec();
+        for hw in [0xE002u16, 0xFA21, 0xF703, 0x2800] {
+            buggy.extend_from_slice(&hw.to_le_bytes());
+        }
+        assert_eq!(buggy.len(), 38, "pre-#916 expansion was 38 bytes");
+
+        match validate_expansion(&synth_core::WasmOp::I64ShrU, &pseudo, &buggy) {
+            Err(ExpansionError::Counterexample {
+                wasm_op_label,
+                description,
+            }) => {
+                println!("✗ #916 shape rejected as required: {wasm_op_label}: {description}");
+            }
+            other => panic!(
+                "#916 bug shape (transmuted MOVS zero-fill leaves the high half \
+                 unwritten) must FAIL validation, got {other:?}"
+            ),
+        }
+    });
+}

--- a/crates/synth-backend/tests/i64_high_reg_zero_fill_916.rs
+++ b/crates/synth-backend/tests/i64_high_reg_zero_fill_916.rs
@@ -1,0 +1,436 @@
+//! #916 — the 16-bit `MOVS` T1 zero-fill transmutes to `CMP` for a high
+//! destination (R8-R12), so the half that must be zeroed is NEVER WRITTEN.
+//!
+//! `MOVS Rd, #imm8` (T1) is `0010 0 Rd(3) imm8` — the Rd field is **three
+//! bits**. `reg_to_bits(R8)` is 8, so `8 << 8 = 0x0800` lands in bit 11 and
+//! `0x2000 | 0x0800 = 0x2800`, which is not a MOV at all: it is `CMP r0, #0`.
+//! The intended destination keeps whatever it held; the flags are clobbered.
+//!
+//! This is the same class as #180 / H-CODE-9 and the same defect #311 already
+//! fixed for `I64SetCond` / `I64SetCondZ` (emit the 32-bit `MOV.W`, T2
+//! `F04F 0000 | rd<<8 | imm8`, whenever `rd >= R8`).
+//!
+//! ## Scope — the issue named 2 sites; there are FIVE
+//!
+//! | op | register zeroed | reachable via |
+//! |----|-----------------|---------------|
+//! | `I64Shl`         | `rd_lo` (large-shift arm) | `i64.shl`, n >= 32 |
+//! | `I64ShrU`        | `rd_hi` (large-shift arm) | `i64.shr_u`, n >= 32 |
+//! | `I64Clz`         | `rnhi` (high-word clear)  | `i64.clz`, ALWAYS |
+//! | `I64Ctz`         | `rnhi` (high-word clear)  | `i64.ctz`, ALWAYS |
+//! | `I64ExtendI32U`  | `rdhi` (high-word clear)  | `i64.extend_i32_u`, ALWAYS |
+//!
+//! The two shift sites are *conditionally* wrong (only the `n >= 32` path
+//! reaches the MOV). The other three are **unconditionally** wrong for a high
+//! destination — every `i64.clz` / `i64.ctz` / `i64.extend_i32_u` whose high
+//! half lands in R8 returns a value whose upper 32 bits are garbage.
+//!
+//! ## Why this is not a one-liner: instruction SIZE
+//!
+//! `MOV.W` is 4 bytes where `MOVS` was 2. Whether that moves a branch target
+//! has to be settled **per site by decoding the branch imm**, not by eyeballing
+//! the comments:
+//!
+//! * `I64Shl` / `I64ShrU`: `B .done` (`0xE002`) targets halfword 19 = the END
+//!   of the expansion, which is PAST the MOV at halfword 18. Widening the MOV
+//!   moves `.done` → the displacement MUST become `0xE003`. `BPL .large`
+//!   (`0xD50A`) targets halfword 16, BEFORE the MOV, so it is unaffected.
+//! * `I64Clz` / `I64Ctz`: `B .done` targets byte 22 / 30, which IS THE MOV's
+//!   OWN ADDRESS (the branch jumps *to* the final instruction, not past it).
+//!   Widening an instruction does not move its own address → no displacement
+//!   change. `BEQ` targets 14 / 18, before the MOV → unaffected.
+//! * `I64ExtendI32U`: no branches at all.
+//!
+//! `assert_branches_still_land` below re-derives those targets from the emitted
+//! bytes so a mis-recomputed displacement fails here rather than at run time —
+//! trading a data miscompile for a control-flow one would be strictly worse.
+
+use synth_backend::ArmEncoder;
+use synth_synthesis::{ArmOp, Reg};
+
+fn thumb(op: &ArmOp) -> Vec<u8> {
+    ArmEncoder::new_thumb2()
+        .encode(op)
+        .expect("shipped encoder must encode the pseudo-op")
+}
+
+fn halfwords(bytes: &[u8]) -> Vec<u16> {
+    bytes
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect()
+}
+
+/// The 32-bit `MOV.W Rd, #0` (T2): `F04F 0000 | Rd<<8`.
+fn movw_imm_zero(rd: u16) -> [u16; 2] {
+    [0xF04F, rd << 8]
+}
+
+/// Assert the tail of `bytes` zeroes register number `rd` — as the 16-bit
+/// `MOVS` for a low register, as the 32-bit `MOV.W` for a high one — and in
+/// particular that it is NOT the transmuted `0x2800` (`CMP r0, #0`).
+fn assert_zero_fill(label: &str, bytes: &[u8], rd: u16) {
+    let hw = halfwords(bytes);
+    assert!(hw.len() >= 2, "{label}: expansion too short");
+    let tail = *hw.last().unwrap();
+
+    assert_ne!(
+        tail, 0x2800,
+        "{label}: emitted tail halfword is 0x2800 — that is CMP r0,#0, NOT a \
+         zero-fill of R{rd}. The 3-bit MOVS T1 Rd field overflowed (#916): the \
+         half is never written and keeps stale data.\nfull stream: {hw:04X?}"
+    );
+
+    if rd < 8 {
+        assert_eq!(
+            tail,
+            0x2000 | (rd << 8),
+            "{label}: low register must keep the 16-bit MOVS form (byte-identical)"
+        );
+    } else {
+        let want = movw_imm_zero(rd);
+        let got = [hw[hw.len() - 2], hw[hw.len() - 1]];
+        assert_eq!(
+            got, want,
+            "{label}: high register must be zeroed by the 32-bit MOV.W (T2), \
+             the #311 shape.\nfull stream: {hw:04X?}"
+        );
+    }
+}
+
+/// Re-derive every forward branch target in an expansion from the EMITTED
+/// bytes and assert it still lands where the expansion means it to.
+///
+/// Thumb branch semantics: for a branch at halfword index `i`, the target
+/// halfword index is `i + 2 + imm` (PC reads as the instruction address + 4).
+///
+/// `expected` maps a branch's halfword index to its intended target halfword
+/// index. A widened `MOV.W` that shifts a target without the displacement
+/// being recomputed fails here.
+fn assert_branches_still_land(label: &str, bytes: &[u8], expected: &[(usize, usize)]) {
+    let hw = halfwords(bytes);
+    for &(idx, want_target) in expected {
+        let insn = hw[idx];
+        // B (T2, unconditional): 1110 0 imm11.  B<cond> (T1): 1101 cond imm8.
+        let imm: i32 = if (insn & 0xF800) == 0xE000 {
+            let imm11 = (insn & 0x07FF) as i32;
+            if imm11 & 0x400 != 0 {
+                imm11 - 0x800
+            } else {
+                imm11
+            }
+        } else if (insn & 0xF000) == 0xD000 {
+            let imm8 = (insn & 0x00FF) as i32;
+            if imm8 & 0x80 != 0 { imm8 - 0x100 } else { imm8 }
+        } else {
+            panic!("{label}: halfword {idx} = {insn:#06X} is not a branch");
+        };
+        let target = idx as i32 + 2 + imm;
+        assert_eq!(
+            target, want_target as i32,
+            "{label}: branch at halfword {idx} ({insn:#06X}) lands at halfword \
+             {target}, not {want_target}. A displacement was not recomputed \
+             after the zero-fill was widened — this is a CONTROL-FLOW \
+             miscompile, strictly worse than the data bug it replaced.\n\
+             full stream: {hw:04X?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The five defective sites, at a high destination.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn i64_shl_zero_fills_a_high_rd_lo() {
+    // i64.shl with n >= 32: the low half must become 0.
+    let op = ArmOp::I64Shl {
+        rd_lo: Reg::R8,
+        rd_hi: Reg::R7,
+        rn_lo: Reg::R0,
+        rn_hi: Reg::R1,
+        rm_lo: Reg::R2,
+        rm_hi: Reg::R3,
+    };
+    let bytes = thumb(&op);
+    assert_zero_fill("I64Shl{rd_lo=R8}", &bytes, 8);
+}
+
+#[test]
+fn i64_shr_u_zero_fills_a_high_rd_hi() {
+    // i64.shr_u with n >= 32: the high half must become 0.
+    // This is the shape `scripts/repro/rv32_cmp_select_472.wat` actually emits
+    // at `-b arm --target cortex-m4` (rd_hi = R8, allocator pool R0-R8).
+    let op = ArmOp::I64ShrU {
+        rd_lo: Reg::R7,
+        rd_hi: Reg::R8,
+        rn_lo: Reg::R3,
+        rn_hi: Reg::R4,
+        rm_lo: Reg::R5,
+        rm_hi: Reg::R6,
+    };
+    let bytes = thumb(&op);
+    assert_zero_fill("I64ShrU{rd_hi=R8}", &bytes, 8);
+}
+
+#[test]
+fn i64_clz_zero_fills_a_high_high_word() {
+    // i64.clz returns i64 — the high word is ALWAYS cleared, so a high `rnhi`
+    // is unconditionally miscompiled (no `n >= 32` precondition needed).
+    let op = ArmOp::I64Clz {
+        rd: Reg::R0,
+        rnlo: Reg::R1,
+        rnhi: Reg::R8,
+    };
+    let bytes = thumb(&op);
+    assert_zero_fill("I64Clz{rnhi=R8}", &bytes, 8);
+}
+
+#[test]
+fn i64_ctz_zero_fills_a_high_high_word() {
+    let op = ArmOp::I64Ctz {
+        rd: Reg::R0,
+        rnlo: Reg::R1,
+        rnhi: Reg::R8,
+    };
+    let bytes = thumb(&op);
+    assert_zero_fill("I64Ctz{rnhi=R8}", &bytes, 8);
+}
+
+#[test]
+fn i64_extend_i32_u_zero_fills_a_high_rdhi() {
+    // i64.extend_i32_u: the high word is ALWAYS cleared. No branches here, so
+    // widening is a pure size change.
+    let op = ArmOp::I64ExtendI32U {
+        rdlo: Reg::R0,
+        rdhi: Reg::R8,
+        rn: Reg::R1,
+    };
+    let bytes = thumb(&op);
+    assert_zero_fill("I64ExtendI32U{rdhi=R8}", &bytes, 8);
+}
+
+// ---------------------------------------------------------------------------
+// Control flow must survive the widening.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn i64_shl_branches_land_for_both_low_and_high_destinations() {
+    for (rd_lo, tail_hw) in [(Reg::R6, 19usize), (Reg::R8, 20usize)] {
+        let bytes = thumb(&ArmOp::I64Shl {
+            rd_lo,
+            rd_hi: Reg::R7,
+            rn_lo: Reg::R0,
+            rn_hi: Reg::R1,
+            rm_lo: Reg::R2,
+            rm_hi: Reg::R3,
+        });
+        // BPL .large at halfword 4 → halfword 16 (before the MOV, never moves).
+        // B .done at halfword 15 → the END of the expansion (PAST the MOV).
+        assert_branches_still_land(
+            &format!("I64Shl{{rd_lo={rd_lo:?}}}"),
+            &bytes,
+            &[(4, 16), (15, tail_hw)],
+        );
+        assert_eq!(
+            bytes.len(),
+            tail_hw * 2,
+            "I64Shl{{rd_lo={rd_lo:?}}}: unexpected expansion length"
+        );
+    }
+}
+
+#[test]
+fn i64_shr_u_branches_land_for_both_low_and_high_destinations() {
+    for (rd_hi, tail_hw) in [(Reg::R6, 19usize), (Reg::R8, 20usize)] {
+        let bytes = thumb(&ArmOp::I64ShrU {
+            rd_lo: Reg::R7,
+            rd_hi,
+            rn_lo: Reg::R0,
+            rn_hi: Reg::R1,
+            rm_lo: Reg::R2,
+            rm_hi: Reg::R3,
+        });
+        assert_branches_still_land(
+            &format!("I64ShrU{{rd_hi={rd_hi:?}}}"),
+            &bytes,
+            &[(4, 16), (15, tail_hw)],
+        );
+        assert_eq!(
+            bytes.len(),
+            tail_hw * 2,
+            "I64ShrU{{rd_hi={rd_hi:?}}}: unexpected expansion length"
+        );
+    }
+}
+
+#[test]
+fn i64_clz_ctz_branches_target_the_final_mov_itself() {
+    // The discriminating fact vs Shl/ShrU: here `B .done` jumps TO the final
+    // MOV, so widening it in place cannot move the target. Pinned so a future
+    // restructuring that moves `.done` past the MOV is caught.
+    for rnhi in [Reg::R2, Reg::R8] {
+        let clz = thumb(&ArmOp::I64Clz {
+            rd: Reg::R0,
+            rnlo: Reg::R1,
+            rnhi,
+        });
+        // BEQ@2 → hw 7 (byte 14); B@5 → hw 11 (byte 22) = the MOV.
+        assert_branches_still_land(&format!("I64Clz{{rnhi={rnhi:?}}}"), &clz, &[(2, 7), (5, 11)]);
+
+        let ctz = thumb(&ArmOp::I64Ctz {
+            rd: Reg::R0,
+            rnlo: Reg::R1,
+            rnhi,
+        });
+        // BEQ@2 → hw 9 (byte 18); B@7 → hw 15 (byte 30) = the MOV.
+        assert_branches_still_land(&format!("I64Ctz{{rnhi={rnhi:?}}}"), &ctz, &[(2, 9), (7, 15)]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Low registers must be byte-identical: the fix is confined to rd >= R8.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn low_register_expansions_are_byte_identical() {
+    let cases: Vec<(&str, ArmOp, usize)> = vec![
+        (
+            "I64Shl",
+            ArmOp::I64Shl {
+                rd_lo: Reg::R0,
+                rd_hi: Reg::R1,
+                rn_lo: Reg::R2,
+                rn_hi: Reg::R3,
+                rm_lo: Reg::R4,
+                rm_hi: Reg::R5,
+            },
+            38,
+        ),
+        (
+            "I64ShrU",
+            ArmOp::I64ShrU {
+                rd_lo: Reg::R0,
+                rd_hi: Reg::R1,
+                rn_lo: Reg::R2,
+                rn_hi: Reg::R3,
+                rm_lo: Reg::R4,
+                rm_hi: Reg::R5,
+            },
+            38,
+        ),
+        (
+            "I64ShrS",
+            ArmOp::I64ShrS {
+                rd_lo: Reg::R0,
+                rd_hi: Reg::R1,
+                rn_lo: Reg::R2,
+                rn_hi: Reg::R3,
+                rm_lo: Reg::R4,
+                rm_hi: Reg::R5,
+            },
+            40,
+        ),
+        (
+            "I64Clz",
+            ArmOp::I64Clz {
+                rd: Reg::R0,
+                rnlo: Reg::R1,
+                rnhi: Reg::R2,
+            },
+            24,
+        ),
+        (
+            "I64Ctz",
+            ArmOp::I64Ctz {
+                rd: Reg::R0,
+                rnlo: Reg::R1,
+                rnhi: Reg::R2,
+            },
+            32,
+        ),
+        (
+            "I64ExtendI32U",
+            ArmOp::I64ExtendI32U {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                rn: Reg::R2,
+            },
+            4,
+        ),
+    ];
+    for (label, op, want_len) in cases {
+        let bytes = thumb(&op);
+        assert_eq!(
+            bytes.len(),
+            want_len,
+            "{label}: low-register expansion length changed — the #916 fix must \
+             be confined to rd >= R8 so frozen anchors do not move"
+        );
+    }
+}
+
+/// `I64ShrS` has NO 16-bit zero-fill: its large-shift arm sign-fills with the
+/// 32-bit `ASR.W rd_hi, rn_hi, #31`, which has a 4-bit Rd field. Pinned so the
+/// asymmetry is deliberate rather than an oversight.
+#[test]
+fn i64_shr_s_has_no_16bit_zero_fill_to_transmute() {
+    let bytes = thumb(&ArmOp::I64ShrS {
+        rd_lo: Reg::R7,
+        rd_hi: Reg::R8,
+        rn_lo: Reg::R0,
+        rn_hi: Reg::R1,
+        rm_lo: Reg::R2,
+        rm_hi: Reg::R3,
+    });
+    let hw = halfwords(&bytes);
+    assert_eq!(bytes.len(), 40, "I64ShrS length must be register-invariant");
+    assert!(
+        !hw.contains(&0x2800),
+        "I64ShrS must not contain a transmuted MOVS: {hw:04X?}"
+    );
+    // .large arm sign-fill is ASR.W (0xEA4F ...), Rd field is 4 bits.
+    assert_eq!(hw[hw.len() - 2], 0xEA4F, "expected ASR.W sign-fill");
+}
+
+/// The A32 (cortex-r5) expansions do NOT share the defect: A32 `MOV Rd, #imm`
+/// is `0xE3A00000 | Rd<<12` and the Rd field is **four** bits, so R8 encodes
+/// correctly. Pinned so the sweep is recorded, not merely asserted in prose.
+#[test]
+fn a32_zero_fill_is_not_affected_by_a_high_destination() {
+    let enc = ArmEncoder::new_arm32();
+    for (label, op, rd_bits) in [
+        (
+            "I64Shl{rd_lo=R8}",
+            ArmOp::I64Shl {
+                rd_lo: Reg::R8,
+                rd_hi: Reg::R7,
+                rn_lo: Reg::R0,
+                rn_hi: Reg::R1,
+                rm_lo: Reg::R2,
+                rm_hi: Reg::R3,
+            },
+            8u32,
+        ),
+        (
+            "I64ShrU{rd_hi=R8}",
+            ArmOp::I64ShrU {
+                rd_lo: Reg::R7,
+                rd_hi: Reg::R8,
+                rn_lo: Reg::R0,
+                rn_hi: Reg::R1,
+                rm_lo: Reg::R2,
+                rm_hi: Reg::R3,
+            },
+            8u32,
+        ),
+    ] {
+        let bytes = enc.encode(&op).expect("A32 encode");
+        let last = u32::from_le_bytes(bytes[bytes.len() - 4..].try_into().unwrap());
+        assert_eq!(
+            last,
+            0xE3A00000 | (rd_bits << 12),
+            "{label}: A32 MOV Rd,#0 must encode R8 in its 4-bit Rd field"
+        );
+    }
+}

--- a/crates/synth-backend/tests/i64_high_reg_zero_fill_916.rs
+++ b/crates/synth-backend/tests/i64_high_reg_zero_fill_916.rs
@@ -276,7 +276,11 @@ fn i64_clz_ctz_branches_target_the_final_mov_itself() {
             rnhi,
         });
         // BEQ@2 → hw 7 (byte 14); B@5 → hw 11 (byte 22) = the MOV.
-        assert_branches_still_land(&format!("I64Clz{{rnhi={rnhi:?}}}"), &clz, &[(2, 7), (5, 11)]);
+        assert_branches_still_land(
+            &format!("I64Clz{{rnhi={rnhi:?}}}"),
+            &clz,
+            &[(2, 7), (5, 11)],
+        );
 
         let ctz = thumb(&ArmOp::I64Ctz {
             rd: Reg::R0,
@@ -284,7 +288,11 @@ fn i64_clz_ctz_branches_target_the_final_mov_itself() {
             rnhi,
         });
         // BEQ@2 → hw 9 (byte 18); B@7 → hw 15 (byte 30) = the MOV.
-        assert_branches_still_land(&format!("I64Ctz{{rnhi={rnhi:?}}}"), &ctz, &[(2, 9), (7, 15)]);
+        assert_branches_still_land(
+            &format!("I64Ctz{{rnhi={rnhi:?}}}"),
+            &ctz,
+            &[(2, 9), (7, 15)],
+        );
     }
 }
 

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -497,7 +497,11 @@ pub fn estimate_arm_byte_size(op: &ArmOp) -> usize {
         // `CMP r0,#0` and never write the half), so the expansion is 40 bytes
         // there and the encoder widens its internal `B .done` to match.
         ArmOp::I64Shl { rd_lo: rd, .. } | ArmOp::I64ShrU { rd_hi: rd, .. } => {
-            if reg_num(rd) < 8 { 38 } else { 40 }
+            if reg_num(rd) < 8 {
+                38
+            } else {
+                40
+            }
         }
         // I64ShrS: same as ShrU but large block is 8 bytes (ASR+ASR vs LSR+MOV) = 40
         ArmOp::I64ShrS { .. } => 40,
@@ -510,11 +514,19 @@ pub fn estimate_arm_byte_size(op: &ArmOp) -> usize {
         // R0-R7; R8-R12 take `MOV.W` (4), so 26. Unlike the shifts, no branch
         // moves — `B .done` targets the clear's OWN address.
         ArmOp::I64Clz { rnhi, .. } => {
-            if reg_num(rnhi) < 8 { 24 } else { 26 }
+            if reg_num(rnhi) < 8 {
+                24
+            } else {
+                26
+            }
         }
         // I64Ctz: CMP.W(4) + BEQ(2) + RBIT.W(4) + CLZ.W(4) + B(2) + NOP(2) + RBIT.W(4) + CLZ.W(4) + ADD.W(4) + MOV(2) = 32 bytes
         ArmOp::I64Ctz { rnhi, .. } => {
-            if reg_num(rnhi) < 8 { 32 } else { 34 }
+            if reg_num(rnhi) < 8 {
+                32
+            } else {
+                34
+            }
         }
         // I64Popcnt: PUSH/POP + duplicate popcount for lo and hi word (#498:
         // measured 172; #632 result-carry through R12 across the restore pop

--- a/crates/synth-synthesis/src/optimizer_bridge.rs
+++ b/crates/synth-synthesis/src/optimizer_bridge.rs
@@ -491,7 +491,14 @@ pub fn estimate_arm_byte_size(op: &ArmOp) -> usize {
         // I64Mul: MUL(4) + MLA(4) + UMULL(4) + ADD(2) = 14 bytes
         ArmOp::I64Mul { .. } => 14,
         // I64Shl/ShrU: AND.W(4) + SUBS.W(4) + BPL(2) + small_block(22) + B(2) + large_block(6) - but byte_size = total = 38
-        ArmOp::I64Shl { .. } | ArmOp::I64ShrU { .. } => 38,
+        // #916: the large block's trailing zero-fill of the OTHER half is the
+        // 16-bit `MOVS Rd,#0` only for R0-R7 — a 3-bit Rd field. R8-R12 take
+        // the 32-bit `MOV.W` (the encoder used to transmute them into
+        // `CMP r0,#0` and never write the half), so the expansion is 40 bytes
+        // there and the encoder widens its internal `B .done` to match.
+        ArmOp::I64Shl { rd_lo: rd, .. } | ArmOp::I64ShrU { rd_hi: rd, .. } => {
+            if reg_num(rd) < 8 { 38 } else { 40 }
+        }
         // I64ShrS: same as ShrU but large block is 8 bytes (ASR+ASR vs LSR+MOV) = 40
         ArmOp::I64ShrS { .. } => 40,
         // I64Rotl/Rotr (#610): fixed-ABI wrapper (PUSH r0-r3(2) + 3×STR(12) +
@@ -499,9 +506,16 @@ pub fn estimate_arm_byte_size(op: &ArmOp) -> usize {
         // BPL(2) + small(30) + B(2) + large(30) = 70) = 102 bytes.
         ArmOp::I64Rotl { .. } | ArmOp::I64Rotr { .. } => 102,
         // I64Clz: CMP.W(4) + BEQ(2) + CLZ.W(4) + B(2) + NOP(2) + CLZ.W(4) + ADD.W(4) + MOV(2) = 24 bytes
-        ArmOp::I64Clz { .. } => 24,
+        // #916: the trailing high-word clear is `MOVS rnhi,#0` (2) only for
+        // R0-R7; R8-R12 take `MOV.W` (4), so 26. Unlike the shifts, no branch
+        // moves — `B .done` targets the clear's OWN address.
+        ArmOp::I64Clz { rnhi, .. } => {
+            if reg_num(rnhi) < 8 { 24 } else { 26 }
+        }
         // I64Ctz: CMP.W(4) + BEQ(2) + RBIT.W(4) + CLZ.W(4) + B(2) + NOP(2) + RBIT.W(4) + CLZ.W(4) + ADD.W(4) + MOV(2) = 32 bytes
-        ArmOp::I64Ctz { .. } => 32,
+        ArmOp::I64Ctz { rnhi, .. } => {
+            if reg_num(rnhi) < 8 { 32 } else { 34 }
+        }
         // I64Popcnt: PUSH/POP + duplicate popcount for lo and hi word (#498:
         // measured 172; #632 result-carry through R12 across the restore pop
         // + R12-routed marshal + MOV.W hi-clear = +8).

--- a/scripts/repro/i64_high_reg_zero_fill_916.wat
+++ b/scripts/repro/i64_high_reg_zero_fill_916.wat
@@ -1,0 +1,103 @@
+;; #916 — i64 zero-fill mis-encodes for a HIGH destination (R8-R12).
+;;
+;; The 16-bit `MOVS Rd,#imm8` (T1) has a THREE-bit Rd field. `reg_to_bits(R8)`
+;; is 8, so `8 << 8 = 0x0800` and `0x2000 | 0x0800 = 0x2800` — the emitted
+;; halfword is `CMP r0,#0`, not a move. The half that must be zeroed is NEVER
+;; WRITTEN and keeps whatever the destination register held.
+;;
+;; Reachability was already established: `rv32_cmp_select_472.wat` at
+;; `-b arm --target cortex-m4` emits `I64ShrU { rd_hi: R8, .. }` today, with an
+;; allocator pool of R0-R8. It is unobservable THERE only because an
+;; `I32WrapI64` discards the high half one instruction later — luck, not a
+;; guarantee. This module removes the luck: every export KEEPS the half the
+;; broken instruction was supposed to zero.
+;;
+;; * `shru_keep_high`  — i64.shr_u(x, n) for n >= 32 must have high half 0.
+;;                       Returns the FULL i64, so a stale high half is visible.
+;; * `shl_keep_low`    — i64.shl(x, n) for n >= 32 must have low half 0.
+;; * `clz64` / `ctz64` — i64.clz/i64.ctz return i64; the high word is cleared
+;;                       UNCONDITIONALLY (no `n >= 32` precondition), so these
+;;                       were miscompiled for a high `rnhi` on every input.
+;; * `extend_u64`      — i64.extend_i32_u clears the high word unconditionally.
+;; * `pressure_shru`   — the same shr_u under enough live-pair pressure to push
+;;                       the destination into the high half of the R0-R8 pool,
+;;                       with four i32 params pinned in r0-r3 (#193/#204).
+;;
+;; Both shift amounts straddle 32 (the branch that selects the large-shift arm)
+;; so the differential also exercises the `B .done` displacement, which had to
+;; be widened when the zero-fill grew from 2 bytes to 4.
+;;
+;; Differential oracle:
+;;   synth compile scripts/repro/i64_high_reg_zero_fill_916.wat -o /tmp/zf916.elf \
+;;         --target cortex-m4 --relocatable --all-exports
+;;   python scripts/repro/i64_high_reg_zero_fill_916_differential.py /tmp/zf916.elf
+(module
+  ;; i64.shr_u keeping the HIGH half. n is a runtime value so the n<32 / n>=32
+  ;; branch is genuinely taken at run time, not folded.
+  (func (export "shru_keep_high") (param i32) (result i64)
+    i64.const 0xFEDCBA9876543210
+    local.get 0
+    i64.extend_i32_u
+    i64.shr_u)
+
+  ;; i64.shl keeping the LOW half.
+  (func (export "shl_keep_low") (param i32) (result i64)
+    i64.const 0xFEDCBA9876543210
+    local.get 0
+    i64.extend_i32_u
+    i64.shl)
+
+  ;; i64.shr_s — the control: its large-shift arm sign-fills with the 32-bit
+  ;; ASR.W (4-bit Rd), so it was never defective. A regression here would mean
+  ;; the fix damaged a neighbouring expansion.
+  (func (export "shrs_keep_high") (param i32) (result i64)
+    i64.const 0xFEDCBA9876543210
+    local.get 0
+    i64.extend_i32_u
+    i64.shr_s)
+
+  ;; i64.clz / i64.ctz — high word cleared unconditionally.
+  (func (export "clz64") (param i32) (result i64)
+    local.get 0
+    i64.extend_i32_u
+    i64.const 32
+    i64.shl
+    i64.clz)
+
+  (func (export "ctz64") (param i32) (result i64)
+    local.get 0
+    i64.extend_i32_u
+    i64.const 32
+    i64.shl
+    i64.ctz)
+
+  ;; i64.extend_i32_u — high word cleared unconditionally. Returned whole, so a
+  ;; stale high half is visible.
+  (func (export "extend_u64") (param i32) (result i64)
+    local.get 0
+    i64.extend_i32_u)
+
+  ;; Pressure variant: four i32 params pinned in r0-r3 until their last read
+  ;; plus several simultaneously-live i64 pairs, so the shift destination is
+  ;; pushed toward the top of the R0-R8 allocator pool. The fold mixes
+  ;; non-commutative ops so an operand-order or half-swap bug also shows.
+  (func (export "pressure_shru") (param i32 i32 i32 i32) (result i64)
+    i64.const 0x1111111111111111
+    i64.const 0x2222222222222222
+    i64.xor
+    i64.const 0xFEDCBA9876543210
+    local.get 0
+    i64.extend_i32_u
+    i64.shr_u
+    i64.add
+    local.get 1
+    i64.extend_i32_u
+    i64.sub
+    i64.const 0x3333333333333333
+    local.get 2
+    i64.extend_i32_u
+    i64.shl
+    i64.xor
+    local.get 3
+    i64.extend_i32_u
+    i64.add))

--- a/scripts/repro/i64_high_reg_zero_fill_916_differential.py
+++ b/scripts/repro/i64_high_reg_zero_fill_916_differential.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# ci-status: wired
+"""#916 — i64 zero-fill mis-encodes for a HIGH destination (R8-R12).
+
+The 16-bit `MOVS Rd,#imm8` (T1) has a **three-bit** Rd field. `reg_to_bits(R8)`
+is 8, so `8 << 8 = 0x0800` and `0x2000 | 0x0800 = 0x2800` — the emitted halfword
+is `CMP r0,#0`, not a move. The half that must be zeroed is NEVER WRITTEN and
+keeps whatever the destination register held; the flags are clobbered too.
+
+Five expansions carried the defect (`I64Shl`, `I64ShrU`, `I64Clz`, `I64Ctz`,
+`I64ExtendI32U`). The unit test `i64_high_reg_zero_fill_916.rs` pins the emitted
+halfwords and the expansion certifier pins the symbolic semantics; this oracle
+is the third leg — it EXECUTES synth's ARM under unicorn against wasmtime, which
+the byte-level tests cannot do.
+
+That matters specifically because the fix CHANGED INSTRUCTION SIZE. `MOV.W` is
+4 bytes where `MOVS` was 2, and in `I64Shl`/`I64ShrU` the expansion's internal
+`B .done` targets the END of the sequence — PAST the zero-fill — so its
+displacement had to be recomputed (0xE002 -> 0xE003). A mis-recomputed branch
+would sail past the end of the expansion into the next instruction, and NO
+byte-level assertion on the tail halfword would notice. Only execution does.
+The shift amounts below straddle 32 deliberately so both arms of that branch,
+and the branch itself, are exercised.
+
+`pressure_shru` is the reachability witness: with four i32 params pinned in
+r0-r3 (#193/#204) and several live i64 pairs, the allocator puts a zero-fill
+destination in R8. Confirmed present in the emitted image — `MOV.W R8, #0`
+appears in that function's body. Pre-fix that halfword was `0x2800`.
+
+Run:
+  synth compile scripts/repro/i64_high_reg_zero_fill_916.wat -o /tmp/zf916.elf \
+        --target cortex-m4 --relocatable --all-exports
+  python scripts/repro/i64_high_reg_zero_fill_916_differential.py /tmp/zf916.elf
+
+Exits nonzero on any mismatch so it can gate a release.
+"""
+
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R3,
+    UC_ARM_REG_R8,
+    UC_ARM_REG_SP,
+)
+
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/zf916.elf"
+WAT = Path(__file__).with_name("i64_high_reg_zero_fill_916.wat")
+
+# Ground truth: wasmtime.
+eng = wasmtime.Engine()
+mod = wasmtime.Module(eng, WAT.read_bytes())
+store = wasmtime.Store(eng)
+inst = wasmtime.Instance(store, mod, [])
+exports = inst.exports(store)
+
+# synth's ARM under unicorn.
+elf = ELFFile(open(ELF, "rb"))
+text = elf.get_section_by_name(".text").data()
+symtab = [s for s in elf.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+syms = {s.name: s["st_value"] for s in symtab.iter_symbols() if s.name}
+
+CODE, STK = 0x10000, 0x90000
+mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+mu.mem_map(CODE, 0x10000)
+mu.mem_write(CODE, text)
+mu.mem_map(STK, 0x10000)
+RET = CODE + 0xFF00
+mu.mem_write(RET, b"\x00\xbf\x00\xbf")
+
+MASK64 = (1 << 64) - 1
+
+
+def signed32(v):
+    return v - (1 << 32) if v >= 1 << 31 else v
+
+
+# The poison. #916 leaves the destination register UNWRITTEN, so it keeps
+# whatever it held on entry. Seeding R8 (and r0-r3 for the single-param
+# functions) with a value that is not plausibly a correct result is what turns
+# the latent bug into an observable failure: a run that "passes" only because
+# the stale register happened to hold 0 would be a false green.
+POISON = 0xDEADBEEF
+
+
+def run(name, args):
+    for reg, val in zip(
+        (UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3), args
+    ):
+        mu.reg_write(reg, val)
+    # Unused argument registers and R8 are poisoned, never zeroed.
+    for reg in (UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3)[
+        len(args) :
+    ]:
+        mu.reg_write(reg, POISON)
+    mu.reg_write(UC_ARM_REG_R8, POISON)
+    mu.reg_write(UC_ARM_REG_SP, STK + 0x8000)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    mu.emu_start((CODE + syms[name]) | 1, RET, timeout=5_000_000)
+    return mu.reg_read(UC_ARM_REG_R0) | (mu.reg_read(UC_ARM_REG_R1) << 32)
+
+
+# Shift amounts straddle 32 on purpose: below it the small-shift arm runs and
+# the `B .done` whose displacement changed is TAKEN; at/above it the
+# large-shift arm containing the widened zero-fill runs.
+SHIFTS = [0, 1, 31, 32, 33, 40, 63]
+
+CASES = []
+for fn in ("shru_keep_high", "shl_keep_low", "shrs_keep_high"):
+    CASES += [(fn, (n,)) for n in SHIFTS]
+for fn in ("clz64", "ctz64", "extend_u64"):
+    CASES += [
+        (fn, (v,))
+        for v in (0, 1, 2, 0x80000000, 0xFFFFFFFF, 0x0000FF00, 0xDEADBEEF)
+    ]
+CASES += [
+    ("pressure_shru", a)
+    for a in (
+        (0, 0, 0, 0),
+        (32, 1, 32, 2),
+        (40, 7, 33, 11),
+        (63, 0xFFFFFFFF, 40, 0x80000000),
+        (31, 12345, 63, 54321),
+        (1, 0xDEADBEEF, 0, 0xCAFEBABE),
+    )
+]
+
+ok = True
+checked = 0
+for name, args in CASES:
+    expected = exports[name](store, *[signed32(a) for a in args]) & MASK64
+    got = run(name, list(args))
+    checked += 1
+    good = got == expected
+    if not good:
+        ok = False
+    argstr = ",".join(f"{a:#x}" for a in args)
+    print(
+        f"{'OK  ' if good else 'FAIL'} {name}({argstr}) = {got:#018x} "
+        f"expect {expected:#018x}"
+    )
+
+# A differential that silently executed nothing is a false green.
+assert checked == len(CASES) and checked > 0, f"no cases executed ({checked})"
+print(f"checked {checked} executions across {len({c[0] for c in CASES})} functions")
+print("ORACLE:", "PASS" if ok else "FAIL")
+sys.exit(0 if ok else 1)

--- a/scripts/repro/i64_high_reg_zero_fill_916_differential.py
+++ b/scripts/repro/i64_high_reg_zero_fill_916_differential.py
@@ -67,6 +67,44 @@ text = elf.get_section_by_name(".text").data()
 symtab = [s for s in elf.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
 syms = {s.name: s["st_value"] for s in symtab.iter_symbols() if s.name}
 
+# --------------------------------------------------------------------------
+# REACHABILITY WITNESS — this oracle's teeth.
+#
+# Everything below only tests #916 if the allocator actually puts a zero-fill
+# destination in R8-R12 somewhere in this image. If it stops doing so, every
+# assertion still passes and the oracle silently degrades into a no-op that
+# prints "48/48 OK" while testing nothing about the high-register path — the
+# #890 "gate that cannot fail" shape.
+#
+# So assert the witness directly: scan .text for the 32-bit `MOV.W Rd,#0` (T2,
+# F04F 0000 | Rd<<8) with Rd >= 8. That encoding EXISTS ONLY BECAUSE of the
+# #916 fix; before it the same site emitted the 16-bit 0x2800.
+#
+# This is expected to go RED, not silently green, if the allocator changes —
+# e.g. VCR-DEC-001 / #917's interference edge keeps R8 out of the candidate
+# colours. That is correct behavior: it says the module lost its reachability
+# witness and needs a different pressure shape, rather than pretending to
+# still cover the class.
+_hw = [
+    int.from_bytes(text[i : i + 2], "little") for i in range(0, len(text) - 1, 2)
+]
+_high_zero_fills = [
+    (i * 2, (_hw[i + 1] >> 8) & 0xF)
+    for i in range(len(_hw) - 1)
+    if _hw[i] == 0xF04F and (_hw[i + 1] & 0x00FF) == 0 and ((_hw[i + 1] >> 8) & 0xF) >= 8
+]
+assert _high_zero_fills, (
+    "REACHABILITY LOST: no `MOV.W Rd,#0` with Rd >= R8 in .text, so this module "
+    "no longer exercises the #916 high-register zero-fill and the differential "
+    "below proves nothing. The allocator stopped choosing a high register for "
+    "these destinations (an allocator change, or VCR-DEC-001/#917 keeping R8 "
+    "out of the candidate colours). Restore the witness by raising register "
+    "pressure in i64_high_reg_zero_fill_916.wat — do NOT delete this assertion."
+)
+print(
+    "reachability witness: "
+    + ", ".join(f"MOV.W R{rd},#0 @ {off:#x}" for off, rd in _high_zero_fills)
+)
 CODE, STK = 0x10000, 0x90000
 mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
 mu.mem_map(CODE, 0x10000)


### PR DESCRIPTION
Closes #916.

## The defect

The 16-bit `MOVS Rd, #imm8` (T1) is `0010 0 Rd(3) imm8` — the Rd field is **three bits**. `reg_to_bits(R8)` is 8, so `8 << 8 = 0x0800` overflows into bit 11 and `0x2000 | 0x0800 = 0x2800`, which is **`CMP r0, #0`** — not a move at all. The half that had to be zeroed is never written (it keeps whatever the destination register held) and the flags are clobbered on the way past.

Same class as #180 / H-CODE-9, and the same defect #311 already fixed for `I64SetCond`. This follows that shape — 32-bit `MOV.W` (T2, `F04F 0000 | Rd<<8 | imm8`) for `rd >= R8` — behind **one shared helper** (`emit_thumb_zero_fill` / `thumb_zero_fill_halfwords`) so a sixth site cannot reintroduce the class silently.

## The issue named two sites. There are five.

Sweeping every 16-bit imm8 T1 emission in the Thumb-2 encoder:

| expansion | register left unwritten | precondition |
|---|---|---|
| `I64Shl` | `rd_lo` (large-shift arm) | shift `>= 32` |
| `I64ShrU` | `rd_hi` (large-shift arm) | shift `>= 32` |
| **`I64Clz`** | `rnhi` (high-word clear) | **none** |
| **`I64Ctz`** | `rnhi` (high-word clear) | **none** |
| **`I64ExtendI32U`** | `rdhi` (high-word clear) | **none** |

The three extra ones are **worse than the two filed**: they have no `>= 32` guard, so *every* `i64.clz` / `i64.ctz` / `i64.extend_i32_u` whose high half landed in R8 returned garbage in its upper 32 bits. `I64ExtendI32U { rdhi: R8 }` emitted the literal two-halfword stream `[4608, 2800]` — half of a two-instruction expansion was the wrong instruction.

## Red-first evidence (on unmodified main)

```
I64Clz{rnhi=R8}: emitted tail halfword is 0x2800 — that is CMP r0,#0, NOT a zero-fill of R8.
full stream: [F1B8, 0F00, D003, FAB8, F088, E004, BF00, FAB1, F081, F100, 0020, 2800]

I64ExtendI32U{rdhi=R8}: ... full stream: [4608, 2800]
```
7 failing assertions across the 5 sites (commit `dc0dac2`, before any fix).

**Execution differential, encoder reverted to the pre-fix commit:**
```
FAIL pressure_shru(0x20,0x1,0x20,0x2)      = 0x22d3c110320fedcc expect 0x00000007320fedcc
FAIL pressure_shru(0x28,0x7,0x21,0xb)      = 0x7786944434320ff1 expect 0x5555555534320ff1
FAIL pressure_shru(0x3f,0xffffffff,0x28,…) = 0x22d3c121b3333335 expect 0x00000032b3333335
exit 1
```
The three failures are exactly the shift amounts `>= 32` (0x20, 0x28, 0x3f); 0x1 and 0x1f pass because they take the small-shift arm and never reach the zero-fill. The corrupted **high** halves are stale register contents. With the fix: **48/48 OK, exit 0**.

## Instruction size and branch displacements — the reason this wasn't a one-liner

`MOV.W` is 4 bytes where `MOVS` was 2. Whether that moves a branch target was settled **per site by decoding the emitted `imm` fields**, not by reading the comments:

- **`I64Shl` / `I64ShrU`** — `B .done` (`0xE002`) targets halfword 19 = the **END** of the expansion, **past** the zero-fill at halfword 18. The target **moves**. The displacement is now *derived* from the zero-fill's real width (`0xE002` low / `0xE003` high) rather than hard-coded, so the encoder cannot drift from itself. `BPL .large` (`0xD50A`) targets halfword 16, before the zero-fill → unaffected.
- **`I64Clz` / `I64Ctz`** — `B .done` targets byte 22 / 30, which **is the zero-fill's own address**. An instruction cannot move its own address → no displacement change. `BEQ` targets 14 / 18, before it.
- **`I64ExtendI32U`** — no branches.

Reordering the large-shift arm to dodge the size change was **rejected, not overlooked**: zeroing `rd_lo` before the `LSL.W` destroys `rn_lo` in the in-place case `rd_lo == rn_lo`. That reasoning is in the code so it isn't "simplified" away later.

`assert_branches_still_land` re-derives every target from the emitted bytes, so a mis-recomputed displacement fails at test time rather than at run time — trading a data miscompile for a control-flow one would be strictly worse.

**Estimator mirror (#498).** `estimate_arm_byte_size` feeds optimized-path branch resolution and `I64Shl`/`ShrU`/`Clz`/`Ctz` are all classified `OnPath`. Left un-mirrored, a high-reg shift would be under-counted by 2 and every branch spanning it would land short — the #483 class. Now register-shape-sensitive (38/40, 24/26, 32/34), matching the existing house pattern for `Cmn`/`Sxtb`/`Uxth`/`Mov`. The direct selector needs no change: it resolves branches from real `code.len()`. `I64ExtendI32U` is `NotOnPath` (lowered to 32-bit op pairs upstream).

## Three validators were blind to this

1. **`estimator_encoder_agreement` (#498)** tested these ops only at low registers — it would have stayed green while the estimator under-counted every high-reg i64 shift. **+5 high-destination cases.**
2. **The i64 expansion certifier** fed these ops only at R0/R1, and its high-register variant list covered only `I64SetCond`/`SetCondZ`/`Mul`/`Popcnt`. **+5 high-register variants**, plus a RED test splicing the pre-fix tail back on to prove non-vacuity: `✗ #916 shape rejected as required: I64ShrU: a_lo=0xffffffff, b_lo=0x20` — the solver picked exactly shift = 32.
3. **Nothing executed** a `>= 32` shift that *kept* the affected half. New CI-wired differential (48 runs vs wasmtime).

That is the same "validators share a blind spot" pattern recorded in v0.53; this is a third instance in the family.

## Sweep results

- **A32 (cortex-r5) does NOT share the defect** — `MOV Rd,#0` is `0xE3A00000 | Rd<<12`, a **four**-bit Rd field, so R8 encodes correctly. Pinned by a test so the sweep is recorded rather than asserted in prose.
- **`I64ShrS` does not either** — its large arm sign-fills with the 32-bit `ASR.W` (4-bit Rd). Also pinned.
- **Both selectors × both ISAs** compiled and scanned clean (optimized/`--relocatable` and direct, thumb2 and A32): 0 transmuted halfwords in all four.

## Frozen anchors: NOTHING MOVED

`frozen_codegen_bytes` 10/10 green, **byte-identical**. The fix is confined to `rd >= R8` and none of the four anchors has a high-register i64 zero-fill destination, so there is **no re-pin to justify** — low-register expansions are unchanged at 38/38/40/24/32/4 bytes.

## Gates (real exit codes, not piped output)

| gate | exit |
|---|---|
| `cargo fmt --check` | 0 |
| `cargo clippy --workspace --all-targets -D warnings` | 0 |
| `cargo test --workspace` | 0 |
| `frozen_codegen_bytes` (10 anchors) | 0, byte-identical |
| `estimator_encoder_agreement` (#498) | 0 |
| `regression_498_branch_spans_popcnt` | 0 |
| `i64_expansion_certification` (6 tests incl. new RED) | 0 |
| `scripts/oracle_wiring_check.py` | 0 — 159 scripts, 152 wired, 0 unwired, 0 UNDECLARED |
| `scripts/claim_check.py` | 0 — 38/38 |

New differential is CI-wired in the same commit with `set -euo pipefail`, a `# ci-status: wired` header, and a non-zero-count assertion on executions.

## ⚠️ Interaction with #917 (L3) — needs action before either merges

#917 adds `i64_shift_zero_fill_mis_encodes_for_a_high_destination`, which **pins the defect**: it asserts `tail_high == 0x2800` and that `low.len() == high.len()`. Both are now false by design — a test pinning a defect must not outlive the defect. Its own docstring anticipates this ("the day the branch offsets are recomputed the test fails loudly and gets inverted").

Whichever lands second must, in the merge:
- **invert** that test (assert `MOV.W` = `F04F 0800`, and that the high-reg expansion is 2 bytes **longer**) — or simply drop it, since `i64_high_reg_zero_fill_916.rs` here supersedes it across all five sites;
- drop the `artifacts/sw-verification.yaml` run entry that names it;
- update #917's CHANGELOG text describing the defect as unfixed.

#917's allocator-side decline (`i64-16bit-form-high-reg`) is a separate design choice and is **not** invalidated by this fix — but it is no longer load-bearing for correctness, only for conservatism.

## Not closed

- The allocator can still *choose* R8 for these destinations; this makes that choice **correct**, it does not make it *preferred*. Whether VCR-DEC-001 should keep declining the shape is #917's call.
- `I64ExtendI32U`'s estimator entry remains at the `_ => 2` default. Harmless today (it is `NotOnPath`, and the direct selector uses real byte lengths), but it is a latent mirror gap if that op is ever put on the optimized path — worth a follow-up rather than an unrelated change here.

Refs #311, #180, #498, #483, #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L