### PR TITLE
chore(release): v0.56.0 — The factory, not the instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,131 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.56.0] - 2026-08-12
+
+**The factory, not the instances.** Two silent miscompiles closed, and — the
+theme — the *checkers* that should have caught them made potent. Most of this
+release is gates: several were passing over nothing, one covered half of what
+its name claimed, and one told users the opposite of the truth. The recurring
+finding of the last four releases is that defects concentrate in checkers
+rather than checked code, so this release went at the checkers deliberately.
+
+### Fixed
+
+- **RV32 `br` out of a value-producing `block` discarded its value (#931,
+  CRITICAL).** The branch computed its value into one register and the merge
+  read a different one — the *fallthrough* register — so the block yielded the
+  not-taken path's value. `synth compile` exited 0 with no warning. This is the
+  most basic form of structured control flow carrying a value, so the blast
+  radius covered `block`, switch-style dispatch and label shadowing alike (8
+  `labels.wast` assertions).
+
+  ```wat
+  (block $exit (result i32) (br $exit (i32.const 1)) (i32.const 0))
+  ```
+  wasmtime → `1`. RV32 → `0`.
+
+  Root cause: `lower_br` emitted a bare `jal` and moved nothing — and `br` does
+  not pop, so the branch's value stayed on the vstack, the fallthrough
+  expression allocated a *different* register to avoid the live one, and the
+  merge read that one. The stale vstack entry **was** the miscompile.
+
+  `#343` already built this exact join for `if`/`else` arms; it was simply never
+  applied to `br` edges. `br_table`'s own doc comment even recorded that "plain
+  `Br`/`BrIf` share the underlying limitation" — `br_table` loud-declines it,
+  `br` shipped silent.
+
+  Every exit edge now reconciles onto the frame's canonical result registers,
+  with the fallthrough's moves emitted *before* the end label so the taken edge
+  jumps over them. Arity comes from the vstack delta above the frame
+  checkpoint, so no block-type threading (#509) is needed. Where that delta
+  over-counts across frames the selector LOUD-DECLINES rather than pick a
+  register — a **reach reduction with intent**, replacing a silent wrong answer
+  (measured 0 where wasmtime says 42) with a compile error.
+
+  Gated by `rv32_br_value_931_differential.py`: 17 vectors executed under
+  unicorn against wasmtime, **9/17 failing before the fix, 17/17 after**.
+
+- **A 64-bit call argument is now DECLINED instead of miscompiled (#929).**
+
+- **`--proven-safe` could elide bounds guards against a floor it invented
+  (#932, SECURITY).** For a module whose memory is IMPORTED, the derived floor
+  was `0`, because imported memories live in `imports`, not `memories`. The
+  fail-closed contract inverted: the honest document was rejected while the
+  vacuous one stripped real guards, and synth reported proving accesses
+  in-bounds "against the 0 B floor" — self-refuting, since no access is in
+  bounds of a zero-byte memory.
+
+### Changed — gates that now do what their names say
+
+- **The official wast assertions are EXECUTED, not discarded (#928).** The
+  suite graded "did an ELF come out". It now compiles each module, runs it
+  under unicorn, and compares against the `.wast`'s own expected literal —
+  **240 executed assertions over 25 files**. The floor is asserted on the number
+  that means something (`checked`), not on emulator entries: 23 of the 263
+  entries are assertions that fault and then decline, so an `emulations` floor
+  alone would let the executed count fall 240 → 205 and stay green.
+
+- **`Version Pin Sweep` now covers all four release surfaces (#924).** It is one
+  of the nine *required* contexts, so green reads as "the release's versions are
+  consistent" — and it checked two of four. `Cargo.lock` had no backstop of any
+  kind; the only `--locked` in the workflow installs a tool. Caught by hand
+  twice (v0.52 cold review, v0.55 assembly) and never by a gate. Each new leg is
+  negative-controlled, including the case a naive check misses: a member missing
+  from the lock *entirely*, which is a different failure from one at the wrong
+  version. A `cargo metadata --locked` step additionally catches the orphaned-
+  transitive-entry class, which had left `main` red on an unrelated job since
+  the wit-component bump.
+
+- **An artifact cannot claim a test that does not exist (#911).** Shipped
+  unfixed in v0.55; the class is now checked, status-aware — a dangling citation
+  is a note under `proposed` and a failure under `verified`.
+
+- **`codecov/patch` is explicitly informational, with a threshold someone chose
+  (#923).** There was no `codecov.yml` at all, so it ran on defaults nobody
+  picked and failed on essentially every PR. The measurement that preceded it
+  refuted its own premise: differential-asserted files read *higher* (86.2 %)
+  than unit-only ones (83.4 %), and the largest genuine gap turned out to be
+  `synth-verify/src/arm_semantics.rs` (2481 lines, 47.4 %) — not the backend the
+  hypothesis pointed at. `project` at 80 % blocks; `patch` posts but does not
+  pretend to gate.
+
+- **A Bazel step that reported a silent pass now says what it did (#945).** The
+  Renode wast matrix selects **zero** tests, and `|| [ $? -eq 4 ]` was reporting
+  that as green.
+
+### Documentation — claims corrected against measured behaviour
+
+A two-scanner sweep over ~930 claims found **30 genuine disagreements** (#946),
+with both scanners instructed to report the disagreement and never rule on
+which side was right. That framing was load-bearing: of the resolved items the
+answer differed every time, and one scanner *premise* was itself false.
+
+- **`--volatile-segment` is not free.** It was documented as inert plumbing;
+  measured **36 B → 74 B**. With the CSE levers already off the flag changes
+  nothing (98 B either way), which pins the delta as exactly the intended
+  back-off. Most stale docs understate what ships and cost nothing; this one
+  told users a flag that doubles code size was free.
+- **The VCVT precondition now names its guarantor.** "The selector guarantees
+  `dm` is a dead temp" is true of `select_with_stack` — the one the compiler
+  actually uses — and not of `select_default`. The claim "never S0" was removed:
+  it is false (`vcvt.s32.f64 s0, d0` on a three-line module) *and* unnecessary,
+  since `S(2m)` is always `dm`'s own dead half.
+
+  Both belong to a class worth naming: **a soundness argument that is locally
+  true and cites the wrong reason.** Both halves read correct, so neither a
+  prose-vs-prose check nor a doc-vs-source diff finds them — only writing a new
+  consumer does.
+
+### Deferred to v0.57 — logged, not silent
+
+`RQ-56-GPIO` (#846, changes shipping bytes for a 4-byte win), `RQ-56-A64PARAM`
+(#851, aarch64 param homing), and a newly-created `RQ-57-I32CONST` (#933, a Rocq
+*contract* change across 9 `.v` files under the "never weaken a theorem to force
+a Qed" gate). #933 had no rivet artifact at all, and an untriaged issue is
+invisible to the plan.
+
+
 ## [0.55.0] - 2026-08-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,14 +1111,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1178,11 +1178,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.55.0"
+version = "0.56.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1238,14 +1238,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1253,11 +1253,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.55.0"
+version = "0.56.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.55.0"
+version = "0.56.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.55.0"
+version = "0.56.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.55.0",
+    version = "0.56.0",
 )
 
 # Bazel dependencies

--- a/artifacts/status.json
+++ b/artifacts/status.json
@@ -21,7 +21,7 @@
   "sel_dsl_rule_qed": 50,
   "sel_dsl_rules": 50,
   "sel_rules_simplified_basis": 50,
-  "version": "0.55.0",
+  "version": "0.56.0",
   "verus_spec_fns": 8,
   "wasmcert_bridge_qed": 104
 }

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.55.0" }
+synth-core = { path = "../synth-core", version = "0.56.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.55.0" }
+synth-core = { path = "../synth-core", version = "0.56.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.55.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.55.0" }
+synth-core = { path = "../synth-core", version = "0.56.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.56.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
@@ -21,4 +21,4 @@ tracing.workspace = true
 proptest.workspace = true
 # VCR-SEL-005 (#851): the cross-backend op-parity oracle probes the AArch64
 # selector as the THIRD backend (tests/cross_backend_op_parity.rs only).
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.55.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.56.0" }

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.55.0" }
+synth-core = { path = "../synth-core", version = "0.56.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.55.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.55.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.56.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.56.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.55.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.56.0", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -58,23 +58,23 @@ exports_only_275_probe = []
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.55.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.55.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.55.0" }
-synth-backend = { path = "../synth-backend", version = "0.55.0" }
+synth-core = { path = "../synth-core", version = "0.56.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.56.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.56.0" }
+synth-backend = { path = "../synth-backend", version = "0.56.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.55.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.56.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.55.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.55.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.55.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.56.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.56.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.56.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.55.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.56.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.55.0" }
+synth-core = { path = "../synth-core", version = "0.56.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.55.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.56.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.55.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.55.0" }
-synth-opt = { path = "../synth-opt", version = "0.55.0" }
+synth-core = { path = "../synth-core", version = "0.56.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.56.0" }
+synth-opt = { path = "../synth-opt", version = "0.56.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.55.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.55.0" }
-synth-opt = { path = "../synth-opt", version = "0.55.0" }
+synth-core = { path = "../synth-core", version = "0.56.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.56.0" }
+synth-opt = { path = "../synth-opt", version = "0.56.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.55.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.56.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -7,7 +7,7 @@
 > stale. All numbers come from [`artifacts/status.json`](../../artifacts/status.json),
 > which is re-derived from source on every run — never hand-edited.
 
-**Workspace version:** 0.55.0
+**Workspace version:** 0.56.0
 
 ---
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"


### PR DESCRIPTION
Release assembly for **v0.56.0**. No behaviour changes here — version bump,
regenerated docs, CHANGELOG.

## The four release surfaces, checked by the gate this release shipped

```
OK: path-dep pins + MODULE.bazel + Cargo.lock + npm/package.json all at 0.56.0
```

That is #924 verifying its own release. Before this release the sweep covered
**two** of those four, and `Cargo.lock` had no backstop of any kind — it was
caught by hand in the v0.52 cold review and again during v0.55 assembly, never
by a gate.

Regenerated, never hand-edited: `artifacts/status.json` and
`docs/status/FEATURE_MATRIX.md` via `claim_check.py --emit-status`;
`Cargo.lock` via `cargo metadata`.

## Gates on this branch, each read as a real exit code

| gate | result |
|---|---|
| `cargo test --workspace` | **2742 passed / 0 failed** across 135 suites |
| `frozen_codegen_bytes` | **10/10** bit-identical |
| `clippy -D warnings` | exit 0, **0 diagnostics** |
| `claim_check` | 43/43 claims hold |
| `check_version_pins` | 0 |
| `oracle_wiring_check` | 0 (`--min-emulation-floor 295701`) |
| `artifact_citation_check` | 0 |
| `model_coverage_audit` | 0 |
| `repo_metadata_check` | 0 |

The test count is stated because an exit code alone cannot tell a green suite
from a suite that ran nothing — `cargo test --workspace <no-match>` exits 0 over
zero tests, which has bitten this project before.

## CHANGELOG claims re-derived on this tree

v0.55's residual was a document asserting things that did not exist, so every
number in the new section was re-measured **after** the rebase rather than
copied from the lane that produced it:

```
#931 EMULATIONS=17/17            RISC-V br-value #931 ORACLE: PASS
#928 CHECKS=240/240 executed assertions over 25 wast files
vcvt.s32.f64 s0, d0              (the "never S0" counterexample, 1 match)
```

## Scope

Nine lanes merged. Three deferred to v0.57 with reasons recorded in rivet
(#846 shipping-byte optimization, #851 aarch64 param homing, #933 a Rocq
contract change) — deferral is a logged decision, not silence.

**Review note:** this was self-reviewed, not cold-reviewed. v0.55 shipped #911
unfixed for exactly that reason, so it is worth naming rather than leaving
implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L