### PR TITLE
chore(release): v0.56.2 — security + soundness patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.56.2] - 2026-08-13
+
+Security and soundness patch. Three fixes and one verification-coverage
+closure, pulled forward from the v0.57 scope because the first of them is a
+live vulnerability in a shipped release.
+
+### Fixed
+
+- **ARM `--safety-bounds mask` emitted an IDENTITY mask on a zero-byte memory
+  (#959, SECURITY).** The mask path exempted `bytes == 0` from its
+  power-of-two gate, so a module declaring `(memory 0)` compiled with exit 0
+  and `movw r10, #0x0` in the reset handler. The runtime guard computes
+  `R10 - 1`; with `R10 = 0` that is `0 - 1 = 0xFFFFFFFF` — a mask that masks
+  nothing. Every access then executed unmasked at `[R11 + addr]`: unbounded
+  out-of-bounds read *and* write, in the mode whose entire purpose is to bound
+  them. Now refused.
+
+  This is the same disease as #953 one release earlier, on the other backend
+  and in the other direction: there `0` meant "unset" and *invented* a
+  64 KiB bound; here `0` meant "no bound needed" and *erased* the one that
+  existed. Both were a numeric `0` serving as sentinel and legitimate value at
+  once — which is why the fix arrived as a **sweep** of that collision class
+  (54 sites examined, 4 converted) rather than a single patch. The sweep also
+  fixed a regression the #953 patch itself introduced on the rv32
+  `--func-index` path, and a #932 attestation defect.
+
+- **thumb-2: a branch target could land mid-instruction (#930, #961).** An
+  `End`-in-`if` misattribution let a branch resolve to an address inside a
+  32-bit instruction rather than at its start, so execution resumed on the
+  second halfword of a wide encoding — arbitrary decode, not a trap. Fixed,
+  plus an SC-5 branch-target boundary gate that checks every emitted branch
+  target against the instruction-start set, so the class cannot regrow
+  silently.
+
+- **WCET: `I64Const`/`I64Ldr`/`I64Str` were unpriced in the cycle model
+  (#936, #962).** Two opcodes accounted for all nine unmodeled-op declines.
+  An unpriced op contributes zero cycles to a bound that is only useful if it
+  is an *over*-estimate, so this was an unsound-bound risk, not a coverage
+  gap. Priced against the documented Cortex-M3/M4 worst cases.
+
+### Changed
+
+- **`synth verify` now covers `i32.const` and reports the decline denominator
+  (#933/#935, #958).** `i32.const` was covered by *neither* verification half
+  — the Rocq side had it `Admitted` and the SMT side declined `Const`, so a
+  reader of either could reasonably assume the other had it. The Rocq
+  obligation is now discharged with a real `Qed` (592 total), and `verify`
+  reports how many rules it *declined* rather than only how many it checked:
+  a 100 % pass rate over an unstated denominator is not a coverage claim.
+
+Scope note: RQ-57-SENTINEL, RQ-57-BRTARGET, RQ-57-WCET2OPS, RQ-57-I32CONST and
+RQ-57-RULEINV were planned for v0.57 and ship here instead. The move is
+deliberate and logged in the rivet artifacts — SENTINEL carried a live
+security fix, and the other four were already merged on `main`, so a tag that
+excluded them was not available.
+
 ## [0.56.1] - 2026-08-13
 
 Security patch. One fix.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,14 +1111,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1178,11 +1178,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.56.1"
+version = "0.56.2"
 
 [[package]]
 name = "synth-cli"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1239,14 +1239,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1254,11 +1254,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.56.1"
+version = "0.56.2"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.56.1"
+version = "0.56.2"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.56.1"
+version = "0.56.2"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.56.1",
+    version = "0.56.2",
 )
 
 # Bazel dependencies

--- a/artifacts/release-v0.57.yaml
+++ b/artifacts/release-v0.57.yaml
@@ -121,8 +121,8 @@ artifacts:
       NON-VACUITY: this lane produces a NUMBER — how many sites were examined and
       how many were converted — or it has not been done. A sweep that reports
       "looks fine" is the exact shape this release is named against.
-    status: proposed
-    release: v0.57
+    status: implemented
+    release: v0.56.2
     tags: [soundness, sweep, sentinel-collision, mechanism-not-instance]
     links:
       - type: derives-from
@@ -224,8 +224,8 @@ artifacts:
       qemu-system-arm, failing before the fix. Both ARM codegen paths must be
       measured — `--relocatable` forces the direct one, which is the path #740
       was on.
-    status: proposed
-    release: v0.57
+    status: implemented
+    release: v0.56.2
     tags: [soundness, thumb-2, encoder, branch-offset, miscompile, critical]
     links:
       - type: derives-from
@@ -261,8 +261,8 @@ artifacts:
       reads is the same failure as an exit code the build system never sees.
       CONSTRAINT (#166): never weaken a theorem to force a Qed. Whichever
       contract is chosen must be argued in the PR, not applied silently.
-    status: proposed
-    release: v0.57
+    status: implemented
+    release: v0.56.2
     tags: [verification, rocq, coverage-gap, consumer-reported]
     links:
       - type: derives-from
@@ -334,8 +334,8 @@ artifacts:
       shape works.
       NON-VACUITY: the summary line must report a denominator that includes
       declines, and a fixture with a known decline must show it.
-    status: proposed
-    release: v0.57
+    status: implemented
+    release: v0.56.2
     tags: [honesty, verification, reporting, consumer-reported]
     links:
       - type: derives-from
@@ -367,8 +367,8 @@ artifacts:
       tighter and wrong is a regression).
       NON-VACUITY: carries a before/after count of bounded functions on the same
       object, or it is not done.
-    status: proposed
-    release: v0.57
+    status: implemented
+    release: v0.56.2
     tags: [wcet, capability, measured, gale-driver]
     links:
       - type: derives-from

--- a/artifacts/status.json
+++ b/artifacts/status.json
@@ -21,7 +21,7 @@
   "sel_dsl_rule_qed": 50,
   "sel_dsl_rules": 50,
   "sel_rules_simplified_basis": 50,
-  "version": "0.56.1",
+  "version": "0.56.2",
   "verus_spec_fns": 8,
   "wasmcert_bridge_qed": 104
 }

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.56.1" }
+synth-core = { path = "../synth-core", version = "0.56.2" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.56.1" }
+synth-core = { path = "../synth-core", version = "0.56.2" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.56.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.56.1" }
+synth-core = { path = "../synth-core", version = "0.56.2" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.56.2" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
@@ -21,4 +21,4 @@ tracing.workspace = true
 proptest.workspace = true
 # VCR-SEL-005 (#851): the cross-backend op-parity oracle probes the AArch64
 # selector as the THIRD backend (tests/cross_backend_op_parity.rs only).
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.56.1" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.56.2" }

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.56.1" }
+synth-core = { path = "../synth-core", version = "0.56.2" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.56.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.56.1", optional = true }
+synth-core = { path = "../synth-core", version = "0.56.2" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.56.2", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.56.1", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.56.2", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -66,23 +66,23 @@ exports_only_275_probe = []
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.56.1" }
-synth-frontend = { path = "../synth-frontend", version = "0.56.1" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.56.1" }
-synth-backend = { path = "../synth-backend", version = "0.56.1" }
+synth-core = { path = "../synth-core", version = "0.56.2" }
+synth-frontend = { path = "../synth-frontend", version = "0.56.2" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.56.2" }
+synth-backend = { path = "../synth-backend", version = "0.56.2" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.56.1" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.56.2" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.56.1", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.56.1", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.56.1", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.56.2", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.56.2", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.56.2", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.56.1", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.56.2", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.56.1" }
+synth-core = { path = "../synth-core", version = "0.56.2" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.56.1" }
+synth-cfg = { path = "../synth-cfg", version = "0.56.2" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.56.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.56.1" }
-synth-opt = { path = "../synth-opt", version = "0.56.1" }
+synth-core = { path = "../synth-core", version = "0.56.2" }
+synth-cfg = { path = "../synth-cfg", version = "0.56.2" }
+synth-opt = { path = "../synth-opt", version = "0.56.2" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.56.1" }
-synth-cfg = { path = "../synth-cfg", version = "0.56.1" }
-synth-opt = { path = "../synth-opt", version = "0.56.1" }
+synth-core = { path = "../synth-core", version = "0.56.2" }
+synth-cfg = { path = "../synth-cfg", version = "0.56.2" }
+synth-opt = { path = "../synth-opt", version = "0.56.2" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.56.1", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.56.2", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # 0.9 adds the `ordeal::trap` module (trap-preservation VCs, VCR-VER-002 / #166);

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -7,7 +7,7 @@
 > stale. All numbers come from [`artifacts/status.json`](../../artifacts/status.json),
 > which is re-derived from source on every run — never hand-edited.
 
-**Workspace version:** 0.56.1
+**Workspace version:** 0.56.2
 
 ---
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.56.1",
+  "version": "0.56.2",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"


### PR DESCRIPTION
Patch release. **The headline is a live vulnerability in a shipped version**, which is why this is cut now rather than waiting for the v0.57 hub.

## ARM `--safety-bounds mask` emitted an identity mask (#959, SECURITY)

The mask path exempted `bytes == 0` from its power-of-two gate. A module declaring `(memory 0)` compiled with **exit 0** and `movw r10, #0x0` in the reset handler. The runtime guard computes `R10 - 1` — and `0 - 1` is `0xFFFFFFFF`, a mask that masks nothing. Every access then executed unmasked at `[R11 + addr]`: unbounded out-of-bounds **read and write**, in the mode whose entire purpose is to bound them.

This is the same disease as #953 one release earlier, on the other backend and running the other direction:

| | sentinel meaning | effect |
|---|---|---|
| #953 (rv32) | `0` = "unset" | **invented** a 64 KiB bound for a zero-byte memory |
| #959 (ARM) | `0` = "no bound needed" | **erased** the bound that should exist |

Both are a numeric `0` serving as sentinel *and* legitimate value. That is why the fix arrived as a **sweep of the collision class** — 54 sites examined, 4 converted, 3 latent defects found — rather than a third point patch. The v0.53 retrospective finding was that we fix instances and not mechanisms; this is the correction. The sweep also caught a regression the #953 patch itself introduced on the rv32 `--func-index` path, and a #932 attestation defect.

## Also fixed

- **thumb-2 branch target could land mid-instruction (#930, #961)** — an `End`-in-`if` misattribution let a branch resolve *inside* a 32-bit instruction, so execution resumed on the second halfword of a wide encoding: arbitrary decode, not a trap. Fixed, plus an SC-5 gate checking every emitted branch target against the instruction-start set so the class cannot regrow silently.
- **`I64Const`/`I64Ldr`/`I64Str` were unpriced in the WCET model (#936, #962)** — two opcodes accounted for all nine unmodeled-op declines. An unpriced op contributes zero cycles to a bound that is only useful as an *over*-estimate, so this was an unsound-bound risk rather than a coverage gap.
- **`synth verify` now covers `i32.const` and reports the decline denominator (#933/#935, #958)** — `i32.const` was covered by *neither* verification half: `Admitted` on the Rocq side, `Const` declined on the SMT side, so a reader of either could reasonably assume the other had it. Now a real `Qed` (592 total), and `verify` reports what it *declined* — a 100 % pass rate over an unstated denominator is not a coverage claim.

## Release surfaces — all four swept and checker-confirmed

`Cargo.toml [workspace.package]` + 10 path-dep pins · `MODULE.bazel` · `npm/package.json` · `Cargo.lock`
→ `scripts/check_version_pins.py`: **OK on all four**. Derived artifacts regenerated via `--emit-status`. Claim gate **43/43**.

## Scope move — logged, not silent

`RQ-57-SENTINEL`, `RQ-57-BRTARGET`, `RQ-57-WCET2OPS`, `RQ-57-I32CONST`, `RQ-57-RULEINV` were planned for v0.57 and are re-tagged `release: v0.56.2` / `status: implemented`. SENTINEL carried the security fix and the other four were already merged on `main`, so a tag excluding them did not exist. rivet error/warning counts are **unchanged** by the move (50/164 before and after — pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L