### PR TITLE
fix(#936): price I64Const/I64Ldr/I64Str in the WCET cycle model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3390,9 +3390,9 @@ jobs:
           python3 scripts/oracle_evidence.py "$ORACLE_EVIDENCE_JSONL" --min-oracles 11
 
   repro-sweep-wcet-oracle:
-    name: repro sweep — WCET bound soundness cross-checks (phases 2-5)
+    name: repro sweep — WCET bound soundness cross-checks (phases 2-6)
     # #890: the SOUNDNESS evidence for --emit-wcet. The cargo gate
-    # (wcet_bound_gate.rs) pins the bounds analytically; these four harnesses
+    # (wcet_bound_gate.rs) pins the bounds analytically; these five harnesses
     # are the only thing that EXECUTES the fixtures under unicorn and checks
     # `bound_cycles >= executed_instructions`, i.e. that the bound synth
     # publishes is actually an upper bound. They were unwired — the soundness
@@ -3434,6 +3434,8 @@ jobs:
         run: python scripts/oracle_run.py scripts/repro/wcet_phase4_49_recursion_soundness.py
       - name: WCET phase-5 masked-ceiling loop soundness (#778)
         run: python scripts/oracle_run.py scripts/repro/wcet_phase5_778_masked_loop_soundness.py
+      - name: WCET phase-6 I64Const/I64Ldr/I64Str leaf soundness (#936)
+        run: python scripts/oracle_run.py scripts/repro/wcet_phase6_936_i64_leaf_soundness.py
       # #910: close the job with what it EXECUTED. Asserts every oracle
       # met its declared floor AND that the expected number of them
       # reported at all — a step deleted, commented out, or skipped by an
@@ -3444,4 +3446,4 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          python3 scripts/oracle_evidence.py "$ORACLE_EVIDENCE_JSONL" --min-oracles 4
+          python3 scripts/oracle_evidence.py "$ORACLE_EVIDENCE_JSONL" --min-oracles 5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,20 +242,32 @@ frozen and oracle-gated every step:
   unhinted/too-low/unmasked reject) and the `wcet_phase5_778_masked_loop_soundness.py`
   unicorn cross-check (count-down `cd(0)` executes 180 insns ≤ 339 cyc). Richer
   certificates (clamp-bounded controlling values, data-dependent recursion depths,
-  scry) are a named follow-up. #936: `I64Const`/`I64Ldr`/`I64Str` — reachable
-  ONLY on the RELOCATABLE/direct selector (`select_with_stack`, #197), which
-  gale's whole-object `--emit-wcet` run over a real `gust:os` composite showed
-  behind ALL 9 `unmodeled-op` declines (and 11 `callee-unbounded` cascades
-  behind those) — are now PRICED rather than declined. Sized from the REAL
-  Thumb-2 encoder's own byte length per instance
-  (`straightline_expansion_real`), not a hand-mirrored predicate: an exact
-  hand mirror of `i64_effective_base`'s offset-fold threshold was tried first
-  and found UNSOUND at authoring (the address-materialization `ADD` can need
-  its own `MOVW` for a large offset, which only the real encoder's own output
-  reflects) — the same drift class `op_mnemonic`'s "no second source of truth
-  to forget to update" already guards against elsewhere in this file. Gated
-  by `wcet_bound_gate.rs` (leaf + cascade-composition cases) and the
-  `wcet_phase6_936_i64_leaf_soundness.py` unicorn cross-check.
+  scry) are a named follow-up. #936: `I64Const`/`I64Ldr`/`I64Str` are now
+  PRICED rather than declined — reachable on the RELOCATABLE/direct selector
+  (`select_with_stack`, #197; `coverage()` in `estimator_encoder_agreement.rs`
+  hand-asserts they are OffPath for the optimized selector, a claim that file's
+  own doc says it cannot prove exhaustively). `I64Const`/`I64Str` are the two
+  opcode families gale's whole-object `--emit-wcet` run over a real `gust:os`
+  composite found behind all 9 of its `unmodeled-op` declines (and 11
+  `callee-unbounded` cascades behind those); `I64Ldr` is a separate finding —
+  #921's own `unmodeled-op` reproduction used `i64.load` — priced alongside
+  its two siblings because it shares `i64_effective_base`'s address-
+  materialization shape. Sized from the REAL Thumb-2 encoder's own byte length
+  per instance (`straightline_expansion_real`), not a hand-mirrored predicate:
+  an exact hand mirror of `i64_effective_base`'s offset-fold threshold was
+  tried first and found UNSOUND at authoring (the address-materialization
+  `ADD` can need its own `MOVW` for a large offset, which only the real
+  encoder's own output reflects) — the same drift class `op_mnemonic`'s "no
+  second source of truth to forget to update" already guards against
+  elsewhere in this file. HONEST RESIDUAL: `scan_for_decline` reports only the
+  FIRST decline per function, and the #936 audit found `I64Sub` (a saturating
+  trunc-sat conversion sequence), `I64ExtendI32S`/`I64ExtendI32U`, and
+  `I32WrapI64` are ALSO real direct-selector emissions with no price — a
+  function that narrows an i64 read to i32 (`i64.load` + `i32.wrap_i64`, a
+  plausible OS shape) still declines, now on `I32WrapI64` instead of `I64Ldr`
+  (measured); NOT priced by this lane. Gated by `wcet_bound_gate.rs` (leaf +
+  cascade-composition cases) and the `wcet_phase6_936_i64_leaf_soundness.py`
+  unicorn cross-check.
 - **Gate `VCR-VER-001`:** DEMONSTRATED (implemented, evidence in
   `scripts/repro/vcr_ver_001_gate.md`) — the v0.11.20 reciprocal-mult
   cost-gate was deleted outright (PR #322, differential bit-identical); the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,20 @@ frozen and oracle-gated every step:
   unhinted/too-low/unmasked reject) and the `wcet_phase5_778_masked_loop_soundness.py`
   unicorn cross-check (count-down `cd(0)` executes 180 insns ≤ 339 cyc). Richer
   certificates (clamp-bounded controlling values, data-dependent recursion depths,
-  scry) are a named follow-up.
+  scry) are a named follow-up. #936: `I64Const`/`I64Ldr`/`I64Str` — reachable
+  ONLY on the RELOCATABLE/direct selector (`select_with_stack`, #197), which
+  gale's whole-object `--emit-wcet` run over a real `gust:os` composite showed
+  behind ALL 9 `unmodeled-op` declines (and 11 `callee-unbounded` cascades
+  behind those) — are now PRICED rather than declined. Sized from the REAL
+  Thumb-2 encoder's own byte length per instance
+  (`straightline_expansion_real`), not a hand-mirrored predicate: an exact
+  hand mirror of `i64_effective_base`'s offset-fold threshold was tried first
+  and found UNSOUND at authoring (the address-materialization `ADD` can need
+  its own `MOVW` for a large offset, which only the real encoder's own output
+  reflects) — the same drift class `op_mnemonic`'s "no second source of truth
+  to forget to update" already guards against elsewhere in this file. Gated
+  by `wcet_bound_gate.rs` (leaf + cascade-composition cases) and the
+  `wcet_phase6_936_i64_leaf_soundness.py` unicorn cross-check.
 - **Gate `VCR-VER-001`:** DEMONSTRATED (implemented, evidence in
   `scripts/repro/vcr_ver_001_gate.md`) — the v0.11.20 reciprocal-mult
   cost-gate was deleted outright (PR #322, differential bit-identical); the

--- a/claims.yaml
+++ b/claims.yaml
@@ -767,6 +767,22 @@ claims:
         pattern: 'let frames = \(cert\.max_depth as u128\)\.saturating_add\(1\);'
         glob: ['crates/synth-backend/src/wcet_compose.rs']
         expect: 1
+      # #936 — I64Const/I64Ldr/I64Str are PRICED (bounded), not declined
+      # `Unmodeled`. Sound-critical because it is sized from the REAL Thumb-2
+      # encoder's own byte length for the instance (`straightline_expansion_real`),
+      # NOT the synth-synthesis byte-size estimator's `_ => 2` default (which does
+      # not cover these ops and would silently under-count) and NOT a hand-mirrored
+      # predicate (a naive "offset>0xFFF costs 2 extra ADD.W" mirror was proven
+      # WRONG at authoring — the address-materialization ADD itself can need its
+      # own MOVW for a large offset, which only calling the real encoder catches).
+      - kind: count-eq
+        pattern: 'I64Const \{ \.\. \} \| I64Ldr \{ \.\. \} \| I64Str \{ \.\. \} => match straightline_expansion_real'
+        glob: ['crates/synth-backend/src/wcet.rs']
+        expect: 1
+      - kind: count-eq
+        pattern: 'fn straightline_expansion_real\(op: &ArmOp\) -> Option<u64> \{'
+        glob: ['crates/synth-backend/src/wcet.rs']
+        expect: 1
       # #778 phase 5 — the SOUND-critical masked-ceiling BOTH-ENDPOINTS MAX. For a
       # data-dependent masked loop bound `x & K ∈ [0, K]`, the worst-case trip is
       # at the `rhs = K` endpoint for a count-UP loop and the `rhs = 0` endpoint

--- a/crates/synth-backend/src/wcet.rs
+++ b/crates/synth-backend/src/wcet.rs
@@ -100,6 +100,29 @@ fn straightline_expansion(op: &ArmOp) -> u64 {
     (byte_len / 2) * STRAIGHTLINE_CEIL_PER_HALFWORD
 }
 
+/// Worst-case cycles for a straight-line multi-byte expansion, sized from the
+/// REAL Thumb-2 encoder's OWN byte length for THIS exact instance — used for
+/// ops the synth-synthesis byte-size estimator does not cover (#936:
+/// `I64Const`/`I64Ldr`/`I64Str` are RELOCATABLE/direct-selector-only —
+/// `select_with_stack`, forced by `--relocatable`, #197 — so they are
+/// classified `OffPath` for the OPTIMIZED selector `estimator_encoder_agreement`
+/// pins, and `estimate_arm_byte_size` falls to its `_ => 2` default for them,
+/// which would silently under-count). Calling the real encoder directly means
+/// there is nothing to pin against — it cannot drift from itself the way a
+/// hand-written mirror could (`op_mnemonic`'s "no second source of truth to
+/// forget to update"). `None` on an encode failure: a function already
+/// compiled successfully into `arm_instrs`, so every op in it is encodable in
+/// practice; a caller declines `Unmodeled` rather than trusting an un-costed
+/// op. Reuses the SAME pinned `STRAIGHTLINE_CEIL_PER_HALFWORD` ceiling and the
+/// same per-instruction-≤-ceiling argument (I64Const/I64Ldr/I64Str expand to
+/// only MOVW/MOVT/LDR/STR/ADD.W, all already priced well under the ceiling).
+fn straightline_expansion_real(op: &ArmOp) -> Option<u64> {
+    let bytes = crate::arm_encoder::ArmEncoder::new_thumb2()
+        .encode(op)
+        .ok()?;
+    Some((bytes.len() as u64 / 2) * STRAIGHTLINE_CEIL_PER_HALFWORD)
+}
+
 /// Classification of an `ArmOp` for the cycle model.
 enum OpCost {
     /// A single-execution op with this documented worst-case cycle count.
@@ -227,6 +250,39 @@ fn op_cost(op: &ArmOp) -> OpCost {
         | I64Extend16S { .. }
         | I64Extend32S { .. } => Cycles(straightline_expansion(op)),
 
+        // === I64Const / I64Ldr / I64Str (#936): REAL, straight-line, ===
+        // === single-execution — priced, not declined ===
+        // Unlike the rest of the "i64 pseudo binops" bucket below, these three
+        // are NOT always folded upstream: the RELOCATABLE/direct selector
+        // (`select_with_stack`, forced by `--relocatable`, #197) emits them
+        // straight into the final `arm_instrs` stream
+        // (`instruction_selector.rs`: i64.const, i64.load/i64.store,
+        // LocalSet/LocalTee spill and incoming-param-slot stores) — confirmed
+        // reachable by a gale whole-object `--emit-wcet` run over a real
+        // `gust:os` composite, where these were the ONLY two opcodes behind
+        // all 9 `unmodeled-op` declines (I64Ldr shares the identical
+        // `i64_effective_base` address-materialization shape as I64Str and is
+        // priced alongside it to avoid an identical cascade-blocking decline).
+        // `encode_thumb`'s arms for these ops (arm_encoder.rs) each expand to
+        // a FIXED-length sequence of already-priced primitives with NO
+        // internal runtime loop:
+        //   - I64Const: 1-2 `MOVW`/`MOVT` per half (MOVT elided when the half
+        //     fits in 16 bits) = 2..4 instructions, each 1 cycle (same row as
+        //     `Movw`/`Movt` above).
+        //   - I64Ldr/I64Str: `i64_effective_base` optionally materializes an
+        //     indexed address into `ip` first (0, 1, or 2 `ADD`/`ADD.W`, each
+        //     1 cycle, same row as `Add` above — a frame access with no index
+        //     register adds nothing), then two `LDR`/`STR` (2 cycles each,
+        //     same row as `Ldr`/`Str` above).
+        // Priced via [`straightline_expansion_real`] — the REAL encoder's own
+        // byte length for THIS instance, not the (non-covering, `_ => 2`)
+        // synth-synthesis byte-size estimator [`straightline_expansion`]
+        // above uses.
+        I64Const { .. } | I64Ldr { .. } | I64Str { .. } => match straightline_expansion_real(op) {
+            Some(c) => Cycles(c),
+            None => Unmodeled,
+        },
+
         // === prologue/epilogue stack ops: real, straight-line, single-execution ===
         // Cortex-M4 STM/LDM (PUSH/POP) = 1 + N cycles for N registers. A POP that
         // writes PC is also a branch (pipeline refill up to 3). We price BOTH as
@@ -250,7 +306,21 @@ fn op_cost(op: &ArmOp) -> OpCost {
         Call { .. } | CallIndirect { .. } | BrTable { .. } => Unmodeled,
         MemorySize { .. } | MemoryGrow { .. } => Unmodeled,
 
-        // === i64 pseudo binops lowered to 32-bit pairs upstream (never in stream) ===
+        // === i64 pseudo binops/compares: mostly lowered to 32-bit pairs =====
+        // === upstream — NOT a blanket "never in stream" claim (#936 audit) ===
+        // I64Const/I64Ldr/I64Str were priced above, out of this bucket, once
+        // #936 found them REAL on the direct/relocatable selector. Auditing
+        // the rest during that fix found `I64Sub` (a saturating trunc-sat
+        // conversion sequence), `I64ExtendI32S`/`I64ExtendI32U`, and
+        // `I32WrapI64` are ALSO real direct-selector emissions with real
+        // `encode_thumb` support — reachable, just not exercised by ANY
+        // function's FIRST decline on the #936 gale composite (gale's 9
+        // unmodeled-op declines were exhaustively I64Const/I64Str), and not
+        // priced by this lane — a scoped follow-up, not a doc claim to repeat
+        // here. `I64Add`/`I64And`/`I64Or`/`I64Xor`/`I64Eqz`/`I64Eq`/`I64Ne`/
+        // `I64Lt*`/`I64Le*`/`I64Gt*`/`I64Ge*` have NO real emission site in
+        // `instruction_selector.rs` today (checked at the same time) — for
+        // THOSE the original claim holds.
         I64Add { .. }
         | I64Sub { .. }
         | I64And { .. }
@@ -267,9 +337,6 @@ fn op_cost(op: &ArmOp) -> OpCost {
         | I64GtU { .. }
         | I64GeS { .. }
         | I64GeU { .. }
-        | I64Const { .. }
-        | I64Ldr { .. }
-        | I64Str { .. }
         | I64ExtendI32S { .. }
         | I64ExtendI32U { .. }
         | I32WrapI64 { .. } => Unmodeled,
@@ -746,7 +813,7 @@ pub fn function_wcet_intermediate(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use synth_synthesis::{Condition, Operand2, Reg};
+    use synth_synthesis::{Condition, MemAddr, Operand2, Reg};
 
     fn insn(op: ArmOp) -> ArmInstruction {
         ArmInstruction {
@@ -854,6 +921,110 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    // #936 — I64Const/I64Ldr/I64Str are now PRICED (bounded), not declined.
+    // Each expected cycle count is `(real encoder byte-length / 2) ×
+    // STRAIGHTLINE_CEIL_PER_HALFWORD`, cross-checked against the encoder's
+    // own byte length rather than hand-derived, so a future encoder change
+    // to these expansions moves both sides together and this stays honest.
+
+    #[test]
+    fn i64_const_small_is_bounded() {
+        // value=0: both halves fit in 16 bits -> MOVW rdlo + MOVW rdhi only,
+        // no MOVT -> 8 bytes -> (8/2)*5 = 20 cycles.
+        let instrs = vec![
+            insn(ArmOp::I64Const {
+                rdlo: Reg::R0,
+                rdhi: Reg::R1,
+                value: 0,
+            }),
+            insn(ArmOp::Bx { rm: Reg::LR }), // 4
+        ];
+        match function_wcet("k_small", &instrs, "cortex-m4") {
+            WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 20 + 4),
+            other => panic!("expected bounded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn i64_const_wide_is_bounded() {
+        // value=-1: both halves need MOVT -> MOVW+MOVT per half -> 16 bytes
+        // -> (16/2)*5 = 40 cycles.
+        let instrs = vec![insn(ArmOp::I64Const {
+            rdlo: Reg::R0,
+            rdhi: Reg::R1,
+            value: -1,
+        })];
+        match function_wcet("k_wide", &instrs, "cortex-m4") {
+            WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 40),
+            other => panic!("expected bounded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn i64_str_frame_is_bounded() {
+        // No offset_reg (a frame/local store): i64_effective_base emits
+        // nothing extra -> 2x STR -> 8 bytes -> 20 cycles.
+        let instrs = vec![insn(ArmOp::I64Str {
+            rdlo: Reg::R0,
+            rdhi: Reg::R1,
+            addr: MemAddr {
+                base: Reg::SP,
+                offset: 0,
+                offset_reg: None,
+            },
+        })];
+        match function_wcet("s_frame", &instrs, "cortex-m4") {
+            WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 20),
+            other => panic!("expected bounded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn i64_str_indexed_large_offset_is_bounded() {
+        // offset_reg = Some(..) (a real i64.store) with a static offset large
+        // enough that i64_effective_base's address materialization ITSELF
+        // needs a MOVW to build the immediate before the two ADD.W folds ->
+        // 20 bytes -> 50 cycles. This is the #936 case that proved a
+        // hand-mirrored predicate would have UNDER-counted: a naive
+        // "offset>0xFFF costs 2 extra ADDs" mirror predicts 16 bytes/6
+        // cycles here, missing the immediate-materialization ADD.W's own
+        // MOVW — which is exactly why this op is priced from the REAL
+        // encoder ([`straightline_expansion_real`]) and not a hand mirror.
+        let instrs = vec![insn(ArmOp::I64Str {
+            rdlo: Reg::R0,
+            rdhi: Reg::R1,
+            addr: MemAddr {
+                base: Reg::R11,
+                offset: 0x2000,
+                offset_reg: Some(Reg::R2),
+            },
+        })];
+        match function_wcet("s_idx", &instrs, "cortex-m4") {
+            WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 50),
+            other => panic!("expected bounded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn i64_ldr_is_bounded() {
+        // Same shape/derivation as I64Str (shared `i64_effective_base`);
+        // priced alongside it (#936) to avoid a cascade-blocking decline
+        // identical to I64Str's.
+        let instrs = vec![insn(ArmOp::I64Ldr {
+            rdlo: Reg::R0,
+            rdhi: Reg::R1,
+            addr: MemAddr {
+                base: Reg::SP,
+                offset: 0,
+                offset_reg: None,
+            },
+        })];
+        match function_wcet("l_frame", &instrs, "cortex-m4") {
+            WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 20),
+            other => panic!("expected bounded, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/synth-cli/tests/wcet_bound_gate.rs
+++ b/crates/synth-cli/tests/wcet_bound_gate.rs
@@ -525,15 +525,23 @@ fn i64_div_declines_with_looped_expansion_reason() {
 // `--emit-wcet` over a real 31-function `gust:os` composite (0.55.0) and
 // found the 9 `unmodeled-op` declines resolved to exactly two opcode
 // families: `I64Const` (6 functions) and `I64Str` (3 functions), with 11
-// more `callee-unbounded` cascades behind them. These ONLY appear on the
-// RELOCATABLE/direct selector (`select_with_stack`, forced by
-// `--relocatable`, #197) — the OPTIMIZED path never emits them (see
-// `coverage()` in `estimator_encoder_agreement.rs`). `I64Ldr` (the load
-// twin, sharing I64Str's `i64_effective_base` address-materialization
-// shape) is priced alongside it in the same lane to avoid an identical
-// cascade-blocking decline (confirmed live: #921's own repro used
-// `i64.load` as its `unmodeled-op` reproduction, retargeted in
-// `wcet_decline_names_op_921.rs` now that it bounds).
+// more `callee-unbounded` cascades behind them. `I64Ldr` is a SEPARATE
+// finding, not one of gale's 9 (#921's own `unmodeled-op` reproduction used
+// `i64.load`, retargeted in `wcet_decline_names_op_921.rs` now that it
+// bounds) — priced alongside I64Const/I64Str because it shares I64Str's
+// `i64_effective_base` address-materialization shape. These are reachable on
+// the RELOCATABLE/direct selector (`select_with_stack`, forced by
+// `--relocatable`, #197); the OPTIMIZED path is hand-classified `OffPath` for
+// them in `coverage()` (`estimator_encoder_agreement.rs`), a claim that
+// file's own doc says it cannot prove exhaustively going forward.
+//
+// HONEST RESIDUAL: `scan_for_decline` reports only the FIRST decline per
+// function, so pricing these three does not mean every i64-touching function
+// now bounds — `I64Sub`, `I64ExtendI32S`/`I64ExtendI32U`, and `I32WrapI64`
+// are ALSO real direct-selector emissions with no price (found during this
+// audit, not priced here — scoped follow-up). A function that narrows an
+// i64 read to i32 (`i64.load` + `i32.wrap_i64`) still declines, now on
+// `I32WrapI64` rather than `I64Ldr`.
 //
 // Cycle literals below are sized from the REAL Thumb-2 encoder's own byte
 // length for each instance (`straightline_expansion_real`, NOT the
@@ -618,6 +626,41 @@ fn i64_ldr_cascade_composes_to_bounded() {
         cycles > 54,
         "caller: composed bound {cycles} does not exceed the leaf's own 54 — \
          composition did not actually add the callee in"
+    );
+}
+
+/// HONEST RESIDUAL, measured not asserted: pricing I64Const/I64Ldr/I64Str
+/// does NOT mean every i64-touching function now bounds. `scan_for_decline`
+/// reports only the FIRST decline, and `i32.wrap_i64` (narrowing an i64 read
+/// to i32 — a plausible OS shape) still lowers to the unpriced `I32WrapI64`
+/// pseudo-op. This function's i64.load and i64.const/i64.add all price fine;
+/// it declines on the wrap at the end, proving the fix is scoped to exactly
+/// the two (three, with I64Ldr) opcode families it claims and not a general
+/// "i64 is now bounded" claim.
+#[test]
+fn i32_wrap_i64_after_priced_i64_ops_still_declines() {
+    let wat = r#"
+        (module
+          (memory 1)
+          (func (export "narrow") (param i32) (result i32)
+            local.get 0 i64.load i64.const 3 i64.add i32.wrap_i64))
+    "#;
+    let report = compile_wcet_relocatable(wat, "cortex-m4");
+    let f = func(&report, "narrow");
+    assert_eq!(
+        f.get("status").and_then(Value::as_str),
+        Some("declined"),
+        "narrow: expected declined (I32WrapI64 unpriced), got {f}"
+    );
+    assert_eq!(
+        f.get("reason").and_then(Value::as_str),
+        Some("unmodeled-op")
+    );
+    assert_eq!(
+        f.get("op").and_then(Value::as_str),
+        Some("I32WrapI64"),
+        "narrow: expected the residual decline to name I32WrapI64 (the i64.load/ \
+         i64.const/i64.add ahead of it all price now); got {f}"
     );
 }
 

--- a/crates/synth-cli/tests/wcet_bound_gate.rs
+++ b/crates/synth-cli/tests/wcet_bound_gate.rs
@@ -521,6 +521,107 @@ fn i64_div_declines_with_looped_expansion_reason() {
 }
 
 // ---------------------------------------------------------------------------
+// #936 — I64Const/I64Ldr/I64Str are PRICED, not declined. Gale ran
+// `--emit-wcet` over a real 31-function `gust:os` composite (0.55.0) and
+// found the 9 `unmodeled-op` declines resolved to exactly two opcode
+// families: `I64Const` (6 functions) and `I64Str` (3 functions), with 11
+// more `callee-unbounded` cascades behind them. These ONLY appear on the
+// RELOCATABLE/direct selector (`select_with_stack`, forced by
+// `--relocatable`, #197) — the OPTIMIZED path never emits them (see
+// `coverage()` in `estimator_encoder_agreement.rs`). `I64Ldr` (the load
+// twin, sharing I64Str's `i64_effective_base` address-materialization
+// shape) is priced alongside it in the same lane to avoid an identical
+// cascade-blocking decline (confirmed live: #921's own repro used
+// `i64.load` as its `unmodeled-op` reproduction, retargeted in
+// `wcet_decline_names_op_921.rs` now that it bounds).
+//
+// Cycle literals below are sized from the REAL Thumb-2 encoder's own byte
+// length for each instance (`straightline_expansion_real`, NOT the
+// synth-synthesis byte-size estimator, which does not cover these ops) ×
+// the already-pinned `STRAIGHTLINE_CEIL_PER_HALFWORD`; see the unit tests in
+// `synth-backend/src/wcet.rs` for the exact per-shape byte/cycle
+// derivation, and `scripts/repro/wcet_phase6_936_i64_leaf_soundness.py`
+// for an execution-side (unicorn) cross-check that the bound covers real
+// hardware cycles.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn i64_const_relocatable_leaf_is_bounded() {
+    // `i64.const 1000000`: lo32 needs a MOVT (>0xFFFF), hi32=0 does not —
+    // mirrors gale's `gust:os/time@0.1.0#resolution` I64Const decline.
+    let wat = r#"
+        (module
+          (func (export "k") (result i64)
+            i64.const 1000000))
+    "#;
+    let report = compile_wcet_relocatable(wat, "cortex-m4");
+    assert_bounded(&report, "k", 52);
+}
+
+#[test]
+fn i64_str_relocatable_leaf_is_bounded() {
+    // `i64.store` a constant — mirrors gale's `exec_admit` I64Str decline.
+    let wat = r#"
+        (module
+          (memory 1)
+          (func (export "st") (param i32)
+            local.get 0
+            i64.const 42
+            i64.store))
+    "#;
+    let report = compile_wcet_relocatable(wat, "cortex-m4");
+    assert_bounded(&report, "st", 72);
+}
+
+#[test]
+fn i64_ldr_relocatable_leaf_is_bounded() {
+    // `i64.load` — the load twin of I64Str; #921's own reproduction of an
+    // `unmodeled-op` decline used exactly this shape.
+    let wat = r#"
+        (module
+          (memory 1)
+          (func (export "ld") (param i32) (result i64)
+            local.get 0
+            i64.load))
+    "#;
+    let report = compile_wcet_relocatable(wat, "cortex-m4");
+    assert_bounded(&report, "ld", 54);
+}
+
+/// The #936 CASCADE case: a caller with a DIRECT call to an i64.load leaf.
+/// Before #936 the leaf declined `unmodeled-op` (I64Ldr) and the caller
+/// declined `callee-unbounded` — the exact "9 unmodeled-op + 11
+/// callee-unbounded" shape in the issue. Both are now BOUNDED: the leaf
+/// prices, and #778 phase-3 composition (`own_cycles + call-site ×
+/// callee_total`) carries the leaf's bound up through the caller.
+#[test]
+fn i64_ldr_cascade_composes_to_bounded() {
+    let wat = r#"
+        (module
+          (memory 1)
+          (func $leaf (export "leaf") (param i32) (result i64)
+            local.get 0
+            i64.load)
+          (func (export "caller") (param i32) (result i64)
+            local.get 0 call $leaf))
+    "#;
+    let report = compile_wcet_relocatable(wat, "cortex-m4");
+    assert_bounded(&report, "leaf", 54);
+    // caller = own body (BL overhead + param/result plumbing) + 1x leaf(54).
+    assert_bounded(&report, "caller", 84);
+    // Independent soundness floor, same discipline as the other composed
+    // chains: the composed bound must clear the leaf's own bound (every
+    // call-site multiplier is >= 1).
+    let f = func(&report, "caller");
+    let cycles = f.get("cycles").and_then(Value::as_u64).unwrap();
+    assert!(
+        cycles > 54,
+        "caller: composed bound {cycles} does not exceed the leaf's own 54 — \
+         composition did not actually add the callee in"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Unsupported / ambiguous cores — decline as `unsupported-core`.
 // ---------------------------------------------------------------------------
 

--- a/crates/synth-cli/tests/wcet_decline_names_op_921.rs
+++ b/crates/synth-cli/tests/wcet_decline_names_op_921.rs
@@ -26,8 +26,17 @@ fn synth_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_synth"))
 }
 
-/// `i64.load` lowers to `ArmOp::I64Ldr`, which `op_cost` deliberately leaves
-/// unclassified — the shortest local reproduction of gale's decline.
+/// `i32.wrap_i64` lowers to `ArmOp::I32WrapI64`, which `op_cost` deliberately
+/// leaves unclassified — the shortest local reproduction of gale's decline.
+///
+/// #936 RETARGET: this test originally reproduced the decline via `i64.load`
+/// (`ArmOp::I64Ldr`). #936 priced `I64Const`/`I64Ldr`/`I64Str` (gale's actual 9
+/// `unmodeled-op` declines on a real `gust:os` composite resolved to exactly
+/// those two opcode FAMILIES), so `i64.load` no longer declines — exactly the
+/// "good problem" this test's own non-vacuity check was written to catch (see
+/// below). Retargeted at `i32.wrap_i64`, which the #936 audit confirmed is
+/// STILL a real direct-selector emission (`instruction_selector.rs`) with NO
+/// cycle-model price.
 ///
 /// Note that `i64.add`, `i64.ge_s` and `i64.extend_i32_u` do NOT reproduce it:
 /// the selector expands those before the WCET pass sees them. That asymmetry is
@@ -35,17 +44,17 @@ fn synth_binary() -> PathBuf {
 /// distinguish which of the unclassified family a given function tripped over.
 const FIXTURE: &str = r#"(module
   (memory 1)
-  (func (export "f") (param i32) (result i64)
+  (func (export "f") (param i64) (result i32)
     local.get 0
-    i64.load))
+    i32.wrap_i64))
 "#;
 
 #[test]
 fn unmodeled_op_decline_names_the_op_and_offset() {
     let dir = std::env::temp_dir().join("synth-wcet-921");
     std::fs::create_dir_all(&dir).expect("temp dir");
-    let wat = dir.join("i64_load.wat");
-    let obj = dir.join("i64_load.o");
+    let wat = dir.join("i32_wrap_i64.wat");
+    let obj = dir.join("i32_wrap_i64.o");
     std::fs::write(&wat, FIXTURE).expect("write fixture");
 
     let out = Command::new(synth_binary())
@@ -80,22 +89,24 @@ fn unmodeled_op_decline_names_the_op_and_offset() {
         .collect();
 
     // NON-VACUITY: if the fixture ever stops declining (a good thing — it would
-    // mean the cycle model grew to cover `I64Ldr`), this test must FAIL rather
-    // than pass over an empty set. A green assertion about no records is the
-    // exact shape #890/#910 exist to reject.
+    // mean the cycle model grew to cover `I32WrapI64`), this test must FAIL
+    // rather than pass over an empty set. A green assertion about no records is
+    // the exact shape #890/#910 exist to reject. (#936: this is exactly what
+    // happened to the ORIGINAL `i64.load` fixture — retargeted here, not
+    // deleted; see the FIXTURE doc comment above.)
     assert!(
         !declined.is_empty(),
-        "fixture no longer declines — if `I64Ldr` is now costed, retarget this \
-         test at another unclassified op rather than deleting the assertion"
+        "fixture no longer declines — if `I32WrapI64` is now costed, retarget \
+         this test at another unclassified op rather than deleting the assertion"
     );
 
     let d = declined
         .iter()
         .find(|f| f["reason"] == "unmodeled-op")
-        .expect("the i64.load fixture declines `unmodeled-op`");
+        .expect("the i32.wrap_i64 fixture declines `unmodeled-op`");
 
     assert_eq!(
-        d["op"], "I64Ldr",
+        d["op"], "I32WrapI64",
         "the decline must NAME the op (#921); got {d}"
     );
     assert!(

--- a/scripts/repro/wcet_phase6_936_i64_leaf_soundness.py
+++ b/scripts/repro/wcet_phase6_936_i64_leaf_soundness.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# ci-status: wired
+# ci-checks: emulations >= 3
+"""#936 soundness cross-check: `I64Const`/`I64Ldr`/`I64Str` are now PRICED
+(bounded), not declined, in the WCET cycle model. Compile three LEAF
+fixtures — `i64.const`, `i64.store`, `i64.load` — via `--relocatable` (#197:
+the ONLY compile path that reaches these pseudo-ops as real `ArmOp`s;
+`select_with_stack`, forced by `--relocatable`), execute each under unicorn
+(Thumb-2), and confirm:
+
+  1. the functional result matches the WASM-semantics ground truth (a wrong
+     MOVW/MOVT half-split, or a dropped address-materialization ADD.W in
+     `i64_effective_base`, would change it);
+  2. bound_cycles >= executed machine instructions (every machine
+     instruction costs >= 1 cycle) — the priced bound is a sound ceiling on
+     the ACTUAL execution, not a guessed constant.
+
+These fixtures are deliberately LEAF (no direct calls): a `--relocatable`
+object's direct-call `BL`s carry UNRESOLVED relocations (the CLI itself says
+"requires linking with Kiln bridge") — following one under unicorn without a
+link step would execute the wrong target. The cascade/composition half of
+#936 (a caller that was `callee-unbounded` resolving to bounded once its
+i64.load leaf prices) is instead pinned analytically in the cargo gate
+(`wcet_bound_gate.rs`, exact composed literal), matching how the existing
+phase-3 composition script is scoped relative to its own cargo-gate pin.
+
+This is the execution-side evidence the cargo gate cannot produce in-CI (no
+unicorn dep there); the gate pins the same three fixtures' exact cycle
+literals (52 / 72 / 54 at authoring, debug build, cortex-m4).
+
+Usage:
+    SYNTH=/path/to/synth python3 scripts/repro/wcet_phase6_936_i64_leaf_soundness.py
+Requires: pip install unicorn pyelftools
+"""
+import json
+import os
+import subprocess
+import sys
+
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_THUMB, UC_HOOK_CODE
+from unicorn.arm_const import (
+    UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_SP, UC_ARM_REG_LR,
+    UC_ARM_REG_PC, UC_ARM_REG_R10, UC_ARM_REG_R11,
+)
+
+# Reuse the phase-2 harness's ELF/sidecar plumbing verbatim.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from wcet_phase2_778_unicorn_soundness import load_elf, sidecar_entry  # noqa: E402
+
+SYNTH = os.environ.get("SYNTH", "synth")
+RETURN_MAGIC = 0x0000FFFE  # even address outside .text: stop when PC reaches it
+MEM_BASE = 0x20000100  # matches the R10==R11 linear-memory-base convention
+# `i64_effective_base` (arm_encoder.rs) and the phase-2/3/4/5 scripts' `run_func`
+# both key off — see `generate_i64_store_with_bounds_check`'s doc: "R11 = memory
+# base".
+
+
+def compile_wat_relocatable(wat_path, elf_path):
+    """Like phase2's `compile_wat`, but forces `--relocatable` (#197) — the
+    ONLY path that lowers `i64.const`/`i64.load`/`i64.store` onto the
+    `I64Const`/`I64Ldr`/`I64Str` `ArmOp`s this fix prices. Without it these
+    fixtures would compile through the OPTIMIZED selector, which never emits
+    those pseudo-ops at all (see `coverage()` in
+    `estimator_encoder_agreement.rs`) — silently testing nothing."""
+    cmd = [
+        SYNTH, "compile", wat_path, "-o", elf_path,
+        "-t", "cortex-m4", "--relocatable", "--emit-wcet",
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    assert r.returncode == 0, r.stderr
+    return json.load(open(elf_path + ".wcet.json"))
+
+
+def run_leaf(text, text_addr, addr, args=(), mem_writes=()):
+    """Like phase2's `run_func`, extended with an OPTIONAL linear-memory
+    pre-seed (for the `i64.load` fixture) and returning both halves of an
+    i64 result (`r0`=lo, `r1`=hi — AAPCS i64-in-register-pair) plus the raw
+    `Uc` instance so a caller can inspect memory afterward (the `i64.store`
+    fixture)."""
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    base = text_addr & ~0xFFF
+    size = ((text_addr + len(text) - base) + 0xFFF) & ~0xFFF
+    mu.mem_map(base, max(size, 0x1000))
+    mu.mem_write(text_addr, text)
+    mu.mem_map(0x20000000, 0x40000)  # linear memory + stack RAM
+    mu.mem_map(RETURN_MAGIC & ~0xFFF, 0x1000)
+    for waddr, wval in mem_writes:
+        mu.mem_write(waddr, wval)
+    mu.reg_write(UC_ARM_REG_SP, 0x2003FF00)
+    mu.reg_write(UC_ARM_REG_LR, RETURN_MAGIC | 1)  # thumb return-to-magic
+    mu.reg_write(UC_ARM_REG_R10, MEM_BASE)
+    mu.reg_write(UC_ARM_REG_R11, MEM_BASE)
+    for i, v in enumerate(args):
+        mu.reg_write(UC_ARM_REG_R0 + i, v)
+
+    counted = {"n": 0}
+
+    def hook(mu_, addr_, size_, _):
+        counted["n"] += 1
+        if counted["n"] > 5_000_000:
+            mu_.emu_stop()
+
+    mu.hook_add(UC_HOOK_CODE, hook)
+    mu.emu_start(addr | 1, RETURN_MAGIC, timeout=10_000_000)
+    assert mu.reg_read(UC_ARM_REG_PC) & ~1 == RETURN_MAGIC, (
+        f"did not return: pc={mu.reg_read(UC_ARM_REG_PC):#x} "
+        f"after {counted['n']} insns"
+    )
+    return mu.reg_read(UC_ARM_REG_R0), mu.reg_read(UC_ARM_REG_R1), counted["n"], mu
+
+
+# `i64.const 1000000`: lo32=0xF4240 (>0xFFFF, needs MOVT), hi32=0 (no MOVT) —
+# 3 MOVW/MOVT instructions, mirrors gale's gust:os/time@0.1.0#resolution
+# I64Const decline.
+K_WAT = r"""
+(module
+  (func (export "k") (result i64)
+    i64.const 1000000))
+"""
+
+# `i64.store` a constant to [mem_base + param]: no index-register address
+# materialization needed at the STORE site itself (the address IS the param,
+# no static memarg offset) — mirrors gale's exec_admit I64Str decline.
+STR_WAT = r"""
+(module
+  (memory 1)
+  (func (export "st") (param i32)
+    local.get 0
+    i64.const 42
+    i64.store))
+"""
+
+# `i64.load` from [mem_base + param] — mirrors gale's
+# gust:os/timer@0.1.0#slept-shaped I64Ldr decline (I64Ldr shares
+# `i64_effective_base` with I64Str and is priced alongside it in #936 to
+# avoid an identical cascade-blocking decline).
+LDR_WAT = r"""
+(module
+  (memory 1)
+  (func (export "ld") (param i32) (result i64)
+    local.get 0
+    i64.load))
+"""
+
+
+def main():
+    d = os.environ.get("WCET_REPRO_DIR", "/tmp/wcet_phase6_936_repro")
+    os.makedirs(d, exist_ok=True)
+    os.chdir(d)
+
+    print("== I64Const: i64.const 1000000 (needs a MOVT on the lo half only) ==")
+    open("k.wat", "w").write(K_WAT)
+    report = compile_wat_relocatable("k.wat", "k.o")
+    f = sidecar_entry(report, "k")
+    assert f["status"] == "bounded", f"k: expected bounded (I64Const priced), got {f}"
+    text, text_addr, syms = load_elf("k.o")
+    r0, r1, n, _ = run_leaf(text, text_addr, syms["k"])
+    assert r0 == 1000000 and r1 == 0, f"k: r0:r1 = {r0:#x}:{r1:#x}, expected 1000000:0"
+    bound = f["cycles"]
+    assert bound >= n, f"k: UNSOUND — bound {bound} cycles < {n} executed insns"
+    print(f"  OK k: r0:r1={r0}:{r1}, {n} insns <= bound {bound} cycles")
+
+    print("== I64Str: i64.store 42 at [mem_base+param], no index materialization ==")
+    open("st.wat", "w").write(STR_WAT)
+    report = compile_wat_relocatable("st.wat", "st.o")
+    f = sidecar_entry(report, "st")
+    assert f["status"] == "bounded", f"st: expected bounded (I64Str priced), got {f}"
+    text, text_addr, syms = load_elf("st.o")
+    off = 16
+    _, _, n, mu = run_leaf(text, text_addr, syms["st"], args=(off,))
+    stored = mu.mem_read(MEM_BASE + off, 8)
+    got = int.from_bytes(stored, "little")
+    assert got == 42, f"st: stored value {got} != 42 — address materialization is wrong"
+    bound = f["cycles"]
+    assert bound >= n, f"st: UNSOUND — bound {bound} cycles < {n} executed insns"
+    print(f"  OK st: mem[+{off}]={got}, {n} insns <= bound {bound} cycles")
+
+    print("== I64Ldr: i64.load from [mem_base+param] ==")
+    open("ld.wat", "w").write(LDR_WAT)
+    report = compile_wat_relocatable("ld.wat", "ld.o")
+    f = sidecar_entry(report, "ld")
+    assert f["status"] == "bounded", f"ld: expected bounded (I64Ldr priced), got {f}"
+    text, text_addr, syms = load_elf("ld.o")
+    off = 24
+    seed = 0x1122334455667788
+    r0, r1, n, _ = run_leaf(
+        text, text_addr, syms["ld"], args=(off,),
+        mem_writes=[(MEM_BASE + off, seed.to_bytes(8, "little"))],
+    )
+    got = (r1 << 32) | r0
+    assert got == seed, f"ld: r0:r1 = {r0:#x}:{r1:#x}, expected {seed:#x}"
+    bound = f["cycles"]
+    assert bound >= n, f"ld: UNSOUND — bound {bound} cycles < {n} executed insns"
+    print(f"  OK ld: r0:r1={r0:#x}:{r1:#x}, {n} insns <= bound {bound} cycles")
+
+    print("\nALL PHASE-6 (#936) I64CONST/I64STR/I64LDR LEAF SOUNDNESS CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #936

## What

`--emit-wcet`'s cycle model declined every function touching `I64Const`,
`I64Ldr`, or `I64Str` as `unmodeled-op` (never priced, never a guessed
number). Gale re-ran `--emit-wcet` over a real 31-function `gust:os`
composite (0.55.0) and found the 9 `unmodeled-op` declines on that object
resolved to exactly two opcode families: `I64Const` (6 functions) and
`I64Str` (3), with 11 more `callee-unbounded` cascades behind them. These
are RELOCATABLE/direct-selector-only (`select_with_stack`, forced by
`--relocatable`, #197) — the optimized selector never emits them, which is
why the model's own comment ("lowered to 32-bit pairs upstream, never in
stream") was wrong for these three ops. `I64Ldr` is a separate finding —
#921's own `unmodeled-op` reproduction used `i64.load` — priced alongside
`I64Str` because it shares its `i64_effective_base` address-materialization
shape.

## How it's priced

A new `straightline_expansion_real()` sizes each instance from the **real**
Thumb-2 encoder's own byte length (constructing `ArmEncoder::new_thumb2()`
and calling `.encode(op)` directly), not the synth-synthesis byte-size
estimator (`estimate_arm_byte_size`) the rest of the i64 straight-line family
uses — that estimator does not cover these three ops and falls to its
unsound `_ => 2` default for them. A hand-mirrored predicate of
`i64_effective_base`'s offset-fold threshold was tried first and found
**unsound** at authoring: a large-offset address materialization can need
its own `MOVW` before the two `ADD.W` folds, which only the real encoder's
own output reflects (measured 20 bytes where the naive mirror predicted 16).
Calling the real encoder means there's nothing to drift out of sync with —
it can't go stale the way a hand mirror can.

Result is `(real_byte_len / 2) × STRAIGHTLINE_CEIL_PER_HALFWORD` — the same
already-pinned ceiling every other i64 straight-line expansion uses.

## Honest scope — what this does NOT fix

`scan_for_decline` reports only the **first** decline per function. Pricing
these three opcodes does not mean every i64-touching function bounds now.
The #936 audit found `I64Sub` (a saturating trunc-sat conversion sequence),
`I64ExtendI32S`/`I64ExtendI32U`, and `I32WrapI64` are **also** real
direct-selector emissions with no price. A new gate test
(`i32_wrap_i64_after_priced_i64_ops_still_declines`) proves this: a function
doing `i64.load` + `i64.const` + `i64.add` + `i32.wrap_i64` prices the first
three fine and still declines, now on `I32WrapI64` instead of `I64Ldr`.
Left as a scoped follow-up — worth flagging that `I64Add`/`I64And`/`I64Or`/
`I64Xor`/the i64 compares have **zero** emission sites today, so the
reproducible-decline population for a follow-up lane is thin (`I64Sub`,
`I64ExtendI32S`, `I64ExtendI32U`, `I32WrapI64` only).

## Non-vacuity (measured, not gale's actual object — see below)

Gale's repro needs `meld fuse` + `loom optimize` over a `fused-gustos.component.wasm`
not available in this environment. Built a 7-function fixture that mirrors
the composite's exact shape instead (the same exported names from the
issue: `time@0.1.0#resolution`/`#elapsed`, `exec_admit`,
`timer@0.1.0#sleep`/`#slept`, plus two cascade callers) and compared a
pre-fix `synth` binary (built from `origin/main`) against this branch on the
identical fixture:

| | before (origin/main) | after (this branch) |
|---|---|---|
| bounded | 0 / 7 | **7 / 7** |
| declined `unmodeled-op` (I64Const/I64Ldr/I64Str) | 5 | 0 |
| declined `callee-unbounded` (cascade) | 2 | 0 |

Report this as "0/7 → 7/7 on a constructed fixture mirroring gale's shape,"
not as a prediction about gale's actual object — see the honest-scope note
above for what's confirmed vs. what would still block a real composite
(the `I32WrapI64`-class residual).

## Gates

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace`: green (135 `test result: ok` blocks, 0 failed)
- Frozen anchors: 10/10 (WCET touches no `.text` by construction — pure post-hoc analysis)
- `python3 scripts/claim_check.py claims.yaml`: 43/43 (two new evidence entries under the existing `SYNTH-WCET-CYCLE-MODEL` id, no new claim id)
- `python3 scripts/oracle_wiring_check.py --min-emulation-floor 295710`: green (157 wired, 0 unwired-debt) — the new unicorn script was initially a `# ci-status: wired` declaration with no workflow step (an inert #890-class gate); fixed by wiring it into the existing `repro-sweep-wcet-oracle` job and bumping that job's own evidence-ledger floor 4→5
- New: 5 unit tests in `wcet.rs` (exact byte/cycle derivation per shape, including the case that disproved the hand-mirror), 5 cases in `wcet_bound_gate.rs` (3 leaves + 1 cascade-composition + 1 honest-residual), 1 unicorn cross-check script (`scripts/repro/wcet_phase6_936_i64_leaf_soundness.py`, functional correctness + `bound >= executed instructions` on real hardware semantics)
- Retargeted `wcet_decline_names_op_921.rs`'s regression fixture off `i64.load` (now bounded, so it stopped reproducing an `unmodeled-op` decline — caught by that test's own non-vacuity check) onto `i32.wrap_i64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L