### PR TITLE
RQ-59-MEASURE (#242): increment-4 verdict — DO NOT FLIP: colourer wins on net (-122 B / -36 cyc / -31 insns) but does not dominate (7 grew, one shared ldr.w mechanism)

### DIFF
--- a/artifacts/verified-codegen-roadmap.yaml
+++ b/artifacts/verified-codegen-roadmap.yaml
@@ -2631,6 +2631,87 @@ artifacts:
         `shrink_callee_saved_saves`, which is LEAF-ONLY, so a modest byte delta
         with a large reach delta is the EXPECTED result, not a failure.
 
+  - id: VCR-MEASURE-004
+    type: sw-req
+    title: "VCR-DEC-001 increment 4: MEASURE — greedy vs colourer, the explicit flip verdict (RQ-59-MEASURE)"
+    description: >
+      VERDICT (v0.59, RQ-59-MEASURE): DO NOT FLIP. The colourer WINS ON NET but
+      does NOT DOMINATE, and the arc's flip step requires domination plus gale
+      silicon evidence. Increments 2 (joins) and 3 (calls) each ended in a
+      stated verdict; this is increment 4's.
+
+      NUMBERS (measured 2026-08-21 on this branch, greedy baseline re-run in
+      the SAME pass on the SAME host — never remembered numbers; instrument
+      `scripts/repro/vcr_dec_001_join_alloc_measure.py`, which this lane
+      extended with capstone-based per-function instruction/width/frame-traffic
+      metrics). Relocatable corpus, 159 fixtures / 697 functions, flag-off ->
+      flag-on: applied 455 + identity-colouring 69 (75 % handled, the
+      RQ-59-REACH census re-confirmed to the function); bytes 45,190 -> 45,068
+      (-122, -0.27 %); sound wcet bound 29,612 -> 29,576 (-36 over the 517
+      functions bounded on both sides); instruction count 14,317 -> 14,286
+      (-31); wide 32-bit encodings 8,278 -> 8,248 (-30); push/pop breadth
+      6,316 -> 6,244 regs (-72); total frame allocation (SUB sp) UNCHANGED at
+      16,688 B — the colourer adds no spill slots; but FRAME TRAFFIC
+      ([sp,#imm] loads/stores, ALL of which the encoder emits wide) 1,287 ->
+      1,309 (+22). Self-contained half: bytes -144, insns -32, wcet -20, frame
+      traffic +18. Distribution: 33 functions shrank, 7 GREW, 657 unchanged;
+      cycle bounds 16 shrank, 1 grew.
+
+      THE MECHANISM IS ONE MECHANISM WITH TWO SIGNS, confirmed at the
+      mnemonic level: the colourer's low-register bias (a) narrows encodings —
+      `cmp.w`/`moveq.w`/`movne.w` become 16-bit forms once operands stay in
+      r0-r7 — and trims callee-saved push/pop breadth, which is where the -122
+      B comes from; and (b) raises pressure in the low pool, so a value the
+      greedy allocator kept cached in a spare high/callee-saved register
+      (r7/r8) is instead RE-FETCHED from its always-wide [sp,#imm] frame slot.
+      gust_poll is the canonical instance: mov 32 -> 27 (-5) traded for ldr.w
+      38 -> 44 (+6), frame traffic 51 -> 58, +10 B on a 700 B function.
+      Instruction count and byte size move in OPPOSITE directions on the tail
+      (sum_below: equal counts, +4 B) — a verdict quoting only one metric
+      would be misleading, which is why the instrument now reports both.
+
+      THE REGRESSION TAIL IS BOUNDED AND FULLY ATTRIBUTED — all 7 growers are
+      the (b) class: gust_poll +10 B (+1.4 %, +7 frame reloads, one dead
+      `movw #3` a downstream fold no longer matches, identity `mov rN, rN`
+      call-moves left unelided), hp64 +8 B (+4.3 %, 2 movs -> 2 ldr.w + one
+      re-materialized `movw #0`; also the only cycle-bound regression, +3 cyc
+      = +1.2 %), sum_below +4 B (2 movs -> 2 ldr.w), gale_k_msgq_put_decide
+      +4 B (+1 ldr.w), gpio_set/gpio_clear/gpio_toggle +2 B each (param
+      reloaded from frame instead of a live register copy). Worst absolute
+      +10 B, worst relative +4.3 %, total tail +32 B against -154 B of wins.
+
+      WHY NOT FLIP, MECHANICALLY: the Chaitin occurrence-count cost metric
+      prices every use at 1, blind to whether realizing it costs a 2-byte
+      register copy or a 4-byte frame reload. Named levers for increment 5+,
+      in the order the numbers rank them: (1) the RMW tie/coalesce constraint
+      RQ-59-REACH already named (49 single-block declines); (2) a width- and
+      copy-aware cost bias so a live register copy is preferred over a
+      [sp,#imm] reload when a spare register exists; (3) downstream cleanups —
+      identity-move elision and the dead-`movw`-before-shifted-immediate
+      sweep — which would neutralize part of the tail on their own.
+    status: implemented
+    tags: [codegen, register-allocation, graph-colouring, measurement, verdict, track-a]
+    links:
+      - type: derives-from
+        target: VCR-001
+      - type: refines
+        target: VCR-DEC-001
+      - type: refines
+        target: VCR-RA-001
+    fields:
+      req-type: functional
+      priority: must
+      verification-criteria: >
+        The verdict is reproducible from the instrument alone:
+        `python3 scripts/repro/vcr_dec_001_join_alloc_measure.py <synth>` on
+        the same corpus re-derives every number above (the instruction/width/
+        frame-traffic block requires python capstone and degrades to the
+        byte/wcet report without it). `SYNTH_GRAPH_ALLOC` stays OFF by
+        default; flag-off output stays byte-identical (frozen anchors 10/10,
+        `cargo test -p synth-cli --test frozen_codegen_bytes`). The flip
+        itself remains gated on domination + gale silicon evidence, per the
+        VCR-DEC-001 arc.
+
   - id: VCR-DEC-002
     type: sw-req
     title: "Decision: spill-reduction leapfrogs greedy heuristics — optimal-because-tiny + SSA-chordal + proof-carrying facts (gale #209)"

--- a/scripts/repro/vcr_dec_001_join_alloc_measure.py
+++ b/scripts/repro/vcr_dec_001_join_alloc_measure.py
@@ -125,6 +125,92 @@ def wcet_bounds(elf):
     return bounds, declined
 
 
+def insn_metrics(elf):
+    """RQ-59-MEASURE: per-function INSTRUCTION metrics — count, wide (32-bit)
+    encodings, and FRAME TRAFFIC (loads/stores whose base is SP — the direct
+    path's frame addressing) — because bytes and instruction count can move in OPPOSITE
+    directions: the colourer's rewrites can turn a narrow 16-bit op into a wide
+    32-bit one (e.g. an SP-relative `ldr` of a high register must be `ldr.w`),
+    so a verdict quoting only one of the two would be misleading.
+
+    Optional: requires capstone; returns {} when it is not installed (the
+    byte/wcet halves of this report do not depend on it). Same-host, same-pass
+    on BOTH sides, so the host-dependence caveat that rules out `synth disasm`
+    text differentials does not arise."""
+    try:
+        import capstone
+    except ImportError:
+        return {}
+    from elftools.elf.elffile import ELFFile
+    from elftools.elf.sections import SymbolTableSection
+    md = capstone.Cs(capstone.CS_ARCH_ARM,
+                     capstone.CS_MODE_THUMB | capstone.CS_MODE_MCLASS)
+    md.detail = True
+    md.skipdata = True  # literal pools inside a symbol's span must not truncate
+    out = {}
+    with open(elf, "rb") as fh:
+        ef = ELFFile(fh)
+        secs = list(ef.iter_sections())
+        funcs = {}
+        for sec in secs:
+            if not isinstance(sec, SymbolTableSection):
+                continue
+            for sym in sec.iter_symbols():
+                if sym["st_info"]["type"] != "STT_FUNC" or not sym["st_size"]:
+                    continue
+                # st_shndx pins the DEFINING section: in an ET_REL object every
+                # section has sh_addr == 0, so a spanning-address search alone
+                # would silently disassemble the first section that fits.
+                key = (sym["st_value"], sym["st_size"], sym["st_shndx"])
+                prev = funcs.get(key)
+                if prev is None or (prev.startswith("func_") and
+                                    not sym.name.startswith("func_")):
+                    funcs[key] = sym.name
+        for (vaddr, size, shndx), name in funcs.items():
+            addr = vaddr & ~1  # strip the Thumb bit
+            if not isinstance(shndx, int):
+                continue
+            sec = secs[shndx]
+            base = sec["sh_addr"]
+            if (sec["sh_type"] == "SHT_NOBITS"
+                    or not (sec["sh_flags"] & 0x4)  # SHF_EXECINSTR
+                    or addr < base or addr + size > base + sec["sh_size"]):
+                continue
+            body = sec.data()[addr - base: addr - base + size]
+            m = {"insns": 0, "wide": 0, "frame_ld": 0, "frame_st": 0,
+                 "wide_frame": 0, "pushpop_regs": 0, "sp_sub": 0}
+            for ins in md.disasm(body, addr):
+                if ins.mnemonic == ".byte":  # skipdata placeholder (literal pool)
+                    continue
+                m["insns"] += 1
+                if ins.size == 4:
+                    m["wide"] += 1
+                mn = ins.mnemonic
+                if mn.startswith(("push", "pop")):
+                    m["pushpop_regs"] += len(ins.operands)
+                if mn.startswith("sub") and ins.op_str.startswith("sp,"):
+                    ops = ins.operands
+                    if ops and ops[-1].type == capstone.arm.ARM_OP_IMM:
+                        m["sp_sub"] += ops[-1].imm
+                is_ld = mn.startswith(("ldr", "ldm", "ldrd"))
+                is_st = mn.startswith(("str", "stm", "strd"))
+                if is_ld or is_st:
+                    for op in ins.operands:
+                        if op.type != capstone.arm.ARM_OP_MEM:
+                            continue
+                        # The direct path's frame is SP-relative
+                        # (`ldr rd,[sp,#off]`, select_with_stack). R11/R9/R10
+                        # are the linmem/globals/memsize bases and R7 is
+                        # allocatable, so ONLY an SP base is frame traffic.
+                        base_reg = ins.reg_name(op.mem.base) or ""
+                        if base_reg == "sp":
+                            m["frame_ld" if is_ld else "frame_st"] += 1
+                            if ins.size == 4:
+                                m["wide_frame"] += 1
+            out[name] = m
+    return out
+
+
 def parse_set(listing):
     """`Op xN, Op xN` → {op: n} (the complete-set diagnostic line format)."""
     out = {}
@@ -181,17 +267,22 @@ def measure(synth, relocatable):
             s_off, s_on = func_sizes(elf_off), func_sizes(elf_on)
             w_off, d_off = wcet_bounds(elf_off)
             w_on, d_on = wcet_bounds(elf_on)
+            m_off, m_on = insn_metrics(elf_off), insn_metrics(elf_on)
             for name in sorted(set(s_off) & set(s_on)):
                 cyc_off = w_off.get(name)
                 cyc_on = w_on.get(name)
-                rows.append({
+                row = {
                     "fixture": src.name,
                     "func": name,
                     "bytes_off": s_off[name],
                     "bytes_on": s_on[name],
                     "cycles_off": cyc_off,
                     "cycles_on": cyc_on,
-                })
+                }
+                if name in m_off and name in m_on:
+                    row["insn_off"] = m_off[name]
+                    row["insn_on"] = m_on[name]
+                rows.append(row)
     census = {"unmodeled_sets": unmodeled_sets, "inc1_subs": inc1_subs,
               "refused_sets": refused_sets}
     return rows, applied_total, declines, errors, census
@@ -253,6 +344,28 @@ def report(tag, rows, applied, declines, errors):
     print(f"bytes  : {len(shrank)} shrank, {len(grew)} grew, "
           f"{len(rows) - len(changed)} unchanged")
     print(f"cycles : {len(cyc_shrank)} shrank, {len(cyc_grew)} grew")
+    # RQ-59-MEASURE: instruction-level aggregates (capstone-optional) — count
+    # and size can move in OPPOSITE directions (narrow movs traded for wide
+    # ldr.w), so the verdict must quote both.
+    im = [r for r in rows if "insn_off" in r]
+    if im:
+        def tot(side, key):
+            return sum(r[side][key] for r in im)
+        print(f"insns  off={tot('insn_off', 'insns')}  on={tot('insn_on', 'insns')}  "
+              f"delta={tot('insn_on', 'insns') - tot('insn_off', 'insns'):+d}   "
+              f"[{len(im)}/{len(rows)} functions disassembled]")
+        print(f"wide (32-bit) encodings   : off={tot('insn_off', 'wide')}  "
+              f"on={tot('insn_on', 'wide')}  "
+              f"delta={tot('insn_on', 'wide') - tot('insn_off', 'wide'):+d}")
+        ft_off = tot('insn_off', 'frame_ld') + tot('insn_off', 'frame_st')
+        ft_on = tot('insn_on', 'frame_ld') + tot('insn_on', 'frame_st')
+        print(f"frame traffic ([sp,#..] ld/st): off={ft_off}  on={ft_on}  "
+              f"delta={ft_on - ft_off:+d}  "
+              f"(wide: {tot('insn_off', 'wide_frame')} -> {tot('insn_on', 'wide_frame')})")
+        print(f"push/pop breadth (regs)   : off={tot('insn_off', 'pushpop_regs')}  "
+              f"on={tot('insn_on', 'pushpop_regs')}")
+        print(f"frame size (SUB sp bytes) : off={tot('insn_off', 'sp_sub')}  "
+              f"on={tot('insn_on', 'sp_sub')}")
     if declines:
         # RQ-59-REACH separation: `identity-colouring` is the colourer
         # SUCCEEDING with nothing to improve (a validated identity rewrite
@@ -271,9 +384,17 @@ def report(tag, rows, applied, declines, errors):
             if r["cycles_off"] is not None and r["cycles_on"] is not None:
                 dc = f"  cyc {r['cycles_off']}->{r['cycles_on']} " \
                      f"({r['cycles_on'] - r['cycles_off']:+d})"
+            di = ""
+            if "insn_off" in r:
+                io, ion = r["insn_off"], r["insn_on"]
+                fo = io["frame_ld"] + io["frame_st"]
+                fn_ = ion["frame_ld"] + ion["frame_st"]
+                di = f"  insn {io['insns']}->{ion['insns']} " \
+                     f"wide {io['wide']}->{ion['wide']} " \
+                     f"frame {fo}->{fn_}"
             print(f"    {r['fixture']:<34} {r['func']:<24} "
                   f"{r['bytes_off']:>4} -> {r['bytes_on']:>4} "
-                  f"({r['bytes_on'] - r['bytes_off']:+d}){dc}")
+                  f"({r['bytes_on'] - r['bytes_off']:+d}){dc}{di}")
     for e in errors:
         print(f"  ERROR {e}")
     return {"functions": len(rows), "applied": applied,


### PR DESCRIPTION
VCR-DEC-001 increment 4's deliverable (epic #242, rivet `RQ-59-MEASURE`): the explicit
flip verdict, the way increments 2 (joins, v0.53) and 3 (calls, v0.54) each ended in a
stated verdict rather than an impression.

## VERDICT: DO NOT FLIP — wins on net, does not dominate

The colourer beats greedy corpus-wide on every aggregate (bytes, instruction count,
wide encodings, sound wcet bounds, push/pop breadth) — but 7 functions GROW and 1
cycle bound regresses, so **domination fails**, and the flip step additionally
requires gale silicon evidence. `SYNTH_GRAPH_ALLOC` stays OFF (this PR changes no
Rust; flag-off output is trivially byte-identical — frozen anchors re-run 10/10).

Baseline discipline: every number below is flag-off vs flag-on **in the same pass on
the same host** (`vcr_dec_001_join_alloc_measure.py`, debug synth, this branch); the
numbers quoted from RQ-59-REACH were re-derived, not trusted — they reproduced
exactly (455 applied + 69 identity + 173 reach failures = 697; −122 B / −36 cyc;
33 shrank / 7 grew).

## Comparison table (relocatable corpus, 159 fixtures / 697 functions)

| metric | OFF (greedy) | ON (colourer) | delta |
|---|---|---|---|
| `.text` bytes (symtab) | 45,190 | 45,068 | **−122 (−0.27%)** |
| sound wcet bound (517 fn bounded both sides) | 29,612 | 29,576 | **−36 (−0.12%)** |
| instruction count | 14,317 | 14,286 | **−31** |
| wide (32-bit) encodings | 8,278 | 8,248 | **−30** |
| frame traffic (`[sp,#imm]` ld/st, all wide) | 1,287 | 1,309 | **+22** |
| push/pop breadth (regs) | 6,316 | 6,244 | **−72** |
| frame allocation (`SUB sp` total) | 16,688 | 16,688 | **0 — no new spill slots** |
| functions | 33 shrank / 7 grew / 657 unchanged | | |
| cycle bounds | 16 shrank / 1 grew | | |

Self-contained half: bytes −144 (−0.27%), insns −32, wide −40, wcet −20, frame
traffic +18, push/pop −56; 37 shrank / 5 grew (subset of the same 7).

Histogram (relocatable, identity-colouring reported APART — it is a success):
applied 455, identity-colouring 69 (75% handled); reach failures 173 =
single-block 71, unmodeled-op 54, call-indirect-pseudo 17, unreachable-block 15,
numeric-branch 10, i64-16bit-form-high-reg 6.

## The `ldr.w` mechanism: CONFIRMED, and it is ONE mechanism with two signs

The previous (dead) run's single-instance finding is confirmed to the digit on
gust_poll: **`mov` 32→27 (−5), `ldr.w` 38→44 (+6), frame traffic 51→58**, +10 B.
Corpus-wide it generalizes: frame traffic +22 while instruction count falls −31.

Mechanism, from mnemonic-level diffs: the colourer biases toward LOW registers
(r0–r7), which
- **wins**: `cmp.w`/`moveq.w`/`movne.w` narrow to 16-bit forms once operands leave
  r8, and callee-saved push/pop breadth drops (−72 regs) — that is where the −122 B
  lives; and
- **loses**: low-pool pressure rises, so a value greedy parked in a spare
  high/callee-saved register (r7/r8) is instead RE-FETCHED from its `[sp,#imm]`
  frame slot — and the encoder emits **every** SP-relative access wide (measured
  1,287/1,287 OFF, 1,309/1,309 ON), so each such trade is a 2-byte `mov` becoming a
  4-byte `ldr.w`.

Count and size therefore move in opposite directions on the tail (sum_below: equal
instruction counts, +4 B) — the instrument now reports **both**, plus width and
frame-traffic aggregates (capstone-optional extension of
`vcr_dec_001_join_alloc_measure.py`; degrades gracefully to the byte/wcet report
without capstone).

## The 7 regressions, named, with causes — all one class, all bounded

| function | bytes | cause (from disasm diff) |
|---|---|---|
| gust_poll (gust_kernel.wasm) | 700→710 (+10, +1.4%) | +7 wide frame reloads of values greedy kept in r7/r8; one dead `movw r0,#3` before `lsls` (downstream fold no longer pattern-matches the coloured names); identity `mov rN,rN` call-moves left unelided |
| hp64 (i64_pair_exhaust_587.wat) | 188→196 (+8, +4.3%) | 2 narrow `mov` → 2 `ldr.w [sp,..]`; one re-materialized `movw #0`. Only cycle-bound regression: 259→262 (+3, +1.2%) |
| sum_below (loop_param_bound_663.wat) | 70→74 (+4) | 2 narrow `mov` → 2 `ldr.w [sp]` (loop counter re-loaded instead of copied) |
| gale_k_msgq_put_decide (msgq_put_359.wasm) | 186→190 (+4) | +1 `ldr.w` frame reload |
| gpio_set (gpio_thin_846.loom.wasm) | 52→54 (+2) | param reloaded from frame slot (`ldr.w [sp,#0x18]`) instead of live-register `mov r6,r1` |
| gpio_clear (gpio_thin_846.loom.wasm) | 56→58 (+2) | same class (+1 wide frame access) |
| gpio_toggle (gpio_thin_846.loom.wasm) | 110→112 (+2) | param spilled (`str.w`) for a later reload instead of a register copy |

Bounded: worst absolute +10 B, worst relative +4.3%, total tail +32 B against
−154 B of wins; no function's frame grows (SUB sp unchanged everywhere); exactly one
wcet-bound regression (+3 cyc). Nothing here reproduces with the flag off — the OFF
side IS the same-pass baseline.

Root cause, mechanically: the Chaitin occurrence-count spill/cost metric prices
every use at 1, blind to whether realizing that use costs a 2-byte register copy or
a 4-byte always-wide frame reload. Named levers for increment 5+ (recorded in
`VCR-MEASURE-004`): (1) the RMW tie RQ-59-REACH named (49 single-block declines);
(2) width/copy-aware cost bias; (3) downstream cleanups — identity-move elision and
the dead-`movw`-before-shifted-immediate sweep.

## RQ-59-REACH single-block attribution: CONFIRMED

Re-derived in the same pass: 71/71 single-block declines attribute as **49
`apply-colouring`** refusals — complete refused sets `Movt/rmw-colour-mismatch` 28
functions / 28 occurrences, `SelectMove/rmw-colour-mismatch` 26 functions / 59
occurrences, zero `no-rewrite-arm` — and **22 `DefClobbersEquation`**
trace-validator rejects. Exactly as REACH reported. The RMW tie is NOT implemented
here — that is the next increment.

## Side observation (free size lever, colourer-independent)

The encoder emits ALL `[sp,#imm]` accesses as 32-bit `ldr.w`/`str.w` (1,287 of
1,287 on the OFF side). The 16-bit T2 SP-relative form (r0–r7, imm8×4) exists and
would cover a large fraction of these — a potential multi-hundred-byte corpus win
on the shipping path, orthogonal to this increment. Not acted on here.

## What changed in-repo

- `scripts/repro/vcr_dec_001_join_alloc_measure.py` — capstone-optional
  per-function instruction/width/frame-traffic/push-pop/frame-size metrics (also
  fixes an ET_REL hazard: function bodies are now located via the symbol's
  `st_shndx`, never a spanning-address search that could silently disassemble a
  non-text section).
- `artifacts/verified-codegen-roadmap.yaml` — new `VCR-MEASURE-004` entry recording
  the verdict, the numbers, the mechanism, and the named levers.

Gates: fmt/clippy/workspace tests green (true exit code), frozen anchors 10/10,
`claim_check` 50/50, `model_coverage_audit --check` ok, artifact citation gate ok,
no new rivet errors. Flag stays OFF; no Rust touched.

Refs #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
