### PR TITLE
RQ-59-WCETI64 (#936): price the residual four — I32WrapI64, I64ExtendI32S/U, I64Sub — from the real encoder's own bytes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3758,6 +3758,8 @@ jobs:
         run: python scripts/oracle_run.py scripts/repro/wcet_phase5_778_masked_loop_soundness.py
       - name: WCET phase-6 I64Const/I64Ldr/I64Str leaf soundness (#936)
         run: python scripts/oracle_run.py scripts/repro/wcet_phase6_936_i64_leaf_soundness.py
+      - name: WCET phase-7 I32WrapI64/I64ExtendI32S/U conversion soundness (RQ-59-WCETI64, #936)
+        run: python scripts/oracle_run.py scripts/repro/wcet_phase7_936_i64_conv_soundness.py
       # #910: close the job with what it EXECUTED. Asserts every oracle
       # met its declared floor AND that the expected number of them
       # reported at all — a step deleted, commented out, or skipped by an
@@ -3768,7 +3770,7 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          python3 scripts/oracle_evidence.py "$ORACLE_EVIDENCE_JSONL" --min-oracles 5
+          python3 scripts/oracle_evidence.py "$ORACLE_EVIDENCE_JSONL" --min-oracles 6
 
   mcdc-structural-coverage:
     name: MC/DC structural coverage over synth's decision logic (RQ-57-MCDC, #912)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,15 +321,23 @@ frozen and oracle-gated every step:
   `ADD` can need its own `MOVW` for a large offset, which only the real
   encoder's own output reflects) — the same drift class `op_mnemonic`'s "no
   second source of truth to forget to update" already guards against
-  elsewhere in this file. HONEST RESIDUAL: `scan_for_decline` reports only the
-  FIRST decline per function, and the #936 audit found `I64Sub` (a saturating
-  trunc-sat conversion sequence), `I64ExtendI32S`/`I64ExtendI32U`, and
-  `I32WrapI64` are ALSO real direct-selector emissions with no price — a
-  function that narrows an i64 read to i32 (`i64.load` + `i32.wrap_i64`, a
-  plausible OS shape) still declines, now on `I32WrapI64` instead of `I64Ldr`
-  (measured); NOT priced by this lane. Gated by `wcet_bound_gate.rs` (leaf +
-  cascade-composition cases) and the `wcet_phase6_936_i64_leaf_soundness.py`
-  unicorn cross-check.
+  elsewhere in this file. The #936 audit's HONEST RESIDUAL —
+  `scan_for_decline` reports only the FIRST decline per function, and
+  `I64Sub` (a saturating trunc-sat conversion sequence),
+  `I64ExtendI32S`/`I64ExtendI32U`, and `I32WrapI64` were ALSO real
+  direct-selector emissions with no price — was closed by RQ-59-WCETI64
+  (v0.59): all four are priced by the same real-encoder mechanism (measured
+  per op, decline scan re-run after each; nothing new surfaced behind any of
+  them), so the narrowing shape (`i64.load` + `i32.wrap_i64`) and the
+  widen-store shape (`i64.extend_i32_s` + `i64.store`) now BOUND. `I64Sub`'s
+  only real emission (the f64 trunc-sat decompose) cannot even compile on a
+  sound core — priced so a future integer-path emission is covered, not
+  latent. Still-loud declines, measured: `memory.size`/`memory.grow`
+  (`unmodeled-op`), i64 software div/rem (`looped-expansion`, deliberate).
+  Gated by `wcet_bound_gate.rs` (leaf + cascade-composition + converted
+  narrow shape + still-declines pins) and the
+  `wcet_phase6_936_i64_leaf_soundness.py` +
+  `wcet_phase7_936_i64_conv_soundness.py` unicorn cross-checks.
 - **Gate `VCR-VER-001`:** DEMONSTRATED (implemented, evidence in
   `scripts/repro/vcr_ver_001_gate.md`) — the v0.11.20 reciprocal-mult
   cost-gate was deleted outright (PR #322, differential bit-identical); the

--- a/claims.yaml
+++ b/claims.yaml
@@ -1716,16 +1716,21 @@ claims:
         pattern: 'let frames = \(cert\.max_depth as u128\)\.saturating_add\(1\);'
         glob: ['crates/synth-backend/src/wcet_compose.rs']
         expect: 1
-      # #936 — I64Const/I64Ldr/I64Str are PRICED (bounded), not declined
-      # `Unmodeled`. Sound-critical because it is sized from the REAL Thumb-2
-      # encoder's own byte length for the instance (`straightline_expansion_real`),
-      # NOT the synth-synthesis byte-size estimator's `_ => 2` default (which does
-      # not cover these ops and would silently under-count) and NOT a hand-mirrored
-      # predicate (a naive "offset>0xFFF costs 2 extra ADD.W" mirror was proven
-      # WRONG at authoring — the address-materialization ADD itself can need its
-      # own MOVW for a large offset, which only calling the real encoder catches).
+      # #936 + RQ-59-WCETI64 — the direct-selector i64 pseudo-ops with real
+      # emissions (I64Const/I64Ldr/I64Str, then the #936 audit's residual four:
+      # I32WrapI64/I64ExtendI32S/I64ExtendI32U/I64Sub) are PRICED (bounded),
+      # not declined `Unmodeled`. Sound-critical because each is sized from the
+      # REAL Thumb-2 encoder's own byte length for the instance
+      # (`straightline_expansion_real`), NOT the synth-synthesis byte-size
+      # estimator's `_ => 2` default (which does not cover these ops and would
+      # silently under-count) and NOT a hand-mirrored predicate (a naive
+      # "offset>0xFFF costs 2 extra ADD.W" mirror was proven WRONG at #936
+      # authoring — the address-materialization ADD itself can need its own
+      # MOVW for a large offset, which only calling the real encoder catches).
+      # The pattern enumerates ALL SEVEN variants of the priced arm, `\s*`
+      # format-tolerant: dropping any one out of the arm reddens this pin.
       - kind: count-eq
-        pattern: 'I64Const \{ \.\. \} \| I64Ldr \{ \.\. \} \| I64Str \{ \.\. \} => match straightline_expansion_real'
+        pattern: '(?s)I64Const \{ \.\. \}\s*\| I64Ldr \{ \.\. \}\s*\| I64Str \{ \.\. \}\s*\| I32WrapI64 \{ \.\. \}\s*\| I64ExtendI32S \{ \.\. \}\s*\| I64ExtendI32U \{ \.\. \}\s*\| I64Sub \{ \.\. \} => match straightline_expansion_real'
         glob: ['crates/synth-backend/src/wcet.rs']
         expect: 1
       - kind: count-eq

--- a/crates/synth-backend/src/wcet.rs
+++ b/crates/synth-backend/src/wcet.rs
@@ -298,7 +298,40 @@ fn op_cost(op: &ArmOp) -> OpCost {
         // byte length for THIS instance, not the (non-covering, `_ => 2`)
         // synth-synthesis byte-size estimator [`straightline_expansion`]
         // above uses.
-        I64Const { .. } | I64Ldr { .. } | I64Str { .. } => match straightline_expansion_real(op) {
+        //
+        // RQ-59-WCETI64 (#936 residual): `I64Sub`, `I64ExtendI32S`,
+        // `I64ExtendI32U` and `I32WrapI64` — the four ops #936's own audit
+        // named as real emissions with no price — join the same
+        // real-encoder-priced arm. Each `encode_thumb` expansion is a FIXED
+        // sequence of already-priced 1-cycle primitives with NO internal
+        // runtime loop and NO SP motion:
+        //   - I64Sub: `SUBS` (16-bit) + `SBC.W` (32-bit) = 6 B;
+        //   - I64ExtendI32S: optional `MOV` + `ASR.W rdhi, rdlo, #31` = 4-6 B;
+        //   - I64ExtendI32U: optional `MOV` + `MOV/MOV.W rdhi, #0` = 2-6 B;
+        //   - I32WrapI64: `NOP` (rd == rnlo) or `MOV` = 2 B.
+        // Reachability, MEASURED per op (decline scan re-run after each, since
+        // `scan_for_decline` reports only the FIRST decline per function):
+        //   - I32WrapI64 (rule_i32_wrap_i64) and I64ExtendI32S
+        //     (rule_i64_extend_i32_s) are live pseudo-ops on the
+        //     direct/relocatable selector — pricing them flips the #936
+        //     "narrow an i64 read to i32" OS shape from declined to bounded;
+        //   - I64ExtendI32U's pseudo was already retired from the direct path
+        //     by RQ-58-SELDSL (rule_i64_extend_i32_u emits raw Mov/Movw
+        //     primitives), so `i64.extend_i32_u` bounded BEFORE this change —
+        //     priced belt-and-braces for the `select_default` fallback arm
+        //     that still emits the pseudo;
+        //   - I64Sub's only real emission is inside
+        //     `lower_i64_trunc_sat_from_f64` (the saturating trunc-sat
+        //     decompose), whose stream leads with scalar-f64 VFP ops and is
+        //     only compilable on a double-precision-FPU target (GI-FPU-002 →
+        //     cortex-m7dp), which `sound_core_class` declines
+        //     `unsupported-core` before any op scan — so pricing it moves no
+        //     decline today; it is priced so a future integer-path emission
+        //     is covered rather than latent.
+        I64Const { .. }
+        | I64Ldr { .. }
+        | I64Str { .. }
+        | I32WrapI64 { .. } => match straightline_expansion_real(op) {
             Some(c) => Cycles(c),
             None => Unmodeled,
         },
@@ -358,8 +391,7 @@ fn op_cost(op: &ArmOp) -> OpCost {
         | I64GeS { .. }
         | I64GeU { .. }
         | I64ExtendI32S { .. }
-        | I64ExtendI32U { .. }
-        | I32WrapI64 { .. } => Unmodeled,
+        | I64ExtendI32U { .. } => Unmodeled,
 
         // === all F32/F64 scalar VFP + all MVE vector: not on the sound integer path ===
         F32Add { .. }

--- a/crates/synth-backend/src/wcet.rs
+++ b/crates/synth-backend/src/wcet.rs
@@ -135,7 +135,10 @@ fn straightline_expansion(op: &ArmOp) -> u64 {
 /// practice; a caller declines `Unmodeled` rather than trusting an un-costed
 /// op. Reuses the SAME pinned `STRAIGHTLINE_CEIL_PER_HALFWORD` ceiling and the
 /// same per-instruction-≤-ceiling argument (I64Const/I64Ldr/I64Str expand to
-/// only MOVW/MOVT/LDR/STR/ADD.W, all already priced well under the ceiling).
+/// only MOVW/MOVT/LDR/STR/ADD.W; the RQ-59-WCETI64 four — I64Sub,
+/// I64ExtendI32S/U, I32WrapI64 — to only SUBS/SBC.W/MOV/MOV.W/ASR.W/NOP: all
+/// 1-cycle-class primitives already priced well under the ceiling, with no
+/// internal branch, loop, or SP motion).
 fn straightline_expansion_real(op: &ArmOp) -> Option<u64> {
     let bytes = crate::arm_encoder::ArmEncoder::new_thumb2()
         .encode(op)
@@ -325,13 +328,18 @@ fn op_cost(op: &ArmOp) -> OpCost {
         //     decompose), whose stream leads with scalar-f64 VFP ops and is
         //     only compilable on a double-precision-FPU target (GI-FPU-002 →
         //     cortex-m7dp), which `sound_core_class` declines
-        //     `unsupported-core` before any op scan — so pricing it moves no
-        //     decline today; it is priced so a future integer-path emission
-        //     is covered rather than latent.
+        //     `unsupported-core` before any op scan (measured: the trunc-sat
+        //     fixture does not even COMPILE on cortex-m4 — "no functions
+        //     compiled successfully") — so pricing it moves no decline today;
+        //     it is priced so a future integer-path emission is covered
+        //     rather than latent.
         I64Const { .. }
         | I64Ldr { .. }
         | I64Str { .. }
-        | I32WrapI64 { .. } => match straightline_expansion_real(op) {
+        | I32WrapI64 { .. }
+        | I64ExtendI32S { .. }
+        | I64ExtendI32U { .. }
+        | I64Sub { .. } => match straightline_expansion_real(op) {
             Some(c) => Cycles(c),
             None => Unmodeled,
         },
@@ -362,20 +370,19 @@ fn op_cost(op: &ArmOp) -> OpCost {
         // === i64 pseudo binops/compares: mostly lowered to 32-bit pairs =====
         // === upstream — NOT a blanket "never in stream" claim (#936 audit) ===
         // I64Const/I64Ldr/I64Str were priced above, out of this bucket, once
-        // #936 found them REAL on the direct/relocatable selector. Auditing
-        // the rest during that fix found `I64Sub` (a saturating trunc-sat
-        // conversion sequence), `I64ExtendI32S`/`I64ExtendI32U`, and
-        // `I32WrapI64` are ALSO real direct-selector emissions with real
-        // `encode_thumb` support — reachable, just not exercised by ANY
-        // function's FIRST decline on the #936 gale composite (gale's 9
-        // unmodeled-op declines were exhaustively I64Const/I64Str), and not
-        // priced by this lane — a scoped follow-up, not a doc claim to repeat
-        // here. `I64Add`/`I64And`/`I64Or`/`I64Xor`/`I64Eqz`/`I64Eq`/`I64Ne`/
-        // `I64Lt*`/`I64Le*`/`I64Gt*`/`I64Ge*` have NO real emission site in
-        // `instruction_selector.rs` today (checked at the same time) — for
-        // THOSE the original claim holds.
+        // #936 found them REAL on the direct/relocatable selector; the #936
+        // audit's four residual real emissions (`I64Sub`,
+        // `I64ExtendI32S`/`I64ExtendI32U`, `I32WrapI64`) followed in
+        // RQ-59-WCETI64 (see the priced arm above). What REMAINS here is
+        // exactly the set with NO real emission site in
+        // `instruction_selector.rs` today (checked in the #936 audit and
+        // re-checked by RQ-59-WCETI64): `I64Add`/`I64And`/`I64Or`/`I64Xor`/
+        // `I64Eqz`/`I64Eq`/`I64Ne`/`I64Lt*`/`I64Le*`/`I64Gt*`/`I64Ge*` — the
+        // selector expands those WASM ops to 32-bit primitives before the
+        // WCET pass sees them (measured: `i64.lt_s`/`i64.eqz`/`i64.sub`
+        // fixtures all bound WITHOUT touching these pseudo arms). Unmodeled =
+        // belt-and-braces decline, not a live decline surface.
         I64Add { .. }
-        | I64Sub { .. }
         | I64And { .. }
         | I64Or { .. }
         | I64Xor { .. }
@@ -389,9 +396,7 @@ fn op_cost(op: &ArmOp) -> OpCost {
         | I64GtS { .. }
         | I64GtU { .. }
         | I64GeS { .. }
-        | I64GeU { .. }
-        | I64ExtendI32S { .. }
-        | I64ExtendI32U { .. } => Unmodeled,
+        | I64GeU { .. } => Unmodeled,
 
         // === all F32/F64 scalar VFP + all MVE vector: not on the sound integer path ===
         F32Add { .. }
@@ -1075,6 +1080,108 @@ mod tests {
         })];
         match function_wcet("l_frame", &instrs, "cortex-m4") {
             WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 20),
+            other => panic!("expected bounded, got {other:?}"),
+        }
+    }
+
+    // RQ-59-WCETI64 (#936 residual) — the audit's remaining four real
+    // direct-selector emissions are PRICED by the same real-encoder
+    // mechanism. Expected cycles = `(real encoder byte-length / 2) ×
+    // STRAIGHTLINE_CEIL_PER_HALFWORD` (= 5), with the byte length taken from
+    // `encode_thumb`'s actual output per shape — both the aliased
+    // (register-reuse) and non-aliased forms are pinned because the encoder
+    // emits DIFFERENT byte lengths for them (the exact per-instance
+    // sensitivity a hand-mirrored size predicate would have gotten wrong).
+
+    #[test]
+    fn i32_wrap_i64_aliased_is_bounded() {
+        // rd == rnlo: a genuine 16-bit NOP -> 2 bytes -> (2/2)*5 = 5 cycles.
+        let instrs = vec![insn(ArmOp::I32WrapI64 {
+            rd: Reg::R0,
+            rnlo: Reg::R0,
+        })];
+        match function_wcet("w_alias", &instrs, "cortex-m4") {
+            WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 5),
+            other => panic!("expected bounded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn i32_wrap_i64_move_is_bounded() {
+        // rd != rnlo: a 16-bit MOV -> 2 bytes -> 5 cycles.
+        let instrs = vec![insn(ArmOp::I32WrapI64 {
+            rd: Reg::R0,
+            rnlo: Reg::R2,
+        })];
+        match function_wcet("w_mov", &instrs, "cortex-m4") {
+            WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 5),
+            other => panic!("expected bounded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn i64_extend_i32_s_aliased_is_bounded() {
+        // rdlo == rn: no MOV, just ASR.W rdhi, rdlo, #31 -> 4 bytes -> 10.
+        let instrs = vec![insn(ArmOp::I64ExtendI32S {
+            rdlo: Reg::R0,
+            rdhi: Reg::R1,
+            rn: Reg::R0,
+        })];
+        match function_wcet("es_alias", &instrs, "cortex-m4") {
+            WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 10),
+            other => panic!("expected bounded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn i64_extend_i32_s_move_is_bounded() {
+        // rdlo != rn: 16-bit MOV + 32-bit ASR.W -> 6 bytes -> 15.
+        let instrs = vec![insn(ArmOp::I64ExtendI32S {
+            rdlo: Reg::R2,
+            rdhi: Reg::R3,
+            rn: Reg::R0,
+        })];
+        match function_wcet("es_mov", &instrs, "cortex-m4") {
+            WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 15),
+            other => panic!("expected bounded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn i64_extend_i32_u_is_bounded() {
+        // rdlo == rn, low rdhi: just the 16-bit `MOVS rdhi, #0` zero-fill ->
+        // 2 bytes -> 5. (The direct selector itself emits raw Mov/Movw via
+        // rule_i64_extend_i32_u since RQ-58-SELDSL — this pseudo remains
+        // live only on the `select_default` fallback path; priced
+        // belt-and-braces so a stream carrying it bounds rather than
+        // silently declining.)
+        let instrs = vec![insn(ArmOp::I64ExtendI32U {
+            rdlo: Reg::R0,
+            rdhi: Reg::R1,
+            rn: Reg::R0,
+        })];
+        match function_wcet("eu", &instrs, "cortex-m4") {
+            WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 5),
+            other => panic!("expected bounded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn i64_sub_is_bounded() {
+        // SUBS (16-bit) + SBC.W (32-bit) -> 6 bytes -> 15. Today's only real
+        // emission is inside the f64 trunc-sat decompose (unreachable on a
+        // sound core: cortex-m4 cannot even compile it); priced so a future
+        // integer-path emission is covered rather than latent.
+        let instrs = vec![insn(ArmOp::I64Sub {
+            rdlo: Reg::R0,
+            rdhi: Reg::R1,
+            rnlo: Reg::R0,
+            rnhi: Reg::R1,
+            rmlo: Reg::R2,
+            rmhi: Reg::R3,
+        })];
+        match function_wcet("sb", &instrs, "cortex-m4") {
+            WcetFunction::Bounded { cycles, .. } => assert_eq!(cycles, 15),
             other => panic!("expected bounded, got {other:?}"),
         }
     }

--- a/crates/synth-cli/tests/wcet_bound_gate.rs
+++ b/crates/synth-cli/tests/wcet_bound_gate.rs
@@ -659,13 +659,18 @@ fn assert_sp_motion_loop_bounded(report: &Value, name: &str, cycles: u64) {
 // them in `coverage()` (`estimator_encoder_agreement.rs`), a claim that
 // file's own doc says it cannot prove exhaustively going forward.
 //
-// HONEST RESIDUAL: `scan_for_decline` reports only the FIRST decline per
-// function, so pricing these three does not mean every i64-touching function
-// now bounds — `I64Sub`, `I64ExtendI32S`/`I64ExtendI32U`, and `I32WrapI64`
-// are ALSO real direct-selector emissions with no price (found during this
-// audit, not priced here — scoped follow-up). A function that narrows an
-// i64 read to i32 (`i64.load` + `i32.wrap_i64`) still declines, now on
-// `I32WrapI64` rather than `I64Ldr`.
+// RQ-59-WCETI64 closed the #936 audit's residual: `I32WrapI64`,
+// `I64ExtendI32S`, `I64ExtendI32U`, and `I64Sub` are priced by the SAME
+// real-encoder mechanism (measured per op with the decline scan re-run after
+// each, since `scan_for_decline` reports only the FIRST decline per
+// function — nothing new surfaced behind any of the four). The narrow shape
+// that this section previously pinned as STILL-declining
+// (`i64.load` + `i32.wrap_i64`, declining on `I32WrapI64` after `I64Ldr`
+// priced) now BOUNDS — see `i32_wrap_i64_after_priced_i64_ops_now_bounds`.
+// The `unmodeled-op` decline class itself stays alive and loud for genuinely
+// unpriced ops (`memory_size_still_declines_unmodeled_op` below pins one),
+// and the deliberate declines (i64 software div/rem `looped-expansion`,
+// loops, calls, recursion, unsupported cores) are untouched.
 //
 // Cycle literals below are sized from the REAL Thumb-2 encoder's own byte
 // length for each instance (`straightline_expansion_real`, NOT the
@@ -753,16 +758,14 @@ fn i64_ldr_cascade_composes_to_bounded() {
     );
 }
 
-/// HONEST RESIDUAL, measured not asserted: pricing I64Const/I64Ldr/I64Str
-/// does NOT mean every i64-touching function now bounds. `scan_for_decline`
-/// reports only the FIRST decline, and `i32.wrap_i64` (narrowing an i64 read
-/// to i32 — a plausible OS shape) still lowers to the unpriced `I32WrapI64`
-/// pseudo-op. This function's i64.load and i64.const/i64.add all price fine;
-/// it declines on the wrap at the end, proving the fix is scoped to exactly
-/// the two (three, with I64Ldr) opcode families it claims and not a general
-/// "i64 is now bounded" claim.
+/// RQ-59-WCETI64 (#936 residual): the EXACT fixture this gate previously
+/// pinned as the honest residual — an i64 read narrowed to i32, the plausible
+/// OS shape — CONVERTS from `declined unmodeled-op op=I32WrapI64` to bounded
+/// now that `I32WrapI64` is priced (real-encoder byte length: a 2 B
+/// `MOV`/`NOP`). The decline was converted, not deleted: see
+/// `memory_size_still_declines_unmodeled_op` for the still-live decline class.
 #[test]
-fn i32_wrap_i64_after_priced_i64_ops_still_declines() {
+fn i32_wrap_i64_after_priced_i64_ops_now_bounds() {
     let wat = r#"
         (module
           (memory 1)
@@ -770,11 +773,97 @@ fn i32_wrap_i64_after_priced_i64_ops_still_declines() {
             local.get 0 i64.load i64.const 3 i64.add i32.wrap_i64))
     "#;
     let report = compile_wcet_relocatable(wat, "cortex-m4");
-    let f = func(&report, "narrow");
+    assert_bounded(&report, "narrow", 80);
+}
+
+/// RQ-59-WCETI64 leaf: `i32.wrap_i64` alone (i64 param, low word out).
+/// `ArmOp::I32WrapI64` prices from the real encoder's own byte length for the
+/// instance (2 B — a 16-bit `MOV`, or a genuine `NOP` when rd == rnlo).
+#[test]
+fn i32_wrap_i64_relocatable_leaf_is_bounded() {
+    let wat = r#"
+        (module
+          (memory 1)
+          (func (export "w") (param i64) (result i32)
+            local.get 0
+            i32.wrap_i64))
+    "#;
+    let report = compile_wcet_relocatable(wat, "cortex-m4");
+    assert_bounded(&report, "w", 28);
+}
+
+/// RQ-59-WCETI64 leaf: `i64.extend_i32_s` lowers (via the Rocq-proved
+/// `rule_i64_extend_i32_s`) to the `ArmOp::I64ExtendI32S` pseudo — optional
+/// 16-bit `MOV` + 32-bit `ASR.W rdhi, rdlo, #31`, 4-6 B from the real encoder.
+#[test]
+fn i64_extend_i32_s_relocatable_leaf_is_bounded() {
+    let wat = r#"
+        (module
+          (func (export "es") (param i32) (result i64)
+            local.get 0
+            i64.extend_i32_s))
+    "#;
+    let report = compile_wcet_relocatable(wat, "cortex-m4");
+    assert_bounded(&report, "es", 39);
+}
+
+/// RQ-59-WCETI64 control: `i64.extend_i32_u` bounded BEFORE this change —
+/// RQ-58-SELDSL's `rule_i64_extend_i32_u` emits raw `Mov`/`Movw` primitives
+/// (already priced), so the `ArmOp::I64ExtendI32U` pseudo never reaches the
+/// direct-selector stream. Its price is belt-and-braces for the
+/// `select_default` fallback arm that still emits the pseudo. This pin proves
+/// the claim "bounded before" stays true (16 cycles, unchanged from v0.58).
+#[test]
+fn i64_extend_i32_u_relocatable_leaf_is_bounded() {
+    let wat = r#"
+        (module
+          (func (export "eu") (param i32) (result i64)
+            local.get 0
+            i64.extend_i32_u))
+    "#;
+    let report = compile_wcet_relocatable(wat, "cortex-m4");
+    assert_bounded(&report, "eu", 16);
+}
+
+/// RQ-59-WCETI64 composite: widen-then-store (`i64.extend_i32_s` +
+/// `i64.store`) — the second measured OS shape that declined on
+/// `I64ExtendI32S` before this change (behind the already-priced `I64Str`).
+#[test]
+fn i64_extend_i32_s_store_composite_is_bounded() {
+    let wat = r#"
+        (module
+          (memory 1)
+          (func (export "ws") (param i32 i32)
+            local.get 0
+            local.get 1
+            i64.extend_i32_s
+            i64.store))
+    "#;
+    let report = compile_wcet_relocatable(wat, "cortex-m4");
+    assert_bounded(&report, "ws", 67);
+}
+
+/// HONEST RESIDUAL, measured not asserted (the #936 discipline, kept):
+/// pricing the four RQ-59-WCETI64 ops does NOT mean `unmodeled-op` went away
+/// as a class. `memory.size` lowers to the unpriced `ArmOp::MemorySize`
+/// pseudo and still LOUD-declines, naming the op (#921 schema). This is the
+/// non-vacuity pin that the decline machinery this fix narrows is still
+/// alive — if THIS ever bounds, the model grew again and this test must
+/// retarget, not delete (same rule as `wcet_decline_names_op_921.rs`).
+#[test]
+fn memory_size_still_declines_unmodeled_op() {
+    let wat = r#"
+        (module
+          (memory 1)
+          (func (export "ms") (result i32)
+            memory.size))
+    "#;
+    let report = compile_wcet_relocatable(wat, "cortex-m4");
+    let f = func(&report, "ms");
     assert_eq!(
         f.get("status").and_then(Value::as_str),
         Some("declined"),
-        "narrow: expected declined (I32WrapI64 unpriced), got {f}"
+        "ms: expected declined (MemorySize unpriced), got {f}"
     );
     assert_eq!(
         f.get("reason").and_then(Value::as_str),
@@ -782,9 +871,8 @@ fn i32_wrap_i64_after_priced_i64_ops_still_declines() {
     );
     assert_eq!(
         f.get("op").and_then(Value::as_str),
-        Some("I32WrapI64"),
-        "narrow: expected the residual decline to name I32WrapI64 (the i64.load/ \
-         i64.const/i64.add ahead of it all price now); got {f}"
+        Some("MemorySize"),
+        "ms: the decline must NAME the op (#921); got {f}"
     );
 }
 

--- a/crates/synth-cli/tests/wcet_decline_names_op_921.rs
+++ b/crates/synth-cli/tests/wcet_decline_names_op_921.rs
@@ -26,7 +26,7 @@ fn synth_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_synth"))
 }
 
-/// `i32.wrap_i64` lowers to `ArmOp::I32WrapI64`, which `op_cost` deliberately
+/// `memory.size` lowers to `ArmOp::MemorySize`, which `op_cost` deliberately
 /// leaves unclassified — the shortest local reproduction of gale's decline.
 ///
 /// #936 RETARGET: this test originally reproduced the decline via `i64.load`
@@ -34,27 +34,29 @@ fn synth_binary() -> PathBuf {
 /// `unmodeled-op` declines on a real `gust:os` composite resolved to exactly
 /// those two opcode FAMILIES), so `i64.load` no longer declines — exactly the
 /// "good problem" this test's own non-vacuity check was written to catch (see
-/// below). Retargeted at `i32.wrap_i64`, which the #936 audit confirmed is
-/// STILL a real direct-selector emission (`instruction_selector.rs`) with NO
-/// cycle-model price.
+/// below), and the test moved to `i32.wrap_i64`.
 ///
-/// Note that `i64.add`, `i64.ge_s` and `i64.extend_i32_u` do NOT reproduce it:
-/// the selector expands those before the WCET pass sees them. That asymmetry is
-/// exactly why naming the op matters — the reason string alone cannot
-/// distinguish which of the unclassified family a given function tripped over.
+/// RQ-59-WCETI64 RETARGET (second time, same rule): pricing the #936 audit's
+/// residual four (`I32WrapI64`, `I64ExtendI32S`/`I64ExtendI32U`, `I64Sub`)
+/// un-declined `i32.wrap_i64` too. Retargeted at `memory.size` — measured
+/// STILL a live `unmodeled-op op=MemorySize` decline on the direct/relocatable
+/// selector (probed alongside `f32.add`, which does not COMPILE on cortex-m4,
+/// and the i64 binops/compares, which the selector expands to priced 32-bit
+/// primitives before the WCET pass sees them). That asymmetry is exactly why
+/// naming the op matters — the reason string alone cannot distinguish which of
+/// the unclassified family a given function tripped over.
 const FIXTURE: &str = r#"(module
   (memory 1)
-  (func (export "f") (param i64) (result i32)
-    local.get 0
-    i32.wrap_i64))
+  (func (export "f") (result i32)
+    memory.size))
 "#;
 
 #[test]
 fn unmodeled_op_decline_names_the_op_and_offset() {
     let dir = std::env::temp_dir().join("synth-wcet-921");
     std::fs::create_dir_all(&dir).expect("temp dir");
-    let wat = dir.join("i32_wrap_i64.wat");
-    let obj = dir.join("i32_wrap_i64.o");
+    let wat = dir.join("memory_size.wat");
+    let obj = dir.join("memory_size.o");
     std::fs::write(&wat, FIXTURE).expect("write fixture");
 
     let out = Command::new(synth_binary())
@@ -89,24 +91,25 @@ fn unmodeled_op_decline_names_the_op_and_offset() {
         .collect();
 
     // NON-VACUITY: if the fixture ever stops declining (a good thing — it would
-    // mean the cycle model grew to cover `I32WrapI64`), this test must FAIL
+    // mean the cycle model grew to cover `MemorySize`), this test must FAIL
     // rather than pass over an empty set. A green assertion about no records is
     // the exact shape #890/#910 exist to reject. (#936: this is exactly what
-    // happened to the ORIGINAL `i64.load` fixture — retargeted here, not
-    // deleted; see the FIXTURE doc comment above.)
+    // happened to the ORIGINAL `i64.load` fixture, and RQ-59-WCETI64 repeated
+    // it on the `i32.wrap_i64` retarget — retargeted again, not deleted; see
+    // the FIXTURE doc comment above.)
     assert!(
         !declined.is_empty(),
-        "fixture no longer declines — if `I32WrapI64` is now costed, retarget \
+        "fixture no longer declines — if `MemorySize` is now costed, retarget \
          this test at another unclassified op rather than deleting the assertion"
     );
 
     let d = declined
         .iter()
         .find(|f| f["reason"] == "unmodeled-op")
-        .expect("the i32.wrap_i64 fixture declines `unmodeled-op`");
+        .expect("the memory.size fixture declines `unmodeled-op`");
 
     assert_eq!(
-        d["op"], "I32WrapI64",
+        d["op"], "MemorySize",
         "the decline must NAME the op (#921); got {d}"
     );
     assert!(

--- a/scripts/repro/wcet_phase7_936_i64_conv_soundness.py
+++ b/scripts/repro/wcet_phase7_936_i64_conv_soundness.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# ci-status: wired
+# ci-checks: emulations >= 4
+"""RQ-59-WCETI64 (#936 residual) soundness cross-check: the #936 audit's four
+remaining real direct-selector emissions — `I32WrapI64`, `I64ExtendI32S`,
+`I64ExtendI32U`, `I64Sub` — are now PRICED (bounded), not declined, in the
+WCET cycle model. Compile four fixtures via `--relocatable` (#197: the ONLY
+compile path that reaches these pseudo-ops as real `ArmOp`s), execute each
+under unicorn (Thumb-2), and confirm:
+
+  1. the functional result matches the WASM-semantics ground truth (a wrong
+     ASR sign-fill, a dropped high-word clear — the #916 class — or a wrong
+     low-word move would change it);
+  2. bound_cycles >= executed machine instructions (every machine
+     instruction costs >= 1 cycle) — the priced bound is a sound ceiling on
+     the ACTUAL execution, not a guessed constant.
+
+The fixture set is the measured RQ-59 step ledger:
+
+  - `w`  (`i32.wrap_i64` leaf) and `narrow` (`i64.load` + `i64.add` +
+    `i32.wrap_i64`, the #936 "narrow an i64 read to i32" OS shape) declined
+    `unmodeled-op op=I32WrapI64` before this fix;
+  - `es` (`i64.extend_i32_s` leaf) declined `unmodeled-op op=I64ExtendI32S`;
+  - `eu` (`i64.extend_i32_u` leaf) is the CONTROL: it bounded BEFORE the fix
+    (RQ-58-SELDSL's rule emits raw Mov/Movw primitives), so its pass here
+    pins that pricing the pseudo did not disturb the already-bounded path.
+
+`I64Sub` has no unicorn fixture ON PURPOSE: its only real emission today is
+inside the f64 trunc-sat decompose, which does not even COMPILE on a sound
+core (cortex-m4 has no double-precision FPU — measured: "no functions
+compiled successfully"), so there is no reachable stream to execute. Its
+price is pinned analytically in the `synth-backend` unit tests
+(`i64_sub_is_bounded`: SUBS + SBC.W = 6 B -> 15 cycles).
+
+The `narrow` seed is chosen so the i64.add CARRIES across the word boundary
+(0xFFFFFFFE + 3 = 0x1_00000001 -> wrap = 1): a bound-only harness would pass
+with a broken ADDS/ADC pair, this result does not.
+
+This is the execution-side evidence the cargo gate cannot produce in-CI (no
+unicorn dep there); the gate (`wcet_bound_gate.rs`) pins the same fixtures'
+exact cycle literals (28 / 80 / 39 / 16 at authoring, debug build,
+cortex-m4).
+
+Usage:
+    SYNTH=/path/to/synth python3 scripts/repro/wcet_phase7_936_i64_conv_soundness.py
+Requires: pip install unicorn pyelftools
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from wcet_phase2_778_unicorn_soundness import load_elf, sidecar_entry  # noqa: E402
+from wcet_phase6_936_i64_leaf_soundness import (  # noqa: E402
+    MEM_BASE,
+    compile_wat_relocatable,
+    run_leaf,
+)
+
+WRAP_WAT = r"""
+(module
+  (memory 1)
+  (func (export "w") (param i64) (result i32)
+    local.get 0
+    i32.wrap_i64))
+"""
+
+NARROW_WAT = r"""
+(module
+  (memory 1)
+  (func (export "narrow") (param i32) (result i32)
+    local.get 0 i64.load i64.const 3 i64.add i32.wrap_i64))
+"""
+
+EXT_S_WAT = r"""
+(module
+  (func (export "es") (param i32) (result i64)
+    local.get 0
+    i64.extend_i32_s))
+"""
+
+EXT_U_WAT = r"""
+(module
+  (func (export "eu") (param i32) (result i64)
+    local.get 0
+    i64.extend_i32_u))
+"""
+
+
+def check(name, wat, args, expect, mem_writes=(), expect_hi=None):
+    open(f"{name}.wat", "w").write(wat)
+    report = compile_wat_relocatable(f"{name}.wat", f"{name}.o")
+    f = sidecar_entry(report, name)
+    assert f["status"] == "bounded", f"{name}: expected bounded, got {f}"
+    text, text_addr, syms = load_elf(f"{name}.o")
+    r0, r1, n, _ = run_leaf(text, text_addr, syms[name], args=args,
+                            mem_writes=mem_writes)
+    assert r0 == expect, f"{name}: r0 = {r0:#x}, expected {expect:#x}"
+    if expect_hi is not None:
+        assert r1 == expect_hi, f"{name}: r1 = {r1:#x}, expected {expect_hi:#x}"
+    bound = f["cycles"]
+    assert bound >= n, f"{name}: UNSOUND — bound {bound} cycles < {n} executed insns"
+    print(f"  OK {name}: r0={r0:#x} r1={r1:#x}, {n} insns <= bound {bound} cycles")
+
+
+def main():
+    d = os.environ.get("WCET_REPRO_DIR", "/tmp/wcet_phase7_936_repro")
+    os.makedirs(d, exist_ok=True)
+    os.chdir(d)
+
+    print("== I32WrapI64: i32.wrap_i64 leaf (i64 param in r0:r1, low word out) ==")
+    check("w", WRAP_WAT, (0x11223344, 0xAABBCCDD), 0x11223344)
+
+    print("== I32WrapI64 behind priced i64 ops: the #936 narrow OS shape ==")
+    print("   (seed 0xFFFFFFFE + 3 carries across the word boundary -> 1)")
+    check(
+        "narrow", NARROW_WAT, (16,), 0x00000001,
+        mem_writes=[(MEM_BASE + 16, (0xFFFFFFFE).to_bytes(8, "little"))],
+    )
+
+    print("== I64ExtendI32S: sign-extend a NEGATIVE i32 (-5) ==")
+    check("es", EXT_S_WAT, (0xFFFFFFFB,), 0xFFFFFFFB, expect_hi=0xFFFFFFFF)
+
+    print("== I64ExtendI32U (control, bounded pre-fix): zero-extend sign-bit-set ==")
+    check("eu", EXT_U_WAT, (0x80000001,), 0x80000001, expect_hi=0)
+
+    print("\nALL PHASE-7 (RQ-59-WCETI64 / #936 residual) CONVERSION SOUNDNESS CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## RQ-59-WCETI64 (#936 residual)

#936 priced `I64Const`/`I64Ldr`/`I64Str` and recorded an HONEST RESIDUAL: `I64Sub`, `I64ExtendI32S`, `I64ExtendI32U`, `I32WrapI64` — real direct-selector emissions with NO price, so an i64-read-narrowed-to-i32 function (a plausible OS shape) still loud-declined, on `I32WrapI64` instead of `I64Ldr`. This PR closes that residual with the SAME mechanism #936 shipped — and NOT the one it first tried and proved unsound (a hand-mirrored size predicate): every price is the REAL Thumb-2 encoder's own byte length for the instance (`straightline_expansion_real`) × the pinned `STRAIGHTLINE_CEIL_PER_HALFWORD`.

### Ops priced, with encoder-derived sizes

| op | `encode_thumb` expansion | bytes | cycles |
|---|---|---|---|
| `I32WrapI64` | 16-bit `MOV` (or genuine `NOP` when rd == rnlo) | 2 | 5 |
| `I64ExtendI32S` | optional 16-bit `MOV` + `ASR.W rdhi, rdlo, #31` | 4–6 | 10–15 |
| `I64ExtendI32U` | optional `MOV` + 16/32-bit zero-fill (#916 shape) | 2–6 | 5–15 |
| `I64Sub` | `SUBS` (16-bit) + `SBC.W` (32-bit) | 6 | 15 |

All are fixed branch-free sequences of 1-cycle-class primitives, no internal loop, no SP motion — the per-instruction ≤ ceiling argument extends unchanged. Both aliased and non-aliased forms are pinned in unit tests because the encoder emits DIFFERENT byte lengths for them — exactly the per-instance sensitivity a hand mirror would get wrong.

### Before/after decline set at each step (measured, decline scan re-run after each op)

Baseline = main. `scan_for_decline` reports only the FIRST decline per function, so each step could surface a new op behind the priced one — none did.

| fixture | baseline | +I32WrapI64 | +I64ExtendI32S | +I64ExtendI32U, +I64Sub |
|---|---|---|---|---|
| `i32.wrap_i64` leaf | declined `I32WrapI64` | **bounded 28** | 28 | 28 |
| narrow (`i64.load`+`i64.add`+`i32.wrap_i64`, the #936 OS shape) | declined `I32WrapI64` | **bounded 80** | 80 | 80 |
| `i64.extend_i32_s` leaf | declined `I64ExtendI32S` | declined `I64ExtendI32S` | **bounded 39** | 39 |
| widen-store (`extend_i32_s`+`i64.store`) | declined `I64ExtendI32S` | declined `I64ExtendI32S` | **bounded 67** | 67 |
| `i64.extend_i32_u` leaf (CONTROL) | bounded 16 | 16 | 16 | 16 |
| roundtrip (load+add+wrap+extend_u+wrap) | declined `I32WrapI64` | **bounded 87** | 87 | 87 |

- `I64ExtendI32U` bounded BEFORE this change (RQ-58-SELDSL's `rule_i64_extend_i32_u` emits raw `Mov`/`Movw` primitives) — priced belt-and-braces for the `select_default` fallback pseudo; the control pin proves the already-bounded path is undisturbed.
- `I64Sub` moves no decline today: its only real emission is inside the f64 trunc-sat decompose, which does not even COMPILE on a sound core (measured on cortex-m4: "no functions compiled successfully"; dp-FPU targets decline `unsupported-core` before any op scan). Priced so a future integer-path emission is covered rather than latent.

### Soundness cross-check (unicorn, new `scripts/repro/wcet_phase7_936_i64_conv_soundness.py`, CI-wired, oracle floor 5→6)

| fixture | executed insns | bound | margin | functional check |
|---|---|---|---|---|
| `w` (wrap leaf) | 6 | 28 | 4.7× | low word of r0:r1 pair returned |
| `narrow` | 13 | 80 | 6.2× | seed 0xFFFFFFFE + 3 **carries across the word boundary** → 1 |
| `es` (extend_s) | 8 | 39 | 4.9× | −5 sign-fills r1 = 0xFFFFFFFF |
| `eu` (control) | 6 | 16 | 2.7× | high word cleared (the #916 class) |

Bound ≥ actual everywhere. `I64Sub` has no unicorn fixture ON PURPOSE (no reachable stream to execute — see above); it is pinned analytically in the `synth-backend` unit tests.

### `.text` unchanged

All **10 frozen anchors pass untouched** (`frozen_codegen_bytes.rs`). The sidecar is byte-invisible; pricing changed the BOUND, never the emitted code.

### Decline honesty (moved, never deleted)

- The gate's narrow-shape test CONVERTS: `i32_wrap_i64_after_priced_i64_ops_still_declines` → `..._now_bounds` (80).
- New gate pin `memory_size_still_declines_unmodeled_op`: the `unmodeled-op` class is still alive and still NAMES the op.
- `wcet_decline_names_op_921.rs` retargeted at `memory.size` (its second retarget, same non-vacuity rule — probed `f32.add` does not compile on cortex-m4, i64 binops/compares expand to priced 32-bit primitives upstream).
- i64 software div/rem keep their deliberate `looped-expansion` decline (untouched, still gate-pinned).

### claims.yaml

The `SYNTH-WCET-CYCLE-MODEL` priced-arm pin now enumerates ALL SEVEN variants of the arm (`\s*` format-tolerant): dropping any one out of the priced arm reddens claim-check. No new model constants — the four ops reuse the already-pinned ceiling.

### Salvaged WIP commit (c6137b51)

**Kept after review, then completed.** Its ~35 lines staged step 1 (pricing `I32WrapI64` only) plus a comment making claims about all four ops. I verified every claim independently before building on it: the encoder expansions, the selector emission sites (`rule_i32_wrap_i64` / `rule_i64_extend_i32_s` live; `rule_i64_extend_i32_u` primitive-emitting; `I64Sub` trunc-sat-only), and the reachability measurements all check out. It had one defect: the single-line→multi-line rewrite of the priced arm broke the `SYNTH-WCET-CYCLE-MODEL` claims pin (claim-check red at c6137b51) — fixed here with the seven-variant pin.

### Final residual, stated plainly

- **No `unmodeled-op` decline remains reachable in the probed i64 corpus** (wrap/extend/narrow/widen-store/roundtrip/cmp/eqz/mul/select/shifted-extend/global-i64/extend32_s all bound; i64 binops/compares never reach their pseudo arms — the selector expands them upstream, re-checked this lane).
- `unmodeled-op` survives as a class: `memory.size` / `memory.grow` still loud-decline naming `MemorySize`/`MemoryGrow` (now gate-pinned).
- The deliberate declines are untouched: i64 software div/rem (`looped-expansion`), loops/calls/recursion per their phases, non-M3/M4 cores (`unsupported-core`).
- Standing #936 caveat, unchanged: `coverage()` in `estimator_encoder_agreement.rs` hand-asserts these ops OffPath for the OPTIMIZED selector, a claim that file's own doc says it cannot prove exhaustively going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
