### PR TITLE
fix(ci): rustc 1.98.0 added clippy::chunks_exact_to_as_chunks — sweep all 15 sites

### DIFF
--- a/crates/synth-abi/src/lift.rs
+++ b/crates/synth-abi/src/lift.rs
@@ -14,10 +14,8 @@ pub fn lift_string<M: Memory>(mem: &M, ptr: u32, len: u32, opts: &AbiOptions) ->
                 return Err(AbiError::InvalidUtf16);
             }
 
-            let utf16: Vec<u16> = data
-                .chunks_exact(2)
-                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
-                .collect();
+            let (pairs, _rest) = data.as_chunks::<2>();
+            let utf16: Vec<u16> = pairs.iter().map(|&pair| u16::from_le_bytes(pair)).collect();
 
             String::from_utf16(&utf16).map_err(|_| AbiError::InvalidUtf16)
         }

--- a/crates/synth-backend-riscv/src/backend.rs
+++ b/crates/synth-backend-riscv/src/backend.rs
@@ -743,7 +743,12 @@ mod tests {
         ];
         let f = b.compile_function("ldsafe", &ops, &cfg).unwrap();
         // Look for at least one branch-opcode (0x63) instruction in the bytes.
-        let has_branch_opcode = f.code.chunks_exact(4).any(|w| (w[0] & 0x7F) == 0x63);
+        let has_branch_opcode = f
+            .code
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .any(|w| (w[0] & 0x7F) == 0x63);
         assert!(
             has_branch_opcode,
             "expected at least one BRANCH-opcode (0x63) word in: {:?}",

--- a/crates/synth-backend/src/arm_backend.rs
+++ b/crates/synth-backend/src/arm_backend.rs
@@ -2292,7 +2292,9 @@ mod tests {
         // (0x2000 | rd<<8 → LE bytes [0x00, 0x20+rd]) somewhere in the body.
         let has_movs_zero = declared
             .code
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .any(|h| h[0] == 0x00 && (0x20..=0x27).contains(&h[1]));
         assert!(
             has_movs_zero,

--- a/crates/synth-backend/src/arm_encoder.rs
+++ b/crates/synth-backend/src/arm_encoder.rs
@@ -9222,8 +9222,10 @@ mod tests {
             "expected MOVW + CMP + BLO + UDF + MOV + LDR + BLX (7 words): {bytes:02x?}"
         );
         let words: Vec<u32> = bytes
-            .chunks_exact(4)
-            .map(|w| u32::from_le_bytes(w.try_into().unwrap()))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&w| u32::from_le_bytes(w))
             .collect();
         // #642 bounds guard: MOVW r12, #4; CMP r0, r12; BLO +1; UDF
         assert_eq!(words[0], 0xE300_C004, "MOVW r12,#4: {:#010x}", words[0]);
@@ -9247,8 +9249,10 @@ mod tests {
         // The bug: a single NOP word. Must never come back.
         assert!(
             !bytes
-                .chunks_exact(4)
-                .any(|w| w == 0xE1A0_0000u32.to_le_bytes()),
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .any(|&w| w == 0xE1A0_0000u32.to_le_bytes()),
             "call_indirect must not contain a NOP (#594): {bytes:02x?}"
         );
 
@@ -9486,8 +9490,10 @@ mod tests {
             })
             .unwrap();
         let words: Vec<u32> = bytes
-            .chunks_exact(4)
-            .map(|w| u32::from_le_bytes(w.try_into().unwrap()))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&w| u32::from_le_bytes(w))
             .collect();
         assert_eq!(words[0], 0xE300_C029, "MOVW r12,#41: {:#010x}", words[0]);
         assert_eq!(words[1], 0xE151_000C, "CMP r1,r12: {:#010x}", words[1]);
@@ -9575,8 +9581,10 @@ mod tests {
         let blx_at = without.len() - 4;
         assert_eq!(&with[..blx_at], &without[..blx_at], "shared prefix");
         let words: Vec<u32> = with[blx_at..]
-            .chunks_exact(4)
-            .map(|w| u32::from_le_bytes(w.try_into().unwrap()))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&w| u32::from_le_bytes(w))
             .collect();
         assert_eq!(words[0], 0xE35C_0000, "CMP r12,#0: {:#010x}", words[0]);
         assert_eq!(words[1], 0x1A00_0000, "BNE +1 insn: {:#010x}", words[1]);
@@ -9660,8 +9668,10 @@ mod tests {
         let guard_end = 16;
         assert_eq!(&with[..guard_end], &without[..guard_end], "shared guard");
         let words: Vec<u32> = with[guard_end..guard_end + 24]
-            .chunks_exact(4)
-            .map(|w| u32::from_le_bytes(w.try_into().unwrap()))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&w| u32::from_le_bytes(w))
             .collect();
         assert_eq!(
             words[0], 0xE1A0_C101,

--- a/crates/synth-backend/tests/i64_high_reg_zero_fill_916.rs
+++ b/crates/synth-backend/tests/i64_high_reg_zero_fill_916.rs
@@ -56,8 +56,10 @@ fn thumb(op: &ArmOp) -> Vec<u8> {
 
 fn halfwords(bytes: &[u8]) -> Vec<u16> {
     bytes
-        .chunks_exact(2)
-        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|&c| u16::from_le_bytes(c))
         .collect()
 }
 

--- a/crates/synth-cli/tests/fact_spec_bounds_494.rs
+++ b/crates/synth-cli/tests/fact_spec_bounds_494.rs
@@ -189,8 +189,10 @@ impl Compiled {
     /// Count aligned 16-bit words equal to `hw` in a function's region.
     fn halfword_count(&self, func: &str, hw: u16) -> usize {
         self.func(func)
-            .chunks_exact(2)
-            .filter(|c| u16::from_le_bytes([c[0], c[1]]) == hw)
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .filter(|&&c| u16::from_le_bytes(c) == hw)
             .count()
     }
 }

--- a/crates/synth-cli/tests/fact_spec_div_494.rs
+++ b/crates/synth-cli/tests/fact_spec_div_494.rs
@@ -213,8 +213,10 @@ impl Compiled {
             .funcs
             .get(func)
             .unwrap_or_else(|| panic!("symbol '{func}' missing from symtab"));
-        code.chunks_exact(2)
-            .filter(|c| u16::from_le_bytes([c[0], c[1]]) == hw)
+        code.as_chunks::<2>()
+            .0
+            .iter()
+            .filter(|&&c| u16::from_le_bytes(c) == hw)
             .count()
     }
 }

--- a/crates/synth-cli/tests/heterogeneous_table_676.rs
+++ b/crates/synth-cli/tests/heterogeneous_table_676.rs
@@ -81,8 +81,10 @@ fn test_676_heterogeneous_table_compiles_with_sidecar() {
             .unwrap_or_else(|| panic!("{target}: .synth.table_type_ids section missing (#676)"));
         let data = sidecar.data().expect("sidecar data");
         let ids: Vec<u32> = data
-            .chunks_exact(4)
-            .map(|w| u32::from_le_bytes(w.try_into().unwrap()))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|&w| u32::from_le_bytes(w))
             .collect();
         assert_eq!(
             ids,

--- a/crates/synth-cli/tests/multi_sp_rebase_707.rs
+++ b/crates/synth-cli/tests/multi_sp_rebase_707.rs
@@ -71,8 +71,10 @@ fn global_slots(path: &str) -> Vec<i32> {
         .expect(".data present")
         .data()
         .expect(".data bytes");
-    data.chunks_exact(4)
-        .map(|w| i32::from_le_bytes(w.try_into().unwrap()))
+    data.as_chunks::<4>()
+        .0
+        .iter()
+        .map(|&w| i32::from_le_bytes(w))
         .collect()
 }
 

--- a/crates/synth-cli/tests/proven_safe_bounds_901.rs
+++ b/crates/synth-cli/tests/proven_safe_bounds_901.rs
@@ -115,8 +115,10 @@ struct Compiled {
 impl Compiled {
     fn udf_count(&self) -> usize {
         self.probe
-            .chunks_exact(2)
-            .filter(|c| u16::from_le_bytes([c[0], c[1]]) == UDF0)
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .filter(|&&c| u16::from_le_bytes(c) == UDF0)
             .count()
     }
 }

--- a/crates/synth-cli/tests/sentinel_sweep_rq57.rs
+++ b/crates/synth-cli/tests/sentinel_sweep_rq57.rs
@@ -85,8 +85,10 @@ fn disasm_words(obj: &std::path::Path) -> Vec<String> {
         .data()
         .expect("read .text")
         .to_vec();
-    text.chunks_exact(4)
-        .map(|w| format!("{:08x}", u32::from_le_bytes([w[0], w[1], w[2], w[3]])))
+    text.as_chunks::<4>()
+        .0
+        .iter()
+        .map(|&w| format!("{:08x}", u32::from_le_bytes(w)))
         .collect()
 }
 

--- a/crates/synth-cli/tests/wast_compile.rs
+++ b/crates/synth-cli/tests/wast_compile.rs
@@ -726,8 +726,10 @@ fn relocatable_conditional_branch_targets_instruction_boundary_202() {
     // byte offset, distinguishing 16- from 32-bit Thumb-2 (top 5 bits of the
     // first halfword are 0b11101/0b11110/0b11111 for 32-bit).
     let hw: Vec<u16> = text
-        .chunks_exact(2)
-        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|&c| u16::from_le_bytes(c))
         .collect();
     let mut boundaries: std::collections::HashSet<i32> = std::collections::HashSet::new();
     let mut branches: Vec<(i32, i32)> = Vec::new(); // (byte_addr, halfword imm)


### PR DESCRIPTION
**Unblocks every open PR.** This is toolchain drift, not a code change.

## What happened

The Clippy job uses an unpinned `dtolnay/rust-toolchain@stable`, and the GitHub runner's stable moved **1.97.1 → 1.98.0** partway through 2026-08-20. Proven from the runs' own logs:

| run | time | rustc | Clippy |
|---|---|---|---|
| `main` @ `32c7e195` (the v0.58.0 release commit) | 06:27Z | **1.97.1** | pass |
| a branch adding **only a YAML file** (#1011) | 20:22Z | **1.98.0** | **fail** |

1.98.0 introduced `clippy::chunks_exact_to_as_chunks`, which `-D warnings` promotes to a hard error. Every open PR reds until this lands.

## CI reported one site. There were fifteen.

`cargo clippy` fails a crate on its first error and never reaches the rest, so the reported site is a **lower bound, not the set** — the same "first decline only" shape as `scan_for_decline` in the WCET model. The compiler enumerated the real set across three passes as each crate unblocked the next: 1 → 8 → 15, across `synth-abi`, `synth-backend`, `synth-backend-riscv` and seven `synth-cli` tests.

## Fixed, not suppressed

`slice::as_chunks` stabilised in **exactly 1.88.0** — read from the local std source's `#[rustc_const_stable(feature = "slice_as_chunks", since = "1.88.0")]`, and 1.88 is this workspace's MSRV. So the idiomatic fix is available without an `#[allow]` or an MSRV bump. Four `try_into().unwrap()` calls disappear as a side effect, since `as_chunks` yields `[u8; N]` directly.

## One subtlety, caught by the compiler

The closure rewrite **differs between `.map()` and `.filter()`**. After `.iter()`, map's closure receives `&[u8; N]`, so `|&c|` binds `[u8; N]` correctly — but filter's receives `&&[u8; N]`, so `|&c|` leaves a `&[u8; N]` and `from_le_bytes` rejects it. Three filter sites needed `|&&c|`.

A pattern that is right for one adapter and wrong for the neighbouring one is exactly what a local verification pass exists to catch. I could not have caught it locally at first: **rustc 1.96.1 does not have this lint at all**, so `cargo clippy` would have stayed silent whether the fix was right or wrong. I installed 1.98.0 to match CI and reproduced the failure before changing a line.

## Gates — both toolchains, exit codes captured directly

```
rustc 1.98.0:  clippy 0   cargo test --workspace 0  (146 result blocks, 0 failed)
rustc 1.96.1:  clippy 0   (does not trade one break for another)
fmt --check 0  ·  claim_check 49/49  ·  model_coverage_audit --check 0
```

**Byte-identity:** `frozen_codegen_bytes` is in the passing suite, so the 10 anchors are unchanged. These sites *decode* bytes; they do not emit them.

## Worth a follow-up, not fixed here

This is the **second** `dtolnay/rust-toolchain` break this session, from opposite causes: #984 bumped a **pinned** ref on the MC/DC job (where the ref *is* the compiler and the floors are counts over lowered wasm), and today an **unpinned** ref moved on its own under Clippy. The right answer differs per job — measurement jobs must pin, lint jobs arguably should float so new lints get caught — but a floating ref means a Rust release can red an unrelated PR at any moment, which is exactly what happened to a YAML-only change. A coherent float-vs-pin policy belongs alongside #965's dependency-hold enforcement in v0.59.

Refs #242.