### PR TITLE
chore(rivet): mark RQ-58-SELDSL and RQ-58-FLAKE implemented (#242)

### DIFF
--- a/artifacts/release-v0.58.yaml
+++ b/artifacts/release-v0.58.yaml
@@ -282,7 +282,7 @@ artifacts:
       stands. That is a real finding about the DSL's expressiveness and should
       be reported as such — with the specific construct that defeats it —
       rather than quietly reducing the target from 20.
-    status: proposed
+    status: implemented
     release: v0.58
     tags: [north-star, vcr-sel-001, rocq, subtraction]
     links:
@@ -509,7 +509,7 @@ artifacts:
       fixture a process-scoped temp path if the collision hypothesis holds.
       That converts a confusing flake into a precise message and closes the
       silent direction at the same time.
-    status: proposed
+    status: implemented
     release: v0.58
     tags: [flake, stale-artifact, harness, silent-direction]
     links:


### PR DESCRIPTION
Both lanes shipped and merged with all 9 required contexts green, but neither bumped its own rivet status, so `artifacts/release-v0.58.yaml` still carried `status: proposed` for work that is on `main`.

| artifact | shipped as | evidence on main |
|---|---|---|
| `RQ-58-SELDSL` | #1004 | `sel_dsl_rules` derives **74** (was 50); selector code −79 lines |
| `RQ-58-FLAKE` | #1006 | merged `29b1a853`; stale-ELF guard + 10/58 sites converted |

**Why this is worth its own PR.** Release readiness is a *query* over these statuses, not an opinion — "the release is cuttable when every artifact in scope is implemented/verified". A stale `proposed` on merged work makes the v0.58 gate under-report its own scope, and it would otherwise have surfaced at release assembly as a late blocker on work that was actually done weeks earlier in the hub.

Found by re-reading the scope against fresh `main` rather than trusting the lane reports — the same discipline that caught 4 factual errors in the v0.57 CHANGELOG.

`claim_check.py` is 49/49 with the change.

Refs #242.