### PR TITLE
fix(#924): Version Pin Sweep now covers all four release surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,30 @@ jobs:
       # v0.7.0-class desync that breaks release.yml + publish at tag-push time.
       - name: Check intra-workspace version pins
         run: python3 scripts/check_version_pins.py
+      - uses: dtolnay/rust-toolchain@stable
+      # #924: the OTHER lockfile failure. `check_version_pins.py` above asserts
+      # every workspace member is in Cargo.lock at the workspace version — that
+      # catches a lock left BEHIND at the previous release. It does not catch a
+      # lock whose versions are all correct but which is stale in a different
+      # way: a dependabot manifest bump that orphans a transitive entry.
+      #
+      # That one is not theoretical. `main` was red on VCR-VER-004 from
+      # 3eec0d37 (wit-component 0.254->0.255) until 2026-08-12, because an
+      # orphaned `wasm-encoder 0.254.0` entry meant the first cargo invocation
+      # in any job regenerated the lock and its `git diff --exit-code` cleanup
+      # assert failed. The oracle in that job PASSED; only the tree-restore
+      # check went red, in a job with nothing to do with dependencies.
+      #
+      # `--locked` is the direct check: it fails if the lock would need
+      # updating. Usable here because every path dep is intra-workspace — a
+      # repo with sibling-repo path deps has inherent lock churn and cannot
+      # use it. `cargo metadata` resolves without compiling, so this is fast.
+      - name: Cargo.lock is consistent with the manifests (#924)
+        run: |
+          cargo metadata --locked --format-version 1 > /dev/null || {
+            echo "::error::Cargo.lock is stale. Run 'cargo metadata' and commit the result."
+            exit 1
+          }
 
   claim-check:
     name: Claim Check

--- a/scripts/check_version_pins.py
+++ b/scripts/check_version_pins.py
@@ -82,22 +82,111 @@ def check_module_bazel(root: Path, expected: str) -> list[str]:
     return []
 
 
+def workspace_members(root: Path) -> list[str]:
+    """Crate names from `[workspace] members` — the set `Cargo.lock` must carry."""
+    members: list[str] = []
+    in_members = False
+    for line in (root / "Cargo.toml").read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("members"):
+            in_members = True
+            continue
+        if in_members:
+            if stripped.startswith("]"):
+                break
+            m = re.match(r'"crates/([^"]+)"', stripped)
+            if m:
+                members.append(m.group(1))
+    return members
+
+
+def check_cargo_lock(root: Path, expected: str) -> list[str]:
+    """#924: every workspace member must appear in `Cargo.lock` at `expected`.
+
+    This surface had NO gate. The only `--locked` anywhere in `ci.yml` is
+    `cargo install --locked kani-verifier` — installing a tool, not verifying
+    this lockfile — so a lock left at the previous version builds and tests
+    green all the way to a tag. Measured twice by hand and never by a gate: the
+    v0.52 cold review, and again during v0.55 assembly where the lock held ZERO
+    `0.55.0` entries after the bump.
+    """
+    lock = root / "Cargo.lock"
+    if not lock.exists():
+        return [f"Cargo.lock missing at {lock}"]
+    text = lock.read_text()
+    # `name = "x"` followed within the same [[package]] block by `version = "y"`.
+    versions: dict[str, str] = {}
+    name: str | None = None
+    for line in text.splitlines():
+        s = line.strip()
+        if s == "[[package]]":
+            name = None
+        elif s.startswith("name = "):
+            q = re.match(r'name\s*=\s*"([^"]+)"', s)
+            name = q.group(1) if q else None
+        elif s.startswith("version = ") and name is not None:
+            q = VERSION_RE.match(s)
+            if q:
+                versions[name] = q.group(1)
+                name = None
+    errors: list[str] = []
+    for member in workspace_members(root):
+        got = versions.get(member)
+        if got is None:
+            errors.append(f"Cargo.lock: workspace member `{member}` has no entry")
+        elif got != expected:
+            errors.append(
+                f'Cargo.lock: `{member}` locked at "{got}" but workspace is "{expected}"'
+            )
+    return errors
+
+
+def check_npm_package(root: Path, expected: str) -> list[str]:
+    """#924: `npm/package.json` version must equal the workspace version.
+
+    The npm wrapper is a published release surface; nothing gated it.
+    """
+    pkg = root / "npm" / "package.json"
+    if not pkg.exists():
+        return []
+    for n, line in enumerate(pkg.read_text().splitlines(), 1):
+        m = re.match(r'\s*"version"\s*:\s*"([^"]+)"', line)
+        if m:
+            if m.group(1) != expected:
+                return [
+                    f'npm/package.json:{n}: version "{m.group(1)}" '
+                    f'but workspace is "{expected}"'
+                ]
+            return []
+    return ["npm/package.json: no `version` key found"]
+
+
 def main() -> int:
     root = Path(__file__).resolve().parent.parent
     expected = workspace_version(root)
-    errors = check_path_dep_pins(root, expected) + check_module_bazel(root, expected)
+    errors = (
+        check_path_dep_pins(root, expected)
+        + check_module_bazel(root, expected)
+        + check_cargo_lock(root, expected)
+        + check_npm_package(root, expected)
+    )
     if errors:
-        print(f"Version-pin desync (workspace = {expected}) — issue #145:\n")
+        print(f"Version-pin desync (workspace = {expected}) — issues #145/#924:\n")
         for e in errors:
             print(f"  {e}")
         print(
-            "\nBump every intra-workspace path-dep `version =` pin + MODULE.bazel "
-            "in lockstep with [workspace.package].version before tagging.\n"
-            "Helper: scripts/check_version_pins.py is the gate; the sweep itself "
-            "is a one-liner perl over Cargo.toml + MODULE.bazel."
+            "\nBump every release surface in lockstep with "
+            "[workspace.package].version before tagging:\n"
+            "  1. intra-workspace path-dep `version =` pins (crates/*/Cargo.toml)\n"
+            "  2. MODULE.bazel `module(version = ...)`\n"
+            "  3. Cargo.lock          — regenerate with `cargo metadata`\n"
+            "  4. npm/package.json\n"
         )
         return 1
-    print(f"OK: all intra-workspace pins + MODULE.bazel at {expected}")
+    print(
+        f"OK: path-dep pins + MODULE.bazel + Cargo.lock + npm/package.json "
+        f"all at {expected}"
+    )
     return 0
 
 


### PR DESCRIPTION
`Version Pin Sweep` is one of the nine **required** contexts, so a reviewer
seeing it green reasonably concludes the release's versions are consistent. It
checked **two of the four** surfaces a release bump touches — the gate-potency
shape where a check is potent for what it covers and its *name* overstates the
coverage.

| surface | before | after |
|---|---|---|
| path-dep `version =` pins | ✅ | ✅ |
| `MODULE.bazel` | ✅ | ✅ |
| **`Cargo.lock`** | ❌ | ✅ |
| **`npm/package.json`** | ❌ | ✅ |

`Cargo.lock` had no backstop of any kind. The only `--locked` in the workflow
is `cargo install --locked kani-verifier` — installing a tool, saying nothing
about this lockfile — so a lock left at the previous version builds and tests
green all the way to a tag. Caught **by hand twice** (v0.52 cold review; v0.55
assembly, where the lock held zero `0.55.0` entries after the bump) and never
by a gate.

## Negative-controlled, per the issue's own step 2

A gate added without this is only *presumed* potent. Each leg was mutated, and
the mutation asserted to have applied before the run:

| mutation | result |
|---|---|
| lock entry `synth-cli` `0.55.0` → `0.54.0` | **RC=1** — `locked at "0.54.0" but workspace is "0.55.0"` |
| `npm/package.json` `0.55.0` → `0.54.0` | **RC=1** — `npm/package.json:3: version "0.54.0" …` |
| whole `synth-backend-aarch64` block removed from the lock | **RC=1** — `workspace member … has no entry` |
| unmutated tree | **RC=0** |

The third leg is not redundant: "member missing entirely" is a different
failure from "member at the wrong version", and a check written only against
the second passes over it.

## Plus the *other* lockfile failure, which none of the above catches

A lock can have every version correct and still be stale — a dependabot
manifest bump that **orphans a transitive entry**.

`main` was red on **VCR-VER-004** from `3eec0d37` (wit-component 0.254→0.255)
until today for exactly that: an orphaned `wasm-encoder 0.254.0` entry meant
the first cargo invocation in any job regenerated the lock, and that job's
`git diff --exit-code` cleanup assert failed. The oracle inside it **passed** —
only the tree-restore check went red, in a job with nothing to do with
dependencies. It cost three branches a rebase today (#947/#943/#942), and the
symptom points at the wrong thing twice: wrong job, and "the mutation
persisted" rather than "the lock moved".

`cargo metadata --locked` is the direct check, verified both ways:

```
main's pre-fix lock (orphan present)  ->  RC=101, "cannot update the lock file"
the fixed lock                        ->  RC=0
```

Usable here **only because every path dep is intra-workspace** — a repo with
sibling-repo path deps has inherent lock churn and cannot use `--locked`. I
checked that before wiring it. `cargo metadata` resolves without compiling, so
the step stays fast on the light runner.

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L