### PR TITLE
fix(#930): branch target lands mid-instruction — End-in-if misattribution + SC-5 branch-target boundary gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/oracle_wiring_check.py --json /tmp/oracle-wiring.json --list \
-            --min-emulation-floor 295710 \
+            --min-emulation-floor 295726 \
             | tee /tmp/oracle-wiring.log
           python3 - <<'PY'
           import json, sys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1141,6 +1141,23 @@ jobs:
       # 32-bit T3 conditional branch. RED on v0.42.0 (5/6 cases) -> GREEN.
       - name: Run wide-B<cond>.W branch-target oracle (#740, cortex-m4)
         run: SYNTH=./target/debug/synth python scripts/oracle_run.py scripts/repro/brif_outer_740_differential.py
+      # #930: sibling of #740 on the SAME SC-5 sentence ("branch offset
+      # calculation shall account for Thumb instruction alignment and variable
+      # instruction widths"). The direct selector's End handler misattributed
+      # a block-End inside an if-arm to the enclosing if, so the block's end
+      # label was NEVER emitted and its `br` encoded as a `b #0` placeholder
+      # landing on the second halfword of a 32-bit movw (labels.wast br /
+      # br_if2 — silent wrong value, exit 0). Executes both labels.wast shapes
+      # plus both if-edges and both br_if-edges under unicorn vs wasmtime on
+      # BOTH ARM codegen paths (--relocatable direct + default optimized),
+      # scratch registers seeded with a nonzero sentinel so a read of the
+      # never-written condition register cannot green by lucky zero.
+      # RED on 47f8ab84 (14/16 vectors, both paths) -> GREEN with the fix.
+      # The compile-time half of SC-5's discharge is validate_branch_targets
+      # (arm_backend.rs): any branch target outside the instruction-start set
+      # of the final stream is a hard compile error, not silent garbage.
+      - name: Run branch-target mid-instruction boundary oracle (#930, cortex-m3)
+        run: SYNTH=./target/debug/synth python scripts/oracle_run.py scripts/repro/branch_boundary_930_differential.py
       # #406 (VCR-MEM-002 phase 1): N wasm memories = N DISTINCT native base
       # regions. Memory 0 keeps the runtime R11 base; memory k > 0 is
       # addressed via its own __synth_wasm_data_<k> symbol at the base of the

--- a/artifacts/system-requirements.yaml
+++ b/artifacts/system-requirements.yaml
@@ -280,3 +280,48 @@ artifacts:
         Bounds checks present for all memory access instructions;
         CFI preserved through control flow translation; stack overflow
         detection verified on Cortex-M4 via Renode.
+
+  # ---------------------------------------------------------------------------
+  # FR-009 — the SC-5 discharge chain (#740, #930).
+  #
+  # SC-5's only satisfiers were FR-002 and FR-008: omnibus, status draft, and
+  # verified by nothing that targets SC-5's actual sentence. Both known escapes
+  # of that sentence (#740 B<cond>.W T3 offset halved; #930 dropped inner-block
+  # end label -> `b #0` placeholder landing mid-instruction) were silent and
+  # found from outside. This requirement carries SC-5's sentence VERBATIM at
+  # requirement granularity so a verification artifact (VER-SC5-001) can land
+  # `verifies` on it specifically — not on FR-002 generally, which is the
+  # coarse-granularity anti-pattern that left the chain open.
+  # ---------------------------------------------------------------------------
+
+  - id: FR-009
+    type: system-req
+    title: Branch targets are instruction-stream boundaries
+    description: >
+      Branch offset calculation shall account for Thumb instruction
+      alignment and variable instruction widths (SC-5). Concretely: every
+      branch target emitted for Thumb-2 shall be a member of the
+      instruction-start set of the final instruction stream, and every
+      locally-defined branch label shall resolve — a compile where either
+      fails shall hard-error rather than emit the miscompiled object.
+      Thumb-2 mixes 16- and 32-bit encodings, so a target off by one
+      halfword executes the second halfword of a wide instruction as if it
+      were an instruction: silent garbage with exit 0.
+    status: implemented
+    tags: [branch-targets, thumb-2, instruction-boundary, control-flow, safety]
+    links:
+      - type: derives-from
+        target: BR-001
+      - type: constraint-satisfies
+        target: SC-5
+    fields:
+      req-type: safety
+      priority: must
+      verification-criteria: >
+        validate_branch_targets (crates/synth-backend/src/arm_backend.rs)
+        hard-errors any Thumb-2 compile whose stream contains a numeric
+        branch target outside the instruction-start set or an unresolved
+        .L-local label branch, on BOTH codegen paths. Regression escapes
+        #740 and #930 are pinned by execution differentials
+        (brif_outer_740_differential.py, branch_boundary_930_differential.py)
+        under unicorn vs wasmtime.

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -440,3 +440,64 @@ artifacts:
           28+ tests: roundtrip primitives, string encoding (UTF-8,
           UTF-16, Latin-1), records, variants, options, results, enums,
           flags, lists, memory bounds checking
+
+  # ---------------------------------------------------------------------------
+  # SC-5 discharge (#740, #930) — branch-target instruction-boundary gate
+  #
+  # SC-5's last sentence ("Branch offset calculation shall account for Thumb
+  # instruction alignment and variable instruction widths") had NO verification
+  # artifact: its only downward links were two omnibus draft requirements
+  # (FR-002, FR-008), and both known escapes of the sentence (#740, #930) were
+  # silent and found from outside. This artifact's subject IS that sentence,
+  # linked `verifies` onto SC-5 itself — not onto FR-002 generally, which is
+  # the coarse-granularity anti-pattern that left the chain open.
+  # ---------------------------------------------------------------------------
+
+  - id: VER-SC5-001
+    type: sys-verification
+    title: Branch targets are instruction-stream boundaries (SC-5 discharge)
+    description: >
+      Verifies SC-5: "Branch offset calculation shall account for Thumb
+      instruction alignment and variable instruction widths." Every branch
+      target emitted for Thumb-2 must be a member of the instruction-start
+      set of the final instruction stream — Thumb-2 mixes 16- and 32-bit
+      encodings, so an off-by-one-halfword target lands on the second
+      halfword of a wide instruction and the CPU executes bytes that were
+      never an instruction (silent wrong value, exit 0). Two mechanisms:
+      (1) a compile-time TOTAL gate, validate_branch_targets
+      (crates/synth-backend/src/arm_backend.rs), runs unconditionally on the
+      final Thumb-2 stream of BOTH codegen paths (direct/--relocatable and
+      optimized) and hard-errors the compile when any numeric branch target
+      is outside the instruction-start set OR any .L-local label branch
+      survives unresolved (a dropped label — only external targets are
+      legitimately absent and relocation-patched); (2) execution
+      differentials pinning both known escapes of the sentence as regression
+      cases, executed under unicorn against wasmtime. Non-vacuity, measured:
+      sweeping the gate over the whole fixture corpus (404 ARM compiles)
+      with the pre-#930-fix selector finds the #930 fixture plus exactly one
+      pre-existing silent victim (rv32_br_value_931.wat 'nested', #930's
+      shape, only ever CI-compiled for RV32); with the fix, zero violations.
+    status: implemented
+    tags: [sc-5, branch-targets, thumb-2, instruction-boundary, stpa-discharge]
+    links:
+      # `verifies` may only target a requirement (schema), so the discharge
+      # chain is: VER-SC5-001 --verifies--> FR-009 --constraint-satisfies-->
+      # SC-5, where FR-009 carries SC-5's sentence VERBATIM at requirement
+      # granularity. NOT linked onto FR-002/FR-008 — omnibus targets are the
+      # coarse-granularity anti-pattern that left SC-5 undischarged.
+      - type: verifies
+        target: FR-009
+    fields:
+      method: automated-test
+      steps:
+        gate: >
+          validate_branch_targets — unconditional on every Thumb-2 compile,
+          both ARM codegen paths; violation = hard compile error
+        unit: "cargo test -p synth-backend --lib -- validate_branch_targets_sc5_930 930_brif2"
+        oracle-930: "SYNTH=./target/debug/synth python scripts/oracle_run.py scripts/repro/branch_boundary_930_differential.py"
+        oracle-740: "SYNTH=./target/debug/synth python scripts/oracle_run.py scripts/repro/brif_outer_740_differential.py"
+        regression-escapes: >
+          #740 (B<cond>.W T3 packed halfword_offset >> 1, offset halved past
+          254 bytes) and #930 (block-End inside an if-arm misattributed to
+          the enclosing if; dropped end label -> b #0 placeholder landing
+          mid-instruction), both pinned by the oracles above

--- a/claims.yaml
+++ b/claims.yaml
@@ -1133,7 +1133,7 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-ORACLE-CHECK-FLOORS-910-CI
     doc: .github/workflows/ci.yml
-    text: "--min-emulation-floor 295710"
+    text: "--min-emulation-floor 295726"
     evidence:
       - kind: count-min                      # oracle steps routed through the driver
         pattern: 'oracle_run\.py scripts/repro/'

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -1905,6 +1905,7 @@ fn validate_branch_targets(instrs: &[ArmInstruction], encoder: &ArmEncoder) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
+    use synth_synthesis::{Operand2, Reg};
 
     /// #539: `i32.const 0; memory.grow m` folds to `memory.size m`; other deltas
     /// (const non-zero, runtime) are left as `memory.grow` (→ the sound fixed-
@@ -1942,6 +1943,187 @@ mod tests {
             ]),
             vec![WasmOp::LocalGet(0), WasmOp::MemorySize(0), WasmOp::I32Add]
         );
+    }
+
+    /// SC-5 (#740/#930): the branch-target boundary gate. Every emitted branch
+    /// target must be a member of the instruction-start set of the final
+    /// Thumb-2 stream; a `.L`-local label branch surviving unresolved is a
+    /// dropped label. Red-first: both rejection arms were written against the
+    /// exact #930 stream shape (a `b #0` placeholder whose pc+4 target falls
+    /// on the second halfword of a 32-bit `movw`) and fail without the gate.
+    #[test]
+    fn test_validate_branch_targets_sc5_930() {
+        let enc = ArmEncoder::new_thumb2();
+        let ins = |op: ArmOp| ArmInstruction {
+            op,
+            source_line: None,
+        };
+
+        // 1. Boundary-valid stream: b over a wide movw onto the mov — OK.
+        //    positions: 0 BOffset(2B), 2 Movw(4B), 6 Mov(2B)
+        //    target = 0 + 4 + 2*1 = 6 = start of Mov.
+        let good = vec![
+            ins(ArmOp::BOffset { offset: 1 }),
+            ins(ArmOp::Movw {
+                rd: Reg::R3,
+                imm16: 1,
+            }),
+            ins(ArmOp::Mov {
+                rd: Reg::R0,
+                op2: Operand2::Reg(Reg::R3),
+            }),
+        ];
+        assert!(validate_branch_targets(&good, &enc).is_ok());
+
+        // 2. The exact #930 shape: `b #0` (offset 0) -> target = pc+4 = 4,
+        //    the SECOND halfword of the 4-byte movw spanning 2..6. Hard error.
+        let mid = vec![
+            ins(ArmOp::BOffset { offset: 0 }),
+            ins(ArmOp::Movw {
+                rd: Reg::R3,
+                imm16: 1,
+            }),
+            ins(ArmOp::Mov {
+                rd: Reg::R0,
+                op2: Operand2::Reg(Reg::R3),
+            }),
+        ];
+        let err = validate_branch_targets(&mid, &enc).unwrap_err();
+        assert!(err.contains("SC-5"), "boundary violation names SC-5: {err}");
+        assert!(err.contains("not an instruction boundary"), "{err}");
+
+        // 3. Conditional form of the same violation.
+        let mid_cond = vec![
+            ins(ArmOp::BCondOffset {
+                cond: synth_synthesis::Condition::NE,
+                offset: 0,
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R3,
+                imm16: 1,
+            }),
+            ins(ArmOp::Mov {
+                rd: Reg::R0,
+                op2: Operand2::Reg(Reg::R3),
+            }),
+        ];
+        assert!(validate_branch_targets(&mid_cond, &enc).is_err());
+
+        // 4. A `.L`-local label branch that was never resolved (the dropped
+        //    end label, #930's mechanism) is a hard error even though it
+        //    would encode as a well-formed placeholder.
+        let dropped = vec![
+            ins(ArmOp::B {
+                label: ".Lblock_end_3".to_string(),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R3,
+                imm16: 1,
+            }),
+        ];
+        let err = validate_branch_targets(&dropped, &enc).unwrap_err();
+        assert!(err.contains(".Lblock_end_3"), "{err}");
+        assert!(err.contains("dropped label"), "{err}");
+
+        // 5. An EXTERNAL label branch (no `.L` prefix) is legitimately absent
+        //    (patched via relocation / vector table) and must NOT trip the
+        //    gate — the carve-out that used to swallow #930 stays for real
+        //    externals only.
+        let external = vec![
+            ins(ArmOp::B {
+                label: "Trap_Handler".to_string(),
+            }),
+            ins(ArmOp::Movw {
+                rd: Reg::R3,
+                imm16: 1,
+            }),
+        ];
+        assert!(validate_branch_targets(&external, &enc).is_ok());
+
+        // 6. Labels are zero-width: a target on a Label position is the start
+        //    of the instruction that follows it — OK.
+        let labeled = vec![
+            ins(ArmOp::BOffset { offset: 1 }),
+            ins(ArmOp::Movw {
+                rd: Reg::R3,
+                imm16: 1,
+            }),
+            ins(ArmOp::Label {
+                name: ".Lend".to_string(),
+            }),
+            ins(ArmOp::Mov {
+                rd: Reg::R0,
+                op2: Operand2::Reg(Reg::R3),
+            }),
+        ];
+        assert!(validate_branch_targets(&labeled, &enc).is_ok());
+    }
+
+    /// SC-5 (#930) end-to-end at the backend seam: the labels.wast `br_if2`
+    /// shape — a `br_if` exiting an enclosing block from inside an `if`, its
+    /// value operand a block-that-branches — must COMPILE (the pre-fix
+    /// selector dropped the inner block's end label, which the SC-5 gate now
+    /// turns into a hard error, so compile success proves the label was
+    /// emitted) and every branch in the emitted bytes must land on an
+    /// instruction boundary (re-derived from the encoded halfwords, not from
+    /// the resolver's own bookkeeping).
+    #[test]
+    fn test_930_brif2_shape_compiles_and_targets_boundaries() {
+        let backend = ArmBackend::new();
+        let ops = vec![
+            WasmOp::Block, // $l0 (result i32)
+            WasmOp::I32Const(1),
+            WasmOp::If,
+            WasmOp::Block, // $l1 (result i32)
+            WasmOp::I32Const(1),
+            WasmOp::Br(0), // br $l1
+            WasmOp::End,
+            WasmOp::I32Const(1),
+            WasmOp::BrIf(1), // br_if $l0
+            WasmOp::Drop,
+            WasmOp::End, // end if
+            WasmOp::I32Const(0),
+            WasmOp::End, // end $l0
+            WasmOp::End,
+        ];
+        let config = CompileConfig::default();
+        let func = backend
+            .compile_function("t", &ops, &config)
+            .expect("#930 shape must compile (SC-5 gate passes)");
+
+        // Walk the encoded halfwords: collect instruction starts, then check
+        // every narrow/wide B / B<cond> target is a member.
+        let code = &func.code;
+        let mut starts = std::collections::HashSet::new();
+        let mut widths = Vec::new();
+        let mut off = 0usize;
+        while off + 2 <= code.len() {
+            starts.insert(off as i64);
+            let hw = u16::from_le_bytes([code[off], code[off + 1]]);
+            let wide = (hw & 0xF800) >= 0xE800; // 0b11101/0b11110/0b11111
+            widths.push((off, hw, wide));
+            off += if wide { 4 } else { 2 };
+        }
+        for (off, hw, wide) in widths {
+            let target = if !wide && (hw & 0xF800) == 0xE000 {
+                // T2 B: imm11, halfwords
+                let imm = ((hw & 0x7FF) as i32) << 21 >> 21;
+                Some(off as i64 + 4 + 2 * imm as i64)
+            } else if !wide && (hw & 0xF000) == 0xD000 && (hw & 0x0F00) < 0x0E00 {
+                // T1 B<cond>: imm8, halfwords
+                let imm = ((hw & 0xFF) as i32) << 24 >> 24;
+                Some(off as i64 + 4 + 2 * imm as i64)
+            } else {
+                None
+            };
+            if let Some(t) = target {
+                assert!(
+                    starts.contains(&t),
+                    "branch at 0x{off:x} (hw 0x{hw:04x}) targets 0x{t:x}, \
+                     not an instruction boundary — the #930 miscompile shape"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -1546,7 +1546,12 @@ fn compile_wasm_to_arm(
     // sits between the branch and its target (UsageFault on real hardware).
     // Only meaningful for Thumb-2 (the offset units are halfword/PC+4).
     let arm_instrs = if use_thumb2 {
-        resolve_label_branches(arm_instrs, &encoder)?
+        let resolved = resolve_label_branches(arm_instrs, &encoder)?;
+        // SC-5 (#740/#930): hard-gate every branch target onto the
+        // instruction-start set of the final stream — both codegen paths
+        // funnel through here. See `validate_branch_targets`.
+        validate_branch_targets(&resolved, &encoder)?;
+        resolved
     } else {
         arm_instrs
     };
@@ -1812,6 +1817,89 @@ fn resolve_label_branches(
         }
     }
     Ok(resolved)
+}
+
+/// SC-5 branch-target boundary gate (#740, #930): every emitted branch target
+/// must be a member of the instruction-start set of the final stream.
+///
+/// "Branch offset calculation shall account for Thumb instruction alignment
+/// and variable instruction widths" (`safety/stpa/system-constraints.yaml`
+/// SC-5). Thumb-2 mixes 16- and 32-bit encodings, so an off-by-one-halfword
+/// target lands on the SECOND halfword of a wide instruction and the CPU
+/// executes a halfword that was never an instruction — silent garbage, exit 0
+/// (#930: the skipped `movw` left the `br_if` condition register at its reset
+/// value). Both known escapes of that sentence were of this class: #740
+/// (`B<cond>.W` T3 offset halved) and #930 (inner-block end label never
+/// emitted, `b #0` placeholder). The encoder knows where every instruction
+/// starts, so a target outside that set is a hard error here rather than
+/// silent garbage on target.
+///
+/// Runs on the FINAL Thumb-2 stream for BOTH codegen paths — the direct
+/// (`select_with_stack`, label branches byte-resolved above) and the optimized
+/// (`optimizer_bridge`, numeric `BOffset`/`BCondOffset` pre-resolved inline) —
+/// since both funnel through this encode pipeline. Two checks, jointly total
+/// over local control flow:
+///
+/// 1. every numeric branch target is in the instruction-start set;
+/// 2. no LOCAL (`.L`-prefixed) label branch survives unresolved — the resolver
+///    deliberately skips labels it cannot find because an external target
+///    (`Trap_Handler`, `func_N`) is legitimately absent and patched by
+///    relocation, but a `.L` label is only ever defined in this same stream,
+///    so an unresolved one is a dropped label (#930), not an external.
+///
+/// A32 (Cortex-R5) is fixed-width, so the mid-instruction class needs no gate
+/// there (and its branches do not flow through the Thumb-2 resolver).
+fn validate_branch_targets(instrs: &[ArmInstruction], encoder: &ArmEncoder) -> Result<(), String> {
+    use std::collections::HashSet;
+
+    // Byte position of each element (`Label` encodes to 0 bytes, so a label's
+    // position is exactly the start of the instruction that follows it).
+    let mut positions = Vec::with_capacity(instrs.len());
+    let mut pos: i64 = 0;
+    for instr in instrs {
+        positions.push(pos);
+        pos += encoder
+            .encode(&instr.op)
+            .map_err(|e| format!("SC-5 branch-target gate: size probe failed: {}", e))?
+            .len() as i64;
+    }
+    let starts: HashSet<i64> = positions.iter().copied().collect();
+
+    for (i, instr) in instrs.iter().enumerate() {
+        let offset = match &instr.op {
+            ArmOp::BOffset { offset } => *offset,
+            ArmOp::BCondOffset { offset, .. } => *offset,
+            ArmOp::B { label }
+            | ArmOp::Bcc { label, .. }
+            | ArmOp::Bhs { label }
+            | ArmOp::Blo { label }
+                if label.starts_with(".L") =>
+            {
+                return Err(format!(
+                    "SC-5 branch-target gate: local branch label '{}' is not \
+                     defined anywhere in the emitted stream (branch at byte \
+                     offset 0x{:x}). A `.L` label is only ever defined locally, \
+                     so this is a dropped label (the #930 class) — the branch \
+                     would encode as a `b #0` placeholder and land \
+                     mid-instruction. Refusing to emit a miscompiled object.",
+                    label, positions[i]
+                ));
+            }
+            _ => continue,
+        };
+        // Thumb branch semantics: target = branch_pc + 4 + 2*offset.
+        let target = positions[i] + 4 + 2 * offset as i64;
+        if !starts.contains(&target) {
+            return Err(format!(
+                "SC-5 branch-target gate: branch at byte offset 0x{:x} targets \
+                 0x{:x}, which is not an instruction boundary (instruction-start \
+                 set violation — the target lands mid-instruction, the \
+                 #740/#930 class). Refusing to emit a miscompiled object.",
+                positions[i], target
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/synth-synthesis/src/instruction_selector.rs
+++ b/crates/synth-synthesis/src/instruction_selector.rs
@@ -13843,8 +13843,22 @@ impl InstructionSelector {
                 End => {
                     cf.exit_block();
                     // If this closes an if-block, emit the end label
-                    // and possibly the else label (if no else was present)
-                    if let Some((else_label, end_label)) = if_labels.last().cloned() {
+                    // and possibly the else label (if no else was present).
+                    //
+                    // #930: "closes an if-block" is decided by the INNERMOST open
+                    // construct (`block_labels.last()`), never by `if_labels`
+                    // alone. A plain block/loop nested inside an if's then/else
+                    // arm reaches its `End` while the enclosing if's labels are
+                    // still on `if_labels`; the old `if_labels.last()` test
+                    // misattributed that `End` to the if — emitting the if's
+                    // else/end labels at the inner block's position, popping the
+                    // wrong stacks, and NEVER emitting the inner block's own end
+                    // label. Its `B .Lblock_end_N` then stayed an unresolved
+                    // `b #0` placeholder landing mid-instruction (labels.wast
+                    // br / br_if2, silent wrong value).
+                    if block_labels.last().is_some_and(|bl| bl.is_if)
+                        && let Some((else_label, end_label)) = if_labels.last().cloned()
+                    {
                         // Check if the else label was already emitted
                         // by looking for it in the instructions
                         let else_emitted = instructions

--- a/scripts/repro/branch_boundary_930.wat
+++ b/scripts/repro/branch_boundary_930.wat
@@ -1,0 +1,52 @@
+(module
+  ;; #930 — labels.wast `br_if2`: a `br_if` exiting an enclosing block FROM
+  ;; INSIDE an `if`, whose value operand is itself a block that branches.
+  ;; Pre-fix, the inner block's `End` was misattributed to the enclosing `if`
+  ;; (the selector tested `if_labels` alone), so `.Lblock_end_N` was never
+  ;; emitted and its `b` encoded as a `b #0` placeholder landing on the second
+  ;; halfword of the following 32-bit `movw` — the br_if condition register
+  ;; was never written and the branch silently fell through.
+  (func (export "brif2") (result i32)
+    (block $l0 (result i32)
+      (if (i32.const 1)
+        (then
+          (drop
+            (br_if $l0
+              (block $l1 (result i32) (br $l1 (i32.const 1)))
+              (i32.const 1)))))
+      (i32.const 0)))
+
+  ;; #930 — labels.wast `br`: the plain-`br` form of the same shape.
+  (func (export "br") (result i32)
+    (block $l0 (result i32)
+      (if (i32.const 1)
+        (then (br $l0 (block $l1 (result i32) (br $l1 (i32.const 1)))))
+        (else (block (drop (block $l1 (result i32) (br $l1 (i32.const 1)))))))
+      (i32.const 1)))
+
+  ;; The if-condition as a parameter: exercises BOTH edges of the enclosing
+  ;; `if`. The pre-fix miscompile also mis-placed the if's ELSE label at the
+  ;; inner block's position (a boundary-valid but semantically wrong target),
+  ;; so the condition-false path read an uninitialised register — invisible to
+  ;; the const-1 shape above and to the boundary invariant alone.
+  (func (export "brif2p") (param i32) (result i32)
+    (block $l0 (result i32)
+      (if (local.get 0)
+        (then
+          (drop
+            (br_if $l0
+              (block $l1 (result i32) (br $l1 (i32.const 1)))
+              (i32.const 1)))))
+      (i32.const 0)))
+
+  ;; The br_if-condition as a parameter: both edges of the br_if itself
+  ;; (taken -> block-value 1, not-taken -> fallthrough 0).
+  (func (export "brifc") (param i32) (result i32)
+    (block $l0 (result i32)
+      (if (i32.const 1)
+        (then
+          (drop
+            (br_if $l0
+              (block $l1 (result i32) (br $l1 (i32.const 1)))
+              (local.get 0)))))
+      (i32.const 0))))

--- a/scripts/repro/branch_boundary_930_differential.py
+++ b/scripts/repro/branch_boundary_930_differential.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# ci-status: wired
+# ci-checks: emulations >= 16
+"""#930 — thumb-2 branch target lands mid-instruction (labels.wast br / br_if2).
+
+A `br`/`br_if` exiting an enclosing block FROM INSIDE an `if`, whose value
+operand is itself a block-that-branches, silently produced the wrong value on
+thumb-2 (exit 0, no diagnostic). Root cause: `select_with_stack`'s `End`
+handler decided "this End closes an if" by looking at `if_labels` ALONE, so
+the `End` of a plain block nested inside a then/else arm was misattributed to
+the enclosing `if` — the if's else/end labels were emitted at the inner
+block's position, the wrong stacks were popped, and the inner block's own end
+label was NEVER emitted. Its `B .Lblock_end_N` then stayed an unresolved
+`b #0` placeholder whose target (pc+4) fell on the SECOND halfword of the
+following 32-bit `movw`: the br_if condition register was never written and
+the CPU executed a halfword that was never an instruction. Sibling of #740
+(B<cond>.W T3 offset halved) — the same SC-5 sentence, "branch offset
+calculation shall account for Thumb instruction alignment and variable
+instruction widths".
+
+The same misattribution ALSO mis-placed the if's else label at the inner
+block's position — a boundary-VALID but semantically wrong `beq` target on the
+condition-false path. `brif2p(0)` pins that half; the instruction-start-set
+invariant alone cannot see it.
+
+This oracle EXECUTES each export under unicorn (thumb) and compares against
+wasmtime, on BOTH ARM codegen paths — `--relocatable` forces the direct
+selector (`select_with_stack`, the path #740 was on and #930 is on) and the
+default standalone image takes the optimized path. Scratch registers are
+seeded with a nonzero sentinel so a "reset value" read is observably wrong
+rather than a lucky zero.
+
+Symbols come from the ELF `.symtab` (SHT_SYMTAB), not `synth disasm` text.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/branch_boundary_930_differential.py
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R3,
+    UC_ARM_REG_R4,
+    UC_ARM_REG_R5,
+    UC_ARM_REG_R6,
+    UC_ARM_REG_R7,
+    UC_ARM_REG_R8,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("branch_boundary_930.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+CODE = 0x0
+SP_INIT = 0x2004_0000
+SENTINEL = 0xA5A5_A5A5  # "reset value" that is loudly wrong, never a lucky 0
+
+# (export, args) — labels.wast br_if2 / br as filed, plus both edges of the
+# enclosing if (brif2p) and of the br_if itself (brifc).
+VECTORS = [
+    ("brif2", ()),
+    ("br", ()),
+    ("brif2p", (1,)),
+    ("brif2p", (0,)),
+    ("brifc", (1,)),
+    ("brifc", (0,)),
+    ("brifc", (7,)),
+    ("brifc", (0xA5A5A5A5,)),
+]
+
+
+def compile_elf(out, relocatable):
+    args = [SYNTH, "compile", str(WAT), "-b", "arm", "-t", "cortex-m3",
+            "--all-exports", "-o", out]
+    if relocatable:
+        args.append("--relocatable")
+    r = subprocess.run(args, capture_output=True, text=True)
+    if r.returncode != 0:
+        sys.exit(f"compile failed ({'relocatable' if relocatable else 'default'}): "
+                 f"{r.stderr}")
+
+
+def load(elf):
+    with open(elf, "rb") as fh:
+        f = ELFFile(fh)
+        text = f.get_section_by_name(".text").data()
+        syms = {}
+        for sec in f.iter_sections():
+            if sec.header.sh_type == "SHT_SYMTAB":
+                for s in sec.iter_symbols():
+                    if s.name and s["st_info"]["type"] == "STT_FUNC":
+                        syms[s.name] = s["st_value"]
+        return text, syms
+
+
+def run_unicorn(text, faddr, args):
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x10000)
+    mu.mem_map(0x2000_0000, 0x8_0000)
+    mu.mem_write(CODE, text)
+    mu.reg_write(UC_ARM_REG_SP, SP_INIT)
+    # Seed every scratch/callee-saved register the fixtures touch with a
+    # nonzero sentinel: the pre-fix miscompile READS a never-written register
+    # ("its movw was skipped over"), and a zero-initialised emulator can grade
+    # that read as a lucky PASS.
+    for reg in (UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3, UC_ARM_REG_R4,
+                UC_ARM_REG_R5, UC_ARM_REG_R6, UC_ARM_REG_R7, UC_ARM_REG_R8):
+        mu.reg_write(reg, SENTINEL)
+    ret = CODE + 0xFF00
+    mu.mem_write(ret, b"\x00\xbf\x00\xbf")
+    mu.reg_write(UC_ARM_REG_LR, ret | 1)
+    for i, a in enumerate(args):
+        mu.reg_write(UC_ARM_REG_R0 + i, a & 0xFFFFFFFF)
+    if not args:
+        mu.reg_write(UC_ARM_REG_R0, SENTINEL)
+    try:
+        mu.emu_start((faddr & ~1) | 1, ret, timeout=5_000_000, count=100_000)
+    except UcError as e:
+        return None, str(e)
+    return mu.reg_read(UC_ARM_REG_R0) & 0xFFFFFFFF, ""
+
+
+def main():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module(engine, WAT.read_bytes())
+
+    def wt(name, args):
+        store = wasmtime.Store(engine)
+        inst = wasmtime.Instance(store, module, [])
+        return inst.exports(store)[name](store, *args) & 0xFFFFFFFF
+
+    fails = 0
+    executed = 0
+    for label, relocatable in [("direct/--relocatable", True),
+                               ("optimized/default", False)]:
+        out = f"/tmp/branch_boundary_930_{'rel' if relocatable else 'std'}.o"
+        compile_elf(out, relocatable)
+        text, syms = load(out)
+        print(f"--- path: {label} ---")
+        for name, args in VECTORS:
+            gt = wt(name, args)
+            faddr = syms.get(name)
+            if faddr is None:
+                fails += 1
+                print(f"FAIL {name}{args}: symbol missing (function skipped?)")
+                continue
+            res, err = run_unicorn(text, faddr, args)
+            ok = res == gt
+            fails += 0 if ok else 1
+            executed += 1 if res is not None else 0
+            shown = f"0x{res:08x}" if res is not None else f"ERR({err})"
+            shown_args = ", ".join(str(a) for a in args)
+            print(f"{'OK  ' if ok else 'FAIL'} {name}({shown_args}) = {shown} "
+                  f"(wasmtime 0x{gt:08x})")
+
+    # NON-VACUITY, ASSERTED: every vector must actually reach the emulator on
+    # BOTH paths — a decline or a skipped function must not green this gate.
+    total = 2 * len(VECTORS)
+    print(f"\n#930 EMULATIONS={executed}/{total}")
+    if executed != total:
+        print(f"FAIL: only {executed} of {total} vectors reached the emulator")
+        sys.exit(1)
+    print("ARM branch-boundary #930 ORACLE:", "PASS" if not fails else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refs #930

## Root cause (one level deeper than the issue's framing)

The branch offset arithmetic is fine. The direct selector's `End` handler decided
"this `End` closes an if" by looking at `if_labels` ALONE
(`instruction_selector.rs`). A plain block/loop nested inside an if's then/else
arm reaches its `End` while the enclosing if's labels are still on `if_labels`,
so that `End` was misattributed to the if:

- the if's else/end labels were emitted at the INNER block's position
  (`.Lelse_1` at 0x12 — a boundary-valid but semantically wrong `beq` target on
  the condition-false path, invisible to the boundary invariant alone);
- the wrong stacks were popped;
- the inner block's own end label (`.Lblock_end_3`) was **never emitted**. Its
  `B .Lblock_end_N` survived to the resolver, hit the missing-label carve-out
  meant for EXTERNAL targets (`Trap_Handler`), and encoded as a `b #0`
  placeholder → target = pc+4 = 0x14, the second halfword of the following
  32-bit `movw`. The br_if condition register was never written; silent wrong
  value, exit 0 (labels.wast `br` / `br_if2`).

**Fix:** gate the if-path on the INNERMOST open construct
(`block_labels.last().is_if`), pushed/popped in lockstep with `if_labels` for
real ifs. One conditional; cures both the dropped label and the misplaced else
label.

## SC-5 discharged (the point)

`SC-5` ("Branch offset calculation shall account for Thumb instruction
alignment and variable instruction widths") had NO verification artifact; both
known escapes of that sentence (#740, #930) shipped silently.

1. **General invariant, compile-time, total** — `validate_branch_targets`
   (`arm_backend.rs`): on the FINAL Thumb-2 stream of BOTH codegen paths,
   (a) every numeric `BOffset`/`BCondOffset` target must be a member of the
   instruction-start set, and (b) no `.L`-local label branch may survive
   unresolved (only external targets are legitimately absent and
   relocation-patched — a missing local label is a dropped label). Violation =
   hard compile error, not silent garbage on target.
2. **Rivet chain** — the schema allows `verifies` only onto requirements, so:
   `VER-SC5-001` —verifies→ **`FR-009`** (NEW system-req carrying SC-5's
   sentence VERBATIM, status implemented) —constraint-satisfies→ `SC-5`.
   Deliberately NOT linked onto omnibus FR-002/FR-008 (the coarse-granularity
   anti-pattern that left the chain open). #740 + #930 are pinned as its
   regression escapes. `rivet validate` under the CI filter: 0 OURS errors.

## Red-first evidence

- **Execution differential** `scripts/repro/branch_boundary_930_differential.py`
  (wired in CI next to the #740 oracle, `ci-checks: emulations >= 16`): the
  labels.wast `br`/`br_if2` shapes + both if-edges + both br_if-edges, executed
  under unicorn vs wasmtime on BOTH ARM paths (`--relocatable` direct +
  default optimized), scratch registers seeded `0xA5A5A5A5` so a read of the
  never-written condition register cannot green by lucky zero.
  **RED on 47f8ab84: 14/16 FAIL on both paths** (returns `0x1000` = the
  garbage `lsls` result, `0xa5a5a5a5` = the reset-value read) → GREEN, 16/16.
- **Unit red-first**: `test_930_brif2_shape_compiles_and_targets_boundaries`
  FAILS on the pre-fix selector (the SC-5 gate refuses the compile);
  `test_validate_branch_targets_sc5_930` exercises both rejection arms and the
  external-label carve-out.
- With only the invariant (fix reverted), `synth compile` on the repro
  **hard-errors naming `.Lblock_end_3`** instead of exiting 0 with garbage.

## Non-vacuity sweep (the number)

The invariant swept over the WHOLE fixture corpus (202 .wat/.wasm, 404 ARM
cortex-m4 compiles, both paths), pre-fix selector: **2 fixtures trip — #930's
own fixture plus exactly ONE pre-existing silent victim**:
`scripts/repro/rv32_br_value_931.wat` (`nested` — #930's shape, annotated
"correct today by luck; pin it" — only ever CI-compiled for RV32, so its ARM
miscompile had shipped unnoticed; same dropped `.Lblock_end_3`). Post-fix:
**0 violations** across all 404 compiles.

## Frozen anchors

**Byte-identical — no movement.** All 10 `frozen_codegen_bytes` tests pass
unchanged. Structurally expected: the fix only alters emission for streams
that previously DROPPED a label (which the frozen set never contained — the
sweep found the only two such fixtures), and the validator emits nothing.

## Gates

- `cargo fmt --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` exit 0 ✓
- `cargo test --workspace` exit 0 ✓ · `cargo test -p synth-cli --test frozen_codegen_bytes` 10/10 ✓
- `claim_check` 43/43 ✓ · `oracle_wiring_check` 157 wired / floor 295726 (ratcheted) ✓
- `artifact_citation_check` all cited filters resolve ✓ · both oracles PASS through `oracle_run.py` with floors met ✓

Verify-then-close: leaving #930 open until the release-side verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L