### PR TITLE
fix(#929): DECLINE a 64-bit call argument instead of miscompiling it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,16 +1535,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.254.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09480d646178e5fdd12bb06e812d0af9a3a191dbc9cd697fdc86687beade7393"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.254.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.255.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b524283fb5df62eec102ed0574838961bdd7ba5ac9c50d38e2756c51c971a42"
@@ -1582,17 +1572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.254.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
-dependencies = [
- "bitflags",
- "indexmap",
- "semver",
 ]
 
 [[package]]

--- a/crates/synth-cli/tests/i64_call_arg_decline_929.rs
+++ b/crates/synth-cli/tests/i64_call_arg_decline_929.rs
@@ -1,0 +1,144 @@
+//! #929 (CRITICAL) — a 64-bit call argument in a register position must DECLINE,
+//! not miscompile.
+//!
+//! Measured on v0.55.0, executed under qemu against wasmtime:
+//!
+//! ```wat
+//! (func $g (param i64 i32) (result i32) (local.get 1))
+//! (func (export "f") (param i32 i32) (result i32)
+//!   (call $g (i64.const 1234605616436508552) (local.get 0)))
+//! ```
+//!
+//! | | `f(7)` | `f(42)` |
+//! |---|---|---|
+//! | wasmtime | 7 | 42 |
+//! | thumb-2  | **287454020** | **287454020** |
+//!
+//! `287454020` = `0x11223344` = the i64's HIGH half, returned regardless of the
+//! actual argument. `synth compile` exited 0 with no warning.
+//!
+//! # Root cause, and why the refusal covers the whole class
+//!
+//! `emit_arg_moves` maps one argument to one register (`arg_srcs[i]` ->
+//! `ARG_REGS[i]`). AAPCS gives a 64-bit argument an EVEN-ALIGNED register PAIR,
+//! so the high half was never placed and every later argument shifted down.
+//!
+//! Its docstring has always said it cannot do this — *"i64/f64 arguments —
+//! which AAPCS passes in register pairs — are NOT marshalled"* — and it
+//! marshalled them anyway. A documented non-capability with nothing enforcing
+//! it is not a limitation; it is a silent miscompile.
+//!
+//! The refusal covers EVERY i64 register argument, not just the "not last"
+//! shape the issue measured. For `(i32, i64)` AAPCS places the i64 in `r2:r3`
+//! while synth puts its low half in `r1`: that shape looked correct only
+//! because the callee under test returned the i32, so the wrong i64 was never
+//! read. Refusing the class is the honest boundary.
+//!
+//! FOLLOW-UP: real AAPCS pair marshalling. The #928 conformance gate declines
+//! 118 assertions as `i64-pair` — that is precisely this capability, and it is
+//! the acceptance oracle already in place.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn synth() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_synth"))
+}
+
+fn compile(tag: &str, wat: &str) -> (bool, String, String) {
+    let dir = std::env::temp_dir().join(format!("synth-929-{tag}"));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let src = dir.join("m.wat");
+    std::fs::write(&src, wat).expect("write wat");
+    let obj = dir.join("m.o");
+    let out = Command::new(synth())
+        .args([
+            "compile",
+            src.to_str().unwrap(),
+            "-b",
+            "arm",
+            "-t",
+            "cortex-m3",
+            "--all-exports",
+            "--relocatable",
+            "-o",
+            obj.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run synth");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+const I64_FIRST: &str = r#"(module
+  (func $g (param i64 i32) (result i32) (local.get 1))
+  (func (export "f") (param i32 i32) (result i32)
+    (call $g (i64.const 1234605616436508552) (local.get 0))))
+"#;
+
+const I64_LAST: &str = r#"(module
+  (func $g (param i32 i64) (result i32) (local.get 0))
+  (func (export "f") (param i32 i32) (result i32)
+    (call $g (local.get 0) (i64.const 1234605616436508552))))
+"#;
+
+const I32_ONLY: &str = r#"(module
+  (func $g (param i32 i32) (result i32) (local.get 1))
+  (func (export "f") (param i32 i32) (result i32)
+    (call $g (local.get 0) (local.get 1))))
+"#;
+
+/// gale's exact repro: the function must NOT be emitted, and the reason must
+/// name #929. Emitting it at all is the miscompile.
+#[test]
+fn i64_first_argument_is_declined_not_miscompiled() {
+    let (ok, _out, err) = compile("first", I64_FIRST);
+    assert!(ok, "the compile itself should still succeed: {err}");
+    assert!(
+        err.contains("#929"),
+        "the decline must name #929 so a consumer can act on it: {err}"
+    );
+    assert!(
+        err.contains("skipped") && err.contains("'f'")
+            || err.contains("f\n")
+            || err.contains(": f"),
+        "the caller must be OMITTED from the object, not emitted with wrong \
+         argument marshalling: {err}"
+    );
+}
+
+/// The i64-LAST shape is refused too. It is not a regression: AAPCS places that
+/// i64 in r2:r3 while synth put its low half in r1, so the i64 parameter was
+/// already wrong — it merely went unnoticed because the callee returned the
+/// i32. This test exists so that fact is recorded rather than rediscovered.
+#[test]
+fn i64_last_argument_is_also_declined_because_it_was_never_right() {
+    let (ok, _out, err) = compile("last", I64_LAST);
+    assert!(ok, "the compile itself should still succeed: {err}");
+    assert!(
+        err.contains("#929"),
+        "an i64 in ANY register argument position is mis-marshalled and must be \
+         declined; passing here would mean the class is only partly refused: {err}"
+    );
+}
+
+/// NON-VACUITY, and the regression guard: an all-i32 call must still compile
+/// and emit its caller. Without this, a refusal that swallowed every call would
+/// pass the two tests above.
+#[test]
+fn i32_only_call_still_compiles_and_is_emitted() {
+    let (ok, _out, err) = compile("i32", I32_ONLY);
+    assert!(ok, "an all-i32 call must compile: {err}");
+    assert!(
+        !err.contains("#929"),
+        "the #929 refusal must not fire for i32 arguments — that would be a \
+         refusal of everything, which passes the decline tests vacuously: {err}"
+    );
+    assert!(
+        !err.contains("skipped"),
+        "the all-i32 caller must be EMITTED, not skipped: {err}"
+    );
+}

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -9756,6 +9756,43 @@ impl InstructionSelector {
                 }
             }
         }
+        // #929 (CRITICAL): the SAME refusal for REGISTER argument positions,
+        // which had none — so a 64-bit argument was silently marshalled as one
+        // 32-bit register and every later argument shifted down one.
+        //
+        // `emit_arg_moves` has always DOCUMENTED that it cannot do this
+        // ("i64/f64 arguments — which AAPCS passes in register *pairs* — are NOT
+        // marshalled"), and then marshalled them anyway. A documented
+        // non-capability with nothing enforcing it is not a limitation, it is a
+        // silent miscompile: `synth compile` exited 0, no warning, and the
+        // callee received garbage.
+        //
+        // The refusal is for EVERY i64 register argument, not only the
+        // "not last" shape gale measured. AAPCS assigns an i64 an EVEN-ALIGNED
+        // pair, so for `(i32, i64)` the second argument belongs in r2:r3 while
+        // synth places its low half in r1. That shape looked correct only
+        // because the callee under test returned the i32; the i64 parameter was
+        // already wrong. Refusing the whole class is the honest boundary.
+        //
+        // FOLLOW-UP (named, gated): real AAPCS pair marshalling. The #928
+        // conformance gate currently declines 118 assertions as `i64-pair` —
+        // that is exactly this capability, and it is the acceptance oracle
+        // waiting for the implementation.
+        if stack.len() >= n {
+            let base = stack.len() - n;
+            for k in 0..n.min(ARG_REGS.len()) {
+                if stack[base + k].is_i64() {
+                    return Err(synth_core::Error::synthesis(format!(
+                        "#929: call arg {k} is 64-bit and would be passed in a \
+                         register; AAPCS requires an even-aligned register PAIR \
+                         and synth marshals only one 32-bit register per \
+                         argument, so the high half would be dropped and every \
+                         later argument shifted down. Declining rather than \
+                         emitting a silent miscompile"
+                    )));
+                }
+            }
+        }
         let mut srcs: Vec<Reg> = Vec::with_capacity(n);
         for _ in 0..n {
             let r = pop_operand(stack, next_temp, instructions, spill, &[], idx)?;


### PR DESCRIPTION
Closes #929. v0.56 lane `RQ-56-I64CALL`.

## The defect

```
(func $g (param i64 i32) (result i32) (local.get 1))
f(7)  -> wasmtime 7,  thumb-2 287454020
f(42) -> wasmtime 42, thumb-2 287454020   (= 0x11223344, the i64's HIGH half)
```

`emit_arg_moves` maps **one argument to one register**. AAPCS gives a 64-bit argument an **even-aligned pair**, so the high half was never placed and every later argument shifted down.

## The part worth reading

Its docstring has always said it cannot do this:

> *"i64/f64 arguments — which AAPCS passes in register **pairs** — are **NOT marshalled**"*

…and it marshalled them anyway. **A documented non-capability with nothing enforcing it is not a limitation; it's a silent miscompile.** `pop_call_args` already refused this exact shape for *stack* argument positions (#503) — register positions never got the equivalent. This adds it.

## The refusal is wider than the reported shape, deliberately

@avrabe recorded `(i32, i64)` as correct. **It isn't.** AAPCS places that i64 in `r2:r3`; synth puts its low half in `r1`. It looked right only because the callee under test returned the i32, so the wrong i64 was never read.

Refusing every i64 register argument is the honest boundary. Refusing only "i64 not last" would leave an accidental correctness in place to break later.

## Outcome

The caller is **omitted** with a named `#929` diagnostic (`1 of 2 functions were skipped`). No wrong bytes ship; a consumer gets a link error instead of a wrong answer.

## Follow-up, with its oracle already in place

Real AAPCS pair marshalling. The #928 conformance gate declines **118 assertions** as `i64-pair` — that is precisely this capability, waiting to accept the implementation.

## Red-first

Removing the refusal fails both decline tests **while the all-i32 regression guard stays green** — so the refusal is provably not a blanket one.

fmt 0 · clippy 0 · 135 test suites.