### PR TITLE
docs(README): make the North Star a portal, not a second copy of the roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,36 +257,47 @@ The `synth-verify` crate encodes WASM and ARM semantics as QF_BV formulas and ch
 
 ## Roadmap — North Star
 
-**Replace synth's patch-accreting code generator with foundationally-verified, allocator-robust infrastructure — so correctness comes from construction, not from an ever-growing pile of locally-correct patches.**
+**Replace synth's patch-accreting code generator with foundationally-verified,
+allocator-robust infrastructure — correctness from construction, not an
+ever-growing pile of locally-correct patches.** In one sentence: moving from
+*"we patched every bug we found"* to *"the structure makes the bug
+unrepresentable."*
 
-The recurring greedy fixes (the reciprocal-multiply cost-gate, the register-exhaustion hard-fail, the "selector missed an op" class behind #223/#226/#232) are all symptoms of one root cause: two single-pass, hand-written components — the **instruction selector** and the **register allocator**. The fix is filed as a phased, parallelizable rivet program (**VCR-\***, [epic #242](https://github.com/pulseengine/synth/issues/242), `artifacts/verified-codegen-roadmap.yaml`), built incrementally alongside the per-issue cadence — never a big-bang rewrite, **behavior frozen and oracle-gated at every step**.
+That is the means. The end it buys: **match native code generation, and beat it
+where a verified compiler can do something an unverified one cannot.**
 
-The one-sentence version: moving synth's correctness from *"we patched every bug we found"* to *"the structure makes the bug unrepresentable."*
+Measured today (`artifacts/parity-benchmark.md`, regenerable): the default path
+is **1.64×–3.48× larger** than native C/Rust at `-Os`. Supplied with a *proven
+premise* as a certificate, the same kernels reach **0.54×** on the clamp shape —
+below `gcc -Os`, within two bytes of the LLVM floor — and **1.00×** on software
+bounds, where the guarded build equals the *unguarded* one and the guard tax is
+gone entirely.
 
-**Historical motivation** (gale, #209, on NUCLEO-G474RE, mid-2026): the fully-composed `flat_flight` ran **315 cyc vs 99 native (3.18×)** with **61 % redundant constant materializations** and **17 stack spills**. Those numbers set the allocator track's agenda; the v0.19–v0.30 arc has since retired them.
+LLVM cannot do the second. It cannot elide a check it cannot prove redundant,
+and it has no way to accept a proof from outside. That asymmetry is the
+programme: verification is not a tax paid for safety, it is the mechanism that
+lets this compiler go somewhere an unverified one cannot follow.
 
-### Shipped (v0.19.0 → v0.30.2, 2026-07)
+**Cycles are not measured.** Every `cycles` cell in the benchmark reads
+`OPEN — gale silicon (DWT)`. The size story is real; the speed story is
+unproven, and this line stays until that changes.
 
-- **`VCR-RA-001` — allocator with liveness-based Belady spilling: `verified`, default-on since v0.24.0** (`SYNTH_SPILL_REALLOC`). `flat_flight` reaches its Belady optimum — 412→388 B, hot-segment frame traffic 3 ld + 3 st → **0** — with every re-pinned fixture execution-proven vs wasmtime first.
-- **const-CSE default-on** (v0.29.0, #604) — the redundant-materialization datum retired; gale-confirmed on its kernel (`gust_mix` 90→86 B loom-inlined, direct-compile `func_1` 70→66 B).
-- **The lever ladder, all default-on and evidence-gated** with CI-pinned `=0`/escape-hatch opt-outs: cmp→select fusion (ARM v0.13.0, RV32 v0.28.0), i32 local promotion (v0.14.0, with the v0.15.1 never-cause-a-compile-failure fallback), immediate-shift folding (ARM v0.15.0, RV32 v0.30.0), base-CSE into R11 (v0.27.0), dead-frame-elim + uxth-fold (v0.30.0).
-- **i64 completeness arc**: direct-path i64 stack params + pair spill-pool growth (#503, v0.29.0), pair right-shifts (#599, v0.28.0), rotl/rotr/div/rem silent-zero fix (#610, v0.30.1), and the A32 (`cortex-r5`) i64 family — previously silently encoding to NOP — rebuilt with a **221-variant no-wildcard tripwire** so no silent-NOP arm can regrow (#615, v0.30.2).
-- **Verification substrate**: [ordeal](https://github.com/pulseengine/ordeal) (pure-Rust QF_BV) is the default translation-validation engine since v0.27.0; Z3 demoted to a feature-gated differential oracle (141/141 agreement). Track C's differential oracles are CI-gated jobs (cmp-select, RV32 shift-fold/const-addr-fold, callee-saved, spill-frame, control_step/flight_seam symtab-based fixtures, …).
+### Where the North Star actually lives
 
-### In flight / next
+[**Epic #242**](https://github.com/pulseengine/synth/issues/242) is the source of
+truth — tracks, per-item status, done-criteria and the open gaps.
+This section is a **pointer, on purpose**: it used to restate the roadmap, and
+restating it is exactly how three of its status claims drifted out of date while
+the machine-derived badges above stayed correct.
 
-| Track | Item | What it does | Status |
-|-------|------|--------------|--------|
-| **A — codegen core** | `VCR-SEL-001` | Rocq-discharged verified selector DSL — *"ISLE with a proof-assistant backend"*; a missing lowering rule becomes an enumerable coverage gap, not a silent miscompile | increments 1–4 shipped default-on (`SYNTH_SEL_DSL`, opt-out `SYNTH_NO_SEL_DSL=1`): every manifest rule has a 1:1 Qed correctness theorem in `coq/Synth/Synth/VcrSelRules.v` (count-same CI-gated against `coq/vcr_sel_rules.manifest`; current counts: `artifacts/status.json`), plus pilot lemmas in `coq/Synth/Synth/VcrSelPilot.v`; the DSL is now the SHIPPED lowering path for its covered ops (byte-invisible flip — every rule was mirror-pinned byte-identical to the hand-written arm it replaces, frozen anchors unmoved) |
-| | `VCR-PERF-002` | Proof-carrying specialization (#494): loom's `wsc.facts` invariants become premises for per-elision proof obligations, certificate-checked by the ordeal-backed validator — toward gale's measured **0.45× (below-native) floor** | design traced (v0.30.0); phase 1 (facts ingestion) landed ([PR #624](https://github.com/pulseengine/synth/pull/624), v0.31.0) |
-| | `SYNTH_SPILL_ON_EXHAUST` | Replace the register-exhaustion decline with allocation-time Belady spilling (#580) — the last piece of the exhaustion hard-fail | built, flag-off; default-on held for silicon cycle numbers |
-| **B — authoritative semantics** | `VCR-ISA-001` | Re-base ARM/RISC-V semantics on Sail-generated Rocq (the official ISA spec); generate the selector model, don't mirror it (#667) | approved — Sail/ASL bridge spike landed (`coq/Synth/ARM/SailArmBridge.v`); #667 "generate, don't mirror" landed: the shipped `sel_dsl::RULES` table emits the covered ops' Rocq lowerings (`coq/Synth/Synth/VcrSelRulesGenerated.v`), and `VcrSelRules.v` DEFINES `rule_X := Gen.rule_X` — the generated file is the single model source, the per-rule correctness Qed are stated directly about it, and a selector-table change breaks the matching proof (no hand-written copy left to drift) |
-| | `VCR-WASM-001` | Anchor WASM source semantics on WasmCert-Coq | phases 1-3 landed: the i32 integer fragment (19 ops) AND the i64 integer family (22 ops — arithmetic/bitwise/shifts/rotates/eqz/comparisons) transcribed from the same pinned coq9.0-wasm-2.2.0 sources with line-level provenance (`coq/Synth/WASM/WasmCertReference.v`) and proven refined by `exec_wasm_instr` (`WasmCertBridge.v`; op-level for all, executor-level for the wired ops — the 6 i64 arithmetic/bitwise ops are op-level-only, a named residual; lemma count: `artifacts/status.json`); still a hand transcription, the real external dep is nix-feasible, bazel-deferred on three named blockers (unfree CompCert 3.16 in the pin) |
-| **Gate** | `VCR-VER-001` | Success = a previously load-bearing greedy-fix becomes *revertable*, with the full differential bit-identical and cycles equal-or-better | **demonstrated** (implemented; [evidence](scripts/repro/vcr_ver_001_gate.md)): the v0.11.20 reciprocal-mult cost-gate deleted outright (PR #322, bit-identical); the #496 exhaustion decline revertable behind `SYNTH_SPILL_ON_EXHAUST` — red case green, anchors byte-identical, declines 14→8; flip held on a measured i32-shape cycle regression |
-
-Honest open items: the RV32 local-promotion flip is held on a failed no-grow gate (#601); float residual — `i64.trunc_sat_f32_*` declines on single-precision FPUs (the falcon cortex-m7dp VFP tail closed v0.53, #881); SIMD/Helium is untested on hardware.
-
-**What it buys us:** synth stops being a real-ish compiler held together by oracle-gated patches and becomes a genuinely best-in-class *verified* compiler — and the verified selector DSL is the part that is potentially novel/publishable, not just catching up to Cranelift.
+| looking for | read |
+|---|---|
+| the roadmap and each item's status | [epic #242](https://github.com/pulseengine/synth/issues/242) · [`artifacts/verified-codegen-roadmap.yaml`](artifacts/verified-codegen-roadmap.yaml) |
+| the numbers behind the claims above | [`artifacts/parity-benchmark.md`](artifacts/parity-benchmark.md) |
+| proof coverage, per file and tier | [`coq/STATUS.md`](coq/STATUS.md) |
+| the exact op surface and every decline | [`docs/status/FEATURE_MATRIX.md`](docs/status/FEATURE_MATRIX.md) |
+| what shipped in which release | [`CHANGELOG.md`](CHANGELOG.md) |
+| release scope as a live query | `artifacts/release-v*.yaml` (rivet `release:` + `status:`) |
 
 ## Crate Map
 

--- a/claims.yaml
+++ b/claims.yaml
@@ -406,16 +406,14 @@ claims:
   # "verified"/"implemented" wording — bound to the roadmap yaml's status
   # field, never free-floating prose. rivet's status lifecycle is the source.
   # ---------------------------------------------------------------------------
-  - id: SYNTH-VCR-RA-001-VERIFIED
-    doc: README.md
-    text: "allocator with liveness-based Belady spilling: `verified`"
-    evidence:
-      - kind: yaml-field
-        path: artifacts/verified-codegen-roadmap.yaml
-        id: VCR-RA-001
-        field: status
-        equals: verified
-
+  # NOTE (v0.57 README portal): the README no longer RESTATES per-item VCR
+  # statuses — it points at epic #242 and the roadmap yaml instead, because
+  # restating them is precisely how three of these drifted stale while the
+  # machine-derived badges stayed correct. Claims that pinned the deleted
+  # README prose were re-pointed to CLAUDE.md, which still makes the claim in
+  # prose; the EVIDENCE is unchanged, so the gate lost no strength. The old
+  # SYNTH-VCR-RA-001-VERIFIED was dropped outright rather than re-pointed —
+  # the -CLAUDE-MD twin below already asserts the identical yaml-field.
   - id: SYNTH-VCR-RA-001-VERIFIED-CLAUDE-MD
     doc: CLAUDE.md
     text: "`VCR-RA-001` allocator with Belady spilling — **verified,"
@@ -427,8 +425,8 @@ claims:
         equals: verified
 
   - id: SYNTH-VCR-VER-001-DEMONSTRATED
-    doc: README.md
-    text: "**demonstrated** (implemented; [evidence](scripts/repro/vcr_ver_001_gate.md))"
+    doc: CLAUDE.md
+    text: "DEMONSTRATED (implemented, evidence in"
     evidence:
       - kind: yaml-field
         path: artifacts/verified-codegen-roadmap.yaml
@@ -515,8 +513,8 @@ claims:
         expect: 1
 
   - id: SYNTH-VCR-SEL-001-STATUS
-    doc: README.md
-    text: "increments 1–4 shipped default-on (`SYNTH_SEL_DSL`, opt-out `SYNTH_NO_SEL_DSL=1`)"
+    doc: CLAUDE.md
+    text: "increments 1–4 shipped **default-on**"
     evidence:
       - kind: yaml-field
         path: artifacts/verified-codegen-roadmap.yaml
@@ -525,8 +523,8 @@ claims:
         equals: implemented
 
   - id: SYNTH-VCR-ISA-001-STATUS
-    doc: README.md
-    text: "approved — Sail/ASL bridge spike landed"
+    doc: CLAUDE.md
+    text: "approved, Sail/ASL bridge spike landed"
     evidence:
       - kind: yaml-field
         path: artifacts/verified-codegen-roadmap.yaml
@@ -535,6 +533,36 @@ claims:
         equals: approved
       - kind: file-exists                    # lemma count flows via status.json
         path: coq/Synth/ARM/SailArmBridge.v
+
+  # ---------------------------------------------------------------------------
+  # Parity numbers (#390 / VCR-PERF-002). The v0.57 README North Star section is
+  # a POINTER, but it still QUOTES four figures from the benchmark — the
+  # 1.64x-3.48x default-path spread, and the 0.54x / 1.00x proven-premise
+  # results that carry the "verification buys something LLVM cannot" argument.
+  # A number quoted in the README is exactly what this ledger exists to pin, so
+  # the benchmark joins the claim surface rather than being allowlisted out of
+  # it. (Both endpoints of the spread are pinned, not just the headline: a
+  # single endpoint would let the other drift silently, which is the same
+  # one-sided-bound mistake the WCET masked-loop work had to fix.)
+  #
+  # The count-min is a deliberate FLOOR ON UNMEASURED-NESS, not on progress: it
+  # goes red when gale's silicon lands and cells stop reading OPEN — which is
+  # exactly when the README's "Cycles are not measured" caveat must be rewritten
+  # rather than quietly left standing as a false disclaimer.
+  - id: SYNTH-PARITY-BENCH-NUMBERS
+    doc: artifacts/parity-benchmark.md
+    text: "0.54x"
+    evidence:
+      - kind: verbatim                       # bounds-guard tax gone: guarded == unguarded
+        text: "1.00x"
+      - kind: verbatim                       # worst default-path row (gust_poll)
+        text: "3.48x"
+      - kind: verbatim                       # best default-path row (falcon_axis f32)
+        text: "1.64x"
+      - kind: count-min
+        pattern: 'OPEN — gale silicon \(DWT\)'
+        glob: ['artifacts/parity-benchmark.md']
+        min: 15
 
   # ---------------------------------------------------------------------------
   # ISA-model basis (#867) — the #682 class made an explicit, counted,
@@ -639,7 +667,11 @@ claims:
   # ---------------------------------------------------------------------------
   - id: SYNTH-SEL-DSL-RULES
     doc: README.md
-    text: "every manifest rule has a 1:1 Qed correctness theorem"
+    # README asserted this TWICE — once in the North Star section (deleted in
+    # the v0.57 portal rewrite) and once here in the verification section,
+    # where it wraps across a line. Pin the surviving single-line substring;
+    # the assertion and its count-same evidence are unchanged.
+    text: "rule has a 1:1 Qed correctness theorem"
     evidence:
       - kind: count-same
         legs:


### PR DESCRIPTION
The README's North Star section had grown into a full restatement of epic #242 — shipped-features list, in-flight status table, gate row. Restating status in a second place is how status goes stale, and it had.

## The three claims that were wrong at HEAD

| README said | truth at HEAD |
|---|---|
| "the 6 i64 arithmetic/bitwise ops are op-level-only, a named residual" | `coq/STATUS.md:10` — that residual is **CLOSED**; all 22 i64 integer ops carry both op-level *and* executor-level refinement |
| `VCR-PERF-002` "phase 1 (facts ingestion) landed (PR #624, v0.31.0)" | fact-spec has shipped and is **MEASURED** in the parity benchmark (0.54x clamp, 1.00x bounds) — several phases past |
| "### Shipped (v0.19.0 → v0.30.2, 2026-07)" | 26 releases stale |

None were catchable by a doc-vs-doc or doc-vs-source check: each was a locally-coherent sentence that had simply stopped being true. The machine-derived badges *directly above them* stayed correct — the duplicated prose drifted, the derived values did not.

## What the section is now

A pointer, plus the parts a portal should keep: the North Star statement itself, the measured parity numbers, and the LLVM-asymmetry argument those numbers support. Everything else names where it actually lives — epic #242 as source of truth, the roadmap yaml, the parity benchmark, `coq/STATUS.md`, `FEATURE_MATRIX.md`, `CHANGELOG.md`, `release-v*.yaml`.

It keeps an explicit **"Cycles are not measured"** caveat: every `cycles` cell in the benchmark still reads `OPEN — gale silicon (DWT)`, and the size story must not be read as a speed story.

## Claim ledger — 43/43, count unchanged

- `SYNTH-VCR-{VER-001,SEL-001,ISA-001}` re-pointed from `README.md` to `CLAUDE.md`, which still makes each claim in prose. The **evidence is untouched** (yaml-field on the roadmap's status), so the gate lost no strength.
- `SYNTH-VCR-RA-001-VERIFIED` dropped rather than re-pointed — the `-CLAUDE-MD` twin beside it already asserts the identical yaml-field.
- `SYNTH-SEL-DSL-RULES` stays on `README.md`: it was asserted **twice** and only the North Star copy went; now pinned to the surviving (line-wrapped) substring.
- **New** `SYNTH-PARITY-BENCH-NUMBERS` puts `artifacts/parity-benchmark.md` *in* the claim surface rather than allowlisting it out — the README quotes four of its figures, and a number quoted in the README is exactly what this ledger is for. **Both endpoints** of the 1.64x–3.48x spread are pinned, not just the headline; a single endpoint lets the other drift unobserved (the same one-sided-bound mistake the WCET masked-loop work had to fix).

The new claim's `count-min` is a deliberate **floor on unmeasured-ness**: it goes red when gale's silicon lands and cells stop reading `OPEN` — precisely when the "Cycles are not measured" line must be rewritten rather than left standing as a false disclaimer.

## Gate potency — mutation-tested, not assumed

| mutation | result |
|---|---|
| headline `0.54x` → `0.53x` | **FAIL** ✅ |
| opposite endpoint `1.64x` → `1.65x` | **FAIL** ✅ |
| one `OPEN` cycles cell → measured | **FAIL** — `track shrank below floor: 14 < recorded min 15` ✅ |
| restored | 43/43, doc byte-identical to HEAD ✅ |

The first attempt at the third mutation reported `ok` — indistinguishable from a weak claim. BSD `sed`'s `0,/re/s//repl/` had silently no-opped on the em-dash pattern. Counting the needle before *and* after is what revealed the **mutation** was vacuous, not the claim. Same shape as the recurring finding: a control case has to be sensitive to the failure it is controlling for.

Refs #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L