### PR TITLE
release(v0.58.0): "Delete the thing you replaced"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,137 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.58.0] - 2026-08-20
+
+**Delete the thing you replaced.**
+
+A rule is not done when it is proven. It is done when the hand-written arm it
+replaces is **deleted**. That correction is the whole release, and it came from
+measuring what the previous fifteen releases actually produced rather than what
+they claimed.
+
+From v0.42.0 to v0.57.0 the instruction selector grew **24,909 → 29,616 lines**
+— 5,515 added against 808 deleted, a ratio of 6.8:1 — while the count of
+Rocq-verified selection rules went 40 → 50 and then sat **flat for twelve
+releases**. Nothing was wrong with any individual rule. The verified path was
+being built *alongside* the unverified one, and the unverified one was winning
+on volume, because "replace" was asserted and never measured.
+
+So the metric is now subtraction, and it is pinned in CI so it can go the wrong
+way. This is the first release in the epic's history where the selector
+**shrank while the verified rule count grew**.
+
+| | v0.57.0 | v0.58.0 |
+|---|---|---|
+| Rocq-verified selection rules | 50 | **74** |
+| …each with a 1:1 correctness theorem | 50 | **74** |
+| Rocq `Qed` (whole suite) | 592 | **617** |
+| selector, non-test region | 18,480 | **17,961** |
+| selector wildcard arms, non-test | 62 | **55** |
+| selector, total lines | 29,616 | **28,582** |
+
+### Added
+
+- **The subtraction ratchet (#991).** Seven directed pins in `claims.yaml`:
+  selector line count and wildcard count are **ceilings that must fall**, the
+  verified-rule count is a **floor that must rise**, and mixed populations are
+  tracked without a direction. Each carries a value that must *equal* the live
+  derivation — there is no "current + slack" to hide in, so every movement of a
+  pinned number is a visible diff in the PR that caused it. Adding a
+  hand-written lowering without deleting one now turns the gate red. When a lane
+  legitimately needs growth, the ceiling moves via a `waivers:` entry bound to
+  the new value with a written reason — permission for one growth, never
+  standing.
+
+- **`synth verify` ships in released artifacts (#1000, #1002).** Every published
+  binary was built *without* `--features verify`, so the verifier this project
+  is named for could not be run by anyone who installed it. It is now in the
+  released artifacts, gated by a smoke test that runs `synth verify` on a module
+  compiled by the binary **extracted from each release tarball** and asserts a
+  non-vacuous result (`verified >= 1 && failed == 0`).
+
+- **24 further Rocq-proved selection rules, 50 → 74 (#242, #1004).** Dynamic
+  immediate folds, width conversions and the select family — each one deleting
+  the hand-written emission it supersedes, which is the point. The DSL gained a
+  dynamic-immediate parameter class to express shapes previously called
+  inexpressible, and the ARM model gained `flags_set_reg` so that "IT;MOV
+  preserves flags" is machine-checked rather than assumed.
+
+### Fixed
+
+- **A selector wildcard was a live, executed miscompile (#946, #1003).**
+  `wasm_stack_effect`'s trailing `_ => (0, 0)` silently claimed that unhandled
+  operations neither consume nor produce stack values. This was not a latent
+  hole: it mis-modelled reachable i64 width operations, so the virtual stack
+  drifted and the wrong register was read.
+
+- **ARM `select` on an i64 comparison returned the then-arm unconditionally
+  (#973, #992).** Landed red-first — the unicorn-vs-wasmtime execution
+  differential went in *before* the fix, on the record at 264/360. The same lane
+  found an ARM leg of the corpus CI that had never compiled at all.
+
+- **A differential read a non-ELF — and the silent direction read a stale one
+  (#977, #1006).** Two `#[test]` functions in one binary computed the same
+  `/tmp` output path and ran on parallel threads against a `File::create` that
+  truncates before writing, so a reader could land mid-write. Reproduced 10/48,
+  then 0/48 after. The loud failure was the lesser half: one step away is
+  reading a **stale but valid** ELF and passing, re-confirming the previous
+  run's digest as this run's evidence. A survey found the class is sharp — of 58
+  compile-then-parse sites, exit status is checked at all 58, but freshness at
+  only 7. Ten sites were converted, chosen to include every site in
+  `frozen_codegen_bytes.rs`, whose SHA-256 anchors every other byte gate leans on.
+
+- **`object` 0.39 → 0.40 (#938, #1008).** A 0.x-minor that broke 16 call sites
+  across three unrelated newtype surfaces — relocation types, a
+  `RelocationFlags::Elf { r_type }` destructuring pattern that no method-call
+  search finds, and symbol bind/type — in the crate the ELF differentials read
+  symtabs with.
+
+### Changed
+
+- **The hand-written arms the proved rules replaced are gone (#242, #999).**
+  −1,312 lines (345 insertions against 1,657 deletions), **byte-identical**
+  across all frozen anchors: the proved rules were already the shipped lowering
+  path for their covered operations, so deleting the superseded arms had to
+  change nothing, and did not. The arms that are *not* yet deletable — reachable
+  on one selector path but not the other — were measured and stated rather than
+  deleted and discovered downstream.
+
+- **Generate, don't mirror (#242, #993).** `check_generated_fresh` byte-compares
+  the rendered FEATURE_MATRIX against its *template*, which proves the render is
+  faithful to the template and never that the template is faithful to the
+  **code**. The aarch64 decline list cost the most under that blind spot: it
+  went stale twice, and at v0.57 still named a capability that release had
+  shipped. It is now derived by probing the real selector for every `WasmOp`
+  representative, with the test asserting that none falls through a wildcard.
+
+- **`synth verify` no longer declines the shift rules (#981, #1005).** The
+  stated reason — that SMT modelling of the variable-shift register encoding was
+  an open gap — became false in v0.57 and the wiring was left behind. All five
+  shift/rotate rules are now checked, instantiated from the same generated table
+  the Rocq model is emitted from rather than hand-mirrored. Declines on the
+  shared fixture fell 7 → 2, and the `immediate-shift-encoding` reason is
+  retired outright. Sensitivity was proven rather than assumed: 20 perturbations
+  all flip to Invalid, including an extra `UXTB` appended to a correct lowering
+  — the exact shape that returned a false *Verified* in v0.57.
+
+- **The selector is split along the seam that already existed (#197, #1009).**
+  `select_default` and `select_with_stack` now live in named modules; this lane
+  moved 10,298 lines out, taking the root file 28,533 → 18,284. Both moves are pure relocations — every line
+  in the new modules that is not in the original is a doc comment or
+  `use super::*;`, with one exception: `select_default` gained `pub(super)`
+  because its caller left the module. Byte-identical across all ten frozen
+  anchors, per unit. The ratchet was made family-aware *first*, so the
+  relocation earned no credit for the lines it moved.
+
+  The headers now state what was previously archaeological: `arm_backend.rs`
+  calls `select_with_stack` exclusively — it is the production path, the one
+  `--relocatable` forces — and `select_default` is the legacy blind path
+  reachable in full only through the `pub fn select()` API used by tests and
+  benchmarks. A shipped scanner had claimed the opposite direction, and nothing
+  in 28,000 interleaved lines contradicted it.
+
+
 ## [0.57.0] - 2026-08-14
 
 **The checkers were the defects.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,14 +1111,14 @@ dependencies = [
 
 [[package]]
 name = "synth-abi"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "synth-wit",
 ]
 
 [[package]]
 name = "synth-analysis"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-aarch64"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "synth-core",
  "thiserror",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-awsm"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-riscv"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "synth-backend-wasker"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1178,11 +1178,11 @@ dependencies = [
 
 [[package]]
 name = "synth-cfg"
-version = "0.57.0"
+version = "0.58.0"
 
 [[package]]
 name = "synth-cli"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "synth-core"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "synth-frontend"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "synth-core",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "synth-mcdc-harness"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "synth-backend-riscv",
  "synth-core",
@@ -1247,14 +1247,14 @@ dependencies = [
 
 [[package]]
 name = "synth-memory"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "synth-opt"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "criterion",
  "synth-cfg",
@@ -1262,11 +1262,11 @@ dependencies = [
 
 [[package]]
 name = "synth-qemu"
-version = "0.57.0"
+version = "0.58.0"
 
 [[package]]
 name = "synth-synthesis"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "proptest",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "synth-test"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "synth-verify"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "synth-wit"
-version = "0.57.0"
+version = "0.58.0"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 # semver to publish, so the convention now catches up: workspace
 # version follows the release tag, bumped pre-tag in the release
 # checklist. See docs/release-process.md.
-version = "0.57.0"
+version = "0.58.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["PulseEngine Team"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     name = "synth",
     # Kept in lockstep with [workspace.package] version in Cargo.toml.
     # Both are bumped pre-tag — see docs/release-process.md.
-    version = "0.57.0",
+    version = "0.58.0",
 )
 
 # Bazel dependencies

--- a/artifacts/release-v0.58.yaml
+++ b/artifacts/release-v0.58.yaml
@@ -317,7 +317,7 @@ artifacts:
       SCOPE HONESTY: this is the lane most likely to be partially completed. A
       half-finished split with a stated boundary is acceptable; an unstated one
       is not.
-    status: proposed
+    status: implemented
     release: v0.58
     tags: [structure, two-selector, byte-identical, readability]
     links:
@@ -413,7 +413,7 @@ artifacts:
       hides unhandled match sites. Either land it with that evidence or pin
       `object` with a stated reason. #965 (make the hold enforce) is the
       companion and should land first or alongside.
-    status: proposed
+    status: implemented
     release: v0.58
     tags: [dependencies, breaking, 0x-minor, differentials]
     links:

--- a/artifacts/status.json
+++ b/artifacts/status.json
@@ -32,7 +32,7 @@
   "selector_lines_total": 28582,
   "selector_wildcard_arms_code": 55,
   "selector_wildcard_arms_total": 90,
-  "version": "0.57.0",
+  "version": "0.58.0",
   "verus_spec_fns": 8,
   "wasmcert_bridge_qed": 104
 }

--- a/crates/synth-backend-aarch64/Cargo.toml
+++ b/crates/synth-backend-aarch64/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "AArch64 (A64) host-native backend for synth — integer subset (milestone 1, #538)"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.57.0" }
+synth-core = { path = "../synth-core", version = "0.58.0" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/synth-backend-awsm/Cargo.toml
+++ b/crates/synth-backend-awsm/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "aWsm backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.57.0" }
+synth-core = { path = "../synth-core", version = "0.58.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend-riscv/Cargo.toml
+++ b/crates/synth-backend-riscv/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 description = "RISC-V encoder, ELF builder, PMP allocator, and bare-metal startup for synth"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.57.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.57.0" }
+synth-core = { path = "../synth-core", version = "0.58.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.58.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
@@ -21,4 +21,4 @@ tracing.workspace = true
 proptest.workspace = true
 # VCR-SEL-005 (#851): the cross-backend op-parity oracle probes the AArch64
 # selector as the THIRD backend (tests/cross_backend_op_parity.rs only).
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.57.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.58.0" }

--- a/crates/synth-backend-wasker/Cargo.toml
+++ b/crates/synth-backend-wasker/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 description = "Wasker backend integration for the Synth compiler"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.57.0" }
+synth-core = { path = "../synth-core", version = "0.58.0" }
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-backend/Cargo.toml
+++ b/crates/synth-backend/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arm-cortex-m"]
 arm-cortex-m = ["synth-synthesis"]
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.57.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.57.0", optional = true }
+synth-core = { path = "../synth-core", version = "0.58.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.58.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 
@@ -24,4 +24,4 @@ thiserror.workspace = true
 # #667 move 2: the i64 pseudo-op expansion certification oracle
 # (tests/i64_expansion_certification.rs) feeds THIS crate's emitted encoder
 # bytes to the synth-verify expansion validator. Dev-only — no prod-dep edge.
-synth-verify = { path = "../synth-verify", version = "0.57.0", features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.58.0", features = ["arm"] }

--- a/crates/synth-cli/Cargo.toml
+++ b/crates/synth-cli/Cargo.toml
@@ -66,23 +66,23 @@ exports_only_275_probe = []
 # Path deps carry `version` so `cargo publish` rewrites them to the
 # crates.io coordinate. Bumping the workspace version requires
 # updating these in lockstep — see docs/release-process.md.
-synth-core = { path = "../synth-core", version = "0.57.0" }
-synth-frontend = { path = "../synth-frontend", version = "0.57.0" }
-synth-synthesis = { path = "../synth-synthesis", version = "0.57.0" }
-synth-backend = { path = "../synth-backend", version = "0.57.0" }
+synth-core = { path = "../synth-core", version = "0.58.0" }
+synth-frontend = { path = "../synth-frontend", version = "0.58.0" }
+synth-synthesis = { path = "../synth-synthesis", version = "0.58.0" }
+synth-backend = { path = "../synth-backend", version = "0.58.0" }
 
 # AArch64 host-native backend (#538) — small pure-Rust crate, always on.
-synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.57.0" }
+synth-backend-aarch64 = { path = "../synth-backend-aarch64", version = "0.58.0" }
 
 # Optional external backends
-synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.57.0", optional = true }
-synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.57.0", optional = true }
-synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.57.0", optional = true }
+synth-backend-awsm = { path = "../synth-backend-awsm", version = "0.58.0", optional = true }
+synth-backend-wasker = { path = "../synth-backend-wasker", version = "0.58.0", optional = true }
+synth-backend-riscv = { path = "../synth-backend-riscv", version = "0.58.0", optional = true }
 
 # Optional translation validation — pure-Rust ordeal engine by default (#553),
 # no C++ toolchain needed. For the Z3 differential oracle build with
 # `--features verify,synth-verify/z3-solver` (+ SYNTH_SOLVER_DIFF=1 at runtime).
-synth-verify = { path = "../synth-verify", version = "0.57.0", optional = true, features = ["arm"] }
+synth-verify = { path = "../synth-verify", version = "0.58.0", optional = true, features = ["arm"] }
 
 # Optional PulseEngine WASM optimizer
 # Uncomment when loom crate is available:

--- a/crates/synth-frontend/Cargo.toml
+++ b/crates/synth-frontend/Cargo.toml
@@ -14,7 +14,7 @@ description = "WASM/WAT parser and module decoder frontend for the Synth compile
 # Internal path deps carry an explicit version so `cargo publish`
 # can rewrite to the crates.io coordinate. `path` is used for
 # in-workspace builds; `version` is what crates.io sees.
-synth-core = { path = "../synth-core", version = "0.57.0" }
+synth-core = { path = "../synth-core", version = "0.58.0" }
 
 wasmparser.workspace = true
 wasm-encoder.workspace = true

--- a/crates/synth-opt/Cargo.toml
+++ b/crates/synth-opt/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Peephole optimization passes for the Synth compiler"
 
 [dependencies]
-synth-cfg = { path = "../synth-cfg", version = "0.57.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.58.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/synth-synthesis/Cargo.toml
+++ b/crates/synth-synthesis/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 description = "WASM-to-ARM instruction selection and peephole optimizer"
 
 [dependencies]
-synth-core = { path = "../synth-core", version = "0.57.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.57.0" }
-synth-opt = { path = "../synth-opt", version = "0.57.0" }
+synth-core = { path = "../synth-core", version = "0.58.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.58.0" }
+synth-opt = { path = "../synth-opt", version = "0.58.0" }
 serde.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/synth-verify/Cargo.toml
+++ b/crates/synth-verify/Cargo.toml
@@ -22,12 +22,12 @@ arm = ["synth-synthesis"]
 
 [dependencies]
 # Core dependencies (always required)
-synth-core = { path = "../synth-core", version = "0.57.0" }
-synth-cfg = { path = "../synth-cfg", version = "0.57.0" }
-synth-opt = { path = "../synth-opt", version = "0.57.0" }
+synth-core = { path = "../synth-core", version = "0.58.0" }
+synth-cfg = { path = "../synth-cfg", version = "0.58.0" }
+synth-opt = { path = "../synth-opt", version = "0.58.0" }
 
 # ARM synthesis (optional, behind 'arm' feature)
-synth-synthesis = { path = "../synth-synthesis", version = "0.57.0", optional = true }
+synth-synthesis = { path = "../synth-synthesis", version = "0.58.0", optional = true }
 
 # Default SMT engine: pure-Rust, certificate-checked QF_BV solver (#553).
 # EXACT-PINNED deliberately: for a 0.x solver a MINOR bump is a breaking bump,

--- a/docs/status/FEATURE_MATRIX.md
+++ b/docs/status/FEATURE_MATRIX.md
@@ -7,7 +7,7 @@
 > stale. All numbers come from [`artifacts/status.json`](../../artifacts/status.json),
 > which is re-derived from source on every run — never hand-edited.
 
-**Workspace version:** 0.57.0
+**Workspace version:** 0.58.0
 
 ---
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/synth",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "synth — a WebAssembly-to-ARM/RISC-V/AArch64 compiler with mechanized correctness proofs. Produces bare-metal ELF binaries for embedded targets.",
   "bin": {
     "synth": "./run.js"


### PR DESCRIPTION
All **11 of 11** `RQ-58-*` artifacts are implemented and merged, so the release-readiness query over `artifacts/release-v0.58.yaml` is satisfied.

## The release in one number

| | v0.57.0 | v0.58.0 |
|---|---|---|
| Rocq-verified selection rules | 50 | **74** |
| …each with a 1:1 correctness theorem | 50 | **74** |
| Rocq `Qed` (whole suite) | 592 | **617** |
| selector, non-test region | 18,480 | **17,961** |
| selector wildcard arms, non-test | 62 | **55** |
| selector, total lines | 29,616 | **28,582** |

**The first release in the epic's history where the selector shrank while the verified rule count grew.** From v0.42.0 → v0.57.0 it had gone the other way: 24,909 → 29,616 lines (5,515 added / 808 deleted, 6.8:1) while verified rules went 40 → 50 and sat flat for twelve releases.

## Every number re-derived from merged code

Not from PR bodies — v0.57's cold review found **4 factual errors** in release prose written the same way, by the same author. Sources: `coq/vcr_sel_rules.manifest` and `VcrSelRules.v` at tag vs HEAD; the `coq/Synth` tree; the selector files measured with the ratchet's own region marker.

**Two corrections the cold review caught in my own draft:**

1. **The v0.57.0 baseline is 18,480 / 62 wildcards, not 18,582 / 63.** The latter pair is the METRIC pin's *creation* value — measured mid-v0.58 after #992 grew the file — not the v0.57.0 release value. I had carried the wrong pair through several working notes. Re-measured at the tag with the ratchet's own marker (`#[cfg(test)]\nmod tests`, asserted unique) so the delta is like-for-like.

2. **The SPLIT bullet originally read "the root file went 29,616 → 18,284."** True release-over-release, but it credits SPLIT with a drop that RETIRE (−1,312) and SELDSL (−79) partly produced. Corrected to SPLIT's own effect: 10,298 lines moved out, 28,533 → 18,284. A locally-true sentence with wrong attribution — the same shape as all four v0.57 errors.

## Contents

- **Version pin sweep** across all four surfaces + `Cargo.lock` — `check_version_pins.py` exits 0 at 0.58.0 (30 replacements, 13 files).
- **Regenerated** `artifacts/status.json` + `docs/status/FEATURE_MATRIX.md` via `--emit-status`.
- **Rivet**: `RQ-58-OBJECT` and `RQ-58-SPLIT` → `implemented`, completing 11/11.
- **CHANGELOG**: the v0.58.0 entry.

## Gates

`claim_check.py` **49/49** · `check_version_pins.py` **0** · `model_coverage_audit.py --check` **0** · `cargo fmt --check` **0**.

Refs #242.