### PR TITLE
RQ-58-OBJECT (#938): compile against object 0.40 — three newtype surfaces, 16 errors, 4 files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+checksum = "dd229a0361b9d0d4396176e02d65897f487eebeab7caa6d443855ee152ca0b9c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ tracing-subscriber = "0.3"
 proptest = "1.11"
 
 # ELF parsing
-object = { version = "0.39", default-features = false, features = ["read", "elf"] }
+object = { version = "0.40", default-features = false, features = ["read", "elf"] }
 
 # PulseEngine WASM optimizer (feature-gated in synth-cli)
 # Uncomment when loom crate is published or available:

--- a/crates/synth-cli/src/main.rs
+++ b/crates/synth-cli/src/main.rs
@@ -8917,7 +8917,7 @@ mod tests {
                 .expect("rel section")
                 .expect("has rel entries");
             for rel in rels {
-                match rel.r_type(endian) {
+                match rel.r_type(endian).0 {
                     R_ARM_ABS32 => abs32 += 1,
                     R_ARM_MOVW_ABS_NC | R_ARM_MOVT_ABS => movw_movt += 1,
                     _ => {}

--- a/crates/synth-cli/tests/dwarf_debug_line_emit_394.rs
+++ b/crates/synth-cli/tests/dwarf_debug_line_emit_394.rs
@@ -377,7 +377,7 @@ fn rel_debug_relocations_shift_addresses_to_correct_line_394() {
         // R_ARM_ABS32 against __synth_text_base.
         match reloc.flags() {
             object::RelocationFlags::Elf { r_type } => assert_eq!(
-                r_type, R_ARM_ABS32,
+                r_type.0, R_ARM_ABS32,
                 "{sec_name} reloc must be R_ARM_ABS32, got r_type={r_type}"
             ),
             other => panic!("{sec_name} reloc has non-ELF flags: {other:?}"),
@@ -432,7 +432,7 @@ fn rel_debug_relocations_shift_addresses_to_correct_line_394() {
         for (offset, reloc) in &relocs {
             match reloc.flags() {
                 object::RelocationFlags::Elf { r_type } => assert_eq!(
-                    r_type, R_ARM_ABS32,
+                    r_type.0, R_ARM_ABS32,
                     ".debug_info reloc must be R_ARM_ABS32, got r_type={r_type}"
                 ),
                 other => panic!(".debug_info reloc has non-ELF flags: {other:?}"),

--- a/crates/synth-cli/tests/elf_tooling_637_656.rs
+++ b/crates/synth-cli/tests/elf_tooling_637_656.rs
@@ -68,7 +68,7 @@ fn module_with_internal_helper(export: &str, mul: u32) -> String {
 }
 
 /// Parsed symtab entry: (name, st_value, binding, type, defined).
-type SymEntry = (String, u32, u8, u8, bool);
+type SymEntry = (String, u32, elf::SymbolBind, elf::SymbolType, bool);
 
 fn read_symbols(bytes: &[u8]) -> (Vec<SymEntry>, u32) {
     let header = elf::FileHeader32::<Endianness>::parse(bytes).expect("valid ELF32");
@@ -182,7 +182,7 @@ fn relocations_reindexed_consistently_656() {
     assert_eq!(rels.len(), 1, "one internal BL call site");
     let rel = &rels[0];
     assert_eq!(
-        rel.r_type(endian),
+        rel.r_type(endian).0,
         10, // R_ARM_THM_CALL (object's elf module names it R_ARM_THM_PC22)
         "Thumb BL uses R_ARM_THM_CALL (#167)"
     );

--- a/crates/synth-cli/tests/wast_compile.rs
+++ b/crates/synth-cli/tests/wast_compile.rs
@@ -448,7 +448,7 @@ fn compile_internal_call_is_linkable_167() {
     for section in elf.sections() {
         for (_off, reloc) in section.relocations() {
             if let object::RelocationFlags::Elf { r_type } = reloc.flags()
-                && r_type == R_ARM_THM_CALL
+                && r_type.0 == R_ARM_THM_CALL
             {
                 thm_call_relocs += 1;
             }
@@ -855,7 +855,7 @@ fn compile_standalone_internal_call_resolves_bl_170() {
     for section in elf.sections() {
         for (_off, reloc) in section.relocations() {
             if let object::RelocationFlags::Elf { r_type } = reloc.flags()
-                && r_type == R_ARM_THM_CALL
+                && r_type.0 == R_ARM_THM_CALL
             {
                 thm_call_relocs += 1;
             }


### PR DESCRIPTION
Supersedes #938 (dependabot's bare bump, which was red on `Test` + `Clippy` and based on a **week-old `v0.56.1` main**). This branch carries dependabot's bump commit rebased onto current `main`, plus the code changes that make it compile.

## Why the bump was held

`object` is the crate the ELF differentials read symtabs and relocations with, so a 0.x-minor here is genuinely breaking — the [0.x-minor hold](https://github.com/pulseengine/synth/issues/965) exists for exactly this. Three separate newtype conversions broke, on surfaces that are **not reachable from one search**:

| # | surface | sites | fix |
|---|---|---|---|
| 1 | `Rel*::r_type()` → `elf::RelocationType` (was `u32`) | 2 | read through the newtype's public field |
| 2 | `RelocationFlags::Elf { r_type }` **destructuring** | 4 | `.0` on the comparison operand only |
| 3 | `st_bind()`/`st_type()` → `SymbolBind`/`SymbolType` | 10 | type the `SymEntry` alias once |

Surface 2 is a struct pattern, not a method call, so no `.r_type(` search finds it. Surface 3 has nothing to do with relocations at all. For (2), the newtype impls `Display`, so `{r_type}` in the assert messages still renders. For (3), object's own `STB_*`/`STT_*` constants are now typed too, so typing the alias fixes all 10 errors at once and every downstream `== elf::STB_LOCAL` keeps working unchanged.

The local `const R_ARM_*: u32` values are deliberately kept — they document the ABI numbers at the point of use, and adopting object's typed constants would make those match arms depend on structural-match of an external newtype.

## Method note, recorded because it cost two rounds

An earlier revision of the fix commit asserted completeness on the strength of a `grep -rn '\.r_type('` sweep. **That was wrong twice over: 2 sites → 6 → 16, across 4 files.** A grep is a hypothesis about where a change lands; the compiler is the oracle. The completeness claim here rests on a clean `cargo test --workspace --no-run`, not on a search.

## Gates

Exit codes captured **directly**, not through a pipe (a piped `grep`/`tail` returns *tail's* status and reports a clean-looking green over a failed run):

```
FMT_EXIT=0   CLIPPY_EXIT=0   TEST_EXIT=0   CLAIM_EXIT=0   MODELCOV_EXIT=0
```

`cargo test --workspace`: 146 result blocks, **0 failures**. `claim_check.py` 49/49. `model_coverage_audit.py --check` ok.

Closes #938. Refs #965, #242.