### PR TITLE
fix(#944): verified machine-readable origins for compiler-introduced object branches — the 9 were never unattributed, the real 33 now are attributed

### DIFF
--- a/crates/synth-cli/tests/provenance_introduced_origin_944.rs
+++ b/crates/synth-cli/tests/provenance_introduced_origin_944.rs
@@ -1,0 +1,206 @@
+//! #944 — the compiler-introduced object-branch attribution gate.
+//!
+//! Issue #944 surfaced object conditional branches the `synth-provenance-v1`
+//! map could not explain: they trace to no source-level DECISION, because
+//! synth's lowering introduced them (bulk-memory expansion loops, division
+//! trap guards) or because the source decision family was uncovered (`if`).
+//! The fix gives each such branch a machine-readable `origin` derived from
+//! the encode-time `line_map` — the op whose lowering emitted the branch —
+//! restricted to op families whose branch shape was verified by disassembly.
+//!
+//! This gate holds the floor in BOTH directions:
+//!
+//!   (1) UNATTRIBUTED FLOOR = 0 for the fixture: every object conditional
+//!       branch either resolves to a covered source decision or carries a
+//!       named origin. A new unattributed branch (new lowering, regressed
+//!       classification) turns this red.
+//!
+//!   (2) NO EXCUSE-WIDENING: the per-origin counts are pinned EXACTLY
+//!       (1 fill-loop, 3 copy-loop, 3+1+1+1 division guards) and the origin
+//!       vocabulary is a closed set. Reaching "0 unattributed" by
+//!       blanket-labeling (the failure mode #944's own follow-up data warned
+//!       about — a plausible label tested and found wrong) changes these
+//!       counts or mints a new label, and turns this red too.
+//!
+//! The `if` half: a structured `if` decision must be COVERED (a `preserved`
+//! "If" entry whose conditional branch resolves), not bucketed with the
+//! introduced branches — that mis-bucketing was the other half of #944.
+
+use serde_json::Value;
+use std::process::Command;
+
+fn synth() -> &'static str {
+    env!("CARGO_BIN_EXE_synth")
+}
+
+fn fixture(name: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("scripts/repro")
+        .join(name)
+}
+
+/// The closed origin vocabulary. Adding a value here requires disassembly
+/// verification of the op family's branch shape (see
+/// `synth_core::provenance::introduced_branch_origin`) — that is the
+/// deliberate friction that keeps "0 unattributed" honest.
+const VERIFIED_ORIGINS: &[&str] = &[
+    "bulk-memory-fill-loop",
+    "bulk-memory-copy-loop",
+    "division-trap-guard",
+];
+
+#[test]
+fn introduced_branches_carry_verified_origins_944() {
+    let path = fixture("provenance_introduced_944.wat");
+    let out = "/tmp/prov_introduced_944.elf";
+    let sidecar = "/tmp/prov_introduced_944.elf.provenance.json";
+    let _ = std::fs::remove_file(sidecar);
+
+    let res = Command::new(synth())
+        .args([
+            "compile",
+            path.to_str().unwrap(),
+            "-o",
+            out,
+            "--target",
+            "cortex-m3",
+            "--all-exports",
+            "--relocatable",
+            "--emit-provenance",
+        ])
+        .output()
+        .expect("run synth");
+    assert!(
+        res.status.success(),
+        "synth compile failed: {}",
+        String::from_utf8_lossy(&res.stderr)
+    );
+
+    let map: Value =
+        serde_json::from_slice(&std::fs::read(sidecar).expect("sidecar written")).expect("json");
+    assert_eq!(map["schema"], "synth-provenance-v1");
+    let funcs = map["functions"].as_array().expect("functions");
+
+    let by_name = |n: &str| -> &Value {
+        funcs
+            .iter()
+            .find(|f| f["name"] == n)
+            .unwrap_or_else(|| panic!("function '{n}' missing from provenance map"))
+    };
+    let origins = |f: &Value| -> Vec<String> {
+        f["object_cond_branches"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|b| b["resolved"] == false)
+            .map(|b| {
+                b["origin"]
+                    .as_str()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "UNATTRIBUTED".to_string())
+            })
+            .collect()
+    };
+
+    // --- (2) exact per-origin counts: the no-excuse-widening pin. ---
+    let mut bulk = origins(by_name("bulk"));
+    bulk.sort();
+    assert_eq!(
+        bulk,
+        vec![
+            "bulk-memory-copy-loop",
+            "bulk-memory-copy-loop",
+            "bulk-memory-copy-loop",
+            "bulk-memory-fill-loop",
+        ],
+        "memory.fill must introduce exactly 1 loop-bound branch and memory.copy \
+         exactly 3 (overlap-direction + two copy-loop bounds)"
+    );
+    assert_eq!(
+        origins(by_name("divs")),
+        vec!["division-trap-guard"; 3],
+        "i32.div_s must introduce exactly 3 guard branches (div-by-zero + the \
+         INT_MIN/-1 overflow pair)"
+    );
+    for f in ["divu", "rems", "remu"] {
+        assert_eq!(
+            origins(by_name(f)),
+            vec!["division-trap-guard"],
+            "{f} must introduce exactly the div-by-zero guard branch"
+        );
+    }
+
+    // --- the `if` half: a source decision, covered and resolved. ---
+    let decide = by_name("decide");
+    let if_entries: Vec<&Value> = decide["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|e| e["op"] == "If")
+        .collect();
+    assert_eq!(
+        if_entries.len(),
+        1,
+        "the if decision must be a covered entry"
+    );
+    assert_eq!(if_entries[0]["kind"], "preserved");
+    assert!(
+        !if_entries[0]["object_pcs"].as_array().unwrap().is_empty(),
+        "the If entry must carry its object realization"
+    );
+    let decide_branches = decide["object_cond_branches"].as_array().unwrap();
+    assert!(
+        !decide_branches.is_empty(),
+        "the if must produce a real object conditional branch"
+    );
+    for b in decide_branches {
+        assert_eq!(
+            b["resolved"], true,
+            "the if decision's branch must RESOLVE (it is a source decision, \
+             not a compiler-introduced branch): {b}"
+        );
+    }
+
+    // --- (1) module-wide unattributed floor = 0, with a closed vocabulary. ---
+    let mut total_introduced = 0usize;
+    for f in funcs {
+        for b in f["object_cond_branches"].as_array().unwrap() {
+            if b["resolved"] == true {
+                assert!(
+                    b["origin"].is_null(),
+                    "a resolved branch must not carry an introduced origin: {b}"
+                );
+                continue;
+            }
+            total_introduced += 1;
+            let origin = b["origin"].as_str().unwrap_or_else(|| {
+                panic!(
+                    "UNATTRIBUTED object conditional branch in '{}' at pc {} — \
+                     the #944 floor is 0 for this fixture. Either a new lowering \
+                     introduced an unclassified branch (verify its shape by \
+                     disassembly and extend introduced_branch_origin) or the \
+                     classification regressed. Note: {:?}",
+                    f["name"], b["pc"], b["note"]
+                )
+            });
+            assert!(
+                VERIFIED_ORIGINS.contains(&origin),
+                "origin '{origin}' is not in the closed, disassembly-verified \
+                 vocabulary {VERIFIED_ORIGINS:?} — widening the vocabulary \
+                 requires verifying the new family's branch shape first"
+            );
+            // Every introduced branch anchors at the introducing op's wasm
+            // byte offset — the consumer's join key.
+            assert!(
+                b["instruction_offset"].is_number(),
+                "an introduced branch must carry its introducing op's offset: {b}"
+            );
+        }
+    }
+    // The fixture is known to introduce exactly 10 branches (4 bulk + 6 div).
+    assert_eq!(
+        total_introduced, 10,
+        "fixture must exercise exactly the 10 verified introduced branches"
+    );
+}

--- a/crates/synth-core/src/provenance.rs
+++ b/crates/synth-core/src/provenance.rs
@@ -40,14 +40,35 @@
 //! ## Bounded v1 — covered vs uncovered
 //!
 //! GATE-EXERCISED: `br_if`, `br` (preserved), `select` (folded-predication),
-//! `br_table` (split). `eliminated-constant` is WIRED (schema + emitter, correct
+//! `br_table` (split), `if` (preserved — the structured-decision conditional
+//! branch, #944). `eliminated-constant` is WIRED (schema + emitter, correct
 //! byte-offset join key) but not yet gate-exercised — a fixture that drops a
 //! covered branch op is a v1 follow-up. Every object conditional branch that does
 //! NOT resolve to one of the covered source ops is surfaced in
-//! `object_cond_branches` with `resolved: false` and a `note` (e.g. an `i64`
-//! expansion branch or a div/mem trap guard) — an "only-in-synth"-style
-//! divergence the consumer SEES rather than a silent gap. Naming the uncovered
-//! ones is the deliverable's explicit follow-up boundary.
+//! `object_cond_branches` with `resolved: false` — and, since #944, with a
+//! machine-readable `origin` naming WHY synth introduced it when the introducing
+//! op family is one whose lowering is verified to emit exactly that control flow
+//! (see [`introduced_branch_origin`]). An introduced branch whose family is NOT
+//! in that verified map stays `origin: None` with the op named in the note — an
+//! unexplained-but-declared branch beats a confident wrong label (#944's own
+//! finding: a plausible "guard" label for these was tested and found wrong).
+//!
+//! ## Compiler-introduced branch origins (#944)
+//!
+//! `origin` values are kebab-case and each is backed by disassembly-verified
+//! lowering shape on the direct/relocatable ARM path:
+//! - `bulk-memory-fill-loop` — `memory.fill` expands to a byte-store loop; its
+//!   one conditional branch is the loop bound test (`cmp; bhs` — zero-trip safe).
+//! - `bulk-memory-copy-loop` — `memory.copy` (memmove semantics) expands to an
+//!   overlap-direction test (`cmp dst,src; bhi`) plus a forward- and a
+//!   backward-copy loop bound test: exactly three conditional branches.
+//! - `division-trap-guard` — `i32.div_s` emits the divide-by-zero guard plus the
+//!   two-test `INT_MIN / -1` overflow guard (three branches, each skipping a
+//!   `udf`); `i32.div_u` / `i32.rem_s` / `i32.rem_u` emit the zero guard alone.
+//!
+//! These fields are ADDITIVE on the `synth-provenance-v1` wire format: the
+//! deployed consumer (witness `object-disposition`, whose serde ignores unknown
+//! fields) keeps parsing maps that carry them.
 
 use serde::{Deserialize, Serialize};
 
@@ -109,9 +130,18 @@ pub struct ObjectCondBranch {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instruction_offset: Option<u32>,
     /// True iff this branch resolves to a covered source condition (`br_if` /
-    /// `br_table`). False = an uncovered/only-in-synth object branch (e.g. an
-    /// i64-expansion or trap-guard branch) — a v1 follow-up, surfaced not hidden.
+    /// `br_table` / `if`). False = a compiler-introduced object branch —
+    /// surfaced not hidden, and carrying `origin` when its introducing op
+    /// family is in the verified classification (#944).
     pub resolved: bool,
+    /// #944: machine-readable origin for a compiler-introduced branch
+    /// (`resolved: false`), derived from the source op the branch's encode-time
+    /// `line_map` entry traces to — never guessed. `None` for a resolved branch,
+    /// and for an introduced branch whose op family is not in the verified map
+    /// (declared-unattributed; the gate pins that count). Additive field: absent
+    /// on the wire when `None`, so pre-#944 consumers are unaffected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<String>,
     /// Human note when `resolved` is false.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
@@ -163,6 +193,33 @@ fn source_op_name(op: &WasmOp) -> Option<&'static str> {
         WasmOp::Br(_) => Some("Br"),
         WasmOp::BrTable { .. } => Some("BrTable"),
         WasmOp::Select => Some("Select"),
+        // #944: `if` is a real source decision — its conditional branch was
+        // previously mis-bucketed with the compiler-introduced branches.
+        WasmOp::If => Some("If"),
+        _ => None,
+    }
+}
+
+/// #944: the machine-readable origin of a compiler-introduced conditional
+/// branch, keyed by the source op whose LOWERING emits it (known exactly — the
+/// encode-time `line_map` records which op each machine instruction came from).
+///
+/// Deliberately narrow: an op family is listed ONLY once its lowering's branch
+/// shape has been verified by disassembly (see the module header for each
+/// family's shape). Anything else returns `None` and stays declared-unattributed
+/// — mislabelling a branch is worse than declaring it unexplained (#944).
+pub fn introduced_branch_origin(op: &WasmOp) -> Option<&'static str> {
+    match op {
+        // memory.fill byte-store loop: one bound-test branch (zero-trip safe).
+        WasmOp::MemoryFill => Some("bulk-memory-fill-loop"),
+        // memory.copy memmove expansion: overlap-direction test + forward- and
+        // backward-copy loop bound tests (three branches).
+        WasmOp::MemoryCopy => Some("bulk-memory-copy-loop"),
+        // WASM trap semantics: divide-by-zero guard (all four), plus the
+        // INT_MIN/-1 overflow guard pair for `i32.div_s`.
+        WasmOp::I32DivS | WasmOp::I32DivU | WasmOp::I32RemS | WasmOp::I32RemU => {
+            Some("division-trap-guard")
+        }
         _ => None,
     }
 }
@@ -217,7 +274,10 @@ pub fn derive_function_provenance(
         }
 
         let (kind, object_pcs, count) = match op {
-            WasmOp::BrIf(_) => (ProvKind::Preserved, cond_pcs.clone(), None),
+            // #944: an `if` decision is realized by its conditional branch, like
+            // a `br_if` (its then-end unconditional jump is control flow, not
+            // the decision).
+            WasmOp::BrIf(_) | WasmOp::If => (ProvKind::Preserved, cond_pcs.clone(), None),
             WasmOp::Br(_) => (ProvKind::Preserved, uncond_pcs.clone(), None),
             WasmOp::BrTable { .. } => {
                 let n = cond_pcs.len();
@@ -262,21 +322,37 @@ pub fn derive_function_provenance(
         if *class != BranchClass::CondBranch {
             continue;
         }
-        let (resolved, note, instruction_offset) = match oi {
+        let (resolved, origin, note, instruction_offset) = match oi {
             Some(idx) => match ops.get(*idx) {
-                Some(WasmOp::BrIf(_)) | Some(WasmOp::BrTable { .. }) => {
-                    (true, None, op_offsets.get(*idx).copied())
+                Some(WasmOp::BrIf(_)) | Some(WasmOp::BrTable { .. }) | Some(WasmOp::If) => {
+                    (true, None, None, op_offsets.get(*idx).copied())
                 }
-                Some(other) => (
-                    false,
-                    Some(format!(
-                        "object conditional branch from non-branch source op {other:?} \
-                         (uncovered in v1: i64-expansion / trap-guard / bounds-check branch)"
-                    )),
-                    op_offsets.get(*idx).copied(),
-                ),
+                Some(other) => {
+                    // #944: a compiler-introduced branch. When the introducing
+                    // op family's branch shape is verified, carry its
+                    // machine-readable origin; otherwise declare it
+                    // unattributed with the op named — never guess a label.
+                    let origin = introduced_branch_origin(other);
+                    let note = match origin {
+                        Some(o) => format!(
+                            "compiler-introduced: {o} — emitted lowering source op {other:?} \
+                             (serves that op's WASM semantics; not a source-level decision)"
+                        ),
+                        None => format!(
+                            "object conditional branch from non-branch source op {other:?} \
+                             (unattributed: op family not in the verified origin map, #944)"
+                        ),
+                    };
+                    (
+                        false,
+                        origin.map(str::to_string),
+                        Some(note),
+                        op_offsets.get(*idx).copied(),
+                    )
+                }
                 None => (
                     false,
+                    None,
                     Some(
                         "object conditional branch traces to an out-of-range op index".to_string(),
                     ),
@@ -285,6 +361,7 @@ pub fn derive_function_provenance(
             },
             None => (
                 false,
+                None,
                 Some(
                     "object conditional branch with no source op (prologue/epilogue synth branch)"
                         .to_string(),
@@ -297,6 +374,7 @@ pub fn derive_function_provenance(
             wasm_op_index: *oi,
             instruction_offset,
             resolved,
+            origin,
             note,
         });
     }
@@ -352,10 +430,115 @@ mod tests {
         let fp = derive_function_provenance(0, "g", &ops, &op_offsets, &line_map, &branch_map, &[]);
         // No covered source entries (I32DivU isn't a covered source branch)...
         assert!(fp.entries.is_empty());
-        // ...but the object branch is NOT missing: it's surfaced unresolved.
+        // ...but the object branch is NOT missing: it's surfaced unresolved,
+        // and (#944) with its verified machine-readable origin.
         assert_eq!(fp.object_cond_branches.len(), 1);
         assert!(!fp.object_cond_branches[0].resolved);
         assert!(fp.object_cond_branches[0].note.is_some());
+        assert_eq!(
+            fp.object_cond_branches[0].origin.as_deref(),
+            Some("division-trap-guard")
+        );
+    }
+
+    /// #944: an `if` decision's conditional branch is a SOURCE decision —
+    /// covered (preserved entry) and resolved, not a compiler-introduced branch.
+    #[test]
+    fn if_decision_branch_is_covered_and_resolved() {
+        let ops = vec![WasmOp::If];
+        let op_offsets = vec![50u32];
+        let line_map: LineMap = vec![(0x00, Some(0)), (0x04, Some(0))];
+        let branch_map: BranchMap = vec![
+            (0x00, BranchClass::Other),      // the cmp
+            (0x04, BranchClass::CondBranch), // the beq to the else/end arm
+        ];
+        let fp = derive_function_provenance(0, "f", &ops, &op_offsets, &line_map, &branch_map, &[]);
+        assert_eq!(fp.entries.len(), 1);
+        assert_eq!(fp.entries[0].op, "If");
+        assert_eq!(fp.entries[0].kind, ProvKind::Preserved);
+        assert_eq!(fp.entries[0].object_pcs, vec![0x04]);
+        assert_eq!(fp.object_cond_branches.len(), 1);
+        assert!(fp.object_cond_branches[0].resolved);
+        assert!(fp.object_cond_branches[0].origin.is_none());
+    }
+
+    /// #944 classified origins: bulk-memory expansion branches carry the
+    /// verified origin of the op whose lowering emitted them.
+    #[test]
+    fn bulk_memory_branches_carry_verified_origin() {
+        let ops = vec![WasmOp::MemoryFill, WasmOp::MemoryCopy];
+        let op_offsets = vec![10u32, 20u32];
+        // fill: one loop-bound branch; copy: direction test + two loop bounds.
+        let line_map: LineMap = vec![
+            (0x00, Some(0)),
+            (0x08, Some(1)),
+            (0x10, Some(1)),
+            (0x20, Some(1)),
+        ];
+        let branch_map: BranchMap = vec![
+            (0x00, BranchClass::CondBranch),
+            (0x08, BranchClass::CondBranch),
+            (0x10, BranchClass::CondBranch),
+            (0x20, BranchClass::CondBranch),
+        ];
+        let fp = derive_function_provenance(0, "b", &ops, &op_offsets, &line_map, &branch_map, &[]);
+        let origins: Vec<_> = fp
+            .object_cond_branches
+            .iter()
+            .map(|b| b.origin.as_deref())
+            .collect();
+        assert_eq!(
+            origins,
+            vec![
+                Some("bulk-memory-fill-loop"),
+                Some("bulk-memory-copy-loop"),
+                Some("bulk-memory-copy-loop"),
+                Some("bulk-memory-copy-loop"),
+            ]
+        );
+        // Each also carries the introducing op's byte offset — the join anchor.
+        assert_eq!(
+            fp.object_cond_branches[0].instruction_offset,
+            Some(10),
+            "fill branch anchors at the memory.fill op offset"
+        );
+    }
+
+    /// #944 negative control (non-vacuity): the origin map must NOT blanket-label.
+    /// A conditional branch tracing to an op family whose lowering shape has not
+    /// been disassembly-verified stays declared-unattributed (`origin: None`) —
+    /// widening the map without verification is exactly the failure mode the
+    /// gate exists to prevent.
+    #[test]
+    fn unverified_op_family_stays_declared_unattributed() {
+        let ops = vec![WasmOp::I64Shl];
+        let op_offsets = vec![70u32];
+        let line_map: LineMap = vec![(0x00, Some(0))];
+        let branch_map: BranchMap = vec![(0x00, BranchClass::CondBranch)];
+        let fp = derive_function_provenance(0, "u", &ops, &op_offsets, &line_map, &branch_map, &[]);
+        let b = &fp.object_cond_branches[0];
+        assert!(!b.resolved);
+        assert!(b.origin.is_none(), "must not invent an origin: {:?}", b.origin);
+        assert!(
+            b.note.as_deref().unwrap_or("").contains("unattributed"),
+            "the note must declare the gap, not guess: {:?}",
+            b.note
+        );
+    }
+
+    /// #944: a branch with NO source op at all (prologue/epilogue) is declared,
+    /// not silently labeled.
+    #[test]
+    fn no_source_op_branch_is_declared() {
+        let ops: Vec<WasmOp> = vec![];
+        let op_offsets: Vec<u32> = vec![];
+        let line_map: LineMap = vec![(0x00, None)];
+        let branch_map: BranchMap = vec![(0x00, BranchClass::CondBranch)];
+        let fp = derive_function_provenance(0, "p", &ops, &op_offsets, &line_map, &branch_map, &[]);
+        let b = &fp.object_cond_branches[0];
+        assert!(!b.resolved);
+        assert!(b.origin.is_none());
+        assert!(b.note.is_some());
     }
 
     #[test]

--- a/crates/synth-core/src/provenance.rs
+++ b/crates/synth-core/src/provenance.rs
@@ -518,7 +518,11 @@ mod tests {
         let fp = derive_function_provenance(0, "u", &ops, &op_offsets, &line_map, &branch_map, &[]);
         let b = &fp.object_cond_branches[0];
         assert!(!b.resolved);
-        assert!(b.origin.is_none(), "must not invent an origin: {:?}", b.origin);
+        assert!(
+            b.origin.is_none(),
+            "must not invent an origin: {:?}",
+            b.origin
+        );
         assert!(
             b.note.as_deref().unwrap_or("").contains("unattributed"),
             "the note must declare the gap, not guess: {:?}",

--- a/scripts/repro/provenance_introduced_944.wat
+++ b/scripts/repro/provenance_introduced_944.wat
@@ -1,0 +1,58 @@
+;; #944 — compiler-introduced object-branch attribution fixture.
+;;
+;; Exercises every op family in the VERIFIED introduced-branch origin map
+;; (synth_core::provenance::introduced_branch_origin), plus the `if` source
+;; decision that #944 found mis-bucketed with the introduced branches:
+;;
+;;   bulk:    memory.fill -> 1 loop-bound branch   (bulk-memory-fill-loop)
+;;            memory.copy -> 3 branches: overlap-direction test + forward and
+;;                           backward copy-loop bounds (bulk-memory-copy-loop)
+;;   divs:    i32.div_s   -> 3 branches: div-by-zero guard + INT_MIN/-1
+;;                           overflow guard pair    (division-trap-guard)
+;;   divu/rems/remu: 1 div-by-zero guard each      (division-trap-guard)
+;;   decide:  if          -> 1 conditional branch, a SOURCE decision
+;;                           (covered "If" entry, resolved: true)
+;;
+;; The gate (crates/synth-cli/tests/provenance_introduced_origin_944.rs) pins
+;; the EXACT per-origin counts, so both widening the origin map without
+;; verification and losing an attribution turn it red — and asserts the
+;; module-wide unattributed count stays at its justified floor: 0.
+(module
+  (memory (export "memory") 1)
+  (func (export "bulk") (param i32 i32 i32)
+    local.get 0
+    local.get 1
+    local.get 2
+    memory.fill
+    local.get 0
+    local.get 1
+    local.get 2
+    memory.copy)
+  (func (export "divs") (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.div_s)
+  (func (export "divu") (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.div_u)
+  (func (export "rems") (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.rem_s)
+  (func (export "remu") (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.rem_u)
+  (func (export "decide") (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.lt_s
+    if (result i32)
+      local.get 0
+      local.get 1
+      i32.add
+    else
+      local.get 1
+    end)
+)


### PR DESCRIPTION
## #944 — the 9 "object branches with no WASM origin": triage, attribution, gate

### The premise was false — in a good way

Reproducing the count from the committed evidence (`pulseengine/gale` `benches/gust/drivers/mcdc/evidence/switch-thin.{witness,provenance}.json`, joined exactly as `witness object-disposition` does, on `(func_index, instruction_offset)`) gives **exactly the 9 keys** from the issue — and every one of them is a provenance **entry for a real source WASM op**, not an object branch without origin:

| # | func | off | function | source op | kind in map | object realization |
|---|------|-----|----------|-----------|-------------|--------------------|
| 1 | 6 | 740 | `wit_bindgen::rt::cabi_realloc` | `br` | `preserved` | **unconditional** B @ 0x4e |
| 2 | 12 | 929 | `…fsm::Guest>::tick` | `br` | `preserved` | unconditional B @ 0xea |
| 3 | 16 | 1251 | `…fsm::Guest>::run_switch` | `br` | `preserved` | unconditional B @ 0xdc |
| 4 | 16 | 1292 | `…fsm::Guest>::run_switch` | `select` | `folded-predication` | predicated IT-move @ 0x11c — **no branch at all** |
| 5 | 16 | 1357 | `…fsm::Guest>::run_switch` | `br` | `preserved` | unconditional B @ 0x18c |
| 6 | 23 | 1842 | `…fsm::Guest>::mark_resumed` | `select` | `folded-predication` | predicated IT-move @ 0x12e |
| 7 | 24 | 1960 | `_export_mark_swapped_cabi` wrapper | `br` | `preserved` | unconditional B @ 0xe0 |
| 8 | 25 | 2145 | `…fsm::Guest>::current_window` | `select` | `folded-predication` | predicated IT-move @ 0x13e |
| 9 | 28 | 2166 | (function with no instrumentable branch) | `br` | `preserved` | unconditional B @ 0x2 |

**Category verdict: none of the 9 is a miscompile, and none is even an unattributed compiler-introduced branch.** They are 6 unconditional `br`s and 3 `select`s folded to predication — source ops synth's map records faithfully, which **witness never instruments** (its manifest carries only `br_if` / `br_table_target` / `br_table_default` / `if_then` / `if_else`). `only_in_synth` in witness's reconciler means "synth entry with no witness branch record"; its hardcoded divergence text — *"(object branch witness never instrumented)"* — is what turned "uninstrumented `br`/`select`" into "object branch with no source", and the issue's framing followed from that message. The 9→8→4 movement across the source variants in the follow-up comment tracks which `br`/`select` **source ops** survive each source-level simplification — consistent, and the "irreducible 4" are the `br`/`select` ops in `cabi_realloc` and the export wrappers. Witness-side classification (filter/label `only_in_synth` by the `op` field synth already emits) is witness#109 territory.

### The REAL unattributed population — and its attribution

The genuinely compiler-introduced conditional branches on `switch-thin` are the **33 `resolved: false` entries in `object_cond_branches`** (invisible to witness's join, surfaced only with a free-text guessing note). All 33 trace, via the encode-time `line_map`, to `memory.fill` / `memory.copy` lowerings. Reproduced and disassembly-verified on current main (ELF bytes via pyelftools+capstone, never `synth disasm` text), per introducing op:

| introducing op | branches | verified shape | verdict |
|---|---|---|---|
| `memory.fill` | 1 | loop bound test (`cmp; bhs`, zero-trip safe) | **(a)** serves fill count semantics |
| `memory.copy` | 3 | overlap-direction test (`cmp dst,src; bhi`) + forward and backward copy-loop bound tests | **(a)** serves memmove overlap semantics |
| `i32.div_s` | 3 | div-by-zero guard + `INT_MIN`/`-1` overflow guard pair, each skipping a `udf` | **(a)** WASM trap semantics |
| `i32.div_u` / `i32.rem_s` / `i32.rem_u` | 1 each | div-by-zero guard | **(a)** WASM trap semantics |
| `if` | 1 | the decision's own conditional branch | **not introduced at all** — a source decision v1 mis-bucketed |

Probed-and-clean on the same path (no cond branches emitted): `call_indirect`, `memory.grow`, i64 div/rem (software), i64 shifts/clz/eqz/compares. **No category (b) — no branch that should not exist — was found anywhere in this lane.**

### What this PR changes

- `crates/synth-core/src/provenance.rs`
  - `ObjectCondBranch` gains an **additive** `origin` field (absent when `None`; witness's serde ignores unknown fields, wire format stays `synth-provenance-v1`): a kebab-case machine-readable origin derived from the op the branch's `line_map` entry traces to — never guessed. Closed, disassembly-verified vocabulary: `bulk-memory-fill-loop`, `bulk-memory-copy-loop`, `division-trap-guard`.
  - An introduced branch whose op family is NOT in the verified map stays `origin: None` with the op named in the note — unexplained-but-declared beats a confident wrong label (the issue's own follow-up demonstrated the plausible label being wrong).
  - `if` is now a **covered source decision** ("If" `preserved` entry; its conditional branch resolves). Bonus for the witness join: witness *does* instrument `if_then`/`if_else`, so covered `if` entries can now match instead of falling into `no-provenance`.
- `scripts/repro/provenance_introduced_944.wat` + `crates/synth-cli/tests/provenance_introduced_origin_944.rs` — the gate:
  - **unattributed floor = 0** on the fixture: every object conditional branch either resolves to a source decision or carries a named origin;
  - **no excuse-widening**: exact per-origin counts pinned (1 fill + 3 copy + 3/1/1/1 division) and a closed origin vocabulary — reaching 0 by blanket-labeling turns it red;
  - mutation-verified red-first: unmapping `MemoryCopy` → 3 `UNATTRIBUTED` panics; blanket-labeling (`_ => Some("division-trap-guard")`) trips the synth-core negative-control unit test.

No CHANGELOG/version/status.json changes (release-hub constraint). No doc-claim changes; `claim_check` stays 43/43.

Closes #944.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
