### PR TITLE
RQ-58-FLAKE (#977): the flake was a shared output path — and the silent direction was reading a STALE ELF and passing

### DIFF
--- a/crates/synth-cli/tests/artifact_guard/mod.rs
+++ b/crates/synth-cli/tests/artifact_guard/mod.rs
@@ -1,0 +1,132 @@
+//! RQ-58-FLAKE (#977) — the compile-then-parse guard the integration tests owe.
+//!
+//! Every byte-gate in `crates/synth-cli/tests/` has the same shape: run
+//! `synth compile -o <path>`, then read `<path>` back and parse it as an ELF.
+//! Two things go wrong with that shape, and only one of them is loud.
+//!
+//! **Loud.** The read lands on something that is not an ELF and `object`
+//! reports `Could not read file magic` (#960, #974, #977). It looks like an
+//! assertion failure in a file the PR never touched, so it reads as noise.
+//!
+//! **Silent, and the reason this module exists.** The read lands on a
+//! *previous run's* ELF. `synth compile` opens the output with
+//! `File::create` — truncate-then-write — so a failed or half-finished
+//! compile leaves either nothing, a zero-length file, or the bytes that were
+//! already there. Parse those and the gate passes on evidence it did not
+//! produce. v0.56 lived through exactly this with the opposite sign: a
+//! compile failed, `-o` wrote nothing, the previous run's `.o` was still on
+//! disk, and executing it looked like a fresh miscompile.
+//!
+//! So the contract here is: **nothing parses an artifact until the artifact is
+//! proven to be this invocation's output.** In order —
+//!
+//! 1. the output path is removed before the compile runs,
+//! 2. the compile's exit status is asserted, carrying synth's own stderr,
+//! 3. the file is asserted to exist,
+//! 4. the file is asserted non-empty,
+//!
+//! and only then are the bytes handed back. A bad compile reports as a bad
+//! compile, at the compile, with the compiler's message — not as a parse error
+//! twenty lines later, and never as a pass.
+//!
+//! Freshness is additionally guaranteed *by construction*: [`unique_artifact`]
+//! hands out a path that is unique per call (pid + a process-wide counter), so
+//! no two compiles — in different libtest threads of one binary, or in two
+//! binaries/CI runs sharing one `/tmp` — can ever name the same file. That is
+//! the collision that produced #977: `shift_mask_elide_686.rs` derived its
+//! output name from `(fixture, relocatable, flag)` only, and its two `#[test]`
+//! fns walk the *same* corpus with the *same* flag values on parallel libtest
+//! threads, so both wrote and read one path. Under concurrency this
+//! reproduced `Could not read file magic` in 10 of 48 runs.
+//!
+//! Deliberately NOT checked: mtime. Filesystem timestamp granularity is coarse
+//! enough that an mtime freshness test would become its own flake source.
+//! Remove-first plus a unique path is stronger and has no clock in it.
+//!
+//! The guards are observed firing by the `artifact_guard_*` tests in
+//! `shift_mask_elide_686.rs` — a guard nobody watched fire is not a guard.
+
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Process-wide, so two calls in two libtest threads cannot collide.
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// A path no other call — in this process or any other — will produce.
+///
+/// `tag` is a human-readable hint (test/fixture name); it only has to be
+/// filesystem-safe, uniqueness comes from the pid and the counter.
+pub fn unique_artifact(tag: &str, ext: &str) -> PathBuf {
+    let safe: String = tag
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join("synth-test-artifacts");
+    // Best-effort: a pre-existing dir is fine, and a failure here surfaces as
+    // the "was not created" guard below rather than as a silent stale read.
+    let _ = std::fs::create_dir_all(&dir);
+    dir.join(format!("{safe}-{}-{n}.{ext}", std::process::id()))
+}
+
+/// Prove `path` is a readable, non-empty file and return its bytes.
+///
+/// Split out from [`compile_artifact`] so the empty/missing guards can be
+/// exercised directly, without having to persuade a compiler to emit a
+/// zero-byte object.
+pub fn read_artifact(path: &Path) -> Result<Vec<u8>, String> {
+    let meta = std::fs::metadata(path).map_err(|e| {
+        format!(
+            "output artifact {} was NOT created by this invocation ({e}) — \
+             refusing to parse anything else that may be at that path",
+            path.display()
+        )
+    })?;
+    if meta.len() == 0 {
+        return Err(format!(
+            "output artifact {} is EMPTY (0 bytes) — the compile produced no \
+             object; refusing to parse it",
+            path.display()
+        ));
+    }
+    std::fs::read(path).map_err(|e| format!("could not read {}: {e}", path.display()))
+}
+
+/// Run a `synth compile` (or any producer) that writes to `out`, and return the
+/// artifact's bytes only if this invocation actually produced them.
+///
+/// `cmd` must already carry `-o <out>`. The path is removed first, so a stale
+/// artifact from an earlier run can never be mistaken for this one's output.
+pub fn compile_artifact(cmd: &mut Command, out: &Path) -> Result<Vec<u8>, String> {
+    // (0) Freshness: whatever is there now is not ours.
+    let _ = std::fs::remove_file(out);
+
+    // (1) The compile must succeed, and its own stderr is the diagnostic.
+    let output = cmd
+        .output()
+        .map_err(|e| format!("could not spawn {:?}: {e}", cmd.get_program()))?;
+    if !output.status.success() {
+        return Err(format!(
+            "synth compile FAILED ({}) — refusing to parse {}\n--- stderr ---\n{}\n--- stdout ---\n{}",
+            output.status,
+            out.display(),
+            String::from_utf8_lossy(&output.stderr).trim(),
+            String::from_utf8_lossy(&output.stdout).trim(),
+        ));
+    }
+
+    // (2)+(3) It must exist and be non-empty before anything parses it.
+    read_artifact(out)
+}
+
+/// [`compile_artifact`], panicking with `ctx` prefixed — the ergonomic form for
+/// a byte gate whose only sane response to a failed compile is to stop.
+pub fn compile_artifact_or_panic(cmd: &mut Command, out: &Path, ctx: &str) -> Vec<u8> {
+    match compile_artifact(cmd, out) {
+        Ok(bytes) => bytes,
+        Err(e) => panic!("{ctx}: {e}"),
+    }
+}

--- a/crates/synth-cli/tests/artifact_guard/mod.rs
+++ b/crates/synth-cli/tests/artifact_guard/mod.rs
@@ -123,10 +123,21 @@ pub fn compile_artifact(cmd: &mut Command, out: &Path) -> Result<Vec<u8>, String
 }
 
 /// [`compile_artifact`], panicking with `ctx` prefixed — the ergonomic form for
-/// a byte gate whose only sane response to a failed compile is to stop.
+/// a byte gate whose only sane response to a failed compile is to stop. Leaves
+/// the artifact in place for callers that need the path afterwards.
 pub fn compile_artifact_or_panic(cmd: &mut Command, out: &Path, ctx: &str) -> Vec<u8> {
     match compile_artifact(cmd, out) {
         Ok(bytes) => bytes,
         Err(e) => panic!("{ctx}: {e}"),
     }
+}
+
+/// [`compile_artifact_or_panic`] for gates that only want the bytes: the
+/// artifact is deleted once read. Per-call unique paths mean nothing is ever
+/// reused, so without this the temp dir would grow by one file per compile on a
+/// long-lived (self-hosted) runner.
+pub fn compile_bytes_or_panic(cmd: &mut Command, out: &Path, ctx: &str) -> Vec<u8> {
+    let bytes = compile_artifact_or_panic(cmd, out, ctx);
+    let _ = std::fs::remove_file(out);
+    bytes
 }

--- a/crates/synth-cli/tests/frozen_codegen_bytes.rs
+++ b/crates/synth-cli/tests/frozen_codegen_bytes.rs
@@ -42,6 +42,8 @@ use std::process::Command;
 use object::{Object, ObjectSection};
 use sha2::{Digest, Sha256};
 
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -71,9 +73,9 @@ fn fixture(name: &str) -> std::path::PathBuf {
 /// `.text` arch-agnostically (ARM Thumb-2 and RV32 alike).
 fn text_sha256(wasm: &str, backend: &str, target: &str) -> (String, usize) {
     let path = fixture(wasm);
-    let elf = format!("/tmp/frozenbytes_{backend}_{wasm}.elf");
-    let out = Command::new(synth())
-        .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
+    let elf = artifact_guard::unique_artifact(&format!("frozenbytes_{backend}_{wasm}"), "elf");
+    let mut cmd = Command::new(synth());
+    cmd.env_remove("SYNTH_NO_CMP_SELECT_FUSE")
         .env_remove("SYNTH_NO_LOCAL_PROMOTE")
         .env_remove("SYNTH_NO_IMM_SHIFT_FOLD")
         .env_remove("SYNTH_NO_STACK_FWD")
@@ -90,22 +92,15 @@ fn text_sha256(wasm: &str, backend: &str, target: &str) -> (String, usize) {
             "compile",
             path.to_str().unwrap(),
             "-o",
-            &elf,
+            elf.to_str().unwrap(),
             "-b",
             backend,
             "--target",
             target,
             "--all-exports",
             "--relocatable",
-        ])
-        .output()
-        .expect("run synth");
-    assert!(
-        out.status.success(),
-        "synth compile failed for {wasm} ({backend}/{target}): {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let bytes = std::fs::read(&elf).expect("read elf");
+        ]);
+    let bytes = artifact_guard::compile_bytes_or_panic(&mut cmd, &elf, wasm);
     let obj = object::File::parse(&*bytes).expect("parse elf");
     let text = obj
         .section_by_name(".text")
@@ -301,9 +296,9 @@ fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
         ),
     ];
     for &(wasm, golden, golden_len) in &old {
-        let elf = format!("/tmp/frozen_nofwd_{wasm}.elf");
-        let out = Command::new(synth())
-            .env("SYNTH_SHIFT_MASK_ELIDE", "0")
+        let elf = artifact_guard::unique_artifact(&format!("frozen_nofwd_{wasm}"), "elf");
+        let mut cmd = Command::new(synth());
+        cmd.env("SYNTH_SHIFT_MASK_ELIDE", "0")
             .env("SYNTH_NO_STACK_FWD", "1")
             .env("SYNTH_SPILL_REALLOC", "0")
             .env("SYNTH_CONST_CSE", "0")
@@ -317,18 +312,15 @@ fn frozen_fixtures_stack_fwd_escape_hatch_restores_old_bytes() {
                 "compile",
                 fixture(wasm).to_str().unwrap(),
                 "-o",
-                &elf,
+                elf.to_str().unwrap(),
                 "-b",
                 "arm",
                 "--target",
                 "cortex-m4",
                 "--all-exports",
                 "--relocatable",
-            ])
-            .output()
-            .expect("run synth");
-        assert!(out.status.success(), "compile failed for {wasm}");
-        let bytes = std::fs::read(&elf).expect("read elf");
+            ]);
+        let bytes = artifact_guard::compile_bytes_or_panic(&mut cmd, &elf, wasm);
         let obj = object::File::parse(&*bytes).expect("parse elf");
         let data = obj
             .section_by_name(".text")
@@ -395,9 +387,9 @@ fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
         ),
     ];
     for &(wasm, golden, golden_len) in &old {
-        let elf = format!("/tmp/frozen_nospillrealloc_{wasm}.elf");
-        let out = Command::new(synth())
-            .env("SYNTH_SHIFT_MASK_ELIDE", "0")
+        let elf = artifact_guard::unique_artifact(&format!("frozen_nospillrealloc_{wasm}"), "elf");
+        let mut cmd = Command::new(synth());
+        cmd.env("SYNTH_SHIFT_MASK_ELIDE", "0")
             .env("SYNTH_SPILL_REALLOC", "0")
             .env("SYNTH_CONST_CSE", "0")
             .env("SYNTH_DEAD_FRAME_ELIM", "0")
@@ -411,18 +403,15 @@ fn frozen_fixtures_spill_realloc_escape_hatch_restores_old_bytes() {
                 "compile",
                 fixture(wasm).to_str().unwrap(),
                 "-o",
-                &elf,
+                elf.to_str().unwrap(),
                 "-b",
                 "arm",
                 "--target",
                 "cortex-m4",
                 "--all-exports",
                 "--relocatable",
-            ])
-            .output()
-            .expect("run synth");
-        assert!(out.status.success(), "compile failed for {wasm}");
-        let bytes = std::fs::read(&elf).expect("read elf");
+            ]);
+        let bytes = artifact_guard::compile_bytes_or_panic(&mut cmd, &elf, wasm);
         let obj = object::File::parse(&*bytes).expect("parse elf");
         let data = obj
             .section_by_name(".text")
@@ -484,9 +473,9 @@ fn frozen_fixtures_const_cse_escape_hatch_restores_old_bytes() {
         ),
     ];
     for &(wasm, golden, golden_len) in &old {
-        let elf = format!("/tmp/frozen_nocse_{wasm}.elf");
-        let out = Command::new(synth())
-            .env("SYNTH_SHIFT_MASK_ELIDE", "0")
+        let elf = artifact_guard::unique_artifact(&format!("frozen_nocse_{wasm}"), "elf");
+        let mut cmd = Command::new(synth());
+        cmd.env("SYNTH_SHIFT_MASK_ELIDE", "0")
             .env("SYNTH_CONST_CSE", "0")
             .env("SYNTH_DEAD_FRAME_ELIM", "0")
             .env("SYNTH_UXTH_FOLD", "0")
@@ -500,18 +489,15 @@ fn frozen_fixtures_const_cse_escape_hatch_restores_old_bytes() {
                 "compile",
                 fixture(wasm).to_str().unwrap(),
                 "-o",
-                &elf,
+                elf.to_str().unwrap(),
                 "-b",
                 "arm",
                 "--target",
                 "cortex-m4",
                 "--all-exports",
                 "--relocatable",
-            ])
-            .output()
-            .expect("run synth");
-        assert!(out.status.success(), "compile failed for {wasm}");
-        let bytes = std::fs::read(&elf).expect("read elf");
+            ]);
+        let bytes = artifact_guard::compile_bytes_or_panic(&mut cmd, &elf, wasm);
         let obj = object::File::parse(&*bytes).expect("parse elf");
         let data = obj
             .section_by_name(".text")
@@ -573,9 +559,9 @@ fn frozen_fixtures_dead_frame_elim_escape_hatch_restores_old_bytes() {
         ),
     ];
     for &(wasm, golden, golden_len) in &old {
-        let elf = format!("/tmp/frozen_nodfe_{wasm}.elf");
-        let out = Command::new(synth())
-            .env("SYNTH_SHIFT_MASK_ELIDE", "0")
+        let elf = artifact_guard::unique_artifact(&format!("frozen_nodfe_{wasm}"), "elf");
+        let mut cmd = Command::new(synth());
+        cmd.env("SYNTH_SHIFT_MASK_ELIDE", "0")
             .env("SYNTH_DEAD_FRAME_ELIM", "0")
             .env_remove("SYNTH_UXTH_FOLD")
             .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
@@ -589,18 +575,15 @@ fn frozen_fixtures_dead_frame_elim_escape_hatch_restores_old_bytes() {
                 "compile",
                 fixture(wasm).to_str().unwrap(),
                 "-o",
-                &elf,
+                elf.to_str().unwrap(),
                 "-b",
                 "arm",
                 "--target",
                 "cortex-m4",
                 "--all-exports",
                 "--relocatable",
-            ])
-            .output()
-            .expect("run synth");
-        assert!(out.status.success(), "compile failed for {wasm}");
-        let bytes = std::fs::read(&elf).expect("read elf");
+            ]);
+        let bytes = artifact_guard::compile_bytes_or_panic(&mut cmd, &elf, wasm);
         let obj = object::File::parse(&*bytes).expect("parse elf");
         let data = obj
             .section_by_name(".text")
@@ -651,9 +634,9 @@ fn frozen_fixtures_uxth_fold_escape_hatch_restores_old_bytes() {
         314usize,
     )];
     for &(wasm, golden, golden_len) in &old {
-        let elf = format!("/tmp/frozen_nouxth_{wasm}.elf");
-        let out = Command::new(synth())
-            .env("SYNTH_SHIFT_MASK_ELIDE", "0")
+        let elf = artifact_guard::unique_artifact(&format!("frozen_nouxth_{wasm}"), "elf");
+        let mut cmd = Command::new(synth());
+        cmd.env("SYNTH_SHIFT_MASK_ELIDE", "0")
             .env("SYNTH_UXTH_FOLD", "0")
             .env_remove("SYNTH_DEAD_FRAME_ELIM")
             .env_remove("SYNTH_NO_CMP_SELECT_FUSE")
@@ -667,18 +650,15 @@ fn frozen_fixtures_uxth_fold_escape_hatch_restores_old_bytes() {
                 "compile",
                 fixture(wasm).to_str().unwrap(),
                 "-o",
-                &elf,
+                elf.to_str().unwrap(),
                 "-b",
                 "arm",
                 "--target",
                 "cortex-m4",
                 "--all-exports",
                 "--relocatable",
-            ])
-            .output()
-            .expect("run synth");
-        assert!(out.status.success(), "compile failed for {wasm}");
-        let bytes = std::fs::read(&elf).expect("read elf");
+            ]);
+        let bytes = artifact_guard::compile_bytes_or_panic(&mut cmd, &elf, wasm);
         let obj = object::File::parse(&*bytes).expect("parse elf");
         let data = obj
             .section_by_name(".text")
@@ -796,30 +776,30 @@ fn frozen_fixtures_rv32_shift_fold_escape_hatch_restores_old_bytes() {
     ];
     for &(wasm, golden, golden_len) in &cases {
         let path = fixture(wasm);
-        let elf = format!("/tmp/frozenbytes_rv32_shiftfold_off_{wasm}.elf");
+        let elf = artifact_guard::unique_artifact(
+            &format!("frozenbytes_rv32_shiftfold_off_{wasm}"),
+            "elf",
+        );
         // COMPOSITION (#601 promo flip): local promotion is default-on but
         // byte-neutral on these fixtures; pin it off anyway so the rollback
         // stays an exact pre-flip composition, not a byte-neutrality bet.
-        let out = Command::new(synth())
-            .env("SYNTH_RV_LOCAL_PROMO", "0")
+        let mut cmd = Command::new(synth());
+        cmd.env("SYNTH_RV_LOCAL_PROMO", "0")
             .env_remove("SYNTH_RV_CMP_SELECT")
             .env("SYNTH_RV_SHIFT_FOLD", "0")
             .args([
                 "compile",
                 path.to_str().unwrap(),
                 "-o",
-                &elf,
+                elf.to_str().unwrap(),
                 "-b",
                 "riscv",
                 "--target",
                 "rv32imac",
                 "--all-exports",
                 "--relocatable",
-            ])
-            .output()
-            .expect("run synth");
-        assert!(out.status.success(), "compile failed for {wasm}");
-        let bytes = std::fs::read(&elf).expect("read elf");
+            ]);
+        let bytes = artifact_guard::compile_bytes_or_panic(&mut cmd, &elf, wasm);
         let obj = object::File::parse(&*bytes).expect("parse elf");
         let data = obj
             .section_by_name(".text")
@@ -877,29 +857,27 @@ fn frozen_fixtures_rv32_cmp_select_escape_hatch_restores_old_bytes() {
     ];
     for &(wasm, golden, golden_len) in &cases {
         let path = fixture(wasm);
-        let elf = format!("/tmp/frozenbytes_rv32_cmpsel_off_{wasm}.elf");
+        let elf =
+            artifact_guard::unique_artifact(&format!("frozenbytes_rv32_cmpsel_off_{wasm}"), "elf");
         // COMPOSITION (#601 promo flip): see the shift-fold hatch — promo is
         // pinned off so the rollback composition stays exact.
-        let out = Command::new(synth())
-            .env("SYNTH_RV_LOCAL_PROMO", "0")
+        let mut cmd = Command::new(synth());
+        cmd.env("SYNTH_RV_LOCAL_PROMO", "0")
             .env("SYNTH_RV_CMP_SELECT", "0")
             .env("SYNTH_RV_SHIFT_FOLD", "0")
             .args([
                 "compile",
                 path.to_str().unwrap(),
                 "-o",
-                &elf,
+                elf.to_str().unwrap(),
                 "-b",
                 "riscv",
                 "--target",
                 "rv32imac",
                 "--all-exports",
                 "--relocatable",
-            ])
-            .output()
-            .expect("run synth");
-        assert!(out.status.success(), "compile failed for {wasm}");
-        let bytes = std::fs::read(&elf).expect("read elf");
+            ]);
+        let bytes = artifact_guard::compile_bytes_or_panic(&mut cmd, &elf, wasm);
         let obj = object::File::parse(&*bytes).expect("parse elf");
         let data = obj
             .section_by_name(".text")
@@ -955,27 +933,25 @@ fn frozen_fixtures_rv32_local_promo_escape_hatch_is_noop() {
     ];
     for &(wasm, golden, golden_len) in &cases {
         let path = fixture(wasm);
-        let elf = format!("/tmp/frozenbytes_rv32_promo_off_{wasm}.elf");
-        let out = Command::new(synth())
-            .env("SYNTH_RV_LOCAL_PROMO", "0")
+        let elf =
+            artifact_guard::unique_artifact(&format!("frozenbytes_rv32_promo_off_{wasm}"), "elf");
+        let mut cmd = Command::new(synth());
+        cmd.env("SYNTH_RV_LOCAL_PROMO", "0")
             .env_remove("SYNTH_RV_CMP_SELECT")
             .env_remove("SYNTH_RV_SHIFT_FOLD")
             .args([
                 "compile",
                 path.to_str().unwrap(),
                 "-o",
-                &elf,
+                elf.to_str().unwrap(),
                 "-b",
                 "riscv",
                 "--target",
                 "rv32imac",
                 "--all-exports",
                 "--relocatable",
-            ])
-            .output()
-            .expect("run synth");
-        assert!(out.status.success(), "compile failed for {wasm}");
-        let bytes = std::fs::read(&elf).expect("read elf");
+            ]);
+        let bytes = artifact_guard::compile_bytes_or_panic(&mut cmd, &elf, wasm);
         let obj = object::File::parse(&*bytes).expect("parse elf");
         let data = obj
             .section_by_name(".text")

--- a/crates/synth-cli/tests/shift_mask_elide_686.rs
+++ b/crates/synth-cli/tests/shift_mask_elide_686.rs
@@ -26,10 +26,21 @@
 //! — re-run green with the flag ON at land time, and red-tested against a
 //! force-elide of a >= 32 case (10 rows red, both paths).
 
+//! RQ-58-FLAKE (#977): this file was the one that kept reading a non-ELF. Its
+//! output path was derived from `(fixture, relocatable, flag)` alone, and its
+//! two `#[test]` fns walk the SAME corpus with the SAME flag values on parallel
+//! libtest threads — so both wrote and read one `/tmp` file, and `synth
+//! compile` truncates on open. Every compile now goes through
+//! `artifact_guard`, which gives each call its own path and refuses to hand
+//! back bytes it did not just watch the compiler produce. The guards are
+//! observed firing by the `artifact_guard_*` tests at the bottom.
+
 use std::collections::BTreeMap;
 use std::process::Command;
 
 use object::{Object, ObjectSection, ObjectSymbol, SymbolKind};
+
+mod artifact_guard;
 
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
@@ -63,11 +74,17 @@ const VARIANTS: &[(&str, bool)] = &[("relocatable", true), ("default", false)];
 /// the same symtab the `.py` differentials read — `st_size` is not populated.
 fn compile(wasm: &str, relocatable: bool, elide: Option<&str>) -> (Vec<u8>, BTreeMap<String, u64>) {
     let path = fixture(wasm);
-    let elf = format!(
-        "/tmp/shift_mask_elide_686_{}_{}_{}.o",
-        wasm.replace('.', "_"),
-        relocatable,
-        elide.unwrap_or("unset")
+    // #977: unique PER CALL, not per (fixture, flag) — the two #[test] fns below
+    // request identical triples on parallel libtest threads, and a shared path
+    // means one thread parses what the other is mid-way through truncating.
+    let elf = artifact_guard::unique_artifact(
+        &format!(
+            "shift_mask_elide_686_{}_{}_{}",
+            wasm.replace('.', "_"),
+            relocatable,
+            elide.unwrap_or("unset")
+        ),
+        "o",
     );
     let mut cmd = Command::new(synth());
     cmd.env_remove("SYNTH_SHIFT_MASK_ELIDE");
@@ -78,7 +95,7 @@ fn compile(wasm: &str, relocatable: bool, elide: Option<&str>) -> (Vec<u8>, BTre
         "compile",
         path.to_str().unwrap(),
         "-o",
-        &elf,
+        elf.to_str().unwrap(),
         "-b",
         "arm",
         "--target",
@@ -88,13 +105,14 @@ fn compile(wasm: &str, relocatable: bool, elide: Option<&str>) -> (Vec<u8>, BTre
     if relocatable {
         cmd.arg("--relocatable");
     }
-    let out = cmd.output().expect("run synth");
-    assert!(
-        out.status.success(),
-        "synth compile failed for {wasm} (relocatable={relocatable}): {}",
-        String::from_utf8_lossy(&out.stderr)
+    let bytes = artifact_guard::compile_artifact_or_panic(
+        &mut cmd,
+        &elf,
+        &format!("{wasm} (relocatable={relocatable}, elide={elide:?})"),
     );
-    let bytes = std::fs::read(&elf).expect("read elf");
+    // Bounded: one artifact per call would otherwise accumulate on a
+    // long-lived (self-hosted) runner.
+    let _ = std::fs::remove_file(&elf);
     let obj = object::File::parse(&*bytes).expect("parse elf");
     let text = obj.section_by_name(".text").expect(".text");
     let data = text.data().expect("read .text").to_vec();
@@ -203,5 +221,171 @@ fn shift_mask_elide_686_per_function_no_grow_and_gust_mix_recovers() {
          ({} -> {} B)",
         off_bytes.len(),
         on_bytes.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// RQ-58-FLAKE (#977) — the guard, observed firing.
+//
+// A guard nobody watched fire is not a guard, so the bad states are constructed
+// deliberately here rather than described. These run in the same binary as the
+// gates above, so CI re-observes them on every commit.
+// ---------------------------------------------------------------------------
+
+/// Build a command that is *guaranteed* to fail the compile without producing
+/// an object: a nonexistent input. (`synth compile` exits 1 and writes nothing.)
+fn failing_compile(out: &std::path::Path) -> Command {
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        "/nonexistent/rq58-flake-977-there-is-no-such-module.wat",
+        "-o",
+        out.to_str().unwrap(),
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+    ]);
+    cmd
+}
+
+/// A command that compiles a real fixture successfully — used to mint a genuine
+/// ELF to pre-plant as "the previous run's object".
+fn good_compile(out: &std::path::Path) -> Command {
+    let mut cmd = Command::new(synth());
+    cmd.env_remove("SYNTH_SHIFT_MASK_ELIDE");
+    cmd.args([
+        "compile",
+        fixture("i32_shift_mask_682.wat").to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+        "--relocatable",
+    ]);
+    cmd
+}
+
+/// LOUD direction. A bad compile must report as a bad compile — at the compile,
+/// with the compiler's own stderr — and never as `Could not read file magic`
+/// twenty lines later in a parser.
+#[test]
+fn artifact_guard_reports_a_failed_compile_as_a_failed_compile() {
+    let out = artifact_guard::unique_artifact("guard_failed_compile", "o");
+    let err = artifact_guard::compile_artifact(&mut failing_compile(&out), &out)
+        .expect_err("a compile of a nonexistent module must not yield bytes");
+
+    assert!(
+        err.contains("synth compile FAILED"),
+        "the failure must name the compile as the failure, got: {err}"
+    );
+    assert!(
+        err.contains("Failed to read input file"),
+        "the compiler's OWN stderr must travel with the failure, got: {err}"
+    );
+    assert!(
+        !err.contains("file magic"),
+        "the parser must never be the one to complain, got: {err}"
+    );
+}
+
+/// SILENT direction — the one that matters.
+///
+/// Pre-plant a genuine, parseable ELF at the output path (the previous run's
+/// object), then fail the compile. The pre-#977 shape — `fs::read` the path and
+/// `File::parse` it — would have parsed those stale bytes and PASSED the gate on
+/// evidence this invocation never produced. That is the v0.56 trap with the sign
+/// flipped, and it is a false green rather than a noisy red.
+///
+/// The guard must REFUSE, and must leave nothing at the path for anyone to pick
+/// up afterwards.
+#[test]
+fn artifact_guard_refuses_a_stale_artifact_instead_of_passing_on_it() {
+    // A real, whole ELF — produced by a compile we know succeeded.
+    let src = artifact_guard::unique_artifact("guard_stale_source", "o");
+    let good_bytes = artifact_guard::compile_artifact_or_panic(
+        &mut good_compile(&src),
+        &src,
+        "minting the stale artifact",
+    );
+    let _ = std::fs::remove_file(&src);
+    let stale = artifact_guard::unique_artifact("guard_stale_planted", "o");
+    std::fs::write(&stale, &good_bytes).expect("plant the stale artifact");
+
+    // Establish the counterfactual: these bytes ARE a valid ELF with a .text,
+    // i.e. an unguarded compile-then-parse would have sailed straight through.
+    let planted = std::fs::read(&stale).expect("read planted");
+    let obj = object::File::parse(&*planted).expect("the planted artifact is a valid ELF");
+    assert!(
+        obj.section_by_name(".text").is_some(),
+        "the planted artifact must be substantial enough to fool an unguarded gate"
+    );
+
+    // Now the compile fails while that stale object is sitting at the path.
+    let err = artifact_guard::compile_artifact(&mut failing_compile(&stale), &stale)
+        .expect_err("REFUSAL REQUIRED: a failed compile must not return last run's bytes");
+    assert!(
+        err.contains("synth compile FAILED"),
+        "the refusal must name the compile failure, got: {err}"
+    );
+    assert!(
+        !err.contains("file magic"),
+        "and must not surface as a parse error, got: {err}"
+    );
+    assert!(
+        !std::path::Path::new(&stale).exists(),
+        "the stale artifact must have been removed BEFORE the compile ran — \
+         leaving it there is how a later reader picks up the wrong object"
+    );
+}
+
+/// The empty-file case, shown against the exact historical symptom: the same
+/// zero bytes that make `object` say `Could not read file magic` are reported by
+/// the guard as an empty artifact, before any parser sees them.
+#[test]
+fn artifact_guard_reports_an_empty_artifact_precisely() {
+    let out = artifact_guard::unique_artifact("guard_empty", "o");
+    std::fs::write(&out, b"").expect("create empty");
+
+    // This is verbatim what #960/#974/#977 reported, from the unguarded shape.
+    let unguarded = object::File::parse(&*std::fs::read(&out).unwrap())
+        .expect_err("empty bytes are not an ELF");
+    assert!(
+        format!("{unguarded}").contains("Could not read file magic"),
+        "sanity: the historical symptom is the empty-file parse, got: {unguarded}"
+    );
+
+    let err = artifact_guard::read_artifact(&out).expect_err("an empty artifact must be refused");
+    assert!(
+        err.contains("EMPTY"),
+        "the guard must name emptiness, got: {err}"
+    );
+    let _ = std::fs::remove_file(&out);
+}
+
+/// And the missing-file case: no artifact means no parse, with the path named.
+#[test]
+fn artifact_guard_reports_a_missing_artifact_precisely() {
+    let out = artifact_guard::unique_artifact("guard_missing", "o");
+    let err = artifact_guard::read_artifact(&out).expect_err("a missing artifact must be refused");
+    assert!(
+        err.contains("was NOT created by this invocation"),
+        "the guard must say the artifact is absent, got: {err}"
+    );
+}
+
+/// The collision itself: two calls that describe the SAME compile must still get
+/// different paths. This is what makes the two `#[test]` fns above unable to
+/// race, on any runner, however the scheduler interleaves them.
+#[test]
+fn artifact_guard_paths_are_unique_per_call() {
+    let a = artifact_guard::unique_artifact("shift_mask_elide_686_same_tag", "o");
+    let b = artifact_guard::unique_artifact("shift_mask_elide_686_same_tag", "o");
+    assert_ne!(
+        a, b,
+        "identical descriptions must NOT map to one path — that is #977"
     );
 }

--- a/crates/synth-cli/tests/shift_mask_elide_686.rs
+++ b/crates/synth-cli/tests/shift_mask_elide_686.rs
@@ -25,7 +25,7 @@
 //! must never fire) is owned by `scripts/repro/i32_shift_mask_682_differential.py`
 //! — re-run green with the flag ON at land time, and red-tested against a
 //! force-elide of a >= 32 case (10 rows red, both paths).
-
+//!
 //! RQ-58-FLAKE (#977): this file was the one that kept reading a non-ELF. Its
 //! output path was derived from `(fixture, relocatable, flag)` alone, and its
 //! two `#[test]` fns walk the SAME corpus with the SAME flag values on parallel
@@ -105,14 +105,11 @@ fn compile(wasm: &str, relocatable: bool, elide: Option<&str>) -> (Vec<u8>, BTre
     if relocatable {
         cmd.arg("--relocatable");
     }
-    let bytes = artifact_guard::compile_artifact_or_panic(
+    let bytes = artifact_guard::compile_bytes_or_panic(
         &mut cmd,
         &elf,
         &format!("{wasm} (relocatable={relocatable}, elide={elide:?})"),
     );
-    // Bounded: one artifact per call would otherwise accumulate on a
-    // long-lived (self-hosted) runner.
-    let _ = std::fs::remove_file(&elf);
     let obj = object::File::parse(&*bytes).expect("parse elf");
     let text = obj.section_by_name(".text").expect(".text");
     let data = text.data().expect("read .text").to_vec();


### PR DESCRIPTION
## Root cause — confirmed, and it is not quite the hypothesis

The brief's hypothesis was *concurrent CI jobs sharing a fixture path*. That specific
form is **not** what happened, and the datum that motivated it rules it out: on #974 the
test passed in `Test` and failed in `coverage` on the identical commit — but `Test` runs
on `ubuntu-latest` (ephemeral GitHub VM) and `coverage` runs on
`[self-hosted, linux, x64, rust-cpu]`. Different machines, so a `/tmp` collision
*between those two jobs* is impossible. (A collision *between two runs of the coverage
job* on that persistent runner is a separate thing and is still possible — see channel 2
below. Both are closed by the same fix.)

What is actually there, confirmed by reading and then by reproducing it:

`crates/synth-cli/tests/shift_mask_elide_686.rs` derived its output path from
`(fixture, relocatable, elide)` **only**:

```rust
let elf = format!("/tmp/shift_mask_elide_686_{}_{}_{}.o", ...);
```

Its two `#[test]` fns walk the **same** `CORPUS` with the **same** `VARIANTS` and the
**same** flag values, and libtest runs them on parallel threads in one binary. So both
threads compute the *identical* path and both write and read it. `synth compile` opens
its output with `File::create` (`crates/synth-cli/src/main.rs:2162`, `:4484`) —
truncate-then-write — so a reader that lands mid-write sees zero or partial bytes, and
`object` says `Could not read file magic`.

Two channels, stated separately because they have different evidence:

1. **Intra-process** (present on *every* runner, proven by construction — the two tests
   emit byte-identical path expressions). llvm-cov instrumentation makes every compile
   dramatically slower, which widens the window; that is the asymmetry behind "passed in
   `Test`, failed in `coverage`".
2. **Inter-run on the persistent self-hosted runner** (plausible, not confirmed from
   here): `/tmp` survives between workflow runs on `rust-cpu`, and the paths are fixed,
   so overlapping runs collide. Supporting negative result from the survey: **zero**
   `/tmp` literals are shared across two different test *files*, so the collision was
   always same-file.

**Reproduced.** 6 concurrent copies of the test binary, 8 rounds: **10 of 48 runs**
failed with the exact reported error at the exact line —
`parse elf: Error("Could not read file magic")` at `shift_mask_elide_686.rs:98`. After
the fix the same harness runs **0 of 48**. (30 sequential single-process runs did not
fire on this hardware; the intra-process channel is argued by construction, and the
guard demos below carry the evidence weight.)

## Why this outranked an ordinary flake

`Could not read file magic` means the harness read something empty. One step over — a
*failed* compile with a *valid previous* object still at the path — the same code reads a
parseable ELF and **passes**, re-confirming last run's digest as this run's evidence.
That is v0.56's trap with the sign flipped, and it is silent.

## The fix

New `crates/synth-cli/tests/artifact_guard/mod.rs`. Nothing parses an artifact until the
artifact is proven to be *this invocation's output*:

- `unique_artifact(tag, ext)` — path unique **per call** (pid + process-wide
  `AtomicU64`), under one `synth-test-artifacts/` dir. Note per-*call*, not per-process:
  a pid-scoped path would have left both `#[test]` fns inside one pid and the race
  intact.
- `compile_artifact(cmd, out)` — (0) remove the path, (1) assert exit status **carrying
  synth's own stderr**, (2) assert the file exists, (3) assert it is non-empty, then hand
  back bytes. A bad compile reports as a bad compile, at the compile.
- `compile_bytes_or_panic` — the same, deleting the artifact after reading, so per-call
  unique paths do not accumulate on a long-lived runner.

**mtime is deliberately not checked.** Coarse filesystem timestamp granularity would make
a freshness assertion its own flake source. Remove-first plus a unique path is stronger
and has no clock in it.

## Sensitivity — the guards observed firing

Both demonstrations are `#[test]`s in the same binary, so CI re-observes them every run
rather than trusting a one-off terminal transcript.

**Loud direction** — `artifact_guard_reports_a_failed_compile_as_a_failed_compile`:
a compile of a nonexistent module. Asserts the message names `synth compile FAILED`,
carries the compiler's own `Failed to read input file`, and does **not** contain
`file magic`. Also `artifact_guard_reports_an_empty_artifact_precisely`, which first
asserts that the unguarded parse of those same zero bytes produces verbatim
`Could not read file magic` (the historical symptom) and then that the guard says
`EMPTY` instead; plus a missing-artifact case and a path-uniqueness case.

**Silent direction — the one that matters** —
`artifact_guard_refuses_a_stale_artifact_instead_of_passing_on_it`:

1. mint a genuine ELF from a compile that succeeded, and pre-plant it at the output path;
2. **prove the counterfactual**: assert those planted bytes parse as an ELF *and* carry a
   `.text` — i.e. the pre-#977 `fs::read` + `File::parse` shape would have sailed through
   and passed the gate;
3. run a **failing** compile at that path;
4. require the guard to return `Err` naming the compile failure, not the parser, and
   require the stale object to be **gone** — left in place, a later reader picks it up.

Verified red-first: an earlier revision of this test planted `.text` bytes instead of a
whole ELF and failed on step 2 (`Unknown file magic`), so step 2 is not vacuous.

## Survey — how much of the class shares the shape

Measured over `crates/*/tests/*.rs` at `origin/main`, per call site (a site = one
`Command::new` whose artifact is read back):

| | |
|---|---|
| compile-then-parse sites | **58**, across **34** files |
| (a) no exit-status assert before the parse | **0** — 3 flagged by the scan, all 3 hand-verified as checked at the call site through a helper split (`multi_sp_rebase_707`, `static_above_sp_739`, `static_downshift_678`) |
| (b) no existence/non-empty check on the produced file | **56 / 58** (only `wast_compile.rs` checks, at 2 sites) |
| (c) no freshness — neither removes the output first nor uses a unique path | **51 / 58** |
| files writing a FIXED output path that have >1 `#[test]` fn (the collision surface) | **38** |

So the finding is sharper than the brief anticipated: **the loud direction is already
covered almost everywhere, and the silent one is covered almost nowhere.** The class is
(b) and (c), not (a).

*Caveat on re-deriving these numbers:* the scan is text-local — it looks for `.success()`
between a `Command::new` and the read-back — so once a site is converted and the assert
moves **inside** the helper, the scan counts it as unguarded. Re-run on this branch it
reports `(a) = 14` and that is an artifact, not a regression. Hence the table is quoted at
`origin/main`, and the script stayed in the scratchpad rather than becoming a repo file.

Python side (`scripts/repro/*.py`, 125 harnesses that run a compile and read a file): 120
check the return code. All 5 flagged were opened, and **all 5 are false positives** —
`arm_corpus_sweep_973.py` handles `p.returncode` explicitly (a decline sweep, where
non-zero is expected, so "check rc" would be the wrong guard anyway), and the other four
(`div_const`, `control_step_riscv`, `controller_step_riscv`,
`signed_div_const_riscv`) do not compile at all: each takes a pre-built ELF as
`sys.argv[1]` and contains no `subprocess.run`/`check_call`/`check_output` — `subprocess`
is an unused import. The CI steps that produce those objects are in
`repro-sweep-selector-oracle` and `repro-sweep-rv32-oracle`, both verified
`runs-on: ubuntu-latest`, under GitHub's default `bash -e`, so a failed compile aborts the
step and the ephemeral `/tmp` cannot be holding a stale object. **No python harness was
changed.**

## Converted vs not

**Converted (10 of 58 sites, 2 files):**
- `shift_mask_elide_686.rs` — the instance (1 site).
- `frozen_codegen_bytes.rs` — all 9 sites. Chosen deliberately: it is the highest-stakes
  instance of the shape in the repo, the SHA-256 anchors every other byte gate leans on,
  reached from one helper called by 10 concurrent `#[test]` fns. A stale read there does
  not fail, it re-confirms the previous digest. The conversion is its own oracle — the 9
  goldens are unchanged and all 10 tests pass, so no emitted byte moved.

**Not converted (48 sites, 32 files).** Named, not hand-waved: `wast_compile.rs` (10),
`call_indirect_275_selfcontained.rs` (3), `cabi_arena_bind_418.rs` (2),
`dwarf_debug_line_emit_394.rs` (2), `elf_tooling_637_656.rs` (2),
`proven_safe_bounds_901.rs` (2), `const_cse_reduction_242.rs` (2), the three
`fact_spec_*_494.rs` (1 each, `required-features = ["verify"]` so they do not build under
default `cargo test --workspace`), `multi_sp_rebase_707.rs`, `static_above_sp_739.rs`,
`static_downshift_678.rs`, `base_cse_flip_468.rs`, `flag_flip_wave_242.rs`,
`heterogeneous_table_676.rs`, `multi_memory_406.rs`, `parity_benchmark_735.rs`,
`promotion_exhaustion_fallback_474.rs`, `provenance_*`, `rv32_*_flip_472.rs`,
`size_attribution_390.rs`, `spill_realloc_242.rs`, `vcr_ver_001_gate_242.rs`,
`vcr_ver_003_addr_777.rs`, `volatile_segment_*_543.rs`, `wsc_facts_ingestion_494.rs`,
`async_intrinsics_gate.rs`, `cabi_arena_realloc_linkability_418.rs`, and
`crates/synth-backend/tests/linker_integration_test.rs` (a different crate — it would
need the helper promoted to a dev crate or duplicated).

The largest single unconverted file is `wast_compile.rs` (10 sites), left deliberately: it
is the only file in the survey that already checks `.exists()` on its output, and a
conformance regression there is loud by construction rather than a digest that silently
re-confirms.

Reason for stopping there rather than sweeping all 34: the remaining sites are **not**
mechanically uniform — they use different path variable names, different `expect`
strings, and several split the compile and the read into separate helper functions that
take a `&str` path (`multi_sp_rebase_707`, `static_above_sp_739`), so a regex conversion
cannot see which read belongs to which compile. Refactoring ~30 gate files without an
oracle per file is the failure mode this repo exists to avoid. The helper is in place and
adoption is a two-line change per site; converting the rest is follow-up work, and this
PR states the residual rather than implying the class is closed.

Also deliberately **not** added: a CI gate that greps for the unguarded shape. v0.58 is
subtracting hand-maintained checkers, and an unwired new one is the wrong direction. The
survey script stayed in the scratchpad.

## Gates

`cargo fmt --all --check` clean · `cargo clippy --workspace --all-targets -D warnings`
clean · `cargo test --workspace` green · `claim_check.py claims.yaml` **49/49** ·
`model_coverage_audit.py --check` ok. No `.wat` added, so `EXPECTED_DECLINES` (#992) is
untouched.

Refs #977
