### PR TITLE
RQ-58-VERIFYWIRE (#981): wire the i32 shift/rotate verify rules to the #975-modelled ops, retire the stale immediate-shift-encoding decline

### DIFF
--- a/artifacts/release-v0.58.yaml
+++ b/artifacts/release-v0.58.yaml
@@ -382,7 +382,7 @@ artifacts:
       Worth stating because it is the general lesson: a decline that is too
       conservative is INVISIBLE. Nothing reds, no test fails, the tool quietly
       checks less than it could while its stated reason drifts from the truth.
-    status: proposed
+    status: implemented
     release: v0.58
     tags: [verification, decline-honesty, wiring, arm-semantics]
     links:

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -2261,8 +2261,10 @@ struct VerifyRuleRecord {
     /// Human-readable SMT rule name when SMT ran (e.g. "i32.and → AND").
     #[serde(skip_serializing_if = "Option::is_none")]
     smt_rule: Option<String>,
-    /// Machine decline reason: "register-operation" |
-    /// "immediate-shift-encoding" | "unmodeled-op".
+    /// Machine decline reason: "register-operation" | "unmodeled-op".
+    /// ("immediate-shift-encoding" was RETIRED in #981: the five shift/rotate
+    /// rules are now routed to the #975-modelled register-shift ops and
+    /// SMT-verified, so the reason no longer has a population.)
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<&'static str>,
     /// The Rocq theorem this decline defers to, when one exists
@@ -2300,15 +2302,6 @@ fn wasm_op_variant_name(op: &WasmOp) -> String {
 /// - `register-operation`: not computational — the whole-op contract is the
 ///   per-rule Rocq theorem named here (the #933 class: a decline is only
 ///   covered if that theorem is Qed).
-/// - `immediate-shift-encoding`: the selector emits immediate-shift forms.
-///   The stated reason USED to be "SMT modeling of the variable-shift
-///   register encoding is an open gap". That gap CLOSED in #975, which
-///   modelled `LslReg`/`LsrReg`/`AsrReg`/`RorReg` faithfully as `Rm<7:0>`
-///   (ARMv7-M A7.7.68/70/12/117) and moved five shift/rotate lowerings from
-///   `Invalid` to `Verified`. The decline that remains is therefore a WIRING
-///   residual — these rules are not yet routed to the modelled ops — not a
-///   modelling gap. Tracked; do not cite the old reason. The named theorem is
-///   the existence-only (T2) Rocq obligation.
 /// - `unmodeled-op`: no SMT rule and no per-rule theorem wired here — an
 ///   honest coverage gap, never silently omitted from the report.
 #[cfg(feature = "verify")]
@@ -2321,11 +2314,6 @@ fn declined_rule_info(op: &WasmOp) -> (&'static str, Option<&'static str>) {
         WasmOp::LocalTee(_) => ("register-operation", Some("local_tee_correct")),
         WasmOp::GlobalGet(_) => ("register-operation", Some("global_get_correct")),
         WasmOp::GlobalSet(_) => ("register-operation", Some("global_set_correct")),
-        WasmOp::I32Shl => ("immediate-shift-encoding", Some("i32_shl_executes")),
-        WasmOp::I32ShrS => ("immediate-shift-encoding", Some("i32_shrs_executes")),
-        WasmOp::I32ShrU => ("immediate-shift-encoding", Some("i32_shru_executes")),
-        WasmOp::I32Rotl => ("immediate-shift-encoding", Some("i32_rotl_executes")),
-        WasmOp::I32Rotr => ("immediate-shift-encoding", Some("i32_rotr_executes")),
         _ => ("unmodeled-op", None),
     }
 }
@@ -2340,6 +2328,7 @@ fn declined_rule_info(op: &WasmOp) -> (&'static str, Option<&'static str>) {
 #[cfg(feature = "verify")]
 fn run_verification(wasm_ops: &[WasmOp], func_name: &str) -> Result<FunctionVerifyReport> {
     use std::collections::HashMap;
+    use synth_synthesis::sel_dsl::generated as sel_rules;
     use synth_synthesis::{ArmOp, Condition, Operand2, Pattern, Reg, Replacement, SynthesisRule};
 
     println!("\nRunning translation validation for '{}'...", func_name);
@@ -2678,10 +2667,86 @@ fn run_verification(wasm_ops: &[WasmOp], func_name: &str) -> Result<FunctionVeri
                     registers: 1,
                 },
             }),
-            // Shift ops use immediate shift values in the instruction selector.
-            // NOTE (#975): the register-shift ops ARE modelled now (Rm<7:0>,
-            // ARMv7-M A7.7.68/70/12/117) — what remains is a WIRING residual,
-            // not the modelling gap the previous comment claimed.
+            // Register-amount shifts and rotates (#981): ROUTED to the ops
+            // #975 modelled (`LslReg`/`LsrReg`/`AsrReg`/`RorReg` as `Rm<7:0>`,
+            // ARMv7-M A7.7.68/70/12/117). The sequences are taken from the
+            // SHIPPED `sel_dsl::generated` rule table — the single source the
+            // Rocq model is generated from (#667) and the only lowering path
+            // for these ops — instantiated at this harness's fixed register
+            // shape (rd=R0, rn=R0 value, rm=R1 amount, rs=R2 scratch), never
+            // hand-mirrored. The `expect`s are on the table's own `rs != rn`
+            // side condition, which the fixed shape satisfies by construction.
+            WasmOp::I32Shl => Some(SynthesisRule {
+                name: "i32.shl → AND #31 + LSL (reg)".into(),
+                priority: 0,
+                pattern: Pattern::WasmInstr(WasmOp::I32Shl),
+                replacement: Replacement::ArmSequence(
+                    sel_rules::rule_i32_shl(Reg::R0, Reg::R0, Reg::R1, Reg::R2)
+                        .expect("side condition rs != rn holds for the fixed R0/R1/R2 shape"),
+                ),
+                cost: synth_synthesis::Cost {
+                    cycles: 2,
+                    code_size: 6,
+                    registers: 3,
+                },
+            }),
+            WasmOp::I32ShrS => Some(SynthesisRule {
+                name: "i32.shr_s → AND #31 + ASR (reg)".into(),
+                priority: 0,
+                pattern: Pattern::WasmInstr(WasmOp::I32ShrS),
+                replacement: Replacement::ArmSequence(
+                    sel_rules::rule_i32_shr_s(Reg::R0, Reg::R0, Reg::R1, Reg::R2)
+                        .expect("side condition rs != rn holds for the fixed R0/R1/R2 shape"),
+                ),
+                cost: synth_synthesis::Cost {
+                    cycles: 2,
+                    code_size: 6,
+                    registers: 3,
+                },
+            }),
+            WasmOp::I32ShrU => Some(SynthesisRule {
+                name: "i32.shr_u → AND #31 + LSR (reg)".into(),
+                priority: 0,
+                pattern: Pattern::WasmInstr(WasmOp::I32ShrU),
+                replacement: Replacement::ArmSequence(
+                    sel_rules::rule_i32_shr_u(Reg::R0, Reg::R0, Reg::R1, Reg::R2)
+                        .expect("side condition rs != rn holds for the fixed R0/R1/R2 shape"),
+                ),
+                cost: synth_synthesis::Cost {
+                    cycles: 2,
+                    code_size: 6,
+                    registers: 3,
+                },
+            }),
+            WasmOp::I32Rotl => Some(SynthesisRule {
+                name: "i32.rotl → RSB #32 + ROR (reg)".into(),
+                priority: 0,
+                pattern: Pattern::WasmInstr(WasmOp::I32Rotl),
+                replacement: Replacement::ArmSequence(
+                    sel_rules::rule_i32_rotl(Reg::R0, Reg::R0, Reg::R1, Reg::R2)
+                        .expect("side condition rs != rn holds for the fixed R0/R1/R2 shape"),
+                ),
+                cost: synth_synthesis::Cost {
+                    cycles: 2,
+                    code_size: 6,
+                    registers: 3,
+                },
+            }),
+            WasmOp::I32Rotr => Some(SynthesisRule {
+                name: "i32.rotr → ROR (reg)".into(),
+                priority: 0,
+                pattern: Pattern::WasmInstr(WasmOp::I32Rotr),
+                replacement: Replacement::ArmSequence(sel_rules::rule_i32_rotr(
+                    Reg::R0,
+                    Reg::R0,
+                    Reg::R1,
+                )),
+                cost: synth_synthesis::Cost {
+                    cycles: 1,
+                    code_size: 4,
+                    registers: 2,
+                },
+            }),
             // LocalGet/LocalSet/Const are register operations, not computational.
             // #935: neither class is silently skipped any more — every
             // unmatched kind lands in the report as a decline with a machine

--- a/crates/synth-cli/tests/verify_report_935.rs
+++ b/crates/synth-cli/tests/verify_report_935.rs
@@ -9,8 +9,11 @@
 //! that only ever prints zeros for declines.
 //!
 //! Non-vacuity contract enforced here:
-//! - the fixture has KNOWN declines (`i32.const`, `local.get`, `i32.shl`) and
-//!   the report must SHOW them, with non-zero counts and machine reasons;
+//! - the fixture has KNOWN declines (`i32.const`, `local.get`) and the report
+//!   must SHOW them, with non-zero counts and machine reasons;
+//! - `i32.shl` must be VERIFIED, not declined (#981): its lowering is routed
+//!   to the #975-modelled register-shift ops, so a reappearing
+//!   `immediate-shift-encoding` decline is a wiring regression;
 //! - the summary denominator must equal verified + failed + unknown + declined;
 //! - declined register-operations must name the Rocq theorem they defer to
 //!   (the #933 join key: a decline is only covered if that theorem is Qed).
@@ -25,7 +28,8 @@ fn synth() -> &'static str {
 }
 
 /// Fixture with a deliberately known op census in the exported function:
-/// 4× i32.const, 2× local.get, 1× i32.shl, plus SMT-verifiable and/add/sub.
+/// 4× i32.const, 2× local.get (declined), plus SMT-verifiable
+/// and/add/sub/shl (`i32.shl` verified since #981).
 const FIXTURE_WAT: &str = r#"(module
   (func (export "mix") (param i32 i32) (result i32)
     local.get 0
@@ -153,9 +157,14 @@ fn declines_are_reported_with_counts_reasons_and_rocq_join_keys() {
     assert_eq!(lget["rocq_theorem"], "local_get_correct");
     assert_eq!(lget["count"], 2);
 
+    // #981: i32.shl is no longer declined — the shift rules are routed to the
+    // #975-modelled `Rm<7:0>` register-shift ops and SMT-verified against the
+    // SHIPPED sel_dsl lowering (AND #31 + LSL (reg)). This assertion is the
+    // red-first gate: on the pre-#981 wiring it fails with
+    // status == "declined", reason == "immediate-shift-encoding".
     let shl = find("I32Shl");
-    assert_eq!(shl["status"], "declined");
-    assert_eq!(shl["reason"], "immediate-shift-encoding");
+    assert_eq!(shl["status"], "verified");
+    assert_eq!(shl["smt_rule"], "i32.shl → AND #31 + LSL (reg)");
 
     // The SMT half still runs and reports — verified rules are in the SAME
     // inventory (one object, one denominator).

--- a/crates/synth-verify/tests/verify_wire_shift_sensitivity_981.rs
+++ b/crates/synth-verify/tests/verify_wire_shift_sensitivity_981.rs
@@ -1,0 +1,384 @@
+//! #981 (RQ-58-VERIFYWIRE) — sensitivity matrix for the newly WIRED shift and
+//! rotate rules in `synth verify`.
+//!
+//! # Why this file exists
+//!
+//! #981 routes `i32.shl` / `i32.shr_s` / `i32.shr_u` / `i32.rotl` /
+//! `i32.rotr` to the register-shift ops #975 modelled (`Rm<7:0>`, ARMv7-M
+//! A7.7.68/70/12/117), removing the stale `immediate-shift-encoding` decline.
+//! The trap #975 itself documented: a rule that returns `Verified` for BOTH
+//! the correct and a corrupted lowering is not wired, it is green-washed —
+//! #975 found `i32.add` + `UXTB` "verifying" while the model executed neither
+//! instruction. So for every rule this lane claims, this file proves the check
+//! is SENSITIVE: the SHIPPED lowering verifies, and each perturbation class
+//! (wrong shift op, wrong operand order, dropped/weakened `#31` mask, an
+//! extra masking instruction, off-by-one on the rotl amount negation) flips
+//! the verdict to `Invalid`.
+//!
+//! The `Verified` half is instantiated from `sel_dsl::generated` — the SAME
+//! single-source table the CLI wiring (#981) and the Rocq model (#667) draw
+//! from — at the verify harness's register shape (rd=R0, rn=R0 value, rm=R1
+//! amount, rs=R2 scratch). If the shipped table changes shape, the `Verified`
+//! half re-verifies the NEW shape or fails loudly; it can never drift into
+//! checking a paraphrase.
+//!
+//! The `verify_rule` entry point is used (not `verify_equivalence` directly)
+//! so the path exercised is the one `synth verify`'s rule inventory takes.
+
+#![cfg(feature = "arm")]
+
+use synth_core::WasmOp;
+use synth_synthesis::sel_dsl::generated as sel_rules;
+use synth_synthesis::{ArmOp, Operand2, Pattern, Reg, Replacement, SynthesisRule};
+use synth_verify::{TranslationValidator, ValidationResult, with_verification_context};
+
+/// Wrap an ARM sequence in a `SynthesisRule` the way the #981 CLI wiring does.
+fn rule_for(wasm_op: WasmOp, name: &str, ops: Vec<ArmOp>) -> SynthesisRule {
+    SynthesisRule {
+        name: name.into(),
+        priority: 0,
+        pattern: Pattern::WasmInstr(wasm_op),
+        replacement: Replacement::ArmSequence(ops),
+        cost: synth_synthesis::Cost {
+            cycles: 2,
+            code_size: 6,
+            registers: 3,
+        },
+    }
+}
+
+fn assert_verified(v: &TranslationValidator, wasm_op: WasmOp, name: &str, ops: Vec<ArmOp>) {
+    let r = v.verify_rule(&rule_for(wasm_op.clone(), name, ops));
+    assert!(
+        matches!(r, Ok(ValidationResult::Verified)),
+        "{name}: shipped lowering for {wasm_op:?} must verify, got {r:?}"
+    );
+}
+
+fn assert_invalid(v: &TranslationValidator, wasm_op: WasmOp, label: &str, ops: Vec<ArmOp>) {
+    let r = v.verify_rule(&rule_for(wasm_op.clone(), label, ops));
+    assert!(
+        matches!(r, Ok(ValidationResult::Invalid { .. })),
+        "{label}: perturbed lowering for {wasm_op:?} MUST be Invalid — a check \
+         that passes the corrupted form too is green-washed, not wired; got {r:?}"
+    );
+}
+
+/// The five shipped instantiations, at the harness register shape.
+fn shipped_shl() -> Vec<ArmOp> {
+    sel_rules::rule_i32_shl(Reg::R0, Reg::R0, Reg::R1, Reg::R2).expect("rs != rn")
+}
+fn shipped_shr_s() -> Vec<ArmOp> {
+    sel_rules::rule_i32_shr_s(Reg::R0, Reg::R0, Reg::R1, Reg::R2).expect("rs != rn")
+}
+fn shipped_shr_u() -> Vec<ArmOp> {
+    sel_rules::rule_i32_shr_u(Reg::R0, Reg::R0, Reg::R1, Reg::R2).expect("rs != rn")
+}
+fn shipped_rotl() -> Vec<ArmOp> {
+    sel_rules::rule_i32_rotl(Reg::R0, Reg::R0, Reg::R1, Reg::R2).expect("rs != rn")
+}
+fn shipped_rotr() -> Vec<ArmOp> {
+    sel_rules::rule_i32_rotr(Reg::R0, Reg::R0, Reg::R1)
+}
+
+const MASK31: ArmOp = ArmOp::And {
+    rd: Reg::R2,
+    rn: Reg::R1,
+    op2: Operand2::Imm(31),
+};
+
+// ---------------------------------------------------------------------------
+// The claimed half: every shipped lowering verifies through `verify_rule`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_five_shipped_shift_and_rotate_rules_verify_via_verify_rule() {
+    with_verification_context(|| {
+        let v = TranslationValidator::new();
+        assert_verified(&v, WasmOp::I32Shl, "i32.shl shipped", shipped_shl());
+        assert_verified(&v, WasmOp::I32ShrS, "i32.shr_s shipped", shipped_shr_s());
+        assert_verified(&v, WasmOp::I32ShrU, "i32.shr_u shipped", shipped_shr_u());
+        assert_verified(&v, WasmOp::I32Rotl, "i32.rotl shipped", shipped_rotl());
+        assert_verified(&v, WasmOp::I32Rotr, "i32.rotr shipped", shipped_rotr());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Sensitivity: each perturbation class flips the verdict to Invalid.
+// ---------------------------------------------------------------------------
+
+/// Wrong shift OPCODE, mask intact. A checker keyed only on "there is a mask
+/// and a shift" would pass these.
+#[test]
+fn wrong_shift_opcode_is_invalid() {
+    with_verification_context(|| {
+        let v = TranslationValidator::new();
+        // shl lowered with a LOGICAL RIGHT shift.
+        assert_invalid(
+            &v,
+            WasmOp::I32Shl,
+            "shl-as-lsr",
+            vec![
+                MASK31,
+                ArmOp::LsrReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R2,
+                },
+            ],
+        );
+        // shr_s lowered LOGICAL instead of ARITHMETIC (differs on negatives).
+        assert_invalid(
+            &v,
+            WasmOp::I32ShrS,
+            "shr_s-as-lsr",
+            vec![
+                MASK31,
+                ArmOp::LsrReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R2,
+                },
+            ],
+        );
+        // shr_u lowered ARITHMETIC instead of LOGICAL.
+        assert_invalid(
+            &v,
+            WasmOp::I32ShrU,
+            "shr_u-as-asr",
+            vec![
+                MASK31,
+                ArmOp::AsrReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R2,
+                },
+            ],
+        );
+        // rotr lowered as a plain right SHIFT (loses the wrapped-around bits).
+        assert_invalid(
+            &v,
+            WasmOp::I32Rotr,
+            "rotr-as-lsr",
+            vec![
+                MASK31,
+                ArmOp::LsrReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R2,
+                },
+            ],
+        );
+    });
+}
+
+/// Wrong OPERAND ORDER: shifting the amount by the value.
+#[test]
+fn swapped_operand_order_is_invalid() {
+    with_verification_context(|| {
+        let v = TranslationValidator::new();
+        assert_invalid(
+            &v,
+            WasmOp::I32Shl,
+            "shl-operands-swapped",
+            vec![
+                MASK31,
+                ArmOp::LslReg {
+                    rd: Reg::R0,
+                    rn: Reg::R2,
+                    rm: Reg::R0,
+                },
+            ],
+        );
+        assert_invalid(
+            &v,
+            WasmOp::I32Rotr,
+            "rotr-operands-swapped",
+            vec![ArmOp::RorReg {
+                rd: Reg::R0,
+                rn: Reg::R1,
+                rm: Reg::R0,
+            }],
+        );
+    });
+}
+
+/// The #682 mask, DROPPED or WEAKENED. This is the class the `Rm<7:0>` model
+/// exists to catch: an unmasked `LSL (register)` shifts by the low EIGHT bits,
+/// so `Rm = 32` clears the register where WASM's mod-32 rule is the identity.
+/// A mask of `#15` (off-by-one on the width) diverges at `Rm = 16`; `#63` at
+/// `Rm = 32`.
+#[test]
+fn dropped_or_weakened_mask_is_invalid() {
+    with_verification_context(|| {
+        let v = TranslationValidator::new();
+        for (wasm_op, label, unmasked, narrow, wide) in [
+            (
+                WasmOp::I32Shl,
+                "shl",
+                vec![ArmOp::LslReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R1,
+                }],
+                ArmOp::LslReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R2,
+                },
+                ArmOp::LslReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R2,
+                },
+            ),
+            (
+                WasmOp::I32ShrU,
+                "shr_u",
+                vec![ArmOp::LsrReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R1,
+                }],
+                ArmOp::LsrReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R2,
+                },
+                ArmOp::LsrReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R2,
+                },
+            ),
+            (
+                WasmOp::I32ShrS,
+                "shr_s",
+                vec![ArmOp::AsrReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R1,
+                }],
+                ArmOp::AsrReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R2,
+                },
+                ArmOp::AsrReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R2,
+                },
+            ),
+        ] {
+            assert_invalid(&v, wasm_op.clone(), &format!("{label}-no-mask"), unmasked);
+            assert_invalid(
+                &v,
+                wasm_op.clone(),
+                &format!("{label}-mask-15"),
+                vec![
+                    ArmOp::And {
+                        rd: Reg::R2,
+                        rn: Reg::R1,
+                        op2: Operand2::Imm(15),
+                    },
+                    narrow,
+                ],
+            );
+            assert_invalid(
+                &v,
+                wasm_op,
+                &format!("{label}-mask-63"),
+                vec![
+                    ArmOp::And {
+                        rd: Reg::R2,
+                        rn: Reg::R1,
+                        op2: Operand2::Imm(63),
+                    },
+                    wide,
+                ],
+            );
+        }
+    });
+}
+
+/// An EXTRA masking instruction appended to a correct lowering — the exact
+/// #975 cautionary shape (`ADD ; UXTB` "verified" while the model executed
+/// neither op). With the model executing every instruction, the appended
+/// `UXTB` must now flip the verdict.
+#[test]
+fn extra_masking_instruction_is_invalid() {
+    with_verification_context(|| {
+        let v = TranslationValidator::new();
+        let mut shl_uxtb = shipped_shl();
+        shl_uxtb.push(ArmOp::Uxtb {
+            rd: Reg::R0,
+            rm: Reg::R0,
+        });
+        assert_invalid(&v, WasmOp::I32Shl, "shl-plus-uxtb", shl_uxtb);
+
+        let mut rotr_uxth = shipped_rotr();
+        rotr_uxth.push(ArmOp::Uxth {
+            rd: Reg::R0,
+            rm: Reg::R0,
+        });
+        assert_invalid(&v, WasmOp::I32Rotr, "rotr-plus-uxth", rotr_uxth);
+    });
+}
+
+/// rotl's amount negation, corrupted: off-by-one on the RSB immediate, the
+/// RSB dropped outright (yielding rotr), and the post-RSB rotate replaced by
+/// a shift.
+#[test]
+fn corrupted_rotl_negation_is_invalid() {
+    with_verification_context(|| {
+        let v = TranslationValidator::new();
+        // RSB #31 instead of #32: off-by-one in the negation.
+        assert_invalid(
+            &v,
+            WasmOp::I32Rotl,
+            "rotl-rsb-31",
+            vec![
+                ArmOp::Rsb {
+                    rd: Reg::R2,
+                    rn: Reg::R1,
+                    imm: 31,
+                },
+                ArmOp::RorReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R2,
+                },
+            ],
+        );
+        // RSB dropped: rotl lowered as rotr.
+        assert_invalid(
+            &v,
+            WasmOp::I32Rotl,
+            "rotl-as-rotr",
+            vec![ArmOp::RorReg {
+                rd: Reg::R0,
+                rn: Reg::R0,
+                rm: Reg::R1,
+            }],
+        );
+        // Correct negation, wrong final op (shift discards wrapped bits).
+        assert_invalid(
+            &v,
+            WasmOp::I32Rotl,
+            "rotl-ror-as-lsl",
+            vec![
+                ArmOp::Rsb {
+                    rd: Reg::R2,
+                    rn: Reg::R1,
+                    imm: 32,
+                },
+                ArmOp::LslReg {
+                    rd: Reg::R0,
+                    rn: Reg::R0,
+                    rm: Reg::R2,
+                },
+            ],
+        );
+    });
+}


### PR DESCRIPTION
# RQ-58-VERIFYWIRE (#981): wire the shift rules to the #975-modelled ops, retire the stale decline

`synth verify` declined `i32.shl` / `i32.shr_s` / `i32.shr_u` / `i32.rotl` /
`i32.rotr` as `immediate-shift-encoding`, citing an SMT modelling gap that
**#975 closed** (`LslReg`/`LsrReg`/`AsrReg`/`RorReg` modelled faithfully as
`Rm<7:0>`, ARMv7-M A7.7.68/70/12/117). This PR routes the five rules to the
modelled ops and retires the decline reason outright — it no longer has a
population.

**Single source, not a mirror:** the verified sequences are instantiated from
`sel_dsl::generated` — the same table the Rocq model is generated from (#667)
and the only lowering path for these ops (RQ-58-RETIRE) — at the harness
register shape (rd=R0, rn=R0 value, rm=R1 amount, rs=R2 scratch). If the
shipped table changes shape, the verify side follows automatically or fails
loudly; it cannot drift into checking a paraphrase.

## Evidence (a): the declined count drops

Same module, same commands, binaries built from the parent commit vs this
branch (`cargo build -p synth-cli --features verify`). Fixture
(`shifts_981.wat`) exercises all five ops in one exported function:

```
synth compile shifts_981.wat -o shifts_981.elf --all-exports
synth verify  shifts_981.wat shifts_981.elf --emit-verify-report report.json
```

| | BEFORE (main @ 53d41a35) | AFTER (this PR) |
|---|---|---|
| verified | 1 | **6** |
| declined kinds | 7 | **2** |
| declined instructions | 16 | **11** |
| `immediate-shift-encoding` | 5 kinds / 5 instructions | **bucket gone** |

Remaining declines are honest residuals untouched by this lane: `LocalGet ×
10: register-operation (Rocq: local_get_correct)` and `End × 1: unmodeled-op`.

BEFORE report (the five records this PR eliminates):

```json
{"rule": "I32Shl",  "status": "declined", "reason": "immediate-shift-encoding", "rocq_theorem": "i32_shl_executes"}
{"rule": "I32ShrS", "status": "declined", "reason": "immediate-shift-encoding", "rocq_theorem": "i32_shrs_executes"}
{"rule": "I32ShrU", "status": "declined", "reason": "immediate-shift-encoding", "rocq_theorem": "i32_shru_executes"}
{"rule": "I32Rotl", "status": "declined", "reason": "immediate-shift-encoding", "rocq_theorem": "i32_rotl_executes"}
{"rule": "I32Rotr", "status": "declined", "reason": "immediate-shift-encoding", "rocq_theorem": "i32_rotr_executes"}
```

AFTER report:

```json
{"rule": "I32Shl",  "status": "verified", "smt_rule": "i32.shl → AND #31 + LSL (reg)"}
{"rule": "I32ShrS", "status": "verified", "smt_rule": "i32.shr_s → AND #31 + ASR (reg)"}
{"rule": "I32ShrU", "status": "verified", "smt_rule": "i32.shr_u → AND #31 + LSR (reg)"}
{"rule": "I32Rotl", "status": "verified", "smt_rule": "i32.rotl → RSB #32 + ROR (reg)"}
{"rule": "I32Rotr", "status": "verified", "smt_rule": "i32.rotr → ROR (reg)"}
```

## Evidence (b): Verified for the right reason — per-rule sensitivity

`crates/synth-verify/tests/verify_wire_shift_sensitivity_981.rs` (6 tests, all
green): each shipped instantiation returns `Verified` through the same
`verify_rule` path the CLI inventory uses, and **20 perturbations each flip
the verdict to `Invalid`** — none of the five checks passes a corrupted
lowering:

| rule | perturbation | verdict |
|---|---|---|
| i32.shl | `LSR` instead of `LSL` (mask intact) | Invalid |
| i32.shl | operands swapped (shift the amount by the value) | Invalid |
| i32.shl | mask dropped (raw `Rm`, diverges at `Rm=32`: WASM identity, ARM 0) | Invalid |
| i32.shl | mask `#15` (off-by-one width, diverges at `Rm=16`) | Invalid |
| i32.shl | mask `#63` (diverges at `Rm=32`) | Invalid |
| i32.shl | shipped + `UXTB` appended (the exact #975 `ADD;UXTB` cautionary shape) | Invalid |
| i32.shr_s | `LSR` instead of `ASR` (differs on negatives) | Invalid |
| i32.shr_s | mask dropped / `#15` / `#63` | Invalid ×3 |
| i32.shr_u | `ASR` instead of `LSR` | Invalid |
| i32.shr_u | mask dropped / `#15` / `#63` | Invalid ×3 |
| i32.rotl | `RSB #31` (off-by-one negation) | Invalid |
| i32.rotl | `RSB` dropped (lowers rotl as rotr) | Invalid |
| i32.rotl | `ROR` replaced by `LSL` after correct negation | Invalid |
| i32.rotr | `LSR` instead of `ROR` (wrapped bits lost) | Invalid |
| i32.rotr | operands swapped | Invalid |
| i32.rotr | shipped + `UXTH` appended | Invalid |

## Red-first

`verify_report_935.rs` is the CI-wired gate (`cargo test -p synth-cli
--features verify --test verify_report_935`, CI "fact-spec" job). Its I32Shl
assertion now demands `status == "verified"` + the exact `smt_rule` string; on
the pre-wiring binary the record is `status: declined / reason:
immediate-shift-encoding` (BEFORE transcript above), so the updated test fails
before the wiring commit and passes after it.

## Narrowed decline / refused claims

None needed — no sub-case remains open for these five rules. The masking
semantics agree end-to-end: WASM's mod-32 rule is supplied by the LOWERING
(`AND #31`, or RSB negation + rotation periodicity for rotl/rotr), and the
model applies the ISA's own `Rm<7:0>` rule (#975); the SMT check closes over
all 2^64 input pairs. Nothing was green-washed: every wired rule has a
demonstrated Invalid-on-perturbation transcript.

Out of scope, stated honestly: `LocalGet`/`I32Const`/`End` declines remain
(register-operation / unmodeled-op) — different reasons, truthfully stated,
not touched by #981.

## Gates

- `cargo fmt --all` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean
  (plus `-p synth-cli --features verify` explicitly, since the wiring is feature-gated)
- `cargo test --workspace` green
- `python3 scripts/claim_check.py claims.yaml` → 49/49 hold
- `python3 scripts/model_coverage_audit.py --check` → ok (no ArmSemantics/coq change; census unmoved)
- No new `.wat` corpus fixtures → `EXPECTED_DECLINES` (#992) untouched
- rivet: `RQ-58-VERIFYWIRE` proposed → implemented

Refs #981
Refs #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
