### PR TITLE
RQ-59-REACH (#242): census verdict — do NOT widen the op model; unmodeled-op is a long tail, the named blocker is a missing RMW tie (Movt/SelectMove)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -2560,7 +2560,37 @@ artifacts:
            op carrying one is DECLINED by name, not guessed at.
       An op that fails a check keeps its decline and the decline is RENAMED so
       the residual stays actionable — the decline MOVES, it is never deleted.
-    status: proposed
+
+      IMPLEMENTED (v0.58, PR #917) — the paragraph above is the plan it shipped
+      to: `liveness::pair_effect` + `pair_early_clobber` + `pair_low_reg_only`
+      landed, applied 316 -> 411, and 114 relocatable functions moved out of
+      `unmodeled-op`.
+
+      MEASURED OUTCOME (v0.59 census, RQ-59-REACH — the re-derived per-function
+      histogram over the same corpus family, now 159 ARM-compilable fixtures /
+      697 functions, `--relocatable` cortex-m4; the v0.54 run was 633 functions
+      of the same growing corpus): the colourer now HANDLES 524 of 697
+      functions (75 %) — 455 rewritten + 69 `identity-colouring`, which is a
+      SUCCESS (a validated rewrite identical to the input), not a reach
+      failure. Genuine reach failures: 173 (single-block 71, unmodeled-op 54,
+      call-indirect-pseudo 17, unreachable-block 15, numeric-branch 10,
+      i64-16bit-form-high-reg 6). The COMPLETE per-function blocker census for
+      the 54 residual `unmodeled-op` functions (gathered by the now-permanent
+      flag-gated complete-set diagnostics, not first-blocker-only) is a LONG
+      TAIL: 15 distinct ops, every function blocked by exactly ONE op, largest
+      family 7 functions (`I64DivS`, `I64Rotl`); the largest mechanism group
+      is the i64 software div/rem loops at 19 functions (11 % of reach
+      failures). Per this artifact's own falsifiability clause, that residue
+      does NOT name a next op-model widening — the op model is no longer the
+      limiting factor. What the census names instead: 49 of the 71
+      `single-block` declines are `apply_range_coloring` refusing an RMW whose
+      use-side and def-side ranges were coloured apart (`Movt` 28 functions /
+      `SelectMove` 26, zero rewriter-coverage gaps), and 22 are
+      `DefClobbersEquation` trace-validator rejects — so the next reach
+      increment is an RMW TIE/COALESCE constraint in the colouring (the def
+      range of a read-modify-write op must receive its use range's colour),
+      not a wider `pair_effect`.
+    status: implemented
     tags: [codegen, register-allocation, graph-colouring, reach, i64, track-a]
     links:
       - type: derives-from

--- a/crates/synth-synthesis/src/graph_alloc.rs
+++ b/crates/synth-synthesis/src/graph_alloc.rs
@@ -105,6 +105,14 @@ fn abi_gate(orig: &[ArmInstruction], new: Vec<ArmInstruction>) -> Option<Vec<Arm
     }
 }
 
+/// The `ArmOp` variant name, derived from `Debug` rather than a match table
+/// (the same no-second-source-of-truth choice as `wcet::op_mnemonic`): a new
+/// variant gets a correct census name for free, and nothing can drift.
+fn variant_name(op: &crate::rules::ArmOp) -> String {
+    let s = format!("{op:?}");
+    s.split([' ', '{', '(']).next().unwrap_or("").to_string()
+}
+
 /// Is `SYNTH_GRAPH_ALLOC` enabled? Any value other than `0` turns the spike on;
 /// unset or `0` keeps the shipping path (byte-identical).
 pub fn enabled() -> bool {
@@ -155,8 +163,25 @@ fn reallocate_straight_line(
         }
     }
 
-    let ranges = straight_line_value_ranges(instrs)?;
+    // Diagnostics only (flag-gated, stderr): increment 1 declines SILENTLY, so
+    // every straight-line function it refuses surfaces downstream as an opaque
+    // `single-block` — the RQ-59-REACH census found that bucket had quietly
+    // become the LARGEST reach failure while carrying no sub-reason at all.
+    // Name the reason at each post-prescan decline point so the histogram can
+    // say WHAT limits increment 1 (spill? validator? no ranges?), the same
+    // "never mistake 'did nothing' for 'nothing to do'" rule as `decline()`.
+    let sub = |reason: &str| {
+        if std::env::var("SYNTH_GRAPH_ALLOC_STATS").is_ok() {
+            eprintln!("[graph-alloc] increment-1 declined: {reason}");
+        }
+    };
+
+    let Some(ranges) = straight_line_value_ranges(instrs) else {
+        sub("no-value-ranges");
+        return None;
+    };
     if ranges.is_empty() {
+        sub("no-value-ranges");
         return None;
     }
 
@@ -222,13 +247,17 @@ fn reallocate_straight_line(
 
     // Spill cost: occurrence count per range (1 per def + 1 per use event),
     // replayed with the same vreg numbering `straight_line_value_ranges` uses.
-    let costs = occurrence_costs(instrs)?;
+    let Some(costs) = occurrence_costs(instrs) else {
+        sub("no-occurrence-costs");
+        return None;
+    };
 
     let (coloring, spilled) = color_ranges(&pool_adj, pool.len(), &pins, &costs);
     if !spilled.is_empty() {
         // Spill code insertion is increment 2+ (reuse the Belady machinery).
         // For now a function that does not fit the pool declines to the shipping
         // path — which HAS spill support.
+        sub("needs-spill");
         return None;
     }
     for (v, c) in &coloring {
@@ -242,7 +271,10 @@ fn reallocate_straight_line(
         for m in nbrs {
             match (assignment.get(n), assignment.get(m)) {
                 (Some(a), Some(b)) if a != b => {}
-                _ => return None,
+                _ => {
+                    sub("edge-recheck");
+                    return None;
+                }
             }
         }
     }
@@ -255,13 +287,27 @@ fn reallocate_straight_line(
     // segment_validator` in liveness.rs: it shows validate_segment_rewrite
     // rejects a value-flow-breaking merge-rename and accepts the identity — the
     // exact Err/Ok this match discharges to decline/accept).
-    let new = apply_range_coloring(instrs, &assignment)?;
+    let Some(new) = apply_range_coloring(instrs, &assignment) else {
+        // In stats mode `apply_range_coloring` itself prints the COMPLETE set
+        // of refused ops with causes (rmw-colour-mismatch / no-rewrite-arm)
+        // just before this decline line.
+        sub("apply-colouring");
+        return None;
+    };
     match validate_segment_rewrite(instrs, &new) {
         // TWO instruments, on different axes: the backward name-equation trace
         // check, and the forward ABI value contract (VCR-VER-004). Both must
         // hold.
         Ok(()) => abi_gate(instrs, new),
-        Err(_) => None,
+        Err(v) => {
+            // Include the violation VARIANT (not the full payload) so the
+            // census can split "shape outside the validated class" from a
+            // genuine equation failure.
+            let s = format!("{v:?}");
+            let variant = s.split([' ', '{', '(']).next().unwrap_or("");
+            sub(&format!("trace-validator-reject/{variant}"));
+            None
+        }
     }
 }
 
@@ -454,6 +500,23 @@ mod joins {
         }
     }
 
+    /// The `unmodeled-op` admission predicate, in ONE place: an interior
+    /// (non-terminator, non-label, non-`bx`) instruction that NONE of the three
+    /// shared effect definitions ([`reg_effect`] / [`call_effect`] /
+    /// [`pair_effect`]) models. [`build_cfg`] declines on the FIRST hit; the
+    /// STATS path re-scans the whole stream with this SAME predicate so the
+    /// decline census names the COMPLETE blocker set per function — the
+    /// first-blocker-only trap is the one `scan_for_decline` fell into (#936:
+    /// three unpriced ops hid behind the first decline for a release).
+    fn is_unmodeled(ins: &ArmInstruction) -> bool {
+        matches!(classify(&ins.op), Term::Ret | Term::Fall)
+            && !matches!(ins.op, ArmOp::Label { .. })
+            && !matches!(ins.op, ArmOp::Bx { .. })
+            && reg_effect(&ins.op).is_none()
+            && call_effect(&ins.op).is_none()
+            && pair_effect(&ins.op).is_none()
+    }
+
     /// The label-form CFG of `instrs`, or `None` to decline. Sound by
     /// construction: a `Some` is a COMPLETE CFG (every block reachable from the
     /// entry, every terminator modeled), never a partial guess.
@@ -469,18 +532,29 @@ mod joins {
                 Term::No(why) => return Err(why),
                 Term::Uncond(_) | Term::Cond(_) => {}
                 Term::Ret | Term::Fall => {
-                    if !matches!(ins.op, ArmOp::Label { .. })
-                        && !matches!(ins.op, ArmOp::Bx { .. })
-                        && reg_effect(&ins.op).is_none()
-                        // INCREMENT 3: a call has no `reg_effect` (deliberately —
-                        // the shipping pipeline depends on that `None`), but it
-                        // DOES have a modeled AAPCS `call_effect`.
-                        && call_effect(&ins.op).is_none()
-                        // INCREMENT 4 (VCR-REACH-001): likewise for the i64
-                        // register-PAIR pseudo-ops — no `reg_effect` by design,
-                        // a modeled `pair_effect` read off the two encoders.
-                        && pair_effect(&ins.op).is_none()
-                    {
+                    // INCREMENT 3 modeled calls (`call_effect`), INCREMENT 4 the
+                    // i64 register-pair pseudo-ops (`pair_effect`) — both are
+                    // deliberate non-`reg_effect` definitions the shipping
+                    // pipeline never sees. The single predicate lives in
+                    // [`is_unmodeled`].
+                    if is_unmodeled(ins) {
+                        // Diagnostics only (flag-gated, stderr): name the
+                        // COMPLETE blocker set, not just this first hit, so the
+                        // census stays actionable — a widening judged from the
+                        // first blocker alone under-counts every op hiding
+                        // behind it (the #936 `scan_for_decline` class).
+                        if std::env::var("SYNTH_GRAPH_ALLOC_STATS").is_ok() {
+                            let mut set: BTreeMap<String, usize> = BTreeMap::new();
+                            for blocked in instrs.iter().filter(|i| is_unmodeled(i)) {
+                                *set.entry(variant_name(&blocked.op)).or_insert(0) += 1;
+                            }
+                            let listing = set
+                                .iter()
+                                .map(|(k, v)| format!("{k} x{v}"))
+                                .collect::<Vec<_>>()
+                                .join(", ");
+                            eprintln!("[graph-alloc] unmodeled-op complete blocker set: {listing}");
+                        }
                         return Err("unmodeled-op");
                     }
                 }

--- a/crates/synth-synthesis/src/liveness.rs
+++ b/crates/synth-synthesis/src/liveness.rs
@@ -3917,6 +3917,17 @@ pub fn apply_range_coloring(
     instrs: &[ArmInstruction],
     assignment: &BTreeMap<usize, Reg>,
 ) -> Option<Vec<ArmInstruction>> {
+    // Census mode (`SYNTH_GRAPH_ALLOC_STATS`, stderr only): a refused rewrite
+    // still returns `None`, but the scan CONTINUES so the report names EVERY
+    // refused op, not the first one hit — first-blocker-only reporting is the
+    // #936 `scan_for_decline` trap, and the RQ-59-REACH census needs the
+    // complete set to attribute a decline to a family. Each entry is annotated
+    // with its cause: an op [`rewrite_expressible`] can express at all but
+    // refused under THESE maps is an RMW whose use-side and def-side ranges
+    // were coloured differently (`/rmw-colour-mismatch`); one it cannot
+    // express under any maps is a rewriter coverage gap (`/no-rewrite-arm`).
+    let census = std::env::var("SYNTH_GRAPH_ALLOC_STATS").is_ok();
+    let mut refused: BTreeMap<String, usize> = BTreeMap::new();
     let mut current: BTreeMap<Reg, usize> = BTreeMap::new(); // reg → open vreg id
     let mut next_vreg = 0usize;
     let mut out = Vec::with_capacity(instrs.len());
@@ -3945,12 +3956,50 @@ pub fn apply_range_coloring(
             current.insert(*r, vreg);
             def_map.insert(*r, *assignment.get(&vreg)?);
         }
-        out.push(ArmInstruction {
-            op: rewrite_op(&ins.op, &use_map, &def_map)?,
-            source_line: ins.source_line,
-        });
+        match rewrite_op(&ins.op, &use_map, &def_map) {
+            Some(op) => out.push(ArmInstruction {
+                op,
+                source_line: ins.source_line,
+            }),
+            None if census => {
+                let s = format!("{:?}", ins.op);
+                let name = s.split([' ', '{', '(']).next().unwrap_or("");
+                let cause = if rewrite_expressible(&ins.op) {
+                    "rmw-colour-mismatch"
+                } else {
+                    "no-rewrite-arm"
+                };
+                *refused.entry(format!("{name}/{cause}")).or_insert(0) += 1;
+            }
+            None => return None,
+        }
+    }
+    if !refused.is_empty() {
+        let listing = refused
+            .iter()
+            .map(|(k, v)| format!("{k} x{v}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        eprintln!("[graph-alloc] rewrite-refused complete set: {listing}");
+        return None;
     }
     Some(out)
+}
+
+/// Census/diagnostics helper (RQ-59-REACH): can [`rewrite_op`] express `op` at
+/// all? Tested under the IDENTITY rename, with the maps built from `op`'s own
+/// [`reg_effect`], so `false` names a REWRITER coverage gap (an op the effect
+/// model handles but `rewrite_op`'s match does not), never a colouring
+/// conflict — identity maps cannot trip the RMW same-register check. Pure;
+/// intended for the flag-gated pass's decline diagnostics, so a "did nothing"
+/// on such a function is never mistaken for "nothing to do".
+pub fn rewrite_expressible(op: &ArmOp) -> bool {
+    let Some(eff) = reg_effect(op) else {
+        return false;
+    };
+    let use_map: BTreeMap<Reg, Reg> = eff.uses.iter().map(|r| (*r, *r)).collect();
+    let def_map: BTreeMap<Reg, Reg> = eff.defs.iter().map(|r| (*r, *r)).collect();
+    rewrite_op(op, &use_map, &def_map).is_some()
 }
 
 /// Why [`validate_segment_rewrite`] rejected an `(original, rewritten)` pair.
@@ -13749,6 +13798,29 @@ mod tests {
                 imm16: 2
             }
         );
+    }
+
+    #[test]
+    fn rewrite_expressible_distinguishes_coverage_from_colouring() {
+        // Expressible: an RMW op under the IDENTITY rename — the same op the
+        // mismatch test above shows REFUSING a split assignment. Together they
+        // pin the diagnostic distinction the RQ-59-REACH census relies on: a
+        // refusal under actual maps with `rewrite_expressible == true` is an
+        // RMW colour mismatch, never a rewriter coverage gap.
+        assert!(rewrite_expressible(&ArmOp::Movt {
+            rd: Reg::R0,
+            imm16: 2
+        }));
+        assert!(rewrite_expressible(&ArmOp::SelectMove {
+            rd: Reg::R0,
+            rm: Reg::R1,
+            cond: Condition::EQ,
+        }));
+        // Not expressible: no `reg_effect` at all (a call is modeled by
+        // `call_effect`, deliberately not by `reg_effect`).
+        assert!(!rewrite_expressible(&ArmOp::Bl {
+            label: "func_1".into()
+        }));
     }
 
     #[test]

--- a/scripts/repro/vcr_dec_001_join_alloc_measure.py
+++ b/scripts/repro/vcr_dec_001_join_alloc_measure.py
@@ -125,10 +125,28 @@ def wcet_bounds(elf):
     return bounds, declined
 
 
+def parse_set(listing):
+    """`Op xN, Op xN` → {op: n} (the complete-set diagnostic line format)."""
+    out = {}
+    for part in listing.split(", "):
+        if part:
+            name, _, n = part.rpartition(" x")
+            out[name] = out.get(name, 0) + int(n)
+    return out
+
+
 def measure(synth, relocatable):
     rows, errors = [], []
     applied_total = 0
     declines = {}
+    # RQ-59-REACH: the census must never report FIRST blockers only (the #936
+    # `scan_for_decline` trap). The pass emits COMPLETE-set diagnostics; this
+    # pairs each set line with the decline that follows it:
+    #   unmodeled_sets  — per declined function, EVERY op no effect fn models;
+    #   inc1_subs       — why increment 1 refused a `single-block` function;
+    #   refused_sets    — per apply-colouring decline, EVERY op `rewrite_op`
+    #                     refused, annotated rmw-colour-mismatch/no-rewrite-arm.
+    unmodeled_sets, inc1_subs, refused_sets = [], {}, []
     with tempfile.TemporaryDirectory() as td_off, tempfile.TemporaryDirectory() as td_on:
         for src in corpus():
             r_off, elf_off = compile_one(synth, src, td_off, relocatable, False)
@@ -142,10 +160,24 @@ def measure(synth, relocatable):
                 continue
             stderr_on = r_on.stderr.decode(errors="replace")
             applied_total += stderr_on.count("whole-function colouring APPLIED")
+            pending_unmodeled = pending_refused = pending_sub = None
             for line in stderr_on.splitlines():
-                if "join colouring DECLINED:" in line:
+                if "unmodeled-op complete blocker set:" in line:
+                    pending_unmodeled = parse_set(line.split("set:", 1)[1].strip())
+                elif "rewrite-refused complete set:" in line:
+                    pending_refused = parse_set(line.split("set:", 1)[1].strip())
+                elif "increment-1 declined:" in line:
+                    pending_sub = line.split("declined:", 1)[1].strip()
+                elif "join colouring DECLINED:" in line:
                     reason = line.rsplit(":", 1)[1].strip()
                     declines[reason] = declines.get(reason, 0) + 1
+                    if reason == "unmodeled-op" and pending_unmodeled:
+                        unmodeled_sets.append(pending_unmodeled)
+                    if reason == "single-block" and pending_sub:
+                        inc1_subs[pending_sub] = inc1_subs.get(pending_sub, 0) + 1
+                        if pending_sub == "apply-colouring" and pending_refused:
+                            refused_sets.append(pending_refused)
+                    pending_unmodeled = pending_refused = pending_sub = None
             s_off, s_on = func_sizes(elf_off), func_sizes(elf_on)
             w_off, d_off = wcet_bounds(elf_off)
             w_on, d_on = wcet_bounds(elf_on)
@@ -160,7 +192,39 @@ def measure(synth, relocatable):
                     "cycles_off": cyc_off,
                     "cycles_on": cyc_on,
                 })
-    return rows, applied_total, declines, errors
+    census = {"unmodeled_sets": unmodeled_sets, "inc1_subs": inc1_subs,
+              "refused_sets": refused_sets}
+    return rows, applied_total, declines, errors, census
+
+
+def census_report(census):
+    """The RQ-59-REACH separation: identity-colouring is a SUCCESS (a validated
+    identity rewrite), so the report prints reach failures apart from it, and
+    every blocker aggregation is over COMPLETE per-function sets."""
+    def agg(sets):
+        by_fn, by_occ = {}, {}
+        for s in sets:
+            for op, n in s.items():
+                by_fn[op] = by_fn.get(op, 0) + 1
+                by_occ[op] = by_occ.get(op, 0) + n
+        return by_fn, by_occ
+
+    if census["unmodeled_sets"]:
+        by_fn, by_occ = agg(census["unmodeled_sets"])
+        print("unmodeled-op COMPLETE blocker sets "
+              f"({len(census['unmodeled_sets'])} functions):")
+        for op, v in sorted(by_fn.items(), key=lambda kv: -kv[1]):
+            print(f"    {op:<26} functions {v:>4}  occurrences {by_occ[op]:>5}")
+    if census["inc1_subs"]:
+        print("single-block sub-reasons (increment-1 refusals):")
+        for k, v in sorted(census["inc1_subs"].items(), key=lambda kv: -kv[1]):
+            print(f"    {k:<40} {v}")
+    if census["refused_sets"]:
+        by_fn, by_occ = agg(census["refused_sets"])
+        print("apply-colouring COMPLETE refused sets "
+              f"({len(census['refused_sets'])} functions):")
+        for op, v in sorted(by_fn.items(), key=lambda kv: -kv[1]):
+            print(f"    {op:<40} functions {v:>4}  occurrences {by_occ[op]:>5}")
 
 
 def report(tag, rows, applied, declines, errors):
@@ -190,8 +254,15 @@ def report(tag, rows, applied, declines, errors):
           f"{len(rows) - len(changed)} unchanged")
     print(f"cycles : {len(cyc_shrank)} shrank, {len(cyc_grew)} grew")
     if declines:
-        print("decline reasons (flag-on):")
-        for k, v in sorted(declines.items(), key=lambda kv: -kv[1]):
+        # RQ-59-REACH separation: `identity-colouring` is the colourer
+        # SUCCEEDING with nothing to improve (a validated identity rewrite
+        # handed to the shipping pass), NOT a reach failure — mixing it into
+        # the histogram made the top "decline" bucket look like a limit.
+        ident = declines.get("identity-colouring", 0)
+        fails = {k: v for k, v in declines.items() if k != "identity-colouring"}
+        print(f"identity-colouring (SUCCESS, nothing to improve): {ident}")
+        print(f"reach failures (flag-on): {sum(fails.values())}")
+        for k, v in sorted(fails.items(), key=lambda kv: -kv[1]):
             print(f"    {k:<26} {v}")
     if changed:
         print("per-function changes:")
@@ -227,9 +298,11 @@ def main():
     for tag, reloc in (("relocatable / label-form branches (fully in scope)", True),
                        ("self-contained / pre-resolved numeric branches "
                         "(branches out of scope; calls in scope)", False)):
-        rows, applied, declines, errors = measure(synth, reloc)
-        summary["relocatable" if reloc else "self_contained"] = report(
-            tag, rows, applied, declines, errors)
+        rows, applied, declines, errors, census = measure(synth, reloc)
+        summ = report(tag, rows, applied, declines, errors)
+        census_report(census)
+        summ["census"] = census
+        summary["relocatable" if reloc else "self_contained"] = summ
     if out_json:
         Path(out_json).write_text(json.dumps(summary, indent=2))
         print(f"\nwrote {out_json}")


### PR DESCRIPTION
## RQ-59-REACH — the census, and the finding that outranks the increment

**Verdict: the shared op model is NOT widened.** The re-derived complete-set
census shows the `unmodeled-op` residue is a long tail with no dominant family,
which is exactly the falsifiability clause of `artifacts/release-v0.59.yaml`
(RQ-59-REACH) firing: op-model reach is no longer the limiting factor. What the
census names instead is a **missing RMW tie constraint in the colouring**
(`Movt`/`SelectMove` use/def ranges coloured apart) — a different, named next
increment. Reporting that with evidence is this lane's deliverable; a widening
that moves ~7 functions per op family would have been manufactured work.

### Which corpus, and how it was identified

The roadmap's "633-function ARM repro corpus" is the per-function population of
`scripts/repro/*.wat` + `*.wasm` on the `--relocatable` cortex-m4 path, as
enumerated by `scripts/repro/vcr_dec_001_join_alloc_measure.py` (its own
verification criteria record the growth: 617 functions at v0.53, 633 at v0.54).
Re-derived on current main it is **159 ARM-compilable fixtures / 697
functions** — the SAME corpus identity, grown by lanes adding fixtures. The
parent brief's "158-file" run is the same corpus counted per FILE; this census
counts per FUNCTION like the roadmap did. Cross-check: 455 applied + 69
identity + 173 failures = 697 — every symtab function has exactly one outcome.

### The census, reach failures SEPARATED from identity-colouring (relocatable)

| outcome | count |
|---|---|
| colouring APPLIED (validated rewrite) | 455 |
| identity-colouring — **SUCCESS, nothing to improve** | 69 |
| **handled** | **524 / 697 (75.2 %)** |
| reach failures | **173 (24.8 %)** |

Reach failure histogram: `single-block` 71 · `unmodeled-op` 54 ·
`call-indirect-pseudo` 17 · `unreachable-block` 15 · `numeric-branch` 10 ·
`i64-16bit-form-high-reg` 6. (v0.54, same corpus family: `unmodeled-op` 175 =
47 % of declines. Increment 4 (#917) did its job — the bucket fell 175 → 54 and
no longer leads.)

Bytes/wcet, flag-on vs shipping (same instrument, same pass): −122 B (−0.27 %),
−36 bound cycles; 33 functions shrank, 7 grew.

### (c) The COMPLETE per-function blocker sets for the 54 `unmodeled-op` declines

Gathered by new **flag-gated complete-set diagnostics** (not first-blocker-only
— the #936 `scan_for_decline` trap), now permanent in the pass and aggregated
by the measure script:

```
I64DivS 7 · I64Rotl 7 · I64Mul 5 · I64RemS 5 · I64Rotr 5 · I64DivU 4 ·
I64Popcnt 4 · I64RemU 3 · I64Clz 3 · I64Ctz 3 · MemorySize 3 · MemoryGrow 2 ·
I64Extend8S 1 · I64Extend16S 1 · I64Extend32S 1
```

Every one of the 54 functions is blocked by exactly ONE op (54/54 sole-blocker
— the corpus's targeted one-op repro fixtures). 15 distinct ops, largest
family 7 functions (4 % of reach failures). Largest mechanism group: the i64
software div/rem loops, 19 functions (11 %). **No dominant family** — v0.54's
census had 167/175 in one family; nothing remotely comparable remains.

### What the census names instead (the actual next increment)

`single-block` (71) is now the largest reach bucket, and it was OPAQUE —
increment 1 declines silently. New flag-gated sub-reason diagnostics attribute
**71/71**:

* **49 = `apply-colouring`**, ALL of them `rmw-colour-mismatch` (zero
  `no-rewrite-arm`): the colourer assigns an RMW op's use-side and def-side
  ranges different colours, and `rewrite_op`'s RMW same-register check
  correctly refuses. Complete refused sets: `Movt` 28 functions (MOVW/MOVT
  const materialization), `SelectMove` 26 (cmp-select fusion output).
* **22 = `trace-validator-reject/DefClobbersEquation`**.

So the named next increment for VCR-DEC-001 is an **RMW tie/coalesce
constraint** (the def range of a read-modify-write op must receive its use
range's colour), not a wider `pair_effect`. Recorded in
`artifacts/verified-codegen-roadmap.yaml` (VCR-REACH-001 → `implemented`, with
the measured outcome — the artifact still described increment 4 as future work,
the staleness the corrected brief called out).

### What this PR changes (diagnostics + record only — no codegen change)

* `graph_alloc.rs`: complete unmodeled-op blocker-set print; increment-1
  decline sub-reasons (`no-value-ranges` / `needs-spill` / `edge-recheck` /
  `apply-colouring` / `trace-validator-reject/<variant>`); single
  `is_unmodeled` predicate (no mirror) + Debug-derived `variant_name`.
* `liveness.rs`: `apply_range_coloring` census mode — on refusal it keeps
  scanning and prints the COMPLETE refused set annotated
  `rmw-colour-mismatch`/`no-rewrite-arm` (still returns `None` exactly as
  before); new pure `rewrite_expressible` helper + unit test pinning the
  coverage-vs-colouring distinction.
* `vcr_dec_001_join_alloc_measure.py`: separates identity-colouring from reach
  failures in its report and aggregates all three complete-set diagnostics —
  the census is re-derivable by anyone from the roadmap's own instrument.

All diagnostics are behind `SYNTH_GRAPH_ALLOC_STATS` on stderr.

### Gates

* Flag off: byte-for-byte identical — frozen anchors **10/10**
  (`cargo test -p synth-cli --test frozen_codegen_bytes`); every new code path
  is env-gated and `apply_range_coloring`'s return value is unchanged in both
  modes.
* `cargo fmt --all` clean · `cargo clippy --workspace --all-targets -D
  warnings` clean · `cargo test --workspace` green (true exit code) ·
  `claim_check.py` 49/49 · `model_coverage_audit.py --check` ok.
* No selector growth — the subtraction ratchet is untouched (no waiver needed).
* The default is NOT flipped; declines still return `None` and fall back.

Refs #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
