### PR TITLE
RQ-59-MINORHOLD (#965): enforce the 0.x-minor dependency hold — disable-and-assert, fail-closed tested classifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,21 @@ jobs:
       # authoring: stubbing check_ratchet to return no failures kills 18 of 32.
       - name: Unit-test the claim-check engine itself (RQ-58-METRIC, #242)
         run: python3 scripts/test_claim_check.py
+      # #965 RQ-59-MINORHOLD: the dependabot 0.x-minor hold classifier is a
+      # NEW checker, and new checkers are new defect surfaces (five releases
+      # running found the defect in checking machinery). Table-driven potency
+      # test — breaking 0.x-minors (the #938 `object` and ordeal specimens),
+      # 0.0.x, majors, prereleases, downgrades, unparseable/empty metadata
+      # (the pre-#965 fail-open hole) and grouped updates must HOLD; 0.x
+      # patches and >=1.0 minors must AUTOMERGE, because a gate that blocks
+      # everything is as useless as one that blocks nothing.
+      # Mutation-verified at authoring: 5/5 seeded classifier mutations red
+      # the suite (transcript in the RQ-59-MINORHOLD PR). Lives in the
+      # already-REQUIRED claim-check job for the standing reason: a brand-new
+      # job is not a required context on main, so it could sit red blocking
+      # nothing.
+      - name: Unit-test the dependabot 0.x-minor hold classifier (RQ-59-MINORHOLD, #965)
+        run: python3 scripts/test_dependabot_minor_hold.py
       # #867: coverage OF the ISA semantics model. Re-derives
       # artifacts/model-coverage.json (static heuristic, documented in the
       # script) and fails if the committed artifact is stale or hand-edited;

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,10 +1,29 @@
-# Auto-merge safe Dependabot updates so patch/minor dep bumps never require
-# hand-gating (they were consuming the maintenance loop one-at-a-time — each
-# merge moved main, staling the next). MAJOR bumps of any dep are HELD for
-# manual review (the ordeal 0.9->0.12 major bump silently broke synth-verify at
-# merge; wasm-tooling majors corrupted Cargo.lock). Auto-merge only enables the
-# merge — GitHub still requires every branch-protection gate to pass first, so
-# a broken bump cannot land.
+# Auto-merge safe Dependabot updates so patch/true-minor dep bumps never
+# require hand-gating (they were consuming the maintenance loop one-at-a-time —
+# each merge moved main, staling the next). BREAKING-CLASS bumps — majors,
+# 0.x-minors (for a 0.x crate the MINOR is the de-facto major), and 0.0.x
+# bumps of any kind — are HELD: auto-merge is actively DISABLED and the job
+# ASSERTS it is off. The hold's success criterion is "auto-merge is off",
+# never "a comment was posted" (#965: the pre-enforcement hold skipped its own
+# enable step but left an already-enabled auto-merge armed on #938, and its
+# `|| true` label silently failed — auto-merge had to be hand-disabled four
+# times: #938, ordeal 0.9->0.12, #997, #998).
+#
+# The classifier is scripts/dependabot_minor_hold.py — a single tested source
+# (table-driven scripts/test_dependabot_minor_hold.py runs in the required
+# Claim Check job), FAIL-CLOSED: anything it cannot parse holds, and the
+# enable step fires only on the exact output `decision=automerge`, so a
+# crashed classifier (empty output) also lands on the hold path. The old
+# inline shell classifier failed OPEN when fetch-metadata returned an empty
+# previous-version (`case "" in 0.*)` matched nothing -> hold=false).
+#
+# A hold is a delay, never a block: merge a held bump BY HAND once the FULL
+# suite is green — branch protection requires all 9 contexts including
+# "Z3 Verification" (the separate `--features z3-solver` path; the ordeal
+# 0.9->0.12 damage only showed there) — the discriminator is CI, not a
+# maintainer's read of the diff. Auto-merge, where enabled, still requires
+# every branch-protection gate to pass first, so a broken compatible bump
+# cannot land either.
 name: Dependabot Auto-Merge
 on: pull_request_target
 permissions:
@@ -15,59 +34,65 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
+      # pull_request_target: this checks out the BASE ref (github.sha on the
+      # base branch), NEVER the PR head — the classifier script that runs
+      # below is always main's copy, not the PR's.
+      - uses: actions/checkout@v7
       - name: Fetch Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@v3
-      # A 0.x MINOR bump is BREAKING by semver convention (for 0.x the MINOR
-      # component is the de-facto major), but Dependabot reports it as
-      # `semver-minor` because the major component is still 0. That gap bit synth
-      # TWICE on the SAME dep: ordeal 0.9->0.12 (added `BvTerm::Urem`, broke every
-      # exhaustive match) and again 0.9->0.16 (#864 — landed with NO CI run and
-      # left `main` uncompilable). So: HOLD when the previous version is 0.x and
-      # the minor component changed.
-      - name: Classify 0.x-minor as breaking (hold)
-        id: zerox
+      - name: Classify the bump (cargo compatibility rule, fail-closed)
+        id: classify
         env:
           # Via env (never interpolated into the script body): this is a
           # pull_request_target workflow with contents:write, so no
-          # ${{ }} expansion inside `run:`.
+          # ${{ }} expansion inside `run:`. The script sanitizes what it
+          # echoes back, so a hostile version string cannot inject extra
+          # GITHUB_OUTPUT lines.
           PREV_VERSION: ${{ steps.meta.outputs.previous-version }}
           NEW_VERSION: ${{ steps.meta.outputs.new-version }}
-          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEPS_JSON: ${{ steps.meta.outputs.updated-dependencies-json }}
         run: |
-          hold=false
-          if [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
-            case "$PREV_VERSION" in
-              0.*)
-                pm=$(printf '%s' "$PREV_VERSION" | cut -d. -f2)
-                nm=$(printf '%s' "$NEW_VERSION" | cut -d. -f2)
-                [ "$pm" != "$nm" ] && hold=true
-                ;;
-            esac
-          fi
-          echo "hold=$hold" >> "$GITHUB_OUTPUT"
-          echo "0.x-minor hold=$hold ($PREV_VERSION -> $NEW_VERSION)"
-      - name: Enable auto-merge for patch + true-minor updates
-        if: (steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor') && steps.zerox.outputs.hold != 'true'
+          python3 scripts/dependabot_minor_hold.py \
+            --prev "$PREV_VERSION" --new "$NEW_VERSION" --deps-json "$DEPS_JSON" \
+            | tee -a "$GITHUB_OUTPUT"
+      - name: Enable auto-merge (compatible patch + >=1.0-minor upgrades only)
+        if: steps.classify.outputs.decision == 'automerge'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Comment + label held 0.x-minor bumps
-        if: steps.zerox.outputs.hold == 'true'
+      # ENFORCED HOLD (#965). Everything that is not exactly `automerge` —
+      # including an empty decision from a crashed classifier — lands here.
+      # Ordered so the enforcement comes first and is ASSERTED before any
+      # reporting: a hold that only skips its own enable step is vacuous when
+      # auto-merge was enabled by an earlier run, a re-pushed branch, or a
+      # hand click (#938 sat for three days with auto-merge ENABLED and two
+      # hold comments posted).
+      - name: HOLD — disable auto-merge and ASSERT it is off
+        if: steps.classify.outputs.decision != 'automerge'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PREV_VERSION: ${{ steps.meta.outputs.previous-version }}
-          NEW_VERSION: ${{ steps.meta.outputs.new-version }}
+          CLASS: ${{ steps.classify.outputs.class }}
+          REASON: ${{ steps.classify.outputs.reason }}
         run: |
-          gh pr edit "$PR_URL" --add-label "major-bump-hold" 2>/dev/null || true
-          gh pr comment "$PR_URL" --body "🔒 **0.x MINOR bump — held for manual review.** \`$PREV_VERSION\` → \`$NEW_VERSION\`: for a 0.x crate the MINOR component is the de-facto major, so this is BREAKING even though Dependabot labels it \`semver-minor\`. This gap broke synth twice on \`ordeal\` (0.9→0.12 added \`BvTerm::Urem\`, breaking every exhaustive match; 0.9→0.16 in #864 landed with no CI run and left main uncompilable). Build EVERY affected feature set (incl. \`--features z3-solver\`) and run the full \`synth-verify\` suite before merging."
-      - name: Comment + label major updates for manual review
-        if: steps.meta.outputs.update-type == 'version-update:semver-major'
-        run: |
-          gh pr edit "$PR_URL" --add-label "major-bump-hold" 2>/dev/null || true
-          gh pr comment "$PR_URL" --body "🔒 **Major version bump — held for manual review.** Not auto-merged: a major bump of a load-bearing dep (solver/wasm-tooling/proof) can break the build at merge (ordeal 0.9→0.12 added an enum variant; wasm-tooling majors corrupted Cargo.lock). Review the changelog + build the affected feature sets before merging."
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Nonzero here usually means auto-merge was not enabled; the ASSERT
+          # below is the gate, so this step's own exit is informational.
+          gh pr merge --disable-auto "$PR_URL" \
+            || echo "disable-auto returned nonzero (auto-merge likely not enabled); asserting actual state"
+          state="$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest')"
+          if [ "$state" != "null" ] && [ -n "$state" ]; then
+            echo "::error::HOLD DID NOT STICK — auto-merge is still enabled: $state"
+            exit 1
+          fi
+          echo "hold enforced: auto-merge confirmed OFF (class=$CLASS)"
+          # No '|| true': the label is the hold's durable, queryable marker;
+          # if labelling fails the job goes RED instead of pretending (#965
+          # defect 2 — the label silently failed because it did not exist).
+          gh pr edit "$PR_URL" --add-label "major-bump-hold"
+          gh pr comment "$PR_URL" --body-file - <<EOF
+          🔒 **HELD — not auto-mergeable** (class: \`$CLASS\`). $REASON
+
+          Auto-merge has been actively **disabled and asserted off** by the hold gate (#965). For a 0.x crate the MINOR component is the de-facto major (and for 0.0.x, the patch): \`ordeal\` 0.9→0.12 auto-merged as "minor" and hung Test+Z3 for days; \`object\` 0.39→0.40 (#938) broke 16 call sites across three unrelated newtype surfaces. Merge this BY HAND only once the **FULL suite is green, including the separate \`--features z3-solver\` path** (required context "Z3 Verification") — the discriminator is CI, not a read of the diff.
+          EOF

--- a/claims.yaml
+++ b/claims.yaml
@@ -2146,3 +2146,47 @@ claims:
         text: "[![Rust-test line coverage]"
       - kind: verbatim
         text: "It understates the testing that exists and is not a completeness measure"
+
+  # ---------------------------------------------------------------------------
+  # #965 RQ-59-MINORHOLD — the 0.x-minor dependency hold is ENFORCED, not
+  # commented. Auto-merge was hand-disabled four times (#938, ordeal 0.9->0.12,
+  # #997, #998) because the hold only skipped its own enable step and posted a
+  # comment; #938 sat three days with auto-merge ENABLED and two hold comments.
+  # The pins below hold the workflow's enforcement claim to its mechanics: the
+  # hold path actively disables auto-merge, ASSERTS the resulting state, labels
+  # without a swallowed failure, and delegates classification to the single
+  # tested script (fail-closed, exact-match enable condition). Weakening any of
+  # these is a visible claims.yaml diff, not a silent regression.
+  # ---------------------------------------------------------------------------
+  - id: SYNTH-DEPENDABOT-MINORHOLD-ENFORCED-965
+    doc: .github/workflows/dependabot-auto-merge.yml
+    text: "The hold's success criterion is \"auto-merge is off\","
+    evidence:
+      - kind: count-eq                       # the hold DISABLES, not just skips
+        pattern: 'gh pr merge --disable-auto'
+        glob: ['.github/workflows/dependabot-auto-merge.yml']
+        expect: 1
+      - kind: count-eq                       # ...and ASSERTS the resulting state
+        pattern: 'autoMergeRequest'
+        glob: ['.github/workflows/dependabot-auto-merge.yml']
+        expect: 2
+      - kind: count-eq                       # single classifier source, invoked
+        pattern: 'python3 scripts/dependabot_minor_hold\.py'
+        glob: ['.github/workflows/dependabot-auto-merge.yml']
+        expect: 1
+      - kind: count-eq                       # enable fires ONLY on the exact
+        pattern: "decision == 'automerge'"   # automerge output (fail-closed:
+        glob: ['.github/workflows/dependabot-auto-merge.yml']
+        expect: 1                            # empty/crashed classifier -> hold)
+      - kind: count-eq                       # the #965 silent-label defect
+        pattern: 'add-label.*\|\| true'      # stays dead: no swallowed label
+        glob: ['.github/workflows/dependabot-auto-merge.yml']
+        expect: 0
+      - kind: file-exists
+        path: scripts/dependabot_minor_hold.py
+      - kind: file-exists
+        path: scripts/test_dependabot_minor_hold.py
+      - kind: count-eq                       # potency test wired in the
+        pattern: 'test_dependabot_minor_hold\.py'  # required Claim Check job
+        glob: ['.github/workflows/ci.yml']
+        expect: 1

--- a/scripts/dependabot_minor_hold.py
+++ b/scripts/dependabot_minor_hold.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Classify a Dependabot version bump: auto-mergeable, or HELD? (#965)
+
+WHY THIS EXISTS. Dependabot labels a bump by semver POSITION, but cargo's
+compatibility rule is the LEFTMOST NONZERO component: for a 0.x crate the
+minor is the de-facto major, and for a 0.0.x crate even the patch is. That
+gap has bitten synth repeatedly — ordeal 0.9->0.12 auto-merged as "minor" and
+hung Test+Z3 for days; `object` 0.39->0.40 (#938) was labelled minor and broke
+16 call sites across three unrelated newtype surfaces. The hold used to be an
+inline shell fragment in dependabot-auto-merge.yml that (a) could not be unit
+tested and (b) FAILED OPEN when fetch-metadata returned an empty
+previous-version (`case "" in 0.*)` does not match, so hold=false). This
+script is the single classifier source, invoked by the workflow and driven by
+scripts/test_dependabot_minor_hold.py in the required Claim Check job.
+
+DECISION CONTRACT (fail-closed):
+  decision=automerge  ONLY for a cargo-compatible upgrade — same leftmost
+                      nonzero component, no prerelease on either side, a real
+                      upgrade (new > prev). Classes: `patch`, `minor`.
+  decision=hold       EVERYTHING else, including anything this script cannot
+                      parse. Classes: `zerox-minor` (0.x minor changed),
+                      `zerox-zero` (0.0.x — every bump is breaking),
+                      `major`, `prerelease`, `downgrade`, `no-change`,
+                      `unparseable`, `grouped-hold` (any member of a grouped
+                      update holds).
+
+The consumer (dependabot-auto-merge.yml) enables auto-merge ONLY on the exact
+string `decision=automerge`; every other outcome — including this script
+crashing, which leaves the output empty — lands on the hold path, which
+actively DISABLES auto-merge and asserts it is off. Holding is a delay, never
+a block: a held bump merges by hand once the FULL suite is green, including
+the separate `--features z3-solver` path (required context "Z3 Verification").
+
+Output (GITHUB_OUTPUT `key=value` lines, sanitized single-line text):
+  decision=automerge|hold
+  class=<one of the classes above>
+  reason=<one human-readable sentence>
+
+Stdlib only. Exit 0 whenever a decision was printed; exit 2 on CLI misuse.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+# Version strings arrive from Dependabot metadata on a pull_request_target
+# workflow — treat them as untrusted input. Sanitize anything echoed back so
+# a hostile string cannot inject extra GITHUB_OUTPUT lines or control chars.
+_UNSAFE_VERSION_CHARS = re.compile(r"[^A-Za-z0-9.+_\-]")
+_LINE_BREAKS = re.compile(r"[\r\n]+")
+
+
+def sanitize_version(s: str, limit: int = 64) -> str:
+    return _UNSAFE_VERSION_CHARS.sub("", s or "")[:limit]
+
+
+def parse_version(s: str):
+    """Parse a version into (major, minor, patch, has_prerelease) or None.
+
+    Lenient on shape (``0.39`` and ``v4`` are real Dependabot outputs: cargo
+    manifests carry two-component reqs, github-actions tags carry ``v``
+    prefixes; missing components read as 0), strict on content (any
+    non-ASCII-numeric release component -> None -> the caller HOLDS). Build
+    metadata (``+...``) is compatibility-irrelevant and stripped; a
+    prerelease (``-...``) is flagged, never ignored.
+    """
+    s = (s or "").strip()
+    if not s:
+        return None
+    if s[0] in ("v", "V"):
+        s = s[1:]
+    s = s.split("+", 1)[0]  # build metadata: ignored for compatibility
+    prerelease = False
+    if "-" in s:
+        s, _ = s.split("-", 1)
+        prerelease = True
+    parts = s.split(".")
+    if not parts or len(parts) > 3:
+        return None
+    nums = []
+    for p in parts:
+        # ASCII-digit-strict: `p.isdigit()` alone admits e.g. Unicode digits.
+        if not p or not all("0" <= c <= "9" for c in p):
+            return None
+        nums.append(int(p, 10))
+    while len(nums) < 3:
+        nums.append(0)
+    return nums[0], nums[1], nums[2], prerelease
+
+
+def classify(prev: str, new: str):
+    """Return (decision, class, reason) for a single PREV -> NEW bump."""
+    shown = f"{sanitize_version(prev) or '<empty>'} -> {sanitize_version(new) or '<empty>'}"
+    p = parse_version(prev)
+    n = parse_version(new)
+    if p is None or n is None:
+        return (
+            "hold",
+            "unparseable",
+            f"cannot parse {shown}; an unclassifiable bump fails CLOSED "
+            "(the pre-#965 shell classifier failed OPEN on an empty previous-version)",
+        )
+    pmaj, pmin, ppat, ppre = p
+    nmaj, nmin, npat, npre = n
+    if ppre or npre:
+        return (
+            "hold",
+            "prerelease",
+            f"{shown} involves a prerelease; prerelease compatibility is undefined",
+        )
+    if (pmaj, pmin, ppat) == (nmaj, nmin, npat):
+        return ("hold", "no-change", f"{shown} is not an upgrade")
+    if (nmaj, nmin, npat) < (pmaj, pmin, ppat):
+        return ("hold", "downgrade", f"{shown} is a downgrade, not an upgrade")
+    if pmaj != nmaj:
+        return ("hold", "major", f"{shown} changes the major component")
+    if pmaj == 0 and pmin != nmin:
+        return (
+            "hold",
+            "zerox-minor",
+            f"{shown}: for a 0.x crate the MINOR is the de-facto major "
+            "(ordeal 0.9->0.12; object 0.39->0.40 / #938)",
+        )
+    if pmaj == 0 and pmin == 0:
+        return (
+            "hold",
+            "zerox-zero",
+            f"{shown}: for a 0.0.x crate EVERY bump is breaking by cargo's "
+            "compatibility rule",
+        )
+    if pmin != nmin:
+        return ("automerge", "minor", f"{shown} is a compatible >=1.0 minor upgrade")
+    return ("automerge", "patch", f"{shown} is a compatible patch upgrade")
+
+
+def classify_all(prev: str, new: str, deps_json: str = ""):
+    """Classify a whole PR: every member of a grouped update must be
+    auto-mergeable, or the PR holds. Falls back to the single prev/new pair
+    when the JSON is empty/absent; a PR with NO classifiable input holds
+    (via classify's unparseable arm)."""
+    pairs = []
+    deps_json = (deps_json or "").strip()
+    if deps_json:
+        try:
+            entries = json.loads(deps_json)
+        except ValueError:
+            return ("hold", "unparseable", "updated-dependencies-json did not parse")
+        if not isinstance(entries, list):
+            return ("hold", "unparseable", "updated-dependencies-json is not a list")
+        for e in entries:
+            if not isinstance(e, dict):
+                return (
+                    "hold",
+                    "unparseable",
+                    "updated-dependencies-json entry is not an object",
+                )
+            pairs.append((str(e.get("prevVersion", "")), str(e.get("newVersion", ""))))
+    if not pairs:
+        pairs = [(prev, new)]
+    verdicts = [classify(p, n) for p, n in pairs]
+    holds = [v for v in verdicts if v[0] != "automerge"]
+    if holds:
+        decision, cls, reason = holds[0]
+        if len(pairs) > 1:
+            return (
+                "hold",
+                "grouped-hold",
+                f"{len(holds)}/{len(pairs)} grouped bumps hold; first: {reason}",
+            )
+        return (decision, cls, reason)
+    if len(pairs) > 1:
+        return (
+            "automerge",
+            verdicts[0][1],
+            f"all {len(pairs)} grouped bumps are compatible upgrades",
+        )
+    return verdicts[0]
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--prev", default="", help="previous version (fetch-metadata previous-version)"
+    )
+    ap.add_argument(
+        "--new", dest="new_", default="", help="new version (fetch-metadata new-version)"
+    )
+    ap.add_argument(
+        "--deps-json",
+        default="",
+        help="fetch-metadata updated-dependencies-json (grouped updates)",
+    )
+    args = ap.parse_args(argv)
+    decision, cls, reason = classify_all(args.prev, args.new_, args.deps_json)
+    print(f"decision={decision}")
+    print(f"class={cls}")
+    print(f"reason={_LINE_BREAKS.sub(' ', reason)[:300]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test_dependabot_minor_hold.py
+++ b/scripts/test_dependabot_minor_hold.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Unit tests for dependabot_minor_hold.py — the 0.x-minor hold classifier (#965).
+
+WHY THIS FILE EXISTS. A new checker is a new defect surface (five consecutive
+releases found the defect in checking machinery, not the checked code), and
+this classifier is what stands between a breaking "semver-minor" bump and an
+unattended squash-merge onto main. The precedent is test_claim_check.py and
+test_mcdc_gate.py: every decision arm is driven here — the HOLDs (0.x-minor,
+0.0.x, major, prerelease, downgrade, no-change, unparseable, grouped) AND the
+ALLOWs (0.x patch, >=1.0 minor/patch), because a gate that blocks everything
+is as useless as one that blocks nothing.
+
+Two arms carry named incident provenance:
+  * 0.39.1 -> 0.40.0 is the `object` bump (#938): semver called it minor,
+    it broke 16 call sites across three unrelated newtype surfaces.
+  * 0.9.1 -> 0.12.0 is the ordeal bump: auto-merged as "minor", hung Test+Z3
+    for 4-6 hours across days.
+  * "" -> anything is the fetch-metadata empty-previous-version hole from
+    #965: the old shell `case "" in 0.*)` failed OPEN; this classifier must
+    fail CLOSED.
+
+Stdlib `unittest` only.
+
+    python3 scripts/test_dependabot_minor_hold.py    (wired in the Claim Check CI job)
+"""
+
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+
+SCRIPTS = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+
+from dependabot_minor_hold import classify, classify_all, parse_version  # noqa: E402
+
+SCRIPT = SCRIPTS / "dependabot_minor_hold.py"
+
+# (prev, new, expected_decision, expected_class, note)
+TABLE = [
+    # --- the incident specimens: 0.x minor is the de-facto major -> HOLD ---
+    ("0.39.1", "0.40.0", "hold", "zerox-minor", "#938 `object`: 16 broken call sites"),
+    ("0.39", "0.40", "hold", "zerox-minor", "two-component cargo req form"),
+    ("0.9.1", "0.12.0", "hold", "zerox-minor", "ordeal: hung Test+Z3 for days"),
+    ("0.9", "0.16", "hold", "zerox-minor", "#864 shape: landed with no CI run"),
+    ("0.1.0", "0.2.0", "hold", "zerox-minor", "generic 0.x minor"),
+    ("0.0.3", "0.1.0", "hold", "zerox-minor", "0.0.x -> 0.1.x crosses the minor"),
+    # --- 0.0.x: EVERY bump is breaking by cargo's compatibility rule -> HOLD ---
+    ("0.0.3", "0.0.4", "hold", "zerox-zero", "0.0.x patch is the de-facto major"),
+    ("0.0.1", "0.0.9", "hold", "zerox-zero", "0.0.x multi-step"),
+    # --- true patches and >=1.0 minors: MUST auto-merge (a gate that blocks
+    # --- everything is as useless as one that blocks nothing) ---
+    ("0.39.1", "0.39.2", "automerge", "patch", "0.x PATCH is compatible"),
+    ("0.9.1", "0.9.2", "automerge", "patch", "ordeal-pin-shaped patch is fine"),
+    ("1.2.3", "1.2.4", "automerge", "patch", ">=1.0 patch"),
+    ("1.2.3", "1.3.0", "automerge", "minor", ">=1.0 REAL minor is compatible"),
+    ("1.2", "1.3", "automerge", "minor", "two-component >=1.0 minor"),
+    ("2.4.9", "2.5.0", "automerge", "minor", "minor with patch reset"),
+    ("1.2.3+build5", "1.2.4+build9", "automerge", "patch", "build metadata stripped"),
+    # --- majors: HOLD (pre-existing behavior, now same classifier) ---
+    ("1.2.3", "2.0.0", "hold", "major", "classic major"),
+    ("0.9.1", "1.0.0", "hold", "major", "0.x -> 1.0 graduation is a major"),
+    ("3", "4", "hold", "major", "github-actions single-component tag"),
+    ("v3", "v4", "hold", "major", "github-actions v-prefixed tag"),
+    # --- v-prefixed non-majors classify by the same rule ---
+    ("v0.39", "v0.40", "hold", "zerox-minor", "v-prefix does not hide a 0.x minor"),
+    ("v1.2.3", "v1.2.4", "automerge", "patch", "v-prefix patch"),
+    # --- prerelease: compatibility undefined -> HOLD ---
+    ("1.2.3-rc.1", "1.2.3", "hold", "prerelease", "prerelease graduation"),
+    ("0.9.0", "0.10.0-beta.1", "hold", "prerelease", "bump INTO a prerelease"),
+    ("1.2.3-alpha", "1.2.4-alpha", "hold", "prerelease", "prerelease to prerelease"),
+    # --- degenerate inputs: fail CLOSED ---
+    ("", "0.40.0", "hold", "unparseable", "#965 empty previous-version hole"),
+    ("0.39.1", "", "hold", "unparseable", "empty new-version"),
+    ("", "", "hold", "unparseable", "no metadata at all"),
+    ("not-a-version", "0.40.0", "hold", "unparseable", "garbage prev"),
+    ("0.39.1", "0.40.0.1", "hold", "unparseable", "four components"),
+    ("0.③9", "0.40", "hold", "unparseable", "unicode digit rejected (ASCII-strict)"),
+    ("1.2.3", "1.2.3", "hold", "no-change", "not an upgrade"),
+    ("1.3.0", "1.2.9", "hold", "downgrade", ">=1.0 downgrade fails closed"),
+    ("0.39.2", "0.39.1", "hold", "downgrade", "0.x downgrade fails closed"),
+]
+
+
+class TestClassifierTable(unittest.TestCase):
+    def test_table(self):
+        for prev, new, want_decision, want_class, note in TABLE:
+            with self.subTest(prev=prev, new=new, note=note):
+                decision, cls, reason = classify(prev, new)
+                self.assertEqual(decision, want_decision, f"{prev}->{new}: {reason}")
+                self.assertEqual(cls, want_class, f"{prev}->{new}: {reason}")
+
+    def test_table_covers_both_verdicts(self):
+        """The table must exercise BOTH arms — a table that only holds (or
+        only allows) tests half a gate."""
+        decisions = {want for _, _, want, _, _ in TABLE}
+        self.assertEqual(decisions, {"hold", "automerge"})
+        holds = sum(1 for _, _, d, _, _ in TABLE if d == "hold")
+        allows = sum(1 for _, _, d, _, _ in TABLE if d == "automerge")
+        self.assertGreaterEqual(holds, 10)
+        self.assertGreaterEqual(allows, 5)
+
+
+class TestGroupedUpdates(unittest.TestCase):
+    """fetch-metadata updated-dependencies-json: one held member holds the PR."""
+
+    def test_grouped_all_compatible_automerges(self):
+        deps = json.dumps(
+            [
+                {"dependencyName": "a", "prevVersion": "1.2.3", "newVersion": "1.2.4"},
+                {"dependencyName": "b", "prevVersion": "0.39.1", "newVersion": "0.39.2"},
+            ]
+        )
+        decision, cls, _ = classify_all("", "", deps)
+        self.assertEqual(decision, "automerge")
+
+    def test_grouped_one_zerox_minor_holds_the_pr(self):
+        deps = json.dumps(
+            [
+                {"dependencyName": "a", "prevVersion": "1.2.3", "newVersion": "1.2.4"},
+                {"dependencyName": "object", "prevVersion": "0.39.1", "newVersion": "0.40.0"},
+            ]
+        )
+        decision, cls, reason = classify_all("", "", deps)
+        self.assertEqual(decision, "hold")
+        self.assertEqual(cls, "grouped-hold")
+        self.assertIn("de-facto major", reason)
+
+    def test_grouped_entry_missing_versions_fails_closed(self):
+        deps = json.dumps([{"dependencyName": "a"}])
+        decision, cls, _ = classify_all("", "", deps)
+        self.assertEqual((decision, cls), ("hold", "unparseable"))
+
+    def test_malformed_json_fails_closed(self):
+        for bad in ("{not json", '"a string"', '{"an": "object"}', "[42]"):
+            with self.subTest(bad=bad):
+                decision, cls, _ = classify_all("1.2.3", "1.2.4", bad)
+                self.assertEqual(decision, "hold", bad)
+                self.assertEqual(cls, "unparseable", bad)
+
+    def test_empty_json_falls_back_to_single_pair(self):
+        self.assertEqual(classify_all("1.2.3", "1.2.4", "")[0], "automerge")
+        self.assertEqual(classify_all("0.39.1", "0.40.0", "  ")[0], "hold")
+        # empty LIST also falls back — and the empty pair fails closed
+        self.assertEqual(classify_all("", "", "[]")[0], "hold")
+
+
+class TestParseVersion(unittest.TestCase):
+    def test_lenient_shapes(self):
+        self.assertEqual(parse_version("0.39"), (0, 39, 0, False))
+        self.assertEqual(parse_version("v4"), (4, 0, 0, False))
+        self.assertEqual(parse_version("1.2.3"), (1, 2, 3, False))
+        self.assertEqual(parse_version("1.2.3+meta"), (1, 2, 3, False))
+        self.assertEqual(parse_version("1.2.3-rc.1"), (1, 2, 3, True))
+
+    def test_strict_content(self):
+        for bad in ("", "  ", "1.2.3.4", "1.x", "one.two", "1..2", ".", "1.2.3;rm"):
+            with self.subTest(bad=bad):
+                self.assertIsNone(parse_version(bad))
+
+
+class TestCliContract(unittest.TestCase):
+    """The workflow consumes stdout as GITHUB_OUTPUT lines and enables
+    auto-merge ONLY on the exact string decision=automerge. Pin that surface."""
+
+    def run_cli(self, *args):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_hold_output_shape(self):
+        r = self.run_cli("--prev", "0.39.1", "--new", "0.40.0")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        lines = r.stdout.splitlines()
+        self.assertEqual(lines[0], "decision=hold")
+        self.assertEqual(lines[1], "class=zerox-minor")
+        self.assertTrue(lines[2].startswith("reason="))
+        self.assertEqual(len(lines), 3)
+
+    def test_automerge_output_shape(self):
+        r = self.run_cli("--prev", "1.2.3", "--new", "1.3.0")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(r.stdout.splitlines()[0], "decision=automerge")
+
+    def test_no_args_fails_closed(self):
+        r = self.run_cli()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(r.stdout.splitlines()[0], "decision=hold")
+
+    def test_hostile_version_cannot_inject_output_lines(self):
+        r = self.run_cli("--prev", "0.1\ndecision=automerge", "--new", "0.2.0")
+        self.assertEqual(r.stdout.splitlines()[0], "decision=hold")
+        self.assertEqual(
+            [ln for ln in r.stdout.splitlines() if ln.startswith("decision=")],
+            ["decision=hold"],
+            "a version string must not be able to smuggle a second decision line",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Refs #965 · rivet `RQ-59-MINORHOLD` (`artifacts/release-v0.59.yaml`) · epic context: four hand-disables of auto-merge (#938, ordeal 0.9→0.12, #997, #998)

## What was broken (the three defects, per #965)

1. **The hold only skipped its own enable step.** Skipping an enable is not a disable: #938 sat three days with auto-merge ENABLED and two hold comments posted. Two failing checks away from rerun-flake, that PR squash-merges itself.
2. **The label silently failed.** `--add-label "major-bump-hold" 2>/dev/null || true` — and the label did not exist in the repo, so the hold's only durable, queryable marker never landed.
3. **The classifier failed OPEN.** `case "" in 0.*)` matches nothing, so an empty fetch-metadata `previous-version` produced `hold=false` on a semver-minor bump.

## The enforcement

- **Single tested classifier**: `scripts/dependabot_minor_hold.py`, cargo's compatibility rule (leftmost nonzero component), **fail-closed** — 0.x-minor, 0.0.x-any, major, prerelease, downgrade, no-change, unparseable/empty metadata, and any held member of a grouped update all HOLD. The workflow's enable step fires only on the exact output `decision=automerge`; a crashed classifier leaves the output empty and lands on the hold path.
- **The hold path enforces, then reports**: `gh pr merge --disable-auto` first, then **ASSERTS** `autoMergeRequest == null` and reds the job if the disable did not stick — the success criterion is "auto-merge is off", never "a comment was posted". Label added with **no** `|| true` (the `major-bump-hold` label now exists in the repo — created as part of this lane); a labelling failure is a red job.
- **Full suite green stays mechanical**: a hold is a *delay*, not a block — a held bump merges BY HAND once branch protection's 9 required contexts are green, which **already include `Z3 Verification`** (the separate `--features z3-solver` path where the ordeal 0.9→0.12 damage showed). The hold comment states exactly that.
- **Potency wiring**: 34-case classifier table + grouped/CLI/output-injection tests (`scripts/test_dependabot_minor_hold.py`) run in the **required** Claim Check job; `claims.yaml` pin `SYNTH-DEPENDABOT-MINORHOLD-ENFORCED-965` holds the workflow's enforcement mechanics to the tree (disable-auto present, assert present, exact-match enable condition, zero swallowed-label patterns, classifier invoked once, test wired once).

## Transcript — the gate REFUSING (0.x-minor and friends)

```console
$ python3 scripts/dependabot_minor_hold.py --prev '0.39.1' --new '0.40.0'   # the object bump, #938
decision=hold
class=zerox-minor
reason=0.39.1 -> 0.40.0: for a 0.x crate the MINOR is the de-facto major (ordeal 0.9->0.12; object 0.39->0.40 / #938)

$ python3 scripts/dependabot_minor_hold.py --prev '0.9.1' --new '0.12.0'    # the ordeal bump
decision=hold
class=zerox-minor

$ python3 scripts/dependabot_minor_hold.py --prev '' --new '0.40.0'         # the fail-open hole, now CLOSED
decision=hold
class=unparseable
reason=cannot parse <empty> -> 0.40.0; an unclassifiable bump fails CLOSED (the pre-#965 shell classifier failed OPEN on an empty previous-version)

$ python3 scripts/dependabot_minor_hold.py --prev '0.0.3' --new '0.0.4'     # 0.0.x: every bump is breaking
decision=hold
class=zerox-zero
```

Hold-**step** rehearsal — the `run:` bodies extracted **verbatim from the workflow YAML** (not a copy) and executed against a mock `gh` holding auto-merge state:

```console
=== SCENARIO A: 0.x-minor bump, auto-merge PRE-ENABLED (the exact #938 shape) ===
mock-gh: auto-merge disabled
hold enforced: auto-merge confirmed OFF (class=zerox-minor)
mock-gh: label added: pr edit .../pull/938 --add-label major-bump-hold
mock-gh: comment posted (body elided)
step exit=0 (0 = hold enforced)
final auto-merge state: null

=== SCENARIO B (potency): disable-auto SILENTLY BROKEN — assert must go RED ===
mock-gh: --disable-auto ACCEPTED but did nothing (simulated defect)
::error::HOLD DID NOT STICK — auto-merge is still enabled: {"enabledBy":"dependabot","mergeMethod":"SQUASH"}
step exit=1 (nonzero = the assert CAN fail)

=== SCENARIO D (potency): label missing (the pre-#965 silent-swallow state) — must go RED ===
mock-gh: auto-merge disabled
hold enforced: auto-merge confirmed OFF (class=zerox-minor)
mock-gh: HTTP 422 could not add label: 'major-bump-hold' not found
step exit=1 (nonzero = no more silent label failure)
```

The rehearsal earned its keep at authoring: the first draft's multi-line `--body` string **escaped the YAML block scalar** (continuation lines at column 0 silently truncated the step at `$REASON`), which only executing the extracted step caught — fixed with an indented `--body-file -` heredoc, re-rehearsed green.

## Transcript — the gate ALLOWING what it must (a gate that blocks everything is as useless as one that blocks nothing)

```console
$ python3 scripts/dependabot_minor_hold.py --prev '0.39.1' --new '0.39.2'   # 0.x PATCH
decision=automerge
class=patch
reason=0.39.1 -> 0.39.2 is a compatible patch upgrade

$ python3 scripts/dependabot_minor_hold.py --prev '1.2.3' --new '1.3.0'     # >=1.0 REAL minor
decision=automerge
class=minor
reason=1.2.3 -> 1.3.0 is a compatible >=1.0 minor upgrade

=== SCENARIO E: compatible bumps take the ENABLE path ===
mock-gh: pr merge --auto --squash .../pull/938
enable step exit=0
```

## Classifier test table (`scripts/test_dependabot_minor_hold.py`, in the required Claim Check job)

| prev → new | decision | class | note |
|---|---|---|---|
| 0.39.1 → 0.40.0 | hold | zerox-minor | #938 `object`: 16 broken call sites |
| 0.39 → 0.40 | hold | zerox-minor | two-component cargo req form |
| 0.9.1 → 0.12.0 | hold | zerox-minor | ordeal: hung Test+Z3 for days |
| 0.9 → 0.16 | hold | zerox-minor | #864 shape |
| 0.1.0 → 0.2.0 | hold | zerox-minor | generic 0.x minor |
| 0.0.3 → 0.1.0 | hold | zerox-minor | crosses the minor |
| 0.0.3 → 0.0.4 | hold | zerox-zero | 0.0.x patch is the de-facto major |
| 0.0.1 → 0.0.9 | hold | zerox-zero | 0.0.x multi-step |
| 0.39.1 → 0.39.2 | automerge | patch | 0.x PATCH is compatible |
| 0.9.1 → 0.9.2 | automerge | patch | ordeal-pin-shaped patch is fine |
| 1.2.3 → 1.2.4 | automerge | patch | >=1.0 patch |
| 1.2.3 → 1.3.0 | automerge | minor | >=1.0 REAL minor |
| 1.2 → 1.3 | automerge | minor | two-component >=1.0 minor |
| 2.4.9 → 2.5.0 | automerge | minor | minor with patch reset |
| 1.2.3+build5 → 1.2.4+build9 | automerge | patch | build metadata stripped |
| 1.2.3 → 2.0.0 | hold | major | classic major |
| 0.9.1 → 1.0.0 | hold | major | 0.x → 1.0 graduation |
| 3 → 4 | hold | major | github-actions single-component tag |
| v3 → v4 | hold | major | v-prefixed tag |
| v0.39 → v0.40 | hold | zerox-minor | v-prefix does not hide a 0.x minor |
| v1.2.3 → v1.2.4 | automerge | patch | v-prefix patch |
| 1.2.3-rc.1 → 1.2.3 | hold | prerelease | prerelease graduation |
| 0.9.0 → 0.10.0-beta.1 | hold | prerelease | bump INTO a prerelease |
| 1.2.3-alpha → 1.2.4-alpha | hold | prerelease | prerelease to prerelease |
| "" → 0.40.0 | hold | unparseable | the #965 empty-previous-version hole |
| 0.39.1 → "" | hold | unparseable | empty new-version |
| "" → "" | hold | unparseable | no metadata at all |
| not-a-version → 0.40.0 | hold | unparseable | garbage prev |
| 0.39.1 → 0.40.0.1 | hold | unparseable | four components |
| 0.③9 → 0.40 | hold | unparseable | unicode digit rejected (ASCII-strict) |
| 1.2.3 → 1.2.3 | hold | no-change | not an upgrade |
| 1.3.0 → 1.2.9 | hold | downgrade | fail-closed |
| 0.39.2 → 0.39.1 | hold | downgrade | fail-closed |

Plus grouped-update tests (one held member holds the PR; malformed/missing-version JSON fails closed; all-compatible group automerges) and a CLI contract test that a hostile version string cannot inject a second `decision=` line into `GITHUB_OUTPUT`.

**Mutation check** (transcript from authoring — the suite can actually fail):

```
mutation: zerox-minor arm returns automerge  -> KILLED  FAILED (failures=10)
mutation: unparseable arm fails OPEN         -> KILLED  FAILED (failures=11)
mutation: grouped hold dropped               -> KILLED  FAILED (failures=1)
mutation: 0.0.x arm returns automerge        -> KILLED  FAILED (failures=2)
mutation: prerelease arm returns automerge   -> KILLED  FAILED (failures=2)
restored original -> OK
```

**Negative controls on the claims.yaml pin** (the pin can actually fail):

```
reintroduce silent label (`|| true`)   -> RED  FAIL SYNTH-DEPENDABOT-MINORHOLD-ENFORCED-965
delete the disable-auto call           -> RED  FAIL SYNTH-DEPENDABOT-MINORHOLD-ENFORCED-965
widen the enable condition (fail-open) -> RED  FAIL SYNTH-DEPENDABOT-MINORHOLD-ENFORCED-965
restored -> 50/50 claims hold.
```

## Deliberately left unenforced (named, with reasons)

- **A human re-enabling auto-merge after the hold ran.** No event re-triggers the workflow between dependabot pushes (it re-fires and re-disables on every `synchronize`). A deliberate human click is a decision, not the forgotten-discretion failure mode this lane closes; making it impossible would require a conditional *required* check, refused below.
- **No new required status context.** The hold does not add a red required check on held PRs: under `enforce_admins` a required context that stays red (or never runs) deadlocks ALL merges — including the legitimate hand-merge after the full suite is green — turning a *delay* into a *block*. "Full suite green" is already mechanical via the existing 9 required contexts (incl. `Z3 Verification`, the `--features z3-solver` path).
- **Advisory (non-required) oracle jobs** are not forced green before a hand-merge — unchanged from the standing definition of the merge gate; widening the required set is out of this lane's scope.
- **`@dependabot merge` comment-commands** bypass this workflow's auto-merge but not branch protection; they are human-issued and covered by the same reasoning as the first bullet.
- **Scope guard**: `.github/dependabot.yml` untouched; no held bump re-litigated.

## Gates

- `cargo fmt --all` (clean) · `cargo clippy --workspace --all-targets -- -D warnings` · `cargo test --workspace` — no Rust source touched by this diff; exit codes captured directly.
- `python3 scripts/claim_check.py claims.yaml` → **50/50 claims hold** · `python3 scripts/model_coverage_audit.py --check` → ok.
- `actionlint` clean on the modified `dependabot-auto-merge.yml` (the `ci.yml` runner-label notes are pre-existing self-hosted labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
