### PR TITLE
fix(#851): home written parameters on aarch64 — and fix the conditional-param-write silent miscompile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,10 +695,15 @@ jobs:
     # float converts, and the DOMAIN-GUARDED trapping i64-target truncations —
     # so the decline-matrix probe moved on to the STRUCTURAL declines. v0.54 L3
     # then landed call_indirect + globals and v0.55 L6 (VCR-A64-CF-001)
-    # `br_table` + value-carrying block/loop/if, so what the probe asserts today
-    # is the NARROWER residue: param writes in a LEAF function, bulk memory,
-    # SIMD, a `br_table` past 16 targets or with value-carrying targets, a block
-    # type with params / multi-value results, and a non-leaf FLOAT param. Each
+    # `br_table` + value-carrying block/loop/if. RQ-57-A64PARAM (#851) then
+    # landed PARAM HOMING, which moved "local.set on a param" off the list —
+    # what replaced it is the narrower FLOAT-param residual, now asserted from
+    # BOTH directions (a non-leaf float param, and a LEAF function that writes a
+    # param), because the home-slot model is single-register-file. So what the
+    # probe asserts today is: bulk memory, SIMD, a `br_table` past 16 targets or
+    # with value-carrying targets, a block type with params / multi-value
+    # results, the table/global structural declines, and a FLOAT param in any
+    # function that homes. Each
     # entry LEAVES this list the day its lowering lands — asserting a decline
     # for a capability that now ships is the same doc-honesty defect as claiming
     # one that does not.
@@ -739,6 +744,23 @@ jobs:
         run: SYNTH=./target/debug/synth python scripts/oracle_run.py scripts/repro/aarch64_divrem_851_differential.py
       - name: Run #851 non-param locals execution oracle
         run: SYNTH=./target/debug/synth python scripts/oracle_run.py scripts/repro/aarch64_locals_851_differential.py
+      - name: Run #851 RQ-57-A64PARAM param-homing execution oracle (writes to own params)
+        # Every export WRITES one of its own params — the shape that
+        # loud-declined before param homing. Includes `cond_write_param`, whose
+        # param is written only on ONE branch: that shape did NOT decline, it
+        # SILENTLY MISCOMPILED (the read-before-write param heuristic demoted the
+        # param to a zero-init local), so the oracle is the only thing that
+        # catches it. NON-VACUITY: assert a non-zero emulation count and the
+        # summary verdict, so a harness that compiled nothing cannot pass
+        # silently. `set -euo pipefail` (not bare `pipefail`, which would leave
+        # the step's status as the LAST command's) makes the script's own
+        # non-zero exit fail the step (#890).
+        run: |
+          set -euo pipefail
+          SYNTH=./target/debug/synth \
+            python scripts/oracle_run.py scripts/repro/aarch64_param_homing_851_differential.py | tee paramhoming851.txt
+          grep -Eq 'emulations=[1-9][0-9]*' paramhoming851.txt
+          grep -q '^RESULT: PASS' paramhoming851.txt
       - name: Run #851 control-flow (if/else + loop back-edge + return) execution oracle
         run: SYNTH=./target/debug/synth python scripts/oracle_run.py scripts/repro/aarch64_ctrlflow_851_differential.py
       - name: Run #865 linear-memory BOUNDS oracle (OOB traps + modes differ + mask/mpu hard-error)
@@ -906,11 +928,17 @@ jobs:
           fi
           # Non-vacuity: extraction failure counts every op as declined (=PASS),
           # so a broken objcopy/objdump would green the gate having checked
-          # nothing. Assert at least gale's 0.50.x accepted-op baseline.
+          # nothing. TIGHT floor — the MEASURED accepted-op count (61 as of
+          # RQ-57-A64PARAM, #851), not gale's stale 0.50.x baseline of 32. At 32
+          # the gate tolerated HALF the surface silently disappearing; the
+          # accepted count is deterministic (it is synth's own compile-accept
+          # decision, not a host property), so pinning it to the real figure is
+          # safe. A lowering that legitimately lands raises this number.
           acc=$(echo "$out" | sed -n 's/aarch64: \([0-9]*\) ops accepted.*/\1/p')
-          if [ "${acc:-0}" -lt 32 ]; then
-            echo "VACUOUS GATE: only ${acc:-0} ops accepted (expected >= 32) — \
-          objcopy/objdump/synth extraction likely broke"; exit 1
+          if [ "${acc:-0}" -lt 61 ]; then
+            echo "VACUOUS GATE: only ${acc:-0} ops accepted (expected >= 61) — \
+          objcopy/objdump/synth extraction likely broke, or an op that used to \
+          compile now declines"; exit 1
           fi
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -744,7 +744,12 @@ jobs:
         run: SYNTH=./target/debug/synth python scripts/oracle_run.py scripts/repro/aarch64_divrem_851_differential.py
       - name: Run #851 non-param locals execution oracle
         run: SYNTH=./target/debug/synth python scripts/oracle_run.py scripts/repro/aarch64_locals_851_differential.py
-      - name: Run #851 RQ-57-A64PARAM param-homing execution oracle (writes to own params)
+      # NOTE the quoting: an UNQUOTED step name containing " #" is truncated by
+      # YAML at the comment marker, so 14 other steps in this file all display
+      # as bare "Run" in the Actions UI — which makes a red oracle job hard to
+      # attribute. Quoting keeps this one legible. (Sweeping the other 14 is a
+      # separate, purely cosmetic change; not done here.)
+      - name: "Run #851 RQ-57-A64PARAM param-homing execution oracle (writes to own params)"
         # Every export WRITES one of its own params — the shape that
         # loud-declined before param homing. Includes `cond_write_param`, whose
         # param is written only on ONE branch: that shape did NOT decline, it

--- a/crates/synth-backend-aarch64/src/backend.rs
+++ b/crates/synth-backend-aarch64/src/backend.rs
@@ -44,14 +44,18 @@ impl AArch64Backend {
         // #457: cap the access-pattern inference with the declared count when
         // the driver supplied one — a read-before-write non-param local (wasm
         // zero-init) is otherwise indistinguishable from a param and would be
-        // read from an argument register (caller garbage). The reclassified
-        // local then hits the selector's "non-param locals not yet supported"
-        // guard: a LOUD skip instead of a silent miscompile (milestone-1
-        // contract; frame-slot zero-init lands with non-param local support).
-        let inferred = count_params(ops);
+        // read from an argument register (caller garbage).
+        //
+        // RQ-57-A64PARAM (#851): with a declared count in hand the bound is
+        // `min(highest REFERENCED index + 1, declared)`, not the read-first
+        // heuristic. The old `min(count_params(ops), declared)` silently
+        // demoted a CONDITIONALLY-written param to a zero-init non-param local
+        // and emitted wrong code (see [`referenced_locals`]); the exact bound
+        // makes it a param again, so it is homed from its argument register.
+        // The `min` keeps the >8-declared-params leniency intact.
         let num_params = match config.current_func_param_count {
-            Some(declared) => inferred.min(declared),
-            None => inferred,
+            Some(declared) => referenced_locals(ops).min(declared),
+            None => count_params(ops),
         };
         // m3: thread the per-param float masks so float params resolve to their
         // AAPCS64 V registers (an independent counter from the GP arg registers).
@@ -175,8 +179,49 @@ fn module_ctx(config: &CompileConfig) -> selector::ModuleCtx {
     }
 }
 
+/// The highest local index the body references, +1 (0 when it touches none).
+///
+/// RQ-57-A64PARAM (#851): this is the param-count bound to use when the DRIVER
+/// SUPPLIED a declared count, because `min(referenced, declared)` is exact —
+/// it names every index that is really a param, and clamps to the declared
+/// count so a genuine non-param local can never be mistaken for one.
+///
+/// It replaces [`count_params`] on that path, which was UNSOUND: that heuristic
+/// counts only indices READ BEFORE WRITTEN in LINEAR op order, so a param
+/// written before it is read — but only CONDITIONALLY — was reclassified as a
+/// non-param local and ZERO-INITIALIZED. The function then compiled SILENTLY
+/// WRONG instead of declining. Measured on c2f9d72 before this fix:
+///
+/// ```wat
+/// (func (export "f") (param i32 i32) (result i32)
+///   (if (local.get 0) (then (local.set 1 (i32.const 5))))
+///   (local.get 1))          ;; f(0, 42): wasmtime 42, synth 0
+/// ```
+///
+/// Using `min(referenced, declared)` rather than plain `declared` also PRESERVES
+/// the existing leniency for a function with more than 8 declared params that
+/// only touches the first few (the selector caps register params at 8): such a
+/// body still lowers, exactly as before.
+fn referenced_locals(ops: &[WasmOp]) -> u32 {
+    ops.iter()
+        .filter_map(|op| match op {
+            WasmOp::LocalGet(i) | WasmOp::LocalSet(i) | WasmOp::LocalTee(i) => Some(*i + 1),
+            _ => None,
+        })
+        .max()
+        .unwrap_or(0)
+}
+
 /// Count register parameters from the op stream (a local index read before it is
 /// written is a parameter). Mirrors the ARM/RISC-V backends' heuristic.
+///
+/// HONEST RESIDUAL (#851): only reachable when the driver supplied NO declared
+/// param count — with a declared count [`referenced_locals`] is exact and this
+/// heuristic is not consulted. Without one, a write-first index is genuinely
+/// AMBIGUOUS (param whose incoming value is dead, or non-param local), and both
+/// readings can be wrong; the read-first rule keeps the #457 behaviour rather
+/// than reading caller garbage for a zero-init local. The CLI always supplies a
+/// declared count, so this path is effectively direct-`compile_function` only.
 fn count_params(ops: &[WasmOp]) -> u32 {
     use std::collections::HashMap;
     let mut first_access: HashMap<u32, bool> = HashMap::new();

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -36,10 +36,8 @@
 //! mechanically-derived complement lives in the cross-backend op-parity oracle
 //! (`crates/synth-backend-riscv/tests/cross_backend_op_parity.rs`, aarch64
 //! leg):**
-//! - `call_indirect`, import calls, `>8` integer args, multi-result or
-//!   float-result callees (returned in v0/d0, not x0), a caller reading its own
-//!   params across a call (param-homing is a later increment), and WRITING a
-//!   parameter (`local.set`/`tee` on a param index).
+//! - import calls, `>8` integer args, multi-result or float-result callees
+//!   (returned in v0/d0, not x0), and a live value-stack temp across a `call`.
 //! - register spilling and bulk memory (`memory.copy`/`memory.fill`).
 //! - Float rounding (`ceil`/`floor`/`trunc`/`nearest`), f32/f64 linear-memory
 //!   load/store, i64→float converts, and the TRAPPING i64-target truncations
@@ -56,10 +54,25 @@
 //! the function actually declares one. `local.get` LOADS the slot into a fresh
 //! temp (copy-semantics — a later `local.set` of the same index cannot alias a
 //! stacked value), `local.set`/`local.tee` store it (tee without popping).
-//! 64-bit slots preserve both i32 and i64. Still declined here: writing a
-//! PARAMETER (params live in arg registers by reference — a later increment
-//! homes them) and FP non-param locals (their types are not threaded to the
-//! backend, so an FP `local.set` is caught by the GP file-check and declined).
+//! 64-bit slots preserve both i32 and i64. Still declined here: FP non-param
+//! locals (their types are not threaded to the backend, so an FP `local.set` is
+//! caught by the GP file-check and declined).
+//!
+//! **RQ-57-A64PARAM (#851) — PARAM HOMING.** A function that CALLS (v0.54 lane
+//! L3) or WRITES a parameter (this increment) gives EVERY local — params
+//! included — an 8-byte slot at `[sp, #idx*8]`; the prologue stores each
+//! incoming argument register into its slot, and every `local.get` becomes a
+//! `ldr` into a fresh temp. That is what makes `local.set`/`local.tee` on a
+//! param index lower at all: the write has a durable home, and because reads
+//! are copies it cannot alias a value the stack already holds — the exact
+//! hazard the old decline was protecting against, now structurally impossible.
+//! `writes_param` is a subset of `references_param`, so this changes behaviour
+//! for exactly one class (leaf functions that write a param, all of which
+//! declined before); non-leaf homing is byte-identical.
+//!
+//! Declined here: a homing function that declares a FLOAT param — the slot
+//! model is single-register-file, so a v-register param would be stored and
+//! reloaded as a GP register (named follow-up: thread the per-local file).
 //!
 //! **Milestone 3 adds scalar floating point** (the separate V/D/S register file):
 //! f32/f64 const, add/sub/mul/div, abs/neg/sqrt, the full compare family, the
@@ -417,20 +430,42 @@ pub fn select_typed_cf_calls(
     //   * every value-stack entry is a temp (x9..x15) again — nothing lives in
     //     x0..x7 by reference — so argument marshalling stays hazard-free.
     //
-    // A LEAF function is untouched (params stay register-resident, bytes
-    // identical), so `local.set`/`local.tee` on a param still declines there.
-    let reads_param = ops.iter().any(
+    // RQ-57-A64PARAM (#851): the SAME machinery also unblocks WRITING a param.
+    //
+    // A LEAF function used to keep its params register-resident, so
+    // `local.set`/`local.tee` on a param index had nowhere durable to write and
+    // loud-declined — two of the four mechanically-derived ARM/aarch64
+    // divergences (`cross_backend_op_parity.rs`). Homing gives the write a home
+    // slot, and the copy-semantics `local.get` makes the aliasing hazard the
+    // decline was guarding against structurally impossible: every value-stack
+    // entry is a fresh temp, never the home location itself.
+    //
+    // `references_param` below matches reads AND writes, so `writes_param` is a
+    // SUBSET of it: widening the predicate changes behaviour for EXACTLY ONE
+    // class — leaf functions that write a param, every one of which declined
+    // before. Non-leaf homing is bit-for-bit unchanged, and no function that
+    // compiled without a frame starts consuming temps for `local.get`.
+    let references_param = ops.iter().any(
         |op| matches!(op, WasmOp::LocalGet(i) | WasmOp::LocalSet(i) | WasmOp::LocalTee(i) if *i < num_params),
     );
-    let home_params = is_non_leaf && reads_param;
-    // FLOAT params live in v0..v7 and would need an FP store to home; the
-    // encoder has no `str s/d` yet, so that shape keeps the old loud decline
-    // rather than homing the wrong register file.
+    let writes_param = ops
+        .iter()
+        .any(|op| matches!(op, WasmOp::LocalSet(i) | WasmOp::LocalTee(i) if *i < num_params));
+    let home_params = (is_non_leaf && references_param) || writes_param;
+    // FLOAT params live in v0..v7, a DIFFERENT register file from the one the
+    // slot model addresses. Homing them is not blocked by the encoder (it has
+    // `str s/d` since the v0.54 L2 float load/store increment) but by the slot
+    // model itself: `slot_resident`/`local_slot_off` are file-agnostic, and a
+    // per-local register file is not threaded through them, so a homed v-param
+    // would be stored and reloaded as a GP register — the wrong file. Rather
+    // than emit that, loud-decline the whole function. Named follow-up: thread
+    // the per-local file so float params home too.
     if home_params && (params_f32.iter().any(|b| *b) || params_f64.iter().any(|b| *b)) {
         return Err(SelectError(
-            "non-leaf function references a FLOAT parameter — homing a v-register \
-             param needs an FP store this encoder does not have; loud-declining \
-             (#851)"
+            "function homes its parameters (it calls, or writes a parameter) but \
+             declares a FLOAT parameter — the aarch64 home-slot model is \
+             single-register-file, so homing a v-register param would store and \
+             reload it as a GP register; loud-declining (#851)"
                 .into(),
         ));
     }
@@ -1482,26 +1517,27 @@ pub fn select_typed_cf_calls(
                 }
             }
             // `local.set i` — pop the top value and store it into local `i`.
-            // Non-param locals live in stack slots (`str` the value). A param
-            // target is LOUD-DECLINED: params live in arg registers BY REFERENCE
-            // on the value stack, so writing one could alias a value already
-            // pushed (the miscompile the slot model avoids for non-param locals);
-            // homing written params is a later increment.
+            // Every local a body writes is slot-resident: non-param locals
+            // always, and a written PARAM because `writes_param` forces
+            // `home_params` (RQ-57-A64PARAM, #851). The `else` is therefore an
+            // INTERNAL INVARIANT, kept as a loud error rather than deleted so a
+            // future change to the homing predicate cannot silently drop a
+            // store.
             WasmOp::LocalSet(i) => {
                 if slot_resident(*i) {
                     let src = pop_gp(&mut stack, "local.set")?;
                     words.push(enc::str_x_imm(src, enc::SP, local_slot_off(*i)));
                 } else {
                     return Err(SelectError(format!(
-                        "local.set {i}: writing a PARAMETER is not yet supported \
-                         for aarch64 (params live in arg registers by reference; \
-                         writing one could alias a stacked value) — loud-declining"
+                        "internal: local.set {i} targets a local with no home slot \
+                         (num_params={num_params}, home_params={home_params}) — the \
+                         homing predicate and the slot model disagree (#851)"
                     )));
                 }
             }
             // `local.tee i` — like `local.set` but leaves the value on the stack.
-            // Store the top value WITHOUT popping it (peek + `str`); a param
-            // target is declined for the same reason as `local.set`.
+            // Store the top value WITHOUT popping it (peek + `str`). Same
+            // slot-residency invariant as `local.set`.
             WasmOp::LocalTee(i) => {
                 if slot_resident(*i) {
                     let top = *stack
@@ -1513,8 +1549,9 @@ pub fn select_typed_cf_calls(
                     words.push(enc::str_x_imm(top.reg, enc::SP, local_slot_off(*i)));
                 } else {
                     return Err(SelectError(format!(
-                        "local.tee {i}: writing a PARAMETER is not yet supported \
-                         for aarch64 — loud-declining"
+                        "internal: local.tee {i} targets a local with no home slot \
+                         (num_params={num_params}, home_params={home_params}) — the \
+                         homing predicate and the slot model disagree (#851)"
                     )));
                 }
             }

--- a/crates/synth-backend-aarch64/src/selector.rs
+++ b/crates/synth-backend-aarch64/src/selector.rs
@@ -484,13 +484,23 @@ pub fn select_typed_cf_calls(
     // Stack slots (not registers) give ALIAS SAFETY BY CONSTRUCTION: every
     // `local.get` is a `ldr` into a FRESH temp — a copy, never the home location —
     // so a later `local.set` of the same index cannot clobber a value already on
-    // the value stack (the read-by-reference param path would miscompile this;
-    // params stay read-only, see the LocalSet/LocalTee decline below).
+    // the value stack. That property is what lets a PARAM be written at all:
+    // when `home_params` is set (RQ-57-A64PARAM, #851) params are slot-resident
+    // too, and a param write is just a `str` to its own slot. The
+    // read-by-reference model — which is still what a NON-homing leaf uses for
+    // its params — could not offer that, which is why writing a param used to
+    // loud-decline rather than emit an aliasing miscompile.
     //
-    // The slot for non-param local L (num_params <= L) is at `[sp, #(L -
-    // num_params)*8]`. The frame is sized to a 16-byte multiple (AArch64 SP
-    // alignment) and only materialized when there is at least one non-param local
-    // — a function with none is byte-identical to before this increment.
+    // Slot addressing depends on whether params are homed:
+    //   * `home_params` — EVERY local (params included) has a slot, local L at
+    //     `[sp, #L*8]`, and the prologue stores each incoming arg register into
+    //     its slot.
+    //   * otherwise — only non-param locals do, local L (num_params <= L) at
+    //     `[sp, #(L - num_params)*8]`, and params stay register-resident.
+    // Either way the frame is sized to a 16-byte multiple (AArch64 SP alignment)
+    // and only materialized when there is at least one slot to hold — a leaf
+    // function with no non-param locals that never writes a param is
+    // byte-identical to before this increment.
     let max_local_idx = ops
         .iter()
         .filter_map(|op| match op {
@@ -3142,20 +3152,86 @@ mod tests {
         assert_eq!(w[3], enc::ldr_x_imm(9, enc::SP, 0));
     }
 
-    /// A LEAF function is untouched by homing: its params stay register-
-    /// resident, so writing one still loud-declines (that gap is a separate
-    /// increment, and its parity-gate entry stays valid).
+    /// RQ-57-A64PARAM (#851): a LEAF function that WRITES a param now homes its
+    /// params and lowers — `writes_param` forces `home_params` even with no
+    /// call in the body. This is the inverse of the old
+    /// `leaf_param_write_still_loud_declines`, which asserted the decline this
+    /// increment removes; the two `cross_backend_op_parity` ledger entries it
+    /// backed (`local.set+get(param)`, `local.tee(param)`) went with it.
     #[test]
-    fn leaf_param_write_still_loud_declines() {
+    fn leaf_param_write_now_lowers_via_homing() {
+        // `local.set` on a param: prologue homes x0 into [sp,#0], then the
+        // written value is stored to that same slot.
         let ops = vec![WasmOp::I32Const(42), WasmOp::LocalSet(0), WasmOp::End];
-        assert!(sel_calls(&ops, 1, 0, &[0], &[0]).is_err());
+        let (w, _) = sel_calls(&ops, 1, 0, &[0], &[0]).expect("leaf local.set(param) must lower");
+        assert!(
+            w.contains(&enc::str_x_imm(0, enc::SP, 0)),
+            "prologue must home arg x0 into its slot: {w:x?}"
+        );
+        // `local.tee` on a param lowers too (store without popping).
         let ops = vec![WasmOp::I32Const(42), WasmOp::LocalTee(0), WasmOp::End];
-        assert!(sel_calls(&ops, 1, 0, &[0], &[0]).is_err());
+        assert!(sel_calls(&ops, 1, 0, &[0], &[0]).is_ok());
     }
 
-    /// A FLOAT param in a non-leaf function keeps the loud decline: homing a
-    /// v-register needs an FP store the encoder does not have, and homing the
-    /// wrong register file would be a silent miscompile.
+    /// The write-then-read round trip a homed param must satisfy: `local.set 0`
+    /// stores to the slot and the following `local.get 0` reads THAT slot back
+    /// (a copy into a fresh temp), never the stale argument register.
+    #[test]
+    fn leaf_param_write_then_read_round_trips_through_the_slot() {
+        let ops = vec![
+            WasmOp::I32Const(42),
+            WasmOp::LocalSet(0),
+            WasmOp::LocalGet(0),
+            WasmOp::End,
+        ];
+        let (w, _) = sel_calls(&ops, 1, 0, &[0], &[0]).expect("write-then-read must lower");
+        let store = w
+            .iter()
+            .position(|&x| x == enc::str_x_imm(9, enc::SP, 0))
+            .expect("the written value must be stored to slot 0");
+        let load = w
+            .iter()
+            .position(|&x| x == enc::ldr_x_imm(9, enc::SP, 0))
+            .expect("the read must LOAD slot 0, not reuse the argument register");
+        assert!(store < load, "the store must precede the reload: {w:x?}");
+    }
+
+    /// RQ-57-A64PARAM (#851): widening `home_params` to `writes_param` also
+    /// widens the FLOAT-param decline onto a shape that previously declined for
+    /// a DIFFERENT reason (the param write itself). A LEAF function that
+    /// declares a float param and writes an INT param must still loud-decline —
+    /// decline→decline, no silent path opens — and must do so with the FLOAT
+    /// reason the decline-matrix probe greps for.
+    #[test]
+    fn leaf_float_param_with_int_param_write_still_loud_declines() {
+        // param 0 is f32 (lives in s0), param 1 is an i32 that the body writes.
+        let ops = vec![WasmOp::I32Const(7), WasmOp::LocalSet(1), WasmOp::End];
+        let r = select_typed_cf_calls(
+            &ops,
+            2,
+            &[true, false], // param 0 is f32
+            &[],
+            &[],
+            0,
+            &[0],
+            &[0],
+            &[false],
+            MemBounds::Unchecked,
+            &ModuleCtx::default(),
+        );
+        let err = r.expect_err("a homing function with a FLOAT param must decline");
+        assert!(
+            err.0.contains("FLOAT parameter"),
+            "decline must carry the FLOAT reason the decline probe asserts, got: {}",
+            err.0
+        );
+    }
+
+    /// A FLOAT param in a non-leaf function keeps the loud decline. The reason
+    /// is NOT a missing FP store (the encoder has `str s/d` since the v0.54 L2
+    /// float load/store increment) but the SLOT MODEL: it is single-register-
+    /// file, so a homed v-register param would be stored and reloaded as a GP
+    /// register — a silent miscompile. Loud-decline instead.
     #[test]
     fn non_leaf_float_param_still_loud_declines() {
         let ops = vec![WasmOp::LocalGet(0), WasmOp::Call(1), WasmOp::End];
@@ -4912,11 +4988,13 @@ mod tests {
     }
 
     #[test]
-    fn set_param_loud_declines() {
-        // Writing a PARAMETER is declined (params are read-by-reference; homing
-        // written params is a later increment) — never silently miscompiled.
+    fn set_param_lowers_via_homing() {
+        // RQ-57-A64PARAM (#851): writing a PARAMETER used to loud-decline
+        // (params were read-by-reference, so a write could alias a stacked
+        // value). It now HOMES the params — every local gets an 8-byte slot and
+        // `local.get` is a copy — so the write has a durable, non-aliasing home.
         let ops = vec![WasmOp::I32Const(1), WasmOp::LocalSet(0), WasmOp::End];
-        assert!(select(&ops, 1).is_err());
+        assert!(select(&ops, 1).is_ok());
     }
 
     #[test]

--- a/crates/synth-backend-riscv/tests/cross_backend_op_parity.rs
+++ b/crates/synth-backend-riscv/tests/cross_backend_op_parity.rs
@@ -946,8 +946,10 @@ fn known_divergences() -> &'static [(&'static str, &'static str)] {
 /// Thirteen were closed in the same change (v0.53 #851: `select` via
 /// CSEL/FCSEL, `drop`, `nop`, `i32.wrap_i64`, `i64.extend_i32_{s,u}`, the five
 /// `extend8/16/32_s` forms, fixed-memory `memory.size`/`memory.grow`). Later
-/// lanes closed `global.get`/`global.set` and `call_indirect` (v0.54) and
-/// `br_table` (v0.55, VCR-A64-CF-001), leaving the FOUR below. This ledger —
+/// lanes closed `global.get`/`global.set` and `call_indirect` (v0.54),
+/// `br_table` (v0.55, VCR-A64-CF-001) and — this increment, RQ-57-A64PARAM —
+/// WRITING a parameter (`local.set+get(param)`, `local.tee(param)`) via param
+/// homing, leaving the TWO below: both halves of bulk memory. This ledger —
 /// the COMPLEMENT of what aarch64 lowers — is the mechanically-derived answer
 /// to "what is missing on armv8?" (#851); the float-surface complement lives in
 /// [`a64_extended_surface`].
@@ -965,18 +967,18 @@ fn aarch64_known_divergences() -> &'static [(&'static str, &'static str)] {
         //  `br_table_subshape_asymmetry_882` below, which goes red in both
         //  directions exactly like this ledger does. Execution differential:
         //  scripts/repro/aarch64_brtable_blockvals_851_differential.py.)
-        (
-            "local.set+get(param)",
-            "aarch64 declines WRITING a parameter: params live in arg registers \
-             by reference on the value stack, so a param write could alias a \
-             stacked value; param HOMING (to callee-saved regs or slots) is the \
-             prerequisite — deferred, #851",
-        ),
-        (
-            "local.tee(param)",
-            "aarch64 declines writing a parameter (same homing prerequisite as \
-             local.set) — deferred, #851",
-        ),
+        // (local.set+get(param) and local.tee(param) CLOSED by RQ-57-A64PARAM
+        //  (#851): the aarch64 selector now HOMES params — `writes_param`
+        //  forces the slot frame even in a LEAF function, so a param write is
+        //  a `str` to its own 8-byte slot and every `local.get` is a `ldr`
+        //  into a fresh temp (a copy). The aliasing hazard the decline was
+        //  guarding against is structurally impossible, so both entries went
+        //  stale and the stale-entry check forced their deletion. Execution
+        //  differential: scripts/repro/aarch64_param_homing_851_differential.py.
+        //  What did NOT close, and is therefore not hidden by this deletion: a
+        //  homing function that declares a FLOAT param still loud-declines (the
+        //  slot model is single-register-file) — asserted end-to-end by
+        //  scripts/repro/aarch64_m2_decline_538.py.)
         (
             "memory.copy",
             "aarch64 selector has no MemoryCopy arm (loud decline); bulk-memory \
@@ -1811,11 +1813,18 @@ fn aarch64_integer_op_parity_851() {
     let (at_parity, unexpected, stale) = run_a64_parity(&ledger);
 
     // Non-vacuity floor: the probe must actually exercise the aarch64 selector
-    // across the shared integer core.
+    // across the shared integer core. TIGHT — set to the MEASURED count (108
+    // after RQ-57-A64PARAM closed the two param-write divergences), not a round
+    // number well below it. The old `>= 60` was ~half the real figure, so the
+    // whole param-write class could have regressed to a decline without the
+    // floor noticing; a floor that cannot notice a regression is the vacuous-
+    // gate class. Raising this when a NEW divergence is legitimately ledgered is
+    // the intended cost — it forces the drop to be looked at rather than absorbed.
     assert!(
-        at_parity >= 60,
+        at_parity >= 108,
         "aarch64 parity leg exercised too few common-core ops ({at_parity}); \
-         the classifier or the aarch64 probe construction regressed"
+         the classifier or the aarch64 probe construction regressed, or an op \
+         that used to reach parity now diverges"
     );
 
     assert!(

--- a/scripts/repro/aarch64_m2_decline_538.py
+++ b/scripts/repro/aarch64_m2_decline_538.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ci-status: wired
-# ci-checks: stdout /^(\d+)/\d+ declined ops loud-declined/ >= 12
+# ci-checks: stdout /^(\d+)/\d+ declined ops loud-declined/ >= 14
 """#538 milestone-2 — assert the aarch64 decline matrix stays HONEST.
 
 Some WASM constructs are DELIBERATELY not lowered on aarch64, and the contract
@@ -70,9 +70,11 @@ DECLINED = [
      '(func (export "f") (param i32) (result i32) '
      '(block (result i32 i32) (i32.const 1) (i32.const 2)) (i32.add))',
      "MULTI-VALUE result block type"),
-    ("local.set on a param",
-     '(func (export "f") (param i32) (result i32) '
-     '(local.set 0 (i32.add (local.get 0) (i32.const 1))) (local.get 0))'),
+    # RQ-57-A64PARAM (#851) moved "local.set on a param" OFF this list: param
+    # HOMING landed, so writing a param lowers (and is execution-verified in
+    # aarch64_param_homing_851_differential.py). What replaced it is NOT
+    # nothing — the narrower FLOAT-param residual at the bottom of this list
+    # stays, because the home-slot model is single-register-file.
     ("memory.fill", '(memory 1)(func (export "f") '
                     '(memory.fill (i32.const 0) (i32.const 0) (i32.const 4)))'),
     ("f32x4.add", '(func (export "f") (param f32) (result f32) '
@@ -112,10 +114,23 @@ DECLINED = [
      '(func (export "f") (param i32) (result i32) '
      '(call_indirect (type $b) (i32.const 1) (i32.const 2) (local.get 0)))',
      "imported function"),
-    ("non-leaf FLOAT param (homing needs an FP store)",
+    # The reason is NOT a missing FP store — the encoder has `str s/d` since the
+    # v0.54 L2 float load/store increment. It is the SLOT MODEL: `slot_resident`
+    # / `local_slot_off` are register-file-agnostic, so a homed v-register param
+    # would be stored and reloaded as a GP register. Loud-decline beats that
+    # silent miscompile (RQ-57-A64PARAM, #851).
+    ("FLOAT param in a homing function (slot model is single-register-file)",
      '(func $g (result i32) (i32.const 1)) '
      '(func (export "f") (param f32) (result f32) '
      '(drop (call $g)) (local.get 0))',
+     "FLOAT parameter"),
+    # The same decline reached the OTHER way (#851): a LEAF function homes its
+    # params as soon as it WRITES one, so a declared float param declines even
+    # with no call in the body. This entry did not exist before param homing —
+    # the shape used to decline on the param write itself.
+    ("FLOAT param in a LEAF function that writes a param",
+     '(func (export "f") (param f32 i32) (result i32) '
+     '(local.set 1 (i32.const 7)) (local.get 1))',
      "FLOAT parameter"),
 ]
 

--- a/scripts/repro/aarch64_param_homing_851.wat
+++ b/scripts/repro/aarch64_param_homing_851.wat
@@ -1,0 +1,106 @@
+;; #851 — aarch64 PARAM HOMING acceptance module (RQ-57-A64PARAM).
+;;
+;; Every exported function WRITES one of its own parameters (`local.set` or
+;; `local.tee` on an index < num_params). Before this increment the aarch64
+;; selector loud-declined that in a LEAF function ("local.set {i}: writing a
+;; PARAMETER is not yet supported for aarch64"), because a param lived only in
+;; its incoming AAPCS64 argument register and was pushed onto the value stack
+;; BY REFERENCE — so writing it could clobber a value already stacked. Only the
+;; NON-LEAF path homed params (v0.54 lane L3, to survive a `bl`), which is why
+;; `param_write_across_call` below is the one case that already compiled.
+;;
+;; After the increment every param a function writes gets an 8-byte stack slot
+;; filled from its argument register in the prologue, `local.get` LOADS a fresh
+;; copy, and `local.set`/`local.tee` STORE — the same copy-semantics slot model
+;; the non-param locals already used. Each result is diffed against wasmtime.
+(module
+  ;; --- the headline ALIASING case -----------------------------------------
+  ;; get, set-same-index, get, add. Correct = old(p) + 5. A by-reference model
+  ;; (the pre-fix shape, had it not declined) writes 5 into the register the
+  ;; first `local.get` already pushed and yields 5 + 5 = 10 for EVERY p.
+  (func (export "get_set_get_param_no_alias") (param i32) (result i32)
+    (local.get 0)          ;; push the INCOMING param
+    (i32.const 5)
+    (local.set 0)          ;; param := 5
+    (local.get 0)          ;; push 5
+    (i32.add))             ;; old(p) + 5
+
+  ;; local.tee on a param: the value must be left on the stack AND be durable.
+  ;; Correct = old(p) + 20. A by-reference model gives 10 + 10 + 10 = 30.
+  (func (export "tee_param_no_alias") (param i32) (result i32)
+    (local.get 0)          ;; push the INCOMING param
+    (i32.const 10)
+    (local.tee 0)          ;; param := 10, 10 stays on the stack
+    (i32.add)              ;; old(p) + 10
+    (local.get 0)          ;; reload 10 from the home slot
+    (i32.add))             ;; old(p) + 20
+
+  ;; local.tee as the sole producer of the result (tee's stack value is used
+  ;; directly, never reloaded). Correct = 100 - p.
+  (func (export "tee_param_result") (param i32) (result i32)
+    (local.tee 0 (i32.sub (i32.const 100) (local.get 0))))
+
+  ;; --- the canonical real shape: a loop counter held in a PARAM ------------
+  ;; sum 1..p, decrementing the param itself. Exercises a slot store/load
+  ;; across a back-edge inside a leaf frame.
+  (func (export "param_countdown_sum") (param i32) (result i32)
+    (local i32)                                        ;; acc, zero-init
+    (block
+      (loop
+        (br_if 1 (i32.eqz (local.get 0)))
+        (local.set 1 (i32.add (local.get 1) (local.get 0)))
+        (local.set 0 (i32.sub (local.get 0) (i32.const 1)))
+        (br 0)))
+    (local.get 1))
+
+  ;; --- param write on BOTH arms of an if/else (SP balance on every path) ---
+  (func (export "param_write_if_else") (param i32) (result i32)
+    (if (local.get 0)
+      (then (local.set 0 (i32.const 111)))
+      (else (local.set 0 (i32.const 222))))
+    (local.get 0))
+
+  ;; --- offset arithmetic: write the LAST of three params, read all three ---
+  ;; Correct = p0 + p1 + p0*p1.
+  (func (export "write_last_of_three") (param i32 i32 i32) (result i32)
+    (local.set 2 (i32.mul (local.get 0) (local.get 1)))
+    (i32.add (i32.add (local.get 0) (local.get 1)) (local.get 2)))
+
+  ;; --- the classic swap: two param writes through a scratch local ----------
+  ;; Correct = p1 - p0 (a lowering that aliased either home would give 0).
+  (func (export "swap_two_params") (param i32 i32) (result i32)
+    (local i32)
+    (local.set 2 (local.get 0))
+    (local.set 0 (local.get 1))
+    (local.set 1 (local.get 2))
+    (i32.sub (local.get 0) (local.get 1)))
+
+  ;; --- param write COEXISTING with a non-param local -----------------------
+  ;; The homed frame now covers index 0..2, so the non-param local (index 2)
+  ;; moved from slot 0 to slot 2 — its zero-init and its offset must both still
+  ;; be right. Local 2 is READ BEFORE it is written, so a lost zero-init shows.
+  ;; Correct = p0 + p1 + 9.
+  (func (export "mixed_param_and_local") (param i32 i32) (result i32)
+    (local i32)
+    (local.set 0 (i32.add (local.get 0) (local.get 2)))  ;; p0 + 0
+    (local.set 2 (i32.const 9))
+    (i32.add (i32.add (local.get 0) (local.get 1)) (local.get 2)))
+
+  ;; --- i64: the home slot must preserve the FULL width ---------------------
+  (func (export "i64_param_write") (param i64) (result i64)
+    (local.set 0 (i64.add (local.get 0) (i64.const 0x0000000100000000)))
+    (local.get 0))
+
+  ;; --- mixed-width params: an i64 param written next to an i32 param -------
+  ;; Correct = p0 * (u64)p1.
+  (func (export "i64_i32_param_write") (param i64 i32) (result i64)
+    (local.set 0 (i64.mul (local.get 0) (i64.extend_i32_u (local.get 1))))
+    (local.get 0))
+
+  ;; --- NON-LEAF regression guard -------------------------------------------
+  ;; This shape already compiled (the v0.54 L3 non-leaf homing); it is here so
+  ;; the widened homing predicate cannot regress it. Correct = 3*p + 1.
+  (func $one (result i32) (i32.const 1))
+  (func (export "param_write_across_call") (param i32) (result i32)
+    (local.set 0 (i32.mul (local.get 0) (i32.const 3)))
+    (i32.add (local.get 0) (call $one))))

--- a/scripts/repro/aarch64_param_homing_851.wat
+++ b/scripts/repro/aarch64_param_homing_851.wat
@@ -97,10 +97,40 @@
     (local.set 0 (i64.mul (local.get 0) (i64.extend_i32_u (local.get 1))))
     (local.get 0))
 
+  ;; --- the #457 param-count INFERENCE miscompile ---------------------------
+  ;; param 1 is written before it is read in LINEAR op order, but only
+  ;; CONDITIONALLY. The aarch64 driver inferred a function's param count from
+  ;; "which indices are READ FIRST" and capped it with the declared count, so
+  ;; param 1 was reclassified as a NON-PARAM local and ZERO-INITIALIZED — and
+  ;; the function compiled SILENTLY WRONG rather than declining: with p0 == 0
+  ;; the `if` never runs and the result must be the INCOMING p1, but the
+  ;; emitted code returned 0. MEASURED on c2f9d72 (before this increment):
+  ;;   cond_write_param(0, 42): wasmtime=42 synth=0
+  ;; The inference now uses the highest REFERENCED index (still capped by the
+  ;; declared count), so param 1 is a param and gets homed from x1.
+  (func (export "cond_write_param") (param i32 i32) (result i32)
+    (if (local.get 0)
+      (then (local.set 1 (i32.const 5))))
+    (local.get 1))
+
+  ;; The same hazard one index further out, and with the write inside a LOOP
+  ;; body that may execute zero times. Correct = p2 when p0 == 0.
+  (func (export "cond_write_param_loop") (param i32 i32 i32) (result i32)
+    (block
+      (loop
+        (br_if 1 (i32.eqz (local.get 0)))
+        (local.set 2 (i32.add (local.get 2) (local.get 1)))
+        (local.set 0 (i32.sub (local.get 0) (i32.const 1)))
+        (br 0)))
+    (local.get 2))
+
   ;; --- NON-LEAF regression guard -------------------------------------------
   ;; This shape already compiled (the v0.54 L3 non-leaf homing); it is here so
-  ;; the widened homing predicate cannot regress it. Correct = 3*p + 1.
+  ;; the widened homing predicate cannot regress it. The `call` is evaluated
+  ;; with an EMPTY value stack on purpose — a live temp across a call is a
+  ;; SEPARATE, still-live aarch64 decline ("value stack holds N entries but
+  ;; needs exactly 0"), not something param homing addresses. Correct = 3*p + 1.
   (func $one (result i32) (i32.const 1))
   (func (export "param_write_across_call") (param i32) (result i32)
     (local.set 0 (i32.mul (local.get 0) (i32.const 3)))
-    (i32.add (local.get 0) (call $one))))
+    (i32.add (call $one) (local.get 0))))

--- a/scripts/repro/aarch64_param_homing_851_differential.py
+++ b/scripts/repro/aarch64_param_homing_851_differential.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ci-status: wired
-# ci-checks: emulations >= 32
+# ci-checks: emulations >= 44
 """#851 (RQ-57-A64PARAM) — aarch64 PARAM HOMING execution differential (RED-first).
 
 Compiles `aarch64_param_homing_851.wat` with `synth compile -b aarch64`, then

--- a/scripts/repro/aarch64_param_homing_851_differential.py
+++ b/scripts/repro/aarch64_param_homing_851_differential.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+# ci-status: wired
+# ci-checks: emulations >= 32
+"""#851 (RQ-57-A64PARAM) — aarch64 PARAM HOMING execution differential (RED-first).
+
+Compiles `aarch64_param_homing_851.wat` with `synth compile -b aarch64`, then
+executes each exported function's emitted A64 `.text` and diffs the result
+against wasmtime ground truth.
+
+Every exported function WRITES one of its own parameters. Before this increment
+the aarch64 selector homed params only on the NON-LEAF path (v0.54 lane L3, so a
+`bl` could not clobber them); a LEAF function's params lived in `x0..x7` and were
+pushed onto the value stack BY REFERENCE, so `local.set`/`local.tee` on a param
+index LOUD-DECLINED. With `--all-exports` that decline makes the whole compile
+exit non-zero — the RED state. AFTER the fix every case matches wasmtime — GREEN.
+
+Execution uses two independent oracles:
+  1. unicorn (UC_ARCH_ARM64) — portable, runs on any host (the CI path).
+  2. native MAP_JIT — on an arm64 host the SAME `.text` is mapped executable and
+     called through ctypes, so the real silicon is the oracle. Skipped off-arm64.
+
+The load-bearing cases are the ones a naive lowering passes but a correct one
+must handle:
+  - `get_set_get_param_no_alias` / `tee_param_no_alias` — the exact hazard the
+    decline was protecting against: a param write must not clobber a value the
+    value stack already holds. A by-reference model returns a CONSTANT (10 / 30)
+    for every input instead of `old(p) + 5` / `old(p) + 20`.
+  - `param_countdown_sum` — the canonical real shape: the loop counter IS the
+    param, stored and reloaded across a back-edge inside a leaf frame.
+  - `mixed_param_and_local` — the homed frame now covers index 0..N, so a
+    non-param local's slot MOVED; its zero-init and offset must both survive.
+  - `swap_two_params` — two param writes through a scratch local (an aliasing
+    lowering collapses to 0).
+  - `i64_param_write` / `i64_i32_param_write` — the 8-byte home slot must
+    preserve the full width, and mixed-width params must not disturb offsets.
+  - POISONED-upper-bits cases (`poison=True`) — homing stores/loads the whole
+    `x` register, so an i32 param arriving with AAPCS64-unspecified garbage in
+    its upper half must still read back as the right i32. unicorn writes the
+    full 64-bit poisoned value; wasmtime sees only the i32.
+  - `param_write_across_call` — the NON-LEAF shape that already compiled, kept
+    as a regression guard on the widened homing predicate.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=<target>/debug/synth python scripts/repro/aarch64_param_homing_851_differential.py
+"""
+import ctypes
+import mmap
+import os
+import platform
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM64, UC_MODE_ARM, Uc, UcError
+from unicorn.arm64_const import (
+    UC_ARM64_REG_LR,
+    UC_ARM64_REG_SP,
+    UC_ARM64_REG_W0,
+    UC_ARM64_REG_X0,
+    UC_ARM64_REG_X1,
+    UC_ARM64_REG_X2,
+)
+
+WAT = Path(__file__).with_name("aarch64_param_homing_851.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+CODE, STK, RET = 0x100000, 0x200000, 0x300000
+X_ARGS = [UC_ARM64_REG_X0, UC_ARM64_REG_X1, UC_ARM64_REG_X2]
+
+M32 = (1 << 32) - 1
+M64 = (1 << 64) - 1
+
+R_AARCH64_CALL26 = 283
+
+# Garbage stuffed into the UPPER half of a 32-bit argument register. AAPCS64
+# leaves those bits UNSPECIFIED for an i32 argument, and param homing now
+# stores/loads the full `x` register, so every i32 consumer must keep taking the
+# `w` view. A lowering that leaked the upper half would return a huge number.
+POISON = 0xDEADBEEF << 32
+
+
+# (fn, [arg widths], result width, [args], poison-upper-half-of-32-bit-args).
+# Widths in bits; args are given as UNSIGNED bit patterns of that width.
+CASES = [
+    # THE aliasing case the decline was protecting against.
+    ("get_set_get_param_no_alias", [32], 32, [7], False),
+    ("get_set_get_param_no_alias", [32], 32, [0], False),
+    ("get_set_get_param_no_alias", [32], 32, [0xFFFFFFFF], False),
+    ("get_set_get_param_no_alias", [32], 32, [7], True),
+    # local.tee on a param: on the stack AND durable.
+    ("tee_param_no_alias", [32], 32, [3], False),
+    ("tee_param_no_alias", [32], 32, [0xFFFFFFF0], False),
+    ("tee_param_no_alias", [32], 32, [3], True),
+    ("tee_param_result", [32], 32, [40], False),
+    ("tee_param_result", [32], 32, [0], False),
+    ("tee_param_result", [32], 32, [0xFFFFFFFF], False),
+    # The param IS the loop counter (store/load across a back-edge).
+    ("param_countdown_sum", [32], 32, [0], False),
+    ("param_countdown_sum", [32], 32, [1], False),
+    ("param_countdown_sum", [32], 32, [5], False),
+    ("param_countdown_sum", [32], 32, [8], True),
+    # Param written on BOTH arms of if/else (SP balance on every path).
+    ("param_write_if_else", [32], 32, [0], False),
+    ("param_write_if_else", [32], 32, [1], False),
+    ("param_write_if_else", [32], 32, [0xFFFFFFFF], False),
+    # Slot-offset arithmetic across three params.
+    ("write_last_of_three", [32, 32, 32], 32, [3, 4, 0], False),
+    ("write_last_of_three", [32, 32, 32], 32, [0xFFFF, 0x10, 999], False),
+    ("write_last_of_three", [32, 32, 32], 32, [0xFFFFFFFF, 2, 7], False),
+    ("write_last_of_three", [32, 32, 32], 32, [3, 4, 0], True),
+    # Two param writes through a scratch local.
+    ("swap_two_params", [32, 32], 32, [5, 9], False),
+    ("swap_two_params", [32, 32], 32, [0, 0], False),
+    ("swap_two_params", [32, 32], 32, [0x7FFFFFFF, 0x80000000], False),
+    # A param write next to a zero-init non-param local whose slot MOVED.
+    ("mixed_param_and_local", [32, 32], 32, [1, 2], False),
+    ("mixed_param_and_local", [32, 32], 32, [0, 0], False),
+    ("mixed_param_and_local", [32, 32], 32, [10, 20], True),
+    # 64-bit home slot keeps the full width.
+    ("i64_param_write", [64], 64, [0], False),
+    ("i64_param_write", [64], 64, [0x0123456789ABCDEF], False),
+    ("i64_param_write", [64], 64, [0xFFFFFFFFFFFFFFFF], False),
+    # Mixed-width params: an i64 param written alongside an i32 param.
+    ("i64_i32_param_write", [64, 32], 64, [0x0000000100000001, 3], False),
+    ("i64_i32_param_write", [64, 32], 64, [0xFFFFFFFFFFFFFFFF, 2], False),
+    ("i64_i32_param_write", [64, 32], 64, [7, 0xFFFFFFFF], False),
+    # NON-LEAF regression guard (this shape already compiled before the fix).
+    ("param_write_across_call", [32], 32, [5], False),
+    ("param_write_across_call", [32], 32, [0], False),
+    ("param_write_across_call", [32], 32, [0xFFFFFFFF], False),
+]
+
+
+def wasmtime_run(fn, args):
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+    store = wasmtime.Store(engine)
+    return wasmtime.Instance(store, module, []).exports(store)[fn](store, *args)
+
+
+def compile_aarch64(out):
+    """Compile the module; returns True on success, False on the RED decline."""
+    cmd = [SYNTH, "compile", str(WAT), "-o", out, "-b", "aarch64", "--all-exports"]
+    r = subprocess.run(cmd, capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin"})
+    if r.returncode != 0 or "skipping" in r.stderr or "not yet supported" in r.stderr:
+        print("compile declined/failed (RED state before param homing):")
+        print("  " + (r.stderr.strip() or r.stdout.strip()).replace("\n", "\n  "))
+        return False
+    return True
+
+
+def load(elf):
+    """Return (relocated .text bytes, sh_addr, {symbol: address}).
+
+    The module contains one direct `call`, so `.text` carries an
+    R_AARCH64_CALL26 whose `bl` still reads `#0` (a branch-to-self infinite
+    loop) until it is resolved. Every function is already concatenated at its
+    final offset, so resolving means only filling in the displacement.
+    """
+    f = ELFFile(open(elf, "rb"))
+    text = f.get_section_by_name(".text")
+    code, base = bytearray(text.data()), text["sh_addr"]
+    symtab = None
+    syms = {}
+    for sec in f.iter_sections():
+        if sec.header.sh_type == "SHT_SYMTAB":
+            symtab = sec
+            for sy in sec.iter_symbols():
+                if sy.name:
+                    syms[sy.name] = sy["st_value"] & ~1
+    rela = f.get_section_by_name(".rela.text")
+    nrel = 0
+    if rela is not None:
+        for rel in rela.iter_relocations():
+            assert rel["r_info_type"] == R_AARCH64_CALL26, (
+                f"unexpected reloc type {rel['r_info_type']} — this harness only "
+                f"resolves R_AARCH64_CALL26"
+            )
+            site = rel["r_offset"] - base
+            target = symtab.get_symbol(rel["r_info_sym"])["st_value"] - base
+            disp = (target + rel["r_addend"] - site) // 4
+            word = struct.unpack_from("<I", code, site)[0]
+            # Keep the opcode bits (bl = 0x94000000), fill imm26.
+            word = (word & 0xFC000000) | (disp & 0x03FFFFFF)
+            struct.pack_into("<I", code, site, word)
+            nrel += 1
+    if nrel:
+        print(f"resolved {nrel} R_AARCH64_CALL26 relocation(s)")
+    return bytes(code), base, syms
+
+
+def encode_arg(width, value, poison):
+    """The 64-bit pattern to place in the argument register."""
+    if width == 64:
+        return value & M64
+    v = value & M32
+    return (POISON | v) if poison else v
+
+
+def unicorn_run(code, base, faddr, arg_widths, result_width, args, poison):
+    off = faddr - base
+    mu = Uc(UC_ARCH_ARM64, UC_MODE_ARM)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(STK - 0x10000, 0x20000)
+    mu.mem_map(RET & ~0xFFF, 0x1000)
+    mu.mem_write(CODE, code)
+    mu.reg_write(UC_ARM64_REG_SP, STK)
+    mu.reg_write(UC_ARM64_REG_LR, RET)
+    for r, w, v in zip(X_ARGS, arg_widths, args):
+        mu.reg_write(r, encode_arg(w, v, poison))
+    try:
+        mu.emu_start(CODE + off, RET, count=4000)
+    except UcError as e:
+        return f"ERR:{e}"
+    if result_width == 32:
+        raw = mu.reg_read(UC_ARM64_REG_W0) & M32
+        return struct.unpack("<i", struct.pack("<I", raw))[0]
+    raw = mu.reg_read(UC_ARM64_REG_X0) & M64
+    return struct.unpack("<q", struct.pack("<Q", raw))[0]
+
+
+# --- native MAP_JIT oracle (arm64 host only) --------------------------------
+#
+# Map the whole relocated `.text` blob RWX (MAP_JIT on Darwin), then call each
+# function at its symbol offset via a ctypes prototype. This runs the emitted
+# bytes on the REAL CPU — the strongest possible oracle for the silicon we
+# target. It cannot force POISONED upper argument bits (ctypes marshals a clean
+# 32-bit value), so the poison probe is unicorn-only by construction.
+_IS_ARM64 = platform.machine() in ("arm64", "aarch64")
+_IS_DARWIN = sys.platform == "darwin"
+
+
+class _NativeText:
+    def __init__(self, code, base, syms):
+        self.base = base
+        self.syms = syms
+        n = (len(code) + 0xFFF) & ~0xFFF
+        if _IS_DARWIN:
+            MAP_JIT = 0x800
+            flags = mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS | MAP_JIT
+            self.buf = mmap.mmap(-1, n, flags=flags,
+                                 prot=mmap.PROT_READ | mmap.PROT_WRITE | mmap.PROT_EXEC)
+            # W^X toggle: make writable, copy, then executable.
+            ctypes.pythonapi.pthread_jit_write_protect_np.restype = None
+            ctypes.pythonapi.pthread_jit_write_protect_np(0)
+            self.buf.write(code)
+            ctypes.pythonapi.pthread_jit_write_protect_np(1)
+            libc = ctypes.CDLL(None)
+            libc.sys_icache_invalidate(
+                ctypes.c_void_p(ctypes.addressof(ctypes.c_char.from_buffer(self.buf))),
+                ctypes.c_size_t(n))
+        else:  # linux arm64
+            self.buf = mmap.mmap(-1, n,
+                                 prot=mmap.PROT_READ | mmap.PROT_WRITE | mmap.PROT_EXEC)
+            self.buf.write(code)
+        self.addr = ctypes.addressof(ctypes.c_char.from_buffer(self.buf))
+
+    def call(self, fn, arg_widths, result_width, args):
+        off = self.syms[fn] - self.base
+        restype = ctypes.c_int64 if result_width == 64 else ctypes.c_int32
+        argtypes = [ctypes.c_int64 if w == 64 else ctypes.c_int32 for w in arg_widths]
+        proto = ctypes.CFUNCTYPE(restype, *argtypes)
+        fptr = proto(self.addr + off)
+        return fptr(*to_signed(arg_widths, args))
+
+
+def to_signed(arg_widths, args):
+    out = []
+    for w, a in zip(arg_widths, args):
+        if w == 64:
+            out.append(struct.unpack("<q", struct.pack("<Q", a & M64))[0])
+        else:
+            out.append(struct.unpack("<i", struct.pack("<I", a & M32))[0])
+    return out
+
+
+def main():
+    out = "/tmp/aarch64_param_homing_851.o"
+    # A stale object from an earlier run reads as a fresh miscompile.
+    if os.path.exists(out):
+        os.remove(out)
+    if not compile_aarch64(out):
+        print("\nRESULT: RED — aarch64 declined writing a PARAMETER "
+              "(expected BEFORE param homing; a FAIL after the fix lands)")
+        sys.exit(1)
+    code, base, syms = load(out)
+
+    native = None
+    if _IS_ARM64:
+        try:
+            native = _NativeText(code, base, syms)
+            print("native MAP_JIT oracle: ENABLED (arm64 host)")
+        except Exception as e:  # noqa: BLE001
+            print(f"native MAP_JIT oracle: unavailable ({e}); unicorn only")
+    else:
+        print("native MAP_JIT oracle: skipped (non-arm64 host); unicorn only")
+
+    fails = 0
+    total = 0
+    for fn, aws, rw, args, poison in CASES:
+        total += 1
+        if fn not in syms:
+            print(f"BUG {fn}: symbol missing from .text (silently declined?)")
+            fails += 1
+            continue
+        exp = wasmtime_run(fn, to_signed(aws, args))
+        m = M32 if rw == 32 else M64
+        uni = unicorn_run(code, base, syms[fn], aws, rw, args, poison)
+        ok = isinstance(uni, int) and (uni & m) == (exp & m)
+        tag = " [poisoned upper halves]" if poison else ""
+        line = (f"{fn}{tuple(hex(a) for a in args)}{tag}: "
+                f"wasmtime={exp} unicorn={uni}")
+        # The native oracle marshals clean 32-bit args, so it cannot reproduce
+        # the poison probe — run it only on the un-poisoned cases.
+        if native is not None and not poison:
+            nat = native.call(fn, aws, rw, args)
+            ok = ok and (nat & m) == (exp & m)
+            line += f" native={nat}"
+        if not ok:
+            fails += 1
+            print("BUG " + line)
+        else:
+            print("ok  " + line)
+    print(f"\n{total - fails}/{total} cases matched wasmtime")
+    print("RESULT:", "PASS — aarch64 param homing matches wasmtime (#851)"
+          if not fails else f"FAIL ({fails})")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/aarch64_param_homing_851_differential.py
+++ b/scripts/repro/aarch64_param_homing_851_differential.py
@@ -126,6 +126,17 @@ CASES = [
     ("i64_i32_param_write", [64, 32], 64, [0x0000000100000001, 3], False),
     ("i64_i32_param_write", [64, 32], 64, [0xFFFFFFFFFFFFFFFF, 2], False),
     ("i64_i32_param_write", [64, 32], 64, [7, 0xFFFFFFFF], False),
+    # The #457 param-count INFERENCE miscompile: a CONDITIONALLY written param
+    # was reclassified as a zero-init non-param local and compiled SILENTLY
+    # WRONG (measured on c2f9d72: cond_write_param(0,42) → 0, wasmtime 42).
+    ("cond_write_param", [32, 32], 32, [0, 42], False),
+    ("cond_write_param", [32, 32], 32, [1, 42], False),
+    ("cond_write_param", [32, 32], 32, [0, 0], False),
+    ("cond_write_param", [32, 32], 32, [0, 0xFFFFFFFF], False),
+    ("cond_write_param", [32, 32], 32, [0, 42], True),
+    ("cond_write_param_loop", [32, 32, 32], 32, [0, 5, 7], False),
+    ("cond_write_param_loop", [32, 32, 32], 32, [3, 5, 7], False),
+    ("cond_write_param_loop", [32, 32, 32], 32, [1, 0, 9], False),
     # NON-LEAF regression guard (this shape already compiled before the fix).
     ("param_write_across_call", [32], 32, [5], False),
     ("param_write_across_call", [32], 32, [0], False),


### PR DESCRIPTION
Closes the aarch64 `local.set`/`local.tee`-on-a-parameter decline by HOMING written params — and fixes a **silent miscompile** found while writing the fixture.

## Two changes

**1. Param homing (the requested capability).** `crates/synth-backend-aarch64/src/selector.rs` widens the homing predicate from `is_non_leaf && references_param` to `(is_non_leaf && references_param) || writes_param`. A written param gets an 8-byte home slot filled from its argument register in the prologue; `local.get` loads a fresh copy, so a param write cannot alias a stacked value — the exact hazard the old decline guarded. `writes_param ⊆ references_param`, so **exactly one class changes**: leaf functions that write a param, all of which declined before. Non-leaf homing is byte-identical. The now-unreachable decline arms are kept as loud internal-invariant errors rather than deleted.

**2. A silent miscompile in `backend.rs` (not in the original scope).** `num_params` was `min(count_params(ops), declared)`, and `count_params` counts only indices *read before written in linear op order*. A param written before it is read — but only **conditionally** — was demoted to a zero-init non-param local and **compiled wrong instead of declining**. Now `min(highest REFERENCED index + 1, declared)`; the `min` preserves the >8-declared-params leniency that plain `declared` would have broken (verified: a hard `num_params > 8` guard sits above the indexing, so plain `declared` would turn a lenient compile into a decline).

## Evidence

**Negative control — the most important artifact here.** Reverting *only* the `referenced_locals` line and rebuilding:

```
BUG cond_write_param('0x0', '0x2a'): wasmtime=42 unicorn=0 native=0
BUG cond_write_param('0x0', '0xffffffff'): wasmtime=-1 unicorn=0 native=0
BUG cond_write_param('0x0', '0x2a') [poisoned upper halves]: wasmtime=42 unicorn=0
41/44 cases matched wasmtime — RESULT: FAIL (3)
```

All three failures are `cond_write_param`, the exact shape the fix guards; the other 41 stay green, so the control is specific rather than a blanket break. They are **miscompiles, not declines** — which is the point: a decline-matrix probe could never have caught this, only an execution oracle. Both oracles (unicorn *and* the native arm64 MAP\_JIT path) agree on the wrong value. Restored, and back to **44/44**.

**Pre-edit RED on both gates** (captured before touching them — each gate self-reds, no new assertion needed):

- `cross_backend_op_parity.rs` flagged both entries stale by its own check:
  `local.set+get(param) — ledgered as an ARM/aarch64 divergence but both now agree (arm_ok=true, aarch64_ok=true); delete the entry` (same for `local.tee(param)`).
- `aarch64_m2_decline_538.py` printed `BUG local.set on a param: compiled — expected a LOUD decline` → `RESULT: FAIL (1 silent)`.

Both are green after the ledger edits.

## Ledger, decline honesty, and floors

Deleted the two stale parity entries; "leaving the FOUR below" is now TWO (both halves of bulk memory). Removed the closed `local.set on a param` decline entry.

**The FLOAT-param decline MOVED rather than disappeared.** Homing on `writes_param` makes a *leaf* function that writes a param hit the float check too, so a declared float param now declines from a second direction. Added as its own decline-probe entry **and** a unit test, both asserting the `FLOAT parameter` machine reason. The old label ("homing needs an FP store") was **false** — the encoder has `str s/d` since v0.54 L2; the real reason is that the home-slot model is single-register-file. Corrected in the probe, the selector message, and the module doc.

Three floors were vacuous — each tolerated a large silent regression. Raised to measured values:

| gate | old | new |
|---|---|---|
| aarch64 parity leg (`at_parity`) | 60 | **108** |
| decline matrix | 12 | **14** |
| matrix accepted ops | 32 | **61** |

The old parity floor was ~half the real count, so the entire param-write class could have regressed to a decline unnoticed. Caveat: the matrix floor was measured locally by running the script (61 accepted, 355 checks, PASS, empty declined frontier), but the CI-side `sed` extraction around it is unchanged and not exercised locally.

Also wires `aarch64_param_homing_851_differential.py` into CI — it was marked `ci-status: wired` but had **no step** — and corrects a stale comment block in `selector.rs` that still read "params stay read-only, see the LocalSet/LocalTee decline below".

## Decline list re-verified, not assumed

I removed `call_indirect` and "reading own params across a call" from the selector module doc's decline list. Both verified by compiling the shapes (`exit 0` each), not by inspection.

## Residual

The `None` branch of `current_func_param_count` still uses the unsound `count_params` heuristic. Unreachable from the CLI — `func_arg_counts` is populated for *every* function index (imports first, then local), so `.get(func.index)` is always `Some` — but the direct `compile_function` API can still reach it. Documented at the function; not fixed here.

## Related finding — filed separately as #970

The same `count_params(ops).min(declared)` shape exists in ARM (`arm_backend.rs:393`) and RISC-V (`effective_num_params`). **RISC-V is confirmed broken by execution**: on the fall-through path it reads an **uninitialised stack slot** (returns the `0xDEADBEEF` poison under unicorn), which is an information-disclosure shape on top of the miscompile — worse than the aarch64 instance, which returned a deterministic `0`. ARM is *incidentally* correct on the simple shape and miscompiles once the param register is clobbered by a call. **Not fixed here** — each backend has a different local/slot model and needs its own differential.

## Gates

- `cargo test --workspace` — **exit 0**, 2909 tests, 0 failures (re-run without a pipe; the earlier ambiguous result was `tail`'s exit code, not cargo's)
- `cargo clippy --workspace --all-targets -- -D warnings` — **exit 0**, no warnings
- `cargo fmt --check` — **exit 0**
- `python3 scripts/claim_check.py claims.yaml` — **43/43**
- param-homing differential — 44/44, unicorn + native arm64
- decline matrix — 14/14
- aarch64 matrix — 61 ops, 355 checks, PASS, empty declined frontier

Base is current with `origin/main` (merged `eea92e11`, #967).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
