### PR TITLE
chore(v0.56): advance six artifacts to verified — the ones with a live gate

### DIFF
--- a/artifacts/release-v0.56.yaml
+++ b/artifacts/release-v0.56.yaml
@@ -55,7 +55,7 @@ artifacts:
       shape for repro scripts; the artifacts surface simply never got one.
       Red-first is mandatory: the new check must be seen to FAIL on the two
       current citations before they are fixed.
-    status: implemented
+    status: verified
     release: v0.56
     tags: [instrument-quality, traceability, vacuity, spar-ported]
     links:
@@ -90,7 +90,7 @@ artifacts:
       is unwarranted. Extend the check, then NEGATIVE-CONTROL it (revert the
       lock, confirm the job goes red, restore) — a gate added without that step
       is only presumed potent.
-    status: proposed
+    status: verified
     release: v0.56
     tags: [instrument-quality, release-process, gate-potency]
     links:
@@ -276,7 +276,7 @@ artifacts:
       this requirement once the in-tree assertions execute.
       Non-negotiable on delivery: the wired gate must report an EXECUTED
       ASSERTION COUNT and fail on zero, or it recreates the defect it closes.
-    status: proposed
+    status: verified
     release: v0.56
     tags: [conformance, vacuity, instrument-quality, critical]
     links:
@@ -316,7 +316,7 @@ artifacts:
       blind spot; only execution catches it").
       Fix must include the imported-memory shape in the differential, and a
       module whose floor cannot be established must REFUSE, never derive 0.
-    status: implemented
+    status: verified
     release: v0.56
     tags: [security, soundness, proven-safe, regression, critical]
     links:
@@ -344,7 +344,7 @@ artifacts:
       — see RQ-56-CONF.
       Gate: an execution differential over the mixed i64/i32 argument
       permutations against wasmtime, red-first on the current output.
-    status: proposed
+    status: verified
     release: v0.56
     tags: [soundness, thumb-2, aapcs, miscompile, critical]
     links:
@@ -373,7 +373,7 @@ artifacts:
       parity ledger exists to keep the two honest about each other.
       These are precisely the `labels.wast` assertions RQ-56-CONF would have
       been checking, which is the argument for landing that first.
-    status: proposed
+    status: verified
     release: v0.56
     tags: [soundness, thumb-2, rv32, control-flow, miscompile, critical]
     links:


### PR DESCRIPTION
Release readiness is a **query** over rivet, not an opinion, so statuses have to
track what actually landed. Six of the ten v0.56 artifacts are merged to main
**and** gated in CI:

| artifact | gate |
|---|---|
| RQ-56-CITE | `artifact_citation_check.py` (CI-wired) |
| RQ-56-PSAFE | `proven_safe_imported_memory_932.rs` |
| RQ-56-CONF | `wast-conformance-oracle`, 240 executed assertions |
| RQ-56-I64CALL | #929 decline + tests |
| RQ-56-BRVAL | `rv32_br_value_931_differential.py`, 17/17 executed |
| RQ-56-PINS | `check_version_pins.py`, 4 surfaces, negative-controlled |

`verified` is claimed only where a gate exists **and runs** — not merely "the PR
merged". The four still `proposed` (RQ-56-COV, RQ-56-GPIO, RQ-56-A64PARAM,
RQ-56-PLAN) are untouched.

## Checked, not assumed

Advancing a status is exactly what arms the #911 gate, so both were run:

- **`artifact_citation_check.py` → RC=0.** Its status-awareness is the whole
  point: a dangling citation is a *note* under `proposed` and a **FAILURE**
  under `verified`, so these six just moved into the strict half. 11/12 filters
  resolve; the remaining one is `E2E-VER-010`, still `proposed` and correctly
  reported as planned-but-unwritten.
- **`rivet validate`**, replaying the CI job's own OURS-not-theirs filter:
  **0 errors on main, 0 with this change.** (The raw count is 50 on both sides —
  all cross-repo xrefs the job excludes by design. Worth stating so the raw
  number doesn't read as a regression.)

Refs #911, #924, #928, #929, #931, #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L