### PR TITLE
plan(v0.59): add RQ-59-A64PANIC (#1013) and RQ-59-PARTIALCENSUS (#1017) from the 805-module corpus

### DIFF
--- a/artifacts/release-v0.59.yaml
+++ b/artifacts/release-v0.59.yaml
@@ -448,3 +448,93 @@ requirements:
       priority: should
       verification-track: differential
       issue: "#242"
+
+  - id: RQ-59-A64PANIC
+    type: system-req
+    title: "aarch64 ELF builder PANICS (exit 101) where ARM and RISC-V decline cleanly"
+    description: >
+      #1013. The aarch64 ELF builder PANICS — exit 101 with a RUST_BACKTRACE
+      note — when a retained function holds a relocation against a function the
+      backend legitimately declined. The DECISION is right: it must not ship an
+      unrelocated placeholder. The MECHANISM is wrong: a panic is not a decline.
+
+      This is a cross-backend PARITY gap with a known-good reference, the same
+      shape as RQ-59-WARALIAS: ARM and RISC-V already do the right thing on the
+      IDENTICAL module (clean exit 1, machine-readable reason). So the fix is to
+      make aarch64 refuse the way its siblings already refuse, not to invent a
+      policy.
+
+      PROVENANCE, which is why it earns a slot in a release it was not planned
+      for: it is the ONLY panic across a corpus of 805 REAL-WORLD wasm modules
+      (toolchain output and wasm.directory components, not spec fixtures) —
+      the other 787 aarch64 refusals were clean. One unhandled path in an
+      otherwise honest frontier.
+
+      RED-FIRST: the repro is a 4.7 KB real-world `httparse` fixture with 5
+      functions, already named in #1013 and present at
+      `loom/tests/corpus/httparse.wasm`. Land a test that FAILS on the panic
+      (asserting a clean non-zero exit and a reason string, NOT merely
+      "does not crash") before the fix. A test that only asserts absence of a
+      panic passes for the wrong reasons the moment the code path moves.
+
+      SCOPE DISCIPLINE: fix the mechanism, not the surrounding aarch64 gaps.
+      #1017 ranks import dispatch (~121 modules) and active data segments (44)
+      far above this one module — those are a v0.60 capability push, not this.
+    status: proposed
+    release: v0.59
+    tags: [soundness, aarch64, panic, cross-backend-parity, real-world-corpus]
+    links:
+      - type: derives-from
+        target: BR-001
+    fields:
+      req-type: functional
+      priority: must
+      verification-track: differential
+      issue: "#1013"
+
+  - id: RQ-59-PARTIALCENSUS
+    type: system-req
+    title: "Measure how much of the real-world decline rate is one-function-blocks-the-module"
+    description: >
+      #1017 surfaced a POLICY question synth has never answered, and asked it
+      without assuming the answer: when a module has one unsupported function,
+      should synth emit the functions that DID compile plus a machine-readable
+      manifest of what was skipped, or keep refusing the whole module?
+
+      Its own framing is worth preserving verbatim, because it names the fork:
+      "I can see the argument that a partially-compiled object must never ship
+      for a safety target — in which case the answer is 'no, by design', and
+      that is worth stating explicitly somewhere, because from outside it
+      currently looks like a capability gap when it is a policy."
+
+      THE DECISION IS DEFERRED PENDING MEASUREMENT (maintainer's call,
+      2026-08-21). This artifact is the measurement, NOT the feature.
+
+      WHAT TO MEASURE, and why the existing number is not enough: #1017 reports
+      ~151 of arm's 265 declines are of the form "N of M functions were skipped"
+      versus ~6 genuine feature refusals — but states plainly that this covers
+      only the TOP-12 decline reasons and is therefore a LOWER BOUND. Re-derive
+      it over the FULL decline set, per module:
+        a. how many modules decline solely because of one-function-blocks-module,
+        b. what fraction of FUNCTIONS in those modules compiled successfully,
+        c. the distribution — is it one bad function in hundreds, or half the
+           module? The policy answer differs sharply between those.
+        d. how many are components (of 101 pulled from wasm.directory, 101
+           declined, 88 for import dispatch) versus plain modules.
+
+      REPORT THE NUMBERS AND STOP. Do not implement `--allow-partial`. The
+      output of this artifact is the census that lets the policy question be
+      answered on evidence rather than intuition — and if the census shows the
+      one-function case is a small minority, the honest answer is that the
+      refusal is policy and should be DOCUMENTED as such rather than softened.
+    status: proposed
+    release: v0.59
+    tags: [measurement, real-world-corpus, policy, decline-honesty]
+    links:
+      - type: derives-from
+        target: NFR-002
+    fields:
+      req-type: process
+      priority: should
+      verification-track: static-analysis
+      issue: "#1017"


### PR DESCRIPTION
Two issues arrived from a stress-compile of **805 real-world wasm modules** (toolchain output plus wasm.directory components) against v0.58.0 — not spec fixtures. Triaged with the maintainer 2026-08-21.

## RQ-59-A64PANIC (#1013) — into this release

The aarch64 ELF builder **panics (exit 101)** when a retained function relocates against a declined one. The *decision* is right — never ship an unrelocated placeholder — but a panic is not a decline.

**ARM and RISC-V already exit 1 cleanly on the identical module.** So this is a cross-backend parity gap with a known-good reference, the same shape as `RQ-59-WARALIAS`, which is what makes it small and well-oracled rather than a design question.

It is also the **only panic in the entire 805-module corpus** — the other 787 aarch64 refusals were clean. One unhandled path in an otherwise honest frontier.

Red-first requirement worth noting: the test must assert a **clean non-zero exit and a reason string**, not merely "does not crash." A test that only asserts absence of a panic starts passing for the wrong reasons the moment the code path moves.

## RQ-59-PARTIALCENSUS (#1017) — measurement only, decision deferred

#1017 asks a policy question synth has never answered, and asks it without assuming the answer:

> I can see the argument that a partially-compiled object must never ship for a safety target — in which case the answer is "no, by design", and that is worth stating explicitly somewhere, because from outside it currently looks like a capability gap when it is a policy.

It reports **~151 of arm's 265 declines** are "N of M functions were skipped" versus ~6 genuine feature refusals — but states plainly that this covers only the **top-12 reasons and is a lower bound**.

So this artifact re-derives it over the full decline set — how many modules, what fraction of functions compiled, the *distribution* (one bad function in hundreds, or half the module? the policy answer differs sharply), components vs plain modules — and **reports**. It does not implement `--allow-partial`.

If the census shows the one-function case is a minority, the honest outcome is to **document the refusal as policy** rather than soften it.

## Deliberately not in v0.59

Per #1017's own ranking by modules blocked:

| modules | gap | tracked as |
|---|---|---|
| 124 | multi-memory | #406 |
| ~121 | aarch64 import dispatch (88 of 101 components) | #851 |
| 44 | aarch64 active data segments | #851 |

Those are a **v0.60 capability push**. #1017's headline — arm **66%**, riscv **14%**, aarch64 **1.6%** of 805 real-world modules — is the priority data that push should be built on, and it's the first time this project has had accept-rate numbers from real toolchain output rather than spec fixtures.

`claim_check` 49/49. Rivet artifact only, no code.

Refs #1013, #1017, #242.