### PR TITLE
RQ-57-SENTINEL: sentinel/value-collision sweep — 54 sites, 4 converted, 3 latent defects fixed

### DIFF
--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -410,11 +410,35 @@ fn compile_wasm_to_arm(
             // linear-memory size is a power of two. With a non-power-of-two
             // size the AND would silently REMAP in-bounds addresses (e.g.
             // 0x18000 & 0x2FFFF = 0x8000 for a 192 KiB memory). Decline
-            // loudly rather than miscompile. `linear_memory_bytes == 0`
-            // means "unknown" (plain per-function path, no module context)
-            // — the startup default of one 64 KiB page is a power of two.
+            // loudly rather than miscompile.
+            //
+            // RQ-57-SENTINEL (#953 sibling): `bytes == 0` used to be EXEMPT
+            // from this check, because 0 was read as "unknown — plain
+            // per-function path, no module context". But 0 is also exactly
+            // what a module declaring `(memory 0)` produces, and for that
+            // module the emitted guard (`SUB R12, R10, #1; AND addr, R12`,
+            // R10 = 0 baked by the startup) computes `0 - 1 = 0xFFFFFFFF` —
+            // an IDENTITY mask. Every access then executes unmasked at
+            // `[R11 + addr]` for any 32-bit addr: an unbounded OOB read/write
+            // in the mode whose purpose is bounding. Same sentinel/value
+            // collision as #932/#953, third backend-mode instance.
+            //
+            // 0 now means what #953 made it mean everywhere: a zero-byte
+            // memory. No mask can bound an access into a memory with no bytes
+            // (wasm semantics: every access traps), and wrap-not-trap has
+            // nothing to wrap into — refuse. Callers with no module context
+            // must state the size (the #953 contract; the CLI single-function
+            // path now threads the module's declared size for all backends).
             let bytes = config.linear_memory_bytes;
-            if bytes != 0 && !bytes.is_power_of_two() {
+            if bytes == 0 {
+                return Err("--safety-bounds mask: the linear memory has ZERO bytes \
+                     (`(memory 0)`, or a driver that did not state the size) — \
+                     every access is out of bounds and a mask cannot express a \
+                     trap. Use --safety-bounds software (traps every access) \
+                     or declare a non-zero memory (RQ-57-SENTINEL, #953)"
+                    .to_string());
+            }
+            if !bytes.is_power_of_two() {
                 return Err(format!(
                     "--safety-bounds mask requires a power-of-two linear-memory \
                      size, got {bytes} bytes — switch to --safety-bounds software \
@@ -2263,13 +2287,18 @@ mod tests {
                 align: 2,
             },
         ];
+        // RQ-57-SENTINEL: mask now requires a STATED non-zero power-of-two
+        // size (0 = zero-byte memory = refused), so the test states one —
+        // exactly what the #953 fix required of the rv32 driver test.
         let cfg_mask_opt = CompileConfig {
             safety_bounds: SafetyBounds::Mask,
+            linear_memory_bytes: 64 * 1024,
             ..Default::default()
         };
         let cfg_mask_direct = CompileConfig {
             no_optimize: true,
             safety_bounds: SafetyBounds::Mask,
+            linear_memory_bytes: 64 * 1024,
             ..Default::default()
         };
         let o = backend.compile_function("st", &ops, &cfg_mask_opt).unwrap();
@@ -2279,6 +2308,39 @@ mod tests {
         assert_eq!(
             o.code, d.code,
             "#377: mask on the optimized path must fall back to the direct selector's masking"
+        );
+    }
+
+    /// RQ-57-SENTINEL (#953 sibling): `--safety-bounds mask` with a ZERO-byte
+    /// linear memory must REFUSE at compile time. Before this fix, `bytes == 0`
+    /// was exempt from the power-of-two gate ("0 means unknown"), and the
+    /// emitted `SUB R12, R10, #1; AND` guard degenerated to an IDENTITY mask
+    /// at runtime (R10 = 0 baked by the startup for a `(memory 0)` module):
+    /// an unbounded OOB access in the mode whose purpose is bounding.
+    /// Red-first: pre-fix this compile SUCCEEDED (verified on the v0.56.1
+    /// tree: exit 0, `movw r10, #0x0` in the reset handler, AND-masked body).
+    #[test]
+    fn arm_safety_bounds_mask_zero_size_refused_rq57() {
+        let backend = ArmBackend::new();
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::I32Load {
+                offset: 0,
+                align: 2,
+            },
+        ];
+        let cfg = CompileConfig {
+            safety_bounds: SafetyBounds::Mask,
+            linear_memory_bytes: 0,
+            ..Default::default()
+        };
+        let err = backend
+            .compile_function("ld", &ops, &cfg)
+            .expect_err("mask over a zero-byte memory must refuse, not emit an identity mask");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("ZERO bytes"),
+            "refusal must name the zero-byte cause, got: {msg}"
         );
     }
 

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2032,17 +2032,20 @@ fn compile_command(
         // reserved stack size under --stack-layout=low; default = 0x2000_0100
         // (byte-identical).
         linmem_base: stack_layout.optimized_linmem_base(),
-        // #865: thread the module's declared memory limit so the aarch64
-        // software bounds check compares against the REAL size. Scoped to the
-        // aarch64 backend: the ARM/RV32 single-function paths never consumed
-        // this field (it defaulted to 0), and widening it here could move
-        // frozen ARM anchor bytes — those paths derive memory context in
-        // `compile_all_exports` instead.
-        linear_memory_bytes: if backend.name() == "aarch64" {
-            single_func_linear_memory_bytes
-        } else {
-            0
-        },
+        // #865: thread the module's declared memory limit so software bounds
+        // checks compare against the REAL size. RQ-57-SENTINEL: this used to be
+        // scoped to aarch64 on the claim that "the ARM/RV32 single-function
+        // paths never consumed this field" — that claim was FALSE for RV32
+        // (its `compile_function` has always read it for the Software/Mask
+        // bound), and after #953 deleted the rv32 64 KiB fallback the forced
+        // `0` here compiled a `(memory 1)` module's every access to the
+        // zero-size `ebreak` fold under `--safety-bounds software`. Passing
+        // the declared size for ALL backends is byte-invisible where the field
+        // is unconsumed (ARM reads it only for the mask power-of-two gate and
+        // the native-pointer statics gate, both off on this path; frozen
+        // anchors are `--all-exports` and don't come through here) and is the
+        // #953 contract everywhere else: 0 means zero bytes, never "unset".
+        linear_memory_bytes: single_func_linear_memory_bytes,
         ..CompileConfig::default()
     };
 
@@ -4152,7 +4155,11 @@ fn compile_all_exports(
                             )
                         })
                         .collect(),
-                    sp_init: stack_pointer_global_opt.map(|(_, v)| v).unwrap_or(0),
+                    // RQ-57-SENTINEL: `None` = no SP global identified — no
+                    // longer flattened to a 0 that collides with a real
+                    // sp_init of 0 (consumers fold None as the max-identity
+                    // and the shadow-stack shrink refuses it loudly).
+                    sp_init: stack_pointer_global_opt.map(|(_, v)| v),
                     // #707: the re-base equivalence class — MUTABLE i32 globals
                     // whose init == sp_init (mutability preserved here because the
                     // `globals` slot list above dropped it). Empty when there is
@@ -4335,10 +4342,15 @@ fn compile_all_exports(
             module_sha256: ing.actual_module_sha256.clone(),
             declared_module_sha256: ing.declared_module_sha256.clone(),
             // #932: an attestation is only reached on an ACCEPTED ingest, and
-            // acceptance now requires an ESTABLISHED floor — so this cannot be
-            // the old invented 0. The `unwrap_or(0)` here is unreachable by
-            // construction; it is not a fallback.
-            memory_min_bytes: proven_safe_module_min_bytes.unwrap_or(0),
+            // acceptance requires an ESTABLISHED floor. RQ-57-SENTINEL: that
+            // used to be `unwrap_or(0)` with a comment arguing unreachability —
+            // the "safe because another region's rule prevents it" (c)-class.
+            // If the acceptance rule ever drifts, a 0 here is the EXACT #932
+            // lie written into a signed attestation; panic loudly instead.
+            memory_min_bytes: proven_safe_module_min_bytes.expect(
+                "#932 invariant violated: proven-safe ingest was ACCEPTED with no \
+                 established memory floor — refusing to attest an invented 0 B floor",
+            ),
             declared_memory_min_bytes: ing.declared_memory_min_bytes,
             safety_bounds: safety_bounds.as_str().to_string(),
             accepted: ing.accepted,
@@ -4540,7 +4552,12 @@ struct NativeGlobalsLayout {
     /// bytes suffice — no data relocations.
     globals: Vec<(u32, i32)>,
     /// The shadow-stack top (the SP global's init); the region must cover it.
-    sp_init: i32,
+    /// RQ-57-SENTINEL: `None` = no stack-pointer global was identified. This
+    /// was an `i32` with 0 standing in for absence — indistinguishable from a
+    /// real SP init of 0. Extent consumers fold `None` to the max-identity 0
+    /// (byte-identical); the `--shadow-stack-size` shrink REFUSES `None`
+    /// (there is no reservation to shrink) instead of shrinking a phantom one.
+    sp_init: Option<i32>,
     /// #707: indices of the globals the shadow-stack shrink may re-base — every
     /// MUTABLE i32 global whose init == sp_init (the same predicate
     /// `identify_stack_pointer_global` selects on, kept here because `globals`
@@ -4746,7 +4763,9 @@ fn build_relocatable_elf(
                 .map(|(off, d)| off + d.len() as u32)
                 .max()
                 .unwrap_or(0);
-            let sp_top = ng.sp_init.max(0) as u32;
+            // None (no SP global) contributes nothing to the extent — the
+            // explicit max-identity, not a sentinel.
+            let sp_top = ng.sp_init.map_or(0, |v| v.max(0) as u32);
             // Layout-bound globals: wasm-ld emits __data_end/__heap_base as
             // i32 globals whose inits mark the static-region extent — the
             // linker's own answer to "how much is used".
@@ -4874,8 +4893,8 @@ fn build_relocatable_elf(
     // gate fails, fall back to the one-PROGBITS arm (fat but always correct).
     let wasm_data_base: u32 = native_layout
         .as_ref()
-        .map(|ng| ng.sp_init.max(0) as u32)
-        .unwrap_or(0);
+        .and_then(|ng| ng.sp_init)
+        .map_or(0, |v| v.max(0) as u32);
     let all_static_data_abs32 = funcs.iter().flat_map(|f| &f.relocations).all(|r| {
         r.symbol != "__synth_wasm_data" || matches!(r.kind, synth_core::backend::RelocKind::Abs32)
     });
@@ -5051,7 +5070,17 @@ fn build_relocatable_elf(
     {
         None => (used_extent, None),
         Some((ng, budget)) => {
-            let sp = ng.sp_init.max(0) as u32;
+            // RQ-57-SENTINEL: absent SP global = nothing to shrink. Before the
+            // Option conversion this fell through as sp = 0 and a
+            // `--shadow-stack-size 0` request proceeded into the re-base
+            // machinery against a reservation that does not exist.
+            let Some(sp) = ng.sp_init.map(|v| v.max(0) as u32) else {
+                anyhow::bail!(
+                    "--shadow-stack-size: no stack-pointer global was identified in this \
+                     module — there is no [0, sp_init) shadow-stack reservation to shrink; \
+                     refusing. VCR-MEM-001/#383."
+                );
+            };
             // Only the per-region split geometries separate statics from the stack
             // reservation; the one-PROGBITS fallback inlines them and is not safe to
             // shrink here.
@@ -5210,18 +5239,16 @@ fn build_relocatable_elf(
             // real failure (no mutable global carries the SP init) — refuse honestly.
             if ng.sp_alias_indices.is_empty() {
                 anyhow::bail!(
-                    "--shadow-stack-size: no mutable global carries init == sp_init {}; cannot \
-                     identify the shadow-stack global to re-base; refusing. VCR-MEM-001/#383.",
-                    ng.sp_init
+                    "--shadow-stack-size: no mutable global carries init == sp_init {sp}; cannot \
+                     identify the shadow-stack global to re-base; refusing. VCR-MEM-001/#383."
                 );
             }
             if ng.sp_alias_indices.len() > 1 {
                 info!(
                     "Native-pointer shadow-stack shrink (#707): re-basing {} aliased \
-                     __stack_pointer globals (all init == sp_init {}) to budget {budget} — a \
+                     __stack_pointer globals (all init == sp_init {sp}) to budget {budget} — a \
                      multi-provider shared-memory fused node shares one reservation.",
                     ng.sp_alias_indices.len(),
-                    ng.sp_init
                 );
             }
             let mut rebased = ng.globals.clone();
@@ -8328,7 +8355,7 @@ mod tests {
         // reservation up to ~64 KiB; one global slot holds that offset.
         let native = NativeGlobalsLayout {
             globals: vec![(0, 65_536)],
-            sp_init: 65_536,
+            sp_init: Some(65_536),
             sp_alias_indices: vec![0],
             shadow_stack_size: None,
         };
@@ -8438,7 +8465,7 @@ mod tests {
         };
         let native = NativeGlobalsLayout {
             globals: vec![(0, 65_536)],
-            sp_init: 65_536,
+            sp_init: Some(65_536),
             sp_alias_indices: vec![0],
             shadow_stack_size: None,
         };
@@ -8534,7 +8561,7 @@ mod tests {
         let data_segments = vec![(SEG_OFF, seg)];
         let native = NativeGlobalsLayout {
             globals: vec![(0, 65_536)],
-            sp_init: 65_536,
+            sp_init: Some(65_536),
             sp_alias_indices: vec![0],
             shadow_stack_size: None,
         };

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -4341,16 +4341,16 @@ fn compile_all_exports(
             scry_version: ing.scry_version.clone(),
             module_sha256: ing.actual_module_sha256.clone(),
             declared_module_sha256: ing.declared_module_sha256.clone(),
-            // #932: an attestation is only reached on an ACCEPTED ingest, and
-            // acceptance requires an ESTABLISHED floor. RQ-57-SENTINEL: that
-            // used to be `unwrap_or(0)` with a comment arguing unreachability —
-            // the "safe because another region's rule prevents it" (c)-class.
-            // If the acceptance rule ever drifts, a 0 here is the EXACT #932
-            // lie written into a signed attestation; panic loudly instead.
-            memory_min_bytes: proven_safe_module_min_bytes.expect(
-                "#932 invariant violated: proven-safe ingest was ACCEPTED with no \
-                 established memory floor — refusing to attest an invented 0 B floor",
-            ),
+            // RQ-57-SENTINEL: this was `unwrap_or(0)` with a #932-era comment
+            // arguing "an attestation is only reached on an ACCEPTED ingest,
+            // so this is unreachable". The sweep's interim `.expect()` proved
+            // that argument FALSE in one test run: attestations are ALSO
+            // emitted for REFUSED ingests (that is #901's refusal-is-attested
+            // rule), and the imported-memory refusal reached this line with no
+            // floor — so shipped v0.56.x attestations recorded an invented
+            // `"memory_min_bytes": 0` on exactly the #932 shape. The absence
+            // is now typed: `None` serializes as an explicit `null`.
+            memory_min_bytes: proven_safe_module_min_bytes,
             declared_memory_min_bytes: ing.declared_memory_min_bytes,
             safety_bounds: safety_bounds.as_str().to_string(),
             accepted: ing.accepted,

--- a/crates/synth-cli/tests/sentinel_sweep_rq57.rs
+++ b/crates/synth-cli/tests/sentinel_sweep_rq57.rs
@@ -64,22 +64,29 @@ const MEM1_WAT: &str = r#"(module
 
 /// Raw instruction words from synth's own disassembler (host-independent —
 /// the #850 lesson: never depend on an installed llvm-objdump).
+/// Every 4-byte little-endian word in the object's `.text`, as lowercase hex.
+///
+/// #850: this reads the ELF SECTION BYTES, not `synth disasm` TEXT. The first
+/// version of this helper parsed `synth disasm` output — it passed on macOS and
+/// returned an EMPTY vector on the ubuntu runner, so both assertions below
+/// failed in CI with `words: []` while the lane's local run was green. The
+/// disassembler decodes with whatever target it defaults to and its rendering is
+/// host-dependent, so its text is not a reliable data source. `.text` bytes are
+/// identical on every host — synth is a cross-compiler and its output is a pure
+/// function of (wasm, flags), which is the same property `frozen_codegen_bytes`
+/// relies on.
 fn disasm_words(obj: &std::path::Path) -> Vec<String> {
-    let out = Command::new(synth())
-        .args(["disasm", obj.to_str().unwrap()])
-        .output()
-        .expect("run synth disasm");
-    String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .filter_map(|l| {
-            let mut it = l.split_whitespace();
-            let first = it.next()?;
-            if !first.ends_with(':') {
-                return None;
-            }
-            let w = it.next()?;
-            (w.len() == 8 && w.chars().all(|c| c.is_ascii_hexdigit())).then(|| w.to_string())
-        })
+    use object::{Object, ObjectSection};
+    let data = std::fs::read(obj).expect("read object");
+    let file = object::File::parse(&*data).expect("parse ELF");
+    let text = file
+        .section_by_name(".text")
+        .expect("object must have a .text section")
+        .data()
+        .expect("read .text")
+        .to_vec();
+    text.chunks_exact(4)
+        .map(|w| format!("{:08x}", u32::from_le_bytes([w[0], w[1], w[2], w[3]])))
         .collect()
 }
 

--- a/crates/synth-cli/tests/sentinel_sweep_rq57.rs
+++ b/crates/synth-cli/tests/sentinel_sweep_rq57.rs
@@ -1,0 +1,197 @@
+//! RQ-57-SENTINEL (Refs #953, #932) — end-to-end pins for the two sentinel/value
+//! collisions this sweep converted, plus the fail-closed control.
+//!
+//! The disease (one mechanism, three shipped instances): a numeric `0` that
+//! means both "unset/unknown" and a value a module can legitimately declare.
+//!
+//! * #932 (v0.56.0): `unwrap_or(0)` turned "no floor establishable" into
+//!   "the floor is 0 bytes" and STRIPPED real bounds guards.
+//! * #953 (v0.56.1): `if linear_memory_bytes > 0 {..} else { 64 * 1024 }`
+//!   INVENTED a 64 KiB bound for a `(memory 0)` module on rv32.
+//! * THIS SWEEP found two more:
+//!   1. ARM `--safety-bounds mask` exempted `bytes == 0` from its power-of-two
+//!      gate ("0 means unknown"), so a `(memory 0)` module compiled with a
+//!      runtime mask of `R10 - 1 = 0 - 1 = 0xFFFFFFFF` — an IDENTITY mask.
+//!      Every access executed unmasked at `[R11 + addr]`: unbounded OOB
+//!      read/write in the mode whose purpose is bounding.
+//!   2. The single-function CLI path forced `linear_memory_bytes: 0` for every
+//!      backend except aarch64, on a comment claiming the field was never
+//!      consumed there — false for RV32, whose `compile_function` reads it for
+//!      the Software/Mask bound. After #953 deleted the rv32 64 KiB fallback,
+//!      `--func-index` + `--safety-bounds software` on a `(memory 1)` module
+//!      compiled EVERY access to the zero-size `ebreak` fold.
+//!
+//! Red-first evidence (recorded on the pre-fix v0.56.1 tree, 2026-08-13):
+//! * `(memory 0)` + arm mask compiled with exit 0, `movw r10, #0x0` in the
+//!   reset handler and AND-masked bodies — test 1 below FAILED.
+//! * `(memory 1)` + rv32 `--func-index 0 --safety-bounds software` emitted
+//!   `00050293 00100073` (addi; ebreak) — an unconditional trap at entry —
+//!   test 2 below FAILED.
+//! * `(memory 0)` + rv32 single-function emitted the same ebreak fold — the
+//!   fail-closed CONTROL (test 3) passed before AND after, proving the fix
+//!   restored the declared bound rather than deleting the trap fold.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn synth() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_synth"))
+}
+
+fn workdir(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir().join(format!("synth-rq57-{tag}"));
+    std::fs::create_dir_all(&d).expect("temp dir");
+    d
+}
+
+const MEM0_WAT: &str = r#"(module
+  (memory 0)
+  (func (export "peek") (param i32) (result i32)
+    local.get 0
+    i32.load)
+  (func (export "poke") (param i32) (param i32)
+    local.get 0
+    local.get 1
+    i32.store))
+"#;
+
+const MEM1_WAT: &str = r#"(module
+  (memory 1)
+  (func (export "peek") (param i32) (result i32)
+    local.get 0
+    i32.load))
+"#;
+
+/// Raw instruction words from synth's own disassembler (host-independent —
+/// the #850 lesson: never depend on an installed llvm-objdump).
+fn disasm_words(obj: &std::path::Path) -> Vec<String> {
+    let out = Command::new(synth())
+        .args(["disasm", obj.to_str().unwrap()])
+        .output()
+        .expect("run synth disasm");
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|l| {
+            let mut it = l.split_whitespace();
+            let first = it.next()?;
+            if !first.ends_with(':') {
+                return None;
+            }
+            let w = it.next()?;
+            (w.len() == 8 && w.chars().all(|c| c.is_ascii_hexdigit())).then(|| w.to_string())
+        })
+        .collect()
+}
+
+/// Sweep finding 1: `--safety-bounds mask` on a `(memory 0)` module must
+/// REFUSE (zero-byte memory, identity-mask hole), not emit unmasked accesses.
+#[test]
+fn arm_mask_zero_memory_refused() {
+    let dir = workdir("mask0");
+    let wat = dir.join("mem0.wat");
+    std::fs::write(&wat, MEM0_WAT).unwrap();
+    let elf = dir.join("mem0.elf");
+    let out = Command::new(synth())
+        .args([
+            "compile",
+            wat.to_str().unwrap(),
+            "-o",
+            elf.to_str().unwrap(),
+            "--all-exports",
+            "--safety-bounds",
+            "mask",
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        !out.status.success(),
+        "mask over a (memory 0) module must fail the compile — pre-fix it \
+         succeeded and emitted an identity mask (R10=0 baked, SUB R12,R10,#1 \
+         = 0xFFFFFFFF)"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("ZERO bytes"),
+        "the refusal must name the zero-byte cause, got:\n{stderr}"
+    );
+}
+
+/// Sweep finding 2: the rv32 single-function path must bound against the
+/// module's DECLARED memory size, not a forced 0. `(memory 1)` = 65536 bytes,
+/// so the software guard materializes 65536 - 4 = 65532:
+/// `lui t1, 0x10` (00010337) + `addi t1, t1, -4` (ffc30313).
+#[test]
+fn rv32_single_func_software_uses_declared_bound() {
+    let dir = workdir("rv32-declared");
+    let wat = dir.join("mem1.wat");
+    std::fs::write(&wat, MEM1_WAT).unwrap();
+    let obj = dir.join("mem1.o");
+    let out = Command::new(synth())
+        .args([
+            "compile",
+            wat.to_str().unwrap(),
+            "-o",
+            obj.to_str().unwrap(),
+            "-b",
+            "riscv",
+            "--func-index",
+            "0",
+            "--safety-bounds",
+            "software",
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        out.status.success(),
+        "rv32 single-function compile failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let words = disasm_words(&obj);
+    assert!(
+        words.iter().any(|w| w == "00010337") && words.iter().any(|w| w == "ffc30313"),
+        "the software guard must carry the declared 1-page bound (lui t1,0x10; \
+         addi t1,t1,-4 = 65532) — pre-fix the forced linear_memory_bytes=0 \
+         emitted the zero-size ebreak fold instead; words: {words:?}"
+    );
+}
+
+/// CONTROL (non-vacuity): `(memory 0)` through the same rv32 single-function
+/// path must KEEP the #953 fail-closed behavior — an unconditional `ebreak`
+/// (00100073) and no invented bound. Proves the fix threads the declared size
+/// rather than resurrecting a fallback.
+#[test]
+fn rv32_single_func_zero_memory_stays_fail_closed() {
+    let dir = workdir("rv32-mem0");
+    let wat = dir.join("mem0.wat");
+    std::fs::write(&wat, MEM0_WAT).unwrap();
+    let obj = dir.join("mem0.o");
+    let out = Command::new(synth())
+        .args([
+            "compile",
+            wat.to_str().unwrap(),
+            "-o",
+            obj.to_str().unwrap(),
+            "-b",
+            "riscv",
+            "--func-index",
+            "0",
+            "--safety-bounds",
+            "software",
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        out.status.success(),
+        "rv32 (memory 0) single-function compile failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let words = disasm_words(&obj);
+    assert!(
+        words.iter().any(|w| w == "00100073"),
+        "(memory 0) must keep the unconditional ebreak fold (#953); words: {words:?}"
+    );
+    assert!(
+        !words.iter().any(|w| w == "00010337"),
+        "(memory 0) must NOT get a 64 KiB bound materialized (#953); words: {words:?}"
+    );
+}

--- a/crates/synth-core/src/proven_safe.rs
+++ b/crates/synth-core/src/proven_safe.rs
@@ -426,8 +426,14 @@ pub struct ElisionAttestation {
     /// authoritative binding — `declared_module_sha256` is what the file said.
     pub module_sha256: String,
     pub declared_module_sha256: String,
-    /// Synth's declared linear-memory minimum, in bytes.
-    pub memory_min_bytes: u32,
+    /// Synth's declared linear-memory minimum, in bytes. RQ-57-SENTINEL:
+    /// `None` = NO floor could be established (e.g. the module's memory is
+    /// imported, #932) — serialized as an explicit `null`, never as a `0` that
+    /// collides with a real (and self-refuting) zero-byte floor. The #932 fix
+    /// commented the CLI's `unwrap_or(0)` "unreachable by construction"; the
+    /// RQ-57 sweep proved that FALSE — refusal attestations reach it — so the
+    /// absence is now typed instead of argued.
+    pub memory_min_bytes: Option<u32>,
     pub declared_memory_min_bytes: u64,
     /// The `--safety-bounds` mode in force. Elisions only change emitted bytes
     /// under `software`; any other mode is recorded so an auditor sees why the
@@ -836,7 +842,7 @@ mod tests {
             scry_version: "3.2.4".to_string(),
             module_sha256: "aa".repeat(32),
             declared_module_sha256: "bb".repeat(32),
-            memory_min_bytes: 65536,
+            memory_min_bytes: Some(65536),
             declared_memory_min_bytes: 65536,
             safety_bounds: "software".to_string(),
             accepted: false,
@@ -853,6 +859,44 @@ mod tests {
         assert!(json.contains("module_sha256 mismatch"));
         assert!(json.contains("\"sites_offered\": 8"));
         assert!(json.contains("\"sites_elided\": 0"));
+        let back: ElisionAttestation = serde_json::from_str(&json).expect("round-trips");
+        assert_eq!(back, a);
+    }
+
+    /// RQ-57-SENTINEL: an attestation with NO establishable floor (imported
+    /// memory, #932) must serialize the absence as an explicit `null` — never
+    /// as a `0` that reads as "synth declared a zero-byte floor". The #932 fix
+    /// left the CLI's `unwrap_or(0)` behind a comment calling it unreachable;
+    /// the sweep proved refusal attestations DO reach it, so v0.56.x shipped
+    /// `"memory_min_bytes": 0` on exactly the #932 shape.
+    #[test]
+    fn no_floor_attests_null_not_zero_rq57() {
+        let a = ElisionAttestation {
+            schema: ELISION_ATTESTATION_SCHEMA.to_string(),
+            synth_version: "0.56.1".to_string(),
+            scry_version: "3.2.4".to_string(),
+            module_sha256: "aa".repeat(32),
+            declared_module_sha256: "aa".repeat(32),
+            memory_min_bytes: None,
+            declared_memory_min_bytes: 65536,
+            safety_bounds: "software".to_string(),
+            accepted: false,
+            refusal: Some("no memory floor can be established".to_string()),
+            sites_offered: 1,
+            sites_elided: 0,
+            sites_not_elided: 1,
+            elisions: Vec::new(),
+            diagnostics: Vec::new(),
+        };
+        let json = a.to_json();
+        assert!(
+            json.contains("\"memory_min_bytes\": null"),
+            "absence must be an explicit null, got:\n{json}"
+        );
+        assert!(
+            !json.contains("\"memory_min_bytes\": 0"),
+            "the invented-0 floor must be unrepresentable, got:\n{json}"
+        );
         let back: ElisionAttestation = serde_json::from_str(&json).expect("round-trips");
         assert_eq!(back, a);
     }

--- a/scripts/repro/sentinel_sweep_rq57.md
+++ b/scripts/repro/sentinel_sweep_rq57.md
@@ -6,9 +6,11 @@ absence, across `synth-core`, `synth-backend`, `synth-backend-riscv`,
 where it carries a bounds value). Non-test code only; line numbers as of the
 sweep commit.
 
-**Denominator: 54 sites examined. 4 converted (with 2 latent defects found and
-fixed), 41 classified (a) with an argument each, 9 classified (c) residuals
-(listed, named, not silently dropped).**
+**Denominator: 54 sites examined. 4 converted — with THREE latent defects
+found and fixed (C1 unbounded-OOB identity mask, C2 rv32 single-function
+all-trap regression, C3 invented-0 floor in shipped refusal attestations) —
+41 classified (a) with an argument each, 9 classified (c) residuals (listed,
+named, not silently dropped).**
 
 Classification key (from the release artifact):
 
@@ -23,7 +25,7 @@ Classification key (from the release artifact):
 |---|------|-----|-------|---------|
 | C1 | `synth-backend/src/arm_backend.rs` mask gate | `bytes != 0 && !is_power_of_two` — 0 exempt as "unknown" | (b) | **LATENT SECURITY DEFECT (third instance of the #932/#953 disease).** A `(memory 0)` module under `--safety-bounds mask` compiled with startup `R10 = 0`; the emitted guard `SUB R12, R10, #1; AND addr, R12` computes `0 − 1 = 0xFFFFFFFF` — an IDENTITY mask. Every access executed unmasked at `[R11 + addr]` for any 32-bit addr: unbounded OOB read AND write in the mode whose purpose is bounding. Verified pre-fix on the v0.56.1 tree (exit 0, `movw r10, #0x0` in the reset handler). Now: zero-byte memory REFUSES loudly. Test: `arm_safety_bounds_mask_zero_size_refused_rq57` + CLI `arm_mask_zero_memory_refused`. |
 | C2 | `synth-cli/src/main.rs` single-function config (`linear_memory_bytes: if aarch64 {..} else { 0 }`) | forced 0 for ARM/RV32 on a comment claiming the field was "never consumed" there | (c) | **LATENT DEFECT — the comment's claim was false for RV32** (its `compile_function` has always read the field), and after #953 deleted the rv32 fallback, `--func-index` + `--safety-bounds software` on a `(memory 1)` module compiled EVERY access to the zero-size `ebreak` fold (verified pre-fix: `00050293 00100073` at entry; a live availability miscompile in v0.56.1). Now: the module's declared size threads to ALL backends. Byte-invisible where unconsumed (ARM reads it only for the mask gate + native-ABI statics gate, both off here; frozen anchors are `--all-exports`). Tests: `rv32_single_func_software_uses_declared_bound` + fail-closed control `rv32_single_func_zero_memory_stays_fail_closed`. |
-| C3 | `synth-cli/src/main.rs` elision attestation `memory_min_bytes: proven_safe_module_min_bytes.unwrap_or(0)` | "unreachable by construction" comment | (c) | Safe only because the ingest closure's acceptance rule refuses a floorless module — a rule in a different code region. If it drifts, the flattened 0 is the exact #932 lie written into a signed attestation. Converted to `.expect(...)` — an invariant break now panics loudly instead of attesting an invented 0 B floor. |
+| C3 | `synth-cli/src/main.rs` elision attestation `memory_min_bytes: proven_safe_module_min_bytes.unwrap_or(0)` | "unreachable by construction" comment | (b) | **LATENT DEFECT — the unreachability argument was FALSE, and the sweep's own interim `.expect()` proved it in one test run.** Attestations are ALSO emitted for REFUSED ingests (#901's refusal-is-attested rule), and the imported-memory refusal (#932's exact shape) reaches this line with no floor — so shipped v0.56.x attestations recorded an invented `"memory_min_bytes": 0`. Converted: `ElisionAttestation.memory_min_bytes` is now `Option<u32>`, absence serializes as an explicit `null`, pinned by `no_floor_attests_null_not_zero_rq57` (accepted-case shape unchanged: `Some(x)` serializes as the bare number, `proven_safe_bounds_901` still asserts 65536). |
 | C4 | `synth-cli/src/main.rs` `NativeGlobalsLayout.sp_init: i32` (0 = "no SP global") | `stack_pointer_global_opt.map(..).unwrap_or(0)` | (c) | 0-for-absent was indistinguishable from a real SP init of 0. Extent consumers happened to treat 0 as the max-fold identity (safe by coincidence of consumer shape), and `--shadow-stack-size 0` on a module with NO SP global fell through into the re-base machinery against a phantom reservation. Converted to `Option<i32>`: extent folds map `None → 0` explicitly as the identity; the shrink REFUSES `None` with a machine reason. Byte-identical otherwise. |
 
 ## Class (a) — sentinel cannot collide (argument per site)

--- a/scripts/repro/sentinel_sweep_rq57.md
+++ b/scripts/repro/sentinel_sweep_rq57.md
@@ -1,0 +1,112 @@
+# RQ-57-SENTINEL — numeric-sentinel audit (Refs #953, #932)
+
+Sweep of every size/count/address path where a NUMERIC SENTINEL stands in for
+absence, across `synth-core`, `synth-backend`, `synth-backend-riscv`,
+`synth-backend-aarch64`, `synth-cli`, `synth-verify` (plus `synth-synthesis`
+where it carries a bounds value). Non-test code only; line numbers as of the
+sweep commit.
+
+**Denominator: 54 sites examined. 4 converted (with 2 latent defects found and
+fixed), 41 classified (a) with an argument each, 9 classified (c) residuals
+(listed, named, not silently dropped).**
+
+Classification key (from the release artifact):
+
+- **(a)** the sentinel CANNOT collide with a legitimate value — argued below.
+- **(b)** it CAN collide — converted.
+- **(c)** it CAN collide and is safe only because ANOTHER pass's rule prevents
+  it (the #946 "true for the wrong reason" class) — convert, or list loudly.
+
+## Converted in this PR
+
+| # | Site | Was | Class | Finding |
+|---|------|-----|-------|---------|
+| C1 | `synth-backend/src/arm_backend.rs` mask gate | `bytes != 0 && !is_power_of_two` — 0 exempt as "unknown" | (b) | **LATENT SECURITY DEFECT (third instance of the #932/#953 disease).** A `(memory 0)` module under `--safety-bounds mask` compiled with startup `R10 = 0`; the emitted guard `SUB R12, R10, #1; AND addr, R12` computes `0 − 1 = 0xFFFFFFFF` — an IDENTITY mask. Every access executed unmasked at `[R11 + addr]` for any 32-bit addr: unbounded OOB read AND write in the mode whose purpose is bounding. Verified pre-fix on the v0.56.1 tree (exit 0, `movw r10, #0x0` in the reset handler). Now: zero-byte memory REFUSES loudly. Test: `arm_safety_bounds_mask_zero_size_refused_rq57` + CLI `arm_mask_zero_memory_refused`. |
+| C2 | `synth-cli/src/main.rs` single-function config (`linear_memory_bytes: if aarch64 {..} else { 0 }`) | forced 0 for ARM/RV32 on a comment claiming the field was "never consumed" there | (c) | **LATENT DEFECT — the comment's claim was false for RV32** (its `compile_function` has always read the field), and after #953 deleted the rv32 fallback, `--func-index` + `--safety-bounds software` on a `(memory 1)` module compiled EVERY access to the zero-size `ebreak` fold (verified pre-fix: `00050293 00100073` at entry; a live availability miscompile in v0.56.1). Now: the module's declared size threads to ALL backends. Byte-invisible where unconsumed (ARM reads it only for the mask gate + native-ABI statics gate, both off here; frozen anchors are `--all-exports`). Tests: `rv32_single_func_software_uses_declared_bound` + fail-closed control `rv32_single_func_zero_memory_stays_fail_closed`. |
+| C3 | `synth-cli/src/main.rs` elision attestation `memory_min_bytes: proven_safe_module_min_bytes.unwrap_or(0)` | "unreachable by construction" comment | (c) | Safe only because the ingest closure's acceptance rule refuses a floorless module — a rule in a different code region. If it drifts, the flattened 0 is the exact #932 lie written into a signed attestation. Converted to `.expect(...)` — an invariant break now panics loudly instead of attesting an invented 0 B floor. |
+| C4 | `synth-cli/src/main.rs` `NativeGlobalsLayout.sp_init: i32` (0 = "no SP global") | `stack_pointer_global_opt.map(..).unwrap_or(0)` | (c) | 0-for-absent was indistinguishable from a real SP init of 0. Extent consumers happened to treat 0 as the max-fold identity (safe by coincidence of consumer shape), and `--shadow-stack-size 0` on a module with NO SP global fell through into the re-base machinery against a phantom reservation. Converted to `Option<i32>`: extent folds map `None → 0` explicitly as the identity; the shrink REFUSES `None` with a machine reason. Byte-identical otherwise. |
+
+## Class (a) — sentinel cannot collide (argument per site)
+
+| # | Site | Pattern | Why 0 (or MAX) cannot lie |
+|---|------|---------|--------------------------|
+| A1 | `synth-backend-riscv/src/backend.rs:75` | `memories.first().map(initial_bytes).unwrap_or(0)` | Post-#953 contract: no defined memory = zero bytes = every access traps (fail-closed). Imported-memory caveat is R1 below. |
+| A2 | `synth-backend-riscv/src/backend.rs:240` | mask `mem_size - 1` after `is_power_of_two` | `0.is_power_of_two() == false` → size 0 REFUSES loudly (generic message, but loud). rv32 never had the ARM C1 exemption. |
+| A3 | `synth-backend-riscv/src/backend.rs:400` | `count_params` `.max().unwrap_or(0)` | 0 is the true count of an empty set — the value IS the count, not a stand-in. |
+| A4 | `synth-backend/src/arm_backend.rs:236` | same | same |
+| A5 | `synth-backend-aarch64/src/backend.rs:198` | same | same |
+| A6 | `synth-backend-aarch64/src/backend.rs:74` | `limit_bytes: linear_memory_bytes as u64` raw | 0 = zero pages folds to unconditional `brk` — statically-correct always-trap (the model #953 adopted). |
+| A7 | `synth-backend-aarch64/src/encoder.rs:577` | `position(|h| h != 0).unwrap_or(0)` | value 0 has no non-zero halfword; emitting `movz w, #0` from position 0 is exactly correct. |
+| A8 | `synth-backend-aarch64/src/selector.rs:1400/1420/1444/1463` | `imm.unwrap_or(0)` | `form_ea` returns `None` = offset fully folded into the EA register, so the residual immediate IS 0; a real residual of 0 encodes identically. Same value, same bytes. |
+| A9 | `synth-backend-aarch64/src/selector.rs:2588` | `type_class_ids.get(ti).unwrap_or(0)` | 0 is a RESERVED id (assignment starts at 1, `wasm_decoder::structural_type_class_ids`) and is checked two lines later: `expected == 0` → loud decline. |
+| A10 | `synth-core/src/wasm_decoder.rs:473` | funcref slot class id `unwrap_or(0)` | id 0 never matches an expected class (≥ 1) → runtime TRAP, not a wrong branch. Documented at the site. |
+| A11 | `synth-core/src/wasm_decoder.rs:562` | `vec![0; size.unwrap_or(0)]` sidecar | zero-filled sidecar words are id 0 = trap-on-dispatch — fail-closed for a statically-unknown table image. |
+| A12 | `synth-core/src/wasm_decoder.rs:1235` | `table_index.unwrap_or(0)` | wasm spec: an elem segment with omitted table index targets table 0. Spec semantics, not a sentinel. |
+| A13 | `synth-core/src/wasm_stack_check.rs:108` | `try_from(max).unwrap_or(u32::MAX)` | saturation UP on overflow = larger claimed stack depth = strictly more conservative. |
+| A14 | `synth-core/src/arena_bind.rs:434` | `unwrap_or(u32::MAX).min(0xFFFF_0000)` | saturating cap immediately clamped; overflow can only shrink the arena, never grow it. |
+| A15 | `synth-core/src/arena_bind.rs:446` | `global_top .max().unwrap_or(0)` | empty set claims nothing; `.max(16)` floor applies regardless. A real global init of 0 also claims nothing — identical meaning. |
+| A16 | `synth-core/src/static_data_addr.rs:493` | `image_extent .max().unwrap_or(0)` | the true extent of zero segments is 0; downstream loops over `[0, 0)` are correct no-ops. |
+| A17 | `synth-core/src/static_data_addr.rs:537` | `runtime.get(addr).unwrap_or(0)` | uncovered address OWES 0 — wasm zero-init semantics; documented at the site. This is the value, not its absence. |
+| A18 | `synth-core/src/static_data_addr.rs:649` | extent, as A16 | same |
+| A19 | `synth-core/src/static_data_addr.rs:375` | `served: served.unwrap_or(0)` | the mismatch DECISION compares `Option`s (`served != Some(runtime_byte)`); only the already-failed report's display flattens. Cannot change a verdict. |
+| A20 | `synth-core/src/dwarf_line.rs:190/193` | line/file 0 | DWARF's own convention: line 0 = "no source line". The consumer speaks DWARF. |
+| A21 | `synth-core/src/dwarf_line.rs:298` | `high_pc = max().unwrap_or(0) + 1` | synthetic end-of-range for an empty table; range stays empty. |
+| A22 | `synth-core/src/dwarf_line.rs:144/223` | `unwrap_or_default()` | collection defaults (no rows/no files), not numeric stand-ins. |
+| A23 | `synth-core/src/sbom.rs:412` | epoch secs `unwrap_or(0)` | pre-1970 clock → 1970 timestamp in SBOM metadata; diagnostic field, collision physically impossible on a sane host, and a wrong date cannot alter any verdict. |
+| A24 | `synth-core/src/provenance.rs` + decoder | `wsc_facts.unwrap_or_default()` | empty facts = "no facts forwarded" = every elision declines (fail-safe rule documented in #494). |
+| A25 | `synth-verify/src/solver.rs:243` | model completion `unwrap_or(0)` | a variable the SAT core never saw is unconstrained; ANY value witnesses (z3 completes with 0 identically). |
+| A26 | `synth-verify/src/solver.rs:348` | timeout `unwrap_or(u32::MAX)` | saturating a deadline UP = weaker timeout, never a wrong verdict (verdicts are Sat/Unsat/Unknown). |
+| A27 | `synth-verify/src/expansion_validator.rs:888` | `last().map(off+len).unwrap_or(0)` | an empty instruction stream has length 0 — the value, not a sentinel. |
+| A28 | `synth-verify/src/fact_spec.rs:194` | `linear_memory_bytes`, `0` documented "= unknown" | the two meanings (unknown / zero-byte memory) COINCIDE in effect: the only consumer action is elision, which requires discharging `addr + len ≤ bound` — impossible at 0 either way → guards stay. Fail-closed under both readings. |
+| A29 | `synth-backend/src/elf_builder.rs:790/912` | `if ph_count > 0 {..} else { 0 }` | zero program headers genuinely have offset/entry-size 0 (ELF spec for empty PH table). |
+| A30 | `synth-cli/src/main.rs:1690` | `func_index.unwrap_or(0)` | documented CLI default: no `--func-index`/`--func-name` = compile function 0. A stated default, not absence-as-value. |
+| A31 | `synth-cli/src/main.rs:1812` | `single_func_linear_memory_bytes` `unwrap_or(0)` | post-#953 contract: no DEFINED memory = zero bytes (software traps, mask refuses per C1). Imported-memory caveat = R1. |
+| A32 | `synth-cli/src/main.rs:2921` | merged-memory `max` seed 0 | max-accumulator seed: any real memory beats "none". |
+| A33 | `synth-cli/src/main.rs:3085` | `linmem_bytes` → SP heuristic | with 0 no candidate passes `0 < v ≤ linmem` → promotion disabled — fail-safe (an optimization declines). |
+| A34 | `synth-cli/src/main.rs:3454` | all-exports `linear_memory_bytes` `unwrap_or(0)` | as A31; the value feeds backends that now uniformly read 0 as zero bytes. |
+| A35 | `synth-cli/src/main.rs:3464` | `memory_pages` slots `max().unwrap_or(0)` | 0 slots is the true count for no memories. |
+| A36 | `synth-cli/src/main.rs:4072` | `rv_mem_size` `unwrap_or(0)` | instantiation-trap guard: with 0, ANY active segment bails loudly (correct: a segment cannot instantiate into a zero-byte memory). |
+| A37 | `synth-cli/src/main.rs:4748–4878` | extent `max().unwrap_or(0)` folds | max-fold identities: each accumulator's 0 means "this source claims no extent", exactly its contribution. |
+| A38 | `synth-cli/src/main.rs:7880` | metadata len `unwrap_or(0)` | println diagnostic on the link summary line. |
+| A39 | `synth-cli/src/main.rs:8362–8576` | section data `unwrap_or_default()` | inspect/disasm path; unparseable section renders empty — diagnostic output only. |
+| A40 | `synth-synthesis/src/instruction_selector.rs:5754` | `addr < linear_memory_bytes` statics gate | native-ABI only; at 0 NOTHING classifies as a static → base-relative path — correct for a zero-byte memory. |
+| A41 | `synth-backend-riscv/src/selector.rs:3055` | `pages = bytes / 65536` | `(memory 0)` → `memory.size` = 0 pages — the spec answer. |
+
+WCET note: `wcet.rs` / `wcet_loops.rs` / `wcet_compose.rs` / `wcet_recursion.rs`
+carry NO numeric absence-sentinels — absence is modeled with enums
+(`Bounded`/`LoopedExpansion`/decline reasons) and `Option` throughout; the two
+`unwrap_or_default()` hits are empty hint-rejection collections. That design is
+the target state this sweep converges the rest of the tree toward.
+
+## Class (c) residuals — listed loudly, named follow-ups, NOT converted here
+
+Ordered by blast radius. Each is safe today only because of another pass's
+rule; none is silent — this table is the telling.
+
+| # | Site | Collision | Today's guardian (the "wrong reason") | Follow-up |
+|---|------|-----------|----------------------------------------|-----------|
+| R1 | `main.rs:1812/3454`, `riscv backend.rs:75` | IMPORTED memory: `all_memories` holds only DEFINED memories, so `(import "env" "memory" (memory 1))` yields `linear_memory_bytes = 0` — and post-#953 every access compiles to a trap on rv32/aarch64 (software mode) for a module whose memory is REAL at runtime. Fail-closed, but a silent always-trap miscompile of a legitimate module — the "tell the caller" class. | wasm validation ("no memory ⇒ no memory ops") makes 0 honest for truly memoryless modules; imported memory breaks that argument. The decoder discards the imported min (`TypeRef::Memory(_) → ImportKind::Memory`), already named on #932. | Carry the imported minimum through the decoder (#932 follow-up), or refuse imported-memory modules loudly on self-contained paths. |
+| R2 | `main.rs:5990` (cortex-m image) | `initial_pages.unwrap_or(1)` "backwards compat": a NO-memory module gets R10 = 65536 baked. | For defined-memory-less modules wasm validation forbids memory ops, so the invented page is unobservable — EXCEPT via an imported memory (R1), where R10 then lies about the size. | Fold into R1's resolution; delete the `unwrap_or(1)` once callers state sizes (the #953 contract applied to the image builder). |
+| R3 | `main.rs:4712` | `emit_wasm_data = needs_wasm_data && linear_memory_bytes > 0`: a `(memory 0)` (or imported-memory) module whose code carries `__synth_wasm_data`/`__synth_globals` relocs gets NO region emitted → dangling symbol. | The final link fails loudly downstream (undefined symbol) — the right failure by the wrong actor, with the wrong message. | Emit the globals region independent of linmem size, or refuse at compile with a named reason. |
+| R4 | `wasm_decoder.rs:941/1031/1399` | type-table `.get(ti).unwrap_or(0)` — an out-of-range type index yields arg/result count 0. | wasmparser validation rejects out-of-range type indices before these lines run. | Convert to a decode error (defense in depth against a validation-skipping caller). |
+| R5 | `validator_pattern.rs:776` | `arity(op).unwrap_or(0)` — an op outside the supported surface seeds no inputs. | the caller dispatches only supported ops here; and a wrong arity under-constrains the EQUIVALENCE check, which can only FAIL spuriously (loud), never pass vacuously. | Return the `Option` and decline the op loudly. |
+| R6 | `arm_backend.rs:127–129` | `params.cloned().unwrap_or_default()` — a driver that supplies no param tables gets "no i64/f32/f64 params", the #518 miscompile mechanism. | the CLI always populates the tables (post-#518/#599); only hand-built `Backend` API callers can omit them. | Make the tables non-optional in `CompileConfig` or decline i64/float-param functions when absent. |
+| R7 | `provenance.rs:199`, `main.rs:3794` | `op_offsets.get(i).unwrap_or(0)` — a missing offset renders as offset 0 (= first op) in the provenance sidecar. | decoder emits `op_offsets` parallel to `ops`, so the index is always in range. | `Option` through the sidecar schema; diagnostic-only blast radius. |
+| R8 | `elf_builder.rs:723` | `name_offsets.get(i).unwrap_or(0)` — a missing name renders as the null strtab entry (empty section name). | the two vectors are built in the same loop, same length. | zip the vectors so the invariant is structural. |
+| R9 | `solver.rs` deadline / `translation_validator.rs:552` | not sentinels (exact-arithmetic guards); listed here only because the grep surfaced them — no absence encoding present. | — | none needed. |
+
+## Red-first evidence (pre-fix probes, v0.56.1 tree, 2026-08-13)
+
+```
+$ synth compile mem0.wat --all-exports --safety-bounds mask ; echo $?
+0                                   # accepted — C1 hole open
+$ synth disasm mem0_mask.elf | grep r10
+movw r10, #0x0                      # zero size baked; SUB R12,R10,#1 = identity mask
+
+$ synth compile mem1.wat -b riscv --func-index 0 --safety-bounds software
+$ synth disasm mem1_rv.o            # first words:
+00050293 00100073                   # addi t0,a0,0 ; ebreak — every access traps (C2)
+
+# post-fix: 00010337 ffc30313 ...   # lui t1,0x10 ; addi t1,t1,-4 = the real 65532 bound
+# control: (memory 0) keeps 00100073 and gains no bound — #953 fail-closed preserved
+```


### PR DESCRIPTION
## What this is

The RQ-57-SENTINEL deliverable from `artifacts/release-v0.57.yaml`: an audit of every size/count/address path where a NUMERIC SENTINEL stands in for absence — the mechanism behind #932 (v0.56.0) and #953 (v0.56.1), two security bugs one release apart with the same root cause in opposite directions.

## The number (non-vacuity)

**54 sites examined / 4 converted / 41 argued-(a) / 9 listed-(c) residuals.**
Full per-site table with arguments: `scripts/repro/sentinel_sweep_rq57.md`.

## Three latent defects found and fixed (the real prize — instances three, four, five of the mechanism)

**1. SECURITY — ARM `--safety-bounds mask` + `(memory 0)` = unbounded OOB read/write.**
`arm_backend.rs` exempted `bytes == 0` from the mask power-of-two gate ("0 means unknown"). A `(memory 0)` module bakes startup `R10 = 0`, so the emitted guard `SUB R12, R10, #1; AND addr, R12` computes `0 − 1 = 0xFFFFFFFF` — an IDENTITY mask. Every access executed unmasked at `[R11 + addr]` for any 32-bit address, in the mode whose purpose is bounding. Verified pre-fix on v0.56.1 (exit 0, `movw r10, #0x0` baked, AND-masked bodies). Zero-byte memory now REFUSES loudly — the same contract #953 gave rv32. This is #953's disease in a third backend-mode, and worse than the 64 KiB invention: no bound at all.

**2. The single-function CLI path regressed under #953.**
`main.rs` forced `linear_memory_bytes: 0` for every backend except aarch64, on a comment (from #865) claiming the field was "never consumed" by ARM/RV32 — false for RV32, whose `compile_function` has always read it. When #953 deleted the rv32 64 KiB fallback, `--func-index` + `--safety-bounds software` on a `(memory 1)` module started compiling EVERY access to the zero-size `ebreak` fold (pre-fix: `00050293 00100073` at entry — a live availability miscompile in v0.56.1). The declared size now threads to ALL backends; byte-invisible where unconsumed (frozen anchors are `--all-exports`).

**3. The #932 fix's own "unreachable by construction" comment was false.**
The sweep's interim `.expect()` on the attestation's `unwrap_or(0)` panicked in one test run: attestations are ALSO emitted for REFUSED ingests (#901's refusal-is-attested rule), and the imported-memory refusal — #932's exact shape — reaches the flattened 0. Shipped v0.56.x refusal attestations recorded an invented `"memory_min_bytes": 0`. `ElisionAttestation.memory_min_bytes` is now `Option<u32>`; absence serializes as an explicit `null` (accepted-case JSON unchanged).

**Also converted:** `NativeGlobalsLayout.sp_init` (0-for-absent → `Option<i32>`; extent folds map `None → 0` as the explicit max-identity, and `--shadow-stack-size` on a module with no SP global now refuses loudly instead of shrinking a phantom reservation).

## The 9 (c)-residuals, listed not silent

Highest blast radius first (details + guardians in the sweep doc): imported-memory modules get `linear_memory_bytes = 0` → silent always-trap compiles on rv32/aarch64 (fail-closed, but the "tell the caller" class — ties to the #932 decoder follow-up); the cortex-m image's `initial_pages.unwrap_or(1)`; the `emit_wasm_data && linear_memory_bytes > 0` region-skip; decoder type-table `.get().unwrap_or(0)` (guarded by wasmparser validation); `validator_pattern` arity; `arm_backend` param-table defaults (#518's mechanism, guarded by the CLI always populating); provenance/ELF-name diagnostic flatteners.

## Red-first evidence

All three defects demonstrated on the pre-fix tree before conversion (transcripts in the sweep doc). New tests:
- `arm_safety_bounds_mask_zero_size_refused_rq57` (unit) + `arm_mask_zero_memory_refused` (CLI, end-to-end reachability)
- `rv32_single_func_software_uses_declared_bound` + non-vacuity control `rv32_single_func_zero_memory_stays_fail_closed` (proves the fix threads the declared size rather than resurrecting a fallback — `(memory 0)` keeps the #953 ebreak fold)
- `no_floor_attests_null_not_zero_rq57` (attestation null, invented-0 unrepresentable)

## Gates

- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` exit 0 (real exit code)
- `cargo test --workspace` exit 0 (136 suites, 0 failures)
- `frozen_codegen_bytes` **10/10** — the Option refactors moved no shipping bytes
- Two pre-existing mask tests updated to STATE their size (`linear_memory_bytes: 64 * 1024`) — exactly what the #953 fix required of the rv32 driver test

Refs #953, #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L