### PR TITLE
fix(#931): reconcile RV32 br exit edges onto the block's result register (CRITICAL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/oracle_wiring_check.py --json /tmp/oracle-wiring.json --list \
-            --min-emulation-floor 295684 \
+            --min-emulation-floor 295701 \
             | tee /tmp/oracle-wiring.log
           python3 - <<'PY'
           import json, sys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3303,6 +3303,10 @@ jobs:
         run: |
           ./target/debug/synth compile scripts/repro/if_else_result_343.wat -b riscv --target riscv32imac --relocatable --all-exports -o /tmp/if343.o
           python scripts/oracle_run.py scripts/repro/if_else_result_343_riscv_differential.py /tmp/if343.o
+      - name: RV32 br-with-value exit-edge reconciliation (#931, CRITICAL)
+        run: |
+          ./target/debug/synth compile scripts/repro/rv32_br_value_931.wat -b riscv --target riscv32imac --relocatable --all-exports -o /tmp/br931.o
+          python scripts/oracle_run.py scripts/repro/rv32_br_value_931_differential.py /tmp/br931.o
       - name: RV32 mask/software bounds effective-address oracle (#655)
         run: python scripts/oracle_run.py scripts/repro/mask_bounds_655_riscv_differential.py
       - name: RV32 cmp->select fusion differential (#472)

--- a/claims.yaml
+++ b/claims.yaml
@@ -1133,7 +1133,7 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-ORACLE-CHECK-FLOORS-910-CI
     doc: .github/workflows/ci.yml
-    text: "--min-emulation-floor 295684"
+    text: "--min-emulation-floor 295701"
     evidence:
       - kind: count-min                      # oracle steps routed through the driver
         pattern: 'oracle_run\.py scripts/repro/'

--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -1208,6 +1208,21 @@ struct ControlFrame {
     /// leave the value in the SAME register(s) at the join. Empty for
     /// blocks/loops and for control-flow-only (arity-0) if/else.
     then_results: Vec<VstackVal>,
+    /// #931: for a value-producing `block`, the CANONICAL result register(s)
+    /// this frame's exit edges agree on.
+    ///
+    /// `lower_br` emitted only a `jal` and moved nothing, so the taken edge
+    /// left its value in whatever register computed it while the merge read the
+    /// FALLTHROUGH register — the block yielded the not-taken path's value,
+    /// silently, at exit 0. This is the same reconciliation #343 already does
+    /// for `if`/`else` arms (`then_results` above), which was simply never
+    /// applied to `br` edges.
+    ///
+    /// The FIRST exit edge to carry a value fixes the canonical registers;
+    /// every later edge (including the fallthrough at `end`) `mv`s into them.
+    /// When an edge already computed into the canonical register NO `mv` is
+    /// emitted, so a register-symmetric block stays byte-identical.
+    br_results: Vec<VstackVal>,
     /// #882: true once a `br`/`br_if` handed out this frame's END label as a
     /// branch target. Decides whether code after this frame's `end` is
     /// reachable when the fall-through path died on a `return` (dead-code
@@ -1495,13 +1510,31 @@ impl Selector {
         format!("{}{}", prefix, n)
     }
 
-    /// Registers currently pinned by a live `vstack` value. Every vstack entry
-    /// is a temp register (locals/params are always copied into a fresh temp by
-    /// `lower_local_get`), so this set is exactly the values that must survive
-    /// until they are popped — `alloc_temp` must never hand any of them out.
+    /// Registers currently pinned by a live `vstack` value — exactly the values
+    /// that must survive until they are popped, and which `alloc_temp` must
+    /// never hand out.
+    ///
+    /// Most entries are temps, but NOT all: `lower_local_get` aliases a
+    /// #472-promoted local's callee-saved s-register directly onto the vstack
+    /// (no load, no copy — that aliasing is where the promotion byte win comes
+    /// from). So a vstack register may be a promoted local's, and writing to
+    /// one writes the LOCAL. See `canonicalize_edge_value`.
+    ///
+    /// #931: the open frames' `br_results` are live too. A `br` that carries a
+    /// value out of a block leaves that value in the frame's canonical
+    /// register and then TRUNCATES the vstack (everything after an
+    /// unconditional branch is unreachable), so the register is no longer
+    /// pinned by any vstack entry — yet it must survive all the way to the
+    /// frame's `end` label, where the taken edge lands. Without this the
+    /// fallthrough code would hand the canonical register straight back out as
+    /// scratch and clobber the branch's value.
     fn live_regs(&self) -> Vec<Reg> {
         let mut live = Vec::with_capacity(self.vstack.len() * 2);
-        for v in &self.vstack {
+        let entries = self
+            .vstack
+            .iter()
+            .chain(self.ctrl.iter().flat_map(|f| f.br_results.iter()));
+        for v in entries {
             match v {
                 VstackVal::I32(r) => live.push(*r),
                 VstackVal::I64 { lo, hi } => {
@@ -1999,6 +2032,7 @@ impl Selector {
                     else_label: None,
                     stack_height_at_entry: self.vstack.len(),
                     then_results: Vec::new(),
+                    br_results: Vec::new(),
                     end_referenced: false,
                     then_unreachable: false,
                 });
@@ -2014,6 +2048,7 @@ impl Selector {
                     else_label: None,
                     stack_height_at_entry: self.vstack.len(),
                     then_results: Vec::new(),
+                    br_results: Vec::new(),
                     end_referenced: false,
                     then_unreachable: false,
                 });
@@ -3068,6 +3103,7 @@ impl Selector {
             else_label: Some(else_label),
             stack_height_at_entry: self.vstack.len(),
             then_results: Vec::new(),
+            br_results: Vec::new(),
             end_referenced: false,
             then_unreachable: false,
         });
@@ -3164,6 +3200,31 @@ impl Selector {
                     self.vstack.extend(then_results);
                 }
             }
+            // #931: a value-carrying `br` out of this frame already fixed the
+            // canonical result register(s). The taken edge jumps straight to
+            // `end_label`, so the moves emitted HERE — before the label — sit
+            // on the FALLTHROUGH path only and the branch jumps over them.
+            // That is exactly the #343 else-arm argument, with the br edge
+            // playing the then-arm.
+            if !frame.br_results.is_empty() {
+                let canonical = frame.br_results;
+                let fallthrough = self.vstack.split_off(frame.stack_height_at_entry);
+                if fallthrough.is_empty() {
+                    // The fallthrough path died (a `return`/`unreachable` tail,
+                    // or a block whose body ends in the `br` itself): nothing
+                    // reaches this join except the branch, whose value is
+                    // already in the canonical registers.
+                } else if fallthrough.len() != canonical.len() {
+                    return Err(SelectorError::ControlMismatch(
+                        "br edge and fallthrough disagree on result arity (#931)",
+                    ));
+                } else {
+                    for (dst, src) in canonical.iter().zip(fallthrough.iter()) {
+                        self.reconcile_if_result(*dst, *src)?;
+                    }
+                }
+                self.vstack.extend(canonical);
+            }
             self.out.push(RiscVOp::Label {
                 name: frame.end_label,
             });
@@ -3233,7 +3294,149 @@ impl Selector {
         }
     }
 
+    /// #931: reconcile a value-carrying exit edge with its target frame's
+    /// CANONICAL result register(s), so every edge into a block's `end` label
+    /// leaves the block's result in the SAME place.
+    ///
+    /// Returns the number of values the edge carries (0 = a control-flow-only
+    /// branch, which is left byte-identical).
+    ///
+    /// # Why the arity is the vstack delta
+    ///
+    /// The decoder discards block types (`Block { .. } => WasmOp::Block`), so
+    /// the selector has no declared arity to consult — the #509
+    /// block-arity-threading class. But it does not need one: at the branch,
+    /// the vstack entries ABOVE the target frame's entry checkpoint are exactly
+    /// the values that edge carries. That is the same delta `br_table` already
+    /// uses to detect the value-carrying case, and the same one `#343` uses to
+    /// capture an if-arm's results.
+    ///
+    /// # Which register becomes canonical
+    ///
+    /// The FIRST value-carrying edge fixes it, and — where it safely can — it
+    /// donates its OWN register, so the common single-`br` block emits no move
+    /// at all and register-symmetric code stays byte-identical. It cannot
+    /// donate a **promoted local's** register: the frame's `end` reconciliation
+    /// writes the canonical register on the fallthrough path, which for `br $l
+    /// (local.get $x)` would clobber `$x` itself for every later read. See
+    /// `canonicalize_edge_value`, which copies into a fresh temp instead.
+    fn reconcile_br_edge(&mut self, depth: u32) -> Result<usize, SelectorError> {
+        let ctrl_height = self.ctrl.len();
+        let idx = ctrl_height - 1 - (depth as usize);
+        let entry = self.ctrl[idx].stack_height_at_entry;
+
+        // A branch to a frame entered at (or above) the current height carries
+        // nothing: plain jump, nothing to reconcile.
+        if self.vstack.len() <= entry {
+            return Ok(0);
+        }
+        let carried: Vec<VstackVal> = self.vstack[entry..].to_vec();
+
+        if self.ctrl[idx].br_results.is_empty() {
+            // First value-carrying edge — it defines the canonical registers.
+            let promoted: Vec<Reg> = self.promoted.values().copied().collect();
+            let mut canonical = Vec::with_capacity(carried.len());
+            for v in &carried {
+                canonical.push(self.canonicalize_edge_value(*v, &promoted));
+            }
+            self.ctrl[idx].br_results = canonical;
+        } else {
+            // A later edge into the same frame: move into the registers the
+            // first edge fixed. Arity disagreement between edges is either
+            // invalid wasm or a shape this single-pass selector cannot thread —
+            // LOUD-DECLINE rather than emit a half-reconciled join.
+            let canonical = self.ctrl[idx].br_results.clone();
+            if canonical.len() != carried.len() {
+                return Err(SelectorError::ControlMismatch(
+                    "br edges disagree on result arity (#931)",
+                ));
+            }
+            for (dst, src) in canonical.iter().zip(carried.iter()) {
+                self.reconcile_if_result(*dst, *src)?;
+            }
+        }
+        Ok(carried.len())
+    }
+
+    /// Pick the canonical register for one result position of a `br` edge,
+    /// emitting a copy only when the edge's own register cannot be donated.
+    ///
+    /// # Status: a COUPLING guard, unreachable today
+    ///
+    /// `lower_local_get` aliases a #472-promoted local's s-register straight
+    /// onto the vstack, so a vstack value CAN be a live local rather than a
+    /// temp. That aliasing is justified there by "any op consuming this value
+    /// allocates a fresh dst, so the s-reg is never clobbered by a consumer" —
+    /// an argument that does not cover a `br` edge, which is a consumer that
+    /// WRITES BACK into its operand at the frame's `end`.
+    ///
+    /// What makes it unreachable is a rule in a different pass:
+    /// `compute_local_promotion` requires `all_depth0`, and a `br` exists only
+    /// at depth >= 1, so no promoted local's register can reach a branch edge.
+    /// Nothing tied those two facts together, so this guard keeps the
+    /// soundness local instead of borrowing it from another pass's eligibility
+    /// rule; `promotion_stays_depth0_or_931_guard_goes_live` pins the coupling
+    /// so relaxing `all_depth0` reports here rather than silently miscompiling.
+    fn canonicalize_edge_value(&mut self, v: VstackVal, promoted: &[Reg]) -> VstackVal {
+        match v {
+            VstackVal::I32(r) if !promoted.contains(&r) => VstackVal::I32(r),
+            VstackVal::I64 { lo, hi } if !promoted.contains(&lo) && !promoted.contains(&hi) => {
+                VstackVal::I64 { lo, hi }
+            }
+            VstackVal::I32(r) => {
+                let c = self.alloc_temp_avoiding(&[r]);
+                self.out.push(RiscVOp::Addi {
+                    rd: c,
+                    rs1: r,
+                    imm: 0,
+                });
+                VstackVal::I32(c)
+            }
+            VstackVal::I64 { lo, hi } => {
+                let cl = self.alloc_temp_avoiding(&[lo, hi]);
+                let ch = self.alloc_temp_avoiding(&[lo, hi, cl]);
+                self.out.push(RiscVOp::Addi {
+                    rd: cl,
+                    rs1: lo,
+                    imm: 0,
+                });
+                self.out.push(RiscVOp::Addi {
+                    rd: ch,
+                    rs1: hi,
+                    imm: 0,
+                });
+                VstackVal::I64 { lo: cl, hi: ch }
+            }
+        }
+    }
+
     fn lower_br(&mut self, depth: u32, _op: &WasmOp) -> Result<(), SelectorError> {
+        let ctrl_height = self.ctrl.len();
+        if (depth as usize) >= ctrl_height {
+            return Err(SelectorError::BrOutOfRange {
+                depth,
+                height: ctrl_height,
+            });
+        }
+        let carried = self.reconcile_br_edge(depth)?;
+        if carried > 0 {
+            // #931: everything between here and the next label is unreachable
+            // (wasm makes the tail of a block stack-polymorphic after an
+            // unconditional branch), and the carried values now live in the
+            // frame's canonical registers — which `live_regs` keeps reserved.
+            // Truncating to the target's checkpoint is what makes the
+            // fallthrough's own results identifiable at `end`: WITHOUT it the
+            // branch value stays on the vstack, the fallthrough `li` allocates
+            // a DIFFERENT register to avoid it, and the merge reads that one.
+            // That stale entry is the #931 miscompile.
+            //
+            // Only the innermost frame's floor may be lowered this way; a `br`
+            // to an OUTER frame must leave the frames between intact, since
+            // each still owes its own `end` a `split_off` at its checkpoint.
+            let entry = self.ctrl[ctrl_height - 1 - (depth as usize)].stack_height_at_entry;
+            let floor = entry.max(self.ctrl[ctrl_height - 1].stack_height_at_entry);
+            self.vstack.truncate(floor);
+        }
         let target_label = self.target_label_for_depth(depth)?;
         self.out.push(RiscVOp::Jal {
             rd: Reg::ZERO,
@@ -3244,6 +3447,18 @@ impl Selector {
 
     fn lower_br_if(&mut self, depth: u32, op: &WasmOp) -> Result<(), SelectorError> {
         let cond = self.pop_i32(op)?;
+        let ctrl_height = self.ctrl.len();
+        if (depth as usize) >= ctrl_height {
+            return Err(SelectorError::BrOutOfRange {
+                depth,
+                height: ctrl_height,
+            });
+        }
+        // #931: reconcile BEFORE the branch, so the canonical register holds
+        // the value on the taken edge. Unlike `br` the vstack is NOT truncated
+        // — `br_if` leaves its operand in place for the not-taken path, which
+        // keeps running with the value on the stack.
+        self.reconcile_br_edge(depth)?;
         let target_label = self.target_label_for_depth(depth)?;
         // bne cond, zero, target — branch when condition is true (non-zero)
         self.out.push(RiscVOp::Branch {
@@ -9425,6 +9640,50 @@ mod tests {
         assert!(
             !writes_reg(&on, Reg::S8),
             "losing local 1 must be excluded by the subset probe (s8): {on:?}"
+        );
+    }
+
+    /// #931: pins the COUPLING that keeps `canonicalize_edge_value`'s
+    /// promoted-local guard unreachable.
+    ///
+    /// A `br` edge donates its value's register to the target frame as the
+    /// canonical result register, and the frame's `end` WRITES that register on
+    /// the fallthrough path. `lower_local_get` aliases a promoted local's
+    /// s-register directly onto the vstack, so if a promoted local's register
+    /// could ever reach a `br` edge, that write would clobber the LOCAL — every
+    /// later read of it returning the fallthrough value.
+    ///
+    /// It cannot today for exactly one reason: promotion requires `all_depth0`
+    /// and a `br` exists only at depth >= 1. That is a fact about a DIFFERENT
+    /// pass, so relaxing `all_depth0` (promoting locals whose accesses sit
+    /// inside control flow) makes the #931 guard load-bearing. If this test
+    /// fails, do not just re-baseline it: verify `canonicalize_edge_value` now
+    /// fires, and add an execution vector to
+    /// `rv32_br_value_931_differential.py` (`promoted`) that reaches it.
+    #[test]
+    fn promotion_stays_depth0_or_931_guard_goes_live() {
+        use std::collections::HashSet;
+        let no_i64 = HashSet::new();
+        // A local read inside a block, feeding a `br` out of it — the exact
+        // shape that would hand a promoted s-register to a branch edge.
+        let inside_block = [
+            WasmOp::LocalGet(0),
+            WasmOp::LocalSet(1),
+            WasmOp::Block,
+            WasmOp::LocalGet(1),
+            WasmOp::Br(0),
+            WasmOp::I32Const(0),
+            WasmOp::End,
+            WasmOp::LocalGet(1),
+            WasmOp::I32Add,
+            WasmOp::End,
+        ];
+        assert!(
+            compute_local_promotion(&inside_block, 1, &no_i64)
+                .0
+                .is_empty(),
+            "a local touched at depth > 0 must NOT promote — the #931 br-edge \
+             canonical-register guard relies on it (see the doc comment)"
         );
     }
 

--- a/crates/synth-backend-riscv/src/selector.rs
+++ b/crates/synth-backend-riscv/src/selector.rs
@@ -5963,6 +5963,70 @@ mod tests {
         }
     }
 
+    /// #931: the arity of a `br` edge is inferred as the vstack delta above the
+    /// target frame's checkpoint (the decoder discards block types — #509). That
+    /// OVER-COUNTS when unrelated values sit on the stack below the branch's own
+    /// value, which wasm permits: `br` is stack-polymorphic and discards the
+    /// excess.
+    ///
+    /// Where the over-count is harmless it must still compile — a value-carrying
+    /// `br` to the INNERMOST frame, where the extra values are all above the
+    /// same checkpoint and the branch is the block's last act, so nothing falls
+    /// through to disagree with.
+    #[test]
+    fn br_value_931_junk_below_the_value_still_compiles() {
+        // (block (result i32) (i32.const 9) (br 0 (i32.const 42)))
+        let ops = [
+            WasmOp::Block,
+            WasmOp::I32Const(9), // junk the br must discard
+            WasmOp::I32Const(42),
+            WasmOp::Br(0),
+            WasmOp::End,
+            WasmOp::End,
+        ];
+        assert!(
+            select(&ops, 1).is_ok(),
+            "a value-carrying br with junk below it must still compile"
+        );
+    }
+
+    /// #931: where the over-count is NOT harmless it must LOUD-DECLINE.
+    ///
+    /// `(block $a (result i32) (block $b (i32.const 9) (br $a (i32.const 42)))
+    /// (i32.const 7))` — the branch leaves the INNER frame, so `$a`'s edge is
+    /// credited with 2 values (the junk `9` and the real `42`) while `$a`'s
+    /// fallthrough produces 1. The counts disagree, and without a declared arity
+    /// there is no way to tell which position is the result.
+    ///
+    /// **This shape COMPILED on v0.55 and returned the wrong answer** — measured
+    /// 0, wasmtime says 42. So this is a reach reduction with intent: a module
+    /// that used to build now fails, loudly, instead of building and lying.
+    /// Threading real block arities (#509) is what would let it compile.
+    #[test]
+    fn br_value_931_cross_frame_junk_loud_declines() {
+        let ops = [
+            WasmOp::Block, // $a (result i32)
+            WasmOp::Block, // $b
+            WasmOp::I32Const(9),
+            WasmOp::I32Const(42),
+            WasmOp::Br(1), // -> $a, carrying 42 (and miscounting the 9)
+            WasmOp::End,   // end $b
+            WasmOp::I32Const(7),
+            WasmOp::End, // end $a
+            WasmOp::End,
+        ];
+        match select(&ops, 1) {
+            Ok(_) => panic!(
+                "a cross-frame br whose carried-value count cannot be trusted \
+                 must decline, not silently pick a register"
+            ),
+            Err(err) => assert!(
+                matches!(err, SelectorError::ControlMismatch(m) if m.contains("#931")),
+                "must surface as the #931 arity ControlMismatch, got: {err:?}"
+            ),
+        }
+    }
+
     /// #882: a br_table depth past the control-stack height is invalid wasm —
     /// surface `BrOutOfRange`, mirroring `br`.
     #[test]

--- a/scripts/repro/rv32_br_value_931.wat
+++ b/scripts/repro/rv32_br_value_931.wat
@@ -1,0 +1,136 @@
+(module
+  (memory 1)
+
+  ;; ── #931 as filed ────────────────────────────────────────────────────────
+  ;; `br` out of a value-producing `block`. The branch computed its value into
+  ;; one register and jumped to the merge; the merge read the FALLTHROUGH
+  ;; register, so the block yielded the not-taken path's value. Exit 0, silent.
+  ;;   simple() = 1     (pre-fix: 0)
+  (func (export "simple") (result i32)
+    (block $exit (result i32)
+      (br $exit (i32.const 1))
+      (i32.const 0)))
+
+  ;; The same shape with a computed (not constant) branch value, so the two
+  ;; edges land in registers that differ for a reason other than allocation
+  ;; order.
+  ;;   computed(n) = n + 10
+  (func (export "computed") (param i32) (result i32)
+    (block $exit (result i32)
+      (br $exit (i32.add (local.get 0) (i32.const 10)))
+      (i32.const 0)))
+
+  ;; ── The canonical-register hazard the fix must NOT introduce ─────────────
+  ;; `br $l (local.get $x)` donates the value's register to the frame as its
+  ;; canonical result register, and the frame's `end` writes that register on
+  ;; the fallthrough path. If the donated register is a PROMOTED local's
+  ;; (#472 local promotion is default-on for RV32), that write clobbers `$x`
+  ;; itself — and every later read of `$x` returns the fallthrough value.
+  ;;
+  ;; `$x` must be read enough times for promotion to repay the callee-saved
+  ;; prologue (5 reads did not — verify with `llvm-objdump` that `$x` has no
+  ;; `lw ..(sp)`), and read AFTER the block so a clobber is observable rather
+  ;; than dead.
+  ;;   promoted() = 7 * 13 = 91   (a clobber shows up as 0: the fallthrough
+  ;;   writes 0 into $x's register, so the block result AND every later read
+  ;;   of $x become 0)
+  (func (export "promoted") (result i32)
+    (local $x i32)
+    (local.set $x (i32.const 7))
+    (block $l (result i32) (br $l (local.get $x)) (i32.const 0))
+    (local.get $x) (i32.add)
+    (local.get $x) (i32.add)
+    (local.get $x) (i32.add)
+    (local.get $x) (i32.add)
+    (local.get $x) (i32.add)
+    (local.get $x) (i32.add)
+    (local.get $x) (i32.add)
+    (local.get $x) (i32.add)
+    (local.get $x) (i32.add)
+    (local.get $x) (i32.add)
+    (local.get $x) (i32.add)
+    (local.get $x) (i32.add))
+
+  ;; ── br_if: the value must reach the merge on the TAKEN edge, and the
+  ;; not-taken path must keep running with the value still on the stack ─────
+  ;;   brif(nonzero) = 11     (taken — the br_if's value)
+  ;;   brif(0)       = 22     (not taken — falls through to the tail)
+  (func (export "brif") (param i32) (result i32)
+    (block $exit (result i32)
+      (drop (br_if $exit (i32.const 11) (local.get 0)))
+      (i32.const 22)))
+
+  ;; ── Two value-carrying edges into ONE frame ──────────────────────────────
+  ;; The first edge fixes the canonical registers; the second must MOVE into
+  ;; them rather than leave its value where it computed it.
+  ;;   two_edges(0) = 100 | two_edges(1) = 200 | two_edges(other) = 300
+  (func (export "two_edges") (param i32) (result i32)
+    (block $exit (result i32)
+      (block $b
+        (br_if $b (local.get 0))
+        (br $exit (i32.const 100)))
+      (if (i32.eq (local.get 0) (i32.const 1))
+        (then (br $exit (i32.const 200))))
+      (i32.const 300)))
+
+  ;; ── i64 result: BOTH halves must be reconciled ───────────────────────────
+  ;; A dropped hi-move corrupts the top 32 bits rather than hiding behind a
+  ;; zero high half, so both halves are nonzero and differ between the edges.
+  ;;   br64() = 0x0000_0009_0000_0005
+  (func (export "br64") (result i64)
+    (block $exit (result i64)
+      (br $exit (i64.add (i64.const 0x900000004) (i64.const 1)))
+      (i64.const 0x100000002)))
+
+  ;; ── A value live ACROSS the block ────────────────────────────────────────
+  ;; `5` is pushed before the block and consumed after `end`. The truncation
+  ;; the fix performs at the `br` must lower the vstack to the frame's OWN
+  ;; checkpoint and no further — dropping the carried `5` would corrupt the
+  ;; surrounding expression instead of the block's result.
+  ;;   carried() = 5 + 1 = 6
+  (func (export "carried") (result i32)
+    (i32.const 5)
+    (block $exit (result i32)
+      (br $exit (i32.const 1))
+      (i32.const 0))
+    (i32.add))
+
+  ;; ── Control-flow-only `br` (arity 0) ─────────────────────────────────────
+  ;; Carries nothing, so the fix must leave it byte-identical and working.
+  ;;   cfonly(nonzero) = 1 | cfonly(0) = 2
+  (func (export "cfonly") (param i32) (result i32)
+    (local $r i32)
+    (local.set $r (i32.const 2))
+    (block $exit
+      (br_if $exit (i32.eqz (local.get 0)))
+      (local.set $r (i32.const 1)))
+    (local.get $r))
+
+  ;; ── #930's shape, on RV32 ────────────────────────────────────────────────
+  ;; A `br_if` out of an enclosing block from inside an `if`, whose VALUE
+  ;; operand is itself a block that branches. Filed against thumb-2; RV32
+  ;; happened to compile it correctly (both edges landed in the same register),
+  ;; so this pins that it stays correct rather than staying lucky.
+  ;;   nested() = 1
+  (func (export "nested") (result i32)
+    (block $l0 (result i32)
+      (if (i32.const 1)
+        (then
+          (drop
+            (br_if $l0
+              (block $l1 (result i32) (br $l1 (i32.const 1)))
+              (i32.const 1)))))
+      (i32.const 0)))
+
+  ;; ── `br 1`: a value-carrying branch to an OUTER frame ────────────────────
+  ;; The truncation may only lower the vstack to the INNERMOST open frame's
+  ;; checkpoint — each frame in between still owes its own `end` a split at
+  ;; its own checkpoint.
+  ;;   outer(nonzero) = 42 | outer(0) = 7
+  (func (export "outer") (param i32) (result i32)
+    (block $a (result i32)
+      (block $b
+        (br_if $b (i32.eqz (local.get 0)))
+        (br $a (i32.const 42)))
+      (i32.const 7)))
+)

--- a/scripts/repro/rv32_br_value_931_differential.py
+++ b/scripts/repro/rv32_br_value_931_differential.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ci-status: wired
-# ci-checks: emulations >= 16
+# ci-checks: emulations >= 17
 """#931 (CRITICAL) — RV32 `br` out of a value-producing `block` discarded its value.
 
 The RV32 selector lowered `br` as a bare `jal` and moved nothing. `br` also does
@@ -141,18 +141,31 @@ def main():
         return lo, ""
 
     fails = 0
+    executed = 0
     for name, args in VECTORS:
         gt = wt(name, args)
         res, err = run(name, args)
         ok = res == gt
         fails += 0 if ok else 1
+        executed += 1 if res is not None else 0
         shown = f"0x{res:08x}={res}" if res is not None else f"ERR({err})"
         shown_args = ", ".join(str(a) for a in args)
         print(f"{name}({shown_args}) = {shown}  wasmtime=0x{gt:08x}={gt}  {'OK' if ok else 'FAIL'}")
 
-    # NON-VACUITY: every vector must have executed. A missing symbol or a
-    # selector decline would otherwise reduce this oracle to a green zero.
-    print(f"\n#931 EMULATIONS={len(VECTORS)}")
+    # NON-VACUITY, ASSERTED — not printed.
+    #
+    # `len(VECTORS)` is a constant, so printing it proves nothing; `executed` is
+    # what a decline or a missing symbol would reduce. Counting the RUNS is the
+    # point: a vector whose function got skipped raises `symbol missing` and is
+    # a FAIL above, but a future edit that filters vectors instead would sail
+    # through a gate that only reported a constant.
+    print(f"\n#931 EMULATIONS={executed}/{len(VECTORS)}")
+    if executed != len(VECTORS):
+        print(
+            f"FAIL: only {executed} of {len(VECTORS)} vectors reached the "
+            "emulator — a function was skipped or declined."
+        )
+        sys.exit(1)
     print(
         "RISC-V br-value #931 ORACLE: PASS"
         if not fails

--- a/scripts/repro/rv32_br_value_931_differential.py
+++ b/scripts/repro/rv32_br_value_931_differential.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# ci-status: wired
+# ci-checks: emulations >= 16
+"""#931 (CRITICAL) — RV32 `br` out of a value-producing `block` discarded its value.
+
+The RV32 selector lowered `br` as a bare `jal` and moved nothing. `br` also does
+not pop, so the branch's value stayed on the vstack; the fallthrough expression
+then allocated a DIFFERENT register to avoid the live one, and the merge read
+that one. The block therefore yielded the not-taken path's value. Measured on
+v0.55.0 for `(block $exit (result i32) (br $exit (i32.const 1)) (i32.const 0))`:
+
+      0: li  t0, 0x1     ; br $exit's value -> t0
+      4: j   0xc         ; br $exit -> merge
+      8: li  t1, 0x0     ; fallthrough value -> t1
+      c: mv  a0, t1      ; merge reads t1, NOT t0
+     10: ret
+
+`synth compile` exits 0 with no warning. This is the most basic form of
+structured control flow with a value, so the blast radius covers `block`,
+`switch`-style dispatch, and label shadowing alike (8 `labels.wast` assertions).
+
+The fix reconciles every exit edge onto the frame's canonical result register —
+the same join #343 already performed for `if`/`else` arms, never applied to `br`
+edges. This oracle EXECUTES each export under unicorn (UC_ARCH_RISCV /
+UC_MODE_RISCV32, ILP32) and compares against wasmtime, so it grades the value
+the hardware would actually return rather than the shape of the disassembly.
+
+Symbols come from the ELF `.symtab` (SHT_SYMTAB), not `synth disasm` text: the
+disassembler is host-dependent and its rendering is not a reliable symbol
+source.
+
+Run:
+  synth compile scripts/repro/rv32_br_value_931.wat -b riscv \
+        --target riscv32imac --relocatable --all-exports -o /tmp/br931.o
+  /tmp/synthvenv/bin/python \
+        scripts/repro/rv32_br_value_931_differential.py /tmp/br931.o
+"""
+
+import sys
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_RISCV, UC_MODE_RISCV32, Uc, UcError
+from unicorn.riscv_const import (
+    UC_RISCV_REG_A0,
+    UC_RISCV_REG_A1,
+    UC_RISCV_REG_RA,
+    UC_RISCV_REG_S11,
+    UC_RISCV_REG_SP,
+)
+
+WAT = "scripts/repro/rv32_br_value_931.wat"
+ELF = sys.argv[1] if len(sys.argv) > 1 else "/tmp/br931.o"
+
+CODE, LIN, RET = 0x100000, 0x40000, 0x200000
+
+# Functions returning i64 hand the result back in the a0:a1 pair (lo:hi) per
+# RV32 ILP32; the harness reads both halves and compares masked to 64 bits.
+I64_FUNCS = {"br64"}
+
+# (export, args). Every value-carrying shape is exercised on BOTH the branch
+# edge and the fallthrough edge where it has one — a fix that reconciled only
+# one direction would pass a single-edge vector.
+VECTORS = [
+    # The issue as filed: pre-fix returns 0.
+    ("simple", ()),
+    # Computed branch value — the edges differ for a reason other than
+    # allocation order.
+    ("computed", (0,)),
+    ("computed", (32,)),
+    # The canonical-register hazard: a promoted local donating its register
+    # would be clobbered by the fallthrough reconciliation (35 -> 28).
+    ("promoted", ()),
+    # br_if, both edges.
+    ("brif", (1,)),
+    ("brif", (0,)),
+    ("brif", (99,)),
+    # Two value-carrying edges into one frame + its fallthrough.
+    ("two_edges", (0,)),
+    ("two_edges", (1,)),
+    ("two_edges", (5,)),
+    # i64 — a dropped hi-move corrupts the top 32 bits.
+    ("br64", ()),
+    # A value live across the block: over-truncating at the `br` would eat it.
+    ("carried", ()),
+    # Arity-0 `br` must keep working (and stay byte-identical).
+    ("cfonly", (1,)),
+    ("cfonly", (0,)),
+    # #930's shape on RV32 — correct today by luck; pin it.
+    ("nested", ()),
+    # Value-carrying `br 1` to an OUTER frame, both edges.
+    ("outer", (1,)),
+    ("outer", (0,)),
+]
+
+
+def symbols(path):
+    with open(path, "rb") as fh:
+        f = ELFFile(fh)
+        st = f.get_section_by_name(".symtab")
+        syms = {}
+        for s in st.iter_symbols():
+            if s.name and s["st_info"]["type"] == "STT_FUNC":
+                syms[s.name] = s["st_value"]
+        return syms, f.get_section_by_name(".text").data()
+
+
+def main():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, WAT)
+
+    def wt(name, args):
+        store = wasmtime.Store(engine)
+        inst = wasmtime.Instance(store, module, [])
+        mask = 0xFFFFFFFFFFFFFFFF if name in I64_FUNCS else 0xFFFFFFFF
+        return inst.exports(store)[name](store, *args) & mask
+
+    syms, code = symbols(ELF)
+
+    def run(name, args):
+        addr = syms.get(name)
+        if addr is None:
+            return None, f"symbol {name} missing (function skipped?)"
+        mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+        for base, size in [(CODE, 0x20000), (LIN, 0x20000), (0x88000, 0x10000), (RET, 0x1000)]:
+            mu.mem_map(base, size)
+        mu.mem_write(CODE, code)
+        mu.reg_write(UC_RISCV_REG_SP, 0x90000)
+        mu.reg_write(UC_RISCV_REG_S11, LIN)
+        for i, a in enumerate(args):
+            mu.reg_write(UC_RISCV_REG_A0 + i, a & 0xFFFFFFFF)
+        mu.reg_write(UC_RISCV_REG_RA, RET)
+        try:
+            mu.emu_start(CODE + addr, RET, count=4000)
+        except UcError as e:
+            return None, str(e)
+        lo = mu.reg_read(UC_RISCV_REG_A0) & 0xFFFFFFFF
+        if name in I64_FUNCS:
+            hi = mu.reg_read(UC_RISCV_REG_A1) & 0xFFFFFFFF
+            return lo | (hi << 32), ""
+        return lo, ""
+
+    fails = 0
+    for name, args in VECTORS:
+        gt = wt(name, args)
+        res, err = run(name, args)
+        ok = res == gt
+        fails += 0 if ok else 1
+        shown = f"0x{res:08x}={res}" if res is not None else f"ERR({err})"
+        shown_args = ", ".join(str(a) for a in args)
+        print(f"{name}({shown_args}) = {shown}  wasmtime=0x{gt:08x}={gt}  {'OK' if ok else 'FAIL'}")
+
+    # NON-VACUITY: every vector must have executed. A missing symbol or a
+    # selector decline would otherwise reduce this oracle to a green zero.
+    print(f"\n#931 EMULATIONS={len(VECTORS)}")
+    print(
+        "RISC-V br-value #931 ORACLE: PASS"
+        if not fails
+        else f"RISC-V br-value #931 ORACLE: FAIL ({fails})"
+    )
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The bug

`br` out of a value-producing `block` **discarded its value** on RV32. The branch
computed into one register; the merge read a different one — the *fallthrough*
register. So the block yielded the **not-taken path's** value. `synth compile`
exited 0 with no warning.

```wat
(block $exit (result i32) (br $exit (i32.const 1)) (i32.const 0))
```
wasmtime → `1`.  RV32 → `0`.

This is the most basic form of structured control flow carrying a value, so the
blast radius covers `block`, switch-style dispatch and label shadowing alike
(8 `labels.wast` assertions). Found by executing the official testsuite (#928).

## Root cause

`lower_br` emitted a bare `jal` and moved nothing — and `br` does not pop. The
branch's value stayed on the vstack, so the fallthrough expression allocated a
**different** register to avoid the live one, and the merge read that one. The
stale vstack entry *is* the miscompile.

`#343` already built this exact join for `if`/`else` arms (`then_results` /
`reconcile_if_result`). It was simply never applied to `br` edges. `br_table`'s
own doc comment records that "plain `Br`/`BrIf` share the underlying
limitation" — `br_table` LOUD-DECLINES it, `br` shipped silent.

## Fix

Every exit edge reconciles onto the frame's canonical result registers
(`ControlFrame::br_results`), and `lower_br` truncates the vstack to the
target's checkpoint so the fallthrough's own results are identifiable at `end`.

The fallthrough's moves are emitted **before** `end_label`, so they sit on the
fallthrough path only and the taken edge jumps over them — the same argument
#343 relies on. The first edge donates its own register where it safely can, so
the common single-`br` block emits **no move at all**.

Arity is the vstack delta above the frame checkpoint, so no block-type threading
(#509) is needed — the same delta `br_table` already uses. Edges that disagree
on arity LOUD-DECLINE rather than emit a half-reconciled join.

`live_regs` now also reserves open frames' `br_results`: after truncation the
canonical register is pinned by no vstack entry, and the fallthrough would
otherwise hand it straight back out as scratch.

## Evidence — red-first, executed

`scripts/repro/rv32_br_value_931_differential.py`, CI-wired: 17 vectors run
under unicorn (RV32 ILP32) and compared against **wasmtime**.

| | result |
|---|---|
| pre-fix | **9/17 FAIL** |
| post-fix | **17/17 PASS** |

Pre-fix failures are not all obvious: `br64` returned `0x900000004` instead of
`0x900000005` (subtly wrong i64, not visibly broken), `carried` returned 1
instead of 6, `outer` returned 0 instead of 42.

Vectors cover **both** edges of each shape — a fix that reconciled only one
direction would pass a single-edge vector: `br_if` taken/not-taken, two
value-carrying edges into one frame, i64 (both halves), a value live *across*
the block, arity-0 `br`, `br 1` to an outer frame, and #930's nested shape
(correct on RV32 today by luck — pinned so it stays correct rather than lucky).

- Frozen anchors **10/10 byte-identical** (`--test frozen_codegen_bytes`)
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0, 0 diagnostics
- `cargo test -p synth-backend-riscv` → **257 passed, 0 failed**

## Two doc-vs-source defects found in the touched code

1. `live_regs` claimed "locals/params are always copied into a fresh temp by
   `lower_local_get`". **False** — `lower_local_get` aliases a #472-promoted
   local's s-register *directly* onto the vstack. Corrected.

2. That aliasing is justified by "any op consuming this value allocates a fresh
   dst, so the s-reg is never clobbered by a consumer" — an argument that does
   **not** cover a `br` edge, which writes *back* into its operand at `end`.
   Donating a promoted local's register would clobber the local itself.

   What blocks it today is a rule in a **different pass**: promotion requires
   `all_depth0`, and `br` exists only at depth ≥ 1.
   `canonicalize_edge_value` guards it locally rather than borrowing soundness
   from that rule, and `promotion_stays_depth0_or_931_guard_goes_live` pins the
   coupling so relaxing `all_depth0` reports here instead of silently
   miscompiling.

## Not in scope

**#930 (the thumb-2 sibling) is not fixed here.** ARM has two codegen paths
(`select_default` vs `select_with_stack`, and `--relocatable` forces the direct
selector), so it needs its own red-first measurement to establish *which* path
is wrong. Separate PR — bundling it would make any frozen-byte movement
ambiguous to bisect.

Refs #931, #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L