### PR TITLE
plan(v0.57): three issues were invisible to the plan — #935, #936, #944

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.56.1] - 2026-08-13
+
+Security patch. One fix.
+
+### Fixed
+
+- **rv32: a module declaring `(memory 0)` got a 65532-byte bounds guard (#953,
+  SECURITY).** `--safety-bounds software` is the mode whose entire purpose is to
+  make every out-of-bounds access trap. A zero-page module got a bound baked at
+  **65532** — byte-for-byte the guard of a 1-page module — so every address in
+  `0..=65532` passed the check and the access was performed against a memory with
+  no bytes. Reads **and** writes.
+
+  ```
+  lui  t1, 0x10          ; 65536
+  addi t1, t1, -0x4      ; 65532   <- bound for a ZERO-byte memory
+  bltu t1, t0, ...       ; trap only if 65532 < addr
+  ```
+
+  Root cause: `0` used as both a value and a sentinel.
+  `config.linear_memory_bytes == 0` meant "unset — a hand-built driver with no
+  module context, fall back to 1 page" **and** is exactly what `(memory 0)`
+  produces. The two were indistinguishable, so the fallback invented a bound for
+  a module that declared none.
+
+  This is the same defect as #932 — fixed in v0.56.0 — running the other way:
+  there `unwrap_or(0)` turned "no floor establishable" into "the floor is 0
+  bytes" and *stripped* guards; here `0` meant "unset" and *invented* one.
+
+  The fallback is deleted. `linear_memory_bytes` is now the size, full stop —
+  `0` means zero bytes, and a caller with no module context states the size.
+  That was measured rather than assumed: removing it broke exactly one test, and
+  the bytes it rejected contained `ebreak` — rv32 already folds to an
+  unconditional trap at size 0, which is correct and is what **aarch64** does
+  (`brk #0`). ARM was never affected; it derives its bound from a runtime
+  register with an underflow check. **rv32 was the anomaly**, which is what makes
+  this a fallback to delete rather than a design gap to fill.
+
+  Gated by `rv32_zero_memory_953_differential.py` (CI-wired): 9 vectors across
+  load/store/load8, asserting synth traps **iff** wasmtime traps, observed as a
+  real `ebreak` intercept rather than a wrong return value. **6/9 failed before
+  the fix, 9/9 pass after**; the three `65536` vectors trapped beforehand too and
+  are the non-vacuity control.
+
+  Reported by gale 30 minutes after v0.56.0 published.
+
+
 ## [0.56.0] - 2026-08-12
 
 **The factory, not the instances.** Two silent miscompiles closed, and — the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,14 +1111,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1178,11 +1178,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.56.0"
+version = "0.56.1"
 
 [[package]]
 name = "synth-cli"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1238,14 +1238,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1253,11 +1253,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.56.0"
+version = "0.56.1"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.56.0"
+version = "0.56.1"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.56.0"
+version = "0.56.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.56.0",
+    version = "0.56.1",
 )
 
 # Bazel dependencies

--- a/artifacts/release-v0.57.yaml
+++ b/artifacts/release-v0.57.yaml
@@ -310,6 +310,111 @@ artifacts:
       verification-track: static-analysis
       issue: "#946"
 
+  - id: RQ-57-RULEINV
+    type: system-req
+    title: "synth verify must report DECLINED rules, not only verified ones"
+    description: >
+      #935, and it belongs in Tier 1 because it is the release theme almost
+      verbatim: synth knows it applied and declined a rule, and does not say so,
+      so a consumer cannot compute a coverage denominator from its output.
+      Measured by gale on a small dissolved object: `Verification summary: 8
+      verified, 0 failed, 0 unknown` reads as complete. It is not — the same
+      object contains 29 `i32.const`, which BIN-VERIFY classes as a register
+      operation and skips WITHOUT REPORTING. A reader concludes "8 of 8"; the
+      truth is "8 of 8 computational rules, plus an unreported const rule whose
+      Rocq theorem is Admitted" (#933).
+      So #935 and #933 compound: #933 is the hole, #935 is what makes the hole
+      invisible. Fixing only #933 leaves a consumer unable to see the next one;
+      fixing only #935 makes an honest report of a gap that is still open. They
+      should land together, and #935 is the cheaper half.
+      DELIVERABLE: the full rule inventory — applied / verified /
+      declined-with-reason — so the denominator is computable. Same discipline
+      as the WCET decline reasons (#921/#922), which turned an opaque
+      `unmodeled-op` into an actionable `{op, offset}` and is the proof this
+      shape works.
+      NON-VACUITY: the summary line must report a denominator that includes
+      declines, and a fixture with a known decline must show it.
+    status: proposed
+    release: v0.57
+    tags: [honesty, verification, reporting, consumer-reported]
+    links:
+      - type: derives-from
+        target: BR-001
+      - type: refines
+        target: NFR-002
+    fields:
+      req-type: functional
+      priority: must
+      verification-track: unit-test
+      issue: "#935"
+
+  - id: RQ-57-WCET2OPS
+    type: system-req
+    title: "Two opcodes account for ALL 9 wcet unmodeled-op declines (+11 cascades)"
+    description: >
+      #936, the payoff of #921/#922 shipping in v0.55. gale re-ran `--emit-wcet`
+      over a whole dissolved `gust:os` composite (31 functions) on 0.55.0 and the
+      9 previously-opaque `unmodeled-op` declines resolve to exactly TWO
+      opcodes: `I64Const` (6 functions) and `I64Str` (3), with byte offsets.
+      Before #922 the only way to learn that was to hand-bisect a 31-function
+      object; afterwards it took one run.
+      That makes this a very small ask with a measured payoff: modelling two
+      opcodes clears 9 direct declines and 11 cascades behind them — 20
+      functions moving from "no bound" to bounded on a real OS composite.
+      Include it BECAUSE the number is known. This is the shape release-planning
+      asks for — an optimization with a measured benefit and a constraint it
+      must not violate (the WCET bound stays SOUND; a bound that is merely
+      tighter and wrong is a regression).
+      NON-VACUITY: carries a before/after count of bounded functions on the same
+      object, or it is not done.
+    status: proposed
+    release: v0.57
+    tags: [wcet, capability, measured, gale-driver]
+    links:
+      - type: derives-from
+        target: BR-001
+      - type: refines
+        target: NFR-002
+    fields:
+      req-type: functional
+      priority: should
+      verification-track: execution-differential
+      issue: "#936"
+
+  - id: RQ-57-PROVGAP
+    type: system-req
+    title: "9 object branches with no WASM origin — obligations nothing can discharge"
+    description: >
+      #944. Running the first WASM->object disposition on a VERIFIED isolation
+      module (gale's `switch-thin`, an ARINC-653 partition-switch FSM) surfaced
+      object branches that `synth-provenance-v1` does not account for: 98
+      branches, 56 no-provenance, **9 only-in-synth** — including
+      `cabi_realloc`, `tick`, and `run_switch`.
+      An object branch with no WASM origin is an object-code coverage obligation
+      that nothing can discharge: the downstream tool cannot decide whether it is
+      justified-infeasible or genuinely uncovered, so it stands forever.
+      On-theme in the same way as the rest of Tier 1 — synth emitted those
+      branches and knows why (they are expansion-internal or ABI-shim control
+      flow), and the provenance record does not say so.
+      TRIAGE FIRST, and this is why it is `could` rather than `must`: the 9 need
+      classifying before any schema change. If they are all compiler-introduced
+      (realloc shims, expansion-internal guards) the fix may be a provenance
+      RECORD KIND for compiler-origin branches rather than new WASM mapping —
+      cheaper and more honest than pretending a WASM origin exists.
+    status: proposed
+    release: v0.57
+    tags: [provenance, traceability, consumer-reported]
+    links:
+      - type: derives-from
+        target: BR-001
+      - type: refines
+        target: NFR-002
+    fields:
+      req-type: functional
+      priority: could
+      verification-track: static-analysis
+      issue: "#944"
+
   # ---------------------------------------------------------------------------
   # TIER 2 — capability and optimization, carried from v0.56 with reasons logged
   # ---------------------------------------------------------------------------

--- a/artifacts/status.json
+++ b/artifacts/status.json
@@ -21,7 +21,7 @@
   "sel_dsl_rule_qed": 50,
   "sel_dsl_rules": 50,
   "sel_rules_simplified_basis": 50,
-  "version": "0.56.0",
+  "version": "0.56.1",
   "verus_spec_fns": 8,
   "wasmcert_bridge_qed": 104
 }

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.56.0" }
+synth-core = { path = "../synth-core", version = "0.56.1" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.56.0" }
+synth-core = { path = "../synth-core", version = "0.56.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.56.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.56.0" }
+synth-core = { path = "../synth-core", version = "0.56.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.56.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
@@ -21,4 +21,4 @@ tracing.workspace = true
 proptest.workspace = true
 # VCR-SEL-005 (#851): the cross-backend op-parity oracle probes the AArch64
 # selector as the THIRD backend (tests/cross_backend_op_parity.rs only).
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.56.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.56.1" }

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.56.0" }
+synth-core = { path = "../synth-core", version = "0.56.1" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.56.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.56.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.56.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.56.1", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.56.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.56.1", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -58,23 +58,23 @@ exports_only_275_probe = []
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.56.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.56.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.56.0" }
-synth-backend = { path = "../synth-backend", version = "0.56.0" }
+synth-core = { path = "../synth-core", version = "0.56.1" }
+synth-frontend = { path = "../synth-frontend", version = "0.56.1" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.56.1" }
+synth-backend = { path = "../synth-backend", version = "0.56.1" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.56.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.56.1" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.56.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.56.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.56.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.56.1", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.56.1", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.56.1", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.56.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.56.1", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.56.0" }
+synth-core = { path = "../synth-core", version = "0.56.1" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.56.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.56.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.56.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.56.0" }
-synth-opt = { path = "../synth-opt", version = "0.56.0" }
+synth-core = { path = "../synth-core", version = "0.56.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.56.1" }
+synth-opt = { path = "../synth-opt", version = "0.56.1" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.56.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.56.0" }
-synth-opt = { path = "../synth-opt", version = "0.56.0" }
+synth-core = { path = "../synth-core", version = "0.56.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.56.1" }
+synth-opt = { path = "../synth-opt", version = "0.56.1" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.56.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.56.1", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -7,7 +7,7 @@
 > stale. All numbers come from [`artifacts/status.json`](../../artifacts/status.json),
 > which is re-derived from source on every run — never hand-edited.
 
-**Workspace version:** 0.56.0
+**Workspace version:** 0.56.1
 
 ---
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.56.0",
+  "version": "0.56.1",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"


### PR DESCRIPTION
Board audit found the anti-pattern I wrote *into* this plan two commits ago —
*"an untriaged issue is invisible to the release plan and resurfaces as a
release-time surprise."* Three open issues had no artifact, so the v0.57 scope I
had just landed had a hole in it.

## #935 belongs in Tier 1 — it is the theme almost verbatim

`synth verify` reports verified rules and never the ones it applied and
**declined**, so a consumer cannot compute a coverage denominator.

```
Verification summary: 8 verified, 0 failed, 0 unknown
```

reads as complete. The same object contains **29 `i32.const`**, which BIN-VERIFY
skips as a register operation *without reporting*. "8 of 8" is really "8 of 8
computational rules, plus an unreported const rule whose Rocq theorem is
Admitted" — which is #933.

**#933 is the hole; #935 is what makes it invisible.** Fixing only #933 leaves a
consumer unable to see the next one; fixing only #935 honestly reports a gap
that's still open. They land together, and #935 is the cheaper half. Precedent
that the shape works: #921/#922 turned an opaque `unmodeled-op` into an
actionable `{op, offset}`.

## #936 — the number is already known

gale re-ran `--emit-wcet` on a whole `gust:os` composite (31 functions) on
0.55.0: all 9 `unmodeled-op` declines resolve to **two opcodes** — `I64Const`
(6) and `I64Str` (3) — plus 11 cascades. Modelling two opcodes moves **20
functions** from "no bound" to bounded on a real OS composite.

Included *because* the number is known: a measured benefit with a constraint it
must not violate (the bound stays **sound** — tighter and wrong is a regression).

## #944 — triage-first, deliberately `could`

98 branches on a verified isolation module: 56 no-provenance, **9 only-in-synth**
(`cabi_realloc`, `tick`, `run_switch`). An object branch with no WASM origin is a
coverage obligation nothing can discharge.

Scoped `could` because those 9 need **classifying** before any schema change — if
they're all compiler-introduced (realloc shims, expansion-internal guards), the
right fix is a provenance *record kind* for compiler-origin branches, not
pretending a WASM origin exists. Deciding that **is** the work.

rivet OURS-errors 0 · claim_check 43/43 · citation check 0.

Refs #935, #936, #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L