### PR TITLE
chore(rivet): RQ-59-MINORHOLD and RQ-59-REACH are implemented

### DIFF
--- a/artifacts/release-v0.59.yaml
+++ b/artifacts/release-v0.59.yaml
@@ -206,7 +206,7 @@ requirements:
       FALSIFIABLE: if the histogram does not move materially, `unmodeled-op`
       was not the real limit and the 167/175 census was wrong. Report that as
       the finding; it outranks the increment.
-    status: proposed
+    status: implemented
     release: v0.59
     tags: [north-star, vcr-dec-001, allocator, reach, decline-histogram]
     links:
@@ -362,7 +362,7 @@ requirements:
       RED-FIRST: the gate must be shown REFUSING a 0.x-minor bump, not merely
       present. A gate that cannot fail is indistinguishable from one that
       passes.
-    status: proposed
+    status: implemented
     release: v0.59
     tags: [ci, dependencies, gate-potency, enforcement]
     links:


### PR DESCRIPTION
#1022 and #1023 merged. **v0.59 now 4/11.**

`RQ-59-REACH` is marked `implemented` on a **negative result**, deliberately — it widened nothing.

Its falsifiability clause fired: the residual `unmodeled-op` declines are a long tail (15 distinct ops, every function blocked by exactly **one**, largest family **7 of 54**), where v0.54 had **167 of 175 in a single family**. Op-model reach is no longer the limiting factor, so the artifact is satisfied by the census and the corrected record rather than by a widening.

Marking it implemented for *measuring and declining to act* is the honest reading. Leaving it `proposed` would imply outstanding work that the data says should not be done.

`claim_check` 49/49. Rivet artifact only.

Refs #965, #242.