### PR TITLE
release: v0.55.0 — "The scry seam"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **The evidence now says what it measures (#910).** `Code Coverage` was red
-  repo-wide until v0.54 fixed a test binary-path bug. Green and quotable, it was
-  structurally misleading: it runs `cargo llvm-cov --workspace`, i.e. the Rust
-  test suite in process, while this project's strongest evidence — the execution
-  differentials — spawns the compiler as a separate, **uninstrumented** process
-  from **other CI jobs**, emitting no profile data at all. So
-  `synth-backend-aarch64/src/backend.rs` reads 41.6 % and
-  `instruction_selector.rs` 42.7 % while both are exercised end-to-end
-  constantly. The number understates real testing *and* cannot be read as
-  completeness. Renamed to **`Rust-test Line Coverage (unit + integration
-  only)`**, with the scope caveat carried in three places that travel with the
-  number (the job body, `$GITHUB_STEP_SUMMARY`, the README badge) and pinned in
-  `claims.yaml` so it cannot be dropped while the percentage stays quotable.
-  #910 option 1 — instrumenting the binary the differentials run — was
-  **declined**: it changes the artifact under test (these oracles exist to
-  execute the *shipped* bytes) and buys precision on an axis that is still the
-  wrong completeness instrument.
+## [0.55.0] - 2026-08-07
 
 ### Added
 
@@ -159,70 +141,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   common blind spot; `VCR-VER-004` closes the shared-*contract* hole, not the
   shared-*op-model* hole, and until `synth-verify`'s `ArmSemantics::encode_op` is
   pinned against it, "three independent validators" would be an overclaim.
-
-### Fixed
-
-- **The traceability graph disagreed with itself in four places, and the gate
-  that should have said so could not see two of them (#893, #396).** No code
-  behaviour changes here; what changes is whether the project's evidence
-  artifacts can be trusted to mean one thing.
-
-  - **`VCR-DEC-003` pointed at an issue NUMBER where an artifact id belongs.**
-    `traces-to: synth:396` reads as "artifact 396 in repo synth" and no such
-    artifact exists. The link is not deleted: synth#396's own body says
-    *"Tracked in rivet as VCR-COV-001"*, and `VCR-COV-001`'s title carries
-    "(synth #396)", so the link now targets the artifact and the issue number
-    moves to the tags, where it is a reference rather than a resolvable target.
-  - **`GI-FPU-002` was declared TWICE, and the stale copy won.** The id existed
-    in `gale-integration.yaml` (`proposed`, the original #369 ask) and again in
-    `verified-codegen-roadmap.yaml` (`implemented`, PR #705's phase-1 delivery
-    record). rivet loaded the second over the first, so the graph reported the
-    requirement as NOT STARTED while README and CHANGELOG report #369 closed,
-    f32 complete v0.41, f64 complete v0.43, VFP spilling v0.53. Merged — not
-    deleted, because each copy carried edges and evidence the other lacked —
-    into the id's namespace home, and de-staled to `implemented` with the two
-    remaining float declines named rather than implied away.
-  - **`VCR-RA-004` was `proposed` for a resolver that shipped in v0.11.38.**
-    v0.53's VFP-spilling lane tagged its work with that id and the issue read it
-    as one id meaning two things. The evidence says otherwise:
-    `synth_synthesis::parallel_move` is verbatim what the artifact specifies,
-    the artifact's own tags already said `release-v0.11.38`, and v0.53 *extended*
-    it to the VFP file rather than reusing its name. Only the status field had
-    never been flipped — minting a second id would have created the collision
-    the issue was trying to remove. Now `implemented`, with `SWVER-022` closing
-    the right side of the V by a typed `verifies` link instead of a paragraph.
-    Deliberately **not** `verified`: the property test the criteria demand does
-    exist and does exactly what they specify (6000 sequentializations against a
-    reference parallel semantics), but the second pitfall the artifact names —
-    split points inside hot loops — is still bounded by assumption, and that
-    residual is now written down.
-  - **`VCR-SEL-005` said "BOTH the ARM and RISC-V selectors"** for a gate that
-    has spanned three backends since v0.53 (#883). Correcting the count exposed
-    that every ledger *size* asserted around it had also drifted — and all in the
-    flattering direction, describing gaps that have since closed: the roadmap
-    said 21 entries for an array of 18, `known_divergences`'s doc comment said
-    19, and `aarch64_known_divergences`'s said "the SEVEN below" over an array of
-    5. The stale-entry check already forces a closed gap to retire its ledger
-    line; nothing forced the prose *about* the ledger to move with it.
-
-- **Two verification artifacts were added to close gaps the status fixes
-  revealed** (`SWVER-022` for VCR-RA-004, `GI-FPU-VER-002` for GI-FPU-002).
-  Neither gap was created by this work — a `proposed` artifact is not
-  lifecycle-checked, so the wrong statuses had been *hiding* them. The evidence
-  existed and was already named in both requirements' criteria; it just had no
-  typed `verifies` link. Measured on `rivet coverage` (the job's second step):
-  sw-req V-closure **31/60 → 33/60**, weighted overall **90.3 % → 90.7 %**.
-
-- **The `Rivet Validation` job had two blind spots — one per defect above.**
-  Both errors sat in a green tree, which is not a coincidence: the filter
-  anchored on `^  ERROR:` and so never saw rivet's filename-prefixed diagnostics
-  (the duplicate-id class), and its cross-repo exemption waved through any target
-  containing a colon — including `synth:`, our own prefix. Fixed structurally
-  rather than by allowlist, and proven red-first by replaying the exact step
-  against both trees: exit 1 naming both errors on the pre-fix artifacts, exit 0
-  after.
-
-### Added
 
 - **aarch64 `br_table` + value-carrying `block`/`loop`/`if` (VCR-A64-CF-001,
   #851).** The two largest entries left in the VCR-SEL-005 third-backend
@@ -385,6 +303,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The evidence now says what it measures (#910).** `Code Coverage` was red
+  repo-wide until v0.54 fixed a test binary-path bug. Green and quotable, it was
+  structurally misleading: it runs `cargo llvm-cov --workspace`, i.e. the Rust
+  test suite in process, while this project's strongest evidence — the execution
+  differentials — spawns the compiler as a separate, **uninstrumented** process
+  from **other CI jobs**, emitting no profile data at all. So
+  `synth-backend-aarch64/src/backend.rs` reads 41.6 % and
+  `instruction_selector.rs` 42.7 % while both are exercised end-to-end
+  constantly. The number understates real testing *and* cannot be read as
+  completeness. Renamed to **`Rust-test Line Coverage (unit + integration
+  only)`**, with the scope caveat carried in three places that travel with the
+  number (the job body, `$GITHUB_STEP_SUMMARY`, the README badge) and pinned in
+  `claims.yaml` so it cannot be dropped while the percentage stays quotable.
+  #910 option 1 — instrumenting the binary the differentials run — was
+  **declined**: it changes the artifact under test (these oracles exist to
+  execute the *shipped* bytes) and buys precision on an axis that is still the
+  wrong completeness instrument.
+
 - **Three named residuals replace two blanket declines.** `br_table` past 16
   targets (`BR_TABLE_MAX_TARGETS`, the same threshold RV32 uses — the chain is
   O(n) and PC-relative jump-table dispatch is a follow-up), a `br_table` whose
@@ -411,6 +347,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and self-contained paths, and all 633 pre-existing relocatable functions plus
   all 1059 self-contained ones byte-identical to v0.54.
 
+### Fixed
+
+- **The traceability graph disagreed with itself in four places, and the gate
+  that should have said so could not see two of them (#893, #396).** No code
+  behaviour changes here; what changes is whether the project's evidence
+  artifacts can be trusted to mean one thing.
+
+  - **`VCR-DEC-003` pointed at an issue NUMBER where an artifact id belongs.**
+    `traces-to: synth:396` reads as "artifact 396 in repo synth" and no such
+    artifact exists. The link is not deleted: synth#396's own body says
+    *"Tracked in rivet as VCR-COV-001"*, and `VCR-COV-001`'s title carries
+    "(synth #396)", so the link now targets the artifact and the issue number
+    moves to the tags, where it is a reference rather than a resolvable target.
+  - **`GI-FPU-002` was declared TWICE, and the stale copy won.** The id existed
+    in `gale-integration.yaml` (`proposed`, the original #369 ask) and again in
+    `verified-codegen-roadmap.yaml` (`implemented`, PR #705's phase-1 delivery
+    record). rivet loaded the second over the first, so the graph reported the
+    requirement as NOT STARTED while README and CHANGELOG report #369 closed,
+    f32 complete v0.41, f64 complete v0.43, VFP spilling v0.53. Merged — not
+    deleted, because each copy carried edges and evidence the other lacked —
+    into the id's namespace home, and de-staled to `implemented` with the two
+    remaining float declines named rather than implied away.
+  - **`VCR-RA-004` was `proposed` for a resolver that shipped in v0.11.38.**
+    v0.53's VFP-spilling lane tagged its work with that id and the issue read it
+    as one id meaning two things. The evidence says otherwise:
+    `synth_synthesis::parallel_move` is verbatim what the artifact specifies,
+    the artifact's own tags already said `release-v0.11.38`, and v0.53 *extended*
+    it to the VFP file rather than reusing its name. Only the status field had
+    never been flipped — minting a second id would have created the collision
+    the issue was trying to remove. Now `implemented`, with `SWVER-022` closing
+    the right side of the V by a typed `verifies` link instead of a paragraph.
+    Deliberately **not** `verified`: the property test the criteria demand does
+    exist and does exactly what they specify (6000 sequentializations against a
+    reference parallel semantics), but the second pitfall the artifact names —
+    split points inside hot loops — is still bounded by assumption, and that
+    residual is now written down.
+  - **`VCR-SEL-005` said "BOTH the ARM and RISC-V selectors"** for a gate that
+    has spanned three backends since v0.53 (#883). Correcting the count exposed
+    that every ledger *size* asserted around it had also drifted — and all in the
+    flattering direction, describing gaps that have since closed: the roadmap
+    said 21 entries for an array of 18, `known_divergences`'s doc comment said
+    19, and `aarch64_known_divergences`'s said "the SEVEN below" over an array of
+    5. The stale-entry check already forces a closed gap to retire its ledger
+    line; nothing forced the prose *about* the ledger to move with it.
+
+- **Two verification artifacts were added to close gaps the status fixes
+  revealed** (`SWVER-022` for VCR-RA-004, `GI-FPU-VER-002` for GI-FPU-002).
+  Neither gap was created by this work — a `proposed` artifact is not
+  lifecycle-checked, so the wrong statuses had been *hiding* them. The evidence
+  existed and was already named in both requirements' criteria; it just had no
+  typed `verifies` link. Measured on `rivet coverage` (the job's second step):
+  sw-req V-closure **31/60 → 33/60**, weighted overall **90.3 % → 90.7 %**.
+
+- **The `Rivet Validation` job had two blind spots — one per defect above.**
+  Both errors sat in a green tree, which is not a coincidence: the filter
+  anchored on `^  ERROR:` and so never saw rivet's filename-prefixed diagnostics
+  (the duplicate-id class), and its cross-repo exemption waved through any target
+  containing a colon — including `synth:`, our own prefix. Fixed structurally
+  rather than by allowlist, and proven red-first by replaying the exact step
+  against both trees: exit 1 naming both errors on the pre-fix artifacts, exit 0
+  after.
+
 ### Verified
 
 - `scripts/repro/aarch64_brtable_blockvals_851_differential.py` (CI-wired): 88
@@ -434,6 +432,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`aarch64_f32_unsupported_554`) differs exactly because its declined function
   now lowers. A void frame reserves no register and emits no reconciliation
   move, so the property holds by construction.
+
+### Documentation
+
+- README's `synth-backend-aarch64` row still said "integer subset". It has not
+  been one since v0.54 — the scalar float surface, globals, `call_indirect` and
+  bounds-checked memory all ship. `CLAUDE.md` carried a byte-identical copy plus
+  a **third** instance worth naming on its own: its Track-C note said aarch64 is
+  N/A for VCR-VER-003 *"(no linear-memory ops in the integer subset)"*. The
+  **verdict is still correct and the reason is false** — aarch64 has had
+  bounds-checked linear-memory load/store since v0.52 (#865); it is N/A because it
+  emits no data section and refuses data-carrying modules loudly (v0.53), so there
+  is no served-vs-runtime image to compare. A right conclusion resting on a rotted
+  premise is the harder version of this defect: the sentence still reads fine, so
+  nothing prompts a re-check. That was the **fourth** copy of a list this project
+  keeps duplicating (parity oracle, matrix row, CHANGELOG, CLAUDE.md); generating
+  the prose from the executable decline list is the standing fix (#911).
+- Filed #912: the feature loop's step 5 (witness MC/DC) has been marked N/A four
+  releases running, past the skill's own three-feature threshold. synth compiles
+  Wasm rather than emitting components, so witness may have no artifact to
+  instrument — but `VCR-COV-001` is the standing argument that the DO-178C
+  6.4.4.2 source-to-object obligation does not go away just because the
+  measurement point does. Recorded for a decision rather than re-skipped.
 
 ### Notes
 
@@ -483,28 +503,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   popcnt/clz/ctz, the narrow sign-extends, `MemorySize`/`MemoryGrow`),
   `identity-colouring` 58, `call-indirect-pseudo` 17, `unreachable-block` 11,
   `numeric-branch` 10, `i64-16bit-form-high-reg` 1.
-
-### Documentation
-
-- README's `synth-backend-aarch64` row still said "integer subset". It has not
-  been one since v0.54 — the scalar float surface, globals, `call_indirect` and
-  bounds-checked memory all ship. `CLAUDE.md` carried a byte-identical copy plus
-  a **third** instance worth naming on its own: its Track-C note said aarch64 is
-  N/A for VCR-VER-003 *"(no linear-memory ops in the integer subset)"*. The
-  **verdict is still correct and the reason is false** — aarch64 has had
-  bounds-checked linear-memory load/store since v0.52 (#865); it is N/A because it
-  emits no data section and refuses data-carrying modules loudly (v0.53), so there
-  is no served-vs-runtime image to compare. A right conclusion resting on a rotted
-  premise is the harder version of this defect: the sentence still reads fine, so
-  nothing prompts a re-check. That was the **fourth** copy of a list this project
-  keeps duplicating (parity oracle, matrix row, CHANGELOG, CLAUDE.md); generating
-  the prose from the executable decline list is the standing fix (#911).
-- Filed #912: the feature loop's step 5 (witness MC/DC) has been marked N/A four
-  releases running, past the skill's own three-feature threshold. synth compiles
-  Wasm rather than emitting components, so witness may have no artifact to
-  instrument — but `VCR-COV-001` is the standing argument that the DO-178C
-  6.4.4.2 source-to-object obligation does not go away just because the
-  measurement point does. Recorded for a decision rather than re-skipped.
 
 ## [0.54.0] - 2026-08-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,14 +1111,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1178,11 +1178,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.54.0"
+version = "0.55.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1238,14 +1238,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1253,11 +1253,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.54.0"
+version = "0.55.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.54.0"
+version = "0.55.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.54.0"
+version = "0.55.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.54.0",
+    version = "0.55.0",
 )
 
 # Bazel dependencies

--- a/artifacts/status.json
+++ b/artifacts/status.json
@@ -21,7 +21,7 @@
   "sel_dsl_rule_qed": 50,
   "sel_dsl_rules": 50,
   "sel_rules_simplified_basis": 50,
-  "version": "0.54.0",
+  "version": "0.55.0",
   "verus_spec_fns": 8,
   "wasmcert_bridge_qed": 104
 }

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.54.0" }
+synth-core = { path = "../synth-core", version = "0.55.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.54.0" }
+synth-core = { path = "../synth-core", version = "0.55.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.54.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.54.0" }
+synth-core = { path = "../synth-core", version = "0.55.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.55.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
@@ -21,4 +21,4 @@ tracing.workspace = true
 proptest.workspace = true
 # VCR-SEL-005 (#851): the cross-backend op-parity oracle probes the AArch64
 # selector as the THIRD backend (tests/cross_backend_op_parity.rs only).
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.54.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.55.0" }

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.54.0" }
+synth-core = { path = "../synth-core", version = "0.55.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.54.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.54.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.55.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.55.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.54.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.55.0", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -58,23 +58,23 @@ exports_only_275_probe = []
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.54.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.54.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.54.0" }
-synth-backend = { path = "../synth-backend", version = "0.54.0" }
+synth-core = { path = "../synth-core", version = "0.55.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.55.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.55.0" }
+synth-backend = { path = "../synth-backend", version = "0.55.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.54.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.55.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.54.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.54.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.54.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.55.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.55.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.55.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.54.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.55.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.54.0" }
+synth-core = { path = "../synth-core", version = "0.55.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.54.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.55.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.54.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.54.0" }
-synth-opt = { path = "../synth-opt", version = "0.54.0" }
+synth-core = { path = "../synth-core", version = "0.55.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.55.0" }
+synth-opt = { path = "../synth-opt", version = "0.55.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.54.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.54.0" }
-synth-opt = { path = "../synth-opt", version = "0.54.0" }
+synth-core = { path = "../synth-core", version = "0.55.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.55.0" }
+synth-opt = { path = "../synth-opt", version = "0.55.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.54.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.55.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -7,7 +7,7 @@
 > stale. All numbers come from [`artifacts/status.json`](../../artifacts/status.json),
 > which is re-derived from source on every run — never hand-edited.
 
-**Workspace version:** 0.54.0
+**Workspace version:** 0.55.0
 
 ---
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"


### PR DESCRIPTION
Six lanes. Version 0.54.0 → 0.55.0.

| lane | what |
|---|---|
| **L2** | **VCR-RA-010 — the scry const-remat seam.** scry's singleton-interval signal promoted from a dev-dependency test to an allocator input. Eligibility is DERIVED from the emitted ARM stream; the hint only GATES consumption and can never create an eligible site. Flag-off. |
| **L1** (v0.55 pre-merge) | `--proven-safe` bounds-check elision on scry's proof, fail-closed on `module_sha256`. |
| **L3** | VCR-DEC-001 increment 4 — the allocator models the i64 register-pair ops; 316→411 applied. |
| **L5** | Oracle steps assert EXECUTION, not exit status. 136 oracles / 295,421 emulator entries, floors measured and pinned on three surfaces. |
| **L6** | aarch64 `br_table` + value-carrying `block`/`loop`/`if`; known divergences 5 → 4. |
| **L7** | Traceability repair — rivet ours-errors 2 → 0, VCR-VER-004 roadmap entry. |
| **#921** | `unmodeled-op` WCET declines now name the op and byte offset (gale's schedulability input). |

## Gates on the assembled tree

```
build 0 · fmt 0 · claim 43/43 · oracle wiring 160 scripts, 0 UNDECLARED
133 test suites · frozen anchors 10/10 bit-identical
Cargo.lock refreshed (18 entries at 0.55.0)
```

## gate-potency audit (run before tagging)

- **audit 5 — skipped ≠ passed:** 0 of the 9 required jobs carry a conditional or paths filter, so none can be *skipped* into green.
- **audit 6 — missing evidence ⇒ red:** 0 bare `set -o pipefail`; 55 steps use `set -euo pipefail`.
- **finding → #924:** `Version Pin Sweep` covers 2 of the 4 surfaces a release bumps. `Cargo.lock` and `npm/package.json` are ungated — the lock had ZERO 0.55.0 entries after the bump and is correct here only because it was checked by hand. Not a blocker for this release; filed.

Deferred to v0.56: #923 (codecov split), #924 (pin-sweep scope), #846 (gpio-thin 502→498 B).