### PR TITLE
fix(#970): count a CONDITIONALLY-written parameter as a parameter — ARM + RV32 uninitialised-stack-slot leak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2148,6 +2148,62 @@ jobs:
           set -euo pipefail
           python3 scripts/oracle_evidence.py "$ORACLE_EVIDENCE_JSONL" --min-oracles 1
 
+  cond-write-param-970-oracle:
+    name: "conditional-param-write oracle (#970, Thumb-2 + RV32)"
+    # #970 (RQ-57-CONDPARAM): a parameter written on ONE arm of an `if` was
+    # demoted to a non-param local by the read-first `count_params` heuristic,
+    # and — its first access being a WRITE — missed the #457 zero-init too, so
+    # the arm that does NOT write it read an UNINITIALISED frame slot. Both
+    # harnesses POISON every stack word below the entry SP (0xDEADBEEF) and
+    # every unused argument register (0xFEEDFACE, a DISTINCT word), so the
+    # failure is legible as a leak of previous-frame bytes rather than as a
+    # plausible zero, and the two mechanisms cannot be confused.
+    #
+    # Measured RED on cb80e60c: 22/38 on EACH backend, 12 memory-poison leaks
+    # each. GREEN after the fix: 38/38, 0 leaks. The two oracles are
+    # INDEPENDENT evidence — reverting only the ARM bound reds ARM and leaves
+    # RV32 green, and vice versa (negative control run both ways).
+    #
+    # The aarch64 instance of the same defect is covered by the #851
+    # param-homing oracle in the aarch64 job; all three backends now share one
+    # `synth_core::referenced_locals`.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Build synth
+        run: cargo build -p synth-cli
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
+      - name: Install emulation deps
+        run: pip install wasmtime unicorn pyelftools
+      - name: "Run #970 conditional-param-write execution oracle (ARM Thumb-2)"
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/oracle_run.py scripts/repro/cond_write_param_970_arm_differential.py
+      - name: "Run #970 conditional-param-write execution oracle (RV32)"
+        env:
+          SYNTH: ./target/debug/synth
+        run: python scripts/oracle_run.py scripts/repro/cond_write_param_970_riscv_differential.py
+      # #910: close the job with what it EXECUTED. Both oracles must report, so
+      # deleting or skipping either leaves the ledger short and reds the job.
+      - name: Differential evidence ledger (#910)
+        if: always()
+        run: |
+          set -euo pipefail
+          python3 scripts/oracle_evidence.py "$ORACLE_EVIDENCE_JSONL" --min-oracles 2
+
   call-indirect-676-heterogeneous-oracle:
     name: heterogeneous-table call_indirect oracle (Thumb-2 + A32)
     # VCR-ORACLE-001 (#242, #676): a HETEROGENEOUS funcref table (mixed

--- a/crates/synth-backend-aarch64/src/backend.rs
+++ b/crates/synth-backend-aarch64/src/backend.rs
@@ -50,7 +50,7 @@ impl AArch64Backend {
         // `min(highest REFERENCED index + 1, declared)`, not the read-first
         // heuristic. The old `min(count_params(ops), declared)` silently
         // demoted a CONDITIONALLY-written param to a zero-init non-param local
-        // and emitted wrong code (see [`referenced_locals`]); the exact bound
+        // and emitted wrong code (see `synth_core::referenced_locals`); the exact bound
         // makes it a param again, so it is homed from its argument register.
         // The `min` keeps the >8-declared-params leniency intact.
         let num_params = match config.current_func_param_count {
@@ -193,7 +193,7 @@ use synth_core::referenced_locals;
 /// written is a parameter). Mirrors the ARM/RISC-V backends' heuristic.
 ///
 /// HONEST RESIDUAL (#851): only reachable when the driver supplied NO declared
-/// param count — with a declared count [`referenced_locals`] is exact and this
+/// param count — with a declared count [`synth_core::referenced_locals`] is exact and this
 /// heuristic is not consulted. Without one, a write-first index is genuinely
 /// AMBIGUOUS (param whose incoming value is dead, or non-param local), and both
 /// readings can be wrong; the read-first rule keeps the #457 behaviour rather

--- a/crates/synth-backend-aarch64/src/backend.rs
+++ b/crates/synth-backend-aarch64/src/backend.rs
@@ -181,36 +181,13 @@ fn module_ctx(config: &CompileConfig) -> selector::ModuleCtx {
 
 /// The highest local index the body references, +1 (0 when it touches none).
 ///
-/// RQ-57-A64PARAM (#851): this is the param-count bound to use when the DRIVER
-/// SUPPLIED a declared count, because `min(referenced, declared)` is exact —
-/// it names every index that is really a param, and clamps to the declared
-/// count so a genuine non-param local can never be mistaken for one.
-///
-/// It replaces [`count_params`] on that path, which was UNSOUND: that heuristic
-/// counts only indices READ BEFORE WRITTEN in LINEAR op order, so a param
-/// written before it is read — but only CONDITIONALLY — was reclassified as a
-/// non-param local and ZERO-INITIALIZED. The function then compiled SILENTLY
-/// WRONG instead of declining. Measured on c2f9d72 before this fix:
-///
-/// ```wat
-/// (func (export "f") (param i32 i32) (result i32)
-///   (if (local.get 0) (then (local.set 1 (i32.const 5))))
-///   (local.get 1))          ;; f(0, 42): wasmtime 42, synth 0
-/// ```
-///
-/// Using `min(referenced, declared)` rather than plain `declared` also PRESERVES
-/// the existing leniency for a function with more than 8 declared params that
-/// only touches the first few (the selector caps register params at 8): such a
-/// body still lowers, exactly as before.
-fn referenced_locals(ops: &[WasmOp]) -> u32 {
-    ops.iter()
-        .filter_map(|op| match op {
-            WasmOp::LocalGet(i) | WasmOp::LocalSet(i) | WasmOp::LocalTee(i) => Some(*i + 1),
-            _ => None,
-        })
-        .max()
-        .unwrap_or(0)
-}
+/// RQ-57-A64PARAM (#851) landed this as a private copy here; #970 found the
+/// identical defect in the ARM and RISC-V backends and moved the ONE
+/// implementation to [`synth_core::referenced_locals`], where its doc comment
+/// lives. Re-exported under the local name so this file's call site and the
+/// #851 references to it keep reading the same — but there is now exactly one
+/// definition for the three backends to agree on, which is the point.
+use synth_core::referenced_locals;
 
 /// Count register parameters from the op stream (a local index read before it is
 /// written is a parameter). Mirrors the ARM/RISC-V backends' heuristic.

--- a/crates/synth-backend-riscv/src/backend.rs
+++ b/crates/synth-backend-riscv/src/backend.rs
@@ -400,19 +400,27 @@ fn count_params(wasm_ops: &[WasmOp]) -> u32 {
         .unwrap_or(0)
 }
 
-/// #457: cap the access-pattern param inference with the DECLARED count when
-/// the driver supplied one. A read-before-write non-param local (which WASM
+/// #457: settle the param count with the DECLARED count when the driver
+/// supplied one. A read-before-write non-param local (which WASM
 /// zero-initializes) is indistinguishable from a param to `count_params` — it
-/// was homed in an argument register and read caller garbage instead of 0.
-/// `min` (not a plain override) keeps every function whose inference is <= the
-/// declared count byte-identical: the inference can only exceed the declared
-/// count via a read-first local index >= it — exactly the read-before-write
-/// locals. The selector zero-inits the reclassified locals' frame slots.
+/// was homed in an argument register and read caller garbage instead of 0. The
+/// selector zero-inits the reclassified locals' frame slots.
+///
+/// #970 (RQ-57-CONDPARAM): the declared-count bound is
+/// `min(highest REFERENCED index + 1, declared)`, NOT `min(count_params(ops),
+/// declared)`. The old rule demoted a CONDITIONALLY-written param to a
+/// non-param local, and because that local's first access is a WRITE the #457
+/// zero-init skipped it too — so the branch that does not write it read an
+/// UNINITIALISED frame slot (`lw t0, 0(sp)` over a slot no path had stored).
+/// Measured under unicorn with the sub-SP stack poisoned, `cond_write_param(0,
+/// 42)` returned the poison word: previous-frame bytes, an information-
+/// disclosure shape rather than merely a wrong value. See
+/// [`synth_core::referenced_locals`]. `min` (not a plain override) keeps the
+/// leniency for a body that only touches the first few of many declared params.
 fn effective_num_params(ops: &[WasmOp], config: &CompileConfig) -> u32 {
-    let inferred = count_params(ops);
     match config.current_func_param_count {
-        Some(declared) => inferred.min(declared),
-        None => inferred,
+        Some(declared) => synth_core::referenced_locals(ops).min(declared),
+        None => count_params(ops),
     }
 }
 
@@ -571,8 +579,51 @@ mod tests {
         assert_eq!(
             effective_num_params(&ops, &over_declared),
             2,
-            "declared >= inferred keeps the inference (byte-identity)"
+            "declared >> referenced stays at the referenced count (byte-identity)"
         );
+    }
+
+    /// #970: a CONDITIONALLY-written param must stay a param.
+    ///
+    /// The read-first heuristic sees `LocalSet(1)` before any `LocalGet(1)` in
+    /// LINEAR op order and demotes index 1 — even though the `if` means the
+    /// write may not execute. The demoted local's first access is a WRITE, so
+    /// the #457 zero-init skipped it too and the fall-through arm executed
+    /// `lw t0, 0(sp)` over a slot no path had stored: previous-frame bytes,
+    /// not the incoming argument (executed evidence:
+    /// `scripts/repro/cond_write_param_970_riscv_differential.py`).
+    #[test]
+    fn conditionally_written_param_stays_a_param_970() {
+        // (param i32 i32): if (local.get 0) { local.set 1 = 5 }; local.get 1
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::If,
+            WasmOp::I32Const(5),
+            WasmOp::LocalSet(1),
+            WasmOp::End,
+            WasmOp::LocalGet(1),
+            WasmOp::End,
+        ];
+        let base = CompileConfig {
+            target: TargetSpec::riscv32imac(),
+            ..Default::default()
+        };
+        assert_eq!(
+            count_params(&ops),
+            1,
+            "the read-first heuristic must still undercount (this is the defect)"
+        );
+        let declared = CompileConfig {
+            current_func_param_count: Some(2),
+            ..base.clone()
+        };
+        assert_eq!(
+            effective_num_params(&ops, &declared),
+            2,
+            "a conditionally-written param must be counted as a param"
+        );
+        // No declared count: the legacy inference, unchanged (honest residual).
+        assert_eq!(effective_num_params(&ops, &base), count_params(&ops));
     }
 
     #[test]

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -236,6 +236,38 @@ fn count_params(wasm_ops: &[WasmOp]) -> u32 {
         .unwrap_or(0)
 }
 
+/// #457/#970: the parameter count the selector is given.
+///
+/// With a DECLARED count from the driver the bound is
+/// `min(`[`synth_core::referenced_locals`]`(ops), declared)` — the highest
+/// local index the body touches, clamped by the signature. That is exact in
+/// both directions: the clamp stops a read-before-write NON-PARAM local (which
+/// WASM zero-initializes) from being homed in an argument register and reading
+/// caller garbage (#457), and taking the max over ALL accesses — writes as well
+/// as reads — stops a PARAM from being demoted to a local.
+///
+/// The previous rule capped [`count_params`] (a READ-FIRST heuristic) with the
+/// declared count, which got the second direction wrong: a param written on ONE
+/// arm of an `if` is "written first" in linear op order, so it was demoted, and
+/// because the demoted local's first access is a WRITE the #457 zero-init
+/// skipped it too. The arm that does NOT write it then read an UNINITIALISED
+/// frame slot — measured under unicorn with the sub-SP stack poisoned,
+/// `cond_write_param(0, 42)` returned the poison word, i.e. previous-frame
+/// bytes rather than 42 (#970; the aarch64 instance was #851).
+///
+/// `min` rather than a plain `declared` override preserves the leniency for a
+/// body that only touches the first few of many declared params.
+///
+/// `None` (no declared signature: hand-built op streams, direct
+/// `compile_function` callers) keeps the legacy pure inference — see the
+/// residual documented on [`CompileConfig::current_func_param_count`].
+fn effective_num_params(wasm_ops: &[WasmOp], config: &CompileConfig) -> u32 {
+    match config.current_func_param_count {
+        Some(declared) => synth_core::referenced_locals(wasm_ops).min(declared),
+        None => count_params(wasm_ops),
+    }
+}
+
 /// #539: fold the `i32.const 0; memory.grow m` idiom to `memory.size m`.
 /// Moved to `synth_core::rewrite_memory_grow_zero` (#242, VCR-SEL-005) so the
 /// ARM and RISC-V backends share ONE implementation and cannot drift; re-export
@@ -383,22 +415,23 @@ fn compile_wasm_to_arm(
     // whose first access is a read is assumed to be a param), so a
     // read-before-write NON-PARAM local — which WASM zero-initializes — was
     // indistinguishable from a param: it got homed in a parameter register and
-    // read caller garbage instead of 0. When the driver supplied the DECLARED
-    // count (`current_func_param_count`, from the module's type section), cap
-    // the inference with it. `min` (not a plain override) keeps every function
-    // whose inference is <= declared byte-identical: the inferred count can only
-    // EXCEED the declared one via a read-first local index >= the declared count
-    // — i.e. exactly the read-before-write locals this issue is about.
+    // read caller garbage instead of 0. The driver supplies the DECLARED count
+    // (`current_func_param_count`, from the module's type section) to settle it.
+    //
+    // #970 (RQ-57-CONDPARAM): see [`effective_num_params`] for the bound and
+    // why the read-first inference is not it.
     let inferred_params = count_params(wasm_ops);
-    let num_params = match config.current_func_param_count {
-        Some(declared) => inferred_params.min(declared),
-        None => inferred_params,
+    let num_params = effective_num_params(wasm_ops, config);
+    // A read-before-write non-param local exists iff the ACCESS-PATTERN
+    // inference overshot the declared count — the read-first rule can only
+    // exceed it via a read-first index >= the declared count, which is exactly
+    // such a local. (Unchanged by #970: `referenced >= inferred` always, so
+    // `num_params < inferred_params` still holds iff `inferred > declared`;
+    // stated directly here rather than left to that algebra.)
+    let has_rbw_local = match config.current_func_param_count {
+        Some(declared) => inferred_params > declared,
+        None => false,
     };
-    // A read-before-write non-param local exists iff the capped count dropped.
-    // Such locals need the wasm-mandated zero-init, which only the direct
-    // selector emits — the optimized path's `ir_to_arm` maps a non-param
-    // local's vreg onto an r4+ temp with no initialization (caller garbage).
-    let has_rbw_local = num_params < inferred_params;
 
     let bounds_config = match config.effective_safety_bounds() {
         SafetyBounds::None => BoundsCheckConfig::None,
@@ -2299,6 +2332,83 @@ mod tests {
         assert_eq!(
             matching.code, inferred.code,
             "declared >= inferred must stay byte-identical"
+        );
+    }
+
+    /// #970: a CONDITIONALLY-written param must stay a param.
+    ///
+    /// The read-first heuristic sees `LocalSet(1)` before any `LocalGet(1)` in
+    /// LINEAR op order and demotes index 1 — even though the `if` means the
+    /// write may not execute at all. `min(referenced, declared)` keeps it.
+    /// The RED symptom this pins is not a wrong constant: the demoted local's
+    /// first access is a WRITE, so the #457 zero-init skips it and the
+    /// fall-through arm reads an UNINITIALISED frame slot (executed evidence:
+    /// `scripts/repro/cond_write_param_970_arm_differential.py`).
+    #[test]
+    fn conditionally_written_param_stays_a_param_970() {
+        // (param i32 i32): if (local.get 0) { local.set 1 = 5 }; local.get 1
+        let ops = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::If,
+            WasmOp::I32Const(5),
+            WasmOp::LocalSet(1),
+            WasmOp::End,
+            WasmOp::LocalGet(1),
+            WasmOp::End,
+        ];
+        let declared = CompileConfig {
+            current_func_param_count: Some(2),
+            ..CompileConfig::default()
+        };
+        // The old rule: index 1 is written before it is read, so it is not
+        // counted — this is the undercount that produced the miscompile.
+        assert_eq!(
+            count_params(&ops),
+            1,
+            "the read-first heuristic must still undercount (this is the defect)"
+        );
+        assert_eq!(
+            effective_num_params(&ops, &declared),
+            2,
+            "a conditionally-written param must be counted as a param"
+        );
+        // The #457 direction is untouched: a genuine non-param local is still
+        // clamped away by the declared count.
+        let rbw = vec![
+            WasmOp::LocalGet(0),
+            WasmOp::LocalGet(1),
+            WasmOp::I32Add,
+            WasmOp::End,
+        ];
+        assert_eq!(
+            effective_num_params(
+                &rbw,
+                &CompileConfig {
+                    current_func_param_count: Some(1),
+                    ..CompileConfig::default()
+                }
+            ),
+            1,
+            "#457: a read-before-write non-param local must NOT become a param"
+        );
+        // Leniency: a body touching only the first few of many declared params
+        // still lowers with the small count (the selector homes at most 4 in
+        // registers; `min` is what keeps this from becoming `declared`).
+        assert_eq!(
+            effective_num_params(
+                &rbw,
+                &CompileConfig {
+                    current_func_param_count: Some(12),
+                    ..CompileConfig::default()
+                }
+            ),
+            2,
+            "declared >> referenced must stay at the referenced count"
+        );
+        // No declared count: the legacy inference, unchanged (honest residual).
+        assert_eq!(
+            effective_num_params(&ops, &CompileConfig::default()),
+            count_params(&ops)
         );
     }
 

--- a/crates/synth-core/src/backend.rs
+++ b/crates/synth-core/src/backend.rs
@@ -265,14 +265,25 @@ pub struct CompileConfig {
     /// param) — which cannot distinguish a param from a read-before-write
     /// non-param local. WASM zero-initializes non-param locals, so such a local
     /// must read 0; the inference instead homed it in a parameter register and
-    /// read caller garbage (#457). The backends cap the inferred count at this
-    /// declared count when it is present, which reclassifies exactly the
-    /// read-before-write locals (an inferred count can only exceed the declared
-    /// one via a read-first index >= the declared count) and leaves every other
-    /// function's codegen byte-identical.
+    /// read caller garbage (#457).
+    ///
+    /// When this is `Some(declared)`, every backend uses
+    /// `min(`[`referenced_locals`](crate::referenced_locals)`(ops), declared)`
+    /// — the highest index the body touches, clamped by the signature. That is
+    /// EXACT in both directions: a genuine non-param local can never be
+    /// mistaken for a param (the clamp), and a param can never be demoted to a
+    /// local (the max over ALL accesses, reads and writes alike). The earlier
+    /// rule capped the READ-FIRST inference instead, which demoted a
+    /// conditionally-written param and produced an uninitialised-frame-slot
+    /// read on ARM and RISC-V and a zero-init local on AArch64 (#970/#851).
     ///
     /// `None` → declared signature unknown (hand-built op streams, direct
     /// `compile_function` callers) → pure inference, the legacy behaviour.
+    /// HONEST RESIDUAL (#970, unchanged from #851): on that path a write-first
+    /// index is genuinely AMBIGUOUS — a param whose incoming value is dead, or
+    /// a non-param local — and both readings can be wrong. The read-first rule
+    /// keeps the #457 behaviour rather than reading caller garbage for a
+    /// zero-init local. The CLI always supplies a declared count.
     pub current_func_param_count: Option<u32>,
     /// (#778 phase 4 / #49) The WASM index of the function CURRENTLY being compiled,
     /// so the WCET pass can identify this function's OWN `func_<idx>` self-call label

--- a/crates/synth-core/src/lib.rs
+++ b/crates/synth-core/src/lib.rs
@@ -34,5 +34,5 @@ pub use wasm_decoder::{
     CallIndirectGuards, DecodedModule, ElemSegmentInfo, FunctionOps, ImportEntry, ImportKind,
     TableGuards, WasmMemory, decode_wasm_functions, decode_wasm_module,
 };
-pub use wasm_op::{WasmOp, rewrite_memory_grow_zero};
+pub use wasm_op::{WasmOp, referenced_locals, rewrite_memory_grow_zero};
 pub use wsc_facts::{FactKind, WSC_FACTS_SECTION_NAME, WscFact, WscFactsParse, parse_wsc_facts};

--- a/crates/synth-core/src/wasm_op.rs
+++ b/crates/synth-core/src/wasm_op.rs
@@ -495,6 +495,50 @@ pub enum WasmOp {
     F32x4ReplaceLane(u8), // f32x4.replace_lane
 }
 
+/// The highest local index the body references, +1 (0 when it touches none).
+///
+/// #970 (RQ-57-CONDPARAM): this is the param-count bound every backend uses
+/// when the driver SUPPLIED a declared count, because `min(referenced,
+/// declared)` is EXACT — it names every index that is really a param, and the
+/// clamp means a genuine non-param local can never be mistaken for one.
+///
+/// It replaces the `count_params` access-pattern heuristic on that path, which
+/// was UNSOUND: that heuristic counts only indices READ BEFORE WRITTEN in
+/// LINEAR op order, so a param written before it is read — but only
+/// CONDITIONALLY — was reclassified as a non-param local. Worse, its first
+/// access being a WRITE meant the read-before-write zero-init (#457) skipped it
+/// too, so the branch that does NOT write it read an UNINITIALISED frame slot:
+///
+/// ```wat
+/// (func (export "f") (param i32 i32) (result i32)
+///   (if (local.get 0) (then (local.set 1 (i32.const 5))))
+///   (local.get 1))          ;; f(0, 42): wasmtime 42, synth <previous frame>
+/// ```
+///
+/// Measured on cb80e60c under unicorn with the sub-SP stack poisoned, BOTH the
+/// ARM and RV32 backends returned the poison word rather than 42 — an
+/// information-disclosure shape, not merely a wrong value.
+///
+/// Using `min(referenced, declared)` rather than plain `declared` PRESERVES the
+/// leniency for a function with more declared params than the backend can
+/// register-home that only touches the first few: such a body still lowers,
+/// exactly as before.
+///
+/// Shared by the ARM (`synth-backend`), RISC-V (`synth-backend-riscv`) and
+/// AArch64 (`synth-backend-aarch64`) backends — three private copies of the
+/// same three-line rule is precisely the drift `rewrite_memory_grow_zero`
+/// below was centralised to avoid (#242, VCR-SEL-005).
+pub fn referenced_locals(wasm_ops: &[WasmOp]) -> u32 {
+    wasm_ops
+        .iter()
+        .filter_map(|op| match op {
+            WasmOp::LocalGet(i) | WasmOp::LocalSet(i) | WasmOp::LocalTee(i) => Some(*i + 1),
+            _ => None,
+        })
+        .max()
+        .unwrap_or(0)
+}
+
 /// Fold `i32.const 0; memory.grow` → `memory.size` up front, on every backend.
 ///
 /// WASM Core §4.4.7: growing a memory by ZERO pages can never fail — it returns

--- a/scripts/repro/cond_write_param_970.wat
+++ b/scripts/repro/cond_write_param_970.wat
@@ -1,0 +1,114 @@
+;; #970 — a CONDITIONALLY-written parameter must keep its incoming argument.
+;;
+;; `count_params` (the ARM/RISC-V backends' access-pattern param inference)
+;; counts only local indices READ BEFORE WRITTEN in LINEAR op order. A parameter
+;; written on ONE branch of an `if` is "written first" in that order, so it was
+;; demoted to a non-param local — losing the fact that its incoming argument
+;; value is still live on the OTHER path. The demoted local is not even
+;; zero-initialized (its first access is a write, so the #457 read-before-write
+;; zero-init skips it), so the fall-through path reads an UNINITIALIZED frame
+;; slot on RISC-V.
+;;
+;; Every `cw_*` export below has its HIGHEST referenced local index written
+;; before it is read in linear order — that is what makes the max-over-read-first
+;; rule undercount. The `guard_*` exports are the shapes the fix must NOT change:
+;; a genuine read-before-write NON-PARAM local still observes the wasm-mandated 0
+;; (#457), and an unconditionally-written param is correct either way.
+(module
+  ;; Callees exist so a param write can be a CALL RESULT: on both ABIs the
+  ;; argument registers are CALLER-saved, so the call clobbers the incoming
+  ;; param register on the path that does NOT take the branch too.
+  (func $mk99 (result i32) (i32.const 99))
+  (func $twice (param i32) (result i32) (i32.add (local.get 0) (local.get 0)))
+
+  ;; ── the conditional-write class ────────────────────────────────────────────
+  ;; THE canonical shape. cond_write_param(0, 42) must be 42.
+  (func (export "cond_write_param") (param i32 i32) (result i32)
+    (if (local.get 0)
+      (then (local.set 1 (i32.const 5))))
+    (local.get 1))
+
+  ;; The same shape with the written value coming from a CALL. This is the ARM
+  ;; instance: the merge-point store no longer happens to catch a live param
+  ;; register, because `bl` clobbered it.
+  (func (export "cw_call") (param i32 i32) (result i32)
+    (if (local.get 0)
+      (then (local.set 1 (call $mk99))))
+    (local.get 1))
+
+  ;; A call that also PASSES an argument, so r0/a0 is written on the way in.
+  (func (export "cw_call_arg") (param i32 i32) (result i32)
+    (if (local.get 0)
+      (then (local.set 1 (call $twice (i32.const 21)))))
+    (local.get 1))
+
+  ;; `local.tee` instead of `local.set` — same demotion, different lowering arm.
+  (func (export "cw_tee") (param i32 i32) (result i32)
+    (if (local.get 0)
+      (then (drop (local.tee 1 (i32.const 5)))))
+    (local.get 1))
+
+  ;; The write is guarded by `br_if` out of a `block`, not by `if`.
+  (func (export "cw_brif") (param i32 i32) (result i32)
+    (block
+      (br_if 0 (i32.eqz (local.get 0)))
+      (local.set 1 (i32.const 5)))
+    (local.get 1))
+
+  ;; A loop that writes the param only while the counter is nonzero, so
+  ;; count=0 leaves the incoming argument untouched.
+  (func (export "cw_loop") (param i32 i32) (result i32)
+    (block
+      (loop
+        (br_if 1 (i32.eqz (local.get 0)))
+        (local.set 1 (i32.add (local.get 1) (i32.const 1)))
+        (local.set 0 (i32.sub (local.get 0) (i32.const 1)))
+        (br 0)))
+    (local.get 1))
+
+  ;; The highest index of THREE params is the conditionally-written one, and
+  ;; the surviving params are summed so a wrong slot offset is visible too.
+  (func (export "cw_last_of_three") (param i32 i32 i32) (result i32)
+    (if (local.get 0)
+      (then (local.set 2 (i32.const 5))))
+    (i32.add (local.get 1) (local.get 2)))
+
+  ;; SIX declared params: on ARM indices 4 and 5 are AAPCS STACK-passed, so this
+  ;; also exercises the leniency the `min(referenced, declared)` bound widens —
+  ;; index 5 must be read from the caller's frame, not from a zero-init local.
+  (func (export "cw_high_param") (param i32 i32 i32 i32 i32 i32) (result i32)
+    (if (local.get 0)
+      (then (local.set 5 (i32.const 7))))
+    (i32.add (local.get 4) (local.get 5)))
+
+  ;; ── guards: shapes the fix must leave alone ────────────────────────────────
+  ;; #457: a genuine read-before-write NON-PARAM local reads the wasm-mandated 0.
+  ;; If the fix over-widened the param count this would read caller garbage.
+  (func (export "guard_rbw_local") (param i32) (result i32)
+    (local i32)
+    (i32.add (local.get 0) (local.get 1)))
+
+  ;; #457 again, with the non-param local as the HIGHEST index and a param
+  ;; conditionally written below it.
+  (func (export "guard_rbw_local_mixed") (param i32 i32) (result i32)
+    (local i32)
+    (if (local.get 0)
+      (then (local.set 1 (i32.const 5))))
+    (i32.add (local.get 1) (local.get 2)))
+
+  ;; Both arms write the param: correct under either rule.
+  (func (export "guard_both_arms") (param i32 i32) (result i32)
+    (if (local.get 0)
+      (then (local.set 1 (i32.const 5)))
+      (else (local.set 1 (i32.const 7))))
+    (local.get 1))
+
+  ;; Unconditional write before the read: the incoming value is genuinely dead.
+  (func (export "guard_write_then_read") (param i32 i32) (result i32)
+    (local.set 1 (i32.const 5))
+    (i32.add (local.get 0) (local.get 1)))
+
+  ;; Plain read-only params.
+  (func (export "guard_plain_params") (param i32 i32) (result i32)
+    (i32.add (local.get 0) (local.get 1)))
+)

--- a/scripts/repro/cond_write_param_970_arm_differential.py
+++ b/scripts/repro/cond_write_param_970_arm_differential.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# ci-status: wired
+# ci-checks: emulations >= 38
+"""#970 — ARM: a CONDITIONALLY-written parameter must keep its incoming argument.
+
+Same defect as the RV32 sibling oracle, different symptom. `count_params`
+(`arm_backend.rs`) counted only local indices READ BEFORE WRITTEN in LINEAR op
+order, so a parameter written on ONE arm of an `if` was demoted to a non-param
+local and its incoming argument register was forgotten.
+
+ARM's symptom was NOT assumed from the RV32 one — it was MEASURED here, and the
+measurement corrected the expectation. #970 predicted ARM would return param
+0's value (an ordinary wrong value) because the demoted local's store looked, in
+a flat disassembly listing, like it sat at the branch MERGE point. It does not:
+the conditional branch jumps PAST it. Measured on cb80e60c, `--target cortex-m4
+--relocatable`, `cond_write_param` lowers to
+
+    push.w {r4, r5, r6, r7, r8, lr}
+    sub.w  sp, sp, #8
+    cmp    r0, #0
+    beq    +8            ; -> the ldr, skipping the store below
+    movw   r1, #5
+    str.w  r1, [sp]      ; INSIDE the then-arm, not at the merge point
+    ldr.w  r2, [sp]      ; <- on the fall-through path this slot was NEVER written
+    mov    r0, r2
+
+so ARM has the SAME uninitialised-frame-slot read as RV32, i.e. the same
+information-disclosure shape, on the plain shape as well as the call one. The
+`cw_call*` cases stay as separate evidence because they are the shape #970
+reasoned about, and because their store is fed by a call-clobbered `r0`.
+
+Two DISTINCT poison words make the mechanism provable rather than inferred:
+every stack word below the entry SP is 0xDEADBEEF and every argument register
+the signature does not use is 0xFEEDFACE, so "read an uninitialised slot" and
+"read the wrong argument register" cannot be confused for one another.
+
+Ground truth is wasmtime on the same `.wat`. Symbols come from the ELF
+`.symtab`, never `synth disasm` text (host-dependent). The two `R_ARM_THM_CALL`
+relocations to the in-module callees are resolved in-process by re-encoding the
+BL, exactly as `ld` would.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/cond_write_param_970_arm_differential.py
+"""
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_ARM, UC_MODE_THUMB, Uc, UcError
+from unicorn.arm_const import (
+    UC_ARM_REG_LR,
+    UC_ARM_REG_R0,
+    UC_ARM_REG_R1,
+    UC_ARM_REG_R2,
+    UC_ARM_REG_R3,
+    UC_ARM_REG_R11,
+    UC_ARM_REG_SP,
+)
+
+WAT = Path(__file__).with_name("cond_write_param_970.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+CODE, LIN = 0x100000, 0x40000
+RET_PAD = CODE + 0x8000  # mapped, halfword-aligned; emulation stops here
+STACK_BASE, STACK_SIZE = 0x80000, 0x10000
+SP0 = STACK_BASE + 0xC000  # entry SP: 48 KiB of poison below, 16 KiB above
+
+MEM_POISON = 0xDEADBEEF   # every stack word below the entry SP
+REG_POISON = 0xFEEDFACE   # every argument register the signature does not use
+CORE_ARGS = [UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3]
+
+R_ARM_THM_CALL, R_ARM_THM_JUMP24 = 10, 30
+M32 = 0xFFFFFFFF
+
+# (export, args) — the same matrix the RV32 sibling runs, so the two backends'
+# evidence is directly comparable while staying independently measured.
+CASES = [
+    ("cond_write_param", [0, 0x2A]),
+    ("cond_write_param", [1, 0x2A]),
+    ("cond_write_param", [0, 0x07]),
+    ("cond_write_param", [0, 0x11112222]),
+    ("cond_write_param", [0, 0xFFFFFFFF]),
+    ("cond_write_param", [0, 0]),
+    # The shape #970 reasoned about for ARM: the written value comes from a
+    # call, so `bl` has clobbered r0-r3 by the time the slot is read.
+    ("cw_call", [0, 0x2A]),
+    ("cw_call", [1, 0x2A]),
+    ("cw_call", [0, 0xABCDEF01]),
+    ("cw_call_arg", [0, 0x2A]),
+    ("cw_call_arg", [1, 0x2A]),
+    ("cw_call_arg", [0, 0x7FFFFFFF]),
+    ("cw_tee", [0, 0x2A]),
+    ("cw_tee", [1, 0x2A]),
+    ("cw_tee", [0, 0x80000000]),
+    ("cw_brif", [0, 0x2A]),
+    ("cw_brif", [1, 0x2A]),
+    ("cw_brif", [0, 0xDEADBEEF]),
+    ("cw_loop", [0, 0x2A]),
+    ("cw_loop", [3, 0x2A]),
+    ("cw_loop", [0, 0xFFFFFFFF]),
+    ("cw_last_of_three", [0, 3, 4]),
+    ("cw_last_of_three", [1, 3, 4]),
+    ("cw_last_of_three", [0, 0x10, 0xFFFF]),
+    # Six params: indices 4 and 5 are AAPCS STACK-passed on ARM, so this is the
+    # case where `min(referenced, declared)` WIDENS the count — index 5 must be
+    # read from the caller's frame, not from a zero-init local slot.
+    ("cw_high_param", [0, 1, 2, 3, 4, 5]),
+    ("cw_high_param", [1, 1, 2, 3, 4, 5]),
+    ("cw_high_param", [0, 9, 9, 9, 0x1000, 0x2000]),
+    # ── guards: the shapes the fix must NOT change ────────────────────────────
+    ("guard_rbw_local", [7]),  # #457: non-param local reads the mandated 0
+    ("guard_rbw_local", [0]),
+    ("guard_rbw_local", [0xFFFFFFFF]),
+    ("guard_rbw_local_mixed", [0, 0x2A]),
+    ("guard_rbw_local_mixed", [1, 0x2A]),
+    ("guard_both_arms", [0, 0x2A]),
+    ("guard_both_arms", [1, 0x2A]),
+    ("guard_write_then_read", [3, 0x2A]),
+    ("guard_write_then_read", [0, 0]),
+    ("guard_plain_params", [11, 31]),
+    ("guard_plain_params", [0xFFFFFFFF, 1]),
+]
+
+
+def die(msg):
+    print(f"FATAL: {msg}")
+    sys.exit(1)
+
+
+def compile_fixture(out):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "--target", "cortex-m4",
+         "--relocatable", "--all-exports", "-o", out],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        die(f"synth compile failed (rc={r.returncode}):\n{r.stdout}\n{r.stderr}")
+    return out
+
+
+def encode_thm_bl(pc, target):
+    """Thumb-2 BL: encode (target - (pc+4)) in the S/J1/J2/imm10/imm11 form."""
+    off = (target - (pc + 4)) & 0x1FFFFFF
+    s = (off >> 24) & 1
+    i1, i2 = (off >> 23) & 1, (off >> 22) & 1
+    imm10, imm11 = (off >> 12) & 0x3FF, (off >> 1) & 0x7FF
+    j1, j2 = (~i1 & 1) ^ s, (~i2 & 1) ^ s
+    return 0xF000 | (s << 10) | imm10, 0xD000 | (j1 << 13) | (j2 << 11) | imm11
+
+
+def load(path):
+    """Return (symbols, .text with R_ARM_THM_CALL relocations applied, count)."""
+    e = ELFFile(open(path, "rb"))
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: s["st_value"] for s in symtab.iter_symbols() if s.name}
+    text = bytearray(e.get_section_by_name(".text").data())
+
+    nrel = 0
+    for sec in e.iter_sections():
+        if sec["sh_type"] not in ("SHT_REL", "SHT_RELA"):
+            continue
+        for r in sec.iter_relocations():
+            t = r["r_info_type"]
+            if t not in (R_ARM_THM_CALL, R_ARM_THM_JUMP24):
+                die(f"unexpected reloc type {t}; this harness only resolves THM_CALL")
+            name = symtab.get_symbol(r["r_info_sym"]).name
+            if name not in syms:
+                die(f"reloc names {name!r}, which is not a defined symbol")
+            off = r["r_offset"]
+            hw1, hw2 = encode_thm_bl(CODE + off, CODE + (syms[name] & ~1))
+            struct.pack_into("<HH", text, off, hw1, hw2)
+            nrel += 1
+    return syms, bytes(text), nrel
+
+
+def run(syms, text, name, args):
+    """Execute one export under unicorn with the sub-SP stack POISONED."""
+    addr = syms.get(name)
+    if addr is None:
+        return None, f"symbol {name} missing from .symtab"
+    mu = Uc(UC_ARCH_ARM, UC_MODE_THUMB)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(LIN, 0x20000)
+    mu.mem_map(STACK_BASE, STACK_SIZE)
+    mu.mem_write(CODE, text)
+    # POISON the whole region the callee's frame can occupy, so an
+    # uninitialised frame-slot read is legible instead of reading as a benign 0.
+    mu.mem_write(STACK_BASE, struct.pack("<I", MEM_POISON) * ((SP0 - STACK_BASE) // 4))
+    mu.reg_write(UC_ARM_REG_SP, SP0)
+    mu.reg_write(UC_ARM_REG_R11, LIN)  # linear-memory base
+    # AAPCS: args 0..3 in r0..r3, the rest on the incoming stack from [sp,#0].
+    for i, a in enumerate(args[:4]):
+        mu.reg_write(CORE_ARGS[i], a & M32)
+    for i in range(len(args), 4):
+        mu.reg_write(CORE_ARGS[i], REG_POISON)  # unused arg regs carry a DISTINCT poison
+    for k, a in enumerate(args[4:]):
+        mu.mem_write(SP0 + 4 * k, struct.pack("<I", a & M32))
+    mu.reg_write(UC_ARM_REG_LR, RET_PAD | 1)
+    try:
+        mu.emu_start((CODE + (addr & ~1)) | 1, RET_PAD, count=20000)
+    except UcError as ex:
+        return None, str(ex)
+    return mu.reg_read(UC_ARM_REG_R0) & M32, ""
+
+
+def main():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+
+    with tempfile.TemporaryDirectory() as td:
+        obj = compile_fixture(os.path.join(td, "cw970_arm.o"))
+        syms, text, nrel = load(obj)
+    print(f"resolved {nrel} R_ARM_THM_CALL relocation(s) in-process")
+
+    fails = 0
+    leaks = 0
+    for name, args in CASES:
+        store = wasmtime.Store(engine)
+        inst = wasmtime.Instance(store, module, [])
+        want = inst.exports(store)[name](store, *[a - (1 << 32) if a >> 31 else a
+                                                  for a in args]) & M32
+        got, err = run(syms, text, name, args)
+        ok = got == want
+        fails += 0 if ok else 1
+        tag = ""
+        if got == MEM_POISON and not ok:
+            leaks += 1
+            tag = "   <- POISON (uninitialised stack slot)"
+        shown = f"0x{got:08x}" if got is not None else f"ERR({err})"
+        argstr = ", ".join(f"0x{a:x}" for a in args)
+        print(f"{'ok ' if ok else 'BUG'} {name}({argstr}): "
+              f"want=0x{want:08x} got={shown}{tag}")
+
+    print(f"\n#970 ARM CHECKS={len(CASES) - fails}/{len(CASES)}"
+          f"  poison-leaks={leaks}")
+    if fails:
+        print("#970 ARM conditional-param-write ORACLE: FAIL")
+    else:
+        print("#970 ARM conditional-param-write ORACLE: PASS")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro/cond_write_param_970_riscv_differential.py
+++ b/scripts/repro/cond_write_param_970_riscv_differential.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+# ci-status: wired
+# ci-checks: emulations >= 38
+"""#970 — RV32: a CONDITIONALLY-written parameter must keep its incoming argument.
+
+`count_params` (the RISC-V backend's `effective_num_params`) counted only local
+indices READ BEFORE WRITTEN in LINEAR op order. A parameter written on ONE arm
+of an `if` is "written first" in that order, so it was demoted to a NON-PARAM
+local — and because its first access is a write, the #457 read-before-write
+zero-init skipped it too. The fall-through path then read an **uninitialised
+frame slot**:
+
+    addi sp, sp, -16
+    mv   t0, a0
+    beqz t0, +12       ; -> the `lw`, skipping BOTH stores below
+    li   t0, 5
+    sw   t0, 0(sp)
+    lw   t0, 0(sp)     ; <- on the taken path this slot was NEVER written
+    mv   a0, t0
+
+That is worse than a deterministic wrong value: the slot holds whatever the
+PREVIOUS frame left there, so the function LEAKS caller/callee stack bytes —
+an information-disclosure shape on top of the miscompile.
+
+This oracle makes that visible instead of accidentally benign. Every stack word
+BELOW the entry stack pointer is pre-filled with 0xDEADBEEF before each run, so
+an uninitialised-slot read returns POISON rather than unicorn's zero fill —
+without it the leak would read as aarch64's deterministic `0` and the finding
+would be lost. Argument registers the signature does not use carry a SECOND,
+distinct poison (0xFEEDFACE), so "read an uninitialised slot" and "read the
+wrong argument register" cannot be mistaken for one another. Measured RED on
+cb80e60c (before the fix):
+
+    BUG cond_write_param(0, 0x2a): want=0x2a got=0xdeadbeef   <- POISON
+    ok  cond_write_param(1, 0x2a): want=0x5  got=0x5
+
+Ground truth is wasmtime on the same `.wat`. Symbols come from the ELF
+`.symtab` (SHT_SYMTAB), never `synth disasm` text — the disassembler decodes RV
+bytes with whatever target it defaults to, so its text is host-dependent.
+
+The two `R_RISCV_CALL` (type 19) relocations to the in-module callees are
+resolved IN-PROCESS by patching the `auipc`/`jalr` pair, exactly as a linker
+would; no external toolchain is needed.
+
+Run (needs wasmtime + unicorn + pyelftools):
+  SYNTH=./target/debug/synth python scripts/repro/cond_write_param_970_riscv_differential.py
+"""
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import wasmtime
+from elftools.elf.elffile import ELFFile
+from unicorn import UC_ARCH_RISCV, UC_MODE_RISCV32, Uc, UcError
+from unicorn.riscv_const import (
+    UC_RISCV_REG_A0,
+    UC_RISCV_REG_A1,
+    UC_RISCV_REG_A2,
+    UC_RISCV_REG_A3,
+    UC_RISCV_REG_A4,
+    UC_RISCV_REG_A5,
+    UC_RISCV_REG_RA,
+    UC_RISCV_REG_S11,
+    UC_RISCV_REG_SP,
+)
+
+WAT = Path(__file__).with_name("cond_write_param_970.wat")
+SYNTH = os.environ.get("SYNTH", "./target/debug/synth")
+
+CODE, LIN, RET = 0x100000, 0x40000, 0x200000
+STACK_BASE, STACK_SIZE = 0x80000, 0x10000
+SP0 = STACK_BASE + 0xC000  # entry SP: 48 KiB of poison below it, 16 KiB above
+
+# The word written into every stack slot BELOW the entry SP. An uninitialised
+# frame-slot read returns THIS, which is what makes the leak legible; without
+# it unicorn's zero fill would make the RV32 bug look like aarch64's
+# deterministic `0` and the finding would be lost.
+MEM_POISON = 0xDEADBEEF   # every stack word below the entry SP
+REG_POISON = 0xFEEDFACE   # every argument register the signature does not use
+
+A_REGS = [
+    UC_RISCV_REG_A0,
+    UC_RISCV_REG_A1,
+    UC_RISCV_REG_A2,
+    UC_RISCV_REG_A3,
+    UC_RISCV_REG_A4,
+    UC_RISCV_REG_A5,
+]
+
+R_RISCV_CALL = 19
+M32 = 0xFFFFFFFF
+
+# (export, args). The `cw_*` cases each have their HIGHEST referenced local
+# index written before it is read in linear op order — the shape the read-first
+# heuristic undercounts. Vectors always include a fall-through (cond = 0) run,
+# which is the one that reads the never-written slot, plus a taken run so a
+# lowering that broke the WRITE path would be caught too.
+CASES = [
+    # THE canonical shape.
+    ("cond_write_param", [0, 0x2A]),
+    ("cond_write_param", [1, 0x2A]),
+    ("cond_write_param", [0, 0x07]),
+    ("cond_write_param", [0, 0x11112222]),
+    ("cond_write_param", [0, 0xFFFFFFFF]),
+    ("cond_write_param", [0, 0]),  # the arg IS 0: only the poison tells them apart
+    # The write is a CALL result — the argument registers are caller-saved.
+    ("cw_call", [0, 0x2A]),
+    ("cw_call", [1, 0x2A]),
+    ("cw_call", [0, 0xABCDEF01]),
+    ("cw_call_arg", [0, 0x2A]),
+    ("cw_call_arg", [1, 0x2A]),
+    ("cw_call_arg", [0, 0x7FFFFFFF]),
+    # local.tee instead of local.set.
+    ("cw_tee", [0, 0x2A]),
+    ("cw_tee", [1, 0x2A]),
+    ("cw_tee", [0, 0x80000000]),
+    # br_if out of a block rather than `if`.
+    ("cw_brif", [0, 0x2A]),
+    ("cw_brif", [1, 0x2A]),
+    ("cw_brif", [0, 0xDEADBEEF]),  # the arg equals the poison: must still match
+    # A loop whose zero-trip case leaves the param untouched.
+    ("cw_loop", [0, 0x2A]),
+    ("cw_loop", [3, 0x2A]),
+    ("cw_loop", [0, 0xFFFFFFFF]),
+    # Three params, the highest one conditionally written.
+    ("cw_last_of_three", [0, 3, 4]),
+    ("cw_last_of_three", [1, 3, 4]),
+    ("cw_last_of_three", [0, 0x10, 0xFFFF]),
+    # Six params (all register-passed on RV32; ARM stack-passes 4 and 5).
+    ("cw_high_param", [0, 1, 2, 3, 4, 5]),
+    ("cw_high_param", [1, 1, 2, 3, 4, 5]),
+    ("cw_high_param", [0, 9, 9, 9, 0x1000, 0x2000]),
+    # ── guards: the shapes the fix must NOT change ────────────────────────────
+    ("guard_rbw_local", [7]),  # #457: non-param local reads the mandated 0
+    ("guard_rbw_local", [0]),
+    ("guard_rbw_local", [0xFFFFFFFF]),
+    ("guard_rbw_local_mixed", [0, 0x2A]),
+    ("guard_rbw_local_mixed", [1, 0x2A]),
+    ("guard_both_arms", [0, 0x2A]),
+    ("guard_both_arms", [1, 0x2A]),
+    ("guard_write_then_read", [3, 0x2A]),
+    ("guard_write_then_read", [0, 0]),
+    ("guard_plain_params", [11, 31]),
+    ("guard_plain_params", [0xFFFFFFFF, 1]),
+]
+
+
+def die(msg):
+    print(f"FATAL: {msg}")
+    sys.exit(1)
+
+
+def compile_fixture(out):
+    r = subprocess.run(
+        [SYNTH, "compile", str(WAT), "-b", "riscv", "--target", "riscv32imac",
+         "--relocatable", "--all-exports", "-o", out],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        die(f"synth compile failed (rc={r.returncode}):\n{r.stdout}\n{r.stderr}")
+    return out
+
+
+def load(path):
+    """Return (symbols, .text with R_RISCV_CALL relocations applied)."""
+    e = ELFFile(open(path, "rb"))
+    symtab = [s for s in e.iter_sections() if s["sh_type"] == "SHT_SYMTAB"][0]
+    syms = {s.name: s["st_value"] for s in symtab.iter_symbols()
+            if s.name and s["st_info"]["type"] == "STT_FUNC"}
+    text = bytearray(e.get_section_by_name(".text").data())
+
+    nrel = 0
+    for sec in e.iter_sections():
+        if sec["sh_type"] not in ("SHT_REL", "SHT_RELA"):
+            continue
+        for r in sec.iter_relocations():
+            if r["r_info_type"] != R_RISCV_CALL:
+                die(f"unexpected reloc type {r['r_info_type']}; "
+                    f"this harness only resolves R_RISCV_CALL (19)")
+            name = symtab.get_symbol(r["r_info_sym"]).name
+            if name not in syms:
+                die(f"reloc names {name!r}, which is not a defined function symbol")
+            off = r["r_offset"]
+            disp = (CODE + syms[name]) - (CODE + off) + (r.entry.get("r_addend") or 0)
+            hi = ((disp + 0x800) >> 12) & 0xFFFFF
+            lo = disp & 0xFFF
+            (auipc,) = struct.unpack_from("<I", text, off)
+            (jalr,) = struct.unpack_from("<I", text, off + 4)
+            if auipc & 0x7F != 0x17 or jalr & 0x7F != 0x67:
+                die(f"reloc site {off:#x} is not an auipc/jalr pair "
+                    f"({auipc:#010x}/{jalr:#010x})")
+            struct.pack_into("<I", text, off, (auipc & 0xFFF) | (hi << 12))
+            struct.pack_into("<I", text, off + 4, (jalr & 0x000FFFFF) | (lo << 20))
+            nrel += 1
+    return syms, bytes(text), nrel
+
+
+def run(syms, text, name, args):
+    """Execute one export under unicorn with the sub-SP stack POISONED."""
+    addr = syms.get(name)
+    if addr is None:
+        return None, f"symbol {name} missing from .symtab"
+    mu = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+    mu.mem_map(CODE, 0x20000)
+    mu.mem_map(LIN, 0x20000)
+    mu.mem_map(STACK_BASE, STACK_SIZE)
+    mu.mem_map(RET, 0x1000)
+    mu.mem_write(CODE, text)
+    # POISON everything the callee's frame can occupy. Without this an
+    # uninitialised-slot read returns unicorn's zero fill and the RV32 defect
+    # would read as a benign `0` rather than as a leak of previous-frame bytes.
+    mu.mem_write(STACK_BASE, struct.pack("<I", MEM_POISON) * ((SP0 - STACK_BASE) // 4))
+    mu.reg_write(UC_RISCV_REG_SP, SP0)
+    mu.reg_write(UC_RISCV_REG_S11, LIN)  # linear-memory base
+    for i, a in enumerate(args):
+        mu.reg_write(A_REGS[i], a & M32)
+    # Argument registers the signature does NOT use also carry poison, so a
+    # lowering that read the wrong a-register is caught as well.
+    for i in range(len(args), len(A_REGS)):
+        mu.reg_write(A_REGS[i], REG_POISON)
+    mu.reg_write(UC_RISCV_REG_RA, RET)
+    try:
+        mu.emu_start(CODE + addr, RET, count=20000)
+    except UcError as ex:
+        return None, str(ex)
+    return mu.reg_read(UC_RISCV_REG_A0) & M32, ""
+
+
+def main():
+    engine = wasmtime.Engine()
+    module = wasmtime.Module.from_file(engine, str(WAT))
+
+    with tempfile.TemporaryDirectory() as td:
+        obj = compile_fixture(os.path.join(td, "cw970_rv.o"))
+        syms, text, nrel = load(obj)
+    print(f"resolved {nrel} R_RISCV_CALL relocation(s) in-process")
+
+    fails = 0
+    leaks = 0
+    for name, args in CASES:
+        store = wasmtime.Store(engine)
+        inst = wasmtime.Instance(store, module, [])
+        want = inst.exports(store)[name](store, *[a - (1 << 32) if a >> 31 else a
+                                                  for a in args]) & M32
+        got, err = run(syms, text, name, args)
+        ok = got == want
+        fails += 0 if ok else 1
+        tag = ""
+        if got == MEM_POISON and not ok:
+            leaks += 1
+            tag = "   <- POISON (uninitialised stack slot)"
+        shown = f"0x{got:08x}" if got is not None else f"ERR({err})"
+        argstr = ", ".join(f"0x{a:x}" for a in args)
+        print(f"{'ok ' if ok else 'BUG'} {name}({argstr}): "
+              f"want=0x{want:08x} got={shown}{tag}")
+
+    print(f"\n#970 RV32 CHECKS={len(CASES) - fails}/{len(CASES)}"
+          f"  poison-leaks={leaks}")
+    if fails:
+        print("#970 RV32 conditional-param-write ORACLE: FAIL")
+    else:
+        print("#970 RV32 conditional-param-write ORACLE: PASS")
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #970.

## The correction first: ARM does not fail the way #970 predicted

#970 read ARM's failure off a disassembly listing and expected `cw_call(0, 42)`
to return **param 0's value** — an ordinary wrong value — because the demoted
local's `str` looked like it sat at the branch **merge point**. Executing it
says otherwise. The `beq` jumps **past** the store (capstone-verified on
`cb80e60c`, `--target cortex-m4 --relocatable`):

```
push.w {r4, r5, r6, r7, r8, lr}
sub.w  sp, sp, #8
cmp    r0, #0
beq    +8            ; -> the ldr, skipping the store below
movw   r1, #5
str.w  r1, [sp]      ; INSIDE the then-arm, not at the merge point
ldr.w  r2, [sp]      ; <- on the fall-through path this slot was NEVER written
mov    r0, r2
```

So **ARM has the same uninitialised-frame-slot read as RV32** — the same
information-disclosure shape, and on the *plain* shape, not only the call one.
This is exactly why the lane executed ARM separately instead of generalising
RV32's evidence.

## Red-first, per backend, by execution

Both harnesses poison **two distinct** words so the mechanism is proven rather
than inferred: every stack word below the entry SP is `0xDEADBEEF`, every
argument register the signature does not use is `0xFEEDFACE`. "Read an
uninitialised slot" and "read the wrong argument register" therefore cannot be
confused. Measured on `cb80e60c`:

| backend | red | green | memory-poison leaks (red) |
|---|---|---|---|
| ARM Thumb-2 | **22/38** | 38/38 | 12 |
| RV32 | **22/38** | 38/38 | 12 |

```
BUG cond_write_param(0x0, 0x2a):       want=0x0000002a got=0xdeadbeef  <- POISON
BUG cw_call(0x0, 0xabcdef01):          want=0xabcdef01 got=0xdeadbeef  <- POISON
BUG cw_last_of_three(0x0, 0x3, 0x4):   want=0x00000007 got=0xdeadbef2
BUG cw_high_param(0x0,...,0x1000,0x2000): want=0x00003000 got=0xdeadceef
ok  cw_loop / guard_* (all 22)         — read-first order already correct here
```

The failures are exactly the 16 `cw_*` fall-through vectors; every `guard_*`
case (the #457 zero-init local, both-arms writes, unconditional write, plain
params) is green in **both** states, so the differentials are sensitive to the
conditional-write class specifically and not to codegen churn.

## The fix

With a declared param count in hand the bound is
`min(referenced_locals(ops), declared)` — the highest local index the body
touches, clamped by the signature — not the read-first `count_params` heuristic
capped by it. The old rule was exact in only one direction: the clamp stops a
read-before-write **non-param local** from being homed in an argument register
(#457), but taking the max over **reads only** demoted a **param** written on
one arm of an `if`. And because the demoted local's first access is a *write*,
the #457 zero-init skipped it too — hence the uninitialised slot rather than a
zero.

`min` (not a plain `declared` override) keeps the leniency for a body that only
touches the first few of many declared params.

`referenced_locals` moves to `synth_core::wasm_op`, next to
`rewrite_memory_grow_zero` and for the same stated reason: #851 landed a private
copy in the aarch64 backend, and shipping two more would make three copies of
one three-line rule that must agree. **All three backends now share one
definition**; the aarch64 copy is deleted.

## Negative control — run both ways, independently

| reverted line | ARM oracle | RV32 oracle |
|---|---|---|
| ARM only | **FAIL 22/38**, 12 leaks | PASS 38/38 |
| RV32 only | PASS 38/38 | **FAIL 22/38**, 12 leaks |

Reverting one backend's bound reds **only** that backend's oracle. The two are
independent evidence, not one measurement reported twice.

## Floors — measured, not computed

`scripts/oracle_run.py` reports `emulations=38` for each harness, so each
declares `# ci-checks: emulations >= 38` — the measured count exactly. The new
CI job closes with the #910 ledger at `--min-oracles 2`, so deleting or skipping
either step reds the job rather than quietly shrinking what CI asserts.

The summed `--min-emulation-floor` is deliberately **not** ratcheted: it is a
floor, the measured total rises 295,773 → 295,849 (both measured by running
`oracle_wiring_check.py` with and without the two new files) against a pinned
minimum of 295,726, and with several v0.57 lanes adding oracles in parallel a
single shared total is a fan-in conflict. Ratchet it once at release assembly,
together with the `ORACLE_WIRING.md` table (already stale at 295,621) and both
`claims.yaml` text pins.

## Blast radius

Every `scripts/repro/*.wat` compiled for **both** backends (310 fixture ×
backend compilations), sha256 of `.text` diffed before/after. **Exactly three
fixtures change**, and no RV32 output changes at all except the new fixture:

| fixture | change |
|---|---|
| `cond_write_param_970.wat` (arm + rv32) | the new fixture — the fix |
| `aarch64_param_homing_851.wat` (arm) | 366 → **348 B**; contains the same `cond_write_param` shapes, now smaller (demoted-local frame slots become param registers) |
| `rv32_cmp_select_472.wat` (arm) | 466 → 466 B, temp renumbering only. Its `clamp` declares 2 params but references only `$a`, so the count goes 1 → 2 and temps start at r2 instead of r1. Executed vs wasmtime: identical 44/49 before and after |

`cond_write_param` itself now lowers to **16 bytes with no frame at all**
(`cmp r0,#0 / beq / movw r2,#5 / mov r1,r2 / mov r0,r1`) — the param stays in
its register.

The one place this change *widens* rather than narrows behaviour is a >4-param
ARM signature. Verified it lands where it should: `cw_high_param` reads indices
4 and 5 from `[sp,#0x18]` / `[sp,#0x1c]` after a `push` of 6 registers with
`frame_size = 0`, i.e. `frame_size + 24 + nsaa` — the **caller's** frame, the
AAPCS incoming-stack-argument area, not a local slot.

## Named residual, deliberately NOT closed

`current_func_param_count == None` still uses the read-first heuristic. It is
unreachable from the CLI (which always supplies a declared count) but reachable
via the direct `compile_function` API. **Not closed here, on purpose**: with no
declared count a write-first index is genuinely *ambiguous* — a param whose
incoming value is dead, or a non-param local — and both readings can be wrong.
Picking one is a `compile_function` API-contract decision, not a bug fix, and
inventing a bound to close a gap is the recurring burn this repo has taken
three releases running. It is documented as an honest residual on
`CompileConfig::current_func_param_count` and on each backend's helper.

## Found in passing, filed separately: #973

The byte-identity sweep compiled `rv32_cmp_select_472.wat` for **ARM**, which
nothing in CI does, and turned up an unrelated **pre-existing** ARM miscompile:
a `select` whose condition is an i64 comparison and whose arms are *computed*
values always returns the then-arm — the else-arm's register is spilled and
reloaded with the then-arm's value, so both `it` arms move the same register.
Confirmed independent of this lane: the same 44/49 vectors match wasmtime on
binaries built **before and after** the #970 fix, with the identical five
failures. Filed as #973 with a minimal repro; not fixed here.

## Gates

Each run without a pipe, exit code captured directly:

- `cargo test --workspace` — **rc=0**, 2787 passed / 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — **rc=0**
- `cargo fmt --check` — **rc=0**
- `python3 scripts/claim_check.py claims.yaml` — **rc=0**, 43/43 claims hold
- `python3 scripts/oracle_wiring_check.py --min-emulation-floor 295726` — **rc=0**,
  161 wired / 7 manual / 0 unwired / 0 undeclared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
