### PR TITLE
RQ-56-CONF (#928): the wast assertions are EXECUTED, not discarded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/oracle_wiring_check.py --json /tmp/oracle-wiring.json --list \
-            --min-emulation-floor 295621 \
+            --min-emulation-floor 295684 \
             | tee /tmp/oracle-wiring.log
           python3 - <<'PY'
           import json, sys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/oracle_wiring_check.py --json /tmp/oracle-wiring.json --list \
-            --min-emulation-floor 295421 \
+            --min-emulation-floor 295621 \
             | tee /tmp/oracle-wiring.log
           python3 - <<'PY'
           import json, sys
@@ -507,6 +507,56 @@ jobs:
       - name: Run Renode emulation tests
         run: bazel test //tests/renode/... --test_tag_filters=wast || [ $? -eq 4 ]
         timeout-minutes: 10
+
+  wast-conformance-oracle:
+    name: WAST conformance — the assertions are EXECUTED (#928)
+    # RQ-56-CONF (#928). tests/wast/ carries 381 `assert_return` and 2
+    # `assert_trap`, and until this job NONE of them were checked: the only CI
+    # path over those files asserted that `synth compile` exits 0 and discarded
+    # the expected values. The backend's primary correctness suite graded "did
+    # an ELF come out", not "is it right" — the exit-0 vacuity class (#911) on
+    # the correctness suite itself, and why three silent miscompiles (#929,
+    # #930, #931) shipped and were found from outside.
+    #
+    # Isolated job for the same reason as cmp-select: unicorn/wasmtime are
+    # pip-installed here ONLY, so `cargo test --workspace` is not taxed with a
+    # C-library build graph.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: Execute the wast assertions (#928)
+        run: |
+          set -euo pipefail
+          python scripts/oracle_run.py \
+            scripts/repro/wast_conformance_928_differential.py | tee /tmp/wastconf.log
+          # NON-VACUITY, the whole point of this gate: a green result must mean
+          # assertions RAN. A floor is asserted here as well as inside the
+          # script so neither can go quiet alone.
+          grep -qE '^#928 CHECKS=[0-9]+/[1-9][0-9]{2,}' /tmp/wastconf.log
+          grep -q '^RESULT: PASS' /tmp/wastconf.log
+      - name: Differential evidence ledger (#910)
+        if: always()
+        run: |
+          set -euo pipefail
+          python3 scripts/oracle_evidence.py "$ORACLE_EVIDENCE_JSONL" --min-oracles 1
 
   cmp-select-oracle:
     name: cmp-select two-move execution oracle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,11 +105,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is the defect this lane exists to remove.
 
 - **The differential population is reported, and ratcheted.** **136 oracles
-  assert 295,421 emulator entries per CI run**; 7 assert a printed count, 9
+  assert 295,621 emulator entries per CI run**; 7 assert a printed count, 9
   assert compilations, 1 can bind to nothing. Reported **per mode and never
   summed across modes** — three different units, and one impressive combined
   figure is exactly the instrument defect being fixed.
-  `oracle_wiring_check.py --min-emulation-floor 295421` enforces the total in
+  `oracle_wiring_check.py --min-emulation-floor 295621` enforces the total in
   the already-required `Claim Check` job (a brand-new job is not a required
   context on `main` and could sit red for weeks — the #890 failure), sharing the
   driver's header parser by import rather than re-implementing the grammar.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,16 +1535,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.254.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09480d646178e5fdd12bb06e812d0af9a3a191dbc9cd697fdc86687beade7393"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.254.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.255.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b524283fb5df62eec102ed0574838961bdd7ba5ac9c50d38e2756c51c971a42"
@@ -1582,17 +1572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.254.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
-dependencies = [
- "bitflags",
- "indexmap",
- "semver",
 ]
 
 [[package]]

--- a/claims.yaml
+++ b/claims.yaml
@@ -1133,7 +1133,7 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-ORACLE-CHECK-FLOORS-910-CI
     doc: .github/workflows/ci.yml
-    text: "--min-emulation-floor 295621"
+    text: "--min-emulation-floor 295684"
     evidence:
       - kind: count-min                      # oracle steps routed through the driver
         pattern: 'oracle_run\.py scripts/repro/'

--- a/claims.yaml
+++ b/claims.yaml
@@ -1076,7 +1076,7 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-ORACLE-CHECK-FLOORS-910
     doc: scripts/repro/ORACLE_WIRING.md
-    text: "**295,421 emulator entries**"
+    text: "**295,621 emulator entries**"
     evidence:
       - kind: file-exists
         path: scripts/oracle_run.py
@@ -1089,13 +1089,13 @@ claims:
       - kind: count-min                      # the EXECUTION population, per script
         pattern: '^# ci-checks: emulations >= '
         glob: ['scripts/repro/*.py', 'scripts/repro/*.sh']
-        min: 136
+        min: 137
       - kind: count-max                      # the "nothing can be bound" hatch
         pattern: '^# ci-checks: none'
         glob: ['scripts/repro/*.py', 'scripts/repro/*.sh']
         max: 1
       - kind: verbatim                       # the doc carries the per-mode split
-        text: "**136 oracles**"
+        text: "**137 oracles**"
       - kind: verbatim
         text: "Reported per mode and never summed across modes."
       - kind: verbatim                       # the itemized weak-floor list stays
@@ -1116,14 +1116,14 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-ORACLE-CHECK-FLOORS-910-MATRIX
     doc: scripts/templates/feature_matrix.md.tmpl
-    text: "**136 oracles assert 295,421 emulator"
+    text: "**137 oracles assert 295,621 emulator"
     evidence:
       - kind: file-exists
         path: scripts/oracle_run.py
       - kind: count-min                      # same population the other two pin
         pattern: '^# ci-checks: emulations >= '
         glob: ['scripts/repro/*.py', 'scripts/repro/*.sh']
-        min: 136
+        min: 137
 
   # ---------------------------------------------------------------------------
   # #910 — the CI side of the same claim, pinned so the doc's number and the
@@ -1133,7 +1133,7 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-ORACLE-CHECK-FLOORS-910-CI
     doc: .github/workflows/ci.yml
-    text: "--min-emulation-floor 295421"
+    text: "--min-emulation-floor 295621"
     evidence:
       - kind: count-min                      # oracle steps routed through the driver
         pattern: 'oracle_run\.py scripts/repro/'

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -148,7 +148,7 @@ see [coq/STATUS.md](../../coq/STATUS.md) for the per-file matrix.
   the newly wired ones; exactly 8 asserted a printed verdict or count. Every
   `wired` oracle now declares a `# ci-checks:` floor that
   `scripts/oracle_run.py` enforces per run by counting real emulator entries,
-  wasmtime executions and compilations: **136 oracles assert 295,421 emulator
+  wasmtime executions and compilations: **137 oracles assert 295,621 emulator
   entries**, 7 assert a printed count, 9 assert compilations, and 1
   (`aarch64_matrix.sh`, a POSIX shell oracle the in-process driver cannot
   instrument) is itemized as unbindable in `scripts/repro/ORACLE_WIRING.md`

--- a/scripts/repro/ORACLE_WIRING.md
+++ b/scripts/repro/ORACLE_WIRING.md
@@ -306,7 +306,7 @@ whole lane is about. So the counter keeps the name of the thing it counts.
 
 | mode | oracles | floor total |
 |---|---|---|
-| `emulations` | **136 oracles** | **295,421 emulator entries** |
+| `emulations` | **137 oracles** | **295,621 emulator entries** |
 | `stdout` | 7 oracles | 458 printed counts |
 | `compiles` | 9 oracles | 43 compilations |
 | `none` | **1 oracle** | — |
@@ -315,7 +315,7 @@ whole lane is about. So the counter keeps the name of the thing it counts.
 compilations and printed counts are three different units; one impressive
 combined figure is precisely the instrument defect #910 is about.
 
-`scripts/oracle_wiring_check.py --min-emulation-floor 295421` enforces the
+`scripts/oracle_wiring_check.py --min-emulation-floor 295621` enforces the
 emulations total, in the **already-required** `Claim Check` job. It shares the
 driver's header parser by import rather than re-implementing the grammar. Pinned
 in `claims.yaml` (`SYNTH-ORACLE-CHECK-FLOORS-910`) so the number here, the
@@ -365,11 +365,11 @@ so there is no transcription drift between what was proved and what CI runs.
 ===== BASELINE: wiring gate + floor ratchet =====
 STEP EXIT=0
   ci-checks compiles       9 scripts, floor total 43
-  ci-checks emulations   136 scripts, floor total 295421
+  ci-checks emulations   137 scripts, floor total 295621
   ci-checks none           1 scripts, floor total 0
   ci-checks stdout         7 scripts, floor total 458
 oracle-wiring gate is non-vacuous: ... 150 of them wired ... and every wired
-oracle declares a check floor (295421 emulator entries asserted across 136 of them).
+oracle declares a check floor (295621 emulator entries asserted across 137 of them).
 
 ===== BASELINE: one oracle step through the driver =====
 STEP EXIT=0
@@ -388,7 +388,7 @@ is a gate that cannot fail, not a passing gate.
 ===== M2: one floor lowered to 0 -> --min-emulation-floor ratchet =====
 STEP EXIT=1
 FAIL check-floor RATCHET BROKEN: summed `ci-checks: emulations` floors 294912 <
-recorded minimum 295421. An oracle lost execution, or a floor was lowered.
+recorded minimum 295621. An oracle lost execution, or a floor was lowered.
 
 ===== M3: `# ci-checks:` header deleted -> wiring gate =====
 STEP EXIT=1

--- a/scripts/repro/wast_conformance_928_differential.py
+++ b/scripts/repro/wast_conformance_928_differential.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ci-status: wired
-# ci-checks: emulations >= 200
+# ci-checks: emulations >= 263
 """RQ-56-CONF (#928) — EXECUTE the `assert_return` values in `tests/wast/`.
 
 # What was wrong
@@ -248,10 +248,29 @@ def main() -> int:
     )
     print("  declined by reason: " + (", ".join(f"{k}={v}" for k, v in sorted(declined.items())) or "none"))
 
-    # NON-VACUITY: a conformance gate that executes nothing must FAIL. This is
-    # the whole defect being closed — do not let it come back as a green zero.
-    if checked == 0:
-        print("FAIL: executed ZERO assertions — this gate would be vacuous")
+    # NON-VACUITY, RATCHETED. A conformance gate that executes nothing must
+    # FAIL — that is the whole defect being closed, and it must not come back
+    # as a green zero.
+    #
+    # But `> 0` is far too weak, and the `ci-checks: emulations` floor does not
+    # cover this either: `emulations` counts EMULATOR ENTRIES, and 23 of them
+    # are assertions that fault and then DECLINE (unmapped memory). So the
+    # executed-assertion count could fall 240 -> 205 while `emulations` stayed
+    # at 263 and both gates passed green. That is this session's own vacuity
+    # class, one level down.
+    #
+    # So the floor lives here, on the number that actually means something,
+    # asserted where it is computed. Raise it when the count rises (adding
+    # fixtures or closing declines is the ratchet direction); a DROP means a
+    # module stopped compiling or an op started declining, and that is a
+    # regression to explain, not a baseline to lower.
+    min_executed = 240
+    if checked < min_executed:
+        print(
+            f"FAIL: only {checked} assertions executed, floor is {min_executed}. "
+            "Something that used to compile-and-run now declines — find which "
+            "and why before touching this number."
+        )
         return 1
     if mismatched:
         print(f"FAIL: {mismatched} assertion(s) disagree with the spec")

--- a/scripts/repro/wast_conformance_928_differential.py
+++ b/scripts/repro/wast_conformance_928_differential.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# ci-status: wired
+# ci-checks: emulations >= 200
+"""RQ-56-CONF (#928) — EXECUTE the `assert_return` values in `tests/wast/`.
+
+# What was wrong
+
+`tests/wast/` carries 381 `assert_return` and 2 `assert_trap` assertions. The
+only CI path over those files (`crates/synth-cli/tests/wast_compile.rs`) asserts
+that `synth compile` exits 0; the expected values are parsed and **discarded**.
+The backend's primary correctness suite therefore graded "did an ELF come out",
+not "is it right" — a codegen change making `i32.rem_s` return the wrong value
+kept it green.
+
+That is the exit-0 vacuity class (#911; the v0.54 `sret_decide` gate that
+printed `MISMATCH <-- BUG` and exited 0) sitting on the CORRECTNESS SUITE
+ITSELF, and it is why three silent miscompiles shipped and were found from
+outside: #929 (thumb-2 mis-places a non-last i64 call argument), #930 and #931
+(a `br` out of a value-producing block loses the value). All three are wrong
+VALUES with exit 0 — invisible to a compile-only run by construction, and caught
+immediately by a run that compares results.
+
+# What this does
+
+For every `assert_return` it can execute: compile the module with synth, run the
+exported function under unicorn, and compare the result against the expected
+literal **written in the .wast** — the spec's own answer, not a second opinion
+from another engine. That is what makes this a conformance check rather than a
+differential.
+
+# Decline honesty
+
+Shapes this cannot execute are COUNTED and NAMED, never skipped silently:
+
+  * `f32`/`f64` arguments or results  -> `float-abi` (VFP arg passing is a
+    separate contract; wrong here would be a false alarm, not a finding)
+  * `i64` values                      -> `i64-pair` (register-pair return needs
+    the r0:r1 convention; enabling it is the natural follow-up and is exactly
+    where #929 lives)
+  * `assert_trap`                     -> `trap` (needs the trap-vector harness)
+  * a module synth declines to compile -> `compile-declined`
+
+The summary prints CHECKED, DECLINED-by-reason and MISMATCHED. A run that
+executes zero assertions FAILS — the whole point is that a green result must
+mean assertions ran.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_HOOK_INTR, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import UC_ARM_REG_LR, UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3, UC_ARM_REG_SP
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SYNTH = os.environ.get("SYNTH", str(ROOT / "target" / "debug" / "synth"))
+WAST_DIR = ROOT / "tests" / "wast"
+
+CODE = 0x1000
+STACK = 0x20000000
+MEM = 0x40000000
+RET = 0x00F0_0000
+
+ARG_REGS = [UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3]
+
+# `(i32.const -5)` / `(i64.const 7)` / `(f32.const 1.5)`
+CONST = re.compile(r"\((i32|i64|f32|f64)\.const\s+([^\s)]+)\)")
+INVOKE = re.compile(r'\(invoke\s+"((?:[^"\\]|\\.)*)"')
+
+
+def sexp_forms(text: str, head: str) -> list[str]:
+    """Every top-level `(head ...)` form, balanced-paren scanned.
+
+    A regex cannot do this: the forms nest. Strings are tracked so a paren
+    inside an export name does not desynchronise the depth count.
+    """
+    out, i, n = [], 0, len(text)
+    needle = "(" + head
+    while True:
+        i = text.find(needle, i)
+        if i < 0:
+            return out
+        depth, j, in_str = 0, i, False
+        while j < n:
+            c = text[j]
+            if in_str:
+                if c == "\\":
+                    j += 2
+                    continue
+                if c == '"':
+                    in_str = False
+            elif c == '"':
+                in_str = True
+            elif c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    out.append(text[i : j + 1])
+                    break
+            j += 1
+        i = j + 1
+
+
+def parse_const(tok_type: str, raw: str) -> int:
+    v = int(raw, 0) if not raw.startswith("-") else -int(raw[1:], 0)
+    bits = 32 if tok_type == "i32" else 64
+    return v & ((1 << bits) - 1)
+
+
+class Decl(Exception):
+    """A shape this harness declines to execute, with a machine reason."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+def compile_module(wat_text: str, tmp: Path) -> tuple[Path, bytes]:
+    src = tmp / "m.wat"
+    src.write_text(wat_text)
+    obj = tmp / "m.o"
+    r = subprocess.run(
+        [SYNTH, "compile", str(src), "-o", str(obj), "--target", "cortex-m4",
+         "--all-exports", "--relocatable"],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0 or not obj.exists():
+        raise Decl("compile-declined")
+    return obj, obj.read_bytes()
+
+
+def symbols(obj: Path) -> dict[str, int]:
+    with obj.open("rb") as fh:
+        elf = ELFFile(fh)
+        # Look up the symbol table by TYPE, never by section name: synth emits a
+        # symtab whose `sh_name` is empty, and a name-based lookup silently finds
+        # nothing (the #850 lesson).
+        st = next(s for s in elf.iter_sections() if s["sh_type"] == "SHT_SYMTAB")
+        return {s.name: s["st_value"] for s in st.iter_symbols() if s.name}
+
+
+def execute(code: bytes, entry: int, args: list[int]) -> int:
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x10_0000)
+    mu.mem_map(STACK - 0x10000, 0x20000)
+    mu.mem_map(MEM, 0x10_0000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_ARM_REG_SP, STACK)
+    mu.reg_write(UC_ARM_REG_LR, RET | 1)
+    for i, a in enumerate(args):
+        if i >= len(ARG_REGS):
+            raise Decl("too-many-args")
+        mu.reg_write(ARG_REGS[i], a & 0xFFFFFFFF)
+    trapped = []
+    mu.hook_add(UC_HOOK_INTR, lambda *_: trapped.append(True))
+    try:
+        mu.emu_start((CODE + entry) | 1, RET, timeout=5_000_000)
+    except UcError as e:
+        raise Decl(f"emu-error:{e}") from e
+    if trapped:
+        raise Decl("trapped")
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF
+
+
+def main() -> int:
+    if not WAST_DIR.is_dir():
+        print(f"FAIL: {WAST_DIR} missing")
+        return 1
+
+    checked = mismatched = 0
+    declined: dict[str, int] = {}
+    failures: list[str] = []
+    files = sorted(WAST_DIR.glob("*.wast"))
+
+    for wast in files:
+        text = wast.read_text()
+        mods = sexp_forms(text, "module")
+        if len(mods) != 1:
+            declined["multi-module"] = declined.get("multi-module", 0) + 1
+            continue
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            try:
+                obj, _ = compile_module(mods[0], tmp)
+                syms = symbols(obj)
+                with obj.open("rb") as fh:
+                    sec = ELFFile(fh).get_section_by_name(".text")
+                    code = sec.data() if sec else b""
+            except (Decl, StopIteration) as e:
+                reason = getattr(e, "reason", "no-symtab")
+                for _ in sexp_forms(text, "assert_return"):
+                    declined[reason] = declined.get(reason, 0) + 1
+                continue
+
+            for form in sexp_forms(text, "assert_return"):
+                m = INVOKE.search(form)
+                if not m:
+                    declined["no-invoke"] = declined.get("no-invoke", 0) + 1
+                    continue
+                fname = m.group(1)
+                consts = CONST.findall(form)
+                if any(t in ("f32", "f64") for t, _ in consts):
+                    declined["float-abi"] = declined.get("float-abi", 0) + 1
+                    continue
+                if any(t == "i64" for t, _ in consts):
+                    declined["i64-pair"] = declined.get("i64-pair", 0) + 1
+                    continue
+                if not consts:
+                    declined["no-values"] = declined.get("no-values", 0) + 1
+                    continue
+                *arg_toks, exp_tok = consts
+                args = [parse_const(t, v) for t, v in arg_toks]
+                expected = parse_const(*exp_tok)
+                entry = syms.get(fname)
+                if entry is None:
+                    declined["symbol-missing"] = declined.get("symbol-missing", 0) + 1
+                    continue
+                try:
+                    actual = execute(code, entry, args)
+                except Decl as e:
+                    declined[e.reason] = declined.get(e.reason, 0) + 1
+                    continue
+                checked += 1
+                if actual != expected:
+                    mismatched += 1
+                    failures.append(
+                        f"{wast.name}: {fname}({', '.join(hex(a) for a in args)}) "
+                        f"= {actual:#x}, spec says {expected:#x}"
+                    )
+
+    for f in failures[:25]:
+        print(f"  MISMATCH {f}")
+    if len(failures) > 25:
+        print(f"  ... and {len(failures) - 25} more")
+
+    total_declined = sum(declined.values())
+    print(
+        f"#928 CHECKS={checked - mismatched}/{checked} executed assertions over "
+        f"{len(files)} wast files; {total_declined} declined"
+    )
+    print("  declined by reason: " + (", ".join(f"{k}={v}" for k, v in sorted(declined.items())) or "none"))
+
+    # NON-VACUITY: a conformance gate that executes nothing must FAIL. This is
+    # the whole defect being closed — do not let it come back as a green zero.
+    if checked == 0:
+        print("FAIL: executed ZERO assertions — this gate would be vacuous")
+        return 1
+    if mismatched:
+        print(f"FAIL: {mismatched} assertion(s) disagree with the spec")
+        return 1
+    print("RESULT: PASS — every executed assertion matches the spec's expected value")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/templates/feature_matrix.md.tmpl
+++ b/scripts/templates/feature_matrix.md.tmpl
@@ -148,7 +148,7 @@ see [coq/STATUS.md](../../coq/STATUS.md) for the per-file matrix.
   the newly wired ones; exactly 8 asserted a printed verdict or count. Every
   `wired` oracle now declares a `# ci-checks:` floor that
   `scripts/oracle_run.py` enforces per run by counting real emulator entries,
-  wasmtime executions and compilations: **136 oracles assert 295,421 emulator
+  wasmtime executions and compilations: **137 oracles assert 295,621 emulator
   entries**, 7 assert a printed count, 9 assert compilations, and 1
   (`aarch64_matrix.sh`, a POSIX shell oracle the in-process driver cannot
   instrument) is itemized as unbindable in `scripts/repro/ORACLE_WIRING.md`

--- a/tests/wast/large_function.wast
+++ b/tests/wast/large_function.wast
@@ -156,7 +156,14 @@
 )
 
 ;; Assertions for large_compute
-(assert_return (invoke "large_compute" (i32.const 1)) (i32.const 287))
+;; #928: this expected 287 and had NEVER been executed — the only CI path over
+;; these files checked that `synth compile` exits 0 and discarded the values.
+;; The first run of the conformance gate disagreed, and wasmtime settles it:
+;;   wasmtime large_compute(1) = 3538945
+;;   synth    large_compute(1) = 3538945   (0x360001)
+;; synth is CORRECT; the hand-written expectation was wrong. Corrected against
+;; wasmtime, which is exactly the class of error an unexecuted assertion hides.
+(assert_return (invoke "large_compute" (i32.const 1)) (i32.const 3538945))
 (assert_return (invoke "large_compute" (i32.const 0)) (i32.const 0))
 
 ;; Assertions for dispatch


### PR DESCRIPTION
Closes #928. The v0.56 centre of gravity — the gate that makes #929/#930/#931 verifiable rather than merely fixed.

## What was wrong

`tests/wast/` carries **381 `assert_return`** and 2 `assert_trap`. **None were checked.** The only CI path over those files asserted `synth compile` exits 0 and discarded the expected values — so the backend's primary correctness suite graded *"did an ELF come out"*, not *"is it right"*.

That is the exit-0 vacuity class (#911; the v0.54 `sret_decide` gate that printed `MISMATCH` and exited 0) sitting on the **correctness suite itself** — and it is why three silent miscompiles shipped and were found from outside.

## What this does

The runner that *can* compare values (`crates/synth-test`) drives **Renode over telnet**, so it cannot run on a stock runner and never has. This uses the mechanism the differentials already use — compile, execute under **unicorn**, compare against the `.wast`'s **own expected literal**. The spec's answer, which is what makes it conformance rather than a second opinion from another engine.

```
#928 CHECKS=240/240 executed assertions over 25 wast files; 141 declined
  declined: i64-pair=118, memory-unmapped=23
RESULT: PASS
```

**From zero executed to 240.** Declines are counted and named, never silent — and the 118 `i64-pair` declines are exactly where #929 lives, so enabling that is the follow-up that would have caught it.

## The first run found a wrong assertion — ours, not synth's

`large_compute(1)`:

| | |
|---|---|
| wasmtime | **3538945** |
| synth | **3538945** ← agree |
| `tests/wast` claimed | **287** ← wrong |

synth is correct; our hand-written expectation had drifted for free because it had never once been executed. Corrected against wasmtime, reasoning recorded in the fixture.

239 of 240 hand-written expectations were right — but **nobody could have known which**.

## Non-vacuity, in two places that cannot go quiet alone

The script **fails on zero executed assertions**, and the CI step independently greps a three-digit `CHECKS` count. A green result must mean assertions ran.

Totals move to **137 oracles / 295,621 entries** on all three pinned surfaces.

*(Caught before push: `printf "%'d"` emitted the European separator, so the docs briefly read `295.621` — and `claim_check` passed 43/43 anyway, because it pins consistency **across** surfaces, not format correctness.)*

fmt 0 · clippy 0 · 134 test suites · claim 43/43 · wiring 161 scripts, 0 UNDECLARED.