### PR TITLE
chore(rivet): RQ-59-MEASURE and RQ-59-WCETI64 are implemented

### DIFF
--- a/artifacts/release-v0.59.yaml
+++ b/artifacts/release-v0.59.yaml
@@ -242,7 +242,7 @@ requirements:
       DO NOT FLIP THE DEFAULT IN THIS RELEASE regardless of the verdict — the
       arc is spike -> measure -> flip-when-dominates -> Rocq-mechanize ->
       retire greedy, and flipping is its own gated step with silicon evidence.
-    status: proposed
+    status: implemented
     release: v0.59
     tags: [north-star, measurement, allocator, verdict]
     links:
@@ -283,7 +283,7 @@ requirements:
 
       Gate: the bound must stay SOUND (>= actual) on the unicorn cross-check,
       and `.text` must be unchanged — the sidecar is byte-invisible.
-    status: proposed
+    status: implemented
     release: v0.59
     tags: [wcet, i64, decline-honesty, soundness]
     links:


### PR DESCRIPTION
#1025 and #1026 merged. **v0.59 now 6/11.**

Like `RQ-59-REACH`, **MEASURE is implemented on a verdict rather than a change**: *DO NOT FLIP*. The colourer wins on net (−122 B, −31 instructions, −72 push/pop registers) but does not dominate — **frame traffic +22** — and the named root cause is that the Chaitin occurrence-count cost metric prices a 2-byte register copy and a 4-byte frame reload identically. Delivering the verdict *is* the artifact; the flip is a separate gated step needing gale silicon evidence.

**WCETI64** closed #936's residual: all four ops priced from the real encoder's byte length (never a hand mirror — that method was tried in #936 and found unsound at authoring). The OS shape that motivated the issue — narrowing an i64 read to i32 — now bounds at **80 cycles** instead of declining. Two of the four ops moved no decline, and the lane reported that rather than counting them as wins.

`claim_check` 50/50. Rivet artifact only.

Refs #242, #936.