### PR TITLE
chore(rivet): RQ-59-WARALIAS and RQ-59-ZEROINIT are implemented

### DIFF
--- a/artifacts/release-v0.59.yaml
+++ b/artifacts/release-v0.59.yaml
@@ -80,7 +80,7 @@ requirements:
       template. Check whether the RV32 guard's own coverage is non-vacuous
       while you are there — a guard nobody can observe firing is the defect
       class this project keeps finding.
-    status: proposed
+    status: implemented
     release: v0.59
     tags: [soundness, arm, war-aliasing, cross-backend-parity, fix-first]
     links:
@@ -111,7 +111,7 @@ requirements:
       first access being a READ, and here the first access is the WRITE — so
       zero-init does not rescue it. Any fix must not regress #970's fixture.
       RED-FIRST with an executed differential.
-    status: proposed
+    status: implemented
     release: v0.59
     tags: [soundness, arm, zero-init, info-disclosure, fix-first]
     links:


### PR DESCRIPTION
Both ARM soundness lanes shipped — #1015 and #1016 — so their rivet status moves to `implemented`.

Doing this **now rather than at release assembly**, because in v0.58 exactly this went stale: SELDSL and FLAKE both merged while their artifacts still read `proposed`, which made the release-readiness query under-report its own scope and would have surfaced as a late blocker on work finished days earlier.

Release readiness is a *query* over these statuses, not an opinion — so a stale status isn't bookkeeping, it's the gate lying.

v0.59 now stands at **2 of 11 implemented**.

`claim_check` 49/49. Rivet artifact only.

Refs #989, #990, #242.