### PR TITLE
RQ-59-FRESHNESS (#977): all 48 named stale-artifact sites converted — freshness coverage 7/58 -> 58/58

### DIFF
--- a/artifacts/release-v0.59.yaml
+++ b/artifacts/release-v0.59.yaml
@@ -399,7 +399,7 @@ requirements:
       ELF, prove the counterfactual (it parses and carries `.text`, so the old
       shape WOULD have passed), then fail the compile and require the harness
       to refuse and leave nothing behind.
-    status: proposed
+    status: implemented
     release: v0.59
     tags: [harness, stale-artifact, silent-direction, class-fix]
     links:

--- a/crates/synth-backend/tests/linker_integration_test.rs
+++ b/crates/synth-backend/tests/linker_integration_test.rs
@@ -127,7 +127,12 @@ fn test_linker_script_file_generation() {
     // Test writing to file
     let generator = LinkerScriptGenerator::new_stm32();
 
-    let temp_file = "/tmp/test_linker.ld";
+    // #977 RQ-59-FRESHNESS: per-process-unique path + remove-first, so the
+    // read below can only ever see THIS invocation's output (a fixed /tmp
+    // path re-reads a previous run's script if generate_to_file regresses).
+    let temp_file = std::env::temp_dir().join(format!("test_linker_{}.ld", std::process::id()));
+    let temp_file = temp_file.to_str().unwrap();
+    let _ = std::fs::remove_file(temp_file);
     generator
         .generate_to_file(temp_file)
         .expect("Failed to write");

--- a/crates/synth-cli/tests/artifact_guard/mod.rs
+++ b/crates/synth-cli/tests/artifact_guard/mod.rs
@@ -101,6 +101,17 @@ pub fn read_artifact(path: &Path) -> Result<Vec<u8>, String> {
 /// `cmd` must already carry `-o <out>`. The path is removed first, so a stale
 /// artifact from an earlier run can never be mistaken for this one's output.
 pub fn compile_artifact(cmd: &mut Command, out: &Path) -> Result<Vec<u8>, String> {
+    compile_artifact_with_output(cmd, out).map(|(bytes, _)| bytes)
+}
+
+/// [`compile_artifact`], additionally handing back the process
+/// [`std::process::Output`] for gates that assert on the compiler's own
+/// stderr (e.g. `SYNTH_SPILL_REPORT` stats). Same guard, same order — this is
+/// the one implementation; [`compile_artifact`] delegates here.
+pub fn compile_artifact_with_output(
+    cmd: &mut Command,
+    out: &Path,
+) -> Result<(Vec<u8>, std::process::Output), String> {
     // (0) Freshness: whatever is there now is not ours.
     let _ = std::fs::remove_file(out);
 
@@ -119,7 +130,7 @@ pub fn compile_artifact(cmd: &mut Command, out: &Path) -> Result<Vec<u8>, String
     }
 
     // (2)+(3) It must exist and be non-empty before anything parses it.
-    read_artifact(out)
+    read_artifact(out).map(|bytes| (bytes, output))
 }
 
 /// [`compile_artifact`], panicking with `ctx` prefixed — the ergonomic form for

--- a/crates/synth-cli/tests/async_intrinsics_gate.rs
+++ b/crates/synth-cli/tests/async_intrinsics_gate.rs
@@ -16,6 +16,10 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 /// Locate the `synth` binary the way every other CLI test does.
 ///
 /// This used to walk two parents up from `current_exe()` and append `synth`,
@@ -55,30 +59,24 @@ fn fixture(name: &str) -> PathBuf {
 fn error_context_family_is_lowered_and_emits_field_name_symbol() {
     let wat = fixture("async_error_context.wat");
     assert!(wat.exists(), "fixture missing: {}", wat.display());
-    let out = std::env::temp_dir().join("synth_async_ec.o");
+    // #977: unique per call + remove-first + status/exists/non-empty guards.
+    let out = artifact_guard::unique_artifact("synth_async_ec", "o");
 
-    let result = Command::new(synth_binary())
-        .args([
-            "compile",
-            wat.to_str().unwrap(),
-            "--no-optimize",
-            "--relocatable",
-            "-o",
-            out.to_str().unwrap(),
-        ])
-        .output()
-        .expect("run synth");
-
-    assert!(
-        result.status.success(),
-        "error-context should compile; stderr={}",
-        String::from_utf8_lossy(&result.stderr)
-    );
+    let mut cmd = Command::new(synth_binary());
+    cmd.args([
+        "compile",
+        wat.to_str().unwrap(),
+        "--no-optimize",
+        "--relocatable",
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    let data =
+        artifact_guard::compile_bytes_or_panic(&mut cmd, &out, "error-context should compile");
 
     // The field-name `error-context.drop` must appear as the BL target symbol
     // in the ELF (the host-link contract). We scan the raw bytes for the
     // symbol string — the relocatable path records it as an UNDEF symbol.
-    let data = std::fs::read(&out).unwrap();
     assert_eq!(&data[0..4], b"\x7fELF", "not an ELF");
     let sym = b"error-context.drop";
     assert!(

--- a/crates/synth-cli/tests/base_cse_flip_468.rs
+++ b/crates/synth-cli/tests/base_cse_flip_468.rs
@@ -38,6 +38,12 @@ use std::process::Command;
 use object::{Object, ObjectSection, ObjectSymbol, SymbolKind};
 use sha2::{Digest, Sha256};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. A stale read
+// in a flip gate does not fail, it re-confirms last run's golden as this
+// run's evidence.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -60,7 +66,10 @@ fn fixture(rel: &str) -> std::path::PathBuf {
 /// the default goldens below are byte-identical under const-CSE (its
 /// size-guarded passes find nothing left on the folded shape), so this gate
 /// keeps pinning the TRUE shipped default.
-fn compile(rel: &str, out: &str, default_on: bool) -> Vec<u8> {
+fn compile(rel: &str, tag: &str, default_on: bool) -> Vec<u8> {
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed /tmp path must never be parsed as this run's.
+    let out = artifact_guard::unique_artifact(tag, "elf");
     let mut cmd = Command::new(synth());
     if default_on {
         cmd.env_remove("SYNTH_CONST_CSE");
@@ -69,26 +78,22 @@ fn compile(rel: &str, out: &str, default_on: bool) -> Vec<u8> {
         cmd.env("SYNTH_CONST_CSE", "0");
         cmd.env("SYNTH_BASE_CSE", "0");
     }
-    let out_status = cmd
-        .args([
-            "compile",
-            fixture(rel).to_str().unwrap(),
-            "-o",
-            out,
-            "-b",
-            "arm",
-            "--target",
-            "cortex-m4",
-            "--all-exports",
-        ])
-        .output()
-        .expect("run synth compile");
-    assert!(
-        out_status.status.success(),
-        "synth compile failed ({rel}, default_on={default_on}): {}",
-        String::from_utf8_lossy(&out_status.stderr)
-    );
-    std::fs::read(out).expect("read ELF")
+    cmd.args([
+        "compile",
+        fixture(rel).to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+    ]);
+    artifact_guard::compile_bytes_or_panic(
+        &mut cmd,
+        &out,
+        &format!("{rel} (default_on={default_on})"),
+    )
 }
 
 fn text_bytes(elf: &[u8]) -> Vec<u8> {
@@ -170,13 +175,13 @@ const GOLDENS: [(&str, &str, usize, &str, usize); 2] = [
 fn base_cse_escape_hatch_restores_old_bytes_468() {
     for &(rel, on_sha, on_len, off_sha, off_len) in &GOLDENS {
         let tag = Path::new(rel).file_stem().unwrap().to_str().unwrap();
-        let on = text_bytes(&compile(rel, &format!("/tmp/bcse468_{tag}_on.elf"), true));
+        let on = text_bytes(&compile(rel, &format!("bcse468_{tag}_on"), true));
         assert_eq!(
             (on.len(), sha256_hex(&on).as_str()),
             (on_len, on_sha),
             "{rel}: shipped DEFAULT .text drifted from the flip golden"
         );
-        let off = text_bytes(&compile(rel, &format!("/tmp/bcse468_{tag}_off.elf"), false));
+        let off = text_bytes(&compile(rel, &format!("bcse468_{tag}_off"), false));
         assert_eq!(
             (off.len(), sha256_hex(&off).as_str()),
             (off_len, off_sha),
@@ -209,8 +214,8 @@ fn base_cse_no_grow_corpus_468() {
             "ng_{}",
             Path::new(rel).file_stem().unwrap().to_str().unwrap()
         );
-        let off = func_sizes(&compile(rel, &format!("/tmp/bcse468_{tag}_off.elf"), false));
-        let on = func_sizes(&compile(rel, &format!("/tmp/bcse468_{tag}_on.elf"), true));
+        let off = func_sizes(&compile(rel, &format!("bcse468_{tag}_off"), false));
+        let on = func_sizes(&compile(rel, &format!("bcse468_{tag}_on"), true));
         for (name, &o) in &off {
             let n = *on.get(name).unwrap_or(&o);
             assert!(
@@ -225,5 +230,69 @@ fn base_cse_no_grow_corpus_468() {
     assert!(
         fired >= 2,
         "non-vacuity: base-CSE must shrink at least the two firing fixtures, saw {fired} shrinking function(s)"
+    );
+}
+
+/// #977 RQ-59-FRESHNESS — the SILENT-direction demonstration for the flip-gate
+/// batch (base_cse_flip_468, const_cse_reduction_242, flag_flip_wave_242,
+/// spill_realloc_242, rv32_*_flip_472, volatile_segment_*_543,
+/// vcr_ver_001_gate_242 — all now compile through `artifact_guard`).
+///
+/// The counterfactual, proven not asserted: plant a VALID ELF (minted by this
+/// file's own compile shape) at the output path, show it parses and carries a
+/// `.text` — i.e. the pre-conversion `fs::read` + `File::parse` shape WOULD
+/// have passed a flip gate on last run's bytes — then fail the compile at that
+/// same path and require the guard to refuse AND to leave nothing behind. A
+/// stale read in a flip gate is worse than a crash: `off == on` re-confirms
+/// the previous run's golden as this run's rollback evidence.
+#[test]
+fn freshness_guard_refuses_stale_flip_artifact_977() {
+    // 1. Mint a genuine ELF with this batch's own compile shape.
+    let good = compile(
+        "scripts/repro/redundant_base_materialization.wat",
+        "bcse468_fresh_demo",
+        true,
+    );
+
+    // 2. Plant it, and prove the OLD shape would have passed on it.
+    let planted_at = artifact_guard::unique_artifact("bcse468_stale_planted", "elf");
+    std::fs::write(&planted_at, &good).expect("plant the stale artifact");
+    let stale_bytes = std::fs::read(&planted_at).expect("read planted");
+    let obj = object::File::parse(&*stale_bytes).expect("planted artifact is a valid ELF");
+    assert!(
+        obj.section_by_name(".text").is_some(),
+        "the planted artifact must carry .text — substantial enough to fool an unguarded flip gate"
+    );
+
+    // 3. A FAILING compile aimed at that exact path (nonexistent input).
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        fixture("scripts/repro/does_not_exist_977.wat")
+            .to_str()
+            .unwrap(),
+        "-o",
+        planted_at.to_str().unwrap(),
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+    ]);
+    let err = artifact_guard::compile_artifact(&mut cmd, &planted_at)
+        .expect_err("REFUSAL REQUIRED: a failed compile must not return last run's bytes");
+
+    // 4. The refusal names the compile, not the parser — and nothing is left.
+    assert!(
+        err.contains("synth compile FAILED"),
+        "the refusal must name the compile failure, got: {err}"
+    );
+    assert!(
+        !err.contains("file magic"),
+        "and must not surface as a parse error, got: {err}"
+    );
+    assert!(
+        !planted_at.exists(),
+        "the stale artifact must be GONE — left in place, a later reader picks it up"
     );
 }

--- a/crates/synth-cli/tests/cabi_arena_bind_418.rs
+++ b/crates/synth-cli/tests/cabi_arena_bind_418.rs
@@ -15,6 +15,10 @@ use std::process::Command;
 use object::read::elf::ElfFile32;
 use object::{Object, ObjectSymbol};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -30,15 +34,30 @@ fn e_type(data: &[u8]) -> u16 {
     u16::from_le_bytes([data[16], data[17]])
 }
 
-fn compile(args: &[&str], out: &str) -> std::process::Output {
+/// #977: guarded — compile and return (bytes proven to be THIS invocation's
+/// output, process Output for the log assertions).
+fn compile(args: &[&str], tag: &str) -> (Vec<u8>, std::process::Output) {
+    let out = artifact_guard::unique_artifact(tag, "elf");
     let mut cmd = Command::new(synth());
     cmd.args(["compile", fixture().to_str().unwrap()])
         .args(args)
-        .args(["--target", "cortex-m3", "--all-exports", "-o", out])
+        .args([
+            "--target",
+            "cortex-m3",
+            "--all-exports",
+            "-o",
+            out.to_str().unwrap(),
+        ])
         // The binding log line is part of the asserted surface below;
         // INFO-level tracing is off by default in a non-TTY test run.
         .env("RUST_LOG", "info");
-    cmd.output().expect("run synth")
+    match artifact_guard::compile_artifact_with_output(&mut cmd, &out) {
+        Ok((bytes, output)) => {
+            let _ = std::fs::remove_file(&out);
+            (bytes, output)
+        }
+        Err(e) => panic!("{tag}: {e}"),
+    }
 }
 
 fn has_undefined_arena(data: &[u8]) -> bool {
@@ -51,13 +70,7 @@ fn has_undefined_arena(data: &[u8]) -> bool {
 /// an executable image with no `__cabi_arena_realloc` seam left.
 #[test]
 fn self_contained_binds_arena_import_418() {
-    let out = "/tmp/cabi_arena_bind_418_default.elf";
-    let r = compile(&[], out);
-    assert!(
-        r.status.success(),
-        "compile failed: {}",
-        String::from_utf8_lossy(&r.stderr)
-    );
+    let (data, r) = compile(&[], "cabi418_default");
     // tracing INFO may land on either stream depending on subscriber config.
     let logs = format!(
         "{}{}",
@@ -68,7 +81,6 @@ fn self_contained_binds_arena_import_418() {
         logs.contains("#418: bound env::__cabi_arena_realloc"),
         "expected the #418 binding log line, got: {logs}"
     );
-    let data = std::fs::read(out).unwrap();
     assert_eq!(
         e_type(&data),
         2,
@@ -84,14 +96,7 @@ fn self_contained_binds_arena_import_418() {
 /// external symbol (the embedder seam), byte-compatible with the old behavior.
 #[test]
 fn opt_out_restores_external_seam_418() {
-    let out = "/tmp/cabi_arena_bind_418_optout.elf";
-    let r = compile(&["--no-bind-cabi-arena"], out);
-    assert!(
-        r.status.success(),
-        "compile failed: {}",
-        String::from_utf8_lossy(&r.stderr)
-    );
-    let data = std::fs::read(out).unwrap();
+    let (data, _r) = compile(&["--no-bind-cabi-arena"], "cabi418_optout");
     assert_eq!(
         e_type(&data),
         1,
@@ -107,14 +112,7 @@ fn opt_out_restores_external_seam_418() {
 /// TCB provides, the linker binds — no in-image allocator.
 #[test]
 fn relocatable_keeps_tcb_seam_418() {
-    let out = "/tmp/cabi_arena_bind_418_reloc.elf";
-    let r = compile(&["--relocatable"], out);
-    assert!(
-        r.status.success(),
-        "compile failed: {}",
-        String::from_utf8_lossy(&r.stderr)
-    );
-    let data = std::fs::read(out).unwrap();
+    let (data, _r) = compile(&["--relocatable"], "cabi418_reloc");
     assert_eq!(e_type(&data), 1);
     assert!(
         has_undefined_arena(&data),
@@ -161,18 +159,20 @@ fn other_imports_keep_host_seam_418() {
         local.get 0 local.get 1 local.get 2 local.get 3 call $a))"#;
     let path = std::env::temp_dir().join("cabi_arena_bind_418_mixed.wat");
     std::fs::write(&path, wat).unwrap();
-    let out = "/tmp/cabi_arena_bind_418_mixed.elf";
-    let r = Command::new(synth())
-        .args(["compile", path.to_str().unwrap()])
-        .args(["--target", "cortex-m3", "--all-exports", "-o", out])
-        .output()
-        .expect("run synth");
-    assert!(
-        r.status.success(),
-        "mixed-import module must still compile (host-linked): {}",
-        String::from_utf8_lossy(&r.stderr)
+    let out = artifact_guard::unique_artifact("cabi418_mixed", "elf");
+    let mut cmd = Command::new(synth());
+    cmd.args(["compile", path.to_str().unwrap()]).args([
+        "--target",
+        "cortex-m3",
+        "--all-exports",
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    let data = artifact_guard::compile_bytes_or_panic(
+        &mut cmd,
+        &out,
+        "mixed-import module must still compile (host-linked)",
     );
-    let data = std::fs::read(out).unwrap();
     assert_eq!(e_type(&data), 1, "mixed imports keep the ET_REL host seam");
     assert!(
         has_undefined_arena(&data),

--- a/crates/synth-cli/tests/cabi_arena_realloc_linkability_418.rs
+++ b/crates/synth-cli/tests/cabi_arena_realloc_linkability_418.rs
@@ -22,6 +22,10 @@ use std::process::Command;
 use object::read::elf::ElfFile32;
 use object::{Object, ObjectSection, ObjectSymbol, RelocationTarget};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -34,28 +38,21 @@ fn fixture() -> PathBuf {
 
 #[test]
 fn cabi_arena_realloc_emits_undefined_symbol_and_reloc_418() {
-    let out = "/tmp/cabi_arena_realloc_418.o";
-    let status = Command::new(synth())
-        .args([
-            "compile",
-            fixture().to_str().unwrap(),
-            "--target",
-            "cortex-m4",
-            "--native-pointer-abi",
-            "--all-exports",
-            "--relocatable",
-            "-o",
-            out,
-        ])
-        .output()
-        .expect("run synth");
-    assert!(
-        status.status.success(),
-        "compile failed: {}",
-        String::from_utf8_lossy(&status.stderr)
-    );
-
-    let data = std::fs::read(out).expect("read .o");
+    // #977: unique per call + remove-first + status/exists/non-empty guards.
+    let out = artifact_guard::unique_artifact("cabi_arena_realloc_418", "o");
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        fixture().to_str().unwrap(),
+        "--target",
+        "cortex-m4",
+        "--native-pointer-abi",
+        "--all-exports",
+        "--relocatable",
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    let data = artifact_guard::compile_bytes_or_panic(&mut cmd, &out, "cabi_arena_realloc.wat");
     let obj = ElfFile32::<object::Endianness>::parse(&*data).expect("parse ELF");
 
     // (1) `__cabi_arena_realloc` is present as an UNDEFINED symbol — left for the

--- a/crates/synth-cli/tests/call_indirect_275_selfcontained.rs
+++ b/crates/synth-cli/tests/call_indirect_275_selfcontained.rs
@@ -26,6 +26,10 @@ use std::process::Command;
 
 use object::{Object, ObjectSymbol};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -48,25 +52,21 @@ fn has_symbol(bytes: &[u8], name: &str) -> bool {
 #[test]
 fn test_275_selfcontained_call_indirect_emits() {
     let path = fixture();
-    let elf = "/tmp/ci275_selfcontained.elf";
-    let out = Command::new(synth())
-        .args([
-            "compile",
-            path.to_str().unwrap(),
-            "--cortex-m",
-            "--target",
-            "cortex-m3",
-            "-o",
-            elf,
-        ])
-        .output()
-        .expect("run synth");
-
-    assert!(
-        out.status.success(),
-        "compile failed: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
+    // #977: unique per call + remove-first + status/exists/non-empty guards.
+    let elf = artifact_guard::unique_artifact("ci275_selfcontained", "elf");
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        path.to_str().unwrap(),
+        "--cortex-m",
+        "--target",
+        "cortex-m3",
+        "-o",
+        elf.to_str().unwrap(),
+    ]);
+    let (bytes, out) = artifact_guard::compile_artifact_with_output(&mut cmd, &elf)
+        .unwrap_or_else(|e| panic!("compile failed: {e}"));
+    let _ = std::fs::remove_file(&elf);
     let stderr = String::from_utf8_lossy(&out.stderr);
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
@@ -78,7 +78,6 @@ fn test_275_selfcontained_call_indirect_emits() {
         "the flash funcref table must be emitted (diagnostic missing), got:\n{stdout}\n{stderr}"
     );
 
-    let bytes = std::fs::read(elf).expect("read elf");
     for f in ["entry", "func_1", "func_2", "func_3"] {
         assert!(
             has_symbol(&bytes, f),
@@ -93,33 +92,30 @@ fn test_275_selfcontained_call_indirect_emits() {
 #[test]
 fn test_275_selfcontained_a32_still_declines_loudly() {
     let path = fixture();
-    let elf = "/tmp/ci275_selfcontained_r5.elf";
-    let out = Command::new(synth())
-        .args([
-            "compile",
-            path.to_str().unwrap(),
-            "--target",
-            "cortex-r5",
-            // #952: `entry` is this fixture's SOLE export, and it is the
-            // function this test expects to be loud-skipped (the residual
-            // A32 #275 decline). Since v0.57 a declined REQUESTED export
-            // exits non-zero by default; this test wants the partial object
-            // (to inspect its symtab below), which is exactly the opt-in
-            // `--allow-skipped-exports` case, not a regression.
-            "--allow-skipped-exports",
-            "-o",
-            elf,
-        ])
-        .output()
-        .expect("run synth");
+    // #977: unique per call + remove-first + status/exists/non-empty guards.
+    let elf = artifact_guard::unique_artifact("ci275_selfcontained_r5", "elf");
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        path.to_str().unwrap(),
+        "--target",
+        "cortex-r5",
+        // #952: `entry` is this fixture's SOLE export, and it is the
+        // function this test expects to be loud-skipped (the residual
+        // A32 #275 decline). Since v0.57 a declined REQUESTED export
+        // exits non-zero by default; this test wants the partial object
+        // (to inspect its symtab below), which is exactly the opt-in
+        // `--allow-skipped-exports` case, not a regression.
+        "--allow-skipped-exports",
+        "-o",
+        elf.to_str().unwrap(),
+    ]);
 
     // The overall compile still succeeds (skip-and-continue), but the decline
     // is LOUD — the diagnostic names #275.
-    assert!(
-        out.status.success(),
-        "compile should skip-and-continue: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
+    let (bytes, out) = artifact_guard::compile_artifact_with_output(&mut cmd, &elf)
+        .unwrap_or_else(|e| panic!("compile should skip-and-continue: {e}"));
+    let _ = std::fs::remove_file(&elf);
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         stderr.contains("skipping function 'entry'"),
@@ -133,7 +129,6 @@ fn test_275_selfcontained_a32_still_declines_loudly() {
         stderr.contains("were skipped"),
         "the skip must be surfaced in the summary count, got:\n{stderr}"
     );
-    let bytes = std::fs::read(elf).expect("read elf");
     assert!(
         !has_symbol(&bytes, "entry"),
         "`entry` must NOT be emitted on the A32 self-contained path — a \
@@ -225,32 +220,28 @@ fn test_275_skipped_table_target_fails_loudly() {
 fn test_275_relocatable_call_indirect_untouched() {
     let path = fixture();
     for target in ["cortex-m3", "cortex-r5"] {
-        let elf = format!("/tmp/ci275_reloc_{target}.o");
-        let out = Command::new(synth())
-            .args([
-                "compile",
-                path.to_str().unwrap(),
-                "--target",
-                target,
-                "--all-exports",
-                "--relocatable",
-                "--no-optimize",
-                "-o",
-                &elf,
-            ])
-            .output()
-            .expect("run synth");
-        assert!(
-            out.status.success(),
-            "relocatable compile failed ({target}): {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
+        // #977: unique per call + remove-first + status/exists/non-empty guards.
+        let elf = artifact_guard::unique_artifact(&format!("ci275_reloc_{target}"), "o");
+        let mut cmd = Command::new(synth());
+        cmd.args([
+            "compile",
+            path.to_str().unwrap(),
+            "--target",
+            target,
+            "--all-exports",
+            "--relocatable",
+            "--no-optimize",
+            "-o",
+            elf.to_str().unwrap(),
+        ]);
+        let (bytes, out) = artifact_guard::compile_artifact_with_output(&mut cmd, &elf)
+            .unwrap_or_else(|e| panic!("relocatable compile failed ({target}): {e}"));
+        let _ = std::fs::remove_file(&elf);
         let stderr = String::from_utf8_lossy(&out.stderr);
         assert!(
             !stderr.contains("skipping function 'entry'"),
             "relocatable path must NOT decline entry ({target}):\n{stderr}"
         );
-        let bytes = std::fs::read(&elf).expect("read object");
         assert!(
             has_symbol(&bytes, "entry"),
             "relocatable path must still emit `entry` with its dispatch ({target}) — #275 \

--- a/crates/synth-cli/tests/const_cse_reduction_242.rs
+++ b/crates/synth-cli/tests/const_cse_reduction_242.rs
@@ -54,6 +54,12 @@ use std::process::Command;
 use object::read::elf::ElfFile32;
 use object::{Object, ObjectSection};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. A stale read
+// in a flip gate does not fail, it re-confirms last run's golden as this
+// run's evidence.
+mod artifact_guard;
+
 /// Golden FNV-1a-64 of the OPT-OUT (`SYNTH_CONST_CSE=0`) optimized-path `.text`
 /// for `const_cse.wat`. Captured against the pre-const-CSE tree (stash-compare
 /// verified) and UNCHANGED by the default-on flip — the opt-out path is the
@@ -81,29 +87,28 @@ fn fixture() -> std::path::PathBuf {
 /// Compile the const-CSE fixture via the optimized path. `cse = true` is the
 /// SHIPPED DEFAULT (env removed so a stray opt-out can't skew a gate);
 /// `cse = false` is the `SYNTH_CONST_CSE=0` opt-out. Returns the raw ELF bytes.
-fn compile(out: &str, cse: bool) -> Vec<u8> {
+fn compile(tag: &str, cse: bool) -> Vec<u8> {
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed /tmp path must never be parsed as this run's.
+    let out = artifact_guard::unique_artifact(tag, "elf");
     let mut cmd = Command::new(synth());
     if cse {
         cmd.env_remove("SYNTH_CONST_CSE");
     } else {
         cmd.env("SYNTH_CONST_CSE", "0");
     }
-    let status = cmd
-        .args([
-            "compile",
-            fixture().to_str().unwrap(),
-            "-o",
-            out,
-            "-b",
-            "arm",
-            "--target",
-            "cortex-m4",
-            "--all-exports",
-        ])
-        .status()
-        .expect("run synth compile");
-    assert!(status.success(), "synth compile failed (cse={cse})");
-    std::fs::read(out).expect("read ELF")
+    cmd.args([
+        "compile",
+        fixture().to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+    ]);
+    artifact_guard::compile_bytes_or_panic(&mut cmd, &out, &format!("const_cse.wat (cse={cse})"))
 }
 
 /// Map every named section to its bytes.
@@ -135,32 +140,30 @@ fn func_text_len(elf: &[u8], name: &str) -> usize {
 /// Compile an arbitrary repo-relative fixture via the optimized path.
 /// `cse` semantics as in [`compile`]: `true` = shipped default, `false` = the
 /// `=0` opt-out.
-fn compile_fixture(rel: &str, out: &str, cse: bool) -> Vec<u8> {
+fn compile_fixture(rel: &str, tag: &str, cse: bool) -> Vec<u8> {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
         .join(rel);
+    // #977: unique per call + remove-first + status/exists/non-empty guards.
+    let out = artifact_guard::unique_artifact(tag, "elf");
     let mut cmd = Command::new(synth());
     if cse {
         cmd.env_remove("SYNTH_CONST_CSE");
     } else {
         cmd.env("SYNTH_CONST_CSE", "0");
     }
-    let status = cmd
-        .args([
-            "compile",
-            path.to_str().unwrap(),
-            "-o",
-            out,
-            "-b",
-            "arm",
-            "--target",
-            "cortex-m4",
-            "--all-exports",
-        ])
-        .status()
-        .expect("run synth compile");
-    assert!(status.success(), "synth compile failed ({rel}, cse={cse})");
-    std::fs::read(out).expect("read ELF")
+    cmd.args([
+        "compile",
+        path.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+    ]);
+    artifact_guard::compile_bytes_or_panic(&mut cmd, &out, &format!("{rel} (cse={cse})"))
 }
 
 /// Every function symbol → its `.text` byte size.
@@ -183,16 +186,8 @@ fn func_sizes(elf: &[u8]) -> HashMap<String, usize> {
 /// (#242) win-recovery invariant: NO function grows under the default. Returns
 /// `(off, on)` size maps for per-function asserts.
 fn corpus_offon(rel: &str, tag: &str) -> (HashMap<String, usize>, HashMap<String, usize>) {
-    let off = func_sizes(&compile_fixture(
-        rel,
-        &format!("/tmp/cse_{tag}_off.elf"),
-        false,
-    ));
-    let on = func_sizes(&compile_fixture(
-        rel,
-        &format!("/tmp/cse_{tag}_on.elf"),
-        true,
-    ));
+    let off = func_sizes(&compile_fixture(rel, &format!("cse_{tag}_off"), false));
+    let on = func_sizes(&compile_fixture(rel, &format!("cse_{tag}_on"), true));
     for (name, &off_len) in &off {
         let on_len = *on.get(name).unwrap_or(&off_len);
         assert!(
@@ -267,7 +262,7 @@ fn fnv1a64(bytes: &[u8]) -> u64 {
 /// passes leaking into the opt-out path.
 #[test]
 fn const_cse_escape_hatch_restores_old_bytes_242() {
-    let off = compile("/tmp/const_cse_off.elf", false);
+    let off = compile("const_cse_off", false);
     let text = sections(&off).remove(".text").expect(".text present");
     assert_eq!(
         text.len(),
@@ -289,7 +284,7 @@ fn const_cse_escape_hatch_restores_old_bytes_242() {
 /// bytes). An accidental change to the default lowering fails loud here.
 #[test]
 fn const_cse_default_matches_flip_golden_242() {
-    let on = compile("/tmp/const_cse_def.elf", true);
+    let on = compile("const_cse_def", true);
     let text = sections(&on).remove(".text").expect(".text present");
     assert_eq!(
         (text.len(), fnv1a64(&text)),
@@ -305,8 +300,8 @@ fn const_cse_default_matches_flip_golden_242() {
 /// reads retargeted by the post-hoc passes.
 #[test]
 fn const_cse_on_shrinks_headroom_function_242() {
-    let off = compile("/tmp/const_cse_red_off.elf", false);
-    let on = compile("/tmp/const_cse_red_on.elf", true);
+    let off = compile("const_cse_red_off", false);
+    let on = compile("const_cse_red_on", true);
 
     let off_len = func_text_len(&off, "large3");
     let on_len = func_text_len(&on, "large3");

--- a/crates/synth-cli/tests/dwarf_debug_line_emit_394.rs
+++ b/crates/synth-cli/tests/dwarf_debug_line_emit_394.rs
@@ -36,6 +36,10 @@ use gimli::{EndianSlice, LittleEndian, SectionId};
 use object::read::elf::ElfFile32;
 use object::{Object, ObjectSection, ObjectSymbol};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -63,16 +67,16 @@ fn compile(wasm: &Path, out: &str, debug_line: bool) -> Vec<u8> {
     if debug_line {
         args.push("--debug-line");
     }
-    let r = Command::new(synth())
-        .args(&args)
-        .output()
-        .expect("run synth");
-    assert!(
-        r.status.success(),
-        "compile failed (debug_line={debug_line}): {}",
-        String::from_utf8_lossy(&r.stderr)
-    );
-    std::fs::read(out).expect("read .o")
+    // #977: remove-first + status/exists/non-empty via artifact_guard — a
+    // stale object at this fixed path must never be parsed as this run's.
+    // The artifact stays in place (the llvm-dwarfdump oracle reads the path).
+    let mut cmd = Command::new(synth());
+    cmd.args(&args);
+    artifact_guard::compile_artifact_or_panic(
+        &mut cmd,
+        Path::new(out),
+        &format!("debug_line={debug_line}"),
+    )
 }
 
 /// ORACLE D — the `--debug-line` HONEST-FAIL contract (#383 / VCR-DBG-001 PR C).
@@ -91,27 +95,23 @@ fn debug_line_is_a_loud_noop_on_self_contained_build_394() {
     // gust_kernel imports nothing, so WITHOUT `--relocatable` synth emits a
     // self-contained executable image (not an ET_REL object).
     let wasm = repro("gust_kernel.wasm");
-    let out = "/tmp/dbg394_selfcontained.elf";
-    let r = Command::new(synth())
-        .args([
-            "compile",
-            wasm.to_str().unwrap(),
-            "--target",
-            "cortex-m4",
-            "--all-exports",
-            "--debug-line",
-            "-o",
-            out,
-        ])
-        .output()
-        .expect("run synth");
-
-    // (1) it still compiles — the flag is a no-op, not an error.
-    assert!(
-        r.status.success(),
-        "self-contained --debug-line must still compile: {}",
-        String::from_utf8_lossy(&r.stderr)
-    );
+    let out = artifact_guard::unique_artifact("dbg394_selfcontained", "elf");
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        wasm.to_str().unwrap(),
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+        "--debug-line",
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    // (1) it still compiles — the flag is a no-op, not an error. #977: the
+    // guard also proves the image read below is THIS invocation's output.
+    let (elf, r) = artifact_guard::compile_artifact_with_output(&mut cmd, &out)
+        .unwrap_or_else(|e| panic!("self-contained --debug-line must still compile: {e}"));
+    let _ = std::fs::remove_file(&out);
 
     // (2) it WARNS loudly (honest-fail), naming the relocatable-object path as
     // the way to actually get DWARF — never silent. The CLI's tracing subscriber
@@ -126,7 +126,6 @@ fn debug_line_is_a_loud_noop_on_self_contained_build_394() {
 
     // (3) the emitted image is a standalone EXECUTABLE (confirms we exercised the
     // self-contained path, not ET_REL) and carries ZERO `.debug_*` sections.
-    let elf = std::fs::read(out).expect("read elf");
     let obj = ElfFile32::<object::Endianness>::parse(&*elf).expect("parse ELF");
     assert_eq!(
         obj.kind(),

--- a/crates/synth-cli/tests/elf_tooling_637_656.rs
+++ b/crates/synth-cli/tests/elf_tooling_637_656.rs
@@ -27,6 +27,10 @@ use object::elf;
 use object::read::elf::{FileHeader, SectionHeader, Sym};
 use object::{Endianness, Object, ObjectSection};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -36,24 +40,22 @@ fn compile(dir: &std::path::Path, name: &str, wat: &str) -> PathBuf {
     let src = dir.join(format!("{name}.wat"));
     std::fs::write(&src, wat).unwrap();
     let out = dir.join(format!("{name}.o"));
-    let status = Command::new(synth())
-        .args([
-            "compile",
-            src.to_str().unwrap(),
-            "-t",
-            "cortex-m3",
-            "--all-exports",
-            "--relocatable",
-            "-o",
-            out.to_str().unwrap(),
-        ])
-        .output()
-        .expect("run synth");
-    assert!(
-        status.status.success(),
-        "synth compile failed: {}",
-        String::from_utf8_lossy(&status.stderr)
-    );
+    // #977: remove-first + status/exists/non-empty via artifact_guard — the
+    // callers (and the co-link test's real linker) consume this path, so the
+    // artifact must be proven to be THIS invocation's output before it is
+    // returned. The artifact stays in place for them.
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        src.to_str().unwrap(),
+        "-t",
+        "cortex-m3",
+        "--all-exports",
+        "--relocatable",
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    artifact_guard::compile_artifact_or_panic(&mut cmd, &out, name);
     out
 }
 

--- a/crates/synth-cli/tests/fact_spec_bounds_494.rs
+++ b/crates/synth-cli/tests/fact_spec_bounds_494.rs
@@ -31,6 +31,10 @@
 use object::{Object, ObjectSection, ObjectSymbol};
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -105,7 +109,9 @@ fn compile(wasm: &[u8], tag: &str, fact_spec: bool, software_bounds: bool) -> Co
     let dir = std::env::temp_dir().join("fact_spec_bounds_494");
     std::fs::create_dir_all(&dir).expect("mk tempdir");
     let input = dir.join(format!("{tag}.wasm"));
-    let elf = dir.join(format!("{tag}.elf"));
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed path must never be parsed as this run's.
+    let elf = artifact_guard::unique_artifact(&format!("fact_spec_bounds_494_{tag}"), "elf");
     std::fs::write(&input, wasm).expect("write wasm");
     let mut cmd = Command::new(synth());
     cmd.args([
@@ -128,13 +134,9 @@ fn compile(wasm: &[u8], tag: &str, fact_spec: bool, software_bounds: bool) -> Co
         cmd.env_remove("SYNTH_FACT_SPEC");
     }
     cmd.env_remove("SYNTH_FACT_SPEC_FORCE_ADMIT");
-    let out = cmd.output().expect("run synth");
-    assert!(
-        out.status.success(),
-        "compile of '{tag}' failed: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let bytes = std::fs::read(&elf).expect("read elf");
+    let (bytes, out) = artifact_guard::compile_artifact_with_output(&mut cmd, &elf)
+        .unwrap_or_else(|e| panic!("compile of '{tag}' failed: {e}"));
+    let _ = std::fs::remove_file(&elf);
     let obj = object::File::parse(&*bytes).expect("parse elf");
     let text_section = obj.section_by_name(".text").expect(".text");
     let text = text_section.data().expect("read .text").to_vec();

--- a/crates/synth-cli/tests/fact_spec_clamp_494.rs
+++ b/crates/synth-cli/tests/fact_spec_clamp_494.rs
@@ -20,6 +20,10 @@
 use object::{Object, ObjectSection};
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -95,7 +99,9 @@ fn compile(wasm: &[u8], tag: &str, fact_spec: bool) -> (Vec<u8>, String) {
     let dir = std::env::temp_dir().join("fact_spec_494");
     std::fs::create_dir_all(&dir).expect("mk tempdir");
     let input = dir.join(format!("{tag}.wasm"));
-    let elf = dir.join(format!("{tag}.elf"));
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed path must never be parsed as this run's.
+    let elf = artifact_guard::unique_artifact(&format!("fact_spec_494_{tag}"), "elf");
     std::fs::write(&input, wasm).expect("write wasm");
     let mut cmd = Command::new(synth());
     cmd.args([
@@ -114,13 +120,9 @@ fn compile(wasm: &[u8], tag: &str, fact_spec: bool) -> (Vec<u8>, String) {
     } else {
         cmd.env_remove("SYNTH_FACT_SPEC");
     }
-    let out = cmd.output().expect("run synth");
-    assert!(
-        out.status.success(),
-        "compile of '{tag}' failed: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let bytes = std::fs::read(&elf).expect("read elf");
+    let (bytes, out) = artifact_guard::compile_artifact_with_output(&mut cmd, &elf)
+        .unwrap_or_else(|e| panic!("compile of '{tag}' failed: {e}"));
+    let _ = std::fs::remove_file(&elf);
     let obj = object::File::parse(&*bytes).expect("parse elf");
     let text = obj
         .section_by_name(".text")

--- a/crates/synth-cli/tests/fact_spec_div_494.rs
+++ b/crates/synth-cli/tests/fact_spec_div_494.rs
@@ -27,6 +27,10 @@
 use object::{Object, ObjectSection, ObjectSymbol};
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -131,7 +135,9 @@ fn compile(wasm: &[u8], tag: &str, fact_spec: bool, force_admit: bool) -> Compil
     let dir = std::env::temp_dir().join("fact_spec_div_494");
     std::fs::create_dir_all(&dir).expect("mk tempdir");
     let input = dir.join(format!("{tag}.wasm"));
-    let elf = dir.join(format!("{tag}.elf"));
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed path must never be parsed as this run's.
+    let elf = artifact_guard::unique_artifact(&format!("fact_spec_div_494_{tag}"), "elf");
     std::fs::write(&input, wasm).expect("write wasm");
     let mut cmd = Command::new(synth());
     cmd.args([
@@ -155,13 +161,9 @@ fn compile(wasm: &[u8], tag: &str, fact_spec: bool, force_admit: bool) -> Compil
     } else {
         cmd.env_remove("SYNTH_FACT_SPEC_FORCE_ADMIT");
     }
-    let out = cmd.output().expect("run synth");
-    assert!(
-        out.status.success(),
-        "compile of '{tag}' failed: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let bytes = std::fs::read(&elf).expect("read elf");
+    let (bytes, out) = artifact_guard::compile_artifact_with_output(&mut cmd, &elf)
+        .unwrap_or_else(|e| panic!("compile of '{tag}' failed: {e}"));
+    let _ = std::fs::remove_file(&elf);
     let obj = object::File::parse(&*bytes).expect("parse elf");
     let text_section = obj.section_by_name(".text").expect(".text");
     let text = text_section.data().expect("read .text").to_vec();

--- a/crates/synth-cli/tests/flag_flip_wave_242.rs
+++ b/crates/synth-cli/tests/flag_flip_wave_242.rs
@@ -42,6 +42,12 @@ use std::process::Command;
 
 use object::{Object, ObjectSymbol, SymbolKind};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. A stale read
+// in a flip gate does not fail, it re-confirms last run's golden as this
+// run's evidence.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -56,7 +62,10 @@ fn fixture(rel: &str) -> std::path::PathBuf {
 /// Compile `rel` with `flag` either at the shipped default (env removed so a
 /// stray opt-out in the test environment can't skew the gate) or the `=0`
 /// opt-out (pre-flip bytes). `backend_args` selects ARM path / RV32.
-fn compile(rel: &str, out: &str, flag: &str, default_on: bool, backend_args: &[&str]) -> Vec<u8> {
+fn compile(rel: &str, tag: &str, flag: &str, default_on: bool, backend_args: &[&str]) -> Vec<u8> {
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed /tmp path must never be parsed as this run's.
+    let out = artifact_guard::unique_artifact(tag, "o");
     let mut cmd = Command::new(synth());
     // #601 promo flip: local promotion is default-on now; pin it OFF in both
     // arms so this gate keeps isolating its own lever against the same
@@ -68,18 +77,19 @@ fn compile(rel: &str, out: &str, flag: &str, default_on: bool, backend_args: &[&
     } else {
         cmd.env(flag, "0");
     }
-    let out_status = cmd
-        .args(["compile", fixture(rel).to_str().unwrap(), "-o", out])
-        .args(backend_args)
-        .args(["--all-exports"])
-        .output()
-        .expect("run synth compile");
-    assert!(
-        out_status.status.success(),
-        "synth compile failed ({rel}, {flag} default_on={default_on}): {}",
-        String::from_utf8_lossy(&out_status.stderr)
-    );
-    std::fs::read(out).expect("read ELF")
+    cmd.args([
+        "compile",
+        fixture(rel).to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ])
+    .args(backend_args)
+    .args(["--all-exports"]);
+    artifact_guard::compile_bytes_or_panic(
+        &mut cmd,
+        &out,
+        &format!("{rel} ({flag} default_on={default_on})"),
+    )
 }
 
 /// Every function symbol → its `.text` byte size (ELF symtab, not disasm
@@ -107,14 +117,14 @@ fn assert_no_grow(flag: &str, corpus: &[&str], configs: &[(&str, &[&str])], min_
         for (mode, args) in configs {
             let off = func_sizes(&compile(
                 rel,
-                &format!("/tmp/ffw242_{flag}_{tag}_{mode}_off.o"),
+                &format!("ffw242_{flag}_{tag}_{mode}_off"),
                 flag,
                 false,
                 args,
             ));
             let on = func_sizes(&compile(
                 rel,
-                &format!("/tmp/ffw242_{flag}_{tag}_{mode}_on.o"),
+                &format!("ffw242_{flag}_{tag}_{mode}_on"),
                 flag,
                 true,
                 args,

--- a/crates/synth-cli/tests/heterogeneous_table_676.rs
+++ b/crates/synth-cli/tests/heterogeneous_table_676.rs
@@ -19,6 +19,10 @@ use std::process::Command;
 
 use object::{Object, ObjectSection, ObjectSymbol};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -34,27 +38,21 @@ fn fixture(name: &str) -> std::path::PathBuf {
 /// return the parsed object bytes.
 fn compile(wasm: &str, target: &str) -> Vec<u8> {
     let path = fixture(wasm);
-    let elf = format!("/tmp/hetero676_{target}_{wasm}.o");
-    let out = Command::new(synth())
-        .args([
-            "compile",
-            path.to_str().unwrap(),
-            "-o",
-            &elf,
-            "--target",
-            target,
-            "--all-exports",
-            "--relocatable",
-            "--no-optimize",
-        ])
-        .output()
-        .expect("run synth");
-    assert!(
-        out.status.success(),
-        "synth compile failed for {wasm} ({target}): {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    std::fs::read(&elf).expect("read object")
+    // #977: unique per call + remove-first + status/exists/non-empty guards.
+    let elf = artifact_guard::unique_artifact(&format!("hetero676_{target}_{wasm}"), "o");
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        path.to_str().unwrap(),
+        "-o",
+        elf.to_str().unwrap(),
+        "--target",
+        target,
+        "--all-exports",
+        "--relocatable",
+        "--no-optimize",
+    ]);
+    artifact_guard::compile_bytes_or_panic(&mut cmd, &elf, &format!("{wasm} ({target})"))
 }
 
 /// #676: the heterogeneous fixture compiles (no decline) and the object

--- a/crates/synth-cli/tests/multi_memory_406.rs
+++ b/crates/synth-cli/tests/multi_memory_406.rs
@@ -31,6 +31,10 @@ use std::process::Command;
 
 use object::{Object, ObjectSection, ObjectSymbol, SectionKind};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -73,6 +77,32 @@ fn compile(input: &std::path::Path, extra: &[&str]) -> std::process::Output {
         .expect("run synth")
 }
 
+/// #977: the guarded READ-BACK form — compile and hand back the object bytes
+/// proven to be this invocation's output (unique path + remove-first +
+/// status/exists/non-empty via `artifact_guard`). [`compile`] above stays for
+/// the refusal tests, which never read an artifact.
+fn compile_read(input: &std::path::Path, extra: &[&str]) -> Vec<u8> {
+    let out = artifact_guard::unique_artifact(
+        &format!("mem406_{}", input.file_stem().unwrap().to_str().unwrap()),
+        "o",
+    );
+    let mut args = vec![
+        "compile",
+        input.to_str().unwrap(),
+        "--all-exports",
+        "-o",
+        out.to_str().unwrap(),
+    ];
+    args.extend_from_slice(extra);
+    let mut cmd = Command::new(synth());
+    cmd.args(&args);
+    artifact_guard::compile_bytes_or_panic(
+        &mut cmd,
+        &out,
+        input.file_stem().unwrap().to_str().unwrap(),
+    )
+}
+
 fn stderr(out: &std::process::Output) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }
@@ -101,16 +131,10 @@ fn assert_refused(out: &std::process::Output, must_mention: &[&str], ctx: &str) 
 /// placed. (Execution equivalence is the python differential's job.)
 #[test]
 fn two_memories_relocatable_green() {
-    let out = compile(
+    let bytes = compile_read(
         &two_mem_fixture(),
         &["--relocatable", "--target", "cortex-m3"],
     );
-    assert!(out.status.success(), "stderr: {}", stderr(&out));
-    let bytes = std::fs::read(
-        std::env::temp_dir()
-            .join("synth_mem406_tests/mem406_multi_memory_relocatabletargetcortexm3.o"),
-    )
-    .expect("read object");
     let obj = object::File::parse(&*bytes).expect("parse ELF");
 
     // Memory 1's region: PROGBITS (has an init segment), exactly 3 pages,
@@ -154,12 +178,7 @@ fn three_memories_relocatable_green() {
         (i32.store $b (local.get $p) (i32.load $c offset=8 (local.get $p)))
         (i32.load $b (local.get $p))))"#;
     let f = wat_file("three_mem.wat", wat);
-    let out = compile(&f, &["--relocatable", "--target", "cortex-m3"]);
-    assert!(out.status.success(), "stderr: {}", stderr(&out));
-    let bytes = std::fs::read(
-        std::env::temp_dir().join("synth_mem406_tests/three_mem_relocatabletargetcortexm3.o"),
-    )
-    .expect("read object");
+    let bytes = compile_read(&f, &["--relocatable", "--target", "cortex-m3"]);
     let obj = object::File::parse(&*bytes).expect("parse ELF");
 
     let mem1 = obj
@@ -375,5 +394,71 @@ fn segment_overflowing_memory_k_refuses() {
         &out,
         &["multi-memory", "#406", "overflows"],
         "overflowing segment",
+    );
+}
+
+/// #977 RQ-59-FRESHNESS — the SILENT-direction demonstration for the
+/// structure/linkability batch (multi_memory_406, dwarf_debug_line_emit_394,
+/// elf_tooling_637_656, heterogeneous_table_676, cabi_arena_bind_418,
+/// cabi_arena_realloc_linkability_418, call_indirect_275_selfcontained,
+/// async_intrinsics_gate, provenance_* — all now compile through
+/// `artifact_guard`).
+///
+/// Prove the counterfactual: a planted VALID relocatable object (minted by
+/// this file's own compile shape) parses and carries the `.synth.wasm_mem_1`
+/// section this file's gates assert on — so the pre-conversion path-based
+/// `fs::read` + `File::parse` WOULD have re-confirmed last run's structure as
+/// this run's evidence. Then fail the compile at that path and require the
+/// guard to refuse AND to leave nothing behind.
+#[test]
+fn freshness_guard_refuses_stale_structure_artifact_977() {
+    // 1. Mint a genuine object with this batch's own compile shape.
+    let good = compile_read(
+        &two_mem_fixture(),
+        &["--relocatable", "--target", "cortex-m3"],
+    );
+
+    // 2. Plant it, and prove the OLD shape would have passed on it.
+    let planted_at = artifact_guard::unique_artifact("mem406_stale_planted", "o");
+    std::fs::write(&planted_at, &good).expect("plant the stale artifact");
+    let stale = std::fs::read(&planted_at).expect("read planted");
+    let obj = object::File::parse(&*stale).expect("planted artifact is a valid ELF");
+    assert!(
+        obj.section_by_name(".synth.wasm_mem_1").is_some(),
+        "the planted artifact must carry the asserted section — substantial \
+         enough to fool an unguarded structure gate"
+    );
+
+    // 3. A FAILING compile aimed at that exact path (nonexistent input).
+    let missing = std::env::temp_dir()
+        .join("synth_mem406_tests")
+        .join("does_not_exist_977.wat");
+    let _ = std::fs::remove_file(&missing);
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        missing.to_str().unwrap(),
+        "--all-exports",
+        "-o",
+        planted_at.to_str().unwrap(),
+        "--relocatable",
+        "--target",
+        "cortex-m3",
+    ]);
+    let err = artifact_guard::compile_artifact(&mut cmd, &planted_at)
+        .expect_err("REFUSAL REQUIRED: a failed compile must not return last run's bytes");
+
+    // 4. The refusal names the compile, not the parser — and nothing is left.
+    assert!(
+        err.contains("synth compile FAILED"),
+        "the refusal must name the compile failure, got: {err}"
+    );
+    assert!(
+        !err.contains("file magic"),
+        "and must not surface as a parse error, got: {err}"
+    );
+    assert!(
+        !planted_at.exists(),
+        "the stale artifact must be GONE — left in place, a later reader picks it up"
     );
 }

--- a/crates/synth-cli/tests/multi_sp_rebase_707.rs
+++ b/crates/synth-cli/tests/multi_sp_rebase_707.rs
@@ -19,6 +19,11 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. The readers
+// below take BYTES, not a path, so no read can outlive its compile.
+mod artifact_guard;
+
 use object::{Object, ObjectSection};
 
 fn synth() -> &'static str {
@@ -31,8 +36,10 @@ fn fixture() -> PathBuf {
         .join("scripts/repro/mem707_multi_sp.wat")
 }
 
-fn compile(extra: &[&str], out: &str) -> std::process::Output {
+fn compile(extra: &[&str], tag: &str) -> Vec<u8> {
     let fx = fixture();
+    // #977: unique per call + remove-first + status/exists/non-empty guards.
+    let out = artifact_guard::unique_artifact(tag, "o");
     let mut args = vec![
         "compile",
         fx.to_str().unwrap(),
@@ -42,18 +49,16 @@ fn compile(extra: &[&str], out: &str) -> std::process::Output {
         "--all-exports",
         "--relocatable",
         "-o",
-        out,
+        out.to_str().unwrap(),
     ];
     args.extend_from_slice(extra);
-    Command::new(synth())
-        .args(&args)
-        .output()
-        .expect("run synth")
+    let mut cmd = Command::new(synth());
+    cmd.args(&args);
+    artifact_guard::compile_bytes_or_panic(&mut cmd, &out, tag)
 }
 
-fn bss_size(path: &str) -> u64 {
-    let data = std::fs::read(path).expect("read .o");
-    let obj = object::File::parse(&*data).expect("parse ELF");
+fn bss_size(data: &[u8]) -> u64 {
+    let obj = object::File::parse(data).expect("parse ELF");
     obj.sections()
         .find(|s| s.name() == Ok(".bss"))
         .expect(".bss present")
@@ -63,9 +68,8 @@ fn bss_size(path: &str) -> u64 {
 /// The materialized global slots in `.data`, decoded as little-endian i32 words.
 /// The fixture has three mutable SP globals + one immutable constant ⇒ four
 /// 4-byte slots (slots 0..2 = sp0/sp1/sp2, slot 3 = the immutable `$konst`).
-fn global_slots(path: &str) -> Vec<i32> {
-    let bytes = std::fs::read(path).expect("read .o");
-    let obj = object::File::parse(&*bytes).expect("parse ELF");
+fn global_slots(bytes: &[u8]) -> Vec<i32> {
+    let obj = object::File::parse(bytes).expect("parse ELF");
     let data = obj
         .section_by_name(".data")
         .expect(".data present")
@@ -83,34 +87,28 @@ fn global_slots(path: &str) -> Vec<i32> {
 /// co-rebases all three to the budget and shrinks the reservation.
 #[test]
 fn all_aliased_sp_globals_rebase_707() {
-    let out = compile(&["--shadow-stack-size", "512"], "/tmp/mem707_test.o");
-    assert!(
-        out.status.success(),
-        "#707: the 3-SP fused node must now COMPILE (was refused): {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
+    let bytes = compile(&["--shadow-stack-size", "512"], "mem707_test");
     // Every MUTABLE global whose init == sp_init (the three SP globals) re-bases
     // to 512; the immutable `$konst` (slot 3) — which merely COINCIDES with
     // sp_init — must stay 4096. Re-basing it would corrupt a program constant.
     assert_eq!(
-        global_slots("/tmp/mem707_test.o"),
+        global_slots(&bytes),
         vec![512, 512, 512, 4096],
         "the three mutable SP globals co-rebase; the immutable constant is untouched"
     );
     // Reservation shrinks 4096 → budget 512 (no static tail above sp_init).
-    assert_eq!(bss_size("/tmp/mem707_test.o"), 512);
+    assert_eq!(bss_size(&bytes), 512);
 }
 
 /// Opt-in / frozen-safe: WITHOUT the flag the same node keeps all three SP slots
 /// at their declared top and the full reservation (byte-identical to pre-#707).
 #[test]
 fn no_flag_leaves_multi_sp_full_707() {
-    let out = compile(&[], "/tmp/mem707_noflag_test.o");
-    assert!(out.status.success());
+    let bytes = compile(&[], "mem707_noflag_test");
     assert_eq!(
-        global_slots("/tmp/mem707_noflag_test.o"),
+        global_slots(&bytes),
         vec![4096, 4096, 4096, 4096],
         "no flag must leave every slot at its declared value"
     );
-    assert_eq!(bss_size("/tmp/mem707_noflag_test.o"), 4096);
+    assert_eq!(bss_size(&bytes), 4096);
 }

--- a/crates/synth-cli/tests/parity_benchmark_735.rs
+++ b/crates/synth-cli/tests/parity_benchmark_735.rs
@@ -27,6 +27,10 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 use object::{Object, ObjectSection, ObjectSymbol, SymbolKind};
 
 fn synth() -> &'static str {
@@ -54,7 +58,9 @@ fn per_function_sizes(wasm: &[u8], tag: &str, target: &str, fact_spec: bool) -> 
     let dir = std::env::temp_dir().join("parity_benchmark_735");
     std::fs::create_dir_all(&dir).expect("mk tempdir");
     let input = dir.join(format!("{tag}.wasm"));
-    let elf = dir.join(format!("{tag}.o"));
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale object at a fixed path must never be parsed as this run's.
+    let elf = artifact_guard::unique_artifact(&format!("parity735_{tag}"), "o");
     std::fs::write(&input, wasm).expect("write wasm");
 
     let mut cmd = Command::new(synth());
@@ -74,12 +80,9 @@ fn per_function_sizes(wasm: &[u8], tag: &str, target: &str, fact_spec: bool) -> 
     } else {
         cmd.env_remove("SYNTH_FACT_SPEC");
     }
-    let out = cmd.output().expect("run synth");
-    assert!(
-        out.status.success(),
-        "synth compile of '{tag}' failed: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
+    let (bytes, out) = artifact_guard::compile_artifact_with_output(&mut cmd, &elf)
+        .unwrap_or_else(|e| panic!("synth compile of '{tag}' failed: {e}"));
+    let _ = std::fs::remove_file(&elf);
     if fact_spec {
         // Non-vacuity: the 14 B pin is only meaningful if BOTH clamp elisions
         // were actually certificate-admitted (a solver-less binary would
@@ -92,7 +95,6 @@ fn per_function_sizes(wasm: &[u8], tag: &str, target: &str, fact_spec: bool) -> 
         );
     }
 
-    let bytes = std::fs::read(&elf).expect("read elf");
     let obj = object::File::parse(&*bytes).expect("parse elf");
     let text = obj.section_by_name(".text").expect(".text");
     let end = text.address() + text.size();

--- a/crates/synth-cli/tests/promotion_exhaustion_fallback_474.rs
+++ b/crates/synth-cli/tests/promotion_exhaustion_fallback_474.rs
@@ -20,6 +20,10 @@
 
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 use object::{Object, ObjectSection};
 
 fn synth() -> &'static str {
@@ -36,9 +40,11 @@ fn fixture() -> std::path::PathBuf {
 /// or forced off, and return the `.text` bytes. Panics if the compile fails — a
 /// FAILED promotion-on compile is exactly the #474 regression this guards.
 fn text_bytes(promotion_off: bool) -> Vec<u8> {
-    let elf = format!(
-        "/tmp/pef_474_{}.elf",
-        if promotion_off { "off" } else { "on" }
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed /tmp path must never be parsed as this run's.
+    let elf = artifact_guard::unique_artifact(
+        &format!("pef_474_{}", if promotion_off { "off" } else { "on" }),
+        "elf",
     );
     let mut cmd = Command::new(synth());
     if promotion_off {
@@ -46,27 +52,25 @@ fn text_bytes(promotion_off: bool) -> Vec<u8> {
     } else {
         cmd.env_remove("SYNTH_NO_LOCAL_PROMOTE");
     }
-    let out = cmd
-        .args([
-            "compile",
-            fixture().to_str().unwrap(),
-            "-o",
-            &elf,
-            "--target",
-            "cortex-m4",
-            "--relocatable",
-            "--all-exports",
-        ])
-        .output()
-        .expect("run synth");
-    assert!(
-        out.status.success(),
-        "#474 REGRESSION: promotion-{} compile FAILED — promotion turned a \
-         compilable function into a skipped one. stderr:\n{}",
-        if promotion_off { "off" } else { "on" },
-        String::from_utf8_lossy(&out.stderr)
+    cmd.args([
+        "compile",
+        fixture().to_str().unwrap(),
+        "-o",
+        elf.to_str().unwrap(),
+        "--target",
+        "cortex-m4",
+        "--relocatable",
+        "--all-exports",
+    ]);
+    let bytes = artifact_guard::compile_bytes_or_panic(
+        &mut cmd,
+        &elf,
+        &format!(
+            "#474 REGRESSION: promotion-{} compile — promotion must never turn \
+             a compilable function into a skipped one",
+            if promotion_off { "off" } else { "on" }
+        ),
     );
-    let bytes = std::fs::read(&elf).expect("read elf");
     let obj = object::File::parse(&*bytes).expect("parse elf");
     obj.section_by_name(".text")
         .expect(".text section")

--- a/crates/synth-cli/tests/proven_safe_bounds_901.rs
+++ b/crates/synth-cli/tests/proven_safe_bounds_901.rs
@@ -31,6 +31,12 @@ use std::path::PathBuf;
 use std::process::Command;
 use synth_core::proven_safe::hex_sha256;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. The elision
+// ATTESTATION sidecar derives its path from the elf path, so a unique elf
+// path makes the sidecar fresh-by-construction too.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -129,7 +135,10 @@ impl Compiled {
 fn compile(tag: &str, software_bounds: bool, verdicts: Option<Option<&str>>) -> Compiled {
     let d = dir();
     let input = d.join(format!("{tag}.wasm"));
-    let elf = d.join(format!("{tag}.elf"));
+    // #977: unique per call + remove-first + status/exists/non-empty guards;
+    // the attestation sidecar path derives from the elf path, so it is fresh
+    // by construction as well.
+    let elf = artifact_guard::unique_artifact(&format!("psb901_{tag}"), "elf");
     std::fs::write(&input, fixture_wasm()).expect("write wasm");
 
     let mut cmd = Command::new(synth());
@@ -161,15 +170,13 @@ fn compile(tag: &str, software_bounds: bool, verdicts: Option<Option<&str>>) -> 
     cmd.env_remove("SYNTH_FACT_SPEC");
     cmd.env_remove("SYNTH_FACT_SPEC_FORCE_ADMIT");
 
-    let out = cmd.output().expect("run synth");
-    assert!(
-        out.status.success(),
-        "compile '{tag}' FAILED (a verdict file must never turn a good compile \
-         into a failed one): {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-
-    let bytes = std::fs::read(&elf).expect("read elf");
+    let (bytes, out) =
+        artifact_guard::compile_artifact_with_output(&mut cmd, &elf).unwrap_or_else(|e| {
+            panic!(
+                "compile '{tag}' FAILED (a verdict file must never turn a good \
+                 compile into a failed one): {e}"
+            )
+        });
     let obj = object::File::parse(&*bytes).expect("parse elf");
     let sec = obj.section_by_name(".text").expect(".text");
     let text = sec.data().expect("read .text").to_vec();
@@ -202,6 +209,9 @@ fn compile(tag: &str, software_bounds: bool, verdicts: Option<Option<&str>>) -> 
     let attestation = std::fs::read_to_string(&att_path)
         .ok()
         .map(|s| serde_json::from_str(&s).expect("attestation is valid JSON"));
+    // Per-call unique names would otherwise accumulate on a long-lived runner.
+    let _ = std::fs::remove_file(&elf);
+    let _ = std::fs::remove_file(&att_path);
 
     Compiled {
         text,
@@ -527,8 +537,10 @@ fn non_arm_backends_attest_zero_elisions_901() {
     std::fs::write(&json, safe_accesses(&module_hash(), 65536, PROVEN)).expect("write");
 
     for (backend, target) in [("riscv", "rv32imac"), ("aarch64", "cortex-a53")] {
-        let run = |with_verdicts: bool, tag: &str| -> (Vec<u8>, String) {
-            let elf = d.join(format!("xback_{backend}_{tag}.elf"));
+        let run = |with_verdicts: bool, tag: &str| -> (Vec<u8>, String, PathBuf) {
+            // #977: unique per call; the sidecar derives from the elf path.
+            let elf =
+                artifact_guard::unique_artifact(&format!("psb901_xback_{backend}_{tag}"), "elf");
             let mut cmd = Command::new(synth());
             cmd.args([
                 "compile",
@@ -546,19 +558,16 @@ fn non_arm_backends_attest_zero_elisions_901() {
             if with_verdicts {
                 cmd.args(["--proven-safe", json.to_str().unwrap()]);
             }
-            let out = cmd.output().expect("run synth");
-            assert!(
-                out.status.success(),
-                "{backend} compile failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
+            let (bytes, out) = artifact_guard::compile_artifact_with_output(&mut cmd, &elf)
+                .unwrap_or_else(|e| panic!("{backend} compile failed: {e}"));
             (
-                std::fs::read(&elf).expect("read elf"),
+                bytes,
                 String::from_utf8_lossy(&out.stderr).into_owned(),
+                elf,
             )
         };
-        let (base, _) = run(false, "base");
-        let (with, stderr) = run(true, "with");
+        let (base, _, _) = run(false, "base");
+        let (with, stderr, with_elf) = run(true, "with");
 
         assert_eq!(
             base, with,
@@ -571,7 +580,7 @@ fn non_arm_backends_attest_zero_elisions_901() {
         );
         let att: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(synth_core::proven_safe::ElisionAttestation::sidecar_path(
-                &d.join(format!("xback_{backend}_with.elf")),
+                &with_elf,
             ))
             .expect("attestation written"),
         )
@@ -733,32 +742,32 @@ fn fact_spec_specialization_refuses_the_scry_marks_901() {
 
     let d = dir();
     let input = d.join("factspec.wasm");
-    let elf = d.join("factspec.elf");
+    // #977: unique per call; the sidecar derives from the elf path.
+    let elf = artifact_guard::unique_artifact("psb901_factspec", "elf");
     let json = d.join("factspec.safe-accesses.json");
     std::fs::write(&input, &wasm).expect("write wasm");
     std::fs::write(&json, safe_accesses(&hex_sha256(&wasm), 65536, PROVEN)).expect("write");
 
-    let out = Command::new(synth())
-        .args([
-            "compile",
-            input.to_str().unwrap(),
-            "-o",
-            elf.to_str().unwrap(),
-            "-b",
-            "arm",
-            "--target",
-            "cortex-m4",
-            "--all-exports",
-            "--safety-bounds",
-            "software",
-            "--proven-safe",
-            json.to_str().unwrap(),
-        ])
-        .env("SYNTH_FACT_SPEC", "1")
-        .env_remove("SYNTH_FACT_SPEC_FORCE_ADMIT")
-        .output()
-        .expect("run synth");
-    assert!(out.status.success());
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        input.to_str().unwrap(),
+        "-o",
+        elf.to_str().unwrap(),
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+        "--safety-bounds",
+        "software",
+        "--proven-safe",
+        json.to_str().unwrap(),
+    ])
+    .env("SYNTH_FACT_SPEC", "1")
+    .env_remove("SYNTH_FACT_SPEC_FORCE_ADMIT");
+    let (_elf_bytes, out) = artifact_guard::compile_artifact_with_output(&mut cmd, &elf)
+        .unwrap_or_else(|e| panic!("factspec compile failed: {e}"));
     let stderr = String::from_utf8_lossy(&out.stderr);
     // NON-VACUITY FIRST: the pass must actually specialize this function,
     // otherwise the refusal below is never exercised and this test asserts

--- a/crates/synth-cli/tests/provenance_introduced_origin_944.rs
+++ b/crates/synth-cli/tests/provenance_introduced_origin_944.rs
@@ -29,6 +29,10 @@
 use serde_json::Value;
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -53,32 +57,29 @@ const VERIFIED_ORIGINS: &[&str] = &[
 #[test]
 fn introduced_branches_carry_verified_origins_944() {
     let path = fixture("provenance_introduced_944.wat");
-    let out = "/tmp/prov_introduced_944.elf";
-    let sidecar = "/tmp/prov_introduced_944.elf.provenance.json";
-    let _ = std::fs::remove_file(sidecar);
+    // #977: unique per call; the provenance sidecar derives its path from the
+    // elf path, so it is fresh by construction as well.
+    let out = artifact_guard::unique_artifact("prov_introduced_944", "elf");
+    let sidecar = format!("{}.provenance.json", out.display());
 
-    let res = Command::new(synth())
-        .args([
-            "compile",
-            path.to_str().unwrap(),
-            "-o",
-            out,
-            "--target",
-            "cortex-m3",
-            "--all-exports",
-            "--relocatable",
-            "--emit-provenance",
-        ])
-        .output()
-        .expect("run synth");
-    assert!(
-        res.status.success(),
-        "synth compile failed: {}",
-        String::from_utf8_lossy(&res.stderr)
-    );
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        path.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "--target",
+        "cortex-m3",
+        "--all-exports",
+        "--relocatable",
+        "--emit-provenance",
+    ]);
+    artifact_guard::compile_artifact_or_panic(&mut cmd, &out, "provenance_introduced_944.wat");
 
-    let map: Value =
-        serde_json::from_slice(&std::fs::read(sidecar).expect("sidecar written")).expect("json");
+    let sidecar_bytes = std::fs::read(&sidecar).expect("sidecar written");
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&sidecar);
+    let map: Value = serde_json::from_slice(&sidecar_bytes).expect("json");
     assert_eq!(map["schema"], "synth-provenance-v1");
     let funcs = map["functions"].as_array().expect("functions");
 

--- a/crates/synth-cli/tests/provenance_reconciliation_396.rs
+++ b/crates/synth-cli/tests/provenance_reconciliation_396.rs
@@ -29,6 +29,10 @@
 use serde_json::Value;
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -43,33 +47,29 @@ fn fixture(name: &str) -> std::path::PathBuf {
 /// Compile the fixture with fusion + provenance on; return the parsed map.
 fn compile_and_parse_provenance(fix: &str, out_stem: &str) -> Value {
     let path = fixture(fix);
-    let out = format!("/tmp/{out_stem}.elf");
-    let sidecar = format!("/tmp/{out_stem}.elf.provenance.json");
-    let _ = std::fs::remove_file(&sidecar);
+    // #977: unique per call; the provenance sidecar derives its path from the
+    // elf path, so it is fresh by construction as well.
+    let out = artifact_guard::unique_artifact(out_stem, "elf");
+    let sidecar = format!("{}.provenance.json", out.display());
 
-    let res = Command::new(synth())
-        .env("SYNTH_CMP_SELECT_FUSE", "1")
-        .args([
-            "compile",
-            path.to_str().unwrap(),
-            "-o",
-            &out,
-            "--target",
-            "cortex-m4",
-            "--all-exports",
-            "--relocatable",
-            "--emit-provenance",
-        ])
-        .output()
-        .expect("run synth");
-    assert!(
-        res.status.success(),
-        "synth compile failed for {fix}: {}",
-        String::from_utf8_lossy(&res.stderr)
-    );
+    let mut cmd = Command::new(synth());
+    cmd.env("SYNTH_CMP_SELECT_FUSE", "1").args([
+        "compile",
+        path.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+        "--relocatable",
+        "--emit-provenance",
+    ]);
+    artifact_guard::compile_artifact_or_panic(&mut cmd, &out, fix);
 
     let bytes = std::fs::read(&sidecar)
         .unwrap_or_else(|e| panic!("provenance sidecar {sidecar} not written: {e}"));
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&sidecar);
     serde_json::from_slice(&bytes).expect("sidecar is valid JSON")
 }
 

--- a/crates/synth-cli/tests/rv32_cmp_select_flip_472.rs
+++ b/crates/synth-cli/tests/rv32_cmp_select_flip_472.rs
@@ -34,6 +34,12 @@ use std::process::Command;
 
 use object::{Object, ObjectSymbol, SymbolKind};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. A stale read
+// in a flip gate does not fail, it re-confirms last run's golden as this
+// run's evidence.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -49,7 +55,10 @@ fn fixture(rel: &str) -> std::path::PathBuf {
 /// `default_on` = the shipped default (env var removed so a stray opt-out in
 /// the test environment can't skew the gate); `false` = the
 /// `SYNTH_RV_CMP_SELECT=0` opt-out (pre-flip bytes).
-fn compile(rel: &str, out: &str, default_on: bool) -> Vec<u8> {
+fn compile(rel: &str, tag: &str, default_on: bool) -> Vec<u8> {
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed /tmp path must never be parsed as this run's.
+    let out = artifact_guard::unique_artifact(tag, "o");
     let mut cmd = Command::new(synth());
     // #601 promo flip: default-on now — pin OFF in both arms (see module doc).
     cmd.env("SYNTH_RV_LOCAL_PROMO", "0");
@@ -61,27 +70,23 @@ fn compile(rel: &str, out: &str, default_on: bool) -> Vec<u8> {
     } else {
         cmd.env("SYNTH_RV_CMP_SELECT", "0");
     }
-    let out_status = cmd
-        .args([
-            "compile",
-            fixture(rel).to_str().unwrap(),
-            "-o",
-            out,
-            "-b",
-            "riscv",
-            "--target",
-            "rv32imac",
-            "--all-exports",
-            "--relocatable",
-        ])
-        .output()
-        .expect("run synth compile");
-    assert!(
-        out_status.status.success(),
-        "synth compile failed ({rel}, default_on={default_on}): {}",
-        String::from_utf8_lossy(&out_status.stderr)
-    );
-    std::fs::read(out).expect("read ELF")
+    cmd.args([
+        "compile",
+        fixture(rel).to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "-b",
+        "riscv",
+        "--target",
+        "rv32imac",
+        "--all-exports",
+        "--relocatable",
+    ]);
+    artifact_guard::compile_bytes_or_panic(
+        &mut cmd,
+        &out,
+        &format!("{rel} (default_on={default_on})"),
+    )
 }
 
 /// Every function symbol → its `.text` byte size (ELF .symtab, not disasm
@@ -119,8 +124,8 @@ fn rv32_cmp_select_no_grow_corpus_472() {
     let mut fired = 0usize;
     for rel in corpus {
         let tag = Path::new(rel).file_stem().unwrap().to_str().unwrap();
-        let off = func_sizes(&compile(rel, &format!("/tmp/rvcs472_{tag}_off.o"), false));
-        let on = func_sizes(&compile(rel, &format!("/tmp/rvcs472_{tag}_on.o"), true));
+        let off = func_sizes(&compile(rel, &format!("rvcs472_{tag}_off"), false));
+        let on = func_sizes(&compile(rel, &format!("rvcs472_{tag}_on"), true));
         for (name, &o) in &off {
             let n = *on.get(name).unwrap_or(&o);
             assert!(

--- a/crates/synth-cli/tests/rv32_local_promo_flip_472.rs
+++ b/crates/synth-cli/tests/rv32_local_promo_flip_472.rs
@@ -38,6 +38,12 @@ use std::process::Command;
 
 use object::{Object, ObjectSymbol, SymbolKind};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. A stale read
+// in a flip gate does not fail, it re-confirms last run's golden as this
+// run's evidence.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -55,7 +61,10 @@ fn fixture(rel: &str) -> std::path::PathBuf {
 /// the gate; `false` = the `=0` opt-out, pre-flip bytes); every other lever
 /// env var is removed so both arms run the shipped defaults and the gate
 /// isolates the promotion lever.
-fn compile(rel: &str, out: &str, promo_on: bool) -> Vec<u8> {
+fn compile(rel: &str, tag: &str, promo_on: bool) -> Vec<u8> {
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed /tmp path must never be parsed as this run's.
+    let out = artifact_guard::unique_artifact(tag, "o");
     let mut cmd = Command::new(synth());
     cmd.env_remove("SYNTH_RV_CMP_SELECT");
     cmd.env_remove("SYNTH_RV_SHIFT_FOLD");
@@ -65,35 +74,27 @@ fn compile(rel: &str, out: &str, promo_on: bool) -> Vec<u8> {
     } else {
         cmd.env("SYNTH_RV_LOCAL_PROMO", "0");
     }
-    let out_status = cmd
-        .args([
-            "compile",
-            fixture(rel).to_str().unwrap(),
-            "-o",
-            out,
-            "-b",
-            "riscv",
-            "--target",
-            "rv32imac",
-            "--all-exports",
-            "--relocatable",
-            // #952: `gust_kernel.wasm`'s `gust_poll` export already declines
-            // on RV32 (unrelated pre-existing gap: `GlobalGet` unsupported in
-            // the RV32 skeleton) in BOTH arms of this corpus sweep. Since
-            // v0.57 that exits non-zero by default; this gate compares
-            // per-function BYTE SIZES across the arms and is unaffected by a
-            // function absent from both, so the partial object is exactly
-            // what it wants.
-            "--allow-skipped-exports",
-        ])
-        .output()
-        .expect("run synth compile");
-    assert!(
-        out_status.status.success(),
-        "synth compile failed ({rel}, promo_on={promo_on}): {}",
-        String::from_utf8_lossy(&out_status.stderr)
-    );
-    std::fs::read(out).expect("read ELF")
+    cmd.args([
+        "compile",
+        fixture(rel).to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "-b",
+        "riscv",
+        "--target",
+        "rv32imac",
+        "--all-exports",
+        "--relocatable",
+        // #952: `gust_kernel.wasm`'s `gust_poll` export already declines
+        // on RV32 (unrelated pre-existing gap: `GlobalGet` unsupported in
+        // the RV32 skeleton) in BOTH arms of this corpus sweep. Since
+        // v0.57 that exits non-zero by default; this gate compares
+        // per-function BYTE SIZES across the arms and is unaffected by a
+        // function absent from both, so the partial object is exactly
+        // what it wants.
+        "--allow-skipped-exports",
+    ]);
+    artifact_guard::compile_bytes_or_panic(&mut cmd, &out, &format!("{rel} (promo_on={promo_on})"))
 }
 
 /// Every function symbol → its `.text` byte size (ELF .symtab, not disasm
@@ -129,8 +130,8 @@ fn rv32_local_promo_no_grow_corpus_472() {
     let mut fired = 0usize;
     for rel in corpus {
         let tag = Path::new(rel).file_stem().unwrap().to_str().unwrap();
-        let off = func_sizes(&compile(rel, &format!("/tmp/rvlp472_{tag}_off.o"), false));
-        let on = func_sizes(&compile(rel, &format!("/tmp/rvlp472_{tag}_on.o"), true));
+        let off = func_sizes(&compile(rel, &format!("rvlp472_{tag}_off"), false));
+        let on = func_sizes(&compile(rel, &format!("rvlp472_{tag}_on"), true));
         // The flag may not change WHICH functions compile — a promoted-only
         // function would dodge the size comparison entirely.
         let mut off_names: Vec<&String> = off.keys().collect();

--- a/crates/synth-cli/tests/size_attribution_390.rs
+++ b/crates/synth-cli/tests/size_attribution_390.rs
@@ -27,6 +27,10 @@ use std::process::Command;
 
 use object::{Object, ObjectSection, ObjectSymbol, SymbolKind};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -40,28 +44,22 @@ fn fixture() -> std::path::PathBuf {
 /// Compile gust_kernel on the DEFAULT optimized path (no `--relocatable`) and
 /// return per-function `.text` sizes by symbol name (sorted-address deltas).
 fn per_function_sizes() -> BTreeMap<String, u64> {
-    let elf = "/tmp/size_attribution_390_gate.o";
-    let out = Command::new(synth())
-        .args([
-            "compile",
-            fixture().to_str().unwrap(),
-            "-o",
-            elf,
-            "-b",
-            "arm",
-            "--target",
-            "cortex-m4",
-            "--all-exports",
-        ])
-        .output()
-        .expect("run synth");
-    assert!(
-        out.status.success(),
-        "synth compile failed: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-
-    let bytes = std::fs::read(elf).expect("read elf");
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed /tmp path must never be parsed as this run's.
+    let elf = artifact_guard::unique_artifact("size_attribution_390_gate", "o");
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        fixture().to_str().unwrap(),
+        "-o",
+        elf.to_str().unwrap(),
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+    ]);
+    let bytes = artifact_guard::compile_bytes_or_panic(&mut cmd, &elf, "gust_kernel.wasm");
     let obj = object::File::parse(&*bytes).expect("parse elf");
     let text = obj.section_by_name(".text").expect(".text");
     let end = text.address() + text.size();

--- a/crates/synth-cli/tests/spill_realloc_242.rs
+++ b/crates/synth-cli/tests/spill_realloc_242.rs
@@ -54,6 +54,12 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. A stale read
+// in a flip gate does not fail, it re-confirms last run's golden as this
+// run's evidence.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -68,34 +74,36 @@ fn fixture(rel: &str) -> std::path::PathBuf {
 /// `true` = the shipped DEFAULT (env var removed so a stray `=0` in the test
 /// environment can't skew the gate), `false` = the `SYNTH_SPILL_REALLOC=0`
 /// opt-out (pre-flip bytes). Returns (ELF bytes, stderr).
-fn compile(rel: &str, out: &str, flag: bool) -> (Vec<u8>, String) {
+fn compile(rel: &str, tag: &str, flag: bool) -> (Vec<u8>, String) {
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed /tmp path must never be parsed as this run's.
+    let out = artifact_guard::unique_artifact(tag, "elf");
     let mut cmd = Command::new(synth());
     if flag {
         cmd.env_remove("SYNTH_SPILL_REALLOC");
     } else {
         cmd.env("SYNTH_SPILL_REALLOC", "0");
     }
-    let output = cmd
-        .env("SYNTH_SPILL_REPORT", "1")
+    cmd.env("SYNTH_SPILL_REPORT", "1")
         .env("SYNTH_FUSE_STATS", "1")
         .args([
             "compile",
             fixture(rel).to_str().unwrap(),
             "-o",
-            out,
+            out.to_str().unwrap(),
             "-b",
             "arm",
             "--target",
             "cortex-m4",
             "--all-exports",
-        ])
-        .output()
-        .expect("run synth compile");
-    assert!(output.status.success(), "synth compile failed ({rel})");
-    (
-        std::fs::read(out).expect("read ELF"),
-        String::from_utf8_lossy(&output.stderr).into_owned(),
-    )
+        ]);
+    match artifact_guard::compile_artifact_with_output(&mut cmd, &out) {
+        Ok((bytes, output)) => {
+            let _ = std::fs::remove_file(&out);
+            (bytes, String::from_utf8_lossy(&output.stderr).into_owned())
+        }
+        Err(e) => panic!("{rel} (flag={flag}): {e}"),
+    }
 }
 
 /// Every function symbol → its `.text` byte size.
@@ -177,16 +185,8 @@ fn forwarded_total(stderr: &str) -> usize {
 #[test]
 fn spill_realloc_no_grow_and_fires_on_flight_seam_242() {
     // flight_seam — the firing fixture.
-    let (off_elf, _) = compile(
-        "scripts/repro/flight_seam.wat",
-        "/tmp/sr242_fs_off.elf",
-        false,
-    );
-    let (on_elf, on_err) = compile(
-        "scripts/repro/flight_seam.wat",
-        "/tmp/sr242_fs_on.elf",
-        true,
-    );
+    let (off_elf, _) = compile("scripts/repro/flight_seam.wat", "sr242_fs_off", false);
+    let (on_elf, on_err) = compile("scripts/repro/flight_seam.wat", "sr242_fs_on", true);
     let (off, on) = (func_sizes(&off_elf), func_sizes(&on_elf));
     for (name, &o) in &off {
         let n = *on.get(name).unwrap_or(&o);
@@ -219,12 +219,12 @@ fn spill_realloc_no_grow_and_fires_on_flight_seam_242() {
     // slots are never read anywhere in the function.
     let (ff_off_elf, ff_off_err) = compile(
         "scripts/repro/flat_flight/flat_flight.loom.wasm",
-        "/tmp/sr242_ff_off.elf",
+        "sr242_ff_off",
         false,
     );
     let (ff_on_elf, ff_on_err) = compile(
         "scripts/repro/flat_flight/flat_flight.loom.wasm",
-        "/tmp/sr242_ff_on.elf",
+        "sr242_ff_on",
         true,
     );
     let (ff_off, ff_on) = (func_sizes(&ff_off_elf), func_sizes(&ff_on_elf));
@@ -284,7 +284,7 @@ fn spill_realloc_no_grow_and_fires_on_flight_seam_242() {
 fn spill_report_shows_flat_flight_headroom_242() {
     let (_, stderr) = compile(
         "scripts/repro/flat_flight/flat_flight.loom.wasm",
-        "/tmp/sr242_ff_rep.elf",
+        "sr242_ff_rep",
         false,
     );
     let reports = parse_reports(&stderr);

--- a/crates/synth-cli/tests/static_above_sp_739.rs
+++ b/crates/synth-cli/tests/static_above_sp_739.rs
@@ -17,6 +17,11 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. The readers
+// below take BYTES, not a path, so no read can outlive its compile.
+mod artifact_guard;
+
 use object::{Object, ObjectSection, ObjectSymbol, RelocationTarget};
 
 fn synth() -> &'static str {
@@ -50,14 +55,36 @@ fn compile(fixture: &str, extra: &[&str], out: &str) -> std::process::Output {
         .expect("run synth")
 }
 
+/// #977: the guarded READ-BACK form — compile and hand back the object bytes
+/// proven to be this invocation's output. [`compile`] above stays for the
+/// flag-honesty refusal test, which never reads an artifact.
+fn compile_read(fixture: &str, extra: &[&str], tag: &str) -> Vec<u8> {
+    let fx = repro(fixture);
+    let out = artifact_guard::unique_artifact(tag, "o");
+    let mut args = vec![
+        "compile",
+        fx.to_str().unwrap(),
+        "--target",
+        "cortex-m3",
+        "--native-pointer-abi",
+        "--all-exports",
+        "--relocatable",
+        "-o",
+        out.to_str().unwrap(),
+    ];
+    args.extend_from_slice(extra);
+    let mut cmd = Command::new(synth());
+    cmd.args(&args);
+    artifact_guard::compile_bytes_or_panic(&mut cmd, &out, tag)
+}
+
 fn parse<'a>(bytes: &'a [u8]) -> object::File<'a> {
     object::File::parse(bytes).expect("parse ELF")
 }
 
 /// All in-place REL addends of `__synth_wasm_data` R_ARM_ABS32 relocs.
-fn wasm_data_addends(path: &str) -> Vec<u32> {
-    let bytes = std::fs::read(path).expect("read .o");
-    let obj = parse(&bytes);
+fn wasm_data_addends(bytes: &[u8]) -> Vec<u32> {
+    let obj = parse(bytes);
     let text = obj.section_by_name(".text").expect(".text");
     let text_data = text.data().expect("text data");
     let mut addends = Vec::new();
@@ -73,9 +100,8 @@ fn wasm_data_addends(path: &str) -> Vec<u32> {
     addends
 }
 
-fn bss_size(path: &str) -> u64 {
-    let bytes = std::fs::read(path).expect("read .o");
-    let obj = parse(&bytes);
+fn bss_size(bytes: &[u8]) -> u64 {
+    let obj = parse(bytes);
     obj.sections()
         .find(|s| s.name() == Ok(".bss"))
         .expect(".bss present")
@@ -85,9 +111,8 @@ fn bss_size(path: &str) -> u64 {
 /// TRUE if `.text` contains an un-relocated MOVW/MOVT pair (same rd)
 /// materializing a constant in `[lo, hi)` — the baked-offset signature the
 /// #739 miscompile shipped (`movw ip,#0xC; movt ip,#0x10` = 0x10000C).
-fn has_baked_pair_in_window(path: &str, lo: u32, hi: u32) -> bool {
-    let bytes = std::fs::read(path).expect("read .o");
-    let obj = parse(&bytes);
+fn has_baked_pair_in_window(bytes: &[u8], lo: u32, hi: u32) -> bool {
+    let obj = parse(bytes);
     let text = obj.section_by_name(".text").expect(".text");
     let code = text.data().expect("text data");
     let reloc_offsets: Vec<u64> = text.relocations().map(|(off, _)| off).collect();
@@ -128,23 +153,18 @@ const BUDGET: u32 = 2048;
 /// #678 shrink down-shifts it to `budget + 12 = 2060`.
 #[test]
 fn above_sp_static_relocates_and_downshifts_739() {
-    let out = compile(
+    let bytes = compile_read(
         "mem739_above_sp.wat",
         &["--shadow-stack-size", "2048"],
-        "/tmp/mem739_shrunk_test.o",
+        "mem739_shrunk_test",
     );
-    assert!(
-        out.status.success(),
-        "must compile: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let addends = wasm_data_addends("/tmp/mem739_shrunk_test.o");
+    let addends = wasm_data_addends(&bytes);
     assert!(
         addends.contains(&(BUDGET + (BSS_STATIC - SP_INIT))),
         "above-SP static must down-shift to budget + 12 = 2060, got addends {addends:?}"
     );
     // Reservation = budget + above-SP tail — nowhere near the 1 MiB page.
-    let bss = bss_size("/tmp/mem739_shrunk_test.o");
+    let bss = bss_size(&bytes);
     assert!(
         (BUDGET as u64..=(BUDGET + 4096) as u64).contains(&bss),
         ".bss must be the shrunk reservation, got {bss}"
@@ -153,7 +173,7 @@ fn above_sp_static_relocates_and_downshifts_739() {
     // materialize a static-region address (post-shrink window starts at the
     // budget — anything at/above it is un-rebased).
     assert!(
-        !has_baked_pair_in_window("/tmp/mem739_shrunk_test.o", BUDGET, LINMEM),
+        !has_baked_pair_in_window(&bytes, BUDGET, LINMEM),
         "un-relocated baked static-region MOVW/MOVT pair survived the shrink"
     );
 }
@@ -164,19 +184,14 @@ fn above_sp_static_relocates_and_downshifts_739() {
 /// region anywhere.
 #[test]
 fn above_sp_static_relocates_without_shrink_739() {
-    let out = compile("mem739_above_sp.wat", &[], "/tmp/mem739_noshrink_test.o");
-    assert!(
-        out.status.success(),
-        "must compile: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let addends = wasm_data_addends("/tmp/mem739_noshrink_test.o");
+    let bytes = compile_read("mem739_above_sp.wat", &[], "mem739_noshrink_test");
+    let addends = wasm_data_addends(&bytes);
     assert!(
         addends.contains(&BSS_STATIC),
         "above-SP static must relocate as __synth_wasm_data + 0x10000C, got {addends:?}"
     );
     assert!(
-        !has_baked_pair_in_window("/tmp/mem739_noshrink_test.o", SP_INIT, LINMEM),
+        !has_baked_pair_in_window(&bytes, SP_INIT, LINMEM),
         "un-relocated baked static-region MOVW/MOVT pair in the un-shrunk object"
     );
 }
@@ -223,33 +238,32 @@ fn i64_static_offset_relocates_746() {
     i32.wrap_i64))"#,
     )
     .unwrap();
-    let obj = dir.join("i64_above_sp.o");
-    let out = Command::new(synth())
-        .args([
-            "compile",
-            wat.to_str().unwrap(),
-            "--target",
-            "cortex-m3",
-            "--native-pointer-abi",
-            "--all-exports",
-            "--relocatable",
-            "-o",
-            obj.to_str().unwrap(),
-        ])
-        .output()
-        .expect("run synth");
-    assert!(
-        out.status.success(),
-        "i64 static-region access must compile (relocated, #746): {}",
-        String::from_utf8_lossy(&out.stderr)
+    // #977: unique per call + remove-first + status/exists/non-empty guards.
+    let obj = artifact_guard::unique_artifact("mem746_i64_above_sp", "o");
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        wat.to_str().unwrap(),
+        "--target",
+        "cortex-m3",
+        "--native-pointer-abi",
+        "--all-exports",
+        "--relocatable",
+        "-o",
+        obj.to_str().unwrap(),
+    ]);
+    let bytes = artifact_guard::compile_bytes_or_panic(
+        &mut cmd,
+        &obj,
+        "i64 static-region access must compile (relocated, #746)",
     );
-    let addends = wasm_data_addends(obj.to_str().unwrap());
+    let addends = wasm_data_addends(&bytes);
     assert!(
         addends.contains(&1_048_584),
         "i64 static must relocate as __synth_wasm_data + 0x100008, got {addends:?}"
     );
     assert!(
-        !has_baked_pair_in_window(obj.to_str().unwrap(), SP_INIT, LINMEM),
+        !has_baked_pair_in_window(&bytes, SP_INIT, LINMEM),
         "un-relocated baked static-region MOVW/MOVT pair in the i64 object"
     );
 }
@@ -262,30 +276,84 @@ fn i64_static_offset_relocates_746() {
 /// fails (all 7 functions loud-decline, nothing to emit).
 #[test]
 fn wide_static_relocates_and_downshifts_746() {
-    let out = compile(
+    let bytes = compile_read(
         "mem746_wide_static.wat",
         &["--shadow-stack-size", "2048"],
-        "/tmp/mem746_shrunk_test.o",
+        "mem746_shrunk_test",
     );
-    assert!(
-        out.status.success(),
-        "must compile: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let addends = wasm_data_addends("/tmp/mem746_shrunk_test.o");
+    let addends = wasm_data_addends(&bytes);
     for want in [BUDGET + 16, BUDGET + 24] {
         assert!(
             addends.contains(&want),
             "above-SP i64 static must down-shift to {want}, got addends {addends:?}"
         );
     }
-    let bss = bss_size("/tmp/mem746_shrunk_test.o");
+    let bss = bss_size(&bytes);
     assert!(
         (BUDGET as u64..=(BUDGET + 4096) as u64).contains(&bss),
         ".bss must be the shrunk reservation, got {bss}"
     );
     assert!(
-        !has_baked_pair_in_window("/tmp/mem746_shrunk_test.o", BUDGET, LINMEM),
+        !has_baked_pair_in_window(&bytes, BUDGET, LINMEM),
         "un-relocated baked static-region MOVW/MOVT pair survived the shrink"
+    );
+}
+
+/// #977 RQ-59-FRESHNESS — the SILENT-direction demonstration for the
+/// helper-split batch (static_above_sp_739, static_downshift_678,
+/// multi_sp_rebase_707 — the guard is now THREADED through: readers take
+/// bytes handed back by the guarded compile, so no read can be attributed to
+/// anything but its own compile).
+///
+/// Prove the counterfactual: a planted VALID object (minted by this file's
+/// own compile shape) parses and carries the `__synth_wasm_data` reloc
+/// addends these gates assert on — so the pre-conversion path-based readers
+/// WOULD have re-confirmed last run's relocation evidence as this run's.
+/// Then fail the compile at that path and require the guard to refuse AND to
+/// leave nothing behind.
+#[test]
+fn freshness_guard_refuses_stale_reloc_artifact_977() {
+    // 1. Mint a genuine object with this batch's own compile shape.
+    let good = compile_read("mem739_above_sp.wat", &[], "mem739_fresh_demo");
+
+    // 2. Plant it, and prove the OLD shape would have passed on it.
+    let planted_at = artifact_guard::unique_artifact("mem739_stale_planted", "o");
+    std::fs::write(&planted_at, &good).expect("plant the stale artifact");
+    let stale = std::fs::read(&planted_at).expect("read planted");
+    assert!(
+        wasm_data_addends(&stale).contains(&BSS_STATIC),
+        "the planted artifact must carry the asserted reloc addend — \
+         substantial enough to fool an unguarded path-based reader"
+    );
+
+    // 3. A FAILING compile aimed at that exact path (nonexistent input).
+    let missing = repro("does_not_exist_977.wat");
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        missing.to_str().unwrap(),
+        "--target",
+        "cortex-m3",
+        "--native-pointer-abi",
+        "--all-exports",
+        "--relocatable",
+        "-o",
+        planted_at.to_str().unwrap(),
+    ]);
+    let err = artifact_guard::compile_artifact(&mut cmd, &planted_at)
+        .expect_err("REFUSAL REQUIRED: a failed compile must not return last run's bytes");
+
+    // 4. The refusal names the compile, not the parser — and nothing is left.
+    assert!(
+        err.contains("synth compile FAILED"),
+        "the refusal must name the compile failure, got: {err}"
+    );
+    assert!(
+        !err.contains("file magic"),
+        "and must not surface as a parse error, got: {err}"
+    );
+    assert!(
+        !planted_at.exists(),
+        "the stale artifact must be GONE — left in place, a later reader picks it up"
     );
 }

--- a/crates/synth-cli/tests/static_downshift_678.rs
+++ b/crates/synth-cli/tests/static_downshift_678.rs
@@ -14,6 +14,11 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. The readers
+// below take BYTES, not a path, so no read can outlive its compile.
+mod artifact_guard;
+
 use object::{Object, ObjectSection, ObjectSymbol, RelocationTarget};
 
 fn synth() -> &'static str {
@@ -47,9 +52,31 @@ fn compile(fixture: &str, extra: &[&str], out: &str) -> std::process::Output {
         .expect("run synth")
 }
 
-fn bss_size(path: &str) -> u64 {
-    let data = std::fs::read(path).expect("read .o");
-    let obj = object::File::parse(&*data).expect("parse ELF");
+/// #977: the guarded READ-BACK form — compile and hand back the object bytes
+/// proven to be this invocation's output. [`compile`] above stays for the
+/// straddle refusal test, which never reads an artifact.
+fn compile_read(fixture: &str, extra: &[&str], tag: &str) -> Vec<u8> {
+    let fx = repro(fixture);
+    let out = artifact_guard::unique_artifact(tag, "o");
+    let mut args = vec![
+        "compile",
+        fx.to_str().unwrap(),
+        "--target",
+        "cortex-m3",
+        "--native-pointer-abi",
+        "--all-exports",
+        "--relocatable",
+        "-o",
+        out.to_str().unwrap(),
+    ];
+    args.extend_from_slice(extra);
+    let mut cmd = Command::new(synth());
+    cmd.args(&args);
+    artifact_guard::compile_bytes_or_panic(&mut cmd, &out, tag)
+}
+
+fn bss_size(data: &[u8]) -> u64 {
+    let obj = object::File::parse(data).expect("parse ELF");
     obj.sections()
         .find(|s| s.name() == Ok(".bss"))
         .expect(".bss present")
@@ -58,9 +85,8 @@ fn bss_size(path: &str) -> u64 {
 
 /// The in-place REL addend of the (unique) `__synth_wasm_data` R_ARM_ABS32 reloc
 /// whose in-place literal word is non-zero — i.e. the down-shifted static addend.
-fn max_wasm_data_addend(path: &str) -> u32 {
-    let bytes = std::fs::read(path).expect("read .o");
-    let obj = object::File::parse(&*bytes).expect("parse ELF");
+fn max_wasm_data_addend(bytes: &[u8]) -> u32 {
+    let obj = object::File::parse(bytes).expect("parse ELF");
     let text = obj.section_by_name(".text").expect(".text");
     let text_data = text.data().expect("text data");
     let mut best = 0u32;
@@ -83,23 +109,18 @@ fn max_wasm_data_addend(path: &str) -> u32 {
 /// shrinks to `budget + tail`.
 #[test]
 fn bss_static_downshifts_678() {
-    let out = compile(
+    let bytes = compile_read(
         "mem678_bss.wat",
         &["--shadow-stack-size", "512"],
-        "/tmp/mem678_bss_test.o",
-    );
-    assert!(
-        out.status.success(),
-        "layer-2 must COMPILE the bss-static node (was refused): {}",
-        String::from_utf8_lossy(&out.stderr)
+        "mem678_bss_test",
     );
     assert_eq!(
-        max_wasm_data_addend("/tmp/mem678_bss_test.o"),
+        max_wasm_data_addend(&bytes),
         576,
         "static at 4160 must rebase to 4160 - (4096-512) = 576"
     );
     // budget 512 + static tail (used_extent 4168 - sp_init 4096 = 72) = 584.
-    assert_eq!(bss_size("/tmp/mem678_bss_test.o"), 584);
+    assert_eq!(bss_size(&bytes), 584);
 }
 
 /// Mixed geometry: a `(data)` segment (retargeted to `.data`) AND a BSS static at
@@ -107,18 +128,13 @@ fn bss_static_downshifts_678() {
 /// `.data`, only the residual BSS reloc is rebased (4200 - 3584 = 616).
 #[test]
 fn buffer_plus_bss_downshifts_678() {
-    let out = compile(
+    let bytes = compile_read(
         "mem678_buf.wat",
         &["--shadow-stack-size", "512"],
-        "/tmp/mem678_buf_test.o",
-    );
-    assert!(
-        out.status.success(),
-        "layer-2 must COMPILE the buffer node: {}",
-        String::from_utf8_lossy(&out.stderr)
+        "mem678_buf_test",
     );
     assert_eq!(
-        max_wasm_data_addend("/tmp/mem678_buf_test.o"),
+        max_wasm_data_addend(&bytes),
         616,
         "bss static at 4200 must rebase to 616; the data-seg read stays in .data"
     );
@@ -147,8 +163,7 @@ fn straddling_static_refused_678() {
 /// reservation and no static is rebased (byte-identical to pre-#678).
 #[test]
 fn no_flag_leaves_statics_inline_678() {
-    let out = compile("mem678_buf.wat", &[], "/tmp/mem678_buf_noflag.o");
-    assert!(out.status.success());
+    let bytes = compile_read("mem678_buf.wat", &[], "mem678_buf_noflag");
     // Un-shifted: the bss static keeps its full wasm addend 4200.
-    assert_eq!(max_wasm_data_addend("/tmp/mem678_buf_noflag.o"), 4200);
+    assert_eq!(max_wasm_data_addend(&bytes), 4200);
 }

--- a/crates/synth-cli/tests/vcr_ver_001_gate_242.rs
+++ b/crates/synth-cli/tests/vcr_ver_001_gate_242.rs
@@ -30,6 +30,12 @@ use std::process::Command;
 
 use object::{Object, ObjectSection};
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. A stale read
+// in a flip gate does not fail, it re-confirms last run's golden as this
+// run's evidence.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -45,9 +51,14 @@ fn fixture(name: &str) -> std::path::PathBuf {
 /// path is eligible, the one the #496 decline and its reversal act on) and
 /// return the `.text` bytes.
 fn default_path_text(wasm: &str, spill_on_exhaust: bool) -> Vec<u8> {
-    let elf = format!(
-        "/tmp/vcr_ver_001_{}_{wasm}.elf",
-        if spill_on_exhaust { "on" } else { "off" }
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed /tmp path must never be parsed as this run's.
+    let elf = artifact_guard::unique_artifact(
+        &format!(
+            "vcr_ver_001_{}_{wasm}",
+            if spill_on_exhaust { "on" } else { "off" }
+        ),
+        "elf",
     );
     let mut cmd = Command::new(synth());
     if spill_on_exhaust {
@@ -55,24 +66,20 @@ fn default_path_text(wasm: &str, spill_on_exhaust: bool) -> Vec<u8> {
     } else {
         cmd.env_remove("SYNTH_SPILL_ON_EXHAUST");
     }
-    let out = cmd
-        .args([
-            "compile",
-            fixture(wasm).to_str().unwrap(),
-            "-o",
-            &elf,
-            "--target",
-            "cortex-m4",
-            "--all-exports",
-        ])
-        .output()
-        .expect("run synth");
-    assert!(
-        out.status.success(),
-        "synth compile failed for {wasm}: {}",
-        String::from_utf8_lossy(&out.stderr)
+    cmd.args([
+        "compile",
+        fixture(wasm).to_str().unwrap(),
+        "-o",
+        elf.to_str().unwrap(),
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+    ]);
+    let bin = artifact_guard::compile_bytes_or_panic(
+        &mut cmd,
+        &elf,
+        &format!("{wasm} (spill_on_exhaust={spill_on_exhaust})"),
     );
-    let bin = std::fs::read(&elf).expect("read ELF");
     let obj = object::File::parse(&*bin).expect("parse ELF");
     obj.section_by_name(".text")
         .expect(".text")

--- a/crates/synth-cli/tests/vcr_ver_003_addr_777.rs
+++ b/crates/synth-cli/tests/vcr_ver_003_addr_777.rs
@@ -25,6 +25,10 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -48,38 +52,38 @@ fn gale_overlapping_segments_compile_clean() {
         "missing gale fixture {}",
         fixture.display()
     );
-    let out = std::env::temp_dir().join("vcr_ver_003_gale.o");
-    let output = Command::new(synth())
-        .args([
-            "compile",
-            fixture.to_str().unwrap(),
-            "--target",
-            "cortex-m3",
-            "--all-exports",
-            "--relocatable",
-            "--native-pointer-abi",
-            "--shadow-stack-size",
-            "2048",
-            "-o",
-            out.to_str().unwrap(),
-        ])
-        .output()
-        .expect("run synth");
-
+    // #977: unique per call + remove-first + status/exists/non-empty guards.
+    let out = artifact_guard::unique_artifact("vcr_ver_003_gale", "o");
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        fixture.to_str().unwrap(),
+        "--target",
+        "cortex-m3",
+        "--all-exports",
+        "--relocatable",
+        "--native-pointer-abi",
+        "--shadow-stack-size",
+        "2048",
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    let (bytes, output) = artifact_guard::compile_artifact_with_output(&mut cmd, &out)
+        .unwrap_or_else(|e| {
+            panic!(
+                "gale module must compile clean under the shipped .rposition() \
+                 retargeting — VCR-VER-003 rejected it, which means the \
+                 overlapping segments resolved to the WRONG segment (the #757 \
+                 miscompile has regressed): {e}"
+            )
+        });
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        output.status.success(),
-        "gale module must compile clean under the shipped .rposition() \
-         retargeting — VCR-VER-003 rejected it, which means the overlapping \
-         segments resolved to the WRONG segment (the #757 miscompile has \
-         regressed):\n{stderr}"
-    );
     // Sanity: the validator must NOT have fired on the correct path.
     assert!(
         !stderr.contains("VCR-VER-003"),
         "VCR-VER-003 must be silent on the runtime-correct resolution:\n{stderr}"
     );
-    assert!(out.exists(), "expected a relocatable .o output");
+    assert!(!bytes.is_empty(), "expected a relocatable .o output");
     let _ = std::fs::remove_file(&out);
 }
 
@@ -94,6 +98,37 @@ fn wat_file(name: &str, wat: &str) -> PathBuf {
     let p = dir.join(name);
     std::fs::write(&p, wat).expect("write wat");
     p
+}
+
+/// #977: the guarded READ-BACK form — compile and hand back the object bytes
+/// proven to be this invocation's output (unique path + remove-first +
+/// status/exists/non-empty via `artifact_guard`), plus combined stdout+stderr.
+/// [`compile`] below stays for the tests that only assert on the process
+/// output (refusals and validator diagnostics) and never read the artifact.
+fn compile_read(input: &std::path::Path, tag: &str, extra: &[&str]) -> (Vec<u8>, String) {
+    let out = artifact_guard::unique_artifact(tag, "o");
+    let mut args = vec![
+        "compile",
+        input.to_str().unwrap(),
+        "--all-exports",
+        "-o",
+        out.to_str().unwrap(),
+    ];
+    args.extend_from_slice(extra);
+    let mut cmd = Command::new(synth());
+    cmd.args(&args);
+    match artifact_guard::compile_artifact_with_output(&mut cmd, &out) {
+        Ok((bytes, output)) => {
+            let _ = std::fs::remove_file(&out);
+            let all = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            (bytes, all)
+        }
+        Err(e) => panic!("{tag}: {e}"),
+    }
 }
 
 fn compile(input: &std::path::Path, out_name: &str, extra: &[&str]) -> std::process::Output {
@@ -236,11 +271,12 @@ fn span_straddle_module_selfcontained_rom_image_validates() {
     );
 }
 
-/// Read a named section's bytes out of an ELF object on disk.
-fn section_bytes(path: &std::path::Path, name: &str) -> Option<Vec<u8>> {
+/// Read a named section's bytes out of an ELF object already in memory
+/// (#977: the bytes come from `compile_read`, never from a path a previous
+/// run may have populated).
+fn section_from_bytes(bytes: &[u8], name: &str) -> Option<Vec<u8>> {
     use object::{Object, ObjectSection};
-    let bytes = std::fs::read(path).expect("read object");
-    let obj = object::File::parse(&*bytes).expect("parse object");
+    let obj = object::File::parse(bytes).expect("parse object");
     obj.section_by_name(name)
         .map(|s| s.data().expect("section data").to_vec())
 }
@@ -259,16 +295,7 @@ fn rv32_nonzero_data_segment_ships_wasm_data_records() {
   (data (i32.const 16) "\01\02\03\04")
   (func (export "get") (result i32) i32.const 16 i32.load))"#;
     let fixture = wat_file("rv32_data_777.wat", wat);
-    let out_path = std::env::temp_dir()
-        .join("synth_vcr_ver_003_ph2")
-        .join("rv32_data_777.o");
-    let out = compile(&fixture, "rv32_data_777.o", &["-b", "riscv"]);
-    let all = format!(
-        "{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
-    );
-    assert!(out.status.success(), "RV32 compile stays green:\n{all}");
+    let (obj_bytes, all) = compile_read(&fixture, "rv32_data_777", &["-b", "riscv"]);
     assert!(
         !all.contains("read as 0x00"),
         "the silent-drop warning must be gone — the data SHIPS now (#798):\n{all}"
@@ -278,8 +305,8 @@ fn rv32_nonzero_data_segment_ships_wasm_data_records() {
         "the shipping info line names the segment count:\n{all}"
     );
     // The object carries the record verbatim: off=16, len=4, bytes 01020304.
-    let records =
-        section_bytes(&out_path, ".wasm_data").expect("the object must ship a .wasm_data section");
+    let records = section_from_bytes(&obj_bytes, ".wasm_data")
+        .expect("the object must ship a .wasm_data section");
     assert_eq!(
         records,
         [16u32.to_le_bytes(), 4u32.to_le_bytes()]
@@ -305,21 +332,12 @@ fn rv32_zero_overwritten_data_ships_both_records_in_order() {
   (data (i32.const 16) "\00\00\00\00")
   (func (export "get") (result i32) i32.const 16 i32.load))"#;
     let fixture = wat_file("rv32_zero_777.wat", wat);
-    let out_path = std::env::temp_dir()
-        .join("synth_vcr_ver_003_ph2")
-        .join("rv32_zero_777.o");
-    let out = compile(&fixture, "rv32_zero_777.o", &["-b", "riscv"]);
-    let all = format!(
-        "{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
-    );
-    assert!(out.status.success(), "RV32 compile stays green:\n{all}");
+    let (obj_bytes, all) = compile_read(&fixture, "rv32_zero_777", &["-b", "riscv"]);
     assert!(
         !all.contains("VCR-VER-003"),
         "the read-back gate must be silent on a correct pack:\n{all}"
     );
-    let records = section_bytes(&out_path, ".wasm_data").expect(".wasm_data present");
+    let records = section_from_bytes(&obj_bytes, ".wasm_data").expect(".wasm_data present");
     let mut expect = Vec::new();
     for seg in [[1u8, 2, 3, 4], [0u8, 0, 0, 0]] {
         expect.extend_from_slice(&16u32.to_le_bytes());
@@ -342,13 +360,9 @@ fn rv32_data_free_module_has_no_wasm_data_section() {
   (memory 1)
   (func (export "get") (result i32) i32.const 16 i32.load))"#;
     let fixture = wat_file("rv32_nodata_798.wat", wat);
-    let out_path = std::env::temp_dir()
-        .join("synth_vcr_ver_003_ph2")
-        .join("rv32_nodata_798.o");
-    let out = compile(&fixture, "rv32_nodata_798.o", &["-b", "riscv"]);
-    assert!(out.status.success());
+    let (obj_bytes, _all) = compile_read(&fixture, "rv32_nodata_798", &["-b", "riscv"]);
     assert!(
-        section_bytes(&out_path, ".wasm_data").is_none(),
+        section_from_bytes(&obj_bytes, ".wasm_data").is_none(),
         "no segments => no .wasm_data section (byte-identical layout)"
     );
 }
@@ -377,5 +391,71 @@ fn rv32_segment_past_memory_is_refused() {
     assert!(
         all.contains("instantiation would trap"),
         "the refusal names the reason:\n{all}"
+    );
+}
+
+/// #977 RQ-59-FRESHNESS — the SILENT-direction demonstration for the
+/// validator/attestation batch (vcr_ver_003_addr_777, proven_safe_bounds_901,
+/// size_attribution_390, parity_benchmark_735,
+/// promotion_exhaustion_fallback_474, wsc_facts_ingestion_494 — all now
+/// compile through `artifact_guard`).
+///
+/// Prove the counterfactual: a planted VALID RV32 object (minted by this
+/// file's own compile shape) parses and carries the `.wasm_data` section the
+/// read-back gates assert on — so the pre-conversion path-based `fs::read` +
+/// `File::parse` WOULD have re-confirmed last run's records as this run's
+/// evidence. Then fail the compile at that path and require refusal AND an
+/// empty path. For a validator gate a stale read is worse than a crash: it
+/// re-certifies the served-image check on an object this run never produced.
+#[test]
+fn freshness_guard_refuses_stale_validator_artifact_977() {
+    // 1. Mint a genuine object with this batch's own compile shape.
+    let wat = r#"(module
+  (memory 1)
+  (data (i32.const 16) "\01\02\03\04")
+  (func (export "get") (result i32) i32.const 16 i32.load))"#;
+    let fixture = wat_file("freshness_demo_977.wat", wat);
+    let (good, _all) = compile_read(&fixture, "freshness_demo_977", &["-b", "riscv"]);
+
+    // 2. Plant it, and prove the OLD shape would have passed on it.
+    let planted_at = artifact_guard::unique_artifact("vcr_ver_003_stale_planted", "o");
+    std::fs::write(&planted_at, &good).expect("plant the stale artifact");
+    let stale = std::fs::read(&planted_at).expect("read planted");
+    assert!(
+        section_from_bytes(&stale, ".wasm_data").is_some(),
+        "the planted artifact must carry .wasm_data — substantial enough to \
+         fool an unguarded read-back gate"
+    );
+
+    // 3. A FAILING compile aimed at that exact path (nonexistent input).
+    let missing = std::env::temp_dir()
+        .join("synth_vcr_ver_003_ph2")
+        .join("does_not_exist_977.wat");
+    let _ = std::fs::remove_file(&missing);
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        missing.to_str().unwrap(),
+        "--all-exports",
+        "-o",
+        planted_at.to_str().unwrap(),
+        "-b",
+        "riscv",
+    ]);
+    let err = artifact_guard::compile_artifact(&mut cmd, &planted_at)
+        .expect_err("REFUSAL REQUIRED: a failed compile must not return last run's bytes");
+
+    // 4. The refusal names the compile, not the parser — and nothing is left.
+    assert!(
+        err.contains("synth compile FAILED"),
+        "the refusal must name the compile failure, got: {err}"
+    );
+    assert!(
+        !err.contains("file magic"),
+        "and must not surface as a parse error, got: {err}"
+    );
+    assert!(
+        !planted_at.exists(),
+        "the stale artifact must be GONE — left in place, a later reader picks it up"
     );
 }

--- a/crates/synth-cli/tests/volatile_segment_flag_543.rs
+++ b/crates/synth-cli/tests/volatile_segment_flag_543.rs
@@ -22,6 +22,12 @@
 use object::{Object, ObjectSection};
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. A stale read
+// in a flip gate does not fail, it re-confirms last run's golden as this
+// run's evidence.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -46,12 +52,15 @@ fn compile_text(
     extra: &[&str],
 ) -> Result<Vec<u8>, String> {
     let path = fixture(fixture_name);
-    let elf = format!("/tmp/volseg543_{out_tag}.elf");
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed /tmp path must never be parsed as this run's.
+    let elf = artifact_guard::unique_artifact(&format!("volseg543_{out_tag}"), "elf");
+    let elf_str = elf.to_str().unwrap();
     let mut args = vec![
         "compile",
         path.to_str().unwrap(),
         "-o",
-        &elf,
+        elf_str,
         "-b",
         "arm",
         "--target",
@@ -65,15 +74,9 @@ fn compile_text(
     for (k, v) in envs {
         cmd.env(k, v);
     }
-    let out = cmd.args(&args).output().expect("run synth");
-    if !out.status.success() {
-        return Err(format!(
-            "exit={:?} stderr={}",
-            out.status.code(),
-            String::from_utf8_lossy(&out.stderr)
-        ));
-    }
-    let bytes = std::fs::read(&elf).expect("read elf");
+    cmd.args(&args);
+    let bytes = artifact_guard::compile_artifact(&mut cmd, &elf)?;
+    let _ = std::fs::remove_file(&elf);
     let obj = object::File::parse(&*bytes).expect("parse elf");
     let text = obj
         .section_by_name(".text")

--- a/crates/synth-cli/tests/volatile_segment_phase2_543.rs
+++ b/crates/synth-cli/tests/volatile_segment_phase2_543.rs
@@ -46,6 +46,12 @@
 use object::{Object, ObjectSection};
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. A stale read
+// in a flip gate does not fail, it re-confirms last run's golden as this
+// run's evidence.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -69,12 +75,15 @@ fn compile_text(
     extra: &[&str],
 ) -> Vec<u8> {
     let path = fixture(fixture_name);
-    let elf = format!("/tmp/volseg543_p2_{out_tag}.elf");
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed /tmp path must never be parsed as this run's.
+    let elf = artifact_guard::unique_artifact(&format!("volseg543_p2_{out_tag}"), "elf");
+    let elf_str = elf.to_str().unwrap();
     let mut args = vec![
         "compile",
         path.to_str().unwrap(),
         "-o",
-        &elf,
+        elf_str,
         "-b",
         "arm",
         "--target",
@@ -88,14 +97,8 @@ fn compile_text(
     for (k, v) in envs {
         cmd.env(k, v);
     }
-    let out = cmd.args(&args).output().expect("run synth");
-    assert!(
-        out.status.success(),
-        "synth compile failed (tag={out_tag}): exit={:?} stderr={}",
-        out.status.code(),
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let bytes = std::fs::read(&elf).expect("read elf");
+    cmd.args(&args);
+    let bytes = artifact_guard::compile_bytes_or_panic(&mut cmd, &elf, &format!("tag={out_tag}"));
     let obj = object::File::parse(&*bytes).expect("parse elf");
     obj.section_by_name(".text")
         .expect("fixture must have a .text section")

--- a/crates/synth-cli/tests/wast_compile.rs
+++ b/crates/synth-cli/tests/wast_compile.rs
@@ -17,6 +17,12 @@ use std::process::Command;
 ///
 /// `CARGO_BIN_EXE_<name>` is the thing Cargo actually sets for integration
 /// tests, and it is layout-independent by construction.
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`. Unique-per-
+// call output paths + the guarded read close the stale-artifact direction
+// (this file's .exists() checks only ever covered the missing-file half).
+mod artifact_guard;
+
 fn synth_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_synth"))
 }
@@ -35,47 +41,30 @@ fn wast_dir() -> PathBuf {
 }
 
 /// Compile a single WAST file and assert success
-fn compile_wast(wast_file: &Path) -> PathBuf {
+fn compile_wast(wast_file: &Path) -> Vec<u8> {
     let stem = wast_file.file_stem().unwrap().to_str().unwrap();
-    let output = std::env::temp_dir().join(format!("synth_test_{}.elf", stem));
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed path must never be parsed as this run's.
+    let output = artifact_guard::unique_artifact(&format!("synth_test_{stem}"), "elf");
 
-    let result = Command::new(synth_binary())
-        .args([
-            "compile",
-            wast_file.to_str().unwrap(),
-            "--all-exports",
-            "--cortex-m",
-            "-o",
-            output.to_str().unwrap(),
-        ])
-        .output()
-        .expect("Failed to run synth binary");
-
-    let stdout = String::from_utf8_lossy(&result.stdout);
-    let stderr = String::from_utf8_lossy(&result.stderr);
-
-    assert!(
-        result.status.success(),
-        "synth compile failed for {}:\nstdout: {}\nstderr: {}",
-        wast_file.display(),
-        stdout,
-        stderr,
-    );
-
-    // Verify the output file exists and looks like an ELF
-    assert!(
-        output.exists(),
-        "Output ELF not created: {}",
-        output.display()
-    );
-    let data = std::fs::read(&output).unwrap();
+    let mut cmd = Command::new(synth_binary());
+    cmd.args([
+        "compile",
+        wast_file.to_str().unwrap(),
+        "--all-exports",
+        "--cortex-m",
+        "-o",
+        output.to_str().unwrap(),
+    ]);
+    let data =
+        artifact_guard::compile_bytes_or_panic(&mut cmd, &output, &wast_file.display().to_string());
     assert!(data.len() > 52, "ELF file too small: {} bytes", data.len());
     assert_eq!(&data[0..4], b"\x7fELF", "Not a valid ELF file");
 
     // Check it's ARM (e_machine = 0x28 = 40)
     assert_eq!(data[18], 0x28, "Not an ARM ELF (e_machine)");
 
-    output
+    data
 }
 
 // --- Individual WAST file compile tests ---
@@ -206,7 +195,7 @@ fn compile_import_call_produces_relocatable_elf() {
 
     assert!(wat.exists(), "import_call.wat not found: {}", wat.display());
 
-    let output = std::env::temp_dir().join("synth_test_import_call.o");
+    let output = artifact_guard::unique_artifact("synth_test_import_call", "o");
 
     let result = Command::new(synth_binary())
         .args([
@@ -229,7 +218,7 @@ fn compile_import_call_produces_relocatable_elf() {
         stderr,
     );
 
-    let data = std::fs::read(&output).unwrap();
+    let data = artifact_guard::read_artifact(&output).unwrap_or_else(|e| panic!("{e}"));
 
     // ELF magic
     assert_eq!(&data[0..4], b"\x7fELF", "Not a valid ELF file");
@@ -298,7 +287,7 @@ fn compile_import_call_produces_relocatable_elf() {
 fn compile_with_relocatable_flag_forces_et_rel() {
     let wast_file = wast_dir().join("i32_arithmetic.wast");
     assert!(wast_file.exists(), "i32_arithmetic.wast missing");
-    let output = std::env::temp_dir().join("synth_test_relocatable.o");
+    let output = artifact_guard::unique_artifact("synth_test_relocatable", "o");
 
     let result = Command::new(synth_binary())
         .args([
@@ -323,7 +312,7 @@ fn compile_with_relocatable_flag_forces_et_rel() {
     );
     assert!(output.exists(), "output not created");
 
-    let data = std::fs::read(&output).unwrap();
+    let data = artifact_guard::read_artifact(&output).unwrap_or_else(|e| panic!("{e}"));
     assert_eq!(&data[0..4], b"\x7fELF", "not an ELF");
     // ET_REL == 1
     let e_type = u16::from_le_bytes([data[16], data[17]]);
@@ -340,7 +329,7 @@ fn compile_with_relocatable_flag_forces_et_rel() {
 #[test]
 fn compile_without_relocatable_flag_produces_et_exec_for_no_imports() {
     let wast_file = wast_dir().join("i32_arithmetic.wast");
-    let output = std::env::temp_dir().join("synth_test_no_relocatable.elf");
+    let output = artifact_guard::unique_artifact("synth_test_no_relocatable", "elf");
 
     let result = Command::new(synth_binary())
         .args([
@@ -359,7 +348,7 @@ fn compile_without_relocatable_flag_produces_et_exec_for_no_imports() {
         "default compile (no --relocatable) failed: stderr={}",
         String::from_utf8_lossy(&result.stderr),
     );
-    let data = std::fs::read(&output).unwrap();
+    let data = artifact_guard::read_artifact(&output).unwrap_or_else(|e| panic!("{e}"));
     let e_type = u16::from_le_bytes([data[16], data[17]]);
     assert_eq!(
         e_type, 2,
@@ -410,7 +399,7 @@ fn compile_internal_call_is_linkable_167() {
         wat.display()
     );
 
-    let output = std::env::temp_dir().join("synth_test_internal_call.o");
+    let output = artifact_guard::unique_artifact("synth_test_internal_call", "o");
     let result = Command::new(synth_binary())
         .args([
             "compile",
@@ -431,7 +420,7 @@ fn compile_internal_call_is_linkable_167() {
         String::from_utf8_lossy(&result.stderr),
     );
 
-    let data = std::fs::read(&output).unwrap();
+    let data = artifact_guard::read_artifact(&output).unwrap_or_else(|e| panic!("{e}"));
     let elf = object::File::parse(&*data).expect("parse ARM ELF object");
 
     // A `func_0` symbol must be defined so internal `BL func_0` resolves.
@@ -499,7 +488,7 @@ fn compile_import_call_uses_field_name_173() {
         wat.display()
     );
 
-    let output = std::env::temp_dir().join("synth_test_import_field_name.o");
+    let output = artifact_guard::unique_artifact("synth_test_import_field_name", "o");
     let result = Command::new(synth_binary())
         .args([
             "compile",
@@ -520,7 +509,7 @@ fn compile_import_call_uses_field_name_173() {
         String::from_utf8_lossy(&result.stderr),
     );
 
-    let data = std::fs::read(&output).unwrap();
+    let data = artifact_guard::read_artifact(&output).unwrap_or_else(|e| panic!("{e}"));
     let elf = object::File::parse(&*data).expect("parse ARM ELF object");
 
     // The import's field name must be an UNDEFINED symbol the host resolves.
@@ -570,7 +559,7 @@ fn pointer_deref_optimized_uses_address_operand_178_180() {
         .join("ptr_deref.wat");
     assert!(wat.exists(), "ptr_deref.wat not found: {}", wat.display());
 
-    let out = std::env::temp_dir().join("synth_ptr_opt.o");
+    let out = artifact_guard::unique_artifact("synth_ptr_opt", "o");
     let result = Command::new(synth_binary())
         .args([
             "compile",
@@ -589,7 +578,7 @@ fn pointer_deref_optimized_uses_address_operand_178_180() {
         "compile failed: {}",
         String::from_utf8_lossy(&result.stderr)
     );
-    let data = std::fs::read(&out).unwrap();
+    let data = artifact_guard::read_artifact(&out).unwrap_or_else(|e| panic!("{e}"));
     let elf = object::File::parse(&*data).expect("parse ELF");
     let text = elf
         .section_by_name(".text")
@@ -634,7 +623,7 @@ fn relocatable_pointer_deref_uses_fp_base_197() {
         .join("ptr_deref.wat");
     assert!(wat.exists(), "ptr_deref.wat not found: {}", wat.display());
 
-    let out = std::env::temp_dir().join("synth_ptr_rel_197.o");
+    let out = artifact_guard::unique_artifact("synth_ptr_rel_197", "o");
     let result = Command::new(synth_binary())
         .args([
             "compile",
@@ -653,7 +642,7 @@ fn relocatable_pointer_deref_uses_fp_base_197() {
         "relocatable compile failed: {}",
         String::from_utf8_lossy(&result.stderr)
     );
-    let data = std::fs::read(&out).unwrap();
+    let data = artifact_guard::read_artifact(&out).unwrap_or_else(|e| panic!("{e}"));
     let elf = object::File::parse(&*data).expect("parse ELF");
     let text = elf
         .section_by_name(".text")
@@ -694,7 +683,7 @@ fn relocatable_conditional_branch_targets_instruction_boundary_202() {
         .join("branch_over_32bit.wat");
     assert!(wat.exists(), "fixture not found: {}", wat.display());
 
-    let out = std::env::temp_dir().join("synth_br32_202.o");
+    let out = artifact_guard::unique_artifact("synth_br32_202", "o");
     let result = Command::new(synth_binary())
         .args([
             "compile",
@@ -713,7 +702,7 @@ fn relocatable_conditional_branch_targets_instruction_boundary_202() {
         "compile failed: {}",
         String::from_utf8_lossy(&result.stderr)
     );
-    let data = std::fs::read(&out).unwrap();
+    let data = artifact_guard::read_artifact(&out).unwrap_or_else(|e| panic!("{e}"));
     let elf = object::File::parse(&*data).expect("parse ELF");
     let text = elf
         .section_by_name(".text")
@@ -816,7 +805,7 @@ fn compile_standalone_internal_call_resolves_bl_170() {
         wat.display()
     );
 
-    let output = std::env::temp_dir().join("synth_test_standalone_internal_call.elf");
+    let output = artifact_guard::unique_artifact("synth_test_standalone_internal_call", "elf");
     let result = Command::new(synth_binary())
         .args([
             "compile",
@@ -837,7 +826,7 @@ fn compile_standalone_internal_call_resolves_bl_170() {
         String::from_utf8_lossy(&result.stderr),
     );
 
-    let data = std::fs::read(&output).unwrap();
+    let data = artifact_guard::read_artifact(&output).unwrap_or_else(|e| panic!("{e}"));
 
     // No linker is involved: this must be a standalone executable (ET_EXEC = 2),
     // NOT a relocatable object (ET_REL = 1).
@@ -927,4 +916,62 @@ fn compile_standalone_internal_call_resolves_bl_170() {
     );
 
     let _ = std::fs::remove_file(&output);
+}
+
+/// #977 RQ-59-FRESHNESS — the SILENT-direction demonstration for the
+/// conformance batch (this file's helper + its nine inline sites).
+///
+/// This file's historical `.exists()` checks only ever covered the
+/// missing-file half. Prove the OTHER half: a planted VALID ELF (minted by
+/// this file's own compile shape) passes every structural check the old
+/// shape ran — parses, ARM e_machine, ELF magic — so a stale artifact WOULD
+/// have re-confirmed a previous run's conformance as this run's. Then fail
+/// the compile at that path and require the guard to refuse AND to leave
+/// nothing behind.
+#[test]
+fn freshness_guard_refuses_stale_conformance_artifact_977() {
+    // 1. Mint genuine bytes with this file's own (guarded) compile shape.
+    let good = compile_wast(&wast_dir().join("i32_arithmetic.wast"));
+
+    // 2. Plant them, and prove the OLD shape would have passed on them.
+    let planted_at = artifact_guard::unique_artifact("wast_stale_planted", "elf");
+    std::fs::write(&planted_at, &good).expect("plant the stale artifact");
+    let stale = std::fs::read(&planted_at).expect("read planted");
+    assert_eq!(
+        &stale[0..4],
+        b"\x7fELF",
+        "planted artifact passes the magic check"
+    );
+    assert_eq!(
+        stale[18], 0x28,
+        "planted artifact passes the ARM e_machine check"
+    );
+
+    // 3. A FAILING compile aimed at that exact path (nonexistent input).
+    let missing = wast_dir().join("does_not_exist_977.wast");
+    let mut cmd = Command::new(synth_binary());
+    cmd.args([
+        "compile",
+        missing.to_str().unwrap(),
+        "--all-exports",
+        "--cortex-m",
+        "-o",
+        planted_at.to_str().unwrap(),
+    ]);
+    let err = artifact_guard::compile_artifact(&mut cmd, &planted_at)
+        .expect_err("REFUSAL REQUIRED: a failed compile must not return last run's bytes");
+
+    // 4. The refusal names the compile, not the parser — and nothing is left.
+    assert!(
+        err.contains("synth compile FAILED"),
+        "the refusal must name the compile failure, got: {err}"
+    );
+    assert!(
+        !err.contains("file magic"),
+        "and must not surface as a parse error, got: {err}"
+    );
+    assert!(
+        !planted_at.exists(),
+        "the stale artifact must be GONE — left in place, a later reader picks it up"
+    );
 }

--- a/crates/synth-cli/tests/wsc_facts_ingestion_494.rs
+++ b/crates/synth-cli/tests/wsc_facts_ingestion_494.rs
@@ -26,6 +26,10 @@
 use object::{Object, ObjectSection};
 use std::process::Command;
 
+// #977 RQ-59-FRESHNESS: nothing here parses an artifact until the artifact is
+// proven to be THIS invocation's output — see `artifact_guard`.
+mod artifact_guard;
+
 fn synth() -> &'static str {
     env!("CARGO_BIN_EXE_synth")
 }
@@ -129,30 +133,30 @@ fn compile_text(wasm: &[u8], tag: &str) -> Vec<u8> {
     let dir = std::env::temp_dir().join("wsc_facts_494");
     std::fs::create_dir_all(&dir).expect("mk tempdir");
     let input = dir.join(format!("{tag}.wasm"));
-    let elf = dir.join(format!("{tag}.elf"));
+    // #977: unique per call + remove-first + status/exists/non-empty guards —
+    // a stale ELF at a fixed path must never be parsed as this run's.
+    let elf = artifact_guard::unique_artifact(&format!("wsc494_{tag}"), "elf");
     std::fs::write(&input, wasm).expect("write wasm");
-    let out = Command::new(synth())
-        .args([
-            "compile",
-            input.to_str().unwrap(),
-            "-o",
-            elf.to_str().unwrap(),
-            "-b",
-            "arm",
-            "--target",
-            "cortex-m4",
-            "--all-exports",
-        ])
-        .output()
-        .expect("run synth");
-    assert!(
-        out.status.success(),
-        "#494 fail-safe violated: compile of '{tag}' failed (exit={:?}) — a \
-         wsc.facts section must NEVER change a compilation outcome.\nstderr: {}",
-        out.status.code(),
-        String::from_utf8_lossy(&out.stderr)
+    let mut cmd = Command::new(synth());
+    cmd.args([
+        "compile",
+        input.to_str().unwrap(),
+        "-o",
+        elf.to_str().unwrap(),
+        "-b",
+        "arm",
+        "--target",
+        "cortex-m4",
+        "--all-exports",
+    ]);
+    let bytes = artifact_guard::compile_bytes_or_panic(
+        &mut cmd,
+        &elf,
+        &format!(
+            "#494 fail-safe violated: compile of '{tag}' — a wsc.facts \
+             section must NEVER change a compilation outcome"
+        ),
     );
-    let bytes = std::fs::read(&elf).expect("read elf");
     let obj = object::File::parse(&*bytes).expect("parse elf");
     obj.section_by_name(".text")
         .expect("fixture must have a .text section")


### PR DESCRIPTION
RQ-58-FLAKE's stated residual, closed: the 48 sites #1006 named as unable to notice a stale artifact are all converted (or, for shapes the guard does not fit, closed with the same discipline). Freshness coverage over the survey's 58 compile-then-parse sites goes **7/58 -> 58/58**. No second guard was written — every conversion routes through `artifact_guard` (#1006), which grew exactly one delegating variant (`compile_artifact_with_output`, for gates that assert on the compiler's own stderr; `compile_artifact` now delegates to it).

## How the sites were ranked

By what a stale read would RE-CERTIFY, the way `frozen_codegen_bytes.rs` re-certified the SHA-256 anchors:

1. **Flip/byte-identity gates first** — their assertions COMPARE two artifacts (`off` vs `on`). A stale arm silently reduces the gate to comparing last run's bytes with itself: the rollback proof for a default-on lever is re-confirmed by evidence this run never produced. These are the CI-pinned opt-out proofs the North Star table leans on.
2. **Validator/attestation gates** — VCR-VER-003's read-back records, the #901 elision attestation sidecar, the #735/#390 measured pins. A stale read re-certifies a validator verdict or an attestation.
3. **Structure/linkability/DWARF/provenance gates** — symbol/section/reloc shape claims.
4. **The helper-split trio** — named structurally resistant in #1006; see below.
5. **The conformance suite and the feature-gated trio** last: `wast_compile.rs` was the one file already checking `.exists()` (loud on the missing-file half), and the fact_spec trio needs the `--features verify` build to run its own oracle.

## Batches, each with its oracle and the SILENT-direction demonstration

Every batch ends green with its own pinned evidence unchanged — that is the byte-identity oracle: the artifacts the gates read after conversion are the same bytes the pinned goldens describe. Nothing the compiler EMITS changed; frozen anchors are 10/10 in the full workspace run.

| Batch | Files (sites) | Oracle | Silent-direction demonstration |
|---|---|---|---|
| 1 — flip gates | base_cse_flip_468 (1), const_cse_reduction_242 (2), flag_flip_wave_242 (1), spill_realloc_242 (1), rv32_cmp_select_flip_472 (1), rv32_local_promo_flip_472 (1), volatile_segment_flag_543 (1), volatile_segment_phase2_543 (1), vcr_ver_001_gate_242 (1) | pinned goldens unchanged (base_cse sha256 pair, const_cse FNV pair, no-grow + non-vacuity floors) | `freshness_guard_refuses_stale_flip_artifact_977` (base_cse_flip_468.rs) |
| 2 — validator/attestation | vcr_ver_003_addr_777 (2), proven_safe_bounds_901 (3), size_attribution_390 (1), parity_benchmark_735 (1), promotion_exhaustion_fallback_474 (1), wsc_facts_ingestion_494 (1) | measured pins unchanged (parity 84 B, proven-safe 138/80/50 partition, promotion off≡on byte-identity, `.wasm_data` record bytes) | `freshness_guard_refuses_stale_validator_artifact_977` (vcr_ver_003_addr_777.rs) |
| 3 — structure/linkability | dwarf_debug_line_emit_394 (2), elf_tooling_637_656 (1), multi_memory_406 (1), heterogeneous_table_676 (1), cabi_arena_bind_418 (2), cabi_arena_realloc_linkability_418 (1), call_indirect_275_selfcontained (3), async_intrinsics_gate (1), provenance_reconciliation_396 (1), provenance_introduced_origin_944 (1) | all symbol/section/DWARF/provenance assertions green; llvm-dwarfdump (independent parser) still verifies; the co-link test's REAL linker still links the guarded artifacts | `freshness_guard_refuses_stale_structure_artifact_977` (multi_memory_406.rs) |
| 4 — helper-split trio, THREADED | multi_sp_rebase_707 (1), static_downshift_678 (1), static_above_sp_739 (2) | pinned structure numbers unchanged (addends 576/616/4200/0x10000C, bss 584/512/4096, slot vectors) | `freshness_guard_refuses_stale_reloc_artifact_977` (static_above_sp_739.rs) |
| 5 — conformance suite | wast_compile (10: the helper behind 20 tests + 9 inline sites) | all 32 tests green (magic/e_machine/e_type/BL-resolution unchanged) | `freshness_guard_refuses_stale_conformance_artifact_977` (wast_compile.rs) |
| 6 — feature-gated + cross-crate | fact_spec_clamp/bounds/div_494 (3), linker_integration_test (synth-backend, 1) | ran with the fact-spec CI job's own invocation (`--features verify`): 12/12 green incl. the flag-off ≡ baseline byte-identity gates | covered by the guard's own always-run `artifact_guard_*` demos; the linker site is not a compile-then-parse (see below) |

Each demonstration proves the counterfactual the way #1006 did: (1) plant a VALID artifact minted by that batch's own compile shape and assert it parses and carries the very thing the batch's gates assert on (`.text`, `.wasm_data`, `.synth.wasm_mem_1`, the `__synth_wasm_data` addend, the ARM `e_machine`) — i.e. the pre-conversion shape WOULD have passed on last run's bytes; (2) run a FAILING compile at that exact path; (3) require the guard to refuse naming the COMPILE (never the parser) and to leave NOTHING at the path. All five run in CI on every push, alongside the four `artifact_guard_*` guard-observation tests from #1006.

## The structurally-resistant shape dissolved

#1006 left the trio (`multi_sp_rebase_707`, `static_above_sp_739`, `static_downshift_678`) because compile and read were split across helpers taking a `&str` path. The small contained change that closes it: every reader (`bss_size`, `global_slots`, `wasm_data_addends`, `max_wasm_data_addend`, `has_baked_pair_in_window`) now takes BYTES, and bytes are only handed out by a guarded compile. After this the split cannot recur in these files — a reader physically cannot open a path a previous run populated. No gate file was restructured beyond its own helpers.

## Stated remaining boundary

- **Refusal-only sites are out of scope by the survey's own definition** (a site = a compile whose artifact is READ BACK). Tests that expect a FAILING compile and assert only on exit/stderr keep their `Output`-returning helpers (multi_memory refusals, the static_* straddle/flag-honesty refusals, cabi bad-sig, call_indirect imports/skip-target, vcr_ver_003 span refusals). A few still name fixed `/tmp` paths, at which nothing is produced or read.
- **`linker_integration_test.rs` is not a compile-then-parse** — a library API (`generate_to_file`) writes the file; there is no `Command` for the guard to wrap and duplicating the guard was refused. Closed with the same discipline the guard encodes: per-process-unique path + remove-first ahead of the write.
- **External-tool reads are by-path by nature**: the dwarf helper and elf_tooling hand a PATH to llvm-dwarfdump / the real linker. The artifact is proven fresh (remove-first + status + exists/non-empty) at hand-out and stays in place for the tool; each path has a single writer in a single test.
- **Python harnesses unchanged**, per #1006's audit: all five flagged were false positives, and the CI steps that produce their objects run under `bash -e` on ephemeral runners.

## Gates

`cargo fmt --all` clean · `cargo clippy --workspace --all-targets -- -D warnings` clean · `cargo clippy -p synth-cli --features verify --all-targets` clean · `cargo test --workspace` TRUE exit 0 (146 green result lines; frozen anchors 10/10) · `cargo test -p synth-cli --features verify --test fact_spec_*` 12/12 · `python3 scripts/claim_check.py claims.yaml` 50/50 · `python3 scripts/model_coverage_audit.py --check` ok. No `.wat` added; no compiler source touched — only how harnesses READ artifacts changed, never what the compiler emits.

Refs #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJK5LZZEkV5smCY1jKn18L
